### PR TITLE
docs(skill/paperclip): omit X-Paperclip-Run-Id header when env var is unset

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -21,7 +21,9 @@ Some adapters also inject `PAPERCLIP_WAKE_PAYLOAD_JSON` on comment-driven wakes.
 
 Manual local CLI mode (outside heartbeat runs): use `paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>` to install Paperclip skills for Claude/Codex and print/export the required `PAPERCLIP_*` environment variables for that agent identity.
 
-**Run audit trail:** You MUST include `-H 'X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID'` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
+**Run audit trail (conditional):** If `$PAPERCLIP_RUN_ID` is set in your environment (verify with `printenv PAPERCLIP_RUN_ID`), you MUST include `-H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID"` on ALL API requests that modify issues (checkout, update, comment, create subtask, release). This links your actions to the current heartbeat run for traceability.
+
+**If `$PAPERCLIP_RUN_ID` is NOT set** (printenv returns nothing — for example, you are in a direct chat/Telegram session or other non-Paperclip-wake context where the harness did not inject heartbeat env vars): OMIT the `X-Paperclip-Run-Id` header entirely. Do NOT invent a value, do NOT compose one from message ids, timestamps, session ids, or other strings. The server requires a real UUID for that header and will return `500 invalid input syntax for type uuid` on anything else (because `activity_log.run_id` has a foreign-key constraint to `heartbeat_runs.id`). An absent header is the correct fallback — `activity_log.run_id` will be `NULL`, the request itself will succeed, and your action will simply not be cross-linked to a heartbeat run.
 
 ## The Heartbeat Procedure
 
@@ -53,7 +55,7 @@ Overrides and special cases:
 - **Blocked-task dedup:** before touching a `blocked` task, check the thread. If your most recent comment was a blocked-status update and no one has replied since, skip entirely — do not checkout, do not re-comment. Only re-engage on new context (comment, status change, event wake).
 - Nothing assigned and no valid mention handoff → exit the heartbeat.
 
-**Step 5 — Checkout.** You MUST checkout before doing any work. Include the run ID header:
+**Step 5 — Checkout.** You MUST checkout before doing any work. Include the run ID header **only when `$PAPERCLIP_RUN_ID` is set** (see "Run audit trail" above):
 
 ```
 POST /api/issues/{issueId}/checkout

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -59,7 +59,9 @@ Overrides and special cases:
 
 ```
 POST /api/issues/{issueId}/checkout
-Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+Headers:
+  Authorization: Bearer $PAPERCLIP_API_KEY
+  X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID   # only if $PAPERCLIP_RUN_ID is set; OMIT this line entirely when unset — do NOT invent a value
 { "agentId": "{your-agent-id}", "expectedStatuses": ["todo", "backlog", "blocked", "in_review"] }
 ```
 
@@ -95,14 +97,15 @@ If `currentParticipant` does not match you, do not try to advance the stage — 
 - If blocked, move the issue to `blocked` with the unblock owner and exact action needed.
 - Respect budget, pause/cancel, approval gates, execution policy stages, and company boundaries.
 
-**Step 8 — Update status and communicate.** Always include the run ID header.
-If you are blocked at any point, you MUST update the issue to `blocked` before exiting the heartbeat, with a comment that explains the blocker and who needs to act.
+**Step 8 — Update status and communicate.** Include the run ID header **only when `$PAPERCLIP_RUN_ID` is set** (same conditional rule as Step 5; see "Run audit trail" above). If you are blocked at any point, you MUST update the issue to `blocked` before exiting the heartbeat, with a comment that explains the blocker and who needs to act.
 
 When writing issue descriptions or comments, follow the ticket-linking rule in **Comment Style** below.
 
 ```json
 PATCH /api/issues/{issueId}
-Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+Headers:
+  Authorization: Bearer $PAPERCLIP_API_KEY
+  X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID   # only if $PAPERCLIP_RUN_ID is set; OMIT this line entirely when unset — do NOT invent a value
 { "status": "done", "comment": "What was done and why." }
 ```
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The agent-side `skills/paperclip/SKILL.md` is the prose contract that LLM agents follow when they call the API
> - Production agents woken outside a heartbeat (interactive Telegram chat sessions, direct chat, custom adapters) inherit the skill but do not get `PAPERCLIP_*` env vars injected
> - The skill's previous wording said agents "MUST include `X-Paperclip-Run-Id`" without qualifying it, so agents reading literally either sent an empty header or synthesized a non-UUID string from contextual ids (e.g. `telegram-{messageId}-{timestamp}`); both forms hit `invalid input syntax for type uuid` at the activity-log insert and surface as opaque 500s with empty bodies, then retried, stalling
> - The server already supports the absent-header path: `server/src/middleware/auth.ts` reads the header optionally in all four auth branches and writes `activity_log.run_id = NULL`, which the schema permits
> - This pull request narrows the skill prose so agents include the header only when `$PAPERCLIP_RUN_ID` is actually set, and explicitly forbids inventing values
> - The benefit is that agents in non-heartbeat contexts get successful 201s with `activity_log.run_id` simply unlinked, rather than 500-loop on a UUID FK violation

## What Changed

- `skills/paperclip/SKILL.md` — Authentication section gains a "Run audit trail (conditional)" subsection that splits the rule into the env-set path (include header) and the env-unset path (OMIT header, do not invent a value, server returns the documented 500 on a non-UUID).
- `skills/paperclip/SKILL.md` — Step 5 (Checkout) prose is now "only when `$PAPERCLIP_RUN_ID` is set", and the code block annotates the header line with the conditional + an explicit warning against inventing a value.
- `skills/paperclip/SKILL.md` — Step 8 (Update status) prose drops the absolute "Always include the run ID header" and references the Step 5 rule; the PATCH example mirrors the same conditional annotation as Step 5.
- No server change. Behavior on the server side is already what we want — the skill prose is the only thing that was misleading agents.

## Verification

Doc-only change (skill prose). Manually verified end-to-end against a running Paperclip 2026.5.x instance:

```
# Without env var (agent in a non-heartbeat session)
$ printenv PAPERCLIP_RUN_ID
$ curl -sS -H "Authorization: Bearer $KEY" \
       -d '{"title":"test","priority":"low","assigneeAgentId":"..."}' \
       http://127.0.0.1:3100/api/companies/{id}/issues | jq '.identifier'
"PER-123"   # 201 Created, activity_log.run_id = NULL

# With env var set to a real heartbeat run UUID — unchanged behavior
$ export PAPERCLIP_RUN_ID=20e28f9d-fb9b-4c06-88d6-41e383ace97f
$ curl -sS -H "Authorization: Bearer $KEY" \
       -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
       -d '...' http://127.0.0.1:3100/api/companies/{id}/issues
# 201 Created, activity_log.run_id linked to the heartbeat run as before
```

Reviewed `server/src/middleware/auth.ts` to confirm all four auth branches (`session`, `board_key`, `agent_jwt`, `agent_apikey`) already pass `runIdHeader ?? undefined` through to `logActivity({ runId: input.runId ?? null, ... })`.

## Risks

- Low. Doc-only change to agent-facing prose; no server, schema, or migration changes.
- Behavioral shift: agents in non-heartbeat contexts will now write `activity_log` rows with `run_id = NULL`. The schema column is already nullable and existing dashboards / queries should handle it; the alternative was the 500-loop they were already producing, so the change is strictly an improvement on the prior path.
- Existing heartbeat agents are unchanged — when `$PAPERCLIP_RUN_ID` is set, the header is still mandatory.

## Model Used

- Provider/model: Anthropic Claude Opus 4.7 (`claude-opus-4-7`)
- Context window: 1M
- Mode: extended-thinking with tool use (file read, code search, API calls)
- Acting as a coding agent through the OpenClaw Claude Code CLI

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass _(doc-only change; no test impact)_
- [x] I have added or updated tests where applicable _(N/A — prose-only)_
- [x] If this change affects the UI, I have included before/after screenshots _(N/A — no UI)_
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge _(addressed in commit 38ccebb — Step 5 code block + Step 8 prose+example)_
