### PR TITLE
KIN-526: enforce issue execution participant gating

### DIFF
--- a/packages/shared/src/telemetry/events.ts
+++ b/packages/shared/src/telemetry/events.ts
@@ -90,6 +90,48 @@ export function trackAgentTaskCompleted(
   });
 }
 
+export function trackIssueExecutionStageTransition(
+  client: TelemetryClient,
+  dims: {
+    fromStatus: string;
+    toStatus: string;
+    fromStageType: string;
+    toStageType: string;
+    fromParticipantType: string;
+    toParticipantType: string;
+    decisionOutcome?: string | null;
+  },
+): void {
+  client.track("issue.execution_stage_transition", {
+    from_status: dims.fromStatus,
+    to_status: dims.toStatus,
+    from_stage_type: dims.fromStageType,
+    to_stage_type: dims.toStageType,
+    from_participant_type: dims.fromParticipantType,
+    to_participant_type: dims.toParticipantType,
+    ...(dims.decisionOutcome ? { decision_outcome: dims.decisionOutcome } : {}),
+  });
+}
+
+export function trackIssueExecutionRejectedActor(
+  client: TelemetryClient,
+  dims: {
+    actorType: string;
+    requestedStatus: string;
+    stageType: string;
+    currentParticipantType: string;
+    actorMatchesCurrentParticipant: boolean;
+  },
+): void {
+  client.track("issue.execution_actor_rejected", {
+    actor_type: dims.actorType,
+    requested_status: dims.requestedStatus,
+    stage_type: dims.stageType,
+    current_participant_type: dims.currentParticipantType,
+    actor_matches_current_participant: dims.actorMatchesCurrentParticipant,
+  });
+}
+
 export function trackErrorHandlerCrash(
   client: TelemetryClient,
   dims: { errorCode: string },

--- a/packages/shared/src/telemetry/index.ts
+++ b/packages/shared/src/telemetry/index.ts
@@ -13,6 +13,8 @@ export {
   trackSkillImported,
   trackAgentFirstHeartbeat,
   trackAgentTaskCompleted,
+  trackIssueExecutionStageTransition,
+  trackIssueExecutionRejectedActor,
   trackErrorHandlerCrash,
 } from "./events.js";
 export type {

--- a/packages/shared/src/telemetry/types.ts
+++ b/packages/shared/src/telemetry/types.ts
@@ -40,5 +40,7 @@ export type TelemetryEventName =
   | "skill.imported"
   | "agent.first_heartbeat"
   | "agent.task_completed"
+  | "issue.execution_stage_transition"
+  | "issue.execution_actor_rejected"
   | "error.handler_crash"
   | `plugin.${string}`;

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -68,6 +68,8 @@ const mockIssueTreeControlService = vi.hoisted(() => ({
 
 vi.mock("@paperclipai/shared/telemetry", () => ({
   trackAgentTaskCompleted: vi.fn(),
+  trackIssueExecutionStageTransition: vi.fn(),
+  trackIssueExecutionRejectedActor: vi.fn(),
   trackErrorHandlerCrash: vi.fn(),
 }));
 
@@ -336,7 +338,7 @@ describe.sequential("issue comment reopen routes", () => {
         details: expect.not.objectContaining({ reopened: true }),
       }),
     );
-  });
+  }, 10_000);
 
   it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
@@ -370,7 +372,7 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       }),
     );
-  });
+  }, 10_000);
 
   it("resolves assignee shortnames before updating an issue", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
@@ -1235,5 +1237,176 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       }),
     ));
+  }, 10_000);
+
+  it("routes review -> approval -> changes requested -> back to approval on resubmit", async () => {
+    const executorAgentId = "22222222-2222-4222-8222-222222222222";
+    const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+    const approverAgentId = "44444444-4444-4444-8444-444444444444";
+    const policy = await normalizePolicy({
+      stages: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "review",
+          participants: [{ type: "agent", agentId: reviewerAgentId }],
+        },
+        {
+          id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          type: "approval",
+          participants: [{ type: "agent", agentId: approverAgentId }],
+        },
+      ],
+    })!;
+    let issue = {
+      ...makeIssue("todo"),
+      status: "in_progress",
+      assigneeAgentId: executorAgentId,
+      executionPolicy: policy,
+      executionState: null,
+    };
+
+    mockIssueService.getById.mockImplementation(async () => issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+      issue = {
+        ...issue,
+        ...patch,
+        updatedAt: new Date(),
+      };
+      return issue;
+    });
+
+    const submitForReview = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: executorAgentId,
+        companyId: "company-1",
+        runId: "run-submit-review",
+      }),
+    )
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "done", comment: "Ready for review" });
+    expect(submitForReview.status).toBe(200);
+    expect(submitForReview.body.executionState).toMatchObject({
+      status: "pending",
+      currentStageType: "review",
+      currentParticipant: { type: "agent", agentId: reviewerAgentId },
+    });
+    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      reviewerAgentId,
+      expect.objectContaining({ reason: "execution_review_requested" }),
+    ));
+
+    const reviewApprove = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: reviewerAgentId,
+        companyId: "company-1",
+        runId: "run-review-approve",
+      }),
+    )
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "done", comment: "Review approved" });
+    expect(reviewApprove.status).toBe(200);
+    expect(reviewApprove.body.assigneeAgentId).toBe(approverAgentId);
+    expect(reviewApprove.body.executionState).toMatchObject({
+      status: "pending",
+      currentStageType: "approval",
+      currentParticipant: { type: "agent", agentId: approverAgentId },
+    });
+    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      approverAgentId,
+      expect.objectContaining({ reason: "execution_approval_requested" }),
+    ));
+
+    const approverRequestsChanges = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: approverAgentId,
+        companyId: "company-1",
+        runId: "run-approval-changes",
+      }),
+    )
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "in_progress", comment: "Needs updates before approval" });
+    expect(approverRequestsChanges.status).toBe(200);
+    expect(approverRequestsChanges.body.assigneeAgentId).toBe(executorAgentId);
+    expect(approverRequestsChanges.body.executionState).toMatchObject({
+      status: "changes_requested",
+      currentStageType: "approval",
+      currentParticipant: { type: "agent", agentId: approverAgentId },
+    });
+    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      executorAgentId,
+      expect.objectContaining({ reason: "execution_changes_requested" }),
+    ));
+
+    const resubmit = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: executorAgentId,
+        companyId: "company-1",
+        runId: "run-resubmit",
+      }),
+    )
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "done", comment: "Addressed and resubmitted" });
+    expect(resubmit.status).toBe(200);
+    expect(resubmit.body.assigneeAgentId).toBe(approverAgentId);
+    expect(resubmit.body.executionState).toMatchObject({
+      status: "pending",
+      currentStageType: "approval",
+      currentParticipant: { type: "agent", agentId: approverAgentId },
+      completedStageIds: expect.arrayContaining([policy.stages[0].id]),
+    });
+    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      approverAgentId,
+      expect.objectContaining({ reason: "execution_approval_requested" }),
+    ));
+  }, 10_000);
+
+  it("rejects stage advancement when actor does not match executionState.currentParticipant", async () => {
+    const policy = await normalizePolicy({
+      stages: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "review",
+          participants: [{ type: "agent", agentId: "33333333-3333-4333-8333-333333333333" }],
+        },
+      ],
+    })!;
+    const issue = {
+      ...makeIssue("todo"),
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0].id,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: "33333333-3333-4333-8333-333333333333" },
+        returnAssignee: { type: "agent", agentId: "22222222-2222-4222-8222-222222222222" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: "22222222-2222-4222-8222-222222222222",
+        companyId: "company-1",
+        runId: "run-bypass-attempt",
+      }),
+    )
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "done", comment: "Attempting to bypass reviewer" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("Only the active reviewer or approver can advance");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 });
+

--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -578,6 +578,35 @@ describe("issue execution policy transitions", () => {
       // No error — just no patch modifications
       expect(result.patch).toEqual({});
     });
+
+    it("non-participant cannot advance even when issue assignment/status drifted", () => {
+      expect(() =>
+        applyIssueExecutionPolicyTransition({
+          issue: {
+            status: "in_progress",
+            assigneeAgentId: coderAgentId,
+            assigneeUserId: null,
+            executionPolicy: policy,
+            executionState: {
+              status: "pending",
+              currentStageId: reviewStageId,
+              currentStageIndex: 0,
+              currentStageType: "review",
+              currentParticipant: { type: "agent", agentId: qaAgentId },
+              returnAssignee: { type: "agent", agentId: coderAgentId },
+              completedStageIds: [],
+              lastDecisionId: null,
+              lastDecisionOutcome: null,
+            },
+          },
+          policy,
+          requestedStatus: "done",
+          requestedAssigneePatch: {},
+          actor: { agentId: coderAgentId },
+          commentBody: "Attempting to bypass reviewer",
+        }),
+      ).toThrow("Only the active reviewer or approver can advance");
+    });
   });
 
   describe("comment requirements", () => {

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeIssueExecutionPolicy } from "../services/issue-execution-policy.ts";
 
 const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
@@ -14,11 +15,15 @@ const mockAgentService = vi.hoisted(() => ({
 }));
 
 const mockTrackAgentTaskCompleted = vi.hoisted(() => vi.fn());
+const mockTrackIssueExecutionStageTransition = vi.hoisted(() => vi.fn());
+const mockTrackIssueExecutionRejectedActor = vi.hoisted(() => vi.fn());
 const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
 
 function registerModuleMocks() {
   vi.doMock("@paperclipai/shared/telemetry", () => ({
     trackAgentTaskCompleted: mockTrackAgentTaskCompleted,
+    trackIssueExecutionStageTransition: mockTrackIssueExecutionStageTransition,
+    trackIssueExecutionRejectedActor: mockTrackIssueExecutionRejectedActor,
     trackErrorHandlerCrash: vi.fn(),
   }));
 
@@ -143,7 +148,7 @@ describe("issue telemetry routes", () => {
         model: "claude-sonnet-4-6",
       });
     });
-  }, 10_000);
+  }, 20_000);
 
   it("does not emit agent task-completed telemetry for board-driven completions", async () => {
     const app = await createApp({
@@ -160,5 +165,108 @@ describe("issue telemetry routes", () => {
     expect(res.status).toBe(200);
     expect(mockTrackAgentTaskCompleted).not.toHaveBeenCalled();
     expect(mockAgentService.getById).not.toHaveBeenCalled();
+  });
+
+  it("emits execution stage-transition telemetry when a workflow enters review", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "review",
+          participants: [{ type: "agent", agentId: "33333333-3333-4333-8333-333333333333" }],
+        },
+        {
+          id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+          type: "approval",
+          participants: [{ type: "user", userId: "local-board" }],
+        },
+      ],
+    })!;
+    const issue = {
+      ...makeIssue("todo"),
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      executionPolicy: policy,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+    }));
+
+    const app = await createApp({
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    });
+    const res = await request(app)
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() => {
+      expect(mockTrackIssueExecutionStageTransition).toHaveBeenCalledWith(expect.anything(), {
+        fromStatus: "none",
+        toStatus: "pending",
+        fromStageType: "none",
+        toStageType: "review",
+        fromParticipantType: "none",
+        toParticipantType: "agent",
+        decisionOutcome: null,
+      });
+    });
+  }, 20_000);
+
+  it("emits rejected-actor telemetry when a non-participant attempts to advance a stage", async () => {
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "review",
+          participants: [{ type: "agent", agentId: "33333333-3333-4333-8333-333333333333" }],
+        },
+      ],
+    })!;
+    const issue = {
+      ...makeIssue("todo"),
+      status: "in_review",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: "33333333-3333-4333-8333-333333333333" },
+        returnAssignee: { type: "agent", agentId: "22222222-2222-4222-8222-222222222222" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const app = await createApp({
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      runId: null,
+    });
+    const res = await request(app)
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ status: "done" });
+
+    expect(res.status).toBe(422);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockTrackIssueExecutionRejectedActor).toHaveBeenCalledWith(expect.anything(), {
+      actorType: "agent",
+      requestedStatus: "done",
+      stageType: "review",
+      currentParticipantType: "agent",
+      actorMatchesCurrentParticipant: false,
+    });
   });
 });

--- a/server/src/__tests__/shared-telemetry-events.test.ts
+++ b/server/src/__tests__/shared-telemetry-events.test.ts
@@ -4,6 +4,8 @@ import {
   trackAgentFirstHeartbeat,
   trackAgentTaskCompleted,
   trackInstallCompleted,
+  trackIssueExecutionRejectedActor,
+  trackIssueExecutionStageTransition,
 } from "@paperclipai/shared/telemetry";
 import type { TelemetryClient } from "@paperclipai/shared/telemetry";
 
@@ -69,5 +71,49 @@ describe("shared telemetry agent events", () => {
       "install.completed",
       expect.objectContaining({ agent_id: expect.any(String) }),
     );
+  });
+
+  it("tracks execution stage transitions", () => {
+    const client = createClient();
+
+    trackIssueExecutionStageTransition(client, {
+      fromStatus: "pending",
+      toStatus: "pending",
+      fromStageType: "review",
+      toStageType: "approval",
+      fromParticipantType: "agent",
+      toParticipantType: "user",
+      decisionOutcome: "approved",
+    });
+
+    expect(client.track).toHaveBeenCalledWith("issue.execution_stage_transition", {
+      from_status: "pending",
+      to_status: "pending",
+      from_stage_type: "review",
+      to_stage_type: "approval",
+      from_participant_type: "agent",
+      to_participant_type: "user",
+      decision_outcome: "approved",
+    });
+  });
+
+  it("tracks rejected execution actors", () => {
+    const client = createClient();
+
+    trackIssueExecutionRejectedActor(client, {
+      actorType: "agent",
+      requestedStatus: "done",
+      stageType: "review",
+      currentParticipantType: "agent",
+      actorMatchesCurrentParticipant: false,
+    });
+
+    expect(client.track).toHaveBeenCalledWith("issue.execution_actor_rejected", {
+      actor_type: "agent",
+      requested_status: "done",
+      stage_type: "review",
+      current_participant_type: "agent",
+      actor_matches_current_participant: false,
+    });
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -31,7 +31,11 @@ import {
   isClosedIsolatedExecutionWorkspace,
   type ExecutionWorkspace,
 } from "@paperclipai/shared";
-import { trackAgentTaskCompleted } from "@paperclipai/shared/telemetry";
+import {
+  trackAgentTaskCompleted,
+  trackIssueExecutionRejectedActor,
+  trackIssueExecutionStageTransition,
+} from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
 import type { StorageService } from "../storage/types.js";
 import { validate } from "../middleware/validate.js";
@@ -380,6 +384,17 @@ function buildExecutionStageWakeup(input: {
   }
 
   return null;
+}
+
+function executionParticipantMatchesActor(input: {
+  participant: ParsedExecutionState["currentParticipant"] | null;
+  actor: { actorType: "agent" | "user"; actorId: string; agentId: string | null };
+}) {
+  if (!input.participant) return false;
+  if (input.participant.type === "agent") {
+    return !!input.actor.agentId && input.participant.agentId === input.actor.agentId;
+  }
+  return input.actor.actorType === "user" && input.participant.userId === input.actor.actorId;
 }
 
 export function issueRoutes(
@@ -2012,22 +2027,51 @@ export function issueRoutes(
       updateFields.assigneeAgentId = normalizedAssigneeAgentId;
     }
 
-    const transition = applyIssueExecutionPolicyTransition({
-      issue: existing,
-      policy: nextExecutionPolicy,
-      requestedStatus: typeof updateFields.status === "string" ? updateFields.status : undefined,
-      requestedAssigneePatch: {
-        assigneeAgentId: normalizedAssigneeAgentId,
-        assigneeUserId:
-          req.body.assigneeUserId === undefined ? undefined : (req.body.assigneeUserId as string | null),
-      },
-      actor: {
-        agentId: actor.agentId ?? null,
-        userId: actor.actorType === "user" ? actor.actorId : null,
-      },
-      commentBody,
-      reviewRequest: reviewRequest === undefined ? undefined : reviewRequest,
-    });
+    let transition: ReturnType<typeof applyIssueExecutionPolicyTransition>;
+    try {
+      transition = applyIssueExecutionPolicyTransition({
+        issue: existing,
+        policy: nextExecutionPolicy,
+        requestedStatus: typeof updateFields.status === "string" ? updateFields.status : undefined,
+        requestedAssigneePatch: {
+          assigneeAgentId: normalizedAssigneeAgentId,
+          assigneeUserId:
+            req.body.assigneeUserId === undefined ? undefined : (req.body.assigneeUserId as string | null),
+        },
+        actor: {
+          agentId: actor.agentId ?? null,
+          userId: actor.actorType === "user" ? actor.actorId : null,
+        },
+        commentBody,
+        reviewRequest: reviewRequest === undefined ? undefined : reviewRequest,
+      });
+    } catch (err) {
+      const existingExecutionState = parseIssueExecutionState(existing.executionState);
+      const tc = getTelemetryClient();
+      if (
+        tc &&
+        err instanceof HttpError &&
+        err.status === 422 &&
+        typeof err.message === "string" &&
+        err.message.includes("Only the active reviewer or approver can advance")
+      ) {
+        trackIssueExecutionRejectedActor(tc, {
+          actorType: actor.actorType,
+          requestedStatus: typeof req.body.status === "string" ? req.body.status : "__omitted__",
+          stageType: existingExecutionState?.currentStageType ?? "none",
+          currentParticipantType: existingExecutionState?.currentParticipant?.type ?? "none",
+          actorMatchesCurrentParticipant: executionParticipantMatchesActor({
+            participant: existingExecutionState?.currentParticipant ?? null,
+            actor: {
+              actorType: actor.actorType,
+              actorId: actor.actorId,
+              agentId: actor.agentId ?? null,
+            },
+          }),
+        });
+      }
+      throw err;
+    }
     const decisionId = transition.decision ? randomUUID() : null;
     if (decisionId) {
       const nextExecutionState = transition.patch.executionState;
@@ -2436,6 +2480,22 @@ export function issueRoutes(
       req.body.status !== undefined;
     const previousExecutionState = parseIssueExecutionState(existing.executionState);
     const nextExecutionState = parseIssueExecutionState(issue.executionState);
+    const executionStateTransitioned =
+      previousExecutionState?.status !== nextExecutionState?.status ||
+      previousExecutionState?.currentStageId !== nextExecutionState?.currentStageId ||
+      !executionPrincipalsEqual(previousExecutionState?.currentParticipant ?? null, nextExecutionState?.currentParticipant ?? null);
+    const telemetryClient = getTelemetryClient();
+    if (telemetryClient && executionStateTransitioned) {
+      trackIssueExecutionStageTransition(telemetryClient, {
+        fromStatus: previousExecutionState?.status ?? "none",
+        toStatus: nextExecutionState?.status ?? "none",
+        fromStageType: previousExecutionState?.currentStageType ?? "none",
+        toStageType: nextExecutionState?.currentStageType ?? "none",
+        fromParticipantType: previousExecutionState?.currentParticipant?.type ?? "none",
+        toParticipantType: nextExecutionState?.currentParticipant?.type ?? "none",
+        decisionOutcome: transition.decision?.outcome ?? nextExecutionState?.lastDecisionOutcome ?? null,
+      });
+    }
     const executionStageWakeup = buildExecutionStageWakeup({
       issueId: issue.id,
       previousState: previousExecutionState,

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -455,15 +455,27 @@ export function applyIssueExecutionPolicyTransition(input: TransitionInput): Tra
       }
     }
 
+    const actorIsCurrentParticipant = principalsEqual(currentParticipant, actor);
+    const requestedStatusAttemptsDecision =
+      requestedStatus === "done" ||
+      (
+        requestedStatus !== undefined &&
+        requestedStatus !== "in_review" &&
+        requestedStatus !== input.issue.status
+      );
+    const assigneePatchAttemptsOverride =
+      requestedAssigneePatchProvided &&
+      !principalsEqual(explicitAssignee, currentParticipant) &&
+      input.issue.status === "in_review";
     const attemptedStageAdvance =
-      (requestedStatus !== undefined && requestedStatus !== "in_review") ||
-      (requestedAssigneePatchProvided && !principalsEqual(explicitAssignee, currentParticipant));
+      requestedStatusAttemptsDecision ||
+      assigneePatchAttemptsOverride;
     const stageStateDrifted =
       input.issue.status !== "in_review" ||
       !principalsEqual(currentAssignee, currentParticipant) ||
       !principalsEqual(existingState?.currentParticipant ?? null, currentParticipant);
 
-    if (attemptedStageAdvance && !stageStateDrifted) {
+    if (attemptedStageAdvance && !actorIsCurrentParticipant) {
       throw unprocessable("Only the active reviewer or approver can advance the current execution stage");
     }
 


### PR DESCRIPTION
## Summary
- Enforce issue execution gating so only active participants can advance execution stages and stage transitions are auditable.
- Add telemetry for execution stage transitions and actor-rejection events.

## Test Plan
- pnpm exec vitest run src/__tests__/issue-execution-policy.test.ts src/__tests__/issue-telemetry-routes.test.ts src/__tests__/shared-telemetry-events.test.ts
- pnpm exec vitest run src/__tests__/issue-comment-reopen-routes.test.ts

Closes KIN-526