### PR TITLE
Control plane: vestigial issue retry suppression (PRO-2884)

### DIFF
--- a/packages/db/src/migrations/0076_vestigial_issue_suppression.sql
+++ b/packages/db/src/migrations/0076_vestigial_issue_suppression.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "superseded_by_id" uuid REFERENCES "issues"("id");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1777572332006,
       "tag": "0075_cultured_sebastian_shaw",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1777884694701,
+      "tag": "0076_vestigial_issue_suppression",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -27,6 +27,7 @@ export const issues = pgTable(
     projectWorkspaceId: uuid("project_workspace_id").references(() => projectWorkspaces.id, { onDelete: "set null" }),
     goalId: uuid("goal_id").references(() => goals.id),
     parentId: uuid("parent_id").references((): AnyPgColumn => issues.id),
+    supersededById: uuid("superseded_by_id").references((): AnyPgColumn => issues.id),
     title: text("title").notNull(),
     description: text("description"),
     status: text("status").notNull().default("backlog"),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -127,6 +127,7 @@ import {
 } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
 import { recoveryService } from "./recovery/service.js";
+import { checkVestigialIssue } from "./recovery/vestigial.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
 import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.js";
@@ -4650,6 +4651,35 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
+
+    if (issueId) {
+      const issueRecord = await db
+        .select()
+        .from(issues)
+        .where(and(eq(issues.companyId, run.companyId), eq(issues.id, issueId)))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (issueRecord) {
+        const vestigialDetection = await checkVestigialIssue(db, issueRecord);
+        if (vestigialDetection) {
+          await appendRunEvent(run, await nextRunEventSeq(run.id), {
+            eventType: "vestigial_issue_detected",
+            stream: "system",
+            level: "warn",
+            message: `Vestigial issue suppressed before retry: ${vestigialDetection.reason}`,
+            payload: { issueId, ...vestigialDetection.details },
+          });
+          await issuesSvc.update(issueId, { status: "cancelled" });
+          return {
+            outcome: "not_scheduled" as const,
+            reason: `Vestigial issue: ${vestigialDetection.reason}`,
+            errorCode: "issue_cancelled" as const,
+            issueId,
+          };
+        }
+      }
+    }
+
     if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON) {
       const gate = await evaluateScheduledRetryGate({ run, agent, contextSnapshot, retryReason });
       if (!gate.allowed) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1421,6 +1421,7 @@ const issueListSelect = {
   requestDepth: issues.requestDepth,
   billingCode: issues.billingCode,
   assigneeAdapterOverrides: issues.assigneeAdapterOverrides,
+  supersededById: issues.supersededById,
   executionPolicy: sql<null>`null`,
   executionState: sql<null>`null`,
   monitorNextCheckAt: issues.monitorNextCheckAt,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -38,6 +38,7 @@ import {
   isStrandedIssueRecoveryOriginKind,
   parseIssueGraphLivenessIncidentKey,
 } from "./origins.js";
+import { checkVestigialIssue, type VestigialDetectionResult } from "./vestigial.js";
 import {
   classifyIssueGraphLiveness,
   type IssueLivenessFinding,
@@ -1577,6 +1578,47 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return updated;
   }
 
+  async function suppressVestigialIssue(input: {
+    issue: typeof issues.$inferSelect;
+    latestRun: LatestIssueRun;
+    detection: VestigialDetectionResult;
+  }) {
+    logger.warn(
+      {
+        issueId: input.issue.id,
+        companyId: input.issue.companyId,
+        vestigialReason: input.detection.reason,
+        vestigialDetails: input.detection.details,
+      },
+      "vestigial_issue_detected",
+    );
+
+    if (input.latestRun) {
+      const [seqRow] = await db
+        .select({ maxSeq: sql<number | null>`MAX(${heartbeatRunEvents.seq})` })
+        .from(heartbeatRunEvents)
+        .where(eq(heartbeatRunEvents.runId, input.latestRun.id));
+      const seq = Number(seqRow?.maxSeq ?? 0) + 1;
+
+      await db.insert(heartbeatRunEvents).values({
+        companyId: input.issue.companyId,
+        runId: input.latestRun.id,
+        agentId: input.latestRun.agentId,
+        seq,
+        eventType: "vestigial_issue_detected",
+        stream: "system",
+        level: "warn",
+        message: `Vestigial issue suppressed: ${input.detection.reason}`,
+        payload: {
+          issueId: input.issue.id,
+          ...input.detection.details,
+        },
+      });
+    }
+
+    await issuesSvc.update(input.issue.id, { status: "cancelled" });
+  }
+
   async function reconcileStrandedAssignedIssues() {
     const candidates = await db
       .select()
@@ -1597,6 +1639,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulContinuationObserved: 0,
       orphanBlockersAssigned: 0,
       escalated: 0,
+      vestigialSuppressed: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
@@ -1625,6 +1668,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
+
+      const vestigialDetection = await checkVestigialIssue(db, issue);
+      if (vestigialDetection) {
+        await suppressVestigialIssue({ issue, latestRun, detection: vestigialDetection });
+        result.vestigialSuppressed += 1;
+        result.issueIds.push(issue.id);
+        continue;
+      }
+
       if (isStrandedIssueRecoveryIssue(issue) && isUnsuccessfulTerminalIssueRun(latestRun)) {
         const updated = await escalateStrandedRecoveryIssueInPlace({
           issue,

--- a/server/src/services/recovery/vestigial.ts
+++ b/server/src/services/recovery/vestigial.ts
@@ -1,0 +1,99 @@
+import { and, eq, isNull } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issues } from "@paperclipai/db";
+
+export type VestigialReason = "parent_cancelled" | "superseded" | "duplicate_resolved";
+
+export interface VestigialDetectionResult {
+  reason: VestigialReason;
+  details: Record<string, unknown>;
+}
+
+/**
+ * Checks whether an issue is effectively dead work and should not be retried.
+ *
+ * Three signals are evaluated in order:
+ *   1. Cancelled parent — parent issue has status `cancelled`.
+ *   2. Superseded — the issue's `supersededById` points to a `done` issue.
+ *   3. Fingerprint dedup — another `done` issue shares the same `originFingerprint`
+ *      in the same (companyId, projectId, goalId) scope.
+ *
+ * Returns the first matching signal, or null if the issue is not vestigial.
+ */
+export async function checkVestigialIssue(
+  db: Db,
+  issue: typeof issues.$inferSelect,
+): Promise<VestigialDetectionResult | null> {
+  // Check 1: cancelled parent
+  if (issue.parentId) {
+    const parent = await db
+      .select({ id: issues.id, status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issue.parentId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (parent?.status === "cancelled") {
+      return {
+        reason: "parent_cancelled",
+        details: { parentId: issue.parentId },
+      };
+    }
+  }
+
+  // Check 2: superseded by a done issue
+  if (issue.supersededById) {
+    const superseder = await db
+      .select({ id: issues.id, status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issue.supersededById))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (superseder?.status === "done") {
+      return {
+        reason: "superseded",
+        details: { supersededById: issue.supersededById },
+      };
+    }
+  }
+
+  // Check 3: fingerprint dedup — another done issue with the same origin fingerprint
+  // in the same (projectId, goalId) scope. Skip if fingerprint is the default sentinel
+  // or if the issue has no project/goal scope.
+  if (
+    issue.originFingerprint !== "default" &&
+    (issue.projectId !== null || issue.goalId !== null)
+  ) {
+    const duplicate = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, issue.companyId),
+          eq(issues.originFingerprint, issue.originFingerprint),
+          eq(issues.status, "done"),
+          // NULL-safe equality for projectId scope
+          issue.projectId !== null
+            ? eq(issues.projectId, issue.projectId)
+            : isNull(issues.projectId),
+          // NULL-safe equality for goalId scope
+          issue.goalId !== null
+            ? eq(issues.goalId, issue.goalId)
+            : isNull(issues.goalId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    // The stalled issue is never `done`, so any match is a distinct duplicate.
+    if (duplicate) {
+      return {
+        reason: "duplicate_resolved",
+        details: {
+          duplicateIssueId: duplicate.id,
+          originFingerprint: issue.originFingerprint,
+        },
+      };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Fixes the root cause of the PRO-2823 incident: stranded-issue recovery (PRO-2854) retried a stalled duplicate after PRO-2844 had already completed the same work, eventually causing a 32MB payload rejection.

Adds a **vestigial issue check** that runs before any retry attempt in two places:
1. `reconcileStrandedAssignedIssues()` in `recovery/service.ts` — the periodic stranded-issue sweep
2. `scheduleBoundedRetryForRun()` in `heartbeat.ts` — the bounded-retry path for max-turn exhaustion and transient failures

**Three signals are evaluated in order before any retry:**

| Signal | Condition | Cancel reason |
|--------|-----------|---------------|
| Cancelled parent | `parentId` is set and parent `status = cancelled` | `parent_cancelled` |
| Superseded | `supersededById` points to a `done` issue | `superseded` |
| Fingerprint dedup | Another `done` issue shares the same `originFingerprint` in the same `(companyId, projectId, goalId)` scope | `duplicate_resolved` |

On any positive match, a `vestigial_issue_detected` event is written to `heartbeat_run_events` (if a prior run exists) and to the application logger, then the issue is cancelled.

## Changes

- **`packages/db/src/schema/issues.ts`** — adds nullable `supersededById` FK for the superseded signal
- **`packages/db/src/migrations/0076_vestigial_issue_suppression.sql`** — migration for `superseded_by_id` column
- **`server/src/services/recovery/vestigial.ts`** — new standalone `checkVestigialIssue(db, issue)` function imported by both service files
- **`server/src/services/recovery/service.ts`** — adds `suppressVestigialIssue()` helper and integrates the check in `reconcileStrandedAssignedIssues()`; adds `vestigialSuppressed` counter to reconcile result
- **`server/src/services/heartbeat.ts`** — integrates the check in `scheduleBoundedRetryForRun()`, returning `{ outcome: "not_scheduled", errorCode: "issue_cancelled" }` on detection

## Test plan

- [ ] Normal retries on healthy issues are unaffected (no regression)
- [ ] Stranded issue with cancelled parent → cancelled with `vestigial_issue_detected` event, no retry enqueued
- [ ] Stranded issue with `supersededById` pointing to done issue → cancelled with `vestigial_issue_detected` event
- [ ] Stranded issue with matching `originFingerprint` in same project/goal where another issue is done → cancelled with `vestigial_issue_detected` event
- [ ] `scheduleBoundedRetryForRun` returns `not_scheduled / issue_cancelled` on vestigial detection
- [ ] `vestigial_issue_detected` appears in `heartbeat_run_events` with correct payload

Ref: PRO-2884 / Incident: PRO-2823

🤖 Generated with [Claude Code](https://claude.com/claude-code)