### PR TITLE
feat(server): add agent.adapterConfig.preCommentHooks block-action hook

### DIFF
--- a/server/src/__tests__/pre-comment-hook.test.ts
+++ b/server/src/__tests__/pre-comment-hook.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+}));
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  buildAuditBlock,
+  evaluatePreCommentHooks,
+  parsePreCommentHooks,
+  type PreCommentHookConfig,
+  type PreCommentHookContext,
+} from "../services/pre-comment-hook.js";
+
+const CCO_AGENT_ID = "02cbe529-20be-4963-9742-a4548680f111";
+
+function makeCtx(overrides: Partial<PreCommentHookContext> = {}): PreCommentHookContext {
+  return {
+    companyId: "company-1",
+    issueId: "issue-1",
+    agentId: CCO_AGENT_ID,
+    body: "",
+    source: "update",
+    statusTransition: "to_done",
+    ...overrides,
+  };
+}
+
+describe("parsePreCommentHooks", () => {
+  it("returns [] when adapterConfig is null/undefined/non-object", () => {
+    expect(parsePreCommentHooks(null)).toEqual([]);
+    expect(parsePreCommentHooks(undefined)).toEqual([]);
+    expect(parsePreCommentHooks("not-an-object")).toEqual([]);
+    expect(parsePreCommentHooks([])).toEqual([]);
+  });
+
+  it("returns [] when preCommentHooks is missing or not an array", () => {
+    expect(parsePreCommentHooks({})).toEqual([]);
+    expect(parsePreCommentHooks({ preCommentHooks: "nope" })).toEqual([]);
+    expect(parsePreCommentHooks({ preCommentHooks: { trigger: {} } })).toEqual([]);
+  });
+
+  it("parses well-formed entries and ignores unknown action values", () => {
+    const cfg = {
+      preCommentHooks: [
+        {
+          trigger: {
+            agentId: CCO_AGENT_ID,
+            statusTransition: "to_done",
+            bodyMatches: "\\b[0-9a-f]{7,40}\\b",
+          },
+          action: "block",
+          message: "phantom hash check",
+        },
+        {
+          trigger: { agentId: CCO_AGENT_ID },
+          action: "frobnicate",
+        },
+      ],
+    };
+    const parsed = parsePreCommentHooks(cfg);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]).toEqual({
+      trigger: {
+        agentId: CCO_AGENT_ID,
+        statusTransition: "to_done",
+        bodyMatches: "\\b[0-9a-f]{7,40}\\b",
+      },
+      action: "block",
+      message: "phantom hash check",
+    });
+    expect(parsed[1].action).toBeUndefined();
+  });
+});
+
+describe("evaluatePreCommentHooks", () => {
+  beforeEach(() => {
+    mockLogActivity.mockReset();
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("(c) backwards-compat: no hooks → not blocked, no audit", async () => {
+    const result = await evaluatePreCommentHooks({} as any, [], makeCtx({ body: "Done at 916caac" }));
+    expect(result.blocked).toBe(false);
+    expect(result.matches).toEqual([]);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("(a) phantom-hash-block: matching hook with action=block blocks", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: {
+          agentId: CCO_AGENT_ID,
+          statusTransition: "to_done",
+          bodyMatches: "\\b[0-9a-f]{7,40}\\b",
+        },
+        action: "block",
+        message: "phantom hash detector",
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "Done at 916caac on master." }),
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].action).toBe("block");
+    expect(result.matches[0].message).toBe("phantom hash detector");
+    expect(result.matches[0].hookIndex).toBe(0);
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.pre_comment_hook_blocked",
+        actorType: "system",
+        actorId: "pre_comment_hook",
+      }),
+    );
+  });
+
+  it("(b) real-hash-pass: hook with bodyMatches that doesn't match → not blocked", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: {
+          agentId: CCO_AGENT_ID,
+          statusTransition: "to_done",
+          bodyMatches: "PHANTOM",
+        },
+        action: "block",
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "Real done at bb9d9b4." }),
+    );
+    expect(result.blocked).toBe(false);
+    expect(result.matches).toEqual([]);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("does not match when agentId differs", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { agentId: CCO_AGENT_ID, bodyMatches: ".+" },
+        action: "block",
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ agentId: "some-other-agent", body: "anything" }),
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  it("does not match when statusTransition differs", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { statusTransition: "to_done", bodyMatches: ".+" },
+        action: "block",
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ statusTransition: "to_in_progress", body: "anything" }),
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  it("matches when statusTransition is 'any'", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { statusTransition: "any", bodyMatches: ".+" },
+        action: "block",
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ statusTransition: null, body: "anything" }),
+    );
+    expect(result.blocked).toBe(true);
+  });
+
+  it("matches when bodyMatches is unset (treat as 'always match')", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { agentId: CCO_AGENT_ID }, action: "block" },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "" }));
+    expect(result.blocked).toBe(true);
+  });
+
+  it("warn action does not block but is recorded as a match and logged", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { agentId: CCO_AGENT_ID, bodyMatches: ".+" }, action: "warn" },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "x" }));
+    expect(result.blocked).toBe(false);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].action).toBe("warn");
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.pre_comment_hook_warned" }),
+    );
+  });
+
+  it("escalate action does not block in iteration 1 but is recorded", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { agentId: CCO_AGENT_ID, bodyMatches: ".+" }, action: "escalate" },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "x" }));
+    expect(result.blocked).toBe(false);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.pre_comment_hook_escalated" }),
+    );
+  });
+
+  it("any blocking hook in a list of mixed actions blocks the comment", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { bodyMatches: "x" }, action: "warn" },
+      { trigger: { bodyMatches: "x" }, action: "block" },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "x" }));
+    expect(result.blocked).toBe(true);
+    expect(result.matches).toHaveLength(2);
+  });
+
+  it("invalid regex pattern is skipped (does not throw, does not block)", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { bodyMatches: "[unterminated" }, action: "block" },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "x" }));
+    expect(result.blocked).toBe(false);
+  });
+
+  it("entries without an action are inert (no match, no log)", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { bodyMatches: ".+" } },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "x" }));
+    expect(result.blocked).toBe(false);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildAuditBlock", () => {
+  it("emits a single-block format with one line per match", () => {
+    const ctx = makeCtx({ body: "Done at 916caac" });
+    const matches = [
+      {
+        hookIndex: 0,
+        action: "block" as const,
+        message: "phantom",
+        matchedBy: { agentId: true, statusTransition: true, bodyMatches: true },
+        trigger: { agentId: CCO_AGENT_ID, statusTransition: "to_done", bodyMatches: "\\b[0-9a-f]{7,40}\\b" },
+      },
+    ];
+    const block = buildAuditBlock(matches, ctx);
+    expect(block).toContain("<!-- pre-comment-hook v1");
+    expect(block).toContain("<!-- /pre-comment-hook -->");
+    expect(block).toContain("hook[0]");
+    expect(block).toContain("action=block");
+    expect(block).toContain(`agentId=${CCO_AGENT_ID}`);
+    expect(block).toContain("statusTransition=to_done");
+    expect(block).toContain("message=phantom");
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3669,6 +3669,33 @@ export function issueRoutes(
       }
     }
 
+    // preCommentHooks pre-commit guard: when this PATCH carries a commentBody, evaluate
+    // the hook BEFORE svc.update commits the status change. Previously the hook ran AFTER
+    // svc.update, which (when a hook returned action:block) left the status transition
+    // persisted while the caller saw a 422. On retry the status would already match the
+    // proposed value, statusTransition would resolve to "none", and the hook would no
+    // longer fire — bypassing the guard. Now the proposed statusTransition is computed
+    // from updateFields against existing.status and the hook decides before any DB write.
+    if (commentBody) {
+      const proposedStatus =
+        typeof (updateFields as { status?: unknown }).status === "string"
+          ? ((updateFields as { status: string }).status)
+          : existing.status;
+      const proposedStatusTransition =
+        proposedStatus !== existing.status ? `to_${proposedStatus}` : "none";
+      if (
+        !(await runPreCommentHooksForActor(res, actor, {
+          companyId: existing.companyId,
+          issueId: existing.id,
+          body: commentBody,
+          source: "update",
+          statusTransition: proposedStatusTransition,
+        }))
+      ) {
+        return;
+      }
+    }
+
     let issue;
     try {
       if (transition.decision && decisionId) {
@@ -4068,18 +4095,8 @@ export function issueRoutes(
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
-      const statusTransition = issue.status !== existing.status ? `to_${issue.status}` : "none";
-      if (
-        !(await runPreCommentHooksForActor(res, actor, {
-          companyId: issue.companyId,
-          issueId: issue.id,
-          body: commentBody,
-          source: "update",
-          statusTransition,
-        }))
-      ) {
-        return;
-      }
+      // preCommentHooks already evaluated above (pre-svc.update guard); proceed directly
+      // to addComment. See the pre-commit guard block earlier in this handler.
       comment = await svc.addComment(id, commentBody, {
         agentId: actor.agentId ?? undefined,
         userId: actor.actorType === "user" ? actor.actorId : undefined,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -109,6 +109,12 @@ import {
   setIssueExecutionPolicyMonitorScheduledBy,
 } from "../services/issue-execution-policy.js";
 import { parseIssueExecutionWorkspaceSettings } from "../services/execution-workspace-policy.js";
+import {
+  buildAuditBlock as buildPreCommentHookAuditBlock,
+  evaluatePreCommentHooks,
+  parsePreCommentHooks,
+  type PreCommentHookContext,
+} from "../services/pre-comment-hook.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
@@ -1100,6 +1106,34 @@ export function issueRoutes(
       ...attachment,
       contentPath: `/api/attachments/${attachment.id}/content`,
     };
+  }
+
+  async function runPreCommentHooksForActor(
+    res: Response,
+    actor: ReturnType<typeof getActorInfo>,
+    ctx: Omit<PreCommentHookContext, "agentId">,
+  ): Promise<boolean> {
+    if (!actor.agentId) return true;
+    const agent = await agentsSvc.getById(actor.agentId);
+    if (!agent) return true;
+    const hooks = parsePreCommentHooks(agent.adapterConfig);
+    if (hooks.length === 0) return true;
+    const evalCtx: PreCommentHookContext = { ...ctx, agentId: actor.agentId };
+    const result = await evaluatePreCommentHooks(db, hooks, evalCtx);
+    if (result.blocked) {
+      res.status(422).json({
+        error: "Comment blocked by pre-comment hook",
+        auditBlock: buildPreCommentHookAuditBlock(result.matches, evalCtx),
+        matches: result.matches.map((m) => ({
+          hookIndex: m.hookIndex,
+          action: m.action,
+          message: m.message,
+          trigger: m.trigger,
+        })),
+      });
+      return false;
+    }
+    return true;
   }
 
   function parseBooleanQuery(value: unknown) {
@@ -4034,6 +4068,18 @@ export function issueRoutes(
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
+      const statusTransition = issue.status !== existing.status ? `to_${issue.status}` : "none";
+      if (
+        !(await runPreCommentHooksForActor(res, actor, {
+          companyId: issue.companyId,
+          issueId: issue.id,
+          body: commentBody,
+          source: "update",
+          statusTransition,
+        }))
+      ) {
+        return;
+      }
       comment = await svc.addComment(id, commentBody, {
         agentId: actor.agentId ?? undefined,
         userId: actor.actorType === "user" ? actor.actorId : undefined,
@@ -5197,6 +5243,18 @@ export function issueRoutes(
           });
         }
       }
+    }
+
+    if (
+      !(await runPreCommentHooksForActor(res, actor, {
+        companyId: currentIssue.companyId,
+        issueId: currentIssue.id,
+        body: typeof req.body.body === "string" ? req.body.body : "",
+        source: "comment",
+        statusTransition: null,
+      }))
+    ) {
+      return;
     }
 
     const comment = await svc.addComment(id, req.body.body, {

--- a/server/src/services/pre-comment-hook.ts
+++ b/server/src/services/pre-comment-hook.ts
@@ -156,6 +156,24 @@ export async function evaluatePreCommentHooks(
   const auditBlock = buildAuditBlock(matches, ctx);
 
   for (const m of matches) {
+    // When the overall evaluation blocks AND this individual match is warn/escalate
+    // (co-fired alongside a block), the conventional "warned"/"escalated" log key would
+    // mislead operators into thinking the comment was allowed. Re-route to a disposition-
+    // aware key so the activity log reflects the actual outcome.
+    let activityKey: string;
+    if (m.action === "block" && blocked) {
+      activityKey = "issue.pre_comment_hook_blocked";
+    } else if (blocked) {
+      // Block co-fired with this non-blocking match → log as suppressed/matched-only,
+      // not warned/escalated (the comment was actually blocked).
+      activityKey = "issue.pre_comment_hook_matched";
+    } else if (m.action === "warn") {
+      activityKey = "issue.pre_comment_hook_warned";
+    } else if (m.action === "escalate") {
+      activityKey = "issue.pre_comment_hook_escalated";
+    } else {
+      activityKey = "issue.pre_comment_hook_matched";
+    }
     try {
       await logActivity(db, {
         companyId: ctx.companyId,
@@ -163,13 +181,7 @@ export async function evaluatePreCommentHooks(
         actorId: "pre_comment_hook",
         agentId: ctx.agentId ?? null,
         runId: null,
-        action: blocked && m.action === "block"
-          ? "issue.pre_comment_hook_blocked"
-          : m.action === "warn"
-          ? "issue.pre_comment_hook_warned"
-          : m.action === "escalate"
-          ? "issue.pre_comment_hook_escalated"
-          : "issue.pre_comment_hook_matched",
+        action: activityKey,
         entityType: "issue",
         entityId: ctx.issueId,
         details: {

--- a/server/src/services/pre-comment-hook.ts
+++ b/server/src/services/pre-comment-hook.ts
@@ -1,0 +1,191 @@
+import type { Db } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+import { logActivity } from "./activity-log.js";
+
+export type PreCommentHookAction = "block" | "warn" | "escalate";
+
+export interface PreCommentHookTrigger {
+  agentId?: string;
+  statusTransition?: string;
+  bodyMatches?: string;
+}
+
+export interface PreCommentHookConfig {
+  trigger?: PreCommentHookTrigger;
+  action?: PreCommentHookAction;
+  message?: string;
+}
+
+export interface PreCommentHookContext {
+  companyId: string;
+  issueId: string;
+  agentId: string | null;
+  body: string;
+  source: "comment" | "update";
+  statusTransition: string | null;
+}
+
+export interface PreCommentHookMatch {
+  hookIndex: number;
+  action: PreCommentHookAction;
+  message: string | null;
+  matchedBy: {
+    agentId: boolean;
+    statusTransition: boolean;
+    bodyMatches: boolean;
+  };
+  trigger: PreCommentHookTrigger;
+}
+
+export interface PreCommentHookEvaluation {
+  blocked: boolean;
+  matches: PreCommentHookMatch[];
+}
+
+const VALID_ACTIONS: ReadonlySet<PreCommentHookAction> = new Set(["block", "warn", "escalate"]);
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function parsePreCommentHooks(adapterConfig: unknown): PreCommentHookConfig[] {
+  if (!isPlainObject(adapterConfig)) return [];
+  const raw = adapterConfig.preCommentHooks;
+  return asArray(raw).map((entry): PreCommentHookConfig => {
+    if (!isPlainObject(entry)) return {};
+    const triggerRaw = isPlainObject(entry.trigger) ? entry.trigger : {};
+    const trigger: PreCommentHookTrigger = {
+      agentId: asString(triggerRaw.agentId),
+      statusTransition: asString(triggerRaw.statusTransition),
+      bodyMatches: asString(triggerRaw.bodyMatches),
+    };
+    const actionRaw = asString(entry.action);
+    const action: PreCommentHookAction | undefined =
+      actionRaw && (VALID_ACTIONS as Set<string>).has(actionRaw)
+        ? (actionRaw as PreCommentHookAction)
+        : undefined;
+    const message = asString(entry.message) ?? null;
+    return { trigger, action, message: message ?? undefined };
+  });
+}
+
+function compileBodyRegex(pattern: string): RegExp | null {
+  try {
+    return new RegExp(pattern);
+  } catch (err) {
+    logger.warn({ err, pattern }, "preCommentHooks: invalid bodyMatches regex, skipping hook");
+    return null;
+  }
+}
+
+function matchHook(hook: PreCommentHookConfig, ctx: PreCommentHookContext): PreCommentHookMatch | null {
+  if (!hook.action) return null;
+  const trigger = hook.trigger ?? {};
+  const matchedBy = {
+    agentId: !trigger.agentId || trigger.agentId === ctx.agentId,
+    statusTransition: !trigger.statusTransition || trigger.statusTransition === "any" || trigger.statusTransition === ctx.statusTransition,
+    bodyMatches: true as boolean,
+  };
+  if (trigger.bodyMatches) {
+    const re = compileBodyRegex(trigger.bodyMatches);
+    if (!re) return null;
+    matchedBy.bodyMatches = re.test(ctx.body);
+  }
+  if (!matchedBy.agentId || !matchedBy.statusTransition || !matchedBy.bodyMatches) {
+    return null;
+  }
+  return {
+    hookIndex: -1,
+    action: hook.action,
+    message: hook.message ?? null,
+    matchedBy,
+    trigger,
+  };
+}
+
+export function buildAuditBlock(
+  matches: PreCommentHookMatch[],
+  ctx: PreCommentHookContext,
+): string {
+  const header = `<!-- pre-comment-hook v1 source=${ctx.source} agent=${ctx.agentId ?? "none"} -->`;
+  const footer = "<!-- /pre-comment-hook -->";
+  const lines = matches.map((m) => {
+    const trig = m.trigger;
+    const parts = [
+      `hook[${m.hookIndex}]`,
+      `action=${m.action}`,
+      trig.agentId ? `agentId=${trig.agentId}` : null,
+      trig.statusTransition ? `statusTransition=${trig.statusTransition}` : null,
+      trig.bodyMatches ? `bodyMatches=${trig.bodyMatches}` : null,
+      m.message ? `message=${m.message}` : null,
+    ].filter(Boolean);
+    return `- ${parts.join(" ")}`;
+  });
+  return [header, ...lines, footer].join("\n");
+}
+
+export async function evaluatePreCommentHooks(
+  db: Db,
+  hooks: PreCommentHookConfig[],
+  ctx: PreCommentHookContext,
+): Promise<PreCommentHookEvaluation> {
+  if (!hooks || hooks.length === 0) {
+    return { blocked: false, matches: [] };
+  }
+  const matches: PreCommentHookMatch[] = [];
+  for (let i = 0; i < hooks.length; i++) {
+    const hook = hooks[i];
+    const m = matchHook(hook, ctx);
+    if (m) {
+      matches.push({ ...m, hookIndex: i });
+    }
+  }
+  if (matches.length === 0) {
+    return { blocked: false, matches };
+  }
+
+  const blocked = matches.some((m) => m.action === "block");
+  const auditBlock = buildAuditBlock(matches, ctx);
+
+  for (const m of matches) {
+    try {
+      await logActivity(db, {
+        companyId: ctx.companyId,
+        actorType: "system",
+        actorId: "pre_comment_hook",
+        agentId: ctx.agentId ?? null,
+        runId: null,
+        action: blocked && m.action === "block"
+          ? "issue.pre_comment_hook_blocked"
+          : m.action === "warn"
+          ? "issue.pre_comment_hook_warned"
+          : m.action === "escalate"
+          ? "issue.pre_comment_hook_escalated"
+          : "issue.pre_comment_hook_matched",
+        entityType: "issue",
+        entityId: ctx.issueId,
+        details: {
+          source: ctx.source,
+          statusTransition: ctx.statusTransition,
+          hookIndex: m.hookIndex,
+          action: m.action,
+          trigger: m.trigger,
+          message: m.message,
+          auditBlock,
+        },
+      });
+    } catch (err) {
+      logger.warn({ err, issueId: ctx.issueId }, "preCommentHooks: failed to log activity");
+    }
+  }
+
+  return { blocked, matches };
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **server-side pre-comment hook** (`agent.adapterConfig.preCommentHooks`) that runs immediately before `svc.addComment` in both comment-emitting routes, and supports a `block` action that returns 422 + an audit block instead of writing the comment. `warn` and `escalate` actions are wired into the activity log (with `escalate` currently behaving like `warn` — issue-spawn is future work).

Backwards-compatible: agents without `preCommentHooks` configured behave exactly as today.

## Why — concrete use case

In our internal fleet we have an agent ("CCO") that has, in the last 30 hours, posted four `done`-status comments where the body cited a commit hash that does not exist in the repo (`100d3e1`, hash from PSY-961, `8947521`, `916caac` — all `fatal: ambiguous argument` against the live `origin/main`). Self-verify discipline at the agent layer has now demonstrably failed four times.

We want a **technical guardrail outside agent self-awareness** that can block or audit comments matching specific patterns from specific agents, particularly during status-transition events (`to_done`).

The exact phantom-detection logic (3-tier reachability: `real_on_main` / `dangling_object` / `phantom`) lives in our internal `cco-hash-verify` CLI — it is **not** part of this PR. This PR ships only the **hook framework** (static pattern + action), so config-driven deployments and operators can layer their own verification on top. We expect a follow-up PR to add a `command:` execution form so external verifiers like ours can plug in via stdin/exit-code.

## Spec reference

The design implemented here follows our internal architecture spec **`docs/context/14-cco-hash-verify-hook.md` v0.2.2** (commit `f0b20d4ad2710d24e8bdc08cefb5052fc7548114` in our internal `Noridem/PsynoraPaperclip` repo, which is the spec-owner repo). The spec doc itself is not part of this upstream PR — it is referenced here for audit-trail completeness and so the scope split between this PR (the hook framework / slot) and the planned follow-up PR (the `command:` execution form) is explicit.

## Design

### Hook config shape (additive in `adapterConfig`)

```jsonc
{
  "preCommentHooks": [
    {
      "trigger": {
        "agentId":          "<uuid>",                         // optional; matches actor.agentId
        "statusTransition": "to_done" | "any" | "none" | ...,// optional; matches request status transition
        "bodyMatches":      "<regex string>"                  // optional; tested against comment body
      },
      "action":  "block" | "warn" | "escalate",
      "message": "operator-readable note"                     // optional, surfaced in audit + 422 body
    }
  ]
}
```

Matching rule: a trigger field is **inert when unset** and **AND-combined when set**. `statusTransition: "any"` matches every transition (including pure comments where the status didn't change). Invalid regex in `bodyMatches` is logged + skipped (the hook is treated as non-matching).

### Where the hook runs

Both call sites of `svc.addComment` in `server/src/routes/issues.ts` are wrapped:

1. `POST /api/issues/:id/comments` — pure comment path. `source: "comment"`, `statusTransition: null`.
2. `PATCH /api/issues/:id` (when a `comment` is embedded with the update) — `source: "update"`, `statusTransition: "to_<newStatus>"` if status changed, `"none"` otherwise.

When the hook returns `blocked: true`, the route responds with HTTP 422 + JSON body containing the audit block (HTML-comment-wrapped) and the matched trigger details. The comment is **not** persisted.

When the hook returns `blocked: false` but matched a `warn` / `escalate`, the comment is persisted normally and a `pre_comment_hook_warned` / `pre_comment_hook_escalated` activity entry is logged.

### Activity log entries

- `issue.pre_comment_hook_blocked` — block decision; comment was rejected.
- `issue.pre_comment_hook_warned` — warn decision; comment was allowed.
- `issue.pre_comment_hook_escalated` — escalate decision; comment was allowed (issue-spawn TBD upstream).

Each entry carries `{source, statusTransition, hookIndex, action, trigger, message, auditBlock}`.

## Alternative layers we evaluated and why server is the right one

| Layer | Verdict | Reasoning |
|---|---|---|
| **Agent self-verify** | rejected | already failed four times — the whole point is to put the guard *outside* agent reasoning. |
| **Adapter (e.g. `claude_local`)** | rejected | requires bespoke per-adapter wiring, no consistent enforcement across adapters that share an agent fleet, and adapter changes don't propagate to existing deployments without redeploy. |
| **Local fork / patch-pinning** | rejected | downstream-only, no audit trail upstream, blocks the rest of our fleet from sharing the framework. |
| **Server (this PR)** | chosen | one place to run the check (matches `assertAgentIssueMutationAllowed` shape), uniform across adapters, observable via existing activity log, cleanly opt-in via `adapterConfig`. |

## Backwards compatibility

`parsePreCommentHooks` returns `[]` for any agent whose `adapterConfig` lacks the `preCommentHooks` field, in which case `evaluatePreCommentHooks` short-circuits before any DB / regex work. The route helper `runPreCommentHooksForActor` returns early when the agent isn't found or the actor isn't an agent. Net effect on existing deployments: zero behavior change until an operator opts in by setting the field.

## Trust assumptions

This hook is only as strong as the access control on `PATCH /api/agents/:id` (the route that writes `adapterConfig`). If the policed agent itself can mutate its own `preCommentHooks` slot, the protection is bypassable by design — the agent could simply remove or weaken the hook before posting the offending comment. Operators deploying this should treat `agent.adapterConfig` as a privileged surface: only roles that should be allowed to remove or weaken the guard should be permitted to write to it. Concretely, the read path (`agentsSvc.getById(actor.agentId)`) is safe — `actor.agentId` comes from the authenticated actor record, not from the request body — but the configuration write path is out-of-scope for this PR and must be governed elsewhere.

## Tests

`server/src/__tests__/pre-comment-hook.test.ts` — 16 cases:

- **(a) Phantom-Hash-Block** — matching hook with `action: "block"` blocks.
- **(b) Real-Hash-Pass** — same hook with non-matching body does not block.
- **(c) Backwards-compat** — empty hook list is a no-op, no activity log written.
- `agentId` mismatch → no match.
- `statusTransition` mismatch → no match.
- `statusTransition: "any"` matches null transition.
- Missing `bodyMatches` is treated as "always match".
- `warn` / `escalate` actions are recorded but do not block.
- Mixed list with one `block` blocks (block wins).
- Invalid regex pattern is skipped without throwing.
- Entries without an `action` are inert.
- `buildAuditBlock` emits the documented format.

Local run:

```text
RUN  v3.2.4 /tmp/upstream-clone/paperclip/server
 ✓ src/__tests__/pre-comment-hook.test.ts (16 tests) 9ms
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

Existing comment-related route tests still pass:

```text
✓ src/__tests__/issue-comment-reopen-routes.test.ts (28 tests)
✓ src/__tests__/issue-update-comment-wakeup-routes.test.ts (2 tests)
✓ src/__tests__/issue-comment-cancel-routes.test.ts (3 tests)
 Test Files  3 passed (3)
      Tests  33 passed (33)
```

## Files

- New: `server/src/services/pre-comment-hook.ts`
- New: `server/src/__tests__/pre-comment-hook.test.ts`
- Modified: `server/src/routes/issues.ts` (import + helper + 2 call sites)

## Out of scope (called out so it's explicit)

- The phantom-hash detection regex / logic itself — operator-side config concern.
- A `command:` exec form (stdin-piped external verifier with `onExit` action mapping). Planned as the follow-up that turns this from a static pattern hook into a programmable verification gate.
- `escalate`-action issue spawning — wired as a non-blocking audit for now; future PR will plumb a `spawnIssue:` hook config.

## Test plan

- [x] Unit tests for hook evaluator and parser (16 cases) pass.
- [x] Existing comment-flow route tests (33 cases) still pass.
- [x] No new TypeScript errors introduced (verified with `tsc --noEmit` on `server/`).
- [ ] Reviewer confirms 422 response shape is acceptable for the standard agent-loop retry semantics.
- [ ] Reviewer confirms placing the helper in the route layer (vs. inside `svc.addComment`) is the right boundary.
