### PR TITLE
scripts: harden paperclip-issue-{comment,update}.sh; force stdin/file body

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Verify release registry test coverage
         run: pnpm run test:release-registry
 
+      - name: Verify paperclip-issue-* helper scripts
+        run: pnpm run test:scripts
+
       - name: Build
         run: pnpm build
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "smoke:openclaw-sse-standalone": "./scripts/smoke/openclaw-sse-standalone.sh",
     "smoke:terminal-bench-loop-skill": "node scripts/smoke/terminal-bench-loop-skill-smoke.mjs",
     "test:release-registry": "node --test scripts/verify-release-registry-state.test.mjs scripts/release-package-map.test.mjs scripts/check-release-package-bootstrap.test.mjs",
+    "test:scripts": "node --test scripts/paperclip-issue-helpers.test.mjs",
     "test:e2e": "npx playwright test --config tests/e2e/playwright.config.ts",
     "test:e2e:headed": "npx playwright test --config tests/e2e/playwright.config.ts --headed",
     "test:e2e:multiuser-authenticated": "npx playwright test --config tests/e2e/playwright-multiuser-authenticated.config.ts",

--- a/scripts/paperclip-issue-comment.sh
+++ b/scripts/paperclip-issue-comment.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# paperclip-issue-comment.sh -- safely post a markdown comment on a Paperclip issue.
+#
+# This is the sanctioned path for an agent to post a comment from shell.
+# Reading the body from stdin / a file (never an inline argument) eliminates the
+# multi-level shell-escaping bugs that have repeatedly produced collapsed,
+# truncated, or syntactically broken comments when markdown bodies are inlined
+# into `node -e` / `python -c` / `curl -d` argument strings.
+#
+# Usage:
+#   scripts/paperclip-issue-comment.sh --issue-id ISSUE_ID [--body-file PATH] [--dry-run]
+#
+# Body source (pick one):
+#   - default: read body from stdin (heredoc-friendly)
+#   - --body-file PATH: read body from a file
+#
+# Required env (unless --dry-run):
+#   PAPERCLIP_API_URL, PAPERCLIP_API_KEY, PAPERCLIP_RUN_ID
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/paperclip-issue-comment.sh --issue-id ISSUE_ID [--body-file PATH] [--dry-run]
+
+Reads the comment body from stdin by default, or from --body-file when provided.
+Never pass the markdown body as an inline shell argument.
+
+Required env (live mode): PAPERCLIP_API_URL, PAPERCLIP_API_KEY, PAPERCLIP_RUN_ID.
+
+--dry-run prints the JSON payload that would be sent and exits 0.
+USAGE
+}
+
+issue_id=""
+body_file=""
+dry_run=0
+
+resolve_python() {
+  # Probe each candidate by actually running it. On Windows, `python3` may
+  # resolve to a Microsoft Store stub that fails on use; PATH lookup alone is
+  # not enough.
+  for candidate in python3 python py; do
+    if command -v "$candidate" >/dev/null 2>&1 \
+        && "$candidate" -c "import sys" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+  echo "Missing working python3/python/py interpreter on PATH" >&2
+  exit 127
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue-id) issue_id="${2:-}"; shift 2 ;;
+    --body-file) body_file="${2:-}"; shift 2 ;;
+    --dry-run) dry_run=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$issue_id" ]]; then
+  echo "--issue-id is required" >&2
+  exit 2
+fi
+
+comment_file="$(mktemp)"
+payload_file="$(mktemp)"
+cleanup() { rm -f "$comment_file" "$payload_file"; }
+trap cleanup EXIT
+
+if [[ -n "$body_file" ]]; then
+  if [[ ! -r "$body_file" ]]; then
+    echo "--body-file '$body_file' not readable" >&2
+    exit 2
+  fi
+  cp "$body_file" "$comment_file"
+else
+  cat > "$comment_file"
+fi
+
+if [[ ! -s "$comment_file" ]]; then
+  echo "Comment body is empty (stdin or --body-file produced no content)" >&2
+  exit 2
+fi
+
+# Build the JSON payload with python's json module so newlines, backticks,
+# fenced code blocks, and unicode survive verbatim.
+"$(resolve_python)" - "$comment_file" "$payload_file" <<'PY'
+import json, pathlib, sys
+body = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+pathlib.Path(sys.argv[2]).write_text(
+    json.dumps({"body": body}, ensure_ascii=False),
+    encoding="utf-8",
+)
+PY
+
+if [[ "$dry_run" -eq 1 ]]; then
+  cat "$payload_file"
+  exit 0
+fi
+
+: "${PAPERCLIP_API_URL:?missing PAPERCLIP_API_URL}"
+: "${PAPERCLIP_API_KEY:?missing PAPERCLIP_API_KEY}"
+: "${PAPERCLIP_RUN_ID:?missing PAPERCLIP_RUN_ID}"
+
+curl --fail-with-body -sS \
+  -X POST \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H "Content-Type: application/json" \
+  --data-binary "@$payload_file" \
+  "$PAPERCLIP_API_URL/api/issues/$issue_id/comments"

--- a/scripts/paperclip-issue-helpers.test.mjs
+++ b/scripts/paperclip-issue-helpers.test.mjs
@@ -1,0 +1,204 @@
+// Tests for scripts/paperclip-issue-comment.sh and scripts/paperclip-issue-update.sh.
+//
+// Run with: node --test scripts/paperclip-issue-helpers.test.mjs
+//
+// These tests invoke the helpers in --dry-run mode and verify the JSON payload
+// they would send to the Paperclip API. The bodies cover the multi-level
+// shell-escaping bug class that collapses or corrupts markdown containing
+// newlines, fenced code blocks, nested backticks, and special characters when
+// inlined into argument strings.
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const COMMENT_SH = resolve(__dirname, "paperclip-issue-comment.sh");
+const UPDATE_SH = resolve(__dirname, "paperclip-issue-update.sh");
+
+function runDryRun(scriptPath, args, stdin = "", extraEnv = {}) {
+  // Strip any inherited PAPERCLIP_TASK_ID so tests can assert "missing
+  // --issue-id" behaviour deterministically. Other PAPERCLIP_* vars are
+  // irrelevant under --dry-run because the script never makes the HTTP call.
+  const env = { ...process.env, ...extraEnv };
+  delete env.PAPERCLIP_TASK_ID;
+  const result = spawnSync("bash", [scriptPath, ...args], {
+    input: stdin,
+    encoding: "utf-8",
+    env,
+  });
+  return result;
+}
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "pc-helpers-test-"));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const FIXTURES = {
+  multilineMarkdown: [
+    "## Update",
+    "",
+    "- Step one",
+    "- Step two",
+    "",
+    "Next action: open the PR.",
+  ].join("\n"),
+
+  fencedPythonBlock: [
+    "Here is the repro:",
+    "",
+    "```python",
+    "def post_comment(issue_id: str, body: str) -> None:",
+    '    payload = {"body": body}',
+    "    print(payload)",
+    "```",
+    "",
+    "End of block.",
+  ].join("\n"),
+
+  nestedBackticks: [
+    "Inline `code` and an embedded fence:",
+    "",
+    "````md",
+    "```python",
+    "x = 1  # nested fence",
+    "```",
+    "````",
+    "",
+    "Done.",
+  ].join("\n"),
+
+  specialCharacters: [
+    'Quotes: "double" and ‘curly’ and \\backslash\\.',
+    "Tabs:\there.",
+    "Unicode: ✅ ⚠️ 🚀",
+    "Shell metas: $VAR ${VAR} `subshell` $(cmd) | & ; > <",
+    "Backslash-n literal: \\n should NOT become a newline.",
+  ].join("\n"),
+};
+
+// Real-world originator pattern: a node -e command line that inlined a fenced markdown
+// body into a multi-level escaped JS string. The body itself is what we care
+// about preserving end-to-end.
+FIXTURES.shellEscapeOriginator = [
+  "Postmortem note: the originator command was inlined into node -e:",
+  "",
+  "```bash",
+  "node -e 'fetch(\"http://localhost:3100/api/issues/PAP-1/comments\", {",
+  "  method: \"POST\",",
+  "  headers: { \"Content-Type\": \"application/json\" },",
+  "  body: JSON.stringify({ body: `### multi-line",
+  "with backticks \\` and quotes \"\"` })",
+  "})'",
+  "```",
+  "",
+  "The originator command above is exactly what the helper makes obsolete.",
+].join("\n");
+
+for (const [name, body] of Object.entries(FIXTURES)) {
+  test(`comment helper preserves body verbatim: ${name} (stdin)`, () => {
+    const r = runDryRun(COMMENT_SH, ["--issue-id", "PAP-1", "--dry-run"], body);
+    assert.equal(r.status, 0, `non-zero exit: ${r.stderr}`);
+    const payload = JSON.parse(r.stdout);
+    assert.deepEqual(Object.keys(payload).sort(), ["body"]);
+    assert.equal(payload.body, body, "body must round-trip without mutation");
+  });
+
+  test(`comment helper preserves body verbatim: ${name} (--body-file)`, () => {
+    withTempDir((dir) => {
+      const path = join(dir, "body.md");
+      writeFileSync(path, body, "utf-8");
+      const r = runDryRun(COMMENT_SH, [
+        "--issue-id",
+        "PAP-1",
+        "--body-file",
+        path,
+        "--dry-run",
+      ]);
+      assert.equal(r.status, 0, `non-zero exit: ${r.stderr}`);
+      const payload = JSON.parse(r.stdout);
+      assert.equal(payload.body, body, "body must round-trip without mutation");
+    });
+  });
+
+  test(`update helper preserves body verbatim: ${name} (stdin + status)`, () => {
+    const r = runDryRun(
+      UPDATE_SH,
+      ["--issue-id", "PAP-1", "--status", "in_review", "--dry-run"],
+      body,
+    );
+    assert.equal(r.status, 0, `non-zero exit: ${r.stderr}`);
+    const payload = JSON.parse(r.stdout);
+    assert.equal(payload.status, "in_review");
+    assert.equal(payload.comment, body, "comment must round-trip without mutation");
+  });
+}
+
+test("comment helper rejects empty stdin body", () => {
+  const r = runDryRun(COMMENT_SH, ["--issue-id", "PAP-1", "--dry-run"], "");
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /empty/);
+});
+
+test("comment helper requires --issue-id", () => {
+  const r = runDryRun(COMMENT_SH, ["--dry-run"], "hi");
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /--issue-id/);
+});
+
+test("update helper requires --issue-id and --status", () => {
+  const noIssue = runDryRun(UPDATE_SH, ["--status", "done", "--dry-run"], "x");
+  assert.notEqual(noIssue.status, 0);
+  // Disable the env-derived default for this assertion.
+  const noStatus = runDryRun(UPDATE_SH, ["--issue-id", "PAP-1", "--dry-run"], "x");
+  assert.notEqual(noStatus.status, 0);
+  assert.match(noStatus.stderr, /--status/);
+});
+
+test("update helper status-only payload (no comment, no blockers)", () => {
+  const r = runDryRun(
+    UPDATE_SH,
+    ["--issue-id", "PAP-1", "--status", "done", "--dry-run"],
+    "",
+  );
+  assert.equal(r.status, 0, `non-zero exit: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.deepEqual(payload, { status: "done" });
+});
+
+test("update helper accepts repeated --blocked-by and serialises them as an array", () => {
+  const r = runDryRun(
+    UPDATE_SH,
+    [
+      "--issue-id",
+      "PAP-1",
+      "--status",
+      "blocked",
+      "--blocked-by",
+      "PAP-100",
+      "--blocked-by",
+      "PAP-101",
+      "--dry-run",
+    ],
+    "Waiting on the two blockers above.",
+  );
+  assert.equal(r.status, 0, `non-zero exit: ${r.stderr}`);
+  const payload = JSON.parse(r.stdout);
+  assert.deepEqual(payload.blockedByIssueIds, ["PAP-100", "PAP-101"]);
+  assert.equal(payload.status, "blocked");
+  assert.equal(payload.comment, "Waiting on the two blockers above.");
+});
+
+test("comment helper rejects unknown flags", () => {
+  const r = runDryRun(COMMENT_SH, ["--issue-id", "PAP-1", "--surprise", "--dry-run"], "x");
+  assert.notEqual(r.status, 0);
+  assert.match(r.stderr, /Unknown argument/);
+});

--- a/scripts/paperclip-issue-update.sh
+++ b/scripts/paperclip-issue-update.sh
@@ -1,110 +1,142 @@
 #!/usr/bin/env bash
-
+# paperclip-issue-update.sh -- safely PATCH a Paperclip issue (status + comment).
+#
+# Sanctioned path for status transitions that carry a markdown comment.
+# Reads the comment body from stdin / a file (never an inline argument) so
+# multi-line markdown, fenced code blocks, and special characters survive
+# the multi-level shell-escaping bug class that occurs when bodies are
+# inlined into `node -e` / `python -c` / `curl -d` argument strings.
+#
+# Usage:
+#   scripts/paperclip-issue-update.sh \
+#     --issue-id ISSUE_ID \
+#     --status STATUS \
+#     [--body-file PATH] \
+#     [--blocked-by ISSUE_ID]... \
+#     [--dry-run]
+#
+# Body source (pick one): stdin (default) or --body-file PATH.
+# Required env (unless --dry-run): PAPERCLIP_API_URL, PAPERCLIP_API_KEY, PAPERCLIP_RUN_ID.
 set -euo pipefail
 
 usage() {
-  cat <<'EOF'
-Usage:
-  scripts/paperclip-issue-update.sh [--issue-id ID] [--status STATUS] [--comment TEXT] [--dry-run]
+  cat <<'USAGE'
+Usage: scripts/paperclip-issue-update.sh --issue-id ISSUE_ID --status STATUS \
+                                         [--body-file PATH] [--blocked-by ISSUE_ID]... [--dry-run]
 
-Reads a multiline markdown comment from stdin when stdin is piped. This preserves
-newlines when building the JSON payload for PATCH /api/issues/{issueId}.
+Reads the update comment body from stdin by default, or from --body-file when provided.
+Never pass the markdown body as an inline shell argument.
 
-Examples:
-  scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status in_progress <<'MD'
-  Investigating formatting
+Status values: backlog, todo, in_progress, in_review, done, blocked, cancelled.
+Pass --blocked-by ISSUE_ID once per blocker to set blockedByIssueIds.
 
-  - Pulled the raw comment body
-  - Comparing it with the run transcript
-  MD
-
-  scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done --dry-run <<'MD'
-  Done
-
-  - Fixed the issue update helper
-  MD
-EOF
-}
-
-require_command() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    printf 'Missing required command: %s\n' "$1" >&2
-    exit 1
-  fi
+--dry-run prints the JSON payload that would be sent and exits 0.
+USAGE
 }
 
 issue_id="${PAPERCLIP_TASK_ID:-}"
 status=""
-comment_arg=""
+body_file=""
 dry_run=0
+declare -a blocked_by=()
+
+resolve_python() {
+  # Probe each candidate by actually running it. On Windows, `python3` may
+  # resolve to a Microsoft Store stub that fails on use; PATH lookup alone is
+  # not enough.
+  for candidate in python3 python py; do
+    if command -v "$candidate" >/dev/null 2>&1 \
+        && "$candidate" -c "import sys" >/dev/null 2>&1; then
+      echo "$candidate"
+      return
+    fi
+  done
+  echo "Missing working python3/python/py interpreter on PATH" >&2
+  exit 127
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --issue-id)
-      issue_id="${2:-}"
-      shift 2
-      ;;
-    --status)
-      status="${2:-}"
-      shift 2
-      ;;
-    --comment)
-      comment_arg="${2:-}"
-      shift 2
-      ;;
-    --dry-run)
-      dry_run=1
-      shift
-      ;;
-    --help|-h)
-      usage
-      exit 0
-      ;;
-    *)
-      printf 'Unknown argument: %s\n' "$1" >&2
-      usage >&2
-      exit 1
-      ;;
+    --issue-id) issue_id="${2:-}"; shift 2 ;;
+    --status) status="${2:-}"; shift 2 ;;
+    --body-file) body_file="${2:-}"; shift 2 ;;
+    --blocked-by) blocked_by+=("${2:-}"); shift 2 ;;
+    --dry-run) dry_run=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
   esac
 done
 
 if [[ -z "$issue_id" ]]; then
-  printf 'Missing issue id. Pass --issue-id or set PAPERCLIP_TASK_ID.\n' >&2
-  exit 1
+  echo "--issue-id is required (or set PAPERCLIP_TASK_ID)" >&2
+  exit 2
+fi
+if [[ -z "$status" ]]; then
+  echo "--status is required" >&2
+  exit 2
 fi
 
-comment=""
-if [[ -n "$comment_arg" ]]; then
-  comment="$comment_arg"
+comment_file="$(mktemp)"
+payload_file="$(mktemp)"
+blocked_file="$(mktemp)"
+cleanup() { rm -f "$comment_file" "$payload_file" "$blocked_file"; }
+trap cleanup EXIT
+
+if [[ -n "$body_file" ]]; then
+  if [[ ! -r "$body_file" ]]; then
+    echo "--body-file '$body_file' not readable" >&2
+    exit 2
+  fi
+  cp "$body_file" "$comment_file"
 elif [[ ! -t 0 ]]; then
-  comment="$(cat)"
+  cat > "$comment_file"
+else
+  : > "$comment_file"
 fi
 
-require_command jq
+# Persist blockers list to a file so the inner python heredoc never sees them
+# as shell-quoted argv (avoids the same escaping bug class as the comment body).
+if [[ ${#blocked_by[@]} -gt 0 ]]; then
+  printf '%s\n' "${blocked_by[@]}" > "$blocked_file"
+else
+  : > "$blocked_file"
+fi
 
-payload="$(
-  jq -nc \
-    --arg status "$status" \
-    --arg comment "$comment" \
-    '
-      (if $status == "" then {} else {status: $status} end) +
-      (if $comment == "" then {} else {comment: $comment} end)
-    '
-)"
+"$(resolve_python)" - "$status" "$comment_file" "$blocked_file" "$payload_file" <<'PY'
+import json, pathlib, sys
+status = sys.argv[1]
+comment_path = pathlib.Path(sys.argv[2])
+blocked_path = pathlib.Path(sys.argv[3])
+out_path = pathlib.Path(sys.argv[4])
 
-if [[ "$dry_run" == "1" ]]; then
-  printf '%s\n' "$payload"
+payload = {"status": status}
+comment = comment_path.read_text(encoding="utf-8")
+if comment.strip():
+    payload["comment"] = comment
+blocked = [
+    line.strip()
+    for line in blocked_path.read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+if blocked:
+    payload["blockedByIssueIds"] = blocked
+
+out_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+PY
+
+if [[ "$dry_run" -eq 1 ]]; then
+  cat "$payload_file"
   exit 0
 fi
 
-if [[ -z "${PAPERCLIP_API_URL:-}" || -z "${PAPERCLIP_API_KEY:-}" || -z "${PAPERCLIP_RUN_ID:-}" ]]; then
-  printf 'Missing PAPERCLIP_API_URL, PAPERCLIP_API_KEY, or PAPERCLIP_RUN_ID.\n' >&2
-  exit 1
-fi
+: "${PAPERCLIP_API_URL:?missing PAPERCLIP_API_URL}"
+: "${PAPERCLIP_API_KEY:?missing PAPERCLIP_API_KEY}"
+: "${PAPERCLIP_RUN_ID:?missing PAPERCLIP_RUN_ID}"
 
-curl -sS -X PATCH \
-  "$PAPERCLIP_API_URL/api/issues/$issue_id" \
+curl --fail-with-body -sS \
+  -X PATCH \
   -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
   -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
-  -H 'Content-Type: application/json' \
-  --data-binary "$payload"
+  -H "Content-Type: application/json" \
+  --data-binary "@$payload_file" \
+  "$PAPERCLIP_API_URL/api/issues/$issue_id"

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -104,7 +104,11 @@ Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 { "status": "done", "comment": "What was done and why." }
 ```
 
-For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string — that is how comments get "smooshed" together. Use the helper below (or an equivalent `jq --arg` pattern reading from a heredoc/file) so literal newlines survive JSON encoding:
+For multiline markdown comments — **always use the helper scripts**. They are the only sanctioned path from shell. Inlining markdown into `node -e`, `python -c`, or hand-rolled JSON via `curl -d` is how comments get "smooshed" together, truncated at the first backtick, or rejected for malformed JSON.
+
+The helpers read the body from stdin (heredoc) or `--body-file PATH` — never from an inline shell argument — and build the JSON with python's `json.dumps`, so newlines, fenced ` ``` ` blocks, nested backticks, and unicode survive verbatim.
+
+**Status update (PATCH `/api/issues/{id}`) — `scripts/paperclip-issue-update.sh`:**
 
 ```bash
 scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
@@ -114,6 +118,23 @@ Done
 - Verified the raw stored comment body keeps paragraph breaks
 MD
 ```
+
+Add `--blocked-by ISSUE_ID` (repeatable) when transitioning to `blocked`. Use `--dry-run` to print the JSON payload without sending. Pass a pre-written file with `--body-file PATH` instead of stdin if the body is large or you've already produced it.
+
+**Plain comment (POST `/api/issues/{id}/comments`) — `scripts/paperclip-issue-comment.sh`:**
+
+```bash
+scripts/paperclip-issue-comment.sh --issue-id "$PAPERCLIP_TASK_ID" <<'MD'
+## Update
+
+- Verified the helper preserves fenced ```python``` blocks
+- Posting via stdin so newlines survive
+MD
+```
+
+Both helpers require `PAPERCLIP_API_URL`, `PAPERCLIP_API_KEY`, and `PAPERCLIP_RUN_ID` in the environment for live mode (omit for `--dry-run`). Both auto-detect `python3` / `python` / `py` for portability.
+
+**Do NOT** invoke `node -e '...'` or `python -c '...'` to post a comment when the argument string contains a triple-backtick fence or a literal `` \` `` escape — that is the multi-level shell-escaping bug class that produces collapsed or syntactically broken comments. If you find yourself reaching for that pattern, the helper script is the answer.
 
 Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`. Priority values: `critical`, `high`, `medium`, `low`. Other updatable fields: `title`, `description`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`, `blockedByIssueIds`.
 
@@ -264,7 +285,7 @@ Never leave bare ticket ids in issue descriptions or comments when a clickable i
 
 Do NOT use unprefixed paths like `/issues/PAP-123` or `/agents/cto` — always include the company prefix.
 
-**Preserve markdown line breaks (required):** build multiline JSON bodies from heredoc/file input (via the helper in Step 8 or `jq -n --arg comment "$comment"`). Never manually compress markdown into a one-line JSON `comment` string unless you intentionally want a single paragraph.
+**Preserve markdown line breaks (required):** post comments and status updates via the helper scripts referenced in **Step 8** (`scripts/paperclip-issue-comment.sh`, `scripts/paperclip-issue-update.sh`). They read the body from stdin / `--body-file` and never from an inline shell argument, so literal newlines, fenced code blocks, nested backticks, and unicode survive JSON encoding. Never hand-inline markdown into `node -e`, `python -c`, or a one-line `jq` command — that is the multi-level shell-escaping bug class that has repeatedly produced collapsed or syntactically broken comments.
 
 Example:
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and almost everything those agents do touches issues — checking them out, posting comments, transitioning status.
> - Most agents reach the comment/PATCH API from shell, where multi-line markdown bodies have to survive several escaping layers (single quotes around `node -e`, backticks inside JS template literals, JSON encoding, `curl -d`).
> - In practice that escaping repeatedly fails: comments arrive collapsed onto one line, truncated at the first backtick, or rejected outright as malformed JSON. The bug is the inlining itself — once a markdown body crosses one shell-quoting layer, every fenced code block becomes a parser landmine.
> - The repo already had `scripts/paperclip-issue-update.sh`, but its `--comment TEXT` flag was a positional argument — exactly the path that produces the bug. There was no comment-only helper at all.
> - This PR makes the helpers actually safe: stdin / `--body-file` only, JSON built with `python json.dumps`, headers consistent, dry-run mode for local verification, and a CI-wired regression suite that round-trips multi-line markdown, fenced ```python``` blocks, nested backticks, and special characters byte-for-byte.
> - It also points the Paperclip skill at these helpers as the only sanctioned path from shell, so future agents stop reaching for `node -e '...'` in the first place.
> - The benefit is a class of recurring agent-side outages disappears, with a regression test that fails loudly the next time anyone tries to add an inline-arg shortcut.

## What Changed

- **New `scripts/paperclip-issue-comment.sh`** — `POST /api/issues/{id}/comments` helper. Reads the body from stdin (heredoc-friendly) or `--body-file PATH`. Sends the correct `{body}` payload shape (the previous off-tree draft sent `{comment}` which the schema rejects). Supports `--dry-run`. Sends `Authorization`, `X-Paperclip-Run-Id`, and `Content-Type` and uses `--fail-with-body` so HTTP failures surface.
- **Rewrote `scripts/paperclip-issue-update.sh`** — removed the `--comment TEXT` inline argument that was the root cause of the multi-level shell-escaping incidents. Now stdin / `--body-file` only, builds the JSON via `python json.dumps`, supports repeated `--blocked-by ID` to populate `blockedByIssueIds`, supports `--dry-run`. Falls back to `PAPERCLIP_TASK_ID` when `--issue-id` is omitted.
- **Cross-platform python detection** — both scripts probe `python3` / `python` / `py` by actually running each candidate, so the Windows Microsoft-Store `python3` stub is correctly skipped instead of being picked up and crashing with "Python was not found".
- **New `scripts/paperclip-issue-helpers.test.mjs`** — `node --test` suite (21 cases) that exercises both helpers in `--dry-run` mode against fixture bodies covering multi-line markdown, fenced ```python``` blocks, nested backticks, special characters (quotes, tabs, unicode, shell metas, escaped sequences), and a "shellEscapeOriginator" body that mirrors the real-world `node -e '...'` pattern. Asserts the body round-trips byte-for-byte through the JSON payload. Also covers error paths (missing flags, empty body, unknown args, status-only updates, blocker arrays).
- **Wired into CI** — new `pnpm run test:scripts` script in `package.json`; new "Verify paperclip-issue-* helper scripts" step in `.github/workflows/pr.yml` (verify job), so the round-trip guarantee holds on every PR.
- **`skills/paperclip/SKILL.md`** — Step 8 (status updates) and the Comment Style "preserve markdown line breaks" rule now point at these helpers as the only sanctioned path from shell. Removed the `node -e` / `python -c` / freeform `jq` examples that started this whole class of bug. The new Step 8 block also documents the `--body-file`, `--dry-run`, and `--blocked-by` flags.

## Verification

- Local: `pnpm run test:scripts` → 21 / 21 passing on Windows + Git Bash + Python 3.13.
- CI: the new `pr.yml` step runs the same suite on the Linux runner, so the helpers are guaranteed against regressions on every PR.
- Manual: `bash scripts/paperclip-issue-comment.sh --issue-id PAP-1 --dry-run <<'MD' ... MD` prints exactly the JSON payload that would be sent — useful when iterating on a comment locally.
- API shape verified against `addIssueCommentSchema` (`{ body }`) and `updateIssueSchema` (`{ status, comment, blockedByIssueIds }`) in `packages/shared/src/validators/issue.ts`.

## Risks

- Low. The helpers ship under `scripts/`, are opt-in, and are exercised by tests on every PR. The only behavioural change from the previous `paperclip-issue-update.sh` is the removal of the `--comment TEXT` inline flag — that flag was the bug, so removing it is the point. Any caller still using `--comment TEXT` will get a clear "Unknown argument" error and the helper exits non-zero (no silent corruption). The skill update calls out the new flag set so future agents don't reach for the old one.
- The `python json.dumps` round-trip uses `ensure_ascii=False`, so unicode bodies are sent verbatim instead of `\uXXXX`-escaped. The server stores raw bytes, so this matches the existing UI behaviour. Tests cover unicode, emojis, and curly quotes.
- The CI step adds ~10s to the verify job (21 bash + python subprocess invocations).

## Model Used

- Provider: Anthropic (Claude)
- Model ID: claude-opus-4-7
- Capabilities: extended-thinking, tool use (Bash, Read, Write, Edit, Grep), multi-turn agent harness
- Used to draft the helper scripts, write the regression suite, harmonize skill documentation, and run the local verification loop.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (`pnpm run test:scripts` → 21/21)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, no UI changes
- [x] I have updated relevant documentation to reflect my changes (`skills/paperclip/SKILL.md`)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
