### PR TITLE
feat(recovery): vestigial issue retry suppression (PRO-2865)

### DIFF
--- a/packages/db/src/schema/issue_relations.ts
+++ b/packages/db/src/schema/issue_relations.ts
@@ -10,7 +10,7 @@ export const issueRelations = pgTable(
     companyId: uuid("company_id").notNull().references(() => companies.id),
     issueId: uuid("issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
     relatedIssueId: uuid("related_issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
-    type: text("type").$type<"blocks">().notNull(),
+    type: text("type").$type<"blocks" | "superseded_by">().notNull(),
     createdByAgentId: uuid("created_by_agent_id").references(() => agents.id, { onDelete: "set null" }),
     createdByUserId: text("created_by_user_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -167,7 +167,7 @@ export interface IssueRelation {
   companyId: string;
   issueId: string;
   relatedIssueId: string;
-  type: "blocks";
+  type: "blocks" | "superseded_by";
   relatedIssue: IssueRelationIssueSummary;
 }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -126,6 +126,7 @@ import {
   readContinuationAttempt,
 } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
+import { checkVestigialSignals } from "./recovery/vestigial-check.js";
 import { recoveryService } from "./recovery/service.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
@@ -4671,6 +4672,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           errorCode: gate.errorCode,
           issueId: gate.issueId,
         };
+      }
+    }
+    if (issueId) {
+      const issueForVestigialCheck = await db
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          parentId: issues.parentId,
+          originFingerprint: issues.originFingerprint,
+          projectId: issues.projectId,
+          goalId: issues.goalId,
+        })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (issueForVestigialCheck) {
+        const vestigialSignal = await checkVestigialSignals(db, issueForVestigialCheck);
+        if (vestigialSignal) {
+          await appendRunEvent(run, await nextRunEventSeq(run.id), {
+            eventType: "vestigial_issue_detected",
+            stream: "system",
+            level: "warn",
+            message: `Retry suppressed — vestigial issue detected (kind=${vestigialSignal.kind})`,
+            payload: { vestigialKind: vestigialSignal.kind, signal: vestigialSignal },
+          });
+          await issuesSvc.update(issueForVestigialCheck.id, { status: "cancelled" });
+          await issuesSvc.addComment(
+            issueForVestigialCheck.id,
+            `Paperclip suppressed a retry attempt — this issue is vestigial (\`${vestigialSignal.kind}\`). No further retries will be scheduled.`,
+            {},
+          );
+          return { outcome: "vestigial_suppressed" as const, vestigialKind: vestigialSignal.kind };
+        }
       }
     }
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);

--- a/server/src/services/recovery/index.ts
+++ b/server/src/services/recovery/index.ts
@@ -42,3 +42,10 @@ export {
 export type {
   RunContinuationDecision,
 } from "./run-liveness-continuations.js";
+export {
+  checkVestigialSignals,
+} from "./vestigial-check.js";
+export type {
+  VestigialIssueInput,
+  VestigialSignal,
+} from "./vestigial-check.js";

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -43,6 +43,7 @@ import {
   type IssueLivenessFinding,
 } from "./issue-graph-liveness.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { checkVestigialSignals, type VestigialSignal } from "./vestigial-check.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
@@ -448,6 +449,81 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       projectId: issue.projectId,
     });
     return Boolean(budgetBlock);
+  }
+
+
+  function vestigialCancellationComment(signal: VestigialSignal, prefix: string) {
+    if (signal.kind === "parent_cancelled") {
+      const parentLabel = signal.parentIdentifier ?? signal.parentId;
+      return [
+        "Paperclip detected this issue is vestigial — its parent",
+        ` [${parentLabel}](/${prefix}/issues/${parentLabel}) is cancelled.`,
+        " Halting retry and marking cancelled with reason `parent_cancelled`.",
+      ].join("");
+    }
+    if (signal.kind === "superseded") {
+      const label = signal.supersedingIdentifier ?? signal.supersedingIssueId;
+      return [
+        "Paperclip detected this issue is vestigial — it has a `superseded_by` relation to the completed issue",
+        ` [${label}](/${prefix}/issues/${label}).`,
+        " Halting retry and marking cancelled with reason `superseded`.",
+      ].join("");
+    }
+    if (signal.kind === "duplicate_resolved") {
+      const label = signal.duplicateIdentifier ?? signal.duplicateIssueId;
+      return [
+        "Paperclip detected this issue is vestigial — its `originFingerprint` already resolved in the completed issue",
+        ` [${label}](/${prefix}/issues/${label}).`,
+        " Halting retry and marking cancelled with reason `duplicate_resolved`.",
+      ].join("");
+    }
+    return "Paperclip detected this issue is vestigial. Halting retry and marking cancelled.";
+  }
+
+  async function suppressVestigialIssueInRecovery(
+    issue: typeof issues.$inferSelect,
+    signal: VestigialSignal,
+  ) {
+    const prefix = await getCompanyIssuePrefix(issue.companyId);
+    logger.info(
+      {
+        companyId: issue.companyId,
+        issueId: issue.id,
+        issueIdentifier: issue.identifier,
+        vestigialKind: signal.kind,
+        signal,
+        source: "recovery.vestigial_issue_detected",
+      },
+      "vestigial_issue_detected",
+    );
+
+    const updated = await issuesSvc.update(issue.id, { status: "cancelled" });
+    if (!updated) return null;
+
+    await issuesSvc.addComment(
+      issue.id,
+      vestigialCancellationComment(signal, prefix),
+      {},
+    );
+
+    await logActivity(db, {
+      companyId: issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issue.id,
+      details: {
+        identifier: issue.identifier,
+        status: "cancelled",
+        vestigialKind: signal.kind,
+        source: "recovery.vestigial_issue_suppression",
+      },
+    });
+
+    return updated;
   }
 
   async function reconcileUnassignedBlockingIssues() {
@@ -1597,6 +1673,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulContinuationObserved: 0,
       orphanBlockersAssigned: 0,
       escalated: 0,
+      vestigialSuppressed: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
@@ -1621,6 +1698,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
         result.skipped += 1;
+        continue;
+      }
+
+      const vestigialSignal = await checkVestigialSignals(db, issue);
+      if (vestigialSignal) {
+        const suppressed = await suppressVestigialIssueInRecovery(issue, vestigialSignal);
+        if (suppressed) {
+          result.vestigialSuppressed += 1;
+          result.issueIds.push(issue.id);
+        } else {
+          result.skipped += 1;
+        }
         continue;
       }
 

--- a/server/src/services/recovery/vestigial-check.ts
+++ b/server/src/services/recovery/vestigial-check.ts
@@ -1,0 +1,100 @@
+import { and, eq, isNull, ne } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issueRelations, issues } from "@paperclipai/db";
+
+export type VestigialSignal =
+  | { kind: "parent_cancelled"; parentId: string; parentIdentifier: string | null }
+  | { kind: "superseded"; supersedingIssueId: string; supersedingIdentifier: string | null }
+  | { kind: "duplicate_resolved"; duplicateIssueId: string; duplicateIdentifier: string | null };
+
+export type VestigialIssueInput = Pick<
+  typeof issues.$inferSelect,
+  "id" | "companyId" | "parentId" | "originFingerprint" | "projectId" | "goalId"
+>;
+
+/**
+ * Checks three signals that indicate an issue is vestigial dead work:
+ * 1. parent_cancelled  — parentId is set and parent has status "cancelled"
+ * 2. superseded        — a superseded_by relation points to a done issue
+ * 3. duplicate_resolved — originFingerprint matches a done issue in the same project/goal scope
+ *
+ * Returns the first matching signal, or null when none match.
+ * The fingerprint check is skipped for the default "default" fingerprint.
+ */
+export async function checkVestigialSignals(
+  db: Db,
+  issue: VestigialIssueInput,
+): Promise<VestigialSignal | null> {
+  // Signal 1: Cancelled parent
+  if (issue.parentId) {
+    const parent = await db
+      .select({ id: issues.id, status: issues.status, identifier: issues.identifier })
+      .from(issues)
+      .where(and(eq(issues.id, issue.parentId), eq(issues.companyId, issue.companyId)))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (parent?.status === "cancelled") {
+      return {
+        kind: "parent_cancelled",
+        parentId: parent.id,
+        parentIdentifier: parent.identifier,
+      };
+    }
+  }
+
+  // Signal 2: superseded_by relation pointing to a done issue
+  const supersedingDone = await db
+    .select({ id: issues.id, identifier: issues.identifier })
+    .from(issueRelations)
+    .innerJoin(
+      issues,
+      and(
+        eq(issues.id, issueRelations.relatedIssueId),
+        eq(issues.status, "done"),
+      ),
+    )
+    .where(
+      and(
+        eq(issueRelations.companyId, issue.companyId),
+        eq(issueRelations.issueId, issue.id),
+        eq(issueRelations.type, "superseded_by"),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+  if (supersedingDone) {
+    return {
+      kind: "superseded",
+      supersedingIssueId: supersedingDone.id,
+      supersedingIdentifier: supersedingDone.identifier,
+    };
+  }
+
+  // Signal 3: originFingerprint dedup — same fingerprint, same project+goal scope, done
+  if (issue.originFingerprint && issue.originFingerprint !== "default") {
+    const duplicate = await db
+      .select({ id: issues.id, identifier: issues.identifier })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, issue.companyId),
+          eq(issues.originFingerprint, issue.originFingerprint),
+          eq(issues.status, "done"),
+          ne(issues.id, issue.id),
+          issue.projectId ? eq(issues.projectId, issue.projectId) : isNull(issues.projectId),
+          issue.goalId ? eq(issues.goalId, issue.goalId) : isNull(issues.goalId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (duplicate) {
+      return {
+        kind: "duplicate_resolved",
+        duplicateIssueId: duplicate.id,
+        duplicateIdentifier: duplicate.identifier,
+      };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Implements Safeguard 3 from the PRO-2823 incident forensics — pre-retry checks that halt retries on issues that are effectively dead work.

Linked issue: [PRO-2865](https://ops.production.city/PRO/issues/PRO-2865)
Reference: [PRO-2823 incident forensics](https://outline.production.city/doc/pro-2823-incident-forensics-32mb-payload-guardrail-proposal-tEGOZPOXDl)

## Changes

### New: `server/src/services/recovery/vestigial-check.ts`
- `checkVestigialSignals(db, issue)` — checks three signals and returns the first match or `null`:
  1. **parent_cancelled** — `parentId` is set and the parent issue is `cancelled`
  2. **superseded** — a `superseded_by` issueRelation points to a `done` issue
  3. **duplicate_resolved** — `originFingerprint` (non-default) matches a `done` issue in the same `projectId`+`goalId` scope

### `packages/db/src/schema/issue_relations.ts`
- Added `"superseded_by"` to the `issueRelations.type` union (TypeScript-level; no SQL migration needed — column is already `TEXT`)

### `packages/shared/src/types/issue.ts`
- Updated `IssueRelation.type` to `"blocks" | "superseded_by"`

### `server/src/services/recovery/service.ts`
- Added `vestigialCancellationComment` — formats the issue comment per signal kind
- Added `suppressVestigialIssueInRecovery` — emits `vestigial_issue_detected` structured log, cancels the issue, adds a comment, logs activity
- In `reconcileStrandedAssignedIssues`: calls `checkVestigialSignals` after the pause-hold guard, before any retry dispatch. Cancels and skips vestigial issues.
- Added `vestigialSuppressed` counter to the reconcile result

### `server/src/services/heartbeat.ts`
- Imported `checkVestigialSignals` from `./recovery/vestigial-check.js`
- In `scheduleBoundedRetryForRun`: after extracting `issueId`, fetches the issue and runs `checkVestigialSignals`. On match: appends `vestigial_issue_detected` run event, cancels the issue, adds a comment, returns `{ outcome: "vestigial_suppressed" }` instead of scheduling the retry.

### `server/src/services/recovery/index.ts`
- Exports `checkVestigialSignals`, `VestigialIssueInput`, and `VestigialSignal`

## Acceptance criteria

- ✅ Retry suppressed when parent is cancelled → issue marked `cancelled` with reason `parent_cancelled`
- ✅ Retry suppressed when `superseded_by` relation points to a done issue → reason `superseded`
- ✅ Retry suppressed when same `originFingerprint` done in same project/goal scope → reason `duplicate_resolved`
- ✅ `vestigial_issue_detected` appears in run log (heartbeat path) or structured logger (recovery path)
- ✅ Normal retries (no matching signals) are unaffected

## What's not included

The `superseded_by` relation type is now a valid DB value (the column accepts any TEXT), but no API surface for _creating_ `superseded_by` links is added here. That's a follow-on: for now the check is forward-compatible and will fire as soon as such links exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)