### PR TITLE
Harness: pre-send payload size gate — 20 MB hard cap (PRO-2863)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -57,6 +57,9 @@ import { prepareClaudePromptBundle } from "./prompt-cache.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
+const PAYLOAD_WARNING_BYTES = 8_388_608;   // 8 MB
+const PAYLOAD_HARD_CAP_BYTES = 20_971_520; // 20 MB
+
 interface ClaudeExecutionInput {
   runId: string;
   agent: AdapterExecutionContext["agent"];
@@ -857,6 +860,32 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   try {
+    const payloadBytes = Buffer.byteLength(prompt, "utf8");
+    if (payloadBytes >= PAYLOAD_HARD_CAP_BYTES) {
+      const structuredError = {
+        type: "payload_too_large",
+        payloadBytes,
+        thresholdBytes: PAYLOAD_HARD_CAP_BYTES,
+      };
+      await onLog(
+        "stderr",
+        `[paperclip] ${JSON.stringify({ ...structuredError, issueId: asString(context.issueId, ""), runId })}\n`,
+      );
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorCode: "payload_too_large",
+        errorMessage: JSON.stringify(structuredError),
+        resultJson: structuredError,
+      };
+    }
+    if (payloadBytes >= PAYLOAD_WARNING_BYTES) {
+      await onLog(
+        "stderr",
+        `[paperclip] ${JSON.stringify({ type: "payload_warning", payloadBytes, issueId: asString(context.issueId, ""), runId })}\n`,
+      );
+    }
     const initial = await runAttempt(sessionId ?? null);
     if (
       sessionId &&

--- a/packages/db/src/migrations/0076_vestigial_issue_suppression.sql
+++ b/packages/db/src/migrations/0076_vestigial_issue_suppression.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "superseded_by_id" uuid REFERENCES "issues"("id");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1777572332006,
       "tag": "0075_cultured_sebastian_shaw",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1777884694701,
+      "tag": "0076_vestigial_issue_suppression",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -27,6 +27,7 @@ export const issues = pgTable(
     projectWorkspaceId: uuid("project_workspace_id").references(() => projectWorkspaces.id, { onDelete: "set null" }),
     goalId: uuid("goal_id").references(() => goals.id),
     parentId: uuid("parent_id").references((): AnyPgColumn => issues.id),
+    supersededById: uuid("superseded_by_id").references((): AnyPgColumn => issues.id),
     title: text("title").notNull(),
     description: text("description"),
     status: text("status").notNull().default("backlog"),

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -1088,4 +1088,80 @@ describe("claude execute", () => {
       await fs.rm(root, { recursive: true, force: true });
     }
   });
+
+  it("aborts with payload_too_large errorCode without spawning claude when prompt exceeds 20MB", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-too-large-"));
+    const { workspace, commandPath, restore } = await setupExecuteEnv(root);
+    const capturePath = path.join(root, "capture.json");
+    try {
+      const logs: Array<{ stream: string; chunk: string }> = [];
+      const result = await execute({
+        runId: "run-too-large",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "x".repeat(21 * 1024 * 1024),
+        },
+        context: { issueId: "PRO-9999" },
+        authToken: "tok",
+        onLog: async (stream, chunk) => { logs.push({ stream, chunk }); },
+        onMeta: async () => {},
+      });
+      expect(result.errorCode).toBe("payload_too_large");
+      expect(result.exitCode).toBe(1);
+      expect(result.timedOut).toBe(false);
+      expect(result.resultJson).toMatchObject({
+        type: "payload_too_large",
+        thresholdBytes: 20971520,
+      });
+      const payloadBytes = (result.resultJson as any).payloadBytes as number;
+      expect(payloadBytes).toBeGreaterThanOrEqual(20971520);
+      await expect(fs.stat(capturePath)).rejects.toThrow();
+      const stderrChunks = logs.filter(l => l.stream === "stderr").map(l => l.chunk).join("");
+      const loggedObj = JSON.parse(stderrChunks.replace("[paperclip] ", "").trim());
+      expect(loggedObj.type).toBe("payload_too_large");
+      expect(loggedObj.payloadBytes).toBeGreaterThanOrEqual(20971520);
+      expect(loggedObj.issueId).toBe("PRO-9999");
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("emits payload_warning to stderr and proceeds normally when prompt is between 8MB and 20MB", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-exec-warn-"));
+    const { workspace, commandPath, capturePath, restore } = await setupExecuteEnv(root);
+    try {
+      const logs: Array<{ stream: string; chunk: string }> = [];
+      const result = await execute({
+        runId: "run-payload-warn",
+        agent: { id: "agent-1", companyId: "co-1", name: "Test", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: { PAPERCLIP_TEST_CAPTURE_PATH: capturePath },
+          promptTemplate: "x".repeat(9 * 1024 * 1024),
+        },
+        context: { issueId: "PRO-9998" },
+        authToken: "tok",
+        onLog: async (stream, chunk) => { logs.push({ stream, chunk }); },
+        onMeta: async () => {},
+      });
+      expect(result.errorCode).toBeUndefined();
+      expect(result.timedOut).toBe(false);
+      const stderrChunks = logs.filter(l => l.stream === "stderr").map(l => l.chunk).join("");
+      const warningLine = stderrChunks.match(/\{.*"type":"payload_warning".*\}/)?.[0];
+      expect(warningLine).toBeDefined();
+      const loggedObj = JSON.parse(warningLine!);
+      expect(loggedObj.payloadBytes).toBeGreaterThanOrEqual(8388608);
+      expect(loggedObj.payloadBytes).toBeLessThan(20971520);
+    } finally {
+      restore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7435,6 +7435,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     status: "todo" | "in_progress";
     latestRun: Pick<typeof heartbeatRuns.$inferSelect, "error" | "errorCode"> | null | undefined;
   }) {
+    if (input.latestRun?.errorCode === "payload_too_large") {
+      const failureSummary = summarizeRunFailureForIssueComment(input.latestRun);
+      return (
+        `Run aborted before dispatch: the assembled prompt payload exceeds the 20 MB hard cap.${failureSummary ?? ""} ` +
+        "No retry will be attempted. Moving issue to `blocked` for human intervention — reduce context or clear session history."
+      );
+    }
     const failureSummary = summarizeRunFailureForIssueComment(input.latestRun);
     if (input.status === "todo") {
       return (
@@ -7739,6 +7746,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       const shouldBlockImmediately =
+        run.errorCode === "payload_too_large" ||
         issue.originKind === RECOVERY_ORIGIN_KINDS.strandedIssueRecovery ||
         !recoveryAgentInvokable ||
         !recoveryAgent ||

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -127,6 +127,7 @@ import {
 } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
 import { recoveryService } from "./recovery/service.js";
+import { checkVestigialIssue } from "./recovery/vestigial.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
 import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.js";
@@ -4650,6 +4651,35 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
+
+    if (issueId) {
+      const issueRecord = await db
+        .select()
+        .from(issues)
+        .where(and(eq(issues.companyId, run.companyId), eq(issues.id, issueId)))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (issueRecord) {
+        const vestigialDetection = await checkVestigialIssue(db, issueRecord);
+        if (vestigialDetection) {
+          await appendRunEvent(run, await nextRunEventSeq(run.id), {
+            eventType: "vestigial_issue_detected",
+            stream: "system",
+            level: "warn",
+            message: `Vestigial issue suppressed before retry: ${vestigialDetection.reason}`,
+            payload: { issueId, ...vestigialDetection.details },
+          });
+          await issuesSvc.update(issueId, { status: "cancelled" });
+          return {
+            outcome: "not_scheduled" as const,
+            reason: `Vestigial issue: ${vestigialDetection.reason}`,
+            errorCode: "issue_cancelled" as const,
+            issueId,
+          };
+        }
+      }
+    }
+
     if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON) {
       const gate = await evaluateScheduledRetryGate({ run, agent, contextSnapshot, retryReason });
       if (!gate.allowed) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -38,6 +38,7 @@ import {
   isStrandedIssueRecoveryOriginKind,
   parseIssueGraphLivenessIncidentKey,
 } from "./origins.js";
+import { checkVestigialIssue, type VestigialDetectionResult } from "./vestigial.js";
 import {
   classifyIssueGraphLiveness,
   type IssueLivenessFinding,
@@ -1577,6 +1578,47 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return updated;
   }
 
+  async function suppressVestigialIssue(input: {
+    issue: typeof issues.$inferSelect;
+    latestRun: LatestIssueRun;
+    detection: VestigialDetectionResult;
+  }) {
+    logger.warn(
+      {
+        issueId: input.issue.id,
+        companyId: input.issue.companyId,
+        vestigialReason: input.detection.reason,
+        vestigialDetails: input.detection.details,
+      },
+      "vestigial_issue_detected",
+    );
+
+    if (input.latestRun) {
+      const [seqRow] = await db
+        .select({ maxSeq: sql<number | null>`MAX(${heartbeatRunEvents.seq})` })
+        .from(heartbeatRunEvents)
+        .where(eq(heartbeatRunEvents.runId, input.latestRun.id));
+      const seq = Number(seqRow?.maxSeq ?? 0) + 1;
+
+      await db.insert(heartbeatRunEvents).values({
+        companyId: input.issue.companyId,
+        runId: input.latestRun.id,
+        agentId: input.latestRun.agentId,
+        seq,
+        eventType: "vestigial_issue_detected",
+        stream: "system",
+        level: "warn",
+        message: `Vestigial issue suppressed: ${input.detection.reason}`,
+        payload: {
+          issueId: input.issue.id,
+          ...input.detection.details,
+        },
+      });
+    }
+
+    await issuesSvc.update(input.issue.id, { status: "cancelled" });
+  }
+
   async function reconcileStrandedAssignedIssues() {
     const candidates = await db
       .select()
@@ -1597,6 +1639,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulContinuationObserved: 0,
       orphanBlockersAssigned: 0,
       escalated: 0,
+      vestigialSuppressed: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
@@ -1625,6 +1668,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
+
+      const vestigialDetection = await checkVestigialIssue(db, issue);
+      if (vestigialDetection) {
+        await suppressVestigialIssue({ issue, latestRun, detection: vestigialDetection });
+        result.vestigialSuppressed += 1;
+        result.issueIds.push(issue.id);
+        continue;
+      }
+
       if (isStrandedIssueRecoveryIssue(issue) && isUnsuccessfulTerminalIssueRun(latestRun)) {
         const updated = await escalateStrandedRecoveryIssueInPlace({
           issue,

--- a/server/src/services/recovery/vestigial.ts
+++ b/server/src/services/recovery/vestigial.ts
@@ -1,0 +1,99 @@
+import { and, eq, isNull } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issues } from "@paperclipai/db";
+
+export type VestigialReason = "parent_cancelled" | "superseded" | "duplicate_resolved";
+
+export interface VestigialDetectionResult {
+  reason: VestigialReason;
+  details: Record<string, unknown>;
+}
+
+/**
+ * Checks whether an issue is effectively dead work and should not be retried.
+ *
+ * Three signals are evaluated in order:
+ *   1. Cancelled parent — parent issue has status `cancelled`.
+ *   2. Superseded — the issue's `supersededById` points to a `done` issue.
+ *   3. Fingerprint dedup — another `done` issue shares the same `originFingerprint`
+ *      in the same (companyId, projectId, goalId) scope.
+ *
+ * Returns the first matching signal, or null if the issue is not vestigial.
+ */
+export async function checkVestigialIssue(
+  db: Db,
+  issue: typeof issues.$inferSelect,
+): Promise<VestigialDetectionResult | null> {
+  // Check 1: cancelled parent
+  if (issue.parentId) {
+    const parent = await db
+      .select({ id: issues.id, status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issue.parentId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (parent?.status === "cancelled") {
+      return {
+        reason: "parent_cancelled",
+        details: { parentId: issue.parentId },
+      };
+    }
+  }
+
+  // Check 2: superseded by a done issue
+  if (issue.supersededById) {
+    const superseder = await db
+      .select({ id: issues.id, status: issues.status })
+      .from(issues)
+      .where(eq(issues.id, issue.supersededById))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (superseder?.status === "done") {
+      return {
+        reason: "superseded",
+        details: { supersededById: issue.supersededById },
+      };
+    }
+  }
+
+  // Check 3: fingerprint dedup — another done issue with the same origin fingerprint
+  // in the same (projectId, goalId) scope. Skip if fingerprint is the default sentinel
+  // or if the issue has no project/goal scope.
+  if (
+    issue.originFingerprint !== "default" &&
+    (issue.projectId !== null || issue.goalId !== null)
+  ) {
+    const duplicate = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, issue.companyId),
+          eq(issues.originFingerprint, issue.originFingerprint),
+          eq(issues.status, "done"),
+          // NULL-safe equality for projectId scope
+          issue.projectId !== null
+            ? eq(issues.projectId, issue.projectId)
+            : isNull(issues.projectId),
+          // NULL-safe equality for goalId scope
+          issue.goalId !== null
+            ? eq(issues.goalId, issue.goalId)
+            : isNull(issues.goalId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    // The stalled issue is never `done`, so any match is a distinct duplicate.
+    if (duplicate) {
+      return {
+        reason: "duplicate_resolved",
+        details: {
+          duplicateIssueId: duplicate.id,
+          originFingerprint: issue.originFingerprint,
+        },
+      };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Adds a pre-call payload size gate to prevent runaway heartbeat payloads reaching upstream models (root cause: PRO-2823 32 MB incident).

- **execute.ts**: PAYLOAD_WARNING_BYTES (8 MB) and PAYLOAD_HARD_CAP_BYTES (20 MB) constants; gate aborts calls >=20 MB with payload_too_large errorCode, emits payload_warning log at 8–20 MB
- **heartbeat.ts**: buildImmediateExecutionPathRecoveryComment handles payload_too_large with no-retry message; shouldBlockImmediately short-circuits on payload_too_large
- **test**: two new tests covering the >=20 MB abort path and 8–20 MB warning path

Closes PRO-2863. Incident reference: PRO-2823.