### PR TITLE
fix(routines): redact sensitive agent fields from routine assignee projection

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -1111,4 +1111,72 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run.source).toBe("webhook");
     expect(run.status).toBe("issue_created");
   });
+
+  it("getDetail does not expose adapterConfig, runtimeConfig or other sensitive agent fields in assignee", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const projectId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: { api_key: "sk-fake-secret-do-not-expose", token: "test-token-synthetic" },
+      runtimeConfig: { secret: "runtime-secret-synthetic" },
+      permissions: { canDoEverything: true },
+    });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Redaction",
+      status: "in_progress",
+    });
+
+    const svc = routineService(db, {});
+    const routine = await svc.create(
+      companyId,
+      {
+        projectId,
+        goalId: null,
+        parentIssueId: null,
+        title: "secret test routine",
+        description: null,
+        assigneeAgentId: agentId,
+        priority: "medium",
+        status: "active",
+        concurrencyPolicy: "coalesce_if_active",
+        catchUpPolicy: "skip_missed",
+      },
+      {},
+    );
+
+    const detail = await svc.getDetail(routine.id);
+
+    expect(detail).not.toBeNull();
+    expect(detail!.assignee).not.toBeNull();
+
+    // Safe summary fields must be present
+    expect(detail!.assignee!.id).toBe(agentId);
+    expect(detail!.assignee!.name).toBe("TestAgent");
+    expect(detail!.assignee!.role).toBe("engineer");
+
+    // Sensitive fields must not be present
+    expect((detail!.assignee as Record<string, unknown>).adapterConfig).toBeUndefined();
+    expect((detail!.assignee as Record<string, unknown>).runtimeConfig).toBeUndefined();
+    expect((detail!.assignee as Record<string, unknown>).permissions).toBeUndefined();
+    expect((detail!.assignee as Record<string, unknown>).budgetMonthlyCents).toBeUndefined();
+    expect((detail!.assignee as Record<string, unknown>).spentMonthlyCents).toBeUndefined();
+  });
 });

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1109,7 +1109,11 @@ export function routineService(
           ? db.select().from(projects).where(eq(projects.id, row.projectId)).then((rows) => rows[0] ?? null)
           : null,
         row.assigneeAgentId
-          ? db.select().from(agents).where(eq(agents.id, row.assigneeAgentId)).then((rows) => rows[0] ?? null)
+          ? db
+              .select({ id: agents.id, name: agents.name, role: agents.role, title: agents.title })
+              .from(agents)
+              .where(eq(agents.id, row.assigneeAgentId))
+              .then((rows) => rows[0] ?? null)
           : null,
         row.parentIssueId ? issueSvc.getById(row.parentIssueId) : null,
         db.select().from(routineTriggers).where(eq(routineTriggers.routineId, row.id)).orderBy(asc(routineTriggers.createdAt)),


### PR DESCRIPTION
Closes TIV-391.

## What changed

- Restricts `routineService.getDetail()` assignee projection to safe summary fields: `id`, `name`, `role`, and `title`.
- Adds embedded Postgres coverage proving routine detail responses do not expose `adapterConfig`, `runtimeConfig`, `permissions`, or budget fields through `assignee`.

## Why

TIV-391 found that routine details could return full agent rows through the assignee relation, including sensitive adapter/runtime configuration. This keeps the routine detail API useful while preventing secret/config leakage.

## Verification

- `pnpm exec vitest run server/src/__tests__/routines-service.test.ts -t "getDetail does not expose adapterConfig"` passed.
- `pnpm exec vitest run server/src/__tests__/routines-service.test.ts` ran 19/23 passing, including the new test; the four existing webhook cases failed in this local environment with `EACCES: permission denied, mkdir '/app/data/secrets'` while creating local secret storage.

## Scope notes

- This PR includes only:
  - `server/src/services/routines.ts`
  - `server/src/__tests__/routines-service.test.ts`
- Other local modified files in the worktree are intentionally excluded because they belong to separate issues.
