### PR TITLE
feat(harness): continuation summary truncation — 30KB chunk / 500KB workspace ceiling (PRO-2864)

### DIFF
--- a/server/src/__tests__/issue-continuation-summary.test.ts
+++ b/server/src/__tests__/issue-continuation-summary.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  CONTINUATION_CHUNK_MAX_BYTES,
+  CONTINUATION_WORKSPACE_TOTAL_MAX_BYTES,
   ISSUE_CONTINUATION_SUMMARY_MAX_BODY_CHARS,
+  assembleContinuationSummaryBody,
   buildContinuationSummaryMarkdown,
 } from "../services/issue-continuation-summary.js";
 
@@ -82,5 +85,67 @@ describe("issue continuation summaries", () => {
 
     expect(body).toContain("Latest run error (adapter_failed): adapter failed");
     expect(body).toContain("Inspect the failed run, fix the cause");
+  });
+});
+
+describe("assembleContinuationSummaryBody", () => {
+  it("returns the chunk unchanged when it is under the 30KB ceiling", () => {
+    const newChunk = "# Continuation Summary\n\nSmall chunk.";
+    const { body, chunkTruncated, workspaceTruncated } = assembleContinuationSummaryBody({
+      newChunk,
+      existingBody: null,
+    });
+    expect(body).toBe(newChunk);
+    expect(chunkTruncated).toBe(false);
+    expect(workspaceTruncated).toBe(false);
+  });
+
+  it("truncates a chunk that exceeds 30KB and appends the spec truncation marker", () => {
+    const bigChunk = "x".repeat(CONTINUATION_CHUNK_MAX_BYTES + 500);
+    const { body, chunkTruncated } = assembleContinuationSummaryBody({
+      newChunk: bigChunk,
+      existingBody: null,
+    });
+    expect(chunkTruncated).toBe(true);
+    expect(body.length).toBeLessThanOrEqual(CONTINUATION_CHUNK_MAX_BYTES);
+    expect(body).toContain("[TRUNCATED — continuation context exceeded safe threshold at");
+    expect(body).toContain("Run context was reset.]");
+  });
+
+  it("prepends the new chunk to the existing body", () => {
+    const newChunk = "# New Run";
+    const existingBody = "# Old Run";
+    const { body } = assembleContinuationSummaryBody({ newChunk, existingBody });
+    expect(body.indexOf("# New Run")).toBeLessThan(body.indexOf("# Old Run"));
+  });
+
+  it("rolls off oldest summaries when workspace total exceeds 500KB", () => {
+    const chunkSize = 10 * 1024; // 10KB each
+    const chunk = "A".repeat(chunkSize);
+    // Build an accumulated body just over 500KB
+    const repetitions = Math.ceil(CONTINUATION_WORKSPACE_TOTAL_MAX_BYTES / chunkSize) + 1;
+    const bigExisting = Array(repetitions).fill(chunk).join("\n\n---\n\n");
+
+    const { body, workspaceTruncated } = assembleContinuationSummaryBody({
+      newChunk: chunk,
+      existingBody: bigExisting,
+    });
+
+    expect(workspaceTruncated).toBe(true);
+    expect(body.length).toBeLessThanOrEqual(CONTINUATION_WORKSPACE_TOTAL_MAX_BYTES + 200);
+    expect(body).toContain("[Oldest continuation summaries removed — workspace ceiling exceeded.]");
+  });
+
+  it("does not truncate normal runs under both thresholds", () => {
+    const normalChunk = "# Continuation Summary\n\n- Item 1\n- Item 2\n";
+    const smallExisting = "# Previous Summary\n\n- Prior item\n";
+    const { body, chunkTruncated, workspaceTruncated } = assembleContinuationSummaryBody({
+      newChunk: normalChunk,
+      existingBody: smallExisting,
+    });
+    expect(chunkTruncated).toBe(false);
+    expect(workspaceTruncated).toBe(false);
+    expect(body).toContain("# Continuation Summary");
+    expect(body).toContain("# Previous Summary");
   });
 });

--- a/server/src/services/issue-continuation-summary.ts
+++ b/server/src/services/issue-continuation-summary.ts
@@ -2,13 +2,18 @@ import { and, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { documents, issueDocuments, issues } from "@paperclipai/db";
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
+import { logger } from "../middleware/logger.js";
 import { documentService } from "./documents.js";
 
 export { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY };
 export const ISSUE_CONTINUATION_SUMMARY_TITLE = "Continuation Summary";
+export const CONTINUATION_CHUNK_MAX_BYTES = 30 * 1024; // 30KB hard ceiling per run chunk
+export const CONTINUATION_WORKSPACE_TOTAL_MAX_BYTES = 500 * 1024; // 500KB hard ceiling per workspace
+// Kept for backwards compatibility — existing tests reference this constant by name
 export const ISSUE_CONTINUATION_SUMMARY_MAX_BODY_CHARS = 8_000;
 const SUMMARY_SECTION_MAX_CHARS = 1_200;
 const PATH_CANDIDATE_RE = /(?:^|[\s`"'(])((?:server|ui|packages|doc|scripts|\.github)\/[A-Za-z0-9._/-]+)/g;
+const CHUNK_SEPARATOR = "\n\n---\n\n";
 
 type IssueSummaryInput = {
   id: string;
@@ -49,6 +54,56 @@ function truncateText(value: string, maxChars: number) {
   const trimmed = value.trim();
   if (trimmed.length <= maxChars) return trimmed;
   return `${trimmed.slice(0, Math.max(0, maxChars - 20)).trimEnd()}\n[truncated]`;
+}
+
+// Apply the spec-mandated truncation marker for per-chunk size overflow.
+function truncateChunk(body: string, maxLen: number): string {
+  if (body.length <= maxLen) return body;
+  const timestamp = new Date().toISOString();
+  const marker = `\n[TRUNCATED — continuation context exceeded safe threshold at ${timestamp}. Run context was reset.]`;
+  return body.slice(0, Math.max(0, maxLen - marker.length)).trimEnd() + marker;
+}
+
+// Trim oldest content (tail) when accumulated workspace summaries exceed the ceiling.
+// Chunks are prepended so the tail always holds the oldest material.
+function applyWorkspaceRolloff(
+  accumulated: string,
+  maxLen: number,
+): { text: string; wasTruncated: boolean } {
+  if (accumulated.length <= maxLen) return { text: accumulated, wasTruncated: false };
+  let trimmed = accumulated.slice(0, maxLen);
+  const lastSepIdx = trimmed.lastIndexOf(CHUNK_SEPARATOR);
+  if (lastSepIdx > 0) {
+    trimmed = trimmed.slice(0, lastSepIdx);
+  }
+  return {
+    text: trimmed + CHUNK_SEPARATOR + "[Oldest continuation summaries removed — workspace ceiling exceeded.]",
+    wasTruncated: true,
+  };
+}
+
+/**
+ * Pure assembly helper — exported for unit testing.
+ *
+ * Prepends newChunk to existingBody (newest chunk at top), enforces the 30KB
+ * per-chunk ceiling and the 500KB workspace ceiling, and returns the final
+ * body along with truncation flags.
+ */
+export function assembleContinuationSummaryBody(input: {
+  newChunk: string;
+  existingBody: string | null;
+}): { body: string; chunkTruncated: boolean; workspaceTruncated: boolean } {
+  const chunk = truncateChunk(input.newChunk, CONTINUATION_CHUNK_MAX_BYTES);
+  const chunkTruncated = chunk.length < input.newChunk.length;
+
+  const accumulated = input.existingBody ? chunk + CHUNK_SEPARATOR + input.existingBody : chunk;
+
+  const { text: body, wasTruncated: workspaceTruncated } = applyWorkspaceRolloff(
+    accumulated,
+    CONTINUATION_WORKSPACE_TOTAL_MAX_BYTES,
+  );
+
+  return { body, chunkTruncated, workspaceTruncated };
 }
 
 function asNonEmptyString(value: unknown) {
@@ -248,12 +303,31 @@ export async function refreshIssueContinuationSummary(input: {
   ]);
 
   if (!issue) return null;
-  const body = buildContinuationSummaryMarkdown({
+
+  const newChunk = buildContinuationSummaryMarkdown({
     issue,
     run,
     agent,
     previousSummaryBody: existing?.body ?? null,
   });
+
+  const { body, chunkTruncated, workspaceTruncated } = assembleContinuationSummaryBody({
+    newChunk,
+    existingBody: existing?.body ?? null,
+  });
+
+  if (chunkTruncated || workspaceTruncated) {
+    logger.info(
+      {
+        type: "continuation_truncated",
+        chunkBytes: newChunk.length,
+        totalBytes: body.length,
+        runId: run.id,
+      },
+      "continuation summary truncated",
+    );
+  }
+
   const result = await documentService(db).upsertIssueDocument({
     issueId,
     key: ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,


### PR DESCRIPTION
## Summary

Implements PRO-2864: adds hard size guards to the harness continuation summary assembly to prevent unbounded accumulation (root cause of the PRO-2823 32MB payload incident).

- **30KB per-chunk ceiling**: each run's summary chunk is truncated at 30,720 bytes with the mandatory marker `[TRUNCATED — continuation context exceeded safe threshold at <ISO timestamp>. Run context was reset.]`
- **500KB workspace ceiling**: new chunks are prepended to the accumulated body (newest first); when the total exceeds 500KB the oldest content is rolled off and a `[Oldest continuation summaries removed — workspace ceiling exceeded.]` marker is appended at the boundary.
- **Structured log event**: every truncation emits `{ type: "continuation_truncated", chunkBytes: N, totalBytes: N, runId: "..." }` via `logger.info`.
- **Backwards compatible**: `ISSUE_CONTINUATION_SUMMARY_MAX_BODY_CHARS` is kept as a named export alias; existing tests pass unchanged.

## Files changed

- `server/src/services/issue-continuation-summary.ts` — core implementation
- `server/src/__tests__/issue-continuation-summary.test.ts` — four new synthetic tests covering all acceptance criteria

## Test plan

- [ ] Run `vitest server/src/__tests__/issue-continuation-summary.test.ts` — all 6 tests pass
- [ ] Confirm chunk > 30KB produces truncation marker
- [ ] Confirm workspace > 500KB rolls off oldest content
- [ ] Confirm normal (small) runs are unaffected
- [ ] Confirm structured log event appears in server.log on truncation

## Notes

- Workspace metadata tracking of `continuationSummaryTotalBytes` is observable via the structured log event. An explicit DB-level counter in workspace metadata can be added in a follow-up if needed for dashboarding; it would require a post-run `executionWorkspacesSvc.update` call and is not in the acceptance criteria for this issue.
- The `buildContinuationSummaryMarkdown` 8KB internal cap is retained as a quality heuristic; `assembleContinuationSummaryBody` enforces the 30KB hard limit independently as a safety net.

Closes PRO-2864
Parent: PRO-2862
Incident: PRO-2823

🤖 Generated with [Claude Code](https://claude.com/claude-code)