### PR TITLE
fix(server): agent_default continuation recovery should not false-block (ARB-42)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -393,6 +393,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     includeIssue?: boolean;
     runErrorCode?: string | null;
     runError?: string | null;
+    assigneeAdapterOverrides?: Record<string, unknown> | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -464,6 +465,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         executionRunId: runId,
         issueNumber: 1,
         identifier: `${issuePrefix}-1`,
+        ...(input?.assigneeAdapterOverrides !== undefined && input.assigneeAdapterOverrides !== null
+          ? { assigneeAdapterOverrides: input.assigneeAdapterOverrides }
+          : {}),
       });
     }
 
@@ -1070,6 +1074,57 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("retried continuation");
     expect(comments[0]?.body).toContain(`Recovery issue: [${recovery.identifier}]`);
+  });
+
+  it("does not block in_progress continuation recovery when assignee opts out of project workspace (agent_default / task_session)", async () => {
+    mockAdapterExecute.mockRejectedValueOnce(new Error("continuation recovery failed"));
+
+    const { agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+      assigneeAdapterOverrides: { useProjectWorkspace: false },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    expect(runs.find((row) => row.id === runId)?.status).toBe("failed");
+    const continuationRun = runs.find((row) => row.id !== runId);
+    expect(continuationRun?.contextSnapshot as Record<string, unknown> | undefined).toMatchObject({
+      retryReason: "issue_continuation_needed",
+      retryOfRunId: runId,
+    });
+
+    const issue = await waitForValue(async () =>
+      db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
+        const row = rows[0] ?? null;
+        return row?.status === "in_progress" && row.executionRunId === null ? row : null;
+      })
+    );
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.executionRunId).toBeNull();
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, issue.companyId),
+          eq(issues.originKind, "stranded_issue_recovery"),
+        ),
+      );
+    expect(recoveryIssues).toHaveLength(0);
   });
 
   it("blocks failed recovery work in place during immediate terminal-run cleanup", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7708,11 +7708,50 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return { kind: "released" as const };
       }
 
+      const expectedRetryReason =
+        issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed";
+      const recoveryFailed = didAutomaticRecoveryFail(run, expectedRetryReason);
+
+      const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
+      let projectExecutionWorkspacePolicyForRecovery: ReturnType<
+        typeof parseProjectExecutionWorkspacePolicy
+      > | null = null;
+      if (issue.projectId) {
+        const projectRow = await tx
+          .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })
+          .from(projects)
+          .where(and(eq(projects.id, issue.projectId), eq(projects.companyId, issue.companyId)))
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        projectExecutionWorkspacePolicyForRecovery = gateProjectExecutionWorkspacePolicy(
+          parseProjectExecutionWorkspacePolicy(projectRow?.executionWorkspacePolicy),
+          isolatedWorkspacesEnabled,
+        );
+      }
+      const issueExecutionWorkspaceSettingsForRecovery = isolatedWorkspacesEnabled
+        ? parseIssueExecutionWorkspaceSettings(issue.executionWorkspaceSettings)
+        : null;
+      const issueAssigneeOverridesForRecovery =
+        issue.assigneeAgentId === run.agentId
+          ? parseIssueAssigneeAdapterOverrides(issue.assigneeAdapterOverrides)
+          : null;
+      const coordinationOnlyNoLiveAgentExecution =
+        issue.status === "in_progress" &&
+        resolveExecutionWorkspaceMode({
+          projectPolicy: projectExecutionWorkspacePolicyForRecovery,
+          issueSettings: issueExecutionWorkspaceSettingsForRecovery,
+          legacyUseProjectWorkspace: issueAssigneeOverridesForRecovery?.useProjectWorkspace ?? null,
+        }) === "agent_default";
+
+      if (recoveryFailed && coordinationOnlyNoLiveAgentExecution) {
+        return { kind: "released" as const };
+      }
+
       const shouldBlockImmediately =
         issue.originKind === RECOVERY_ORIGIN_KINDS.strandedIssueRecovery ||
         !recoveryAgentInvokable ||
         !recoveryAgent ||
-        didAutomaticRecoveryFail(run, issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed");
+        recoveryFailed;
       if (shouldBlockImmediately) {
         const comment = buildImmediateExecutionPathRecoveryComment({
           status: issue.status as "todo" | "in_progress",


### PR DESCRIPTION
## Summary
Fixes **ARB-42**: when an `in_progress` issue uses **`agent_default`** execution workspace (e.g. task_session / assignee opts out of project workspace) and continuation recovery fails after a terminal run, the control plane should **release** the execution slot instead of immediately **`blocked`** + escalation comment.

## Changes
- **`server/src/services/heartbeat.ts`**: In `releaseIssueExecutionAndPromote`, after computing `recoveryFailed`, mirror execution-workspace resolution (project policy, issue settings, assignee `useProjectWorkspace` override, isolated-workspaces gate). If recovery failed but mode is `agent_default` for an `in_progress` issue, return `{ kind: \"released\" }` instead of blocking.
- **`server/src/__tests__/heartbeat-process-recovery.test.ts`**: Extend `seedRunFixture` with optional `assigneeAdapterOverrides`; add regression test for the above path.

## Verification
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t \"does not block in_progress continuation recovery when assignee opts out\"` — **PASS** (Founding Engineer + CEO env).

Refs: **[[ARB-42]]**, parent **[[ARB-40]]**.

Made with [Cursor](https://cursor.com)