### PR TITLE
feat(db): add agent_failure_state table + idempotency index [NOC-186]

### DIFF
--- a/packages/db/src/migrations/0076_agent_failure_state.sql
+++ b/packages/db/src/migrations/0076_agent_failure_state.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS "agent_failure_state" (
+  "agent_id" uuid PRIMARY KEY NOT NULL,
+  "consecutive_adapter_failures" integer DEFAULT 0 NOT NULL,
+  "first_failure_run_id" uuid,
+  "last_failure_run_id" uuid,
+  "open_auto_issue_id" uuid,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "agent_failure_state" ADD CONSTRAINT "agent_failure_state_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "agent_failure_state" ADD CONSTRAINT "agent_failure_state_first_failure_run_id_heartbeat_runs_id_fk" FOREIGN KEY ("first_failure_run_id") REFERENCES "public"."heartbeat_runs"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "agent_failure_state" ADD CONSTRAINT "agent_failure_state_last_failure_run_id_heartbeat_runs_id_fk" FOREIGN KEY ("last_failure_run_id") REFERENCES "public"."heartbeat_runs"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "agent_failure_state" ADD CONSTRAINT "agent_failure_state_open_auto_issue_id_issues_id_fk" FOREIGN KEY ("open_auto_issue_id") REFERENCES "public"."issues"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "idempotency_key" text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "heartbeat_runs_agent_finished_idx" ON "heartbeat_runs" USING btree ("agent_id","finished_at" DESC);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "issues_adapter_failure_idempotency_uq" ON "issues" ("idempotency_key") WHERE "idempotency_key" LIKE 'auto-adapter-failure:%';

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1777572332006,
       "tag": "0075_cultured_sebastian_shaw",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1777900800000,
+      "tag": "0076_agent_failure_state",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agent_failure_state.ts
+++ b/packages/db/src/schema/agent_failure_state.ts
@@ -1,0 +1,15 @@
+import { pgTable, uuid, integer, timestamp } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
+import { heartbeatRuns } from "./heartbeat_runs.js";
+import { issues } from "./issues.js";
+
+export const agentFailureState = pgTable("agent_failure_state", {
+  agentId: uuid("agent_id")
+    .primaryKey()
+    .references(() => agents.id, { onDelete: "cascade" }),
+  consecutiveAdapterFailures: integer("consecutive_adapter_failures").notNull().default(0),
+  firstFailureRunId: uuid("first_failure_run_id").references(() => heartbeatRuns.id),
+  lastFailureRunId: uuid("last_failure_run_id").references(() => heartbeatRuns.id),
+  openAutoIssueId: uuid("open_auto_issue_id").references(() => issues.id),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/db/src/schema/heartbeat_runs.ts
+++ b/packages/db/src/schema/heartbeat_runs.ts
@@ -78,5 +78,9 @@ export const heartbeatRuns = pgTable(
       table.status,
       table.processStartedAt,
     ),
+    agentFinishedIdx: index("heartbeat_runs_agent_finished_idx").on(
+      table.agentId,
+      table.finishedAt,
+    ),
   }),
 );

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -19,6 +19,7 @@ export { agentApiKeys } from "./agent_api_keys.js";
 export { agentRuntimeState } from "./agent_runtime_state.js";
 export { agentTaskSessions } from "./agent_task_sessions.js";
 export { agentWakeupRequests } from "./agent_wakeup_requests.js";
+export { agentFailureState } from "./agent_failure_state.js";
 export { projects } from "./projects.js";
 export { projectWorkspaces } from "./project_workspaces.js";
 export { executionWorkspaces } from "./execution_workspaces.js";

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -64,6 +64,7 @@ export const issues = pgTable(
     completedAt: timestamp("completed_at", { withTimezone: true }),
     cancelledAt: timestamp("cancelled_at", { withTimezone: true }),
     hiddenAt: timestamp("hidden_at", { withTimezone: true }),
+    idempotencyKey: text("idempotency_key"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
@@ -138,5 +139,8 @@ export const issues = pgTable(
           and ${table.hiddenAt} is null
           and ${table.status} not in ('done', 'cancelled')`,
       ),
+    adapterFailureIdempotencyIdx: uniqueIndex("issues_adapter_failure_idempotency_uq")
+      .on(table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} LIKE 'auto-adapter-failure:%'`),
   }),
 );


### PR DESCRIPTION
## Summary

- Adds `agent_failure_state` table (one row per agent) for tracking consecutive adapter failures
- Adds composite index on `agent_runs(agentId, endedAt desc)` and partial unique index on `issues(idempotencyKey)` for `auto-adapter-failure:*` keys
- Drizzle migration 0076 + schema definition

Implementation slice 1/4 for the adapter failure auto-issue feature (NOC-73 §3, §7.1).

## Test plan

- [ ] Migration applies cleanly forward
- [ ] Schema typed correctly in `packages/db/src/schema`
- [ ] Partial unique index verified
- [ ] No data backfill needed — empty table is correct starting state

Co-Authored-By: Paperclip <noreply@paperclip.ing>