### PR TITLE
Raise Docker image build timeout

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     concurrency:
       group: docker-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
Operational follow-up for Paperclip Cloud production deploy.\n\n- The Docker workflow timed out twice while publishing a master image that includes tenant identity bootstrap.\n- Raise the image build job timeout from 30 to 60 minutes so the normal GHCR multi-arch build can publish the tenant image digest.\n\nVerification:\n- Workflow-only timeout change; no runtime code touched.