### PR TITLE
KIN-722: Add retention/pruning for heartbeat run logs

### DIFF
--- a/server/src/__tests__/run-log-store-retention.test.ts
+++ b/server/src/__tests__/run-log-store-retention.test.ts
@@ -1,0 +1,69 @@
+import { mkdtemp, mkdir, rm, stat, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { pruneExpiredRunLogs } from "../services/run-log-store.js";
+
+describe("pruneExpiredRunLogs", () => {
+  it("prunes only files older than retention and removes empty directories", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "paperclip-run-log-retention-"));
+    try {
+      const oldFile = path.join(root, "company-a", "agent-a", "old.ndjson");
+      const newFile = path.join(root, "company-a", "agent-a", "new.ndjson");
+      await mkdir(path.dirname(oldFile), { recursive: true });
+      await writeFile(oldFile, "old-log", "utf8");
+      await writeFile(newFile, "new-log", "utf8");
+
+      const now = new Date("2026-04-30T00:00:00.000Z");
+      const oldMtime = new Date(now.getTime() - (40 * 24 * 60 * 60 * 1_000));
+      const newMtime = new Date(now.getTime() - (2 * 24 * 60 * 60 * 1_000));
+      await utimes(oldFile, oldMtime, oldMtime);
+      await utimes(newFile, newMtime, newMtime);
+
+      const summary = await pruneExpiredRunLogs({
+        basePath: root,
+        retentionDays: 30,
+        now,
+      });
+
+      expect(summary.scannedFiles).toBe(2);
+      expect(summary.prunedFiles).toBe(1);
+      expect(summary.prunedBytes).toBeGreaterThan(0);
+
+      await expect(stat(oldFile)).rejects.toThrow();
+      await expect(stat(newFile)).resolves.toBeTruthy();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("honors maxDeletes to bound each sweep", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "paperclip-run-log-retention-bound-"));
+    try {
+      const now = new Date("2026-04-30T00:00:00.000Z");
+      const oldMtime = new Date(now.getTime() - (40 * 24 * 60 * 60 * 1_000));
+
+      for (let i = 0; i < 3; i += 1) {
+        const filePath = path.join(root, "company-b", "agent-b", `run-${i}.ndjson`);
+        await mkdir(path.dirname(filePath), { recursive: true });
+        await writeFile(filePath, `log-${i}`, "utf8");
+        await utimes(filePath, oldMtime, oldMtime);
+      }
+
+      const summary = await pruneExpiredRunLogs({
+        basePath: root,
+        retentionDays: 30,
+        maxDeletes: 2,
+        now,
+      });
+
+      expect(summary.scannedFiles).toBe(3);
+      expect(summary.prunedFiles).toBe(2);
+
+      const remainingPath = path.join(root, "company-b", "agent-b", "run-2.ndjson");
+      await expect(stat(remainingPath)).resolves.toBeTruthy();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,6 +38,7 @@ import {
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
 import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
+import { startRunLogRetentionSweep } from "./services/run-log-store.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
@@ -668,6 +669,8 @@ export async function startServer(): Promise<StartedServer> {
     .catch((err) => {
       logger.error({ err }, "startup reconciliation of persisted runtime services failed");
     });
+
+  startRunLogRetentionSweep();
   
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any, { pluginWorkerManager });

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import { notFound } from "../errors.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { logger } from "../middleware/logger.js";
 
 export type RunLogStoreType = "local_file";
 
@@ -36,6 +37,16 @@ export interface RunLogStore {
   finalize(handle: RunLogHandle): Promise<RunLogFinalizeSummary>;
   read(handle: RunLogHandle, opts?: RunLogReadOptions): Promise<RunLogReadResult>;
 }
+
+export interface RunLogPruneSummary {
+  scannedFiles: number;
+  prunedFiles: number;
+  prunedBytes: number;
+}
+
+const RUN_LOG_RETENTION_DAYS_DEFAULT = 30;
+const RUN_LOG_RETENTION_SWEEP_INTERVAL_MS_DEFAULT = 6 * 60 * 60 * 1_000;
+const RUN_LOG_RETENTION_MAX_DELETES_PER_SWEEP = 5_000;
 
 function safeSegments(...segments: string[]) {
   return segments.map((segment) => segment.replace(/[^a-zA-Z0-9._-]/g, "_"));
@@ -154,4 +165,104 @@ export function getRunLogStore() {
   const basePath = process.env.RUN_LOG_BASE_PATH ?? path.resolve(resolvePaperclipInstanceRoot(), "data", "run-logs");
   cachedStore = createLocalFileRunLogStore(basePath);
   return cachedStore;
+}
+
+async function listFilesRecursively(dirPath: string): Promise<string[]> {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true }).catch(() => []);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listFilesRecursively(fullPath));
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function pruneEmptyDirs(dirPath: string, stopAtPath: string): Promise<void> {
+  const resolvedStop = path.resolve(stopAtPath);
+  let current = path.resolve(dirPath);
+  while (current.startsWith(resolvedStop) && current !== resolvedStop) {
+    const entries = await fs.readdir(current).catch(() => null);
+    if (!entries || entries.length > 0) break;
+    await fs.rmdir(current).catch(() => {});
+    current = path.dirname(current);
+  }
+}
+
+export async function pruneExpiredRunLogs(input?: {
+  basePath?: string;
+  retentionDays?: number;
+  maxDeletes?: number;
+  now?: Date;
+}): Promise<RunLogPruneSummary> {
+  const basePath = input?.basePath ?? process.env.RUN_LOG_BASE_PATH ?? path.resolve(resolvePaperclipInstanceRoot(), "data", "run-logs");
+  const retentionDays = Math.max(1, Math.floor(input?.retentionDays ?? RUN_LOG_RETENTION_DAYS_DEFAULT));
+  const maxDeletes = Math.max(1, Math.floor(input?.maxDeletes ?? RUN_LOG_RETENTION_MAX_DELETES_PER_SWEEP));
+  const now = input?.now ?? new Date();
+  const cutoffMs = now.getTime() - (retentionDays * 24 * 60 * 60 * 1_000);
+  const resolvedBasePath = path.resolve(basePath);
+  const files = await listFilesRecursively(resolvedBasePath);
+
+  let prunedFiles = 0;
+  let prunedBytes = 0;
+  for (const filePath of files) {
+    if (prunedFiles >= maxDeletes) break;
+    const stat = await fs.stat(filePath).catch(() => null);
+    if (!stat) continue;
+    if (stat.mtimeMs >= cutoffMs) continue;
+
+    await fs.rm(filePath, { force: true }).catch(() => {});
+    prunedFiles += 1;
+    prunedBytes += stat.size;
+    await pruneEmptyDirs(path.dirname(filePath), resolvedBasePath);
+  }
+
+  return {
+    scannedFiles: files.length,
+    prunedFiles,
+    prunedBytes,
+  };
+}
+
+export function startRunLogRetentionSweep(input?: {
+  basePath?: string;
+  retentionDays?: number;
+  intervalMs?: number;
+  maxDeletes?: number;
+}): () => void {
+  const basePath = input?.basePath ?? process.env.RUN_LOG_BASE_PATH ?? path.resolve(resolvePaperclipInstanceRoot(), "data", "run-logs");
+  const retentionDays = Math.max(
+    1,
+    Math.floor(input?.retentionDays ?? (Number(process.env.RUN_LOG_RETENTION_DAYS) || RUN_LOG_RETENTION_DAYS_DEFAULT)),
+  );
+  const intervalMs = Math.max(
+    60_000,
+    Math.floor(input?.intervalMs ?? (Number(process.env.RUN_LOG_RETENTION_SWEEP_INTERVAL_MS) || RUN_LOG_RETENTION_SWEEP_INTERVAL_MS_DEFAULT)),
+  );
+  const maxDeletes = Math.max(1, Math.floor(input?.maxDeletes ?? RUN_LOG_RETENTION_MAX_DELETES_PER_SWEEP));
+
+  const runSweep = (phase: "initial" | "periodic") => {
+    pruneExpiredRunLogs({ basePath, retentionDays, maxDeletes })
+      .then((summary) => {
+        if (summary.prunedFiles > 0) {
+          logger.info(
+            { ...summary, retentionDays, basePath },
+            `${phase === "initial" ? "Initial" : "Periodic"} heartbeat run log retention sweep pruned files`,
+          );
+        }
+      })
+      .catch((err) => {
+        logger.warn({ err, retentionDays, basePath }, `${phase === "initial" ? "Initial" : "Periodic"} heartbeat run log retention sweep failed`);
+      });
+  };
+
+  runSweep("initial");
+  const timer = setInterval(() => runSweep("periodic"), intervalMs);
+  timer.unref?.();
+  return () => clearInterval(timer);
 }


### PR DESCRIPTION
## Scope\n\nImplements KIN-722 end-to-end retention for heartbeat run logs, including runtime pruning and startup scheduling.\n\n## Implementation\n- Added retention support to server/src/services/run-log-store.ts: pruneExpiredRunLogs, pruneEmptyDirs, listFilesRecursively, startRunLogRetentionSweep.\n- Wired periodic + startup retention sweep in server/src/index.ts via startRunLogRetentionSweep().\n- Added environment configurability through RUN_LOG_RETENTION_DAYS and RUN_LOG_RETENTION_SWEEP_INTERVAL_MS (with defaults and validation).\n- Added test coverage in server/src/__tests__/run-log-store-retention.test.ts for age-based pruning and bounded delete sweep behavior.\n\n## References\n- KIN-722\n\n## Note\n\nPR branch is intentionally clean and based on origin/master via a dedicated backport branch (KIN-722-run-log-retention-clean).