### PR TITLE
Atomically transition blocked issues to in_progress on request_confirmation accept

### DIFF
--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -957,4 +957,386 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       },
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // CYC-6101 Layer 1: atomic blocked → in_progress on request_confirmation
+  // accept. Fixture coverage:
+  //   1. blocked w/ no engineering blocker → transitions to in_progress
+  //   2. blocked w/ unresolved engineering blocker → card accepts, issue stays
+  //      blocked
+  //   3. already-in_progress → idempotent no-op (status unchanged)
+  //   4. already-accepted card replay → idempotent no-op (re-accept rejected)
+  // Each fixture independently exercises the new branch in
+  // `acceptRequestConfirmation`. Together they pin the contract that the brief
+  // requires (single-transaction, audit-friendly continuationIssue, idempotent).
+  // ---------------------------------------------------------------------------
+
+  it("CYC-6101 Layer 1: accepting a confirmation on a blocked, unblocked-by-relations issue transitions it to in_progress atomically", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+    const assigneeAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Layer 1 — board-only blocker",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "Founding Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    // The blocked-without-engineering-blocker case is the canonical CYC-5647
+    // shape: `status='blocked'`, no `issueRelations` rows pointing at this
+    // issue. The agent posed a request_confirmation card and is waiting for
+    // the board to accept it.
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Awaiting board confirmation",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId,
+    });
+
+    const created = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Proceed with the proposed plan?",
+        acceptLabel: "Approve",
+        rejectLabel: "Reject",
+      },
+    }, {
+      agentId: assigneeAgentId,
+    });
+
+    const accepted = await interactionsSvc.acceptInteraction({
+      id: issueId,
+      companyId,
+      goalId,
+      projectId: null,
+    }, created.id, {}, {
+      userId: "local-board",
+    });
+
+    expect(accepted.interaction.status).toBe("accepted");
+    // continuationIssue is what the route handler reads to decide whether to
+    // emit the `issue.updated` activity log row with the
+    // `source: "request_confirmation_accept"` audit reason. Layer 1 sets it
+    // whenever a transition actually happened.
+    expect(accepted.continuationIssue).toEqual({
+      id: issueId,
+      assigneeAgentId,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+
+    // Persisted state matches the contract: blocked → in_progress, assignee
+    // preserved, startedAt populated by `applyStatusSideEffects`.
+    const persisted = (await db.select().from(issues)).find((row) => row.id === issueId);
+    expect(persisted).toMatchObject({
+      id: issueId,
+      status: "in_progress",
+      assigneeAgentId,
+    });
+    expect(persisted?.startedAt).toBeInstanceOf(Date);
+  });
+
+  it("CYC-6101 Layer 1: accepting a confirmation on a blocked issue with an unresolved engineering blocker accepts the card but keeps the issue blocked", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const dependentIssueId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const assigneeAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Layer 1 — engineering blocker present",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "Founding Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    // Blocker issue is still in_progress — the dependency edge is unresolved.
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      goalId,
+      title: "Upstream dependency",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId,
+    });
+    await db.insert(issues).values({
+      id: dependentIssueId,
+      companyId,
+      goalId,
+      title: "Awaiting both board and dependency",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId,
+    });
+    // issue_relations row: dependentIssueId is blocked by blockerIssueId.
+    // (In drizzle the row's `issueId` is the blocker, `relatedIssueId` is
+    // the dependent — see services/issues.ts listIssueDependencyReadinessMap.)
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: dependentIssueId,
+      type: "blocks",
+    });
+
+    const created = await interactionsSvc.create({
+      id: dependentIssueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Proceed regardless of dependency?",
+      },
+    }, {
+      agentId: assigneeAgentId,
+    });
+
+    const accepted = await interactionsSvc.acceptInteraction({
+      id: dependentIssueId,
+      companyId,
+      goalId,
+      projectId: null,
+    }, created.id, {}, {
+      userId: "local-board",
+    });
+
+    // The card itself is accepted...
+    expect(accepted.interaction.status).toBe("accepted");
+    // ...but no issue-status transition fired (engineering blocker still
+    // unresolved), so continuationIssue stays null and the route handler
+    // does NOT emit an `issue.updated` audit row.
+    expect(accepted.continuationIssue ?? null).toBeNull();
+
+    const persisted = (await db.select().from(issues)).find((row) => row.id === dependentIssueId);
+    expect(persisted).toMatchObject({
+      id: dependentIssueId,
+      status: "blocked",
+      assigneeAgentId,
+    });
+  });
+
+  it("CYC-6101 Layer 1: accepting a confirmation on an already-in_progress issue is an idempotent no-op (no second transition)", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+    const assigneeAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Layer 1 — already in_progress",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "Founding Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    const startedAt = new Date("2026-04-30T10:00:00.000Z");
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Already running",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId,
+      startedAt,
+    });
+
+    const created = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Continue?",
+      },
+    }, {
+      agentId: assigneeAgentId,
+    });
+
+    const accepted = await interactionsSvc.acceptInteraction({
+      id: issueId,
+      companyId,
+      goalId,
+      projectId: null,
+    }, created.id, {}, {
+      userId: "local-board",
+    });
+
+    expect(accepted.interaction.status).toBe("accepted");
+    // No transition fires because the issue is not `blocked`. The Layer 1
+    // branch is bypassed entirely; the existing `touchIssue` else-branch
+    // handles the bookkeeping.
+    expect(accepted.continuationIssue ?? null).toBeNull();
+
+    const persisted = (await db.select().from(issues)).find((row) => row.id === issueId);
+    expect(persisted).toMatchObject({
+      id: issueId,
+      status: "in_progress",
+      assigneeAgentId,
+    });
+    // startedAt MUST NOT be re-stamped on the no-op path; that would be the
+    // signature of a second transition firing.
+    expect(persisted?.startedAt?.getTime()).toBe(startedAt.getTime());
+  });
+
+  it("CYC-6101 Layer 1: replaying accept on a card that is already accepted is an idempotent no-op (no double transition, no double audit row)", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+    const assigneeAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Layer 1 — replay accept",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "Founding Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Awaiting board confirmation (replay)",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId,
+    });
+
+    const created = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Proceed?",
+      },
+    }, {
+      agentId: assigneeAgentId,
+    });
+
+    // First accept transitions blocked → in_progress.
+    const firstAccept = await interactionsSvc.acceptInteraction({
+      id: issueId,
+      companyId,
+      goalId,
+      projectId: null,
+    }, created.id, {}, {
+      userId: "local-board",
+    });
+    expect(firstAccept.continuationIssue).toMatchObject({
+      id: issueId,
+      status: "in_progress",
+    });
+
+    const persistedAfterFirst = (await db.select().from(issues)).find((row) => row.id === issueId);
+    expect(persistedAfterFirst?.status).toBe("in_progress");
+    const startedAtAfterFirst = persistedAfterFirst?.startedAt;
+    expect(startedAtAfterFirst).toBeInstanceOf(Date);
+
+    // Second accept on the same (already-accepted) interaction must be a
+    // no-op. The interaction-update WHERE clause matches `status='pending'`
+    // and finds zero rows on replay, so the service throws — neither the
+    // interaction row nor the issue row mutates.
+    await expect(interactionsSvc.acceptInteraction({
+      id: issueId,
+      companyId,
+      goalId,
+      projectId: null,
+    }, created.id, {}, {
+      userId: "local-board",
+    })).rejects.toThrow("Interaction has already been resolved");
+
+    const persistedAfterReplay = (await db.select().from(issues)).find((row) => row.id === issueId);
+    expect(persistedAfterReplay?.status).toBe("in_progress");
+    // startedAt still stamped exactly once — the second call did not re-fire
+    // the transition path.
+    expect(persistedAfterReplay?.startedAt?.getTime()).toBe(startedAtAfterFirst!.getTime());
+  });
 });

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -36,7 +36,7 @@ import {
   suggestTasksResultSchema,
 } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
-import { issueService } from "./issues.js";
+import { issueService, listUnresolvedBlockerIssueIdsForIssue } from "./issues.js";
 
 type InteractionActor = {
   agentId?: string | null;
@@ -542,6 +542,47 @@ export function issueThreadInteractionService(db: Db) {
             assigneeUserId: returnedIssue.assigneeUserId ?? null,
             status: returnedIssue.status,
           };
+        }
+      } else if (
+        // CYC-6101 Layer 1: when a request_confirmation card is accepted on a
+        // `blocked` issue that has an active assignee and no unresolved
+        // engineering blockers (blocker relations whose status != 'done'), the
+        // accept itself is the unblock signal. Transition the issue to
+        // `in_progress` atomically inside the same transaction as the
+        // interaction `status='accepted'` UPDATE, so the wake_assignee
+        // continuation fires against an already-correct status and the board
+        // surfacer drops the stale "still blocked" entry on the next refresh.
+        //
+        // Idempotent by construction: if the issue is already in_progress (or
+        // done/cancelled/etc), this branch is a no-op `touchIssue`.
+        // Engineering-blocker case: we leave the issue in `blocked` so the
+        // board still sees the dependency edge — only the card is resolved.
+        issueContext.status === "blocked"
+        && (issueContext.assigneeAgentId !== null || issueContext.assigneeUserId !== null)
+      ) {
+        const unresolvedBlockerIssueIds = await listUnresolvedBlockerIssueIdsForIssue(
+          tx,
+          issueContext.companyId,
+          args.issue.id,
+        );
+        if (unresolvedBlockerIssueIds.length === 0) {
+          const transitioned = await issueService(db).update(args.issue.id, {
+            status: "in_progress",
+            actorAgentId: args.actor.agentId ?? null,
+            actorUserId: args.actor.userId ?? null,
+          }, tx);
+          if (transitioned) {
+            continuationIssue = {
+              id: transitioned.id,
+              assigneeAgentId: transitioned.assigneeAgentId ?? null,
+              assigneeUserId: transitioned.assigneeUserId ?? null,
+              status: transitioned.status,
+            };
+          } else {
+            await touchIssue(tx, args.issue.id);
+          }
+        } else {
+          await touchIssue(tx, args.issue.id);
         }
       } else {
         await touchIssue(tx, args.issue.id);

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -579,6 +579,21 @@ export function issueThreadInteractionService(db: Db) {
               status: transitioned.status,
             };
           } else {
+            // Defensive: should be unreachable. `issueContext` was just read
+            // from the same `tx` a few lines above, so the row must still
+            // exist when we reach `update()`. If we ever land here it means
+            // either (a) something raced an issue delete inside this tx, or
+            // (b) `update()`'s internal guards (status guard, blocker
+            // re-check, etc.) rejected the patch and returned `null`. Either
+            // way the board accept just lost its `issue.updated` audit row,
+            // so surface the divergence loudly so it's debuggable.
+            console.warn(
+              "[issue-thread-interactions] acceptRequestConfirmation: "
+                + "issueService.update() returned null while transitioning "
+                + "blocked → in_progress; falling back to touchIssue. "
+                + `issueId=${args.issue.id} interactionId=${args.current.id} `
+                + `companyId=${issueContext.companyId}`,
+            );
             await touchIssue(tx, args.issue.id);
           }
         } else {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -325,6 +325,25 @@ async function listUnresolvedBlockerIssueIds(
     )
     .then((rows) => rows.map((row) => row.id));
 }
+
+/**
+ * Returns the ids of the issue's unresolved blockers (blocker rows whose
+ * `issues.status` is not `done`). Used by `acceptRequestConfirmation` (CYC-6101
+ * Layer 1) so it can decide whether the dependent issue is safe to transition
+ * out of `blocked` when a board confirmation card is accepted.
+ *
+ * Exported so callers outside `issueService(db)` (specifically
+ * `issue-thread-interactions.ts`) can use the same canonical query as the
+ * `update()` path that gates the `→ in_progress` transition.
+ */
+export async function listUnresolvedBlockerIssueIdsForIssue(
+  dbOrTx: Pick<Db, "select">,
+  companyId: string,
+  issueId: string,
+): Promise<string[]> {
+  const readinessMap = await listIssueDependencyReadinessMap(dbOrTx, companyId, [issueId]);
+  return readinessMap.get(issueId)?.unresolvedBlockerIssueIds ?? [];
+}
 async function getProjectDefaultGoalId(
   db: ProjectGoalReader,
   companyId: string,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -344,6 +344,7 @@ export async function listUnresolvedBlockerIssueIdsForIssue(
   const readinessMap = await listIssueDependencyReadinessMap(dbOrTx, companyId, [issueId]);
   return readinessMap.get(issueId)?.unresolvedBlockerIssueIds ?? [];
 }
+
 async function getProjectDefaultGoalId(
   db: ProjectGoalReader,
   companyId: string,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issue threads carry `request_confirmation` interaction cards: an agent posts a prompt, the board accepts or rejects, the assignee is woken to continue
> - When the agent posed the prompt, the issue is typically held in `blocked` status until the board responds — that's the "do not run, you're waiting on a human" signal
> - Today the accept-handler updates only the interaction row; the issue itself stays in `blocked` even though the card said "approved"
> - Downstream surfaces (board inboxes, dashboards, dependency-readiness queries, fleet auditors) read issue status, so a board-accepted card whose underlying issue is still `blocked` looks like an unanswered question — the board sees the same item again
> - This pull request makes accepting a `request_confirmation` an atomic transaction that flips the interaction to `accepted` AND, when the issue is `blocked` with no unresolved engineering blockers, transitions it to `in_progress` in the same DB transaction, with the route handler logging an `issue.updated` audit row
> - The benefit is a single, race-free unblock signal that downstream surfaces and the woken assignee both observe consistently — no more stale "still blocked" entries in board inboxes after the board has already answered

## What Changed

- `server/src/services/issue-thread-interactions.ts` — new `else if` branch inside `acceptRequestConfirmation`'s transaction. When the existing `shouldReturnAcceptedConfirmationToCreatorAgent` path doesn't fire AND the issue is `blocked` AND it has an active assignee AND `issueRelations` reports zero unresolved blocker rows, the same transaction calls `issueService(db).update(args.issue.id, { status: 'in_progress', actorAgentId, actorUserId }, tx)` and populates `continuationIssue` so the route handler emits the audit row that already exists for the creator-return path. `touchIssue` remains the fallback for every other case (no assignee, engineering blocker still unresolved, issue already `in_progress` / `done` / `cancelled`).
- `server/src/services/issues.ts` — exports a new `listUnresolvedBlockerIssueIdsForIssue(dbOrTx, companyId, issueId)` helper so the interactions service uses the same canonical readiness query as the in-line check inside `issueService.update()`. No behaviour change to existing callers.
- `server/src/__tests__/issue-thread-interactions-service.test.ts` — four new embedded-Postgres fixtures pin the contract:
  1. `blocked` with no engineering blocker → transitions to `in_progress`, `continuationIssue` populated, `startedAt` stamped by `applyStatusSideEffects`.
  2. `blocked` with an unresolved engineering blocker (`issueRelations` row whose blocker status is `in_progress`) → card accepts, `continuationIssue` is `null`, issue stays `blocked` (dependency edge still surfaces).
  3. `in_progress` issue → no-op; the new branch's status guard skips it; `startedAt` is NOT re-stamped (proves no second transition fired).
  4. Replay accept on an already-accepted card → second call rejects with `"Interaction has already been resolved"` (existing pending-only WHERE clause); issue state unchanged from after the first accept.

The `acceptRequestConfirmation` body in full (only the marked branch is new):

```ts
let continuationIssue: IssueWakeTarget | null = null;
if (shouldReturnAcceptedConfirmationToCreatorAgent({ issue: issueContext, current: args.current, actor: args.actor })) {
  // existing creator-return path — unchanged
  ...
} else if (
  issueContext.status === "blocked"
  && (issueContext.assigneeAgentId !== null || issueContext.assigneeUserId !== null)
) {
  const unresolvedBlockerIssueIds = await listUnresolvedBlockerIssueIdsForIssue(tx, issueContext.companyId, args.issue.id);
  if (unresolvedBlockerIssueIds.length === 0) {
    const transitioned = await issueService(db).update(args.issue.id, {
      status: "in_progress",
      actorAgentId: args.actor.agentId ?? null,
      actorUserId: args.actor.userId ?? null,
    }, tx);
    if (transitioned) {
      continuationIssue = { id: transitioned.id, assigneeAgentId: transitioned.assigneeAgentId ?? null, assigneeUserId: transitioned.assigneeUserId ?? null, status: transitioned.status };
    } else {
      await touchIssue(tx, args.issue.id);
    }
  } else {
    await touchIssue(tx, args.issue.id);
  }
} else {
  await touchIssue(tx, args.issue.id);
}
```

The audit row already exists on the route side: when `continuationIssue` is non-null, `server/src/routes/issues.ts` (around the existing `await logActivity(...)` block following `acceptInteraction`) writes an `issue.updated` action with `source: "request_confirmation_accept"`, `interactionId`, and a `_previous` block. No new audit-log shape required.

## Verification

Embedded-Postgres test suite (`server/src/__tests__/`):

```sh
cd server
pnpm exec vitest run \
  src/__tests__/issue-thread-interactions-service.test.ts \
  src/__tests__/issues-service.test.ts \
  src/__tests__/issue-thread-interaction-routes.test.ts \
  src/__tests__/issue-blocker-attention.test.ts
```

Output:

```
✓ src/__tests__/issues-service.test.ts (38 tests) 31589ms
✓ src/__tests__/issue-thread-interactions-service.test.ts (14 tests) 5980ms
✓ src/__tests__/issue-thread-interaction-routes.test.ts (9 tests) 1415ms
✓ src/__tests__/issue-blocker-attention.test.ts (11 tests) 5865ms

Test Files  4 passed (4)
Tests       72 passed (72)
```

Of those 14 `issue-thread-interactions-service` tests, 4 are the new fixtures listed in **What Changed**. They each independently exercise the new branch — the contract is "pinned to ground truth" because each fixture queries `db.select().from(issues)` and asserts the persisted row, not just the function return value.

Repo-wide typecheck:

```sh
pnpm typecheck
```

Passes for `server`, `ui`, `cli`, and every `packages/plugins/**` workspace.

## Risks

- **Low-to-medium risk; well-bounded.** New behaviour only fires inside `acceptRequestConfirmation` — no other accept paths (`acceptSuggestedTasks`, `answerQuestions`, etc.) are touched, and the new branch is gated behind `else if (issueContext.status === "blocked" && ...)` so the existing `touchIssue` path remains the default for every unaffected case. Issues that are not `blocked`, that lack an assignee, or that have an unresolved engineering blocker behave exactly as before.
- **Audit trail uses the existing `issue.updated` action shape**, not a new `status_transition` action. The `details.source` is set to `"request_confirmation_accept"` and `details.interactionId` carries the interaction UUID, so log-ingestion pipelines that already understand `issue.updated` rows work unchanged. If a downstream consumer specifically needs a separate `status_transition` action type, that can be added in a follow-up — out of scope for the bug fix.
- **No schema change.** The brief contemplated a "board sentinel blocker" classification on `issueRelations`, but Paperclip core does not currently model such a concept (every blocker is just another issue). The interpretation here — "no unresolved blocker rows" — is the strongest signal Paperclip's schema can offer, and matches the canonical bug fixture: `blockedBy: []` on the issue that motivated the report.
- **Idempotency is enforced at the existing layer**: the interaction-row UPDATE already restricts to `status='pending'`, so accept replays throw before any issue mutation runs. The new fixture #4 proves this end-to-end against an embedded Postgres instance.
- **Concurrent accept** would have failed even pre-PR — the second concurrent UPDATE finds zero rows (status moved to `accepted`) and throws `"Interaction has already been resolved"` inside the transaction, rolling back the issue-status side effect. No new race exposed.

## Model Used

- Provider: Anthropic Claude (via Cursor IDE)
- Model: `claude-opus-4.7` (Founding Engineer 2 agent)
- Capabilities: extended thinking enabled, full tool use (file ops, shell, Postgres queries against an embedded Paperclip instance for schema verification)
- Context window: 1M tokens
- Reasoning mode: chain-of-thought + verification-before-claim

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — this is a bug fix, not a feature
- [x] I have run tests locally and they pass (72 tests across 4 issue/interaction suites)
- [x] I have added or updated tests where applicable (4 new fixtures pin every leg of the contract)
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

**Filed by:** Cycle Edge fleet (FE2). Tracked downstream as `CYC-6102` (parent: `CYC-6101`). The downstream cycle_edge defense-in-depth surfacer-clear shipped under `CYC-6101` and is independent of this PR; this PR is the upstream root-cause fix.

Made with [Cursor](https://cursor.com)