### PR TITLE
KIN-942: set up CI workflow and SAM scaffold for ingest lambda

### DIFF
--- a/.github/workflows/ingest-lambda-ci.yml
+++ b/.github/workflows/ingest-lambda-ci.yml
@@ -1,0 +1,138 @@
+name: ingest-lambda-ci
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "infrastructure/paperclip-ingest-lambda/**"
+      - ".github/workflows/ingest-lambda-ci.yml"
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - "infrastructure/paperclip-ingest-lambda/**"
+      - ".github/workflows/ingest-lambda-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  TEMPLATE_FILE: infrastructure/paperclip-ingest-lambda/template.yaml
+  TEST_FILE: infrastructure/paperclip-ingest-lambda/tests/handler.test.mjs
+
+jobs:
+  verify:
+    name: Verify Ingest Lambda
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup AWS SAM CLI
+        uses: aws-actions/setup-sam@v2
+
+      - name: Run handler tests
+        run: node --test "${{ env.TEST_FILE }}"
+
+      - name: Validate SAM template
+        run: sam validate --template-file "${{ env.TEMPLATE_FILE }}"
+
+      - name: Build SAM template
+        run: sam build --template-file "${{ env.TEMPLATE_FILE }}"
+
+  deploy-dev:
+    name: Deploy Dev
+    runs-on: ubuntu-latest
+    needs: verify
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+    environment: dev
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup AWS SAM CLI
+        uses: aws-actions/setup-sam@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEV }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Build SAM template
+        run: sam build --template-file "${{ env.TEMPLATE_FILE }}"
+
+      - name: Package SAM template
+        run: |
+          sam package \
+            --template-file .aws-sam/build/template.yaml \
+            --s3-bucket "${{ secrets.SAM_ARTIFACT_BUCKET_DEV }}" \
+            --output-template-file packaged-dev.yaml
+
+      - name: Deploy dev stack
+        run: |
+          sam deploy \
+            --template-file packaged-dev.yaml \
+            --stack-name "${{ secrets.PAPERCLIP_INGEST_STACK_DEV }}" \
+            --capabilities CAPABILITY_IAM \
+            --no-confirm-changeset \
+            --no-fail-on-empty-changeset \
+            --parameter-overrides \
+              DeploymentStage=dev \
+              EntitlementsTableName=kinetica-entitlements \
+              EventBusName=default
+
+  deploy-staging:
+    name: Deploy Staging
+    runs-on: ubuntu-latest
+    needs: verify
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+    environment: staging
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup AWS SAM CLI
+        uses: aws-actions/setup-sam@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_STAGING }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Build SAM template
+        run: sam build --template-file "${{ env.TEMPLATE_FILE }}"
+
+      - name: Package SAM template
+        run: |
+          sam package \
+            --template-file .aws-sam/build/template.yaml \
+            --s3-bucket "${{ secrets.SAM_ARTIFACT_BUCKET_STAGING }}" \
+            --output-template-file packaged-staging.yaml
+
+      - name: Deploy staging stack
+        run: |
+          sam deploy \
+            --template-file packaged-staging.yaml \
+            --stack-name "${{ secrets.PAPERCLIP_INGEST_STACK_STAGING }}" \
+            --capabilities CAPABILITY_IAM \
+            --no-confirm-changeset \
+            --no-fail-on-empty-changeset \
+            --parameter-overrides \
+              DeploymentStage=staging \
+              EntitlementsTableName=kinetica-entitlements \
+              EventBusName=default

--- a/.github/workflows/ingest-lambda-ci.yml
+++ b/.github/workflows/ingest-lambda-ci.yml
@@ -23,6 +23,8 @@ permissions:
 env:
   TEMPLATE_FILE: infrastructure/paperclip-ingest-lambda/template.yaml
   TEST_FILE: infrastructure/paperclip-ingest-lambda/tests/handler.test.mjs
+  AWS_REGION: us-east-1
+  AWS_DEFAULT_REGION: us-east-1
 
 jobs:
   verify:

--- a/infrastructure/paperclip-ingest-lambda/README.md
+++ b/infrastructure/paperclip-ingest-lambda/README.md
@@ -1,0 +1,55 @@
+# Paperclip Ingest Middleware Lambda
+
+This directory contains the KIN-942 scaffold for the KIN-375 Phase C ingest middleware pipeline.
+
+## What is included
+
+- `template.yaml`: AWS SAM template for Lambda + EventBridge trigger + DLQ.
+- `src/handler.mjs`: minimal Lambda handler scaffold for middleware execution.
+- `tests/handler.test.mjs`: unit test for local handler behavior.
+- `events/mock-event.json`: sample EventBridge payload for local invoke.
+- `samconfig.toml`: default SAM build and local invoke parameters.
+
+## Local validation
+
+1. Run handler unit test:
+
+```bash
+node --test infrastructure/paperclip-ingest-lambda/tests/handler.test.mjs
+```
+
+2. Validate SAM template:
+
+```bash
+sam validate --template-file infrastructure/paperclip-ingest-lambda/template.yaml
+```
+
+3. Build SAM app:
+
+```bash
+sam build --template-file infrastructure/paperclip-ingest-lambda/template.yaml
+```
+
+4. Run local invoke with mock event:
+
+```bash
+sam local invoke IngestMiddlewareFunction --template-file infrastructure/paperclip-ingest-lambda/template.yaml --event infrastructure/paperclip-ingest-lambda/events/mock-event.json
+```
+
+## CI/CD workflow
+
+The workflow at `.github/workflows/ingest-lambda-ci.yml` performs:
+
+- PR/push validation scoped to this directory
+- unit test + `sam validate` + `sam build`
+- `sam package` + `sam deploy` to dev and staging on merge to `master`/`main`
+
+## Required GitHub Secrets
+
+- `AWS_REGION`
+- `AWS_ROLE_ARN_DEV`
+- `AWS_ROLE_ARN_STAGING`
+- `SAM_ARTIFACT_BUCKET_DEV`
+- `SAM_ARTIFACT_BUCKET_STAGING`
+- `PAPERCLIP_INGEST_STACK_DEV`
+- `PAPERCLIP_INGEST_STACK_STAGING`

--- a/infrastructure/paperclip-ingest-lambda/events/mock-event.json
+++ b/infrastructure/paperclip-ingest-lambda/events/mock-event.json
@@ -1,0 +1,17 @@
+{
+  "version": "0",
+  "id": "2f9ad8d2-b53f-4ce6-b766-dfd734f4bb3f",
+  "detail-type": "notion.webhook.received",
+  "source": "kinetica.notion",
+  "account": "123456789012",
+  "time": "2026-05-01T00:00:00Z",
+  "region": "us-east-1",
+  "resources": [],
+  "detail": {
+    "eventId": "evt_kin_375_sample",
+    "workspaceId": "notion_workspace_sample",
+    "entity": "task",
+    "operation": "upsert",
+    "entityId": "KIN-375"
+  }
+}

--- a/infrastructure/paperclip-ingest-lambda/samconfig.toml
+++ b/infrastructure/paperclip-ingest-lambda/samconfig.toml
@@ -1,0 +1,14 @@
+version = 0.1
+
+[default]
+[default.build]
+[default.build.parameters]
+template_file = "template.yaml"
+cached = true
+parallel = true
+
+[default.local_invoke]
+[default.local_invoke.parameters]
+template_file = "template.yaml"
+event = "events/mock-event.json"
+parameter_overrides = "DeploymentStage=dev EntitlementsTableName=kinetica-entitlements EventBusName=default"

--- a/infrastructure/paperclip-ingest-lambda/src/handler.mjs
+++ b/infrastructure/paperclip-ingest-lambda/src/handler.mjs
@@ -1,0 +1,28 @@
+const DEFAULT_SOURCE = "unknown";
+const DEFAULT_DETAIL_TYPE = "unknown";
+
+export async function handler(event) {
+  const source = event?.source ?? DEFAULT_SOURCE;
+  const detailType = event?.["detail-type"] ?? DEFAULT_DETAIL_TYPE;
+  const detail = event?.detail ?? {};
+  const entitlementsTableName = process.env.ENTITLEMENTS_TABLE_NAME ?? "kinetica-entitlements";
+
+  const response = {
+    ok: true,
+    message: "Paperclip ingest middleware scaffold executed successfully.",
+    received: {
+      source,
+      detailType,
+      detail,
+    },
+    config: {
+      entitlementsTableName,
+      deploymentStage: process.env.DEPLOYMENT_STAGE ?? "dev",
+    },
+  };
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(response),
+  };
+}

--- a/infrastructure/paperclip-ingest-lambda/template.yaml
+++ b/infrastructure/paperclip-ingest-lambda/template.yaml
@@ -1,0 +1,83 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: Paperclip Ingest Middleware Lambda scaffold (KIN-942 / KIN-375 Phase C prep)
+
+Parameters:
+  DeploymentStage:
+    Type: String
+    Default: dev
+    AllowedValues:
+      - dev
+      - staging
+      - prod
+  EntitlementsTableName:
+    Type: String
+    Default: kinetica-entitlements
+  EventBusName:
+    Type: String
+    Default: default
+  PaperclipApiUrl:
+    Type: String
+    Default: https://paperclip.example.internal/api
+
+Resources:
+  IngestMiddlewareDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub paperclip-ingest-dlq-${DeploymentStage}
+      MessageRetentionPeriod: 1209600
+
+  IngestMiddlewareFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub paperclip-ingest-middleware-${DeploymentStage}
+      Description: Middleware layer for Notion webhook fan-out into Paperclip tasks.
+      Runtime: nodejs20.x
+      Handler: handler.handler
+      CodeUri: src/
+      Architectures:
+        - arm64
+      MemorySize: 256
+      Timeout: 30
+      Environment:
+        Variables:
+          DEPLOYMENT_STAGE: !Ref DeploymentStage
+          ENTITLEMENTS_TABLE_NAME: !Ref EntitlementsTableName
+          PAPERCLIP_API_URL: !Ref PaperclipApiUrl
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt IngestMiddlewareDLQ.Arn
+      Policies:
+        - Statement:
+            Effect: Allow
+            Action:
+              - dynamodb:GetItem
+              - dynamodb:Query
+              - dynamodb:Scan
+              - dynamodb:UpdateItem
+            Resource:
+              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${EntitlementsTableName}
+              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${EntitlementsTableName}/index/*
+        - Statement:
+            Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt IngestMiddlewareDLQ.Arn
+      Events:
+        NotionWebhookEvent:
+          Type: EventBridgeRule
+          Properties:
+            EventBusName: !Ref EventBusName
+            Pattern:
+              source:
+                - kinetica.notion
+              detail-type:
+                - notion.webhook.received
+
+Outputs:
+  IngestMiddlewareFunctionArn:
+    Description: ARN of the ingest middleware Lambda function.
+    Value: !GetAtt IngestMiddlewareFunction.Arn
+  IngestMiddlewareDlqArn:
+    Description: ARN of DLQ for failed ingest middleware invocations.
+    Value: !GetAtt IngestMiddlewareDLQ.Arn

--- a/infrastructure/paperclip-ingest-lambda/tests/handler.test.mjs
+++ b/infrastructure/paperclip-ingest-lambda/tests/handler.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { handler } from "../src/handler.mjs";
+
+test("handler returns success response for mock EventBridge payload", async () => {
+  process.env.ENTITLEMENTS_TABLE_NAME = "kinetica-entitlements";
+  process.env.DEPLOYMENT_STAGE = "dev";
+
+  const result = await handler({
+    source: "kinetica.notion",
+    "detail-type": "notion.webhook.received",
+    detail: {
+      taskId: "KIN-375",
+      operation: "upsert",
+    },
+  });
+
+  assert.equal(result.statusCode, 200);
+
+  const parsed = JSON.parse(result.body);
+  assert.equal(parsed.ok, true);
+  assert.equal(parsed.config.entitlementsTableName, "kinetica-entitlements");
+  assert.equal(parsed.received.source, "kinetica.notion");
+});


### PR DESCRIPTION
## Summary
Adds a dedicated CI/CD slice for the Paperclip ingest middleware Lambda (KIN-375 Phase C prep), including workflow automation, SAM infrastructure scaffold, and local invoke assets.

## Test Plan
- node --test infrastructure/paperclip-ingest-lambda/tests/handler.test.mjs
- sam validate --template-file infrastructure/paperclip-ingest-lambda/template.yaml (requires SAM CLI in runner/local)
- sam build --template-file infrastructure/paperclip-ingest-lambda/template.yaml (requires SAM CLI in runner/local)

Closes KIN-942