### PR TITLE
fix(win32): use directory junctions for skill symlinks on Windows

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1453,7 +1453,9 @@ export async function ensurePaperclipSkillSymlink(
   source: string,
   target: string,
   linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) =>
-    fs.symlink(linkSource, linkTarget),
+    process.platform === "win32"
+      ? fs.symlink(linkSource, linkTarget, "junction")
+      : fs.symlink(linkSource, linkTarget),
 ): Promise<"created" | "repaired" | "skipped"> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {


### PR DESCRIPTION
<!-- Written in Simplified Technical English: short sentences, active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The adapter utilities materialize skills by linking a skill source directory into a target directory.
> - The skill link code in `packages/adapter-utils/src/server-utils.ts` calls `fs.symlink(source, target)` with no link type.
> - On Windows, a directory symlink needs Administrator privileges or Developer Mode. Without them, the call fails with `EPERM: operation not permitted, symlink`.
> - This failure breaks skill injection on all Windows installs that do not run with elevated privileges.
> - This pull request switches to a Windows directory junction on the `win32` platform.
> - The benefit is that Windows users can link skills without elevated privileges, and Linux and macOS behavior does not change.

## Linked Issues or Issue Description

The author references an internal ticket id, which cannot be linked here. The problem is described below instead.

**What happened?**
On Windows, `ensurePaperclipSkillSymlink()` calls `fs.symlink(source, target)` without a link type. Windows directory symlinks require Administrator privileges or Developer Mode. On installs without those privileges, the call fails with `EPERM: operation not permitted, symlink '...\skills\paperclip' -> '...\.claude\skills\paperclip'`.

**Expected behavior**
Skill injection completes on Windows without elevated privileges. Linux and macOS behavior stays the same.

**Environment**
Windows (`win32`). The failure does not occur on Linux or macOS.

## What Changed

- In `ensurePaperclipSkillSymlink()` (`packages/adapter-utils/src/server-utils.ts`), the default `linkSkill` function now checks the platform.
- On `win32`, it calls `fs.symlink(linkSource, linkTarget, "junction")` to create a directory junction.
- On other platforms, it keeps the previous `fs.symlink(linkSource, linkTarget)` call with no type.

## Verification

The author states the following:

- TypeScript compiles clean (`tsc --noEmit`).
- No behavior change on Linux or macOS, because the new branch is guarded by `process.platform`.

## Risks

Low risk. The `win32` branch changes behavior only on Windows. Non-Windows platforms keep the previous code path. Junctions require absolute source paths; the author states all skill sources are absolute paths.

## Model Used

Not stated by the author.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have searched GitHub for duplicate or related PRs and linked them above
- [ ] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [ ] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

## Original description

## Problem

On Windows, `fs.symlink()` for directories requires either Administrator privileges or Developer Mode enabled. The Paperclip skill materialization code calls `fs.symlink(source, target)` without a type, causing:

```
EPERM: operation not permitted, symlink '...\skills\paperclip' -> '...\.claude\skills\paperclip'
```

This breaks skill injection on all Windows installs that don't run with elevated privileges.

## Fix

In `ensurePaperclipSkillSymlink()` (`packages/adapter-utils/src/server-utils.ts`), switch to `'junction'` type on `win32`:

```diff
- linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) =>
-   fs.symlink(linkSource, linkTarget),
+ linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) =>
+   process.platform === "win32"
+     ? fs.symlink(linkSource, linkTarget, "junction")
+     : fs.symlink(linkSource, linkTarget),
```

Windows [directory junctions](https://learn.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions) don't require elevated privileges and are transparent to consumers reading the directory. All skill sources are absolute paths, which is required by junctions.

## Testing

- TypeScript compiles clean (`tsc --noEmit`)
- No behavior change on Linux/macOS (guarded by `process.platform`)

Fixes #WEI-291