### PR TITLE
feat: add DELETE /api/routines/:routineId for hard-delete

### DIFF
--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -110,6 +110,8 @@ const mockRoutineService = vi.hoisted(() => ({
   getTrigger: vi.fn(),
   updateTrigger: vi.fn(),
   deleteTrigger: vi.fn(),
+  deleteRoutine: vi.fn(),
+  hasActiveRun: vi.fn(),
   rotateTriggerSecret: vi.fn(),
   runRoutine: vi.fn(),
   firePublicTrigger: vi.fn(),
@@ -466,5 +468,113 @@ describe("routine routes", () => {
       runId: null,
     });
     expect(mockTrackRoutineCreated).toHaveBeenCalledWith(expect.anything());
+  });
+
+  describe("DELETE /api/routines/:id", () => {
+    it("returns 204 on successful deletion by admin board user", async () => {
+      mockRoutineService.hasActiveRun.mockResolvedValue(false);
+      mockRoutineService.deleteRoutine.mockResolvedValue(true);
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "local_implicit",
+        isInstanceAdmin: true,
+        companyIds: [companyId],
+      });
+
+      const res = await request(app).delete(`/api/routines/${routineId}`);
+
+      expect(res.status).toBe(204);
+      expect(mockRoutineService.deleteRoutine).toHaveBeenCalledWith(routineId);
+      expect(mockLogActivity).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          action: "routine.deleted",
+          entityType: "routine",
+          entityId: routineId,
+        }),
+      );
+    });
+
+    it("returns 404 when routine does not exist", async () => {
+      mockRoutineService.get.mockResolvedValue(null);
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "local_implicit",
+        isInstanceAdmin: true,
+        companyIds: [companyId],
+      });
+
+      const res = await request(app).delete(`/api/routines/${routineId}`);
+
+      expect(res.status).toBe(404);
+      expect(mockRoutineService.deleteRoutine).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when called by an agent (even assignee)", async () => {
+      const app = await createApp({
+        type: "agent",
+        agentId,
+        companyIds: [companyId],
+      });
+
+      const res = await request(app).delete(`/api/routines/${routineId}`);
+
+      expect(res.status).toBe(403);
+      expect(mockRoutineService.deleteRoutine).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when board user lacks tasks:assign permission", async () => {
+      mockAccessService.canUser.mockResolvedValue(false);
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "session",
+        isInstanceAdmin: false,
+        companyIds: [companyId],
+      });
+
+      const res = await request(app).delete(`/api/routines/${routineId}`);
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toContain("tasks:assign");
+      expect(mockRoutineService.deleteRoutine).not.toHaveBeenCalled();
+    });
+
+    it("returns 409 when routine has active runs", async () => {
+      mockRoutineService.hasActiveRun.mockResolvedValue(true);
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "local_implicit",
+        isInstanceAdmin: true,
+        companyIds: [companyId],
+      });
+
+      const res = await request(app).delete(`/api/routines/${routineId}`);
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toContain("active runs");
+      expect(mockRoutineService.deleteRoutine).not.toHaveBeenCalled();
+    });
+
+    it("allows deletion when board user has tasks:assign permission", async () => {
+      mockAccessService.canUser.mockResolvedValue(true);
+      mockRoutineService.hasActiveRun.mockResolvedValue(false);
+      mockRoutineService.deleteRoutine.mockResolvedValue(true);
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "session",
+        isInstanceAdmin: false,
+        companyIds: [companyId],
+      });
+
+      const res = await request(app).delete(`/api/routines/${routineId}`);
+
+      expect(res.status).toBe(204);
+      expect(mockRoutineService.deleteRoutine).toHaveBeenCalledWith(routineId);
+    });
   });
 });

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -238,6 +238,43 @@ export function routineRoutes(
     res.json(result);
   });
 
+  router.delete("/routines/:id", async (req, res) => {
+    const routine = await svc.get(req.params.id as string);
+    if (!routine) {
+      res.status(404).json({ error: "Routine not found" });
+      return;
+    }
+    assertCompanyAccess(req, routine.companyId);
+    if (req.actor.type !== "board") {
+      throw forbidden("Only board users can delete routines");
+    }
+    if (req.actor.source !== "local_implicit" && !req.actor.isInstanceAdmin) {
+      const allowed = await access.canUser(routine.companyId, req.actor.userId, "tasks:assign");
+      if (!allowed) {
+        throw forbidden("Missing permission: tasks:assign");
+      }
+    }
+    const hasActive = await svc.hasActiveRun(routine.id);
+    if (hasActive) {
+      res.status(409).json({ error: "Cannot delete routine with active runs" });
+      return;
+    }
+    await svc.deleteRoutine(routine.id);
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: routine.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "routine.deleted",
+      entityType: "routine",
+      entityId: routine.id,
+      details: { title: routine.title },
+    });
+    res.status(204).end();
+  });
+
   router.get("/routines/:id/runs", async (req, res) => {
     const routine = await svc.get(req.params.id as string);
     if (!routine) {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1768,6 +1768,28 @@ export function routineService(
       });
     },
 
+    deleteRoutine: async (id: string): Promise<boolean> => {
+      const existing = await getRoutineById(id);
+      if (!existing) return false;
+      await db.delete(routines).where(eq(routines.id, id));
+      return true;
+    },
+
+    hasActiveRun: async (routineId: string): Promise<boolean> => {
+      const activeRun = await db
+        .select({ id: routineRuns.id })
+        .from(routineRuns)
+        .where(
+          and(
+            eq(routineRuns.routineId, routineId),
+            inArray(routineRuns.status, ["received", "issue_created"]),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows.length > 0);
+      return activeRun;
+    },
+
     deleteTrigger: async (id: string, actor: Actor = {}): Promise<{ deleted: boolean; revision: RoutineRevision | null }> => {
       const existing = await getTriggerById(id);
       if (!existing) return { deleted: false, revision: null };

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -842,6 +842,7 @@ Terminal states: `done`, `cancelled`
 | GET    | `/api/routines/:routineId` | Routine details including triggers |
 | POST   | `/api/companies/:companyId/routines` | Create routine (`assigneeAgentId` + `projectId` required; agents: own only) |
 | PATCH  | `/api/routines/:routineId` | Update routine (agents: own only, cannot reassign) |
+| DELETE | `/api/routines/:routineId` | Hard-delete routine + triggers + runs (board-only, `tasks:assign` required; 409 if active runs exist) |
 | POST   | `/api/routines/:routineId/triggers` | Add trigger (`schedule`, `webhook`, or `api` kind) |
 | PATCH  | `/api/routine-triggers/:triggerId` | Update trigger (e.g. disable, change cron) |
 | DELETE | `/api/routine-triggers/:triggerId` | Delete trigger |

--- a/skills/paperclip/references/routines.md
+++ b/skills/paperclip/references/routines.md
@@ -132,6 +132,24 @@ No configuration. Fire via the manual run endpoint.
 
 ---
 
+## Deleting a Routine
+
+Hard-deletes a routine along with all its triggers and runs (via database cascade). Board-only — agents cannot delete routines, even if they are the assignee.
+
+```
+DELETE /api/routines/{routineId}
+```
+
+**Authorization:** Board user with `tasks:assign` permission or instance admin.
+
+**Responses:**
+- `204 No Content` — routine deleted successfully.
+- `403 Forbidden` — caller is an agent or board user without `tasks:assign`.
+- `404 Not Found` — routine does not exist.
+- `409 Conflict` — routine has active runs (status `received` or `issue_created`). Wait for them to complete or cancel before deleting.
+
+---
+
 ## Updating and Deleting Triggers
 
 ```


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The routines subsystem manages recurring task scheduling (create, trigger, run)
> - The API currently exposes GET/POST/PATCH for routines but no DELETE — archived routines persist in the DB and dashboard indefinitely
> - The founder requested permanent removal of 7 archived indexation routines polluting the dashboard (SEO-35/SEO-53)
> - This PR adds `DELETE /api/routines/:routineId` with board-only authorization, active-run guards, and cascade cleanup
> - The benefit is that board users can permanently remove stale routines instead of relying on status-based soft-delete

## What Changed

- **Route:** Added `DELETE /api/routines/:id` in `server/src/routes/routines.ts` — returns 204 on success
- **Service:** Added `deleteRoutine` and `hasActiveRun` methods in `server/src/services/routines.ts` — DB cascade handles triggers/runs cleanup
- **Authorization:** Board-only with `tasks:assign` permission or instance admin. Agents are explicitly forbidden (even assignees) since deletion is a destructive board action
- **Error handling:** 404 if routine not found, 403 if caller is agent or lacks permission, 409 if routine has active runs (status `received` or `issue_created`)
- **Tests:** 6 new test cases in `routines-routes.test.ts` covering success, 404, 403 (agent), 403 (no permission), 409 (active runs), and success with permission
- **Docs:** Updated `skills/paperclip/references/api-reference.md` and `skills/paperclip/references/routines.md` with endpoint documentation

## Verification

```bash
cd server
npx vitest run src/__tests__/routines-routes.test.ts
# All 15 tests pass (9 existing + 6 new)
```

Manual verification after deploy:
```bash
# As board admin:
curl -X DELETE $PAPERCLIP_API_URL/api/routines/{routineId} -H "Authorization: Bearer $TOKEN"
# → 204 No Content, routine + triggers + runs removed
```

## Risks

- **Low risk.** The endpoint uses existing DB cascade (`ON DELETE CASCADE` on `routine_triggers` and `routine_runs` foreign keys) — no new migration needed.
- Active-run guard prevents deletion of routines with in-flight execution, avoiding orphaned issues.
- Agent exclusion is intentional and stricter than other routine operations — this matches the destructive-action policy from SEO-53.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.6 (`claude-opus-4-6`)
- Context: 200k tokens
- Capabilities: Tool use, code execution, extended thinking

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge