### PR TITLE
fix(recovery): cooldown + dedup for orphan-blocker reconcile

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1716,6 +1716,263 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it("applies a 10-minute cooldown so rapid orphan-blocker firings do not re-assign the same issue", async () => {
+    const companyId = randomUUID();
+    const creatorAgentId = randomUUID();
+    const blockedAssigneeAgentId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const blockedIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: creatorAgentId,
+        companyId,
+        name: "SecurityEngineer",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: blockedAssigneeAgentId,
+        companyId,
+        name: "CodexCoder",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Fix blocker",
+        status: "todo",
+        priority: "high",
+        createdByAgentId: creatorAgentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked work",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: blockedAssigneeAgentId,
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+      createdByAgentId: creatorAgentId,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const reorphanBlocker = async () => {
+      await db
+        .update(issues)
+        .set({ assigneeAgentId: null, assigneeUserId: null, status: "todo" })
+        .where(eq(issues.id, blockerIssueId));
+      const activeRuns = await db
+        .select({ id: heartbeatRuns.id, wakeupRequestId: heartbeatRuns.wakeupRequestId })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, creatorAgentId));
+      for (const run of activeRuns) {
+        await waitForRunToSettle(heartbeat, run.id);
+      }
+    };
+
+    const first = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(first.orphanBlockersAssigned).toBe(1);
+    expect(first.issueIds).toContain(blockerIssueId);
+
+    await reorphanBlocker();
+    const second = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(second.orphanBlockersAssigned).toBe(0);
+    expect(second.skipped).toBe(1);
+    expect(second.issueIds).not.toContain(blockerIssueId);
+
+    await reorphanBlocker();
+    const third = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(third.orphanBlockersAssigned).toBe(0);
+    expect(third.skipped).toBe(1);
+    expect(third.issueIds).not.toContain(blockerIssueId);
+
+    const blockerAfterCooldown = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, blockerIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(blockerAfterCooldown?.assigneeAgentId).toBeNull();
+
+    const elevenMinutesAgo = new Date(Date.now() - 11 * 60 * 1000);
+    await db
+      .update(activityLog)
+      .set({ createdAt: elevenMinutesAgo })
+      .where(
+        and(
+          eq(activityLog.entityType, "issue"),
+          eq(activityLog.entityId, blockerIssueId),
+        ),
+      );
+
+    await reorphanBlocker();
+    const fourth = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(fourth.orphanBlockersAssigned).toBe(1);
+    expect(fourth.issueIds).toContain(blockerIssueId);
+
+    const finalRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, creatorAgentId));
+    for (const run of finalRuns) {
+      await waitForRunToSettle(heartbeat, run.id);
+    }
+  });
+
+  it("skips orphan-blocker re-assignment when an active heartbeat run already targets the same issue", async () => {
+    const companyId = randomUUID();
+    const creatorAgentId = randomUUID();
+    const blockedAssigneeAgentId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const blockedIssueId = randomUUID();
+    const existingRunId = randomUUID();
+    const existingWakeupId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: creatorAgentId,
+        companyId,
+        name: "SecurityEngineer",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: blockedAssigneeAgentId,
+        companyId,
+        name: "CodexCoder",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Fix blocker",
+        status: "todo",
+        priority: "high",
+        createdByAgentId: creatorAgentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked work",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: blockedAssigneeAgentId,
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+      createdByAgentId: creatorAgentId,
+    });
+    await db.insert(agentWakeupRequests).values({
+      id: existingWakeupId,
+      companyId,
+      agentId: creatorAgentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: blockerIssueId, mutation: "unassigned_blocker_recovery" },
+      status: "claimed",
+      runId: existingRunId,
+      claimedAt: new Date(),
+    });
+    await db.insert(heartbeatRuns).values({
+      id: existingRunId,
+      companyId,
+      agentId: creatorAgentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "running",
+      startedAt: new Date(),
+      wakeupRequestId: existingWakeupId,
+      contextSnapshot: {
+        issueId: blockerIssueId,
+        taskId: blockerIssueId,
+        wakeReason: "issue_assigned",
+        source: "issue.unassigned_blocker_recovery",
+      },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.orphanBlockersAssigned).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).not.toContain(blockerIssueId);
+
+    const blocker = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, blockerIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(blocker?.assigneeAgentId).toBeNull();
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, creatorAgentId));
+    expect(wakeups).toHaveLength(1);
+    expect(wakeups[0]?.id).toBe(existingWakeupId);
+
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "succeeded", finishedAt: new Date() })
+      .where(eq(heartbeatRuns.id, existingRunId));
+    await db
+      .update(agentWakeupRequests)
+      .set({ status: "succeeded", finishedAt: new Date() })
+      .where(eq(agentWakeupRequests.id, existingWakeupId));
+  });
+
   it("re-enqueues continuation for stranded in-progress work with no active run", async () => {
     const { agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -8,6 +8,7 @@ import {
   type IssueGraphLivenessAutoRecoveryPreviewItem,
 } from "@paperclipai/shared";
 import {
+  activityLog,
   agents,
   agentWakeupRequests,
   approvals,
@@ -46,6 +47,9 @@ import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js"
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
+const ORPHAN_BLOCKER_RECONCILE_ACTIVITY_SOURCE = "recovery.reconcile_unassigned_blocking_issue";
+const ORPHAN_BLOCKER_RECONCILE_COOLDOWN_MS = 10 * 60 * 1000;
+const ORPHAN_BLOCKER_DEDUP_HEARTBEAT_RUN_STATUSES = ["queued", "running"] as const;
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
@@ -494,6 +498,42 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
       const creatorAgent = await getAgent(creatorAgentId);
       if (!creatorAgent || creatorAgent.companyId !== candidate.companyId || !isAgentInvokable(creatorAgent)) {
+        skipped += 1;
+        continue;
+      }
+
+      const cooldownCutoff = new Date(Date.now() - ORPHAN_BLOCKER_RECONCILE_COOLDOWN_MS);
+      const [recentReconcile] = await db
+        .select({ createdAt: activityLog.createdAt })
+        .from(activityLog)
+        .where(
+          and(
+            eq(activityLog.companyId, candidate.companyId),
+            eq(activityLog.entityType, "issue"),
+            eq(activityLog.entityId, candidate.id),
+            sql`${activityLog.details} ->> 'source' = ${ORPHAN_BLOCKER_RECONCILE_ACTIVITY_SOURCE}`,
+            gt(activityLog.createdAt, cooldownCutoff),
+          ),
+        )
+        .orderBy(desc(activityLog.createdAt))
+        .limit(1);
+      if (recentReconcile) {
+        skipped += 1;
+        continue;
+      }
+
+      const [activeRunForCandidate] = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.agentId, creatorAgent.id),
+            inArray(heartbeatRuns.status, [...ORPHAN_BLOCKER_DEDUP_HEARTBEAT_RUN_STATUSES]),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${candidate.id}`,
+          ),
+        )
+        .limit(1);
+      if (activeRunForCandidate) {
         skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The recovery scheduler periodically reassigns orphaned blocking issues back to their `createdByAgentId` so dependent work resumes when an assignee disappears
> - `reconcileUnassignedBlockingIssues` had no cooldown between firings on the same candidate issue, and no dedup against heartbeat runs already targeting that issue
> - In production this allowed three rapid `## Assigned Orphan Blocker` system comments + three parallel heartbeat runs on the same agent within five minutes (real repro on a downstream company's `SPL-15` on 2026-05-04 at 03:37 / 03:40 / 03:42), polluting issue threads and stacking redundant runs
> - This pull request adds two guards inside `reconcileUnassignedBlockingIssues`: a 10-minute cooldown driven by the existing `activity_log` entry, and a dedup against heartbeat runs in `queued`/`running` whose `contextSnapshot.issueId` matches the candidate
> - The benefit is one orphan-blocker firing per issue per cooldown window, no duplicate wakes when a run is already in flight, and zero regression on legitimate firings spaced > 10 minutes apart

## What Changed

- `server/src/services/recovery/service.ts` — added cooldown + dedup guards inside `reconcileUnassignedBlockingIssues`. Cooldown reads the most recent `activity_log` row with `details.source = "recovery.reconcile_unassigned_blocking_issue"` for the candidate issue; if the entry is younger than 10 min, the candidate is skipped and counted under `skipped`. Dedup queries `heartbeat_runs` for `queued`/`running` runs whose `contextSnapshot.issueId` matches the candidate and whose agent is the targeted creator agent; if found, the candidate is skipped.
- `server/src/__tests__/heartbeat-process-recovery.test.ts` — added two regression tests. The first loops three rapid firings within six minutes against the same candidate (`assigned = 1, skipped = 2`) and a fourth firing after backdating the `activity_log` to confirm the cooldown releases. The second test stages an in-flight `heartbeat_runs` entry against the candidate and confirms the dedup branch skips reassignment.

## Verification

```bash
pnpm install
pnpm typecheck
pnpm --filter @paperclipai/server test -- heartbeat-process-recovery
```

The new tests cover both new branches and the no-regression path (firings > 10 min apart still assign). Existing recovery suite stays green.

Manual repro (before fix): three orphan-blocker firings within five minutes posted three duplicate `## Assigned Orphan Blocker` system comments + three parallel heartbeat runs against the same agent. After fix: only the first firing assigns + wakes; subsequent firings within the cooldown window are counted under `skipped` and emit no comment / no wake.

## Risks

Low risk. Both guards are additive and apply only inside `reconcileUnassignedBlockingIssues`; no other recovery path is touched, no schema migration, no public API change. The cooldown reads from `activity_log` which is already populated by the same code path on success. The dedup queries `heartbeat_runs` with the existing indexed columns. Worst-case regression would be a slightly delayed reassignment when a stale heartbeat run is stuck in `queued` past the cooldown — already handled by the existing run-timeout reaper, so the orphan-blocker simply waits one extra cycle.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (`claude-opus-4-7`)
- Context window: 200K tokens
- Capabilities used: extended thinking, tool use (file edits, shell, GitHub CLI)
- Authoring agent: SplatImmo CTO (Paperclip local agent), supervised by a human operator

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-side only
- [x] I have updated relevant documentation to reflect my changes — N/A, internal recovery service, behavior covered by tests
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
