### PR TITLE
fix: block agent adapter model self-mutations

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -504,6 +504,55 @@ describe.sequential("agent permission routes", () => {
     expect(mockLogActivity).not.toHaveBeenCalled();
   });
 
+  it("blocks agent-authenticated self-updates that set adapter model", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .patch(`/api/agents/${agentId}`)
+      .send({
+        adapterConfig: {
+          model: "gpt-5-codex",
+        },
+      }));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("model changes require board/user confirmation");
+    expect(res.body.error).toContain("adapterConfig.model");
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("allows agent-authenticated self-updates that do not touch adapter model", async () => {
+    const metadata = { heartbeatNote: "safe-update" };
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .patch(`/api/agents/${agentId}`)
+      .send({ metadata }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({ metadata }),
+      expect.anything(),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: "agent.updated",
+    }));
+  });
+
   it("blocks agent-authenticated self-updates that set cheap-profile host-executed workspace commands", async () => {
     mockAgentService.getById.mockResolvedValue({
       ...baseAgent,
@@ -541,6 +590,76 @@ describe.sequential("agent permission routes", () => {
       "runtimeConfig.modelProfiles.cheap.adapterConfig.workspaceStrategy.provisionCommand",
     );
     expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("blocks agent-authenticated self-updates that set cheap-profile adapter model", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterType: "codex_local",
+    });
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .patch(`/api/agents/${agentId}`)
+      .send({
+        runtimeConfig: {
+          modelProfiles: {
+            cheap: {
+              adapterConfig: {
+                model: "gpt-5-codex",
+              },
+            },
+          },
+        },
+      }));
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("model changes require board/user confirmation");
+    expect(res.body.error).toContain("runtimeConfig.modelProfiles.cheap.adapterConfig.model");
+    expect(mockAgentService.update).not.toHaveBeenCalled();
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("allows board updates that set adapter model", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterType: "codex_local",
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const adapterConfig = {
+      model: "gpt-5.3-codex-spark",
+    };
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .patch(`/api/agents/${agentId}`)
+      .send({ adapterConfig }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining(adapterConfig),
+      }),
+      expect.anything(),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      action: "agent.updated",
+    }));
   });
 
   it("allows board updates that set cheap-profile workspace commands", async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -990,6 +990,18 @@ export function agentRoutes(
     );
   }
 
+  function assertNoAgentAdapterModelMutation(
+    req: Request,
+    adapterConfig: Record<string, unknown> | null | undefined,
+    path = "adapterConfig",
+  ) {
+    if (req.actor.type !== "agent" || !adapterConfig) return;
+    if (adapterConfig.model === undefined) return;
+    throw forbidden(
+      `Agent-authenticated callers cannot modify adapterConfig.model — model changes require board/user confirmation (${path}.model)`,
+    );
+  }
+
   function adapterConfigTouchesInstructionsConfig(adapterConfig: Record<string, unknown>) {
     return KNOWN_INSTRUCTIONS_BUNDLE_KEYS.some((key) => adapterConfig[key] !== undefined);
   }
@@ -1000,6 +1012,7 @@ export function agentRoutes(
     path = "adapterConfig",
   ) {
     assertNoAgentInstructionsConfigMutation(req, adapterConfig, path);
+    assertNoAgentAdapterModelMutation(req, adapterConfig, path);
     assertNoAgentHostWorkspaceCommandMutation(
       req,
       collectAgentAdapterWorkspaceCommandPaths(adapterConfig, path),


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Agent adapter configuration determines which local/provider model an agent runtime uses.
> - DEV-31 showed an agent-authenticated recovery PATCH was able to change an adapter model to an unsupported value.
> - Existing agent-authenticated guards already block sensitive instructions and host command configuration mutations, but left `adapterConfig.model` open.
> - This pull request adds the same kind of strict guard for adapter model selection, including runtime model profile adapter configs.
> - The benefit is a narrower self-mutation surface: agents cannot silently change their own execution model, while board/user authenticated paths remain the explicit escape hatch.

## What Changed

- Added `assertNoAgentAdapterModelMutation` in `server/src/routes/agents.ts` and wired it through `assertNoAgentAdapterConfigMutation`.
- Blocked agent-authenticated requests that include `adapterConfig.model` at the root adapter config path or under `runtimeConfig.modelProfiles.*.adapterConfig.model`.
- Kept board-authenticated and user-authenticated model changes allowed through the existing route behavior.
- Added focused route tests in `server/src/__tests__/agent-permissions-routes.test.ts` for top-level agent rejection, runtime profile agent rejection, board top-level success, metadata-only agent success, and dotted-path error context.
- Parent issues: DEV-49 implemented the guard; DEV-50 owns this PR publish/review/merge handoff.
- Source commit: `7085ad05ade2e7c4691690dea16cd54258a94e52` on `codex/dev-49-agent-adapter-model-guard`, authored/committed as `Codex <codex@keegoid.com>`.

## Verification

- `pnpm vitest run server/src/__tests__/agent-permissions-routes.test.ts`
- Result: 1 test file passed, 47 tests passed.
- PR checks observed by owner: Greptile Review passed; Snyk passed.
- Independent review: DEV-51 / `keegoid-cc` ran `agent-pr-flow review --pr https://github.com/paperclipai/paperclip/pull/5150 --author codex` and returned `VERDICT: approve` as a GitHub comment.

## Risks

- The guard is presence-based: an agent PATCH that echoes the current `adapterConfig.model` value will still 403. This is intentional for the stated threat model because agent-supplied model fields should go through board/user confirmation, even if they appear unchanged.
- `adapterConfig.model: null` is also blocked for agents. This treats clearing the model as a model mutation, which is consistent with the guard intent.
- Greptile noted there is no separate positive test for a board-authenticated runtime profile model update. The implementation gates on `req.actor.type !== "agent"` before model inspection and already has board top-level success plus agent nested rejection coverage; this is a low residual coverage risk for the merge decision.
- `keegoid-cc` has only READ permission on `paperclipai/paperclip`, so the independent approve verdict is comment-only rather than a formal GitHub Approval. DEV CEO still makes the final merge decision.

## Model Used

- OpenAI Codex local agent using GPT-5.5, with shell, git, GitHub wrapper, and Paperclip API tool use. Exact context-window metadata was not surfaced by the adapter run.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no UI change)
- [x] I have updated relevant documentation to reflect my changes (N/A: no docs change needed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge (template issue fixed; remaining non-blocking review notes are documented in Risks for DEV CEO decision)
