### PR TITLE
fix(server): skip auto-block on failed continuation for agent_default workspaces

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -403,6 +403,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     includeIssue?: boolean;
     runErrorCode?: string | null;
     runError?: string | null;
+    assigneeAdapterOverrides?: Record<string, unknown> | null;
   }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -474,6 +475,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         executionRunId: runId,
         issueNumber: 1,
         identifier: `${issuePrefix}-1`,
+        ...(input?.assigneeAdapterOverrides !== undefined && input.assigneeAdapterOverrides !== null
+          ? { assigneeAdapterOverrides: input.assigneeAdapterOverrides }
+          : {}),
       });
     }
 
@@ -1084,6 +1088,57 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("retried continuation");
     expect(comments[0]?.body).toContain(`Recovery issue: [${recovery.identifier}]`);
+  });
+
+  it("does not block in_progress continuation recovery when assignee opts out of project workspace (agent_default / task_session)", async () => {
+    mockAdapterExecute.mockRejectedValueOnce(new Error("continuation recovery failed"));
+
+    const { agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+      assigneeAdapterOverrides: { useProjectWorkspace: false },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    expect(runs.find((row) => row.id === runId)?.status).toBe("failed");
+    const continuationRun = runs.find((row) => row.id !== runId);
+    expect(continuationRun?.contextSnapshot as Record<string, unknown> | undefined).toMatchObject({
+      retryReason: "issue_continuation_needed",
+      retryOfRunId: runId,
+    });
+
+    const issue = await waitForValue(async () =>
+      db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
+        const row = rows[0] ?? null;
+        return row?.status === "in_progress" && row.executionRunId === null ? row : null;
+      })
+    );
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.executionRunId).toBeNull();
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, issue.companyId),
+          eq(issues.originKind, "stranded_issue_recovery"),
+        ),
+      );
+    expect(recoveryIssues).toHaveLength(0);
   });
 
   it("blocks failed recovery work in place during immediate terminal-run cleanup", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8109,11 +8109,50 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return { kind: "released" as const };
       }
 
+      const expectedRetryReason =
+        issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed";
+      const recoveryFailed = didAutomaticRecoveryFail(run, expectedRetryReason);
+
+      const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
+      let projectExecutionWorkspacePolicyForRecovery: ReturnType<
+        typeof parseProjectExecutionWorkspacePolicy
+      > | null = null;
+      if (issue.projectId) {
+        const projectRow = await tx
+          .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })
+          .from(projects)
+          .where(and(eq(projects.id, issue.projectId), eq(projects.companyId, issue.companyId)))
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        projectExecutionWorkspacePolicyForRecovery = gateProjectExecutionWorkspacePolicy(
+          parseProjectExecutionWorkspacePolicy(projectRow?.executionWorkspacePolicy),
+          isolatedWorkspacesEnabled,
+        );
+      }
+      const issueExecutionWorkspaceSettingsForRecovery = isolatedWorkspacesEnabled
+        ? parseIssueExecutionWorkspaceSettings(issue.executionWorkspaceSettings)
+        : null;
+      const issueAssigneeOverridesForRecovery =
+        issue.assigneeAgentId === run.agentId
+          ? parseIssueAssigneeAdapterOverrides(issue.assigneeAdapterOverrides)
+          : null;
+      const coordinationOnlyNoLiveAgentExecution =
+        issue.status === "in_progress" &&
+        resolveExecutionWorkspaceMode({
+          projectPolicy: projectExecutionWorkspacePolicyForRecovery,
+          issueSettings: issueExecutionWorkspaceSettingsForRecovery,
+          legacyUseProjectWorkspace: issueAssigneeOverridesForRecovery?.useProjectWorkspace ?? null,
+        }) === "agent_default";
+
+      if (recoveryFailed && coordinationOnlyNoLiveAgentExecution) {
+        return { kind: "released" as const };
+      }
+
       const shouldBlockImmediately =
         issue.originKind === RECOVERY_ORIGIN_KINDS.strandedIssueRecovery ||
         !recoveryAgentInvokable ||
         !recoveryAgent ||
-        didAutomaticRecoveryFail(run, issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed");
+        recoveryFailed;
       if (shouldBlockImmediately) {
         const comment = buildImmediateExecutionPathRecoveryComment({
           status: issue.status as "todo" | "in_progress",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8113,39 +8113,41 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed";
       const recoveryFailed = didAutomaticRecoveryFail(run, expectedRetryReason);
 
-      const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
-      let projectExecutionWorkspacePolicyForRecovery: ReturnType<
-        typeof parseProjectExecutionWorkspacePolicy
-      > | null = null;
-      if (issue.projectId) {
-        const projectRow = await tx
-          .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })
-          .from(projects)
-          .where(and(eq(projects.id, issue.projectId), eq(projects.companyId, issue.companyId)))
-          .limit(1)
-          .then((rows) => rows[0] ?? null);
-        projectExecutionWorkspacePolicyForRecovery = gateProjectExecutionWorkspacePolicy(
-          parseProjectExecutionWorkspacePolicy(projectRow?.executionWorkspacePolicy),
-          isolatedWorkspacesEnabled,
-        );
-      }
-      const issueExecutionWorkspaceSettingsForRecovery = isolatedWorkspacesEnabled
-        ? parseIssueExecutionWorkspaceSettings(issue.executionWorkspaceSettings)
-        : null;
-      const issueAssigneeOverridesForRecovery =
-        issue.assigneeAgentId === run.agentId
-          ? parseIssueAssigneeAdapterOverrides(issue.assigneeAdapterOverrides)
+      if (recoveryFailed) {
+        const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
+        let projectExecutionWorkspacePolicyForRecovery: ReturnType<
+          typeof parseProjectExecutionWorkspacePolicy
+        > | null = null;
+        if (issue.projectId) {
+          const projectRow = await tx
+            .select({ executionWorkspacePolicy: projects.executionWorkspacePolicy })
+            .from(projects)
+            .where(and(eq(projects.id, issue.projectId), eq(projects.companyId, issue.companyId)))
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
+          projectExecutionWorkspacePolicyForRecovery = gateProjectExecutionWorkspacePolicy(
+            parseProjectExecutionWorkspacePolicy(projectRow?.executionWorkspacePolicy),
+            isolatedWorkspacesEnabled,
+          );
+        }
+        const issueExecutionWorkspaceSettingsForRecovery = isolatedWorkspacesEnabled
+          ? parseIssueExecutionWorkspaceSettings(issue.executionWorkspaceSettings)
           : null;
-      const coordinationOnlyNoLiveAgentExecution =
-        issue.status === "in_progress" &&
-        resolveExecutionWorkspaceMode({
-          projectPolicy: projectExecutionWorkspacePolicyForRecovery,
-          issueSettings: issueExecutionWorkspaceSettingsForRecovery,
-          legacyUseProjectWorkspace: issueAssigneeOverridesForRecovery?.useProjectWorkspace ?? null,
-        }) === "agent_default";
+        const issueAssigneeOverridesForRecovery =
+          issue.assigneeAgentId === run.agentId
+            ? parseIssueAssigneeAdapterOverrides(issue.assigneeAdapterOverrides)
+            : null;
+        const coordinationOnlyNoLiveAgentExecution =
+          issue.status === "in_progress" &&
+          resolveExecutionWorkspaceMode({
+            projectPolicy: projectExecutionWorkspacePolicyForRecovery,
+            issueSettings: issueExecutionWorkspaceSettingsForRecovery,
+            legacyUseProjectWorkspace: issueAssigneeOverridesForRecovery?.useProjectWorkspace ?? null,
+          }) === "agent_default";
 
-      if (recoveryFailed && coordinationOnlyNoLiveAgentExecution) {
-        return { kind: "released" as const };
+        if (coordinationOnlyNoLiveAgentExecution) {
+          return { kind: "released" as const };
+        }
       }
 
       const shouldBlockImmediately =


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and heartbeats; issues can be `in_progress` without a live adapter PID when coordination uses CP-off / `task_session` semantics (`useProjectWorkspace: false` → resolved workspace mode `agent_default`).
> - Orphaned heartbeat recovery retries continuation when a run dies; if automatic continuation recovery fails, the server previously escalated to `blocked` with a "no live execution path" system comment.
> - For coordination-only issues that intentionally have no live execution, that escalation is a false positive: the issue is not blocked on a human dependency, it is simply not runner-backed.
> - The fix gates the "block immediately" path: when recovery has failed **and** the issue is `in_progress` **and** resolved workspace mode is `agent_default`, release execution instead of blocking.
> - This pull request adds that early `released` return and an integration test that seeds `assigneeAdapterOverrides: { useProjectWorkspace: false }`.
> - The benefit is: continuation recovery no longer flips coordination epics to `blocked` without an explicit blocker, matching intended CP-off behavior (company ARB-40 / ARB-42).

## What Changed

- `server/src/services/heartbeat.ts`: in `releaseIssueExecutionAndPromote`, when automatic continuation recovery has failed and the issue is `in_progress` with resolved execution workspace mode `agent_default`, return `{ kind: "released" }` instead of falling through to immediate `blocked` + sys comment.
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: extend `seedRunFixture` with optional `assigneeAdapterOverrides`; add integration test `does not block in_progress continuation recovery when assignee opts out of project workspace (agent_default / task_session)`.

## Verification

- `pnpm install` (repo root)
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "does not block in_progress continuation recovery when assignee opts out"`
- Upstream CI on this PR: `verify`, serialized server suites 1–4/4, `e2e`, Canary Dry Run, policy, Snyk — all pass on latest rebase (`0eb0334`).

## Risks

- **Behavioral:** Only affects the "continuation recovery failed" branch for `in_progress` + `agent_default`; default / shared workspace paths unchanged.
- **Performance (P2 / Greptile):** workspace policy resolution queries run on the recovery path before the new early return; acceptable for this narrow fix; could be tightened behind `recoveryFailed` in a follow-up if profiling warrants.
- **`todo` exclusion (P2 / Greptile):** new early return requires `issue.status === "in_progress"`; `todo` + `agent_default` still follows existing block behavior — intentional for this PR (continuation vs assignment recovery).

## Model Used

Cursor agent–assisted implementation (Claude family via Cursor); exact model ID not surfaced in export. Human operator reviewed CI and Paperclip coordination context.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.
