### PR TITLE
fix: discount zero-work upstream runs, guard terminal-issue comment wakes, freeze blocked issues

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2738,7 +2738,8 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        // HIV-229 Bug 2 layer 1: allow comment wakes through when resume:true is set explicitly.
+        const skipAssigneeCommentWake = selfComment || (isClosed && resumeRequested !== true);
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {
@@ -3742,7 +3743,8 @@ export function issueRoutes(
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
-      const skipWake = selfComment || isClosed;
+      // HIV-229 Bug 2 layer 1: allow comment wakes through when resume:true is set explicitly.
+      const skipWake = selfComment || (isClosed && resumeRequested !== true);
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
           wakeups.set(assigneeId, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5406,6 +5406,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issue.status === "done" || issue.status === "cancelled") {
+      // HIV-229 Bug 2 layer 2: belt-and-braces guard. A comment wake on a terminal issue without
+      // explicit resume intent must always be cancelled, even when wakeCommentId is set. The
+      // wakeCommentId bypass below is only valid for interaction wakes (e.g. a referenced comment
+      // on an in-progress issue), not for the case where the comment itself triggered the wake on
+      // an already-terminal issue — that path is the source of the done→in_progress flip-back loop.
+      const wakeCtx = context && typeof context === "object" ? context : {};
+      const wakeReasonForRun = typeof wakeCtx["wakeReason"] === "string" ? wakeCtx["wakeReason"] : null;
+      const isCommentWake = wakeReasonForRun === "issue_commented" || wakeReasonForRun === "issue_comment_mentioned";
+      if (isCommentWake && !resumeIntent) {
+        return {
+          stale: true,
+          errorCode: "skipped_terminal_issue",
+          reason: `Cancelled because issue is in terminal status (${issue.status}) and the comment wake lacks resume intent`,
+          details: { issueId, currentStatus: issue.status, wakeReason: wakeReasonForRun },
+        };
+      }
       if (!resumeIntent && !wakeCommentId) {
         return {
           stale: true,

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -34,6 +34,30 @@ const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
 export const PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX = "Productivity review evidence refreshed.";
 
+// HIV-229 Bug 1: discriminate zero-work upstream rate-limit failures from real runs.
+// These are failed runs where the Claude API rejected the request before any tokens were consumed.
+// Counting them in elapsed-time or churn calculations produces false-positive productivity triggers.
+export function isZeroWorkUpstream(run: HeartbeatRunRow): boolean {
+  if (!run || run.status !== "failed") return false;
+  const ctx =
+    run.contextSnapshot && typeof run.contextSnapshot === "object" ? (run.contextSnapshot as Record<string, unknown>) : {};
+  const errorFamily = typeof ctx["errorFamily"] === "string" ? ctx["errorFamily"] : null;
+  const livenessReason = typeof run.livenessReason === "string" ? run.livenessReason.toLowerCase() : "";
+  const scheduledRetryReason = typeof run.scheduledRetryReason === "string" ? run.scheduledRetryReason : "";
+  const isUpstream =
+    errorFamily === "transient_upstream" ||
+    livenessReason.includes("claude_transient_upstream") ||
+    livenessReason.includes("transient_upstream") ||
+    scheduledRetryReason === "transient_failure";
+  if (!isUpstream) return false;
+  const usage =
+    run.usageJson && typeof run.usageJson === "object" ? (run.usageJson as Record<string, unknown>) : {};
+  const outputTokens = Number(usage["outputTokens"] ?? 0) || 0;
+  const inputTokens = Number(usage["inputTokens"] ?? 0) || 0;
+  const costUsd = Number(usage["costUsd"] ?? 0) || 0;
+  return outputTokens === 0 && inputTokens === 0 && costUsd === 0;
+}
+
 type IssueRow = typeof issues.$inferSelect;
 type AgentRow = typeof agents.$inferSelect;
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
@@ -382,6 +406,9 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     thresholds: ProductivityReviewThresholds,
     now: Date,
   ): Promise<ProductivityReviewEvidence | null> {
+    // HIV-229 Bug 3: freeze all productivity metrics while the issue is blocked.
+    if (sourceIssue.status === "blocked") return null;
+
     const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
     const sixHoursAgo = new Date(now.getTime() - 6 * 60 * 60 * 1000);
 
@@ -419,23 +446,39 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     const terminalRuns = latestRuns.filter((run) =>
       TERMINAL_RUN_STATUSES.includes(run.status as (typeof TERMINAL_RUN_STATUSES)[number]),
     );
+    // HIV-229 Bug 3: streak floor — runs predating the current in_progress episode (i.e. before
+    // the last blocked→in_progress unblock) do not contribute to the streak. applyStatusSideEffects
+    // already resets startedAt on every *→in_progress transition, so sourceIssue.startedAt is the
+    // unblock timestamp.
+    const sourceStartedAt = sourceIssue.startedAt ?? sourceIssue.executionLockedAt ?? null;
     let noCommentStreak = 0;
     for (const run of terminalRuns) {
+      // HIV-229 Bug 3: don't cross the episode boundary.
+      if (sourceStartedAt && run.startedAt && run.startedAt < sourceStartedAt) break;
+      // HIV-229 Bug 1: zero-work upstream failures are invisible to the streak — they neither
+      // increment it nor break it (they produce no comment, so a break would be wrong too).
+      if (isZeroWorkUpstream(run)) continue;
       if (commentRunIds.has(run.id)) break;
       noCommentStreak += 1;
     }
 
+    // HIV-229 Bug 1: exclude zero-work upstream runs from rolling-window churn counts.
+    // Computed in-memory from the already-fetched latestRuns (100-run cap covers any 6h window).
+    const productiveRuns = latestRuns.filter((run) => !isZeroWorkUpstream(run));
+    const runCountLastHour = productiveRuns.filter(
+      (run) => run.createdAt != null && run.createdAt >= oneHourAgo,
+    ).length;
+    const runCountLastSixHours = productiveRuns.filter(
+      (run) => run.createdAt != null && run.createdAt >= sixHoursAgo,
+    ).length;
+
     const [
-      runCountLastHour,
-      runCountLastSixHours,
       assigneeRunCommentCount,
       assigneeRunCommentCountLastHour,
       assigneeRunCommentCountLastSixHours,
       latestComments,
       costRow,
     ] = await Promise.all([
-      countIssueRunsSince(sourceIssue.companyId, sourceAgent.id, sourceIssue.id, oneHourAgo),
-      countIssueRunsSince(sourceIssue.companyId, sourceAgent.id, sourceIssue.id, sixHoursAgo),
       countIssueCommentsSince(sourceIssue.companyId, sourceIssue.id, sourceAgent.id),
       countIssueCommentsSince(sourceIssue.companyId, sourceIssue.id, sourceAgent.id, oneHourAgo),
       countIssueCommentsSince(sourceIssue.companyId, sourceIssue.id, sourceAgent.id, sixHoursAgo),
@@ -466,10 +509,25 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     const activeRunCount = latestRuns.filter((run) =>
       ACTIVE_RUN_STATUSES.includes(run.status as (typeof ACTIVE_RUN_STATUSES)[number]),
     ).length;
-    const activeStartedAt = sourceIssue.startedAt ?? sourceIssue.executionLockedAt ?? null;
-    const elapsedMs = sourceIssue.status === "in_progress" && activeStartedAt
-      ? Math.max(0, now.getTime() - activeStartedAt.getTime())
-      : null;
+
+    // HIV-229 Bug 1: re-baseline elapsed time to the most recent non-zero-work run so that
+    // a window of consecutive upstream rate-limit failures doesn't inflate the active duration.
+    let elapsedMs: number | null = null;
+    if (sourceIssue.status === "in_progress") {
+      const allZeroWork = productiveRuns.length === 0 && latestRuns.length > 0;
+      if (allZeroWork) {
+        elapsedMs = 0;
+      } else {
+        const productiveLatestRunStartedAt =
+          productiveRuns.length > 0 ? productiveRuns[0]?.startedAt ?? null : null;
+        const episodeStartedAt =
+          productiveLatestRunStartedAt ??
+          sourceIssue.startedAt ??
+          sourceIssue.executionLockedAt ??
+          null;
+        elapsedMs = episodeStartedAt ? Math.max(0, now.getTime() - episodeStartedAt.getTime()) : null;
+      }
+    }
 
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
     const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;


### PR DESCRIPTION
## Summary

Three bug fixes to the productivity-review evaluator and the wake/lock layer, specified by ProdOpsAgent in the [HIV-186 spec comment](https://github.com/paperclipai/paperclip/issues/HIV-186#comment-7093f208). All three share the same files; bundled per ProdOpsAgent's recommendation.

### Bug 1 — discount `claude_transient_upstream` zero-work runs from `long_active_duration`

Adds `isZeroWorkUpstream(run)` predicate: `status=failed` AND upstream signal (errorFamily / livenessReason / scheduledRetryReason) AND `outputTokens=0 AND inputTokens=0 AND costUsd=0`. Rejects `billingType`-only gating per spec.

Applied at three loci in `collectEvidence`:
- **noCommentStreak** — zero-work runs `continue` (neither counted nor streak-breaking)
- **runCountLastHour / runCountLastSixHours** — switched to in-memory filter from already-fetched `latestRuns`; SQL `countIssueRunsSince` calls removed for these two counts
- **currentActiveElapsedMs** — re-baselines to most recent non-zero-work run's `startedAt`; returns `0` when entire window is zero-work

### Bug 2 — drop `issue_commented` wakes on terminal-status issues without `resume: true`

Two-layer fix (both required):

**Layer 1 — wake dispatcher** (`routes/issues.ts`): Both the PATCH and POST comment paths now use `selfComment || (isClosed && resumeRequested !== true)` instead of `selfComment || isClosed`. A comment with `resume: true` on a `done`/`cancelled` issue still queues a wake with `resumeIntent: true` in the context snapshot.

**Layer 2 — lock acquisition guard** (`heartbeat.ts evaluateQueuedRunStaleness`): When the issue is terminal AND `wakeReason` is `issue_commented` or `issue_comment_mentioned` AND `resumeIntent` is absent, cancel with `skipped_terminal_issue`. Closes the manual-requeue / status-PATCH race that bypassed the dispatcher gate.

### Bug 3 — freeze productivity metrics while issue is `blocked` (folds in HIV-191)

`collectEvidence` short-circuits with `return null` when `sourceIssue.status === "blocked"`, freezing all triggers. On `blocked → in_progress` transition, `applyStatusSideEffects` (existing, unchanged) resets `startedAt = now`; the new streak floor (`break` on runs predating `sourceIssue.startedAt`) resets `noCommentStreak` from the unblock timestamp for free.

## Acceptance criteria

- Re-run productivity evaluator over HIV-78 / HIV-186 / HIV-31 windows → no false-positive `long_active_duration` trigger
- POST comment to `done` issue without `resume: true` → no run queued, status unchanged
- POST same comment with `resume: true` → run queues + locks as before
- `in_progress → blocked → in_progress` cycle resets `noCommentStreak` from unblock timestamp

## Test artefacts

Unit suite: `server/src/services/productivity-review-zero-work.test.js` (new file, covers `isZeroWorkUpstream` predicate: HIV-186 evidence run, healthy subscription run, partial-token failure, non-upstream crash, malformed inputs).

Verification script run against the patched local install confirmed all cases pass.

Fixes: HIV-229 (bundles HIV-191)