### PR TITLE
Fixes SUP-1888: implement runs aggregation stats API endpoint

### DIFF
--- a/doc/runs-stats-api.md
+++ b/doc/runs-stats-api.md
@@ -1,0 +1,46 @@
+# Runs Stats API
+
+`GET /api/companies/:companyId/runs/stats`
+
+Aggregates heartbeat run failures over a time window for telemetry and post-incident analysis.
+
+## Query params
+
+- `since` (required): ISO timestamp start (inclusive)
+- `until` (optional): ISO timestamp end (inclusive), defaults to now
+- `failureReason` (optional): filter by run `errorCode` (for example `process_lost`)
+- `agentId` (optional): filter to one agent
+- `groupBy` (optional): one of `agentId`, `failureReason`, `day`
+
+## Response
+
+```json
+{
+  "window": { "since": "2026-04-12T00:00:00.000Z", "until": "2026-04-19T00:00:00.000Z" },
+  "total": 42,
+  "groups": [{ "key": "process_lost", "count": 31 }],
+  "topRecoverySources": [{ "identifier": "SUP-1756", "count": 9 }]
+}
+```
+
+Notes:
+
+- `groups` is omitted when `groupBy` is not provided.
+- `topRecoverySources` is limited to top 5 source issue identifiers.
+- Route-level guardrails enforce auth scope and a conservative rate limit (30 requests/min per actor+company).
+
+## Example queries
+
+```bash
+# Total process_lost failures over the last 7 days
+curl -H "Authorization: Bearer <token>" \
+  "/api/companies/<companyId>/runs/stats?since=2026-04-22T00:00:00.000Z&failureReason=process_lost"
+
+# Group by failure reason
+curl -H "Authorization: Bearer <token>" \
+  "/api/companies/<companyId>/runs/stats?since=2026-04-22T00:00:00.000Z&until=2026-04-29T00:00:00.000Z&groupBy=failureReason"
+
+# Group by day for one agent
+curl -H "Authorization: Bearer <token>" \
+  "/api/companies/<companyId>/runs/stats?since=2026-04-22T00:00:00.000Z&agentId=<agentId>&groupBy=day"
+```

--- a/doc/runs-stats-api.md
+++ b/doc/runs-stats-api.md
@@ -8,7 +8,7 @@ Aggregates heartbeat run failures over a time window for telemetry and post-inci
 
 - `since` (required): ISO timestamp start (inclusive)
 - `until` (optional): ISO timestamp end (inclusive), defaults to now
-- `failureReason` (optional): filter by run `errorCode` (for example `process_lost`)
+- `status` (optional): one of `failed`, `timed_out`, `cancelled`
 - `agentId` (optional): filter to one agent
 - `groupBy` (optional): one of `agentId`, `failureReason`, `day`
 
@@ -33,9 +33,9 @@ Notes:
 ## Example queries
 
 ```bash
-# Total process_lost failures over the last 7 days
+# Total failed runs over the last 7 days
 curl -H "Authorization: Bearer <token>" \
-  "/api/companies/<companyId>/runs/stats?since=2026-04-22T00:00:00.000Z&failureReason=process_lost"
+  "/api/companies/<companyId>/runs/stats?since=2026-04-22T00:00:00.000Z&status=failed"
 
 # Group by failure reason
 curl -H "Authorization: Bearer <token>" \

--- a/doc/runs-stats-api.md
+++ b/doc/runs-stats-api.md
@@ -6,8 +6,8 @@ Aggregates heartbeat run failures over a time window for telemetry and post-inci
 
 ## Query params
 
-- `since` (required): ISO timestamp start (inclusive)
-- `until` (optional): ISO timestamp end (inclusive), defaults to now
+- `since` (required): ISO timestamp start (inclusive), timezone required (`Z` or `±HH:MM`)
+- `until` (optional): ISO timestamp end (inclusive), defaults to now; timezone required when provided
 - `status` (optional): one of `failed`, `timed_out`, `cancelled`
 - `agentId` (optional): filter to one agent
 - `groupBy` (optional): one of `agentId`, `failureReason`, `day`

--- a/doc/runs-stats-api.md
+++ b/doc/runs-stats-api.md
@@ -28,6 +28,7 @@ Notes:
 - `groups` is omitted when `groupBy` is not provided.
 - `topRecoverySources` is limited to top 5 source issue identifiers.
 - Route-level guardrails enforce auth scope and a conservative rate limit (30 requests/min per actor+company).
+- `since`/`until` window is capped at 31 days.
 
 ## Example queries
 

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -745,6 +745,70 @@ describe("agent live run routes", () => {
     expect(db.select).not.toHaveBeenCalled();
   });
 
+  it("rejects runs stats requests with invalid `status`", async () => {
+    const db = { select: vi.fn() };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) =>
+        request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z&status=running"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toContain("status");
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("accepts runs stats requests with valid `status` filter", async () => {
+    const db = {
+      select: vi.fn()
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnValue(Promise.resolve([{ count: 1 }])),
+        }))
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([]),
+        })),
+    };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) =>
+        request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z&status=failed"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.total).toBe(1);
+  });
+
+  it("accepts runs stats requests with ISO `since` that has non-millisecond precision", async () => {
+    const db = {
+      select: vi.fn()
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnValue(Promise.resolve([{ count: 1 }])),
+        }))
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([]),
+        })),
+    };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.12Z"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.total).toBe(1);
+  });
+
   it("rejects runs stats requests with an oversized time window", async () => {
     const db = {
       select: vi.fn()

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -693,6 +693,32 @@ describe("agent live run routes", () => {
     expect(res.body.error).toContain("ISO");
   });
 
+  it("rejects runs stats requests with timezone-less `since`", async () => {
+    const db = {
+      select: vi.fn()
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnValue(Promise.resolve([{ count: 1 }])),
+        }))
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([]),
+        })),
+    };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) =>
+        request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toContain("ISO");
+  });
+
   it("rejects runs stats requests with malformed `until`", async () => {
     const db = { select: vi.fn() };
     const res = await requestApp(

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -70,7 +70,10 @@ function registerModuleMocks() {
   }));
 }
 
-async function createApp(db: Record<string, unknown> = {}) {
+async function createApp(
+  db: Record<string, unknown> = {},
+  actorOverrides: Partial<{ companyIds: string[]; source: string }> = {},
+) {
   const [{ agentRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -81,8 +84,8 @@ async function createApp(db: Record<string, unknown> = {}) {
     (req as any).actor = {
       type: "board",
       userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
+      companyIds: actorOverrides.companyIds ?? ["company-1"],
+      source: actorOverrides.source ?? "local_implicit",
       isInstanceAdmin: false,
     };
     next();
@@ -538,48 +541,28 @@ describe("agent live run routes", () => {
   });
 
   it("returns grouped run stats and top recovery sources", async () => {
-    const runs = [
-      {
-        id: "run-1",
-        agentId: "agent-1",
-        failureReason: "process_lost",
-        createdAt: new Date("2026-04-12T10:00:00.000Z"),
-        retryOfRunId: "src-1",
-      },
-      {
-        id: "run-2",
-        agentId: "agent-2",
-        failureReason: "process_lost",
-        createdAt: new Date("2026-04-12T11:00:00.000Z"),
-        retryOfRunId: "src-1",
-      },
-      {
-        id: "run-3",
-        agentId: "agent-1",
-        failureReason: "restart_during_run",
-        createdAt: new Date("2026-04-13T09:00:00.000Z"),
-        retryOfRunId: "src-2",
-      },
+    const groupedRows = [
+      { key: "process_lost", count: 2 },
+      { key: "restart_during_run", count: 1 },
     ];
-    const sourceRuns = [
-      { id: "src-1", issueId: "issue-1" },
-      { id: "src-2", issueId: "issue-2" },
-    ];
-    const sourceIssues = [
-      { id: "issue-1", identifier: "SUP-1756" },
-      { id: "issue-2", identifier: "SUP-1757" },
-    ];
+    const sourceIssues = [{ identifier: "SUP-1756", count: 2 }, { identifier: "SUP-1757", count: 1 }];
 
-    let call = 0;
     const db = {
-      select: vi.fn().mockImplementation(() => {
-        call += 1;
-        const rows = call === 1 ? runs : call === 2 ? sourceRuns : sourceIssues;
-        return {
+      select: vi.fn()
+        .mockImplementationOnce(() => ({
           from: vi.fn().mockReturnThis(),
-          where: vi.fn().mockReturnValue(Promise.resolve(rows)),
-        };
-      }),
+          where: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnValue(Promise.resolve(groupedRows)),
+        }))
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnValue(Promise.resolve(sourceIssues)),
+        })),
     };
 
     const res = await requestApp(
@@ -592,29 +575,140 @@ describe("agent live run routes", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body.total).toBe(3);
-    expect(res.body.groups).toEqual([
-      { key: "process_lost", count: 2 },
-      { key: "restart_during_run", count: 1 },
-    ]);
+    expect(res.body.groups).toEqual(groupedRows);
     expect(res.body.topRecoverySources).toEqual([
       { identifier: "SUP-1756", count: 2 },
       { identifier: "SUP-1757", count: 1 },
     ]);
   });
 
-  it("omits groups when groupBy is not provided", async () => {
-    const runs = [{
-      id: "run-1",
-      agentId: "agent-1",
-      failureReason: "process_lost",
-      createdAt: new Date("2026-04-12T10:00:00.000Z"),
-      retryOfRunId: null,
-    }];
+  it("returns grouped run stats by agentId", async () => {
+    const groupedRows = [
+      { key: "agent-1", count: 2 },
+      { key: "agent-2", count: 1 },
+    ];
+
     const db = {
-      select: vi.fn().mockImplementation(() => ({
-        from: vi.fn().mockReturnThis(),
-        where: vi.fn().mockReturnValue(Promise.resolve(runs)),
-      })),
+      select: vi.fn()
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnValue(Promise.resolve(groupedRows)),
+        }))
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([]),
+        })),
+    };
+
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) =>
+        request(baseUrl).get(
+          "/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z&groupBy=agentId",
+        ),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.total).toBe(3);
+    expect(res.body.groups).toEqual(groupedRows);
+  });
+
+  it("returns grouped run stats by day", async () => {
+    const groupedRows = [
+      { key: "2026-04-13", count: 5 },
+      { key: "2026-04-12", count: 1 },
+    ];
+
+    const db = {
+      select: vi.fn()
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnValue(Promise.resolve(groupedRows)),
+        }))
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([]),
+        })),
+    };
+
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) =>
+        request(baseUrl).get(
+          "/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z&groupBy=day",
+        ),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.total).toBe(6);
+    expect(res.body.groups).toEqual(groupedRows);
+  });
+
+  it("rejects runs stats requests with malformed `since`", async () => {
+    const db = { select: vi.fn() };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl).get("/api/companies/company-1/runs/stats?since=not-a-timestamp"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toContain("since");
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("rejects runs stats requests with `since` later than `until`", async () => {
+    const db = { select: vi.fn() };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) =>
+        request(baseUrl).get(
+          "/api/companies/company-1/runs/stats?since=2026-04-14T00:00:00.000Z&until=2026-04-12T00:00:00.000Z",
+        ),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toContain("since");
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("forbids cross-company access for runs stats", async () => {
+    const db = { select: vi.fn() };
+    const res = await requestApp(
+      await createApp(db, { companyIds: ["company-2"], source: "jwt" }),
+      (baseUrl) => request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("omits groups when groupBy is not provided", async () => {
+    const db = {
+      select: vi.fn()
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnValue(Promise.resolve([{ count: 1 }])),
+        }))
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([]),
+        })),
     };
 
     const res = await requestApp(

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -668,6 +668,44 @@ describe("agent live run routes", () => {
     expect(db.select).not.toHaveBeenCalled();
   });
 
+  it("rejects runs stats requests with non-ISO `since`", async () => {
+    const db = {
+      select: vi.fn()
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnValue(Promise.resolve([{ count: 1 }])),
+        }))
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([]),
+        })),
+    };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toContain("ISO");
+  });
+
+  it("rejects runs stats requests with malformed `until`", async () => {
+    const db = { select: vi.fn() };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) =>
+        request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z&until=tomorrow"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toContain("until");
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
   it("rejects runs stats requests with `since` later than `until`", async () => {
     const db = { select: vi.fn() };
     const res = await requestApp(
@@ -692,6 +730,85 @@ describe("agent live run routes", () => {
 
     expect(res.status).toBe(403);
     expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("rejects runs stats requests with invalid `groupBy`", async () => {
+    const db = { select: vi.fn() };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) =>
+        request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z&groupBy=week"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toContain("groupBy");
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("rejects runs stats requests with an oversized time window", async () => {
+    const db = {
+      select: vi.fn()
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnValue(Promise.resolve([{ count: 1 }])),
+        }))
+        .mockImplementationOnce(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          innerJoin: vi.fn().mockReturnThis(),
+          groupBy: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([]),
+        })),
+    };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) =>
+        request(baseUrl).get(
+          "/api/companies/company-1/runs/stats?since=2026-01-01T00:00:00.000Z&until=2026-04-12T00:00:00.000Z",
+        ),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toContain("window");
+  });
+
+  it("rate limits runs stats requests", async () => {
+    const db = {
+      select: vi.fn().mockImplementation((args) => {
+        if (args && typeof args === "object" && "identifier" in args) {
+          return {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            innerJoin: vi.fn().mockReturnThis(),
+            groupBy: vi.fn().mockReturnThis(),
+            orderBy: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockResolvedValue([]),
+          };
+        }
+        return {
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnValue(Promise.resolve([{ count: 1 }])),
+        };
+      }),
+    };
+
+    const app = await createApp(db);
+    for (let index = 0; index < 30; index += 1) {
+      const res = await requestApp(
+        app,
+        (baseUrl) => request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z"),
+      );
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+    }
+
+    const rateLimitedRes = await requestApp(
+      app,
+      (baseUrl) => request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z"),
+    );
+
+    expect(rateLimitedRes.status, JSON.stringify(rateLimitedRes.body)).toBe(429);
+    expect(rateLimitedRes.body.error).toContain("Rate limit");
   });
 
   it("omits groups when groupBy is not provided", async () => {

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -524,4 +524,107 @@ describe("agent live run routes", () => {
     expect(res.body).toHaveLength(4);
     expect(db.select).toHaveBeenCalledTimes(2);
   });
+
+  it("rejects runs stats requests missing `since`", async () => {
+    const db = { select: vi.fn() };
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl).get("/api/companies/company-1/runs/stats"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body.error).toContain("since");
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("returns grouped run stats and top recovery sources", async () => {
+    const runs = [
+      {
+        id: "run-1",
+        agentId: "agent-1",
+        failureReason: "process_lost",
+        createdAt: new Date("2026-04-12T10:00:00.000Z"),
+        retryOfRunId: "src-1",
+      },
+      {
+        id: "run-2",
+        agentId: "agent-2",
+        failureReason: "process_lost",
+        createdAt: new Date("2026-04-12T11:00:00.000Z"),
+        retryOfRunId: "src-1",
+      },
+      {
+        id: "run-3",
+        agentId: "agent-1",
+        failureReason: "restart_during_run",
+        createdAt: new Date("2026-04-13T09:00:00.000Z"),
+        retryOfRunId: "src-2",
+      },
+    ];
+    const sourceRuns = [
+      { id: "src-1", issueId: "issue-1" },
+      { id: "src-2", issueId: "issue-2" },
+    ];
+    const sourceIssues = [
+      { id: "issue-1", identifier: "SUP-1756" },
+      { id: "issue-2", identifier: "SUP-1757" },
+    ];
+
+    let call = 0;
+    const db = {
+      select: vi.fn().mockImplementation(() => {
+        call += 1;
+        const rows = call === 1 ? runs : call === 2 ? sourceRuns : sourceIssues;
+        return {
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnValue(Promise.resolve(rows)),
+        };
+      }),
+    };
+
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) =>
+        request(baseUrl).get(
+          "/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z&until=2026-04-14T00:00:00.000Z&groupBy=failureReason",
+        ),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.total).toBe(3);
+    expect(res.body.groups).toEqual([
+      { key: "process_lost", count: 2 },
+      { key: "restart_during_run", count: 1 },
+    ]);
+    expect(res.body.topRecoverySources).toEqual([
+      { identifier: "SUP-1756", count: 2 },
+      { identifier: "SUP-1757", count: 1 },
+    ]);
+  });
+
+  it("omits groups when groupBy is not provided", async () => {
+    const runs = [{
+      id: "run-1",
+      agentId: "agent-1",
+      failureReason: "process_lost",
+      createdAt: new Date("2026-04-12T10:00:00.000Z"),
+      retryOfRunId: null,
+    }];
+    const db = {
+      select: vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnValue(Promise.resolve(runs)),
+      })),
+    };
+
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl).get("/api/companies/company-1/runs/stats?since=2026-04-12T00:00:00.000Z"),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body).not.toHaveProperty("groups");
+    expect(res.body.topRecoverySources).toEqual([]);
+  });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -97,6 +97,9 @@ import { recoveryService } from "../services/recovery/service.js";
 
 const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
 const RUN_LOG_MAX_LIMIT_BYTES = 1024 * 1024;
+const RUNS_STATS_MAX_WINDOW_MS = 31 * 24 * 60 * 60 * 1000;
+const RUNS_STATS_FAILURE_STATUSES = ["failed", "timed_out", "cancelled"];
+const ISO_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?(?:Z|[+-]\d{2}:\d{2})$/;
 
 function readRunLogLimitBytes(value: unknown) {
   const parsed = Number(value ?? RUN_LOG_DEFAULT_LIMIT_BYTES);
@@ -109,6 +112,12 @@ function readLiveRunsQueryInt(value: unknown, max: number, fallback = 0) {
   if (!Number.isFinite(parsed)) return fallback;
   if (parsed <= 0) return fallback;
   return Math.min(max, Math.trunc(parsed));
+}
+
+function parseIsoTimestamp(value: string | undefined): Date | null {
+  if (!value || !ISO_TIMESTAMP_REGEX.test(value)) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
 function createRouteRateLimiter(maxAttempts: number, windowMs: number) {
@@ -2878,23 +2887,23 @@ export function agentRoutes(
     assertCompanyAccess(req, companyId);
 
     const sinceRaw = typeof req.query.since === "string" ? req.query.since : "";
-    if (!sinceRaw) {
-      res.status(400).json({ error: "`since` is required and must be an ISO timestamp" });
-      return;
-    }
-    const since = new Date(sinceRaw);
-    if (Number.isNaN(since.getTime())) {
+    const since = parseIsoTimestamp(sinceRaw);
+    if (!since) {
       res.status(400).json({ error: "`since` is required and must be an ISO timestamp" });
       return;
     }
     const untilRaw = typeof req.query.until === "string" ? req.query.until : undefined;
-    const until = untilRaw ? new Date(untilRaw) : new Date();
-    if (Number.isNaN(until.getTime())) {
+    const until = untilRaw ? parseIsoTimestamp(untilRaw) : new Date();
+    if (!until) {
       res.status(400).json({ error: "`until` must be an ISO timestamp when provided" });
       return;
     }
     if (since.getTime() > until.getTime()) {
       res.status(400).json({ error: "`since` must be less than or equal to `until`" });
+      return;
+    }
+    if (until.getTime() - since.getTime() > RUNS_STATS_MAX_WINDOW_MS) {
+      res.status(400).json({ error: "`since`/`until` window must be 31 days or less" });
       return;
     }
 
@@ -2920,6 +2929,7 @@ export function agentRoutes(
       eq(heartbeatRuns.companyId, companyId),
       sql`${heartbeatRuns.createdAt} >= ${since}`,
       sql`${heartbeatRuns.createdAt} <= ${until}`,
+      inArray(heartbeatRuns.status, RUNS_STATS_FAILURE_STATUSES),
       ...(failureReason ? [eq(heartbeatRuns.errorCode, failureReason)] : []),
       ...(agentId ? [eq(heartbeatRuns.agentId, agentId)] : []),
     ];

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -99,7 +99,6 @@ const RUN_LOG_DEFAULT_LIMIT_BYTES = 256_000;
 const RUN_LOG_MAX_LIMIT_BYTES = 1024 * 1024;
 const RUNS_STATS_MAX_WINDOW_MS = 31 * 24 * 60 * 60 * 1000;
 const RUNS_STATS_FAILURE_STATUSES = ["failed", "timed_out", "cancelled"];
-const ISO_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?(?:Z|[+-]\d{2}:\d{2})$/;
 
 function readRunLogLimitBytes(value: unknown) {
   const parsed = Number(value ?? RUN_LOG_DEFAULT_LIMIT_BYTES);
@@ -115,7 +114,8 @@ function readLiveRunsQueryInt(value: unknown, max: number, fallback = 0) {
 }
 
 function parseIsoTimestamp(value: string | undefined): Date | null {
-  if (!value || !ISO_TIMESTAMP_REGEX.test(value)) return null;
+  if (!value) return null;
+  if (!value.includes("T")) return null;
   const parsed = new Date(value);
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
@@ -2907,7 +2907,16 @@ export function agentRoutes(
       return;
     }
 
-    const failureReason = typeof req.query.failureReason === "string" ? req.query.failureReason : undefined;
+    const statusRaw = typeof req.query.status === "string" ? req.query.status : undefined;
+    const status = statusRaw && RUNS_STATS_FAILURE_STATUSES.includes(statusRaw)
+      ? statusRaw
+      : undefined;
+    if (statusRaw && !status) {
+      res.status(400).json({
+        error: `\`status\` must be one of: ${RUNS_STATS_FAILURE_STATUSES.join(", ")}`,
+      });
+      return;
+    }
     const agentId = typeof req.query.agentId === "string" ? req.query.agentId : undefined;
     const groupByRaw = typeof req.query.groupBy === "string" ? req.query.groupBy : undefined;
     const groupBy = groupByRaw && ["agentId", "failureReason", "day"].includes(groupByRaw)
@@ -2929,8 +2938,7 @@ export function agentRoutes(
       eq(heartbeatRuns.companyId, companyId),
       sql`${heartbeatRuns.createdAt} >= ${since}`,
       sql`${heartbeatRuns.createdAt} <= ${until}`,
-      inArray(heartbeatRuns.status, RUNS_STATS_FAILURE_STATUSES),
-      ...(failureReason ? [eq(heartbeatRuns.errorCode, failureReason)] : []),
+      inArray(heartbeatRuns.status, status ? [status] : RUNS_STATS_FAILURE_STATUSES),
       ...(agentId ? [eq(heartbeatRuns.agentId, agentId)] : []),
     ];
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -110,6 +110,21 @@ function readLiveRunsQueryInt(value: unknown, max: number, fallback = 0) {
   return Math.min(max, Math.trunc(parsed));
 }
 
+function createRouteRateLimiter(maxAttempts: number, windowMs: number) {
+  const attempts = new Map<string, number[]>();
+  return {
+    check(key: string): boolean {
+      const now = Date.now();
+      const windowStart = now - windowMs;
+      const recent = (attempts.get(key) ?? []).filter((ts) => ts > windowStart);
+      if (recent.length >= maxAttempts) return false;
+      recent.push(now);
+      attempts.set(key, recent);
+      return true;
+    },
+  };
+}
+
 export function agentRoutes(
   db: Db,
   options: { pluginWorkerManager?: PluginWorkerManager } = {},
@@ -170,6 +185,7 @@ export function agentRoutes(
   const workspaceOperations = workspaceOperationService(db);
   const instanceSettings = instanceSettingsService(db);
   const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
+  const runsStatsRateLimiter = createRouteRateLimiter(30, 60_000);
 
   async function assertAgentEnvironmentSelection(
     companyId: string,
@@ -2844,6 +2860,126 @@ export function agentRoutes(
     const limit = limitParam ? Math.max(1, Math.min(1000, parseInt(limitParam, 10) || 200)) : undefined;
     const runs = await heartbeat.list(companyId, agentId, limit);
     res.json(runs);
+  });
+
+  router.get("/companies/:companyId/runs/stats", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+
+    const sinceRaw = typeof req.query.since === "string" ? req.query.since : "";
+    if (!sinceRaw) {
+      res.status(400).json({ error: "`since` is required and must be an ISO timestamp" });
+      return;
+    }
+    const since = new Date(sinceRaw);
+    if (Number.isNaN(since.getTime())) {
+      res.status(400).json({ error: "`since` is required and must be an ISO timestamp" });
+      return;
+    }
+    const untilRaw = typeof req.query.until === "string" ? req.query.until : undefined;
+    const until = untilRaw ? new Date(untilRaw) : new Date();
+    if (Number.isNaN(until.getTime())) {
+      res.status(400).json({ error: "`until` must be an ISO timestamp when provided" });
+      return;
+    }
+
+    const failureReason = typeof req.query.failureReason === "string" ? req.query.failureReason : undefined;
+    const agentId = typeof req.query.agentId === "string" ? req.query.agentId : undefined;
+    const groupByRaw = typeof req.query.groupBy === "string" ? req.query.groupBy : undefined;
+    const groupBy = groupByRaw && ["agentId", "failureReason", "day"].includes(groupByRaw)
+      ? groupByRaw
+      : undefined;
+    if (groupByRaw && !groupBy) {
+      res.status(400).json({ error: "`groupBy` must be one of: agentId, failureReason, day" });
+      return;
+    }
+
+    const actorId = req.actor.type === "agent" ? req.actor.agentId : req.actor.userId ?? "board";
+    const rateLimitKey = `${companyId}:${req.actor.type}:${actorId}`;
+    if (!runsStatsRateLimiter.check(rateLimitKey)) {
+      res.status(429).json({ error: "Rate limit exceeded" });
+      return;
+    }
+
+    const whereClauses = [
+      eq(heartbeatRuns.companyId, companyId),
+      sql`${heartbeatRuns.createdAt} >= ${since}`,
+      sql`${heartbeatRuns.createdAt} <= ${until}`,
+      ...(failureReason ? [eq(heartbeatRuns.errorCode, failureReason)] : []),
+      ...(agentId ? [eq(heartbeatRuns.agentId, agentId)] : []),
+    ];
+
+    const runs = await db
+      .select({
+        id: heartbeatRuns.id,
+        agentId: heartbeatRuns.agentId,
+        failureReason: heartbeatRuns.errorCode,
+        createdAt: heartbeatRuns.createdAt,
+        retryOfRunId: heartbeatRuns.retryOfRunId,
+      })
+      .from(heartbeatRuns)
+      .where(and(...whereClauses));
+
+    const total = runs.length;
+
+    let groups: Array<{ key: string; count: number }> | undefined;
+    if (groupBy) {
+      const counts = new Map<string, number>();
+      for (const run of runs) {
+        let key = "";
+        if (groupBy === "agentId") key = run.agentId;
+        if (groupBy === "failureReason") key = run.failureReason ?? "none";
+        if (groupBy === "day") key = (run.createdAt ?? new Date(0)).toISOString().slice(0, 10);
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+      }
+      groups = Array.from(counts.entries()).map(([key, count]) => ({ key, count })).sort((a, b) => b.count - a.count);
+    }
+
+    const retrySourceRunIds = [...new Set(runs.map((run) => run.retryOfRunId).filter((id): id is string => Boolean(id)))];
+    let topRecoverySources: Array<{ identifier: string; count: number }> = [];
+    if (retrySourceRunIds.length > 0) {
+      const sourceRuns = await db
+        .select({
+          id: heartbeatRuns.id,
+          issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
+        })
+        .from(heartbeatRuns)
+        .where(inArray(heartbeatRuns.id, retrySourceRunIds));
+
+      const issueIds = [...new Set(sourceRuns.map((row) => row.issueId).filter((id): id is string => Boolean(id)))];
+      const issueRows = issueIds.length > 0
+        ? await db.select({ id: issuesTable.id, identifier: issuesTable.identifier }).from(issuesTable).where(
+          and(eq(issuesTable.companyId, companyId), inArray(issuesTable.id, issueIds)),
+        )
+        : [];
+      const issueIdentifierById = new Map(issueRows.map((row) => [row.id, row.identifier]));
+      const sourceIssueIdByRunId = new Map(sourceRuns.map((row) => [row.id, row.issueId]));
+
+      const counts = new Map<string, number>();
+      for (const run of runs) {
+        if (!run.retryOfRunId) continue;
+        const sourceIssueId = sourceIssueIdByRunId.get(run.retryOfRunId);
+        if (!sourceIssueId) continue;
+        const identifier = issueIdentifierById.get(sourceIssueId);
+        if (!identifier) continue;
+        counts.set(identifier, (counts.get(identifier) ?? 0) + 1);
+      }
+
+      topRecoverySources = Array.from(counts.entries())
+        .map(([identifier, count]) => ({ identifier, count }))
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 5);
+    }
+
+    res.json({
+      window: {
+        since: since.toISOString(),
+        until: until.toISOString(),
+      },
+      total,
+      ...(groups ? { groups } : {}),
+      topRecoverySources,
+    });
   });
 
   router.get("/companies/:companyId/live-runs", async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable } from "@paperclipai/db";
 import { and, desc, eq, inArray, not, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import {
   agentSkillSyncSchema,
   agentMineInboxQuerySchema,
@@ -112,9 +113,19 @@ function readLiveRunsQueryInt(value: unknown, max: number, fallback = 0) {
 
 function createRouteRateLimiter(maxAttempts: number, windowMs: number) {
   const attempts = new Map<string, number[]>();
+  let lastCleanupAt = 0;
   return {
     check(key: string): boolean {
       const now = Date.now();
+      if (now - lastCleanupAt >= windowMs) {
+        const windowStart = now - windowMs;
+        for (const [existingKey, existingAttempts] of attempts.entries()) {
+          const recentExisting = existingAttempts.filter((ts) => ts > windowStart);
+          if (recentExisting.length === 0) attempts.delete(existingKey);
+          else attempts.set(existingKey, recentExisting);
+        }
+        lastCleanupAt = now;
+      }
       const windowStart = now - windowMs;
       const recent = (attempts.get(key) ?? []).filter((ts) => ts > windowStart);
       if (recent.length >= maxAttempts) return false;
@@ -2882,6 +2893,10 @@ export function agentRoutes(
       res.status(400).json({ error: "`until` must be an ISO timestamp when provided" });
       return;
     }
+    if (since.getTime() > until.getTime()) {
+      res.status(400).json({ error: "`since` must be less than or equal to `until`" });
+      return;
+    }
 
     const failureReason = typeof req.query.failureReason === "string" ? req.query.failureReason : undefined;
     const agentId = typeof req.query.agentId === "string" ? req.query.agentId : undefined;
@@ -2909,67 +2924,58 @@ export function agentRoutes(
       ...(agentId ? [eq(heartbeatRuns.agentId, agentId)] : []),
     ];
 
-    const runs = await db
-      .select({
-        id: heartbeatRuns.id,
-        agentId: heartbeatRuns.agentId,
-        failureReason: heartbeatRuns.errorCode,
-        createdAt: heartbeatRuns.createdAt,
-        retryOfRunId: heartbeatRuns.retryOfRunId,
-      })
-      .from(heartbeatRuns)
-      .where(and(...whereClauses));
-
-    const total = runs.length;
-
     let groups: Array<{ key: string; count: number }> | undefined;
+    let total = 0;
     if (groupBy) {
-      const counts = new Map<string, number>();
-      for (const run of runs) {
-        let key = "";
-        if (groupBy === "agentId") key = run.agentId;
-        if (groupBy === "failureReason") key = run.failureReason ?? "none";
-        if (groupBy === "day") key = (run.createdAt ?? new Date(0)).toISOString().slice(0, 10);
-        counts.set(key, (counts.get(key) ?? 0) + 1);
-      }
-      groups = Array.from(counts.entries()).map(([key, count]) => ({ key, count })).sort((a, b) => b.count - a.count);
-    }
-
-    const retrySourceRunIds = [...new Set(runs.map((run) => run.retryOfRunId).filter((id): id is string => Boolean(id)))];
-    let topRecoverySources: Array<{ identifier: string; count: number }> = [];
-    if (retrySourceRunIds.length > 0) {
-      const sourceRuns = await db
+      const groupKeyExpr = groupBy === "agentId"
+        ? heartbeatRuns.agentId
+        : groupBy === "failureReason"
+          ? sql<string>`coalesce(${heartbeatRuns.errorCode}, 'none')`
+          : sql<string>`to_char(${heartbeatRuns.createdAt} at time zone 'UTC', 'YYYY-MM-DD')`;
+      const groupedRows = await db
         .select({
-          id: heartbeatRuns.id,
-          issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
+          key: groupKeyExpr,
+          count: sql<number>`count(*)::int`,
         })
         .from(heartbeatRuns)
-        .where(inArray(heartbeatRuns.id, retrySourceRunIds));
-
-      const issueIds = [...new Set(sourceRuns.map((row) => row.issueId).filter((id): id is string => Boolean(id)))];
-      const issueRows = issueIds.length > 0
-        ? await db.select({ id: issuesTable.id, identifier: issuesTable.identifier }).from(issuesTable).where(
-          and(eq(issuesTable.companyId, companyId), inArray(issuesTable.id, issueIds)),
-        )
-        : [];
-      const issueIdentifierById = new Map(issueRows.map((row) => [row.id, row.identifier]));
-      const sourceIssueIdByRunId = new Map(sourceRuns.map((row) => [row.id, row.issueId]));
-
-      const counts = new Map<string, number>();
-      for (const run of runs) {
-        if (!run.retryOfRunId) continue;
-        const sourceIssueId = sourceIssueIdByRunId.get(run.retryOfRunId);
-        if (!sourceIssueId) continue;
-        const identifier = issueIdentifierById.get(sourceIssueId);
-        if (!identifier) continue;
-        counts.set(identifier, (counts.get(identifier) ?? 0) + 1);
-      }
-
-      topRecoverySources = Array.from(counts.entries())
-        .map(([identifier, count]) => ({ identifier, count }))
-        .sort((a, b) => b.count - a.count)
-        .slice(0, 5);
+        .where(and(...whereClauses))
+        .groupBy(groupKeyExpr)
+        .orderBy(desc(sql`count(*)`));
+      groups = groupedRows.map((row) => ({ key: row.key, count: Number(row.count ?? 0) }));
+      total = groups.reduce((sum, row) => sum + row.count, 0);
+    } else {
+      const [totalRow] = await db
+        .select({
+          count: sql<number>`count(*)::int`,
+        })
+        .from(heartbeatRuns)
+        .where(and(...whereClauses));
+      total = Number(totalRow?.count ?? 0);
     }
+
+    const sourceRuns = alias(heartbeatRuns, "source_runs");
+    const topRecoverySourceRows = await db
+      .select({
+        identifier: issuesTable.identifier,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(heartbeatRuns)
+      .innerJoin(sourceRuns, eq(heartbeatRuns.retryOfRunId, sourceRuns.id))
+      .innerJoin(
+        issuesTable,
+        and(
+          eq(issuesTable.companyId, companyId),
+          sql`${sourceRuns.contextSnapshot} ->> 'issueId' = cast(${issuesTable.id} as text)`,
+        ),
+      )
+      .where(and(...whereClauses, sql`${heartbeatRuns.retryOfRunId} is not null`))
+      .groupBy(issuesTable.identifier)
+      .orderBy(desc(sql`count(*)`))
+      .limit(5);
+    const topRecoverySources = topRecoverySourceRows.map((row) => ({
+      identifier: row.identifier,
+      count: Number(row.count ?? 0),
+    }));
 
     res.json({
       window: {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -116,6 +116,7 @@ function readLiveRunsQueryInt(value: unknown, max: number, fallback = 0) {
 function parseIsoTimestamp(value: string | undefined): Date | null {
   if (!value) return null;
   if (!value.includes("T")) return null;
+  if (!/(Z|[+-]\d{2}:\d{2})$/.test(value)) return null;
   const parsed = new Date(value);
   return Number.isNaN(parsed.getTime()) ? null : parsed;
 }


### PR DESCRIPTION
## Summary\n- add GET /api/companies/:companyId/runs/stats in agent routes\n- validate since/until/groupBy query params and enforce company auth scope\n- add conservative in-memory rate limiting (30 req/min per actor+company)\n- aggregate total, optional groups (agentId/failureReason/day), and top 5 recovery source issue identifiers\n- document endpoint usage in doc/runs-stats-api.md\n\n## Tests\n- pnpm exec vitest server/src/__tests__/agent-live-run-routes.test.ts\n