### PR TITLE
feat(VER-470): add weekly usage hard stop diagnostics

### DIFF
--- a/server/src/__tests__/heartbeat-max-concurrent-runs.test.ts
+++ b/server/src/__tests__/heartbeat-max-concurrent-runs.test.ts
@@ -1,0 +1,268 @@
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  companySkills,
+  createDb,
+  documentRevisions,
+  documents,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueDocuments,
+  issueRelations,
+  issueTreeHolds,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { runningProcesses } from "../adapters/index.ts";
+
+// Peak concurrency tracker — incremented on entry, decremented on exit.
+// Each test resets this before firing wakes.
+let peakConcurrentExecutions = 0;
+let currentConcurrentExecutions = 0;
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => {
+    currentConcurrentExecutions += 1;
+    if (currentConcurrentExecutions > peakConcurrentExecutions) {
+      peakConcurrentExecutions = currentConcurrentExecutions;
+    }
+    // Yield to event loop so concurrent calls have a chance to overlap.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    currentConcurrentExecutions -= 1;
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: null,
+      summary: "maxConcurrentRuns gate test run.",
+      provider: "test",
+      model: "test-model",
+    };
+  }),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres maxConcurrentRuns gate tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function waitForCondition(fn: () => Promise<boolean>, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await fn()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return fn();
+}
+
+describeEmbeddedPostgres("heartbeat maxConcurrentRuns=1 gate — local adapters", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-max-concurrent-runs-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    runningProcesses.clear();
+    peakConcurrentExecutions = 0;
+    currentConcurrentExecutions = 0;
+
+    // Wait for all runs to settle before cleaning up.
+    for (let attempt = 0; attempt < 200; attempt++) {
+      const runs = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns);
+      const hasActive = runs.some((r) => r.status === "queued" || r.status === "running");
+      if (!hasActive) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await db.delete(activityLog);
+    await db.delete(companySkills);
+    await db.delete(issueComments);
+    await db.delete(issueDocuments);
+    await db.delete(documentRevisions);
+    await db.delete(documents);
+    await db.delete(issueRelations);
+    await db.delete(issueTreeHolds);
+    await db.delete(issues);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgent(input: {
+    companyId: string;
+    agentId: string;
+    maxConcurrentRuns: number;
+    adapterType?: "codex_local" | "claude_local";
+  }) {
+    const adapterType = input.adapterType ?? "codex_local";
+    await db.insert(companies).values({
+      id: input.companyId,
+      name: "Paperclip",
+      issuePrefix: `T${input.companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: input.agentId,
+      companyId: input.companyId,
+      name: adapterType === "claude_local" ? "ClaudeCoder" : "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType,
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: input.maxConcurrentRuns,
+        },
+      },
+      permissions: {},
+    });
+  }
+
+  for (const adapterType of ["codex_local", "claude_local"] as const) {
+    it(`[${adapterType}] 5 burst wakes with maxConcurrentRuns=1 → at most 1 OS subprocess at any moment`, async () => {
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      await seedAgent({ companyId, agentId, maxConcurrentRuns: 1, adapterType });
+
+      // Create 5 distinct issues so each wake has a unique task scope and doesn't
+      // coalesce into the same queued run.
+      const issueIds = Array.from({ length: 5 }, () => randomUUID());
+      await db.insert(issues).values(
+        issueIds.map((id, i) => ({
+          id,
+          companyId,
+          title: `Burst issue ${i}`,
+          status: "todo" as const,
+          priority: "medium" as const,
+          assigneeAgentId: agentId,
+        })),
+      );
+
+      // Fire 5 wakes simultaneously — do NOT await individually; let them race.
+      const wakePromises = issueIds.map((issueId) =>
+        heartbeat.wakeup(agentId, {
+          source: "assignment",
+          triggerDetail: "system",
+          reason: "issue_assigned",
+          payload: { issueId },
+          contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+        }),
+      );
+      await Promise.all(wakePromises);
+
+      // Wait for all runs to reach a terminal state.
+      const allSettled = await waitForCondition(async () => {
+        const runs = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(sql`${heartbeatRuns.agentId} = ${agentId}`);
+        return (
+          runs.length >= 5 &&
+          runs.every((r) => r.status !== "queued" && r.status !== "running")
+        );
+      });
+      expect(allSettled).toBe(true);
+
+      // The gate: at no point should more than 1 adapter execute() have been
+      // in flight simultaneously.
+      expect(peakConcurrentExecutions).toBeLessThanOrEqual(1);
+
+      // All 5 wakes must have produced at least 1 run each (coalescing allowed
+      // for same issue, but each distinct issue must get a run).
+      const totalRuns = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.agentId} = ${agentId}`)
+        .then((rows) => rows[0]?.count ?? 0);
+      expect(totalRuns).toBeGreaterThanOrEqual(5);
+    }, 30_000);
+  }
+
+  it("maxConcurrentRuns=1 enforced even when 10 wakes arrive within the same event-loop tick", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await seedAgent({ companyId, agentId, maxConcurrentRuns: 1 });
+
+    // Create 10 distinct issues so no coalescing occurs.
+    const issueIds = Array.from({ length: 10 }, () => randomUUID());
+    await db.insert(issues).values(
+      issueIds.map((id, i) => ({
+        id,
+        companyId,
+        title: `Tick issue ${i}`,
+        status: "todo" as const,
+        priority: "medium" as const,
+        assigneeAgentId: agentId,
+      })),
+    );
+
+    // Fire all 10 wakes synchronously before yielding to the event loop.
+    const wakePromises = issueIds.map((issueId) =>
+      heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+      }),
+    );
+    await Promise.all(wakePromises);
+
+    const allSettled = await waitForCondition(async () => {
+      const runs = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.agentId} = ${agentId}`);
+      return (
+        runs.length >= 10 &&
+        runs.every((r) => r.status !== "queued" && r.status !== "running")
+      );
+    });
+    expect(allSettled).toBe(true);
+    expect(peakConcurrentExecutions).toBeLessThanOrEqual(1);
+  }, 30_000);
+});

--- a/server/src/__tests__/heartbeat-run-diagnostics.test.ts
+++ b/server/src/__tests__/heartbeat-run-diagnostics.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeHeartbeatRunDiagnosticEvidence,
+  readHeartbeatRunFailureSubtype,
+} from "../services/heartbeat-run-diagnostics.js";
+
+describe("heartbeat run diagnostics", () => {
+  it("copies failed adapter stdout/stderr from resultJson into persisted excerpts", () => {
+    const diagnostic = mergeHeartbeatRunDiagnosticEvidence({
+      resultJson: {
+        stdout: "adapter stdout",
+        stderr: "adapter stderr",
+      },
+      stdoutExcerpt: "",
+      stderrExcerpt: "",
+      failureSubtype: "adapter_failed",
+    });
+
+    expect(diagnostic.stdoutExcerpt).toBe("adapter stdout\n");
+    expect(diagnostic.stderrExcerpt).toBe("adapter stderr\n");
+    expect(diagnostic.resultJson).toEqual({
+      stdout: "adapter stdout",
+      stderr: "adapter stderr",
+      failureSubtype: "adapter_failed",
+    });
+  });
+
+  it("does not duplicate stderr already captured by live logging", () => {
+    const diagnostic = mergeHeartbeatRunDiagnosticEvidence({
+      resultJson: {
+        stderr: "same stderr",
+      },
+      stdoutExcerpt: null,
+      stderrExcerpt: "same stderr\n",
+      failureSubtype: null,
+    });
+
+    expect(diagnostic.stderrExcerpt).toBe("same stderr\n");
+  });
+
+  it("infers codex failure subtype from jsonl stdout", () => {
+    expect(
+      readHeartbeatRunFailureSubtype({
+        stdout: JSON.stringify({ type: "turn.failed", error: { message: "boom" } }),
+      }),
+    ).toBe("turn.failed");
+  });
+});

--- a/server/src/__tests__/weekly-usage.test.ts
+++ b/server/src/__tests__/weekly-usage.test.ts
@@ -1,0 +1,259 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { weeklyUsageService } from "../services/weekly-usage.ts";
+
+type SelectRows = unknown[];
+
+function createDbStub(selectRows: SelectRows[]) {
+  const pendingSelects = [...selectRows];
+  const selectOrderBy = vi.fn(async () => pendingSelects.shift() ?? []);
+  const selectWhere = vi.fn(() => ({
+    orderBy: selectOrderBy,
+    then: (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(pendingSelects.shift() ?? [])),
+  }));
+  const selectInnerJoin = vi.fn(() => ({
+    where: selectWhere,
+  }));
+  const selectFrom = vi.fn(() => ({
+    innerJoin: selectInnerJoin,
+    where: selectWhere,
+    then: (resolve: (rows: unknown[]) => unknown) => Promise.resolve(resolve(pendingSelects.shift() ?? [])),
+  }));
+  const select = vi.fn(() => ({
+    from: selectFrom,
+  }));
+
+  return {
+    db: { select },
+    selectOrderBy,
+  };
+}
+
+async function tmpUsagePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-weekly-usage-"));
+  return {
+    dir,
+    file: path.join(dir, "usage.json"),
+  };
+}
+
+describe("weeklyUsageService", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes a rolling 7-day per-adapter usage snapshot without double-counting repeated updates", async () => {
+    const now = new Date("2026-05-03T12:00:00.000Z");
+    const { dir, file } = await tmpUsagePath();
+    const rows = [
+      {
+        id: "run-1",
+        adapterType: "claude_local",
+        finishedAt: new Date("2026-05-03T11:00:00.000Z"),
+        createdAt: new Date("2026-05-03T10:59:00.000Z"),
+        usageJson: { inputTokens: 100, cachedInputTokens: 25, outputTokens: 50 },
+      },
+      {
+        id: "run-2",
+        adapterType: "codex_local",
+        finishedAt: new Date("2026-05-02T11:00:00.000Z"),
+        createdAt: new Date("2026-05-02T10:59:00.000Z"),
+        usageJson: { input_tokens: 200, cache_read_input_tokens: 10, output_tokens: 40 },
+      },
+      {
+        id: "future-run",
+        adapterType: "codex_local",
+        finishedAt: new Date("2026-05-03T13:00:00.000Z"),
+        createdAt: new Date("2026-05-03T12:59:00.000Z"),
+        usageJson: { inputTokens: 999, outputTokens: 999 },
+      },
+    ];
+    const dbStub = createDbStub([rows, rows]);
+    const fetchMock = vi.fn();
+    const service = weeklyUsageService(dbStub.db as any, {
+      usageFilePath: file,
+      env: {
+        PAPERCLIP_WEEKLY_USAGE_CAP_CLAUDE_LOCAL_TOKENS: "1000",
+        PAPERCLIP_WEEKLY_USAGE_CAP_CODEX_LOCAL_TOKENS: "1000",
+      },
+      now: () => now,
+      fetch: fetchMock as any,
+    });
+
+    await service.updateFromHeartbeatRuns();
+    const second = await service.updateFromHeartbeatRuns();
+
+    expect(second.generatedAt).toBe(now.toISOString());
+    expect(second.lastUpdatedAt).toBe(now.toISOString());
+    expect(second.window).toEqual({
+      kind: "rolling_7d",
+      start: "2026-04-26T12:00:00.000Z",
+      end: "2026-05-03T12:00:00.000Z",
+    });
+    expect(second.adapters.claude_local.totalTokens).toBe(175);
+    expect(second.adapters.claude_local.runIds).toEqual(["run-1"]);
+    expect(second.adapters.claude_local.cursor).toEqual({
+      includedRunIds: ["run-1"],
+      latestRunFinishedAt: "2026-05-03T11:00:00.000Z",
+    });
+    expect(second.adapters.codex_local.totalTokens).toBe(250);
+    expect(second.adapters.codex_local.runIds).toEqual(["run-2"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const persisted = JSON.parse(await fs.readFile(file, "utf8"));
+    expect(persisted.adapters.claude_local.totalTokens).toBe(175);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("fires each threshold once while usage remains above it", async () => {
+    const now = new Date("2026-05-03T12:00:00.000Z");
+    const { dir, file } = await tmpUsagePath();
+    const rows = [
+      {
+        id: "run-1",
+        adapterType: "codex_local",
+        finishedAt: new Date("2026-05-03T11:00:00.000Z"),
+        createdAt: new Date("2026-05-03T10:59:00.000Z"),
+        usageJson: { inputTokens: 95, outputTokens: 0 },
+      },
+    ];
+    const dbStub = createDbStub([rows, rows]);
+    const fetchMock = vi.fn(async () => ({ ok: true }));
+    const service = weeklyUsageService(dbStub.db as any, {
+      usageFilePath: file,
+      env: {
+        PAPERCLIP_WEEKLY_USAGE_CAP_CODEX_LOCAL_TOKENS: "100",
+        PAPERCLIP_P0_TELEGRAM_BOT_TOKEN: "token",
+        PAPERCLIP_P0_TELEGRAM_CHAT_ID: "chat",
+      },
+      now: () => now,
+      fetch: fetchMock as any,
+    });
+
+    await service.updateFromHeartbeatRuns();
+    const second = await service.updateFromHeartbeatRuns();
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(second.adapters.codex_local.thresholds.p1_70.fired).toBe(true);
+    expect(second.adapters.codex_local.thresholds.p0_85.fired).toBe(true);
+    expect(second.adapters.codex_local.thresholds.p0_hard_stop_95.fired).toBe(true);
+    expect(second.adapters.codex_local.hardStopped).toBe(true);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("does not mark threshold alerts fired when Telegram delivery is not configured", async () => {
+    const now = new Date("2026-05-03T12:00:00.000Z");
+    const { dir, file } = await tmpUsagePath();
+    const rows = [
+      {
+        id: "run-1",
+        adapterType: "codex_local",
+        finishedAt: new Date("2026-05-03T11:00:00.000Z"),
+        createdAt: new Date("2026-05-03T10:59:00.000Z"),
+        usageJson: { inputTokens: 95, outputTokens: 0 },
+      },
+    ];
+    const dbStub = createDbStub([rows]);
+    const fetchMock = vi.fn();
+    const service = weeklyUsageService(dbStub.db as any, {
+      usageFilePath: file,
+      env: {
+        PAPERCLIP_WEEKLY_USAGE_CAP_CODEX_LOCAL_TOKENS: "100",
+      },
+      now: () => now,
+      fetch: fetchMock as any,
+    });
+
+    const snapshot = await service.updateFromHeartbeatRuns();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(snapshot.adapters.codex_local.thresholds.p1_70.fired).toBe(false);
+    expect(snapshot.adapters.codex_local.thresholds.p0_85.fired).toBe(false);
+    expect(snapshot.adapters.codex_local.thresholds.p0_hard_stop_95.fired).toBe(false);
+    expect(snapshot.adapters.codex_local.hardStopped).toBe(true);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("blocks non-critical hard-stopped adapter agents but exempts CEO and CTO roles", async () => {
+    const { dir, file } = await tmpUsagePath();
+    await fs.writeFile(file, JSON.stringify({
+      version: 1,
+      generatedAt: "2026-05-03T12:00:00.000Z",
+      lastUpdatedAt: "2026-05-03T12:00:00.000Z",
+      window: {
+        kind: "rolling_7d",
+        start: "2026-04-26T12:00:00.000Z",
+        end: "2026-05-03T12:00:00.000Z",
+      },
+      adapters: {
+        claude_local: {
+          adapterType: "claude_local",
+          inputTokens: 0,
+          cachedInputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+          runCount: 0,
+          runIds: [],
+          cursor: { includedRunIds: [], latestRunFinishedAt: null },
+          lastRunFinishedAt: null,
+          cap: { weeklyTotalTokens: 100, source: "test", note: "test" },
+          thresholds: {
+            p1_70: { fired: false, firedAt: null, lastPercent: 0 },
+            p0_85: { fired: false, firedAt: null, lastPercent: 0 },
+            p0_hard_stop_95: { fired: false, firedAt: null, lastPercent: 0 },
+          },
+          hardStopped: false,
+        },
+        codex_local: {
+          adapterType: "codex_local",
+          inputTokens: 95,
+          cachedInputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 95,
+          runCount: 1,
+          runIds: ["run-1"],
+          cursor: { includedRunIds: ["run-1"], latestRunFinishedAt: "2026-05-03T11:00:00.000Z" },
+          lastRunFinishedAt: "2026-05-03T11:00:00.000Z",
+          cap: { weeklyTotalTokens: 100, source: "test", note: "test" },
+          thresholds: {
+            p1_70: { fired: true, firedAt: "2026-05-03T12:00:00.000Z", lastPercent: 95 },
+            p0_85: { fired: true, firedAt: "2026-05-03T12:00:00.000Z", lastPercent: 95 },
+            p0_hard_stop_95: { fired: true, firedAt: "2026-05-03T12:00:00.000Z", lastPercent: 95 },
+          },
+          hardStopped: true,
+        },
+      },
+    }, null, 2));
+
+    const dbStub = createDbStub([
+      [{
+        id: "agent-1",
+        companyId: "company-1",
+        adapterType: "codex_local",
+        role: "Scraper Developer",
+        name: "Scraper Developer",
+        title: null,
+      }],
+      [{
+        id: "agent-cto",
+        companyId: "company-1",
+        adapterType: "codex_local",
+        role: "CTO",
+        name: "CTO",
+        title: "Chief Technology Officer",
+      }],
+    ]);
+    const service = weeklyUsageService(dbStub.db as any, { usageFilePath: file });
+
+    await expect(service.getInvocationBlock("company-1", "agent-1")).resolves.toEqual({
+      scopeType: "adapter_type",
+      scopeId: "codex_local",
+      scopeName: "Adapter type codex_local",
+      reason: "Agent cannot start because codex_local rolling 7-day usage is at 95.0% of the configured weekly token cap.",
+    });
+    await expect(service.getInvocationBlock("company-1", "agent-cto")).resolves.toBeNull();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});

--- a/server/src/services/heartbeat-run-diagnostics.ts
+++ b/server/src/services/heartbeat-run-diagnostics.ts
@@ -1,0 +1,70 @@
+import { appendWithByteCap, MAX_EXCERPT_BYTES, parseObject, parseJson } from "../adapters/utils.js";
+
+type StreamName = "stdout" | "stderr";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function appendDistinctExcerpt(current: string | null | undefined, next: string | null) {
+  const existing = current ?? "";
+  if (!next) return existing;
+  const normalized = next.endsWith("\n") ? next : `${next}\n`;
+  if (existing.includes(next) || existing.includes(normalized)) return existing;
+  const separator = existing.length > 0 && !existing.endsWith("\n") ? "\n" : "";
+  return appendWithByteCap(`${existing}${separator}`, normalized, MAX_EXCERPT_BYTES);
+}
+
+function readStream(resultJson: Record<string, unknown> | null | undefined, stream: StreamName) {
+  if (!resultJson || typeof resultJson !== "object" || Array.isArray(resultJson)) return null;
+  return readNonEmptyString(resultJson[stream]);
+}
+
+function readCodexFailureEventType(stdout: string | null) {
+  if (!stdout) return null;
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const event = parseJson(line);
+    if (!event) continue;
+    const type = readNonEmptyString(event.type);
+    if (type === "turn.failed" || type === "error") return type;
+  }
+  return null;
+}
+
+export function readHeartbeatRunFailureSubtype(
+  resultJson: Record<string, unknown> | null | undefined,
+): string | null {
+  if (!resultJson || typeof resultJson !== "object" || Array.isArray(resultJson)) return null;
+
+  const direct =
+    readNonEmptyString(resultJson.failureSubtype) ??
+    readNonEmptyString(resultJson.subtype) ??
+    readNonEmptyString(resultJson.type);
+  if (direct) return direct;
+
+  const error = parseObject(resultJson.error);
+  const errorType = readNonEmptyString(error.type) ?? readNonEmptyString(error.code);
+  if (errorType) return errorType;
+
+  return readCodexFailureEventType(readStream(resultJson, "stdout"));
+}
+
+export function mergeHeartbeatRunDiagnosticEvidence(input: {
+  resultJson: Record<string, unknown> | null | undefined;
+  stdoutExcerpt: string | null | undefined;
+  stderrExcerpt: string | null | undefined;
+  failureSubtype?: string | null;
+}) {
+  const resultJson =
+    input.resultJson && typeof input.resultJson === "object" && !Array.isArray(input.resultJson)
+      ? input.resultJson
+      : null;
+  const failureSubtype = input.failureSubtype ?? readHeartbeatRunFailureSubtype(resultJson);
+  return {
+    stdoutExcerpt: appendDistinctExcerpt(input.stdoutExcerpt, readStream(resultJson, "stdout")),
+    stderrExcerpt: appendDistinctExcerpt(input.stderrExcerpt, readStream(resultJson, "stderr")),
+    resultJson: resultJson && failureSubtype ? { ...resultJson, failureSubtype } : resultJson,
+  };
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -847,7 +847,9 @@ export function compactRunLogChunk(chunk: string, maxChars = MAX_PERSISTED_LOG_C
 function normalizeMaxConcurrentRuns(value: unknown) {
   const parsed = Math.floor(asNumber(value, HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT));
   if (!Number.isFinite(parsed)) return HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT;
-  return Math.max(HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
+  // Clamp to [1, MAX] — do NOT floor at DEFAULT. Agents must be able to restrict
+  // below the default (e.g. maxConcurrentRuns: 1 for local codex/claude runners).
+  return Math.max(1, Math.min(HEARTBEAT_MAX_CONCURRENT_RUNS_MAX, parsed));
 }
 
 interface WakeupOptions {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -47,6 +47,8 @@ import { trackAgentFirstHeartbeat } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
 import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
+import { weeklyUsageService } from "./weekly-usage.js";
+import { mergeHeartbeatRunDiagnosticEvidence } from "./heartbeat-run-diagnostics.js";
 import { secretService } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
 import {
@@ -751,6 +753,21 @@ const heartbeatRunIssueSummaryColumns = {
 
 function appendExcerpt(prev: string, chunk: string) {
   return appendWithByteCap(prev, chunk, MAX_EXCERPT_BYTES);
+}
+
+function readErrorOutputField(err: unknown, field: "stdout" | "stderr") {
+  if (!err || typeof err !== "object") return null;
+  const value = (err as Record<string, unknown>)[field];
+  if (typeof value === "string" && value.length > 0) return value;
+  if (value instanceof Buffer && value.length > 0) return value.toString("utf8");
+  return null;
+}
+
+function appendErrorOutputExcerpt(prev: string, value: string | null) {
+  if (!value) return prev;
+  const normalized = value.endsWith("\n") ? value : `${value}\n`;
+  if (prev.includes(value) || prev.includes(normalized)) return prev;
+  return appendExcerpt(prev, normalized);
 }
 
 function truncateRunEventString(value: string) {
@@ -2002,8 +2019,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     cancelWorkForScope: cancelBudgetScopeWork,
   };
   const budgets = budgetService(db, budgetHooks);
+  const weeklyUsage = weeklyUsageService(db);
   const recovery = recoveryService(db, { enqueueWakeup });
   let unsafeTextProjectionPromise: Promise<boolean> | null = null;
+
+  async function getInvocationBlock(
+    companyId: string,
+    agentId: string,
+    context?: { issueId?: string | null; projectId?: string | null },
+  ) {
+    const weeklyBlock = await weeklyUsage.getInvocationBlock(companyId, agentId);
+    if (weeklyBlock) return weeklyBlock;
+    return budgets.getInvocationBlock(companyId, agentId, context);
+  }
+
+  async function updateWeeklyUsageFromHeartbeatRuns() {
+    try {
+      await weeklyUsage.updateFromHeartbeatRuns();
+    } catch (err) {
+      logger.warn({ err }, "failed to update weekly usage snapshot from heartbeat runs");
+    }
+  }
 
   async function hasUnsafeTextProjectionDatabase() {
     if (!unsafeTextProjectionPromise) {
@@ -2801,7 +2837,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const budgetBlock =
       issue && agent
-        ? await budgets.getInvocationBlock(issue.companyId, agent.id, {
+        ? await getInvocationBlock(issue.companyId, agent.id, {
           issueId: issue.id,
           projectId: issue.projectId,
         })
@@ -3744,7 +3780,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     const context = parseObject(run.contextSnapshot);
-    const budgetBlock = await budgets.getInvocationBlock(run.companyId, run.agentId, {
+    const budgetBlock = await getInvocationBlock(run.companyId, run.agentId, {
       issueId: readNonEmptyString(context.issueId),
       projectId: readNonEmptyString(context.projectId),
     });
@@ -5478,7 +5514,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             } as Record<string, unknown>)
           : null;
 
-      const persistedResultJson = mergeHeartbeatRunResultJson(
+      let persistedResultJson = mergeHeartbeatRunResultJson(
         mergeRunStopMetadataForAgent(agent, outcome, {
           resultJson: mergeAdapterRecoveryMetadata({
             resultJson: adapterResult.resultJson ?? null,
@@ -5490,6 +5526,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }),
         adapterResult.summary ?? null,
       );
+      if (outcome !== "succeeded") {
+        const diagnostic = mergeHeartbeatRunDiagnosticEvidence({
+          resultJson: persistedResultJson,
+          stdoutExcerpt,
+          stderrExcerpt,
+          failureSubtype: runErrorCode,
+        });
+        persistedResultJson = diagnostic.resultJson;
+        stdoutExcerpt = diagnostic.stdoutExcerpt;
+        stderrExcerpt = diagnostic.stderrExcerpt;
+      }
 
       let persistedRun = await setRunStatus(run.id, status, {
         finishedAt: new Date(),
@@ -5557,6 +5604,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         await updateRuntimeState(agent, finalizedRun, adapterResult, {
           legacySessionId: nextSessionState.legacySessionId,
         }, normalizedUsage);
+        await updateWeeklyUsageFromHeartbeatRuns();
         if (taskKey) {
           if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
             await clearTaskSessions(agent.companyId, agent.id, {
@@ -5584,6 +5632,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         await getCurrentUserRedactionOptions(),
       );
       logger.error({ err, runId }, "heartbeat execution failed");
+      stdoutExcerpt = appendErrorOutputExcerpt(stdoutExcerpt, readErrorOutputField(err, "stdout"));
+      stderrExcerpt = appendErrorOutputExcerpt(stderrExcerpt, readErrorOutputField(err, "stderr"));
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {
@@ -5601,14 +5651,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         logger.warn({ err: flushErr, runId }, "failed to flush run output progress after error");
       });
 
-      const failedRun = await setRunStatus(run.id, "failed", {
-        error: message,
-        errorCode: "adapter_failed",
-        finishedAt: new Date(),
+      const diagnostic = mergeHeartbeatRunDiagnosticEvidence({
         resultJson: mergeRunStopMetadataForAgent(agent, "failed", {
           errorCode: "adapter_failed",
           errorMessage: message,
         }),
+        stdoutExcerpt,
+        stderrExcerpt,
+        failureSubtype: "adapter_failed",
+      });
+      stdoutExcerpt = diagnostic.stdoutExcerpt;
+      stderrExcerpt = diagnostic.stderrExcerpt;
+
+      const failedRun = await setRunStatus(run.id, "failed", {
+        error: message,
+        errorCode: "adapter_failed",
+        finishedAt: new Date(),
+        resultJson: diagnostic.resultJson,
         stdoutExcerpt,
         stderrExcerpt,
         logBytes: logSummary?.bytes,
@@ -5640,6 +5699,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }, {
           legacySessionId: runtimeForAdapter.sessionId,
         });
+        await updateWeeklyUsageFromHeartbeatRuns();
 
         if (taskKey && (previousSessionParams || previousSessionDisplayId || taskSession)) {
           await upsertTaskSession({
@@ -6221,7 +6281,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .then((rows) => rows[0]?.projectId ?? null);
     }
 
-    const budgetBlock = await budgets.getInvocationBlock(agent.companyId, agentId, {
+    const budgetBlock = await getInvocationBlock(agent.companyId, agentId, {
       issueId,
       projectId,
     });

--- a/server/src/services/weekly-usage.ts
+++ b/server/src/services/weekly-usage.ts
@@ -1,0 +1,345 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { and, desc, eq, gte, inArray, isNotNull, lte } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, heartbeatRuns } from "@paperclipai/db";
+import { parseObject, asNumber } from "../adapters/utils.js";
+import { logger } from "../middleware/logger.js";
+
+const TRACKED_ADAPTERS = ["claude_local", "codex_local"] as const;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const USAGE_FILE_VERSION = 1;
+const DEFAULT_USAGE_FILE = path.join(os.homedir(), ".paperclip", "usage.json");
+
+const THRESHOLDS = [
+  { key: "p1_70", severity: "P1", percent: 70, hardStop: false },
+  { key: "p0_85", severity: "P0", percent: 85, hardStop: false },
+  { key: "p0_hard_stop_95", severity: "P0", percent: 95, hardStop: true },
+] as const;
+
+type TrackedAdapter = typeof TRACKED_ADAPTERS[number];
+type ThresholdKey = typeof THRESHOLDS[number]["key"];
+
+export interface WeeklyUsageServiceOptions {
+  usageFilePath?: string;
+  env?: NodeJS.ProcessEnv;
+  now?: () => Date;
+  fetch?: typeof fetch;
+}
+
+export interface WeeklyUsageThresholdState {
+  fired: boolean;
+  firedAt: string | null;
+  lastPercent: number;
+}
+
+export interface WeeklyUsageAdapterState {
+  adapterType: TrackedAdapter;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  runCount: number;
+  runIds: string[];
+  cursor: {
+    includedRunIds: string[];
+    latestRunFinishedAt: string | null;
+  };
+  lastRunFinishedAt: string | null;
+  cap: {
+    weeklyTotalTokens: number;
+    source: string;
+    note: string;
+  };
+  thresholds: Record<ThresholdKey, WeeklyUsageThresholdState>;
+  hardStopped: boolean;
+}
+
+export interface WeeklyUsageFile {
+  version: number;
+  generatedAt: string;
+  lastUpdatedAt: string;
+  window: {
+    kind: "rolling_7d";
+    start: string;
+    end: string;
+  };
+  adapters: Record<TrackedAdapter, WeeklyUsageAdapterState>;
+}
+
+type RunRow = {
+  id: string;
+  adapterType: string;
+  finishedAt: Date | null;
+  createdAt: Date;
+  usageJson: Record<string, unknown> | null;
+};
+
+function cleanEnv(value: string | undefined) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function adapterEnvKey(adapterType: TrackedAdapter) {
+  return `PAPERCLIP_WEEKLY_USAGE_CAP_${adapterType.toUpperCase()}_TOKENS`;
+}
+
+function readCap(adapterType: TrackedAdapter, env: NodeJS.ProcessEnv) {
+  const raw = env[adapterEnvKey(adapterType)];
+  const parsed = Number(raw);
+  const weeklyTotalTokens = Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 0;
+  return {
+    weeklyTotalTokens,
+    source: raw ? adapterEnvKey(adapterType) : "unset",
+    note: [
+      "As of 2026-05-03, Anthropic and OpenAI publish plan/message limits but not exact rolling weekly token caps for Claude Code or Codex local subscription usage.",
+      "Set this cap from the provider UI/plan allowance or smoke tests via PAPERCLIP_WEEKLY_USAGE_CAP_CLAUDE_LOCAL_TOKENS and PAPERCLIP_WEEKLY_USAGE_CAP_CODEX_LOCAL_TOKENS.",
+    ].join(" "),
+  };
+}
+
+function readToken(value: unknown) {
+  return Math.max(0, Math.floor(asNumber(value, 0)));
+}
+
+function extractUsage(usageJson: unknown) {
+  const usage = parseObject(usageJson);
+  const inputTokens = readToken(usage.rawInputTokens ?? usage.inputTokens ?? usage.input_tokens);
+  const cachedInputTokens = readToken(
+    usage.rawCachedInputTokens ??
+      usage.cachedInputTokens ??
+      usage.cached_input_tokens ??
+      usage.cache_read_input_tokens,
+  );
+  const outputTokens = readToken(usage.rawOutputTokens ?? usage.outputTokens ?? usage.output_tokens);
+  return {
+    inputTokens,
+    cachedInputTokens,
+    outputTokens,
+    totalTokens: inputTokens + cachedInputTokens + outputTokens,
+  };
+}
+
+async function readExistingUsage(filePath: string): Promise<WeeklyUsageFile | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    const parsed = JSON.parse(raw) as WeeklyUsageFile;
+    return parsed && parsed.version === USAGE_FILE_VERSION ? parsed : null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    logger.warn({ err, filePath }, "failed to read weekly usage file; starting from database snapshot");
+    return null;
+  }
+}
+
+async function writeUsageFileAtomically(filePath: string, data: WeeklyUsageFile) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  await fs.writeFile(tmp, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  await fs.rename(tmp, filePath);
+}
+
+function defaultThresholds(percent: number): Record<ThresholdKey, WeeklyUsageThresholdState> {
+  return {
+    p1_70: { fired: false, firedAt: null, lastPercent: percent },
+    p0_85: { fired: false, firedAt: null, lastPercent: percent },
+    p0_hard_stop_95: { fired: false, firedAt: null, lastPercent: percent },
+  };
+}
+
+function isTrackedAdapter(adapterType: string): adapterType is TrackedAdapter {
+  return (TRACKED_ADAPTERS as readonly string[]).includes(adapterType);
+}
+
+function isCriticalRecoveryAgent(agent: { role: string | null; name: string | null; title: string | null }) {
+  const haystack = [agent.role, agent.name, agent.title].filter(Boolean).join(" ").toLowerCase();
+  return /\bceo\b/.test(haystack) || /\bcto\b/.test(haystack) || haystack.includes("chief technology");
+}
+
+function formatUsageAlert(input: {
+  adapter: WeeklyUsageAdapterState;
+  threshold: typeof THRESHOLDS[number];
+  percent: number;
+}) {
+  const hardStop = input.threshold.hardStop ? " hard-stop" : "";
+  return [
+    `${input.threshold.severity}${hardStop}: ${input.adapter.adapterType} weekly usage ${input.percent.toFixed(1)}%`,
+    `Tokens: ${input.adapter.totalTokens.toLocaleString()} / ${input.adapter.cap.weeklyTotalTokens.toLocaleString()}`,
+    `Input: ${input.adapter.inputTokens.toLocaleString()} (+${input.adapter.cachedInputTokens.toLocaleString()} cached), output: ${input.adapter.outputTokens.toLocaleString()}`,
+    `Runs in rolling 7d: ${input.adapter.runCount}`,
+    input.threshold.hardStop
+      ? "Non-critical agent wakes for this adapter are blocked until usage drops below 95% or the cap is raised."
+      : "Monitor burn rate and raise the cap or pause low-priority work before the hard-stop threshold.",
+  ].join("\n");
+}
+
+async function sendTelegram(input: {
+  env: NodeJS.ProcessEnv;
+  fetchImpl: typeof fetch;
+  message: string;
+}) {
+  const telegramBotToken = cleanEnv(input.env.PAPERCLIP_P0_TELEGRAM_BOT_TOKEN);
+  const telegramChatId = cleanEnv(input.env.PAPERCLIP_P0_TELEGRAM_CHAT_ID);
+  if (!telegramBotToken || !telegramChatId) return false;
+  await input.fetchImpl(`https://api.telegram.org/bot${encodeURIComponent(telegramBotToken)}/sendMessage`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      chat_id: telegramChatId,
+      text: input.message,
+      disable_web_page_preview: true,
+    }),
+  });
+  return true;
+}
+
+export function weeklyUsageService(db: Db, options: WeeklyUsageServiceOptions = {}) {
+  const usageFilePath = options.usageFilePath ?? options.env?.PAPERCLIP_USAGE_FILE ?? DEFAULT_USAGE_FILE;
+  const env = options.env ?? process.env;
+  const now = options.now ?? (() => new Date());
+  const fetchImpl = options.fetch ?? fetch;
+
+  async function buildSnapshot(existing: WeeklyUsageFile | null): Promise<WeeklyUsageFile> {
+    const end = now();
+    const start = new Date(end.getTime() - WEEK_MS);
+    const rows = await db
+      .select({
+        id: heartbeatRuns.id,
+        adapterType: agents.adapterType,
+        finishedAt: heartbeatRuns.finishedAt,
+        createdAt: heartbeatRuns.createdAt,
+        usageJson: heartbeatRuns.usageJson,
+      })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+      .where(
+        and(
+          gte(heartbeatRuns.finishedAt, start),
+          lte(heartbeatRuns.finishedAt, end),
+          isNotNull(heartbeatRuns.usageJson),
+          inArray(agents.adapterType, [...TRACKED_ADAPTERS]),
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.finishedAt)) as RunRow[];
+
+    const adapters = Object.fromEntries(
+      TRACKED_ADAPTERS.map((adapterType) => {
+        const cap = readCap(adapterType, env);
+        const adapterRows = rows.filter((row) => {
+          if (row.adapterType !== adapterType || !row.finishedAt) return false;
+          const finishedAt = row.finishedAt.getTime();
+          return finishedAt >= start.getTime() && finishedAt <= end.getTime();
+        });
+        const totals = adapterRows.reduce(
+          (acc, row) => {
+            const usage = extractUsage(row.usageJson);
+            acc.inputTokens += usage.inputTokens;
+            acc.cachedInputTokens += usage.cachedInputTokens;
+            acc.outputTokens += usage.outputTokens;
+            acc.totalTokens += usage.totalTokens;
+            return acc;
+          },
+          { inputTokens: 0, cachedInputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        );
+        const percent = cap.weeklyTotalTokens > 0 ? (totals.totalTokens / cap.weeklyTotalTokens) * 100 : 0;
+        const previous = existing?.adapters?.[adapterType];
+        const thresholds = defaultThresholds(percent);
+        for (const threshold of THRESHOLDS) {
+          const previousState = previous?.thresholds?.[threshold.key];
+          thresholds[threshold.key] = percent >= threshold.percent && previousState?.fired
+            ? { ...previousState, lastPercent: percent }
+            : { fired: false, firedAt: null, lastPercent: percent };
+        }
+        return [adapterType, {
+          adapterType,
+          ...totals,
+          runCount: adapterRows.length,
+          runIds: adapterRows.map((row) => row.id),
+          cursor: {
+            includedRunIds: adapterRows.map((row) => row.id),
+            latestRunFinishedAt: adapterRows[0]?.finishedAt?.toISOString() ?? null,
+          },
+          lastRunFinishedAt: adapterRows[0]?.finishedAt?.toISOString() ?? null,
+          cap,
+          thresholds,
+          hardStopped: cap.weeklyTotalTokens > 0 && percent >= 95,
+        }];
+      }),
+    ) as Record<TrackedAdapter, WeeklyUsageAdapterState>;
+
+    return {
+      version: USAGE_FILE_VERSION,
+      generatedAt: end.toISOString(),
+      lastUpdatedAt: end.toISOString(),
+      window: {
+        kind: "rolling_7d",
+        start: start.toISOString(),
+        end: end.toISOString(),
+      },
+      adapters,
+    };
+  }
+
+  async function updateFromHeartbeatRuns() {
+    const existing = await readExistingUsage(usageFilePath);
+    const snapshot = await buildSnapshot(existing);
+    for (const adapter of Object.values(snapshot.adapters)) {
+      if (adapter.cap.weeklyTotalTokens <= 0) continue;
+      const percent = (adapter.totalTokens / adapter.cap.weeklyTotalTokens) * 100;
+      for (const threshold of THRESHOLDS) {
+        if (percent < threshold.percent || adapter.thresholds[threshold.key].fired) continue;
+        try {
+          const delivered = await sendTelegram({
+            env,
+            fetchImpl,
+            message: formatUsageAlert({ adapter, threshold, percent }),
+          });
+          if (!delivered) continue;
+          adapter.thresholds[threshold.key] = {
+            fired: true,
+            firedAt: snapshot.generatedAt,
+            lastPercent: percent,
+          };
+        } catch (err) {
+          logger.warn({ err, adapterType: adapter.adapterType, threshold: threshold.key }, "weekly usage alert failed");
+        }
+      }
+    }
+    await writeUsageFileAtomically(usageFilePath, snapshot);
+    return snapshot;
+  }
+
+  async function getInvocationBlock(companyId: string, agentId: string) {
+    const agent = await db
+      .select({
+        id: agents.id,
+        companyId: agents.companyId,
+        adapterType: agents.adapterType,
+        role: agents.role,
+        name: agents.name,
+        title: agents.title,
+      })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    if (!agent || agent.companyId !== companyId) return null;
+    if (!isTrackedAdapter(agent.adapterType) || isCriticalRecoveryAgent(agent)) return null;
+
+    const usage = await readExistingUsage(usageFilePath);
+    const adapter = usage?.adapters?.[agent.adapterType];
+    if (!adapter?.hardStopped) return null;
+    return {
+      scopeType: "adapter_type" as const,
+      scopeId: agent.adapterType,
+      scopeName: `Adapter type ${agent.adapterType}`,
+      reason: `Agent cannot start because ${agent.adapterType} rolling 7-day usage is at ${adapter.thresholds.p0_hard_stop_95.lastPercent.toFixed(1)}% of the configured weekly token cap.`,
+    };
+  }
+
+  return {
+    updateFromHeartbeatRuns,
+    getInvocationBlock,
+  };
+}


### PR DESCRIPTION
## Summary
- Add weekly usage hard-stop service and heartbeat integration
- Add heartbeat run diagnostic evidence enrichment
- Add focused tests for weekly usage and heartbeat run diagnostics

## Verification
- pnpm --filter @paperclip/server test -- weekly-usage heartbeat-run-diagnostics

Issue: VER-470