### PR TITLE
fix(recovery): escalate after consecutive needs_followup runs

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2339,6 +2339,143 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("escalates to blocked after consecutive needs_followup recovery runs with no concrete action", async () => {
+    // Simulate the COO-188 pattern: agent repeatedly posts "no change" comments
+    // while waiting for external review, but the issue stays in_progress.
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+    });
+
+    // Update the fixture's initial run to also have needs_followup liveness
+    const fixtureRuns = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    const fixtureRun = fixtureRuns[0];
+    if (fixtureRun) {
+      await db
+        .update(heartbeatRuns)
+        .set({
+          livenessState: "needs_followup",
+          livenessReason: "Run produced useful output but no concrete action evidence",
+        })
+        .where(eq(heartbeatRuns.id, fixtureRun.id));
+    }
+
+    // Seed 2 more consecutive needs_followup runs (total 3 = the threshold)
+    const now = new Date("2026-03-19T00:10:00.000Z");
+    for (let i = 0; i < 2; i++) {
+      const extraRunId = randomUUID();
+      const extraWakeId = randomUUID();
+      await db.insert(agentWakeupRequests).values({
+        id: extraWakeId,
+        companyId,
+        agentId,
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_continuation_needed",
+        payload: { issueId },
+        status: "completed",
+        runId: extraRunId,
+        claimedAt: now,
+        finishedAt: new Date(now.getTime() + 30_000),
+      });
+      await db.insert(heartbeatRuns).values({
+        id: extraRunId,
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "succeeded",
+        wakeupRequestId: extraWakeId,
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+        },
+        livenessState: "needs_followup",
+        livenessReason: "Run produced useful output but no concrete action evidence",
+        startedAt: now,
+        finishedAt: new Date(now.getTime() + 30_000),
+        updatedAt: new Date(now.getTime() + 30_000),
+      });
+    }
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Should NOT re-queue — should escalate to blocked instead
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    // The escalation comment should explain why
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("consecutive recovery runs");
+    expect(comments[0]?.body).toContain("needs_followup");
+  });
+
+  it("does not escalate when consecutive needs_followup runs are below the threshold", async () => {
+    // Only 2 consecutive needs_followup runs (below threshold of 3) — should still re-queue
+    const { agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+    });
+
+    // Seed 1 more needs_followup run (total 2, below threshold of 3)
+    const now = new Date("2026-03-19T00:10:00.000Z");
+    const extraRunId = randomUUID();
+    const extraWakeId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: extraWakeId,
+      companyId: (await db.select().from(agents).where(eq(agents.id, agentId)).then(r => r[0]))!.companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_continuation_needed",
+      payload: { issueId },
+      status: "completed",
+      runId: extraRunId,
+      claimedAt: now,
+      finishedAt: new Date(now.getTime() + 30_000),
+    });
+    await db.insert(heartbeatRuns).values({
+      id: extraRunId,
+      companyId: (await db.select().from(agents).where(eq(agents.id, agentId)).then(r => r[0]))!.companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "succeeded",
+      wakeupRequestId: extraWakeId,
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_continuation_needed",
+        retryReason: "issue_continuation_needed",
+      },
+      livenessState: "needs_followup",
+      livenessReason: "Run produced useful output but no concrete action evidence",
+      startedAt: now,
+      finishedAt: new Date(now.getTime() + 30_000),
+      updatedAt: new Date(now.getTime() + 30_000),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Should still re-queue — below threshold
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.escalated).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {
     const { issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2953,6 +2953,143 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(retryRun?.contextSnapshot as Record<string, unknown>).not.toHaveProperty("modelProfile");
   });
 
+  it("escalates to blocked after consecutive needs_followup recovery runs with no concrete action", async () => {
+    // Simulate the COO-188 pattern: agent repeatedly posts "no change" comments
+    // while waiting for external review, but the issue stays in_progress.
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+    });
+
+    // Update the fixture's initial run to also have needs_followup liveness
+    const fixtureRuns = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    const fixtureRun = fixtureRuns[0];
+    if (fixtureRun) {
+      await db
+        .update(heartbeatRuns)
+        .set({
+          livenessState: "needs_followup",
+          livenessReason: "Run produced useful output but no concrete action evidence",
+        })
+        .where(eq(heartbeatRuns.id, fixtureRun.id));
+    }
+
+    // Seed 2 more consecutive needs_followup runs (total 3 = the threshold)
+    const now = new Date("2026-03-19T00:10:00.000Z");
+    for (let i = 0; i < 2; i++) {
+      const extraRunId = randomUUID();
+      const extraWakeId = randomUUID();
+      await db.insert(agentWakeupRequests).values({
+        id: extraWakeId,
+        companyId,
+        agentId,
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_continuation_needed",
+        payload: { issueId },
+        status: "completed",
+        runId: extraRunId,
+        claimedAt: now,
+        finishedAt: new Date(now.getTime() + 30_000),
+      });
+      await db.insert(heartbeatRuns).values({
+        id: extraRunId,
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "succeeded",
+        wakeupRequestId: extraWakeId,
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+        },
+        livenessState: "needs_followup",
+        livenessReason: "Run produced useful output but no concrete action evidence",
+        startedAt: now,
+        finishedAt: new Date(now.getTime() + 30_000),
+        updatedAt: new Date(now.getTime() + 30_000),
+      });
+    }
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Should NOT re-queue — should escalate to blocked instead
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    // The escalation comment should explain why
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("consecutive recovery runs");
+    expect(comments[0]?.body).toContain("needs_followup");
+  });
+
+  it("does not escalate when consecutive needs_followup runs are below the threshold", async () => {
+    // Only 2 consecutive needs_followup runs (below threshold of 3) — should still re-queue
+    const { agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+    });
+
+    // Seed 1 more needs_followup run (total 2, below threshold of 3)
+    const now = new Date("2026-03-19T00:10:00.000Z");
+    const extraRunId = randomUUID();
+    const extraWakeId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: extraWakeId,
+      companyId: (await db.select().from(agents).where(eq(agents.id, agentId)).then(r => r[0]))!.companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_continuation_needed",
+      payload: { issueId },
+      status: "completed",
+      runId: extraRunId,
+      claimedAt: now,
+      finishedAt: new Date(now.getTime() + 30_000),
+    });
+    await db.insert(heartbeatRuns).values({
+      id: extraRunId,
+      companyId: (await db.select().from(agents).where(eq(agents.id, agentId)).then(r => r[0]))!.companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "succeeded",
+      wakeupRequestId: extraWakeId,
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_continuation_needed",
+        retryReason: "issue_continuation_needed",
+      },
+      livenessState: "needs_followup",
+      livenessReason: "Run produced useful output but no concrete action evidence",
+      startedAt: now,
+      finishedAt: new Date(now.getTime() + 30_000),
+      updatedAt: new Date(now.getTime() + 30_000),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Should still re-queue — below threshold
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.escalated).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {
     const { issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1014,6 +1014,7 @@ export function boundHeartbeatRunEventPayloadForStorage(payload: Record<string, 
 }
 
 function redactInlineBase64ImageData(chunk: string) {
+  if (!chunk) return '';
   return chunk.replace(INLINE_BASE64_IMAGE_DATA_RE, (_match, prefix: string, data: string, suffix: string) =>
     `${prefix}[omitted base64 image data: ${data.length} chars]${suffix}`,
   );

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -310,6 +310,46 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return db.select().from(agents).where(eq(agents.id, agentId)).then((rows) => rows[0] ?? null);
   }
 
+  const MAX_CONSECUTIVE_NEEDS_FOLLOWUP = 3;
+
+  async function countConsecutiveNeedsFollowup(
+    companyId: string,
+    issueId: string,
+    agentId: string,
+  ): Promise<number> {
+    const recentRuns = await db
+      .select({
+        status: heartbeatRuns.status,
+        livenessState: heartbeatRuns.livenessState,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.agentId, agentId),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
+      .limit(MAX_CONSECUTIVE_NEEDS_FOLLOWUP + 1);
+
+    let consecutive = 0;
+    for (const run of recentRuns) {
+      const wakeReason = parseObject(run.contextSnapshot).wakeReason;
+      if (
+        run.status === "succeeded" &&
+        run.livenessState === "needs_followup" &&
+        wakeReason === "issue_continuation_needed"
+      ) {
+        consecutive++;
+      } else {
+        break;
+      }
+    }
+    return consecutive;
+  }
+
   async function getLatestIssueRun(companyId: string, issueId: string): Promise<LatestIssueRun> {
     return db
       .select({
@@ -1742,6 +1782,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
         if (await isInvocationBudgetBlocked(issue, agentId)) {
           result.skipped += 1;
+          continue;
+        }
+
+        const consecutiveFollowup = await countConsecutiveNeedsFollowup(issue.companyId, issue.id, agentId);
+        if (consecutiveFollowup >= MAX_CONSECUTIVE_NEEDS_FOLLOWUP) {
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "in_progress",
+            latestRun: successfulRun,
+            comment:
+              `Paperclip detected ${consecutiveFollowup} consecutive recovery runs that produced no concrete action ` +
+              "(agent reports `needs_followup` each time). This usually means the agent is waiting for external " +
+              "input (e.g., code review, user decision) but the issue was not moved to `in_review`. " +
+              "Moving to `blocked` to stop the recovery loop. Move to `in_review` or `todo` when ready.",
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
           continue;
         }
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -415,6 +415,46 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return db.select().from(agents).where(eq(agents.id, agentId)).then((rows) => rows[0] ?? null);
   }
 
+  const MAX_CONSECUTIVE_NEEDS_FOLLOWUP = 3;
+
+  async function countConsecutiveNeedsFollowup(
+    companyId: string,
+    issueId: string,
+    agentId: string,
+  ): Promise<number> {
+    const recentRuns = await db
+      .select({
+        status: heartbeatRuns.status,
+        livenessState: heartbeatRuns.livenessState,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.agentId, agentId),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
+      .limit(MAX_CONSECUTIVE_NEEDS_FOLLOWUP + 1);
+
+    let consecutive = 0;
+    for (const run of recentRuns) {
+      const wakeReason = parseObject(run.contextSnapshot).wakeReason;
+      if (
+        run.status === "succeeded" &&
+        run.livenessState === "needs_followup" &&
+        wakeReason === "issue_continuation_needed"
+      ) {
+        consecutive++;
+      } else {
+        break;
+      }
+    }
+    return consecutive;
+  }
+
   async function getLatestIssueRun(companyId: string, issueId: string): Promise<LatestIssueRun> {
     return db
       .select({
@@ -2526,6 +2566,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
         if (await isInvocationBudgetBlocked(issue, agentId)) {
           result.skipped += 1;
+          continue;
+        }
+
+        const consecutiveFollowup = await countConsecutiveNeedsFollowup(issue.companyId, issue.id, agentId);
+        if (consecutiveFollowup >= MAX_CONSECUTIVE_NEEDS_FOLLOWUP) {
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "in_progress",
+            latestRun: successfulRun,
+            comment:
+              `Paperclip detected ${consecutiveFollowup} consecutive recovery runs that produced no concrete action ` +
+              "(agent reports `needs_followup` each time). This usually means the agent is waiting for external " +
+              "input (e.g., code review, user decision) but the issue was not moved to `in_review`. " +
+              "Moving to `blocked` to stop the recovery loop. Move to `in_review` or `todo` when ready.",
+          });
+          if (updated) {
+            result.escalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
           continue;
         }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat subsystem owns agent execution continuity and recovery
> - `reconcileStrandedAssignedIssues` re-dispatches agents on in_progress issues where runs have finished
> - When an agent has no actionable work (e.g., waiting for code review), it posts a comment and ends with `livenessState=needs_followup`
> - The `didAutomaticRecoveryFail` guard never triggers because each run succeeds — the agent posts a comment and finishes cleanly
> - This creates an unbounded loop of continuation wakes where the agent is re-dispatched, posts the same comment, and repeats
> - This PR adds `countConsecutiveNeedsFollowup` to detect when N consecutive runs all end with `livenessState=needs_followup` and `wakeReason=issue_continuation_needed`
> - When the threshold (3) is exceeded, escalate to `blocked` instead of re-queuing, with an explanation comment suggesting the likely cause

## What Changed

- Added `countConsecutiveNeedsFollowup` helper in `server/src/services/recovery/service.ts` to count consecutive `needs_followup` runs with `issue_continuation_needed` wake reason
- Modified `recoverStrandedAssignedIssues` to check consecutive count before re-queuing continuation
- When threshold exceeded, set issue status to `blocked` and post structured comment explaining the escalation
- Added test coverage for consecutive counting and threshold escalation
- Configured threshold at 3 consecutive runs before escalation

Relates to paperclipai/paperclip#3882