### PR TITLE
Fix Issues page silently truncating to wrong sort once company exceeds page size

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1003,6 +1003,21 @@ export function issueRoutes(
     }
     const offset = parsedOffset ?? 0;
 
+    const ISSUE_LIST_SORT_FIELDS = ["created", "updated", "priority", "status", "title"] as const;
+    type IssueListSortFieldQuery = (typeof ISSUE_LIST_SORT_FIELDS)[number];
+    const rawSortField = typeof req.query.sortField === "string" ? req.query.sortField : undefined;
+    const rawSortDir = typeof req.query.sortDir === "string" ? req.query.sortDir : undefined;
+    if (rawSortField !== undefined && !ISSUE_LIST_SORT_FIELDS.includes(rawSortField as IssueListSortFieldQuery)) {
+      res.status(400).json({ error: `sortField must be one of: ${ISSUE_LIST_SORT_FIELDS.join(", ")}` });
+      return;
+    }
+    if (rawSortDir !== undefined && rawSortDir !== "asc" && rawSortDir !== "desc") {
+      res.status(400).json({ error: "sortDir must be 'asc' or 'desc'" });
+      return;
+    }
+    const sortField = rawSortField as IssueListSortFieldQuery | undefined;
+    const sortDir = rawSortDir as "asc" | "desc" | undefined;
+
     const result = await svc.list(companyId, {
       status: req.query.status as string | undefined,
       assigneeAgentId: req.query.assigneeAgentId as string | undefined,
@@ -1027,6 +1042,8 @@ export function issueRoutes(
       q: req.query.q as string | undefined,
       limit,
       offset,
+      sortField,
+      sortDir,
     });
     res.json(result);
   });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -106,6 +106,9 @@ function buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(
   };
 }
 
+export type IssueListSortField = "created" | "updated" | "priority" | "status" | "title";
+export type IssueListSortDir = "asc" | "desc";
+
 export interface IssueFilters {
   status?: string;
   assigneeAgentId?: string;
@@ -128,6 +131,8 @@ export interface IssueFilters {
   q?: string;
   limit?: number;
   offset?: number;
+  sortField?: IssueListSortField;
+  sortDir?: IssueListSortDir;
 }
 
 type IssueRow = typeof issues.$inferSelect;
@@ -2220,6 +2225,7 @@ export function issueService(db: Db) {
       conditions.push(isNull(issues.hiddenAt));
 
       const priorityOrder = sql`CASE ${issues.priority} WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 3 ELSE 4 END`;
+      const statusOrder = sql`CASE ${issues.status} WHEN 'in_progress' THEN 0 WHEN 'todo' THEN 1 WHEN 'backlog' THEN 2 WHEN 'in_review' THEN 3 WHEN 'blocked' THEN 4 WHEN 'done' THEN 5 WHEN 'cancelled' THEN 6 ELSE 7 END`;
       const searchOrder = sql<number>`
         CASE
           WHEN ${titleStartsWithMatch} THEN 0
@@ -2232,12 +2238,29 @@ export function issueService(db: Db) {
         END
       `;
       const canonicalLastActivityAt = issueCanonicalLastActivityAtExpr(companyId);
+
+      // Build order. When the caller passes an explicit sortField the chosen
+      // column is primary; the server's traditional priority+activity order
+      // becomes a tie-breaker. Without an explicit sort we keep the old default.
+      const dir = filters?.sortDir === "asc" ? asc : desc;
+      const requestedPrimary = (() => {
+        switch (filters?.sortField) {
+          case "created": return dir(issues.createdAt);
+          case "updated": return dir(issues.updatedAt);
+          case "priority": return filters?.sortDir === "desc" ? desc(priorityOrder) : asc(priorityOrder);
+          case "status": return filters?.sortDir === "desc" ? desc(statusOrder) : asc(statusOrder);
+          case "title": return dir(issues.title);
+          default: return null;
+        }
+      })();
       const baseQuery = db
         .select(issueListSelect)
         .from(issues)
         .where(and(...conditions))
         .orderBy(
-          hasSearch ? asc(searchOrder) : asc(priorityOrder),
+          ...(requestedPrimary
+            ? [requestedPrimary]
+            : [hasSearch ? asc(searchOrder) : asc(priorityOrder)]),
           asc(priorityOrder),
           desc(canonicalLastActivityAt),
           desc(issues.updatedAt),

--- a/ui/src/api/issues.ts
+++ b/ui/src/api/issues.ts
@@ -50,6 +50,8 @@ export const issuesApi = {
       q?: string;
       limit?: number;
       offset?: number;
+      sortField?: "created" | "updated" | "priority" | "status" | "title";
+      sortDir?: "asc" | "desc";
     },
   ) => {
     const params = new URLSearchParams();
@@ -73,6 +75,8 @@ export const issuesApi = {
     if (filters?.q) params.set("q", filters.q);
     if (filters?.limit) params.set("limit", String(filters.limit));
     if (filters?.offset !== undefined) params.set("offset", String(filters.offset));
+    if (filters?.sortField) params.set("sortField", filters.sortField);
+    if (filters?.sortDir) params.set("sortDir", filters.sortDir);
     const qs = params.toString();
     return api.get<Issue[]>(`/companies/${companyId}/issues${qs ? `?${qs}` : ""}`);
   },

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -144,6 +144,11 @@ function getViewState(key: string): IssueViewState {
 
 function saveViewState(key: string, state: IssueViewState) {
   localStorage.setItem(key, JSON.stringify(state));
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent("paperclip:issue-view-state-changed", { detail: { key } }),
+    );
+  }
 }
 
 function getInitialViewState(

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -144,11 +144,9 @@ function getViewState(key: string): IssueViewState {
 
 function saveViewState(key: string, state: IssueViewState) {
   localStorage.setItem(key, JSON.stringify(state));
-  if (typeof window !== "undefined") {
-    window.dispatchEvent(
-      new CustomEvent("paperclip:issue-view-state-changed", { detail: { key } }),
-    );
-  }
+  window.dispatchEvent(
+    new CustomEvent("paperclip:issue-view-state-changed", { detail: { key } }),
+  );
 }
 
 function getInitialViewState(

--- a/ui/src/components/transcript/useLiveRunTranscripts.ts
+++ b/ui/src/components/transcript/useLiveRunTranscripts.ts
@@ -113,6 +113,7 @@ export function useLiveRunTranscripts({
   const pendingLogRowsByRunRef = useRef(new Map<string, string>());
   const logOffsetByRunRef = useRef(new Map<string, number>());
   const missingTerminalLogRunIdsRef = useRef(new Set<string>());
+  const log404CountByRunRef = useRef(new Map<string, number>());
   const transcriptCacheRef = useRef(new Map<string, {
     adapterType: string;
     chunks: RunLogChunk[];
@@ -200,6 +201,11 @@ export function useLiveRunTranscripts({
         missingTerminalLogRunIdsRef.current.delete(runId);
       }
     }
+    for (const runId of log404CountByRunRef.current.keys()) {
+      if (!knownRunIds.has(runId)) {
+        log404CountByRunRef.current.delete(runId);
+      }
+    }
     for (const runId of transcriptCacheRef.current.keys()) {
       if (!knownRunIds.has(runId)) {
         transcriptCacheRef.current.delete(runId);
@@ -222,6 +228,7 @@ export function useLiveRunTranscripts({
         if (cancelled) return;
 
         appendChunks(run.id, parsePersistedLogContent(run.id, result.content, pendingLogRowsByRunRef.current));
+        log404CountByRunRef.current.delete(run.id);
 
         if (result.nextOffset !== undefined) {
           logOffsetByRunRef.current.set(run.id, result.nextOffset);
@@ -231,8 +238,19 @@ export function useLiveRunTranscripts({
           logOffsetByRunRef.current.set(run.id, offset + result.content.length);
         }
       } catch (error) {
-        if (error instanceof ApiError && error.status === 404 && isTerminalStatus(run.status)) {
-          missingTerminalLogRunIdsRef.current.add(run.id);
+        if (error instanceof ApiError && error.status === 404) {
+          if (isTerminalStatus(run.status)) {
+            missingTerminalLogRunIdsRef.current.add(run.id);
+          } else {
+            // Non-terminal runs sometimes 404 transiently while the log file
+            // is being created. Tolerate a few then give up so phantom runs
+            // (server forgot the log) don't generate an infinite poll storm.
+            const next = (log404CountByRunRef.current.get(run.id) ?? 0) + 1;
+            log404CountByRunRef.current.set(run.id, next);
+            if (next >= 3) {
+              missingTerminalLogRunIdsRef.current.add(run.id);
+            }
+          }
         }
       } finally {
         if (!cancelled) {

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -18,6 +18,58 @@ import type { Issue } from "@paperclipai/shared";
 const WORKSPACE_FILTER_ISSUE_LIMIT = 1000;
 const ISSUES_PAGE_SIZE = 500;
 
+const ISSUE_SERVER_SORT_FIELDS = new Set(["created", "updated", "priority", "status", "title"] as const);
+type IssueServerSortField = "created" | "updated" | "priority" | "status" | "title";
+type IssueServerSort = { sortField: IssueServerSortField; sortDir: "asc" | "desc" };
+
+export const ISSUE_VIEW_STATE_CHANGE_EVENT = "paperclip:issue-view-state-changed";
+
+function readPersistedIssueSort(key: string): IssueServerSort | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { sortField?: unknown; sortDir?: unknown };
+    if (typeof parsed?.sortField !== "string") return null;
+    if (!ISSUE_SERVER_SORT_FIELDS.has(parsed.sortField as IssueServerSortField)) return null;
+    if (parsed.sortDir !== "asc" && parsed.sortDir !== "desc") return null;
+    return { sortField: parsed.sortField as IssueServerSortField, sortDir: parsed.sortDir };
+  } catch {
+    return null;
+  }
+}
+
+function usePersistedIssueSort(key: string | null): IssueServerSort | null {
+  const [snapshot, setSnapshot] = useState<IssueServerSort | null>(
+    () => (key ? readPersistedIssueSort(key) : null),
+  );
+  useEffect(() => {
+    if (!key) {
+      setSnapshot(null);
+      return;
+    }
+    setSnapshot(readPersistedIssueSort(key));
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ key?: string }>).detail;
+      if (detail?.key === key) {
+        setSnapshot(readPersistedIssueSort(key));
+      }
+    };
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === key) {
+        setSnapshot(readPersistedIssueSort(key));
+      }
+    };
+    window.addEventListener(ISSUE_VIEW_STATE_CHANGE_EVENT, onChange);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(ISSUE_VIEW_STATE_CHANGE_EVENT, onChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [key]);
+  return snapshot;
+}
+
 export function getNextIssuesPageOffset(
   loadedPageSize: number,
   currentOffset: number,
@@ -121,6 +173,11 @@ export function Issues() {
 
   const issuePageSize = workspaceIdFilter ? WORKSPACE_FILTER_ISSUE_LIMIT : ISSUES_PAGE_SIZE;
 
+  const issueViewStateKey = selectedCompanyId
+    ? `paperclip:issues-view:${selectedCompanyId}`
+    : null;
+  const persistedSort = usePersistedIssueSort(issueViewStateKey);
+
   const {
     data: issuePages,
     isLoading,
@@ -138,6 +195,9 @@ export function Issues() {
       "with-routine-executions",
       "infinite",
       issuePageSize,
+      "sort",
+      persistedSort?.sortField ?? "__default__",
+      persistedSort?.sortDir ?? "__default__",
     ],
     queryFn: ({ pageParam }) => issuesApi.list(selectedCompanyId!, {
       participantAgentId,
@@ -145,6 +205,8 @@ export function Issues() {
       includeRoutineExecutions: true,
       limit: issuePageSize,
       offset: pageParam,
+      sortField: persistedSort?.sortField,
+      sortDir: persistedSort?.sortDir,
     }),
     initialPageParam: 0,
     getNextPageParam: (lastPage, _allPages, lastPageParam) =>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Humans (and agents) browse the work via the Issues page, which is the day-to-day surface for triaging and routing tickets
> - The Issues page lets users pick a sort field (Created / Updated / Status / Priority / Title), assuming the top of the list reflects that choice
> - But once a company exceeds the 500-row server page size, the server's hardcoded `priority + lastActivityAt DESC` order decides what's *in* page 0 — the client-side sort only re-arranges that subset
> - For active companies, agents bumping `lastActivityAt` on already-done issues kept Done dominating page 0, so newly-created in-progress tickets landed on page 1+ and silently disappeared from view until pagination caught up
> - At the same time, the live-run log fetcher was 404-looping forever on phantom non-terminal runs, pegging the main thread and making the page feel frozen — masking the pagination problem and amplifying its impact
> - This pull request forwards the user's sort preference to the server so page 0 actually contains what the user asked for, and stops the log-fetch retry storm so the page renders responsively
> - The benefit is the Issues page stops silently lying about its order at scale, and the worst-offender phantom-run pattern stops eating CPU on every visit

## What Changed

- **Server**: `IssueFilters` accepts `sortField` (`created` | `updated` | `priority` | `status` | `title`) and `sortDir` (`asc` | `desc`); when present, the requested column becomes the primary `ORDER BY`, with the existing priority+activity ordering preserved as a tie-breaker (and as the default when no sort is requested, so behavior is unchanged for callers that don't pass the new params).
- **Server route**: `GET /companies/:companyId/issues` validates `sortField` / `sortDir` against an allowlist and returns 400 on unknown values.
- **UI API client**: `issuesApi.list` adds and serializes the new fields.
- **`Issues.tsx`**: new `usePersistedIssueSort` hook reads the persisted view-state (`paperclip:issues-view:<companyId>`), subscribes to a custom event for same-tab updates and a `storage` event for cross-tab updates; the values feed both the `useInfiniteQuery` query key and the API call so a sort change refetches from offset 0 with the new order.
- **`IssuesList.saveViewState`**: dispatches `paperclip:issue-view-state-changed` after writing localStorage so the parent page reacts without lifting state up.
- **Log-fetch retry storm fix**: in `useLiveRunTranscripts`, a per-run consecutive-404 counter is added; after 3 strikes a non-terminal run is marked missing and stops being polled. The counter clears on a successful fetch and when the run leaves the live runs list, so a freshly-created run that briefly 404s while its log file is being written still recovers.
- The `workflow` sort field is intentionally left as a client-side concern (its order depends on the loaded issue tree); for that case `sortField` is omitted on the request and the server uses its default order.

## Verification

**API checks** (with a dev server up):

```bash
# Honors the sort
curl -s "https://<host>/api/companies/<id>/issues?sortField=created&sortDir=desc&limit=5" | jq '.[].issueNumber'

# Rejects bad input
curl -s -o /dev/null -w "%{http_code}\n" "https://<host>/api/companies/<id>/issues?sortField=garbage"   # 400
curl -s -o /dev/null -w "%{http_code}\n" "https://<host>/api/companies/<id>/issues?sortDir=garbage"     # 400
```

**Manual UI**:
- Open Issues for a company with >500 issues. Confirm the highest-numbered issue is at the top with the default `Created DESC` view-state.
- Change the sort in the UI; network tab shows a fresh request with new `sortField` / `sortDir` and pagination resets to offset 0.
- Switch to the `Workflow` sort: `sortField` is *not* sent on the request and the client re-sorts the result.
- After a few seconds on the Issues page, the console no longer shows `/heartbeat-runs/<id>/log` 404s repeating forever — each phantom run stops after 3 strikes.

**Reproducer for the original bug** (before the fix):
- A company with >500 issues, default `Created DESC` UI sort, plus active agents leaving comments on Done issues. Page 0 fills with Done; new in-progress tickets only appear after pages 1–3 finish loading.

**Screenshots**: working from a headless server with no browser available — before/after screenshots are pending. They'll need to be added before merge by someone with UI access (or by me once a dev environment with a browser is available).

## Risks

- **Low risk for callers that don't pass the new params**: the server keeps its existing `ORDER BY` exactly when `sortField` is absent. All existing callers (`ProjectIssuesList`, the Inbox, exports, plugins) don't pass the new fields and remain on the current behavior.
- **Sort change forces a refetch from offset 0**: by design — the query key now includes the sort. If a user paginates deeply and then changes sort, they lose their accumulated pages. This matches user intent (sorting redefines "page 0"), but worth flagging.
- **Per-tab event dispatch**: `saveViewState` now fires a `CustomEvent`. Adds one synchronous handler invocation per save; only the Issues page listens.
- **No DB migration, no schema change**: pure query/route additions.
- **Minor possibility the 3-strike log threshold is too low** if a real active run takes >3 poll-intervals to flush its first log bytes; in practice the bytes appear within the first tick after the run starts, so 3 strikes (~15s of polling) is generous. If wrong, a freshly-started run misses log streaming until the next page reload — annoying but not data-affecting.

> Checked `ROADMAP.md` — no overlap with planned core sorting/pagination work.

## Model Used

- **Provider**: Anthropic
- **Model**: Claude Opus 4.7 (`claude-opus-4-7`)
- **Context window**: 1,000,000 tokens
- **Reasoning mode**: standard (no extended thinking)
- **Tool use**: filesystem read/write, bash, GitHub CLI
- **Harness**: Claude Code

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass *(pending — needs to run in the project's environment; no test runner invoked from the worktree)*
- [ ] I have added or updated tests where applicable *(no new tests added; existing `Issues.test.tsx` covers list merging — flag if reviewers want tests for the new sort plumbing)*
- [ ] If this change affects the UI, I have included before/after screenshots *(pending — see Verification)*
- [x] I have updated relevant documentation to reflect my changes *(no docs apply; route is self-describing via the validation error responses)*
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
