### PR TITLE
fix(server): honor PAPERCLIP_PUBLIC_URL when composing invite URLs (SAGA-1920)

### DIFF
--- a/server/src/__tests__/invite-create-route.test.ts
+++ b/server/src/__tests__/invite-create-route.test.ts
@@ -76,7 +76,7 @@ function createDbStub() {
   };
 }
 
-async function createApp() {
+async function createApp(routeOpts: { authPublicBaseUrl?: string } = {}) {
   const [{ accessRoutes }, { errorHandler }] = await Promise.all([
     import("../routes/access.js"),
     import("../middleware/index.js"),
@@ -99,6 +99,7 @@ async function createApp() {
       deploymentExposure: "private",
       bindHost: "127.0.0.1",
       allowedHostnames: [],
+      authPublicBaseUrl: routeOpts.authPublicBaseUrl,
     }),
   );
   app.use(errorHandler);
@@ -133,5 +134,31 @@ describe("POST /companies/:companyId/invites", () => {
     expect(res.body.companyName).toBe("Acme Robotics");
     expect(res.body.invitePath).toMatch(/^\/invite\/pcp_invite_/);
     expect(res.body.inviteUrl).toMatch(/^https:\/\/paperclip\.example\/invite\/pcp_invite_/);
+  });
+
+  it("prefers configured authPublicBaseUrl over request host so 127.0.0.1 callers get a shareable URL", async () => {
+    const app = await createApp({
+      authPublicBaseUrl: "https://desktop-9tgto0t.tail302fee.ts.net/",
+    });
+
+    const res = await request(app)
+      .post("/api/companies/company-1/invites")
+      // UI talks to the loopback API; without the override the response
+      // would echo http://127.0.0.1 back as the invite host.
+      .set("host", "127.0.0.1:3100")
+      .send({
+        allowedJoinTypes: "human",
+        humanRole: "viewer",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.inviteUrl).toMatch(
+      /^https:\/\/desktop-9tgto0t\.tail302fee\.ts\.net\/invite\/pcp_invite_/,
+    );
+    expect(res.body.onboardingTextUrl).toMatch(
+      /^https:\/\/desktop-9tgto0t\.tail302fee\.ts\.net\/api\/invites\/pcp_invite_[^/]+\/onboarding\.txt$/,
+    );
+    // No double slash from the trimmed trailing "/" in the override.
+    expect(res.body.inviteUrl).not.toContain(".net//");
   });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -124,6 +124,7 @@ export async function createApp(
     deploymentExposure: DeploymentExposure;
     allowedHostnames: string[];
     bindHost: string;
+    authPublicBaseUrl?: string;
     authReady: boolean;
     companyDeletionEnabled: boolean;
     instanceId?: string;
@@ -288,6 +289,7 @@ export async function createApp(
       deploymentExposure: opts.deploymentExposure,
       bindHost: opts.bindHost,
       allowedHostnames: opts.allowedHostnames,
+      authPublicBaseUrl: opts.authPublicBaseUrl,
     }),
   );
   app.use("/api", api);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -611,6 +611,7 @@ export async function startServer(): Promise<StartedServer> {
     deploymentExposure: config.deploymentExposure,
     allowedHostnames: config.allowedHostnames,
     bindHost: config.host,
+    authPublicBaseUrl: config.authPublicBaseUrl,
     authReady,
     companyDeletionEnabled: config.companyDeletionEnabled,
     pluginMigrationDb: pluginMigrationDb as any,

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -899,12 +899,14 @@ function toInviteSummaryResponse(
       brandColor: string | null;
       logoUrl: string | null;
     }
-    | null = null
+    | null = null,
+  publicBaseUrl?: string
 ) {
   const companyInfo = typeof company === "string"
     ? { name: company, brandColor: null, logoUrl: null }
     : company;
-  const baseUrl = requestBaseUrl(req);
+  const overrideBaseUrl = publicBaseUrl?.trim().replace(/\/+$/, "");
+  const baseUrl = overrideBaseUrl || requestBaseUrl(req);
   const invitePath = `/invite/${token}`;
   const onboardingPath = `/api/invites/${token}/onboarding`;
   const onboardingTextPath = `/api/invites/${token}/onboarding.txt`;
@@ -1519,6 +1521,7 @@ function buildInviteOnboardingManifest(
     deploymentExposure: DeploymentExposure;
     bindHost: string;
     allowedHostnames: string[];
+    authPublicBaseUrl?: string;
   }
 ) {
   const baseUrl = requestBaseUrl(req);
@@ -1550,7 +1553,8 @@ function buildInviteOnboardingManifest(
       req,
       token,
       invite,
-      opts.companyName ?? null
+      opts.companyName ?? null,
+      opts.authPublicBaseUrl
     ),
     onboarding: {
       instructions:
@@ -2433,6 +2437,13 @@ export function accessRoutes(
     deploymentExposure: DeploymentExposure;
     bindHost: string;
     allowedHostnames: string[];
+    /**
+     * Optional explicit public base URL (e.g. https://desktop.tail-scale.ts.net).
+     * When set, invite summary URLs prefer this over the request host so that
+     * "Copy invite link" emits a shareable URL even when the UI talks to
+     * 127.0.0.1. Sourced from PAPERCLIP_PUBLIC_URL / auth.publicBaseUrl.
+     */
+    authPublicBaseUrl?: string;
     inviteResolutionNetwork?: Partial<InviteResolutionNetwork>;
   }
 ) {
@@ -2926,7 +2937,8 @@ export function accessRoutes(
         req,
         token,
         created,
-        companyBranding
+        companyBranding,
+        opts.authPublicBaseUrl
       );
       res.status(201).json({
         ...created,
@@ -2980,7 +2992,8 @@ export function accessRoutes(
         req,
         token,
         created,
-        companyBranding
+        companyBranding,
+        opts.authPublicBaseUrl
       );
       res.status(201).json({
         ...created,
@@ -3020,7 +3033,7 @@ export function accessRoutes(
         )
       : null;
     res.json({
-      ...toInviteSummaryResponse(req, token, invite, companyBranding),
+      ...toInviteSummaryResponse(req, token, invite, companyBranding, opts.authPublicBaseUrl),
       invitedByUserName: inviterName,
       joinRequestStatus: inviteJoinRequest?.status ?? null,
       joinRequestType: inviteJoinRequest?.requestType ?? null,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and operators frequently expose their local instance to remote humans (board members, stakeholders) over Tailscale or a reverse-proxied public hostname.
> - The invite/onboarding subsystem in `server/src/routes/access.ts` composes `inviteUrl` for "Copy invite link", invite-summary responses, and the onboarding manifest.
> - `toInviteSummaryResponse` derives the URL exclusively from `requestBaseUrl(req)`, which echoes whatever host the HTTP request arrived on — typically `127.0.0.1:3100` when the operator's browser is on the same machine.
> - That made invite links unshareable: a board member loading `http://127.0.0.1:3100/invite/<token>` on their phone hits their own loopback, not the operator's host.
> - The existing config knob `PAPERCLIP_PUBLIC_URL` (already parsed into `config.authPublicBaseUrl` at `server/src/config.ts:199-206`) was the obvious override but was never threaded into the invite path.
> - This PR threads `authPublicBaseUrl` from `config → createApp opts → accessRoutes opts → toInviteSummaryResponse` (and through `buildInviteOnboardingManifest` for the embedded summary). When set, `inviteUrl` becomes `${authPublicBaseUrl}${invitePath}`; when unset, behavior is unchanged.
> - Benefit: operators with a Tailscale hostname or any public reverse-proxy can now copy an invite link that actually opens for remote humans, with no new config surface.

## What Changed

- `server/src/config.ts` — no change; reuses existing `auth.publicBaseUrl` field (parsed from `PAPERCLIP_PUBLIC_URL`).
- `server/src/index.ts` — passes `config.authPublicBaseUrl` into `createApp` opts.
- `server/src/app.ts` — adds optional `authPublicBaseUrl?: string` to `createApp` opts and forwards it to `accessRoutes`.
- `server/src/routes/access.ts` — adds optional `authPublicBaseUrl` parameter to `toInviteSummaryResponse` and `buildInviteOnboardingManifest`; threads it through all four `toInviteSummaryResponse` call sites; trims a trailing `/` on the override before concatenating the invite path.
- `server/src/__tests__/invite-create-route.test.ts` — new regression test asserting the configured override beats a `host: 127.0.0.1:3100` request header and that trailing-slash normalization works.
- Untouched on purpose: `buildInviteOnboardingManifest`'s other uses of `baseUrl` (`skillUrl`, `registrationEndpointUrl`, `discoveryDiagnostics`, `connectionCandidates`) — those drive agent network discovery and must stay tied to the actual reachable request host.

## Verification

```bash
# new + existing invite test pass
pnpm --filter @paperclipai/server exec vitest run src/__tests__/invite-create-route.test.ts
# → 2/2 pass

# sibling invite/onboarding suites
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/invite-summary-route.test.ts \
  src/__tests__/invite-list-route.test.ts \
  src/__tests__/invite-accept-existing-member.test.ts \
  src/__tests__/openclaw-invite-prompt-route.test.ts \
  src/__tests__/invite-logo-route.test.ts
# → 13/13 pass

pnpm --filter @paperclipai/server typecheck
# → clean
```

Manual smoke (post-merge):

1. `export PAPERCLIP_PUBLIC_URL=https://<tailnet-host>` on the server host.
2. Restart `npx paperclipai`.
3. Open the local UI, mint a fresh invite, click "Copy invite link".
4. Confirm the clipboard URL echoes the public host (`https://<tailnet-host>/invite/<token>`), not `127.0.0.1:3100`.
5. Unset the env var, restart, repeat — confirm the URL falls back to the request-host derivation (no regression for default local-only operators).

## Risks

- **Low risk.** Behavior is fully gated on `PAPERCLIP_PUBLIC_URL` being set; default code path (env var unset) is byte-identical to today's behavior.
- No DB migrations, no schema changes, no breaking API changes.
- No change to agent network discovery (`buildInviteOnboardingManifest`'s other URL fields are untouched), so adapter handshakes are unaffected.
- One observable change for operators who already set `PAPERCLIP_PUBLIC_URL` for other reasons (e.g. OAuth callbacks): their invite links will now also use that host. This is the intended, documented behavior of that env var per `config.ts`.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4 (claude-opus-4-7), 200K context, extended thinking off
- Capabilities used: tool use (Bash, Read, Edit, Grep, Glob), code execution via the Paperclip CTO (GCP) agent harness on a Windows host
- Authoring agent: Paperclip CTO (GCP) — `d689b39f-7bfc-4c27-bc1b-448ddd358636` — under the dmndbrp-oss GitHub identity (origin push 403, so PR opened cross-repo from the `fork` remote per the repo's documented routing convention)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only change; no UI render path touched)
- [ ] I have updated relevant documentation to reflect my changes — `PAPERCLIP_PUBLIC_URL` is already documented as the canonical public-host override; no doc gap introduced
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

## Summary (preserved from original PR description)

Fixes the SAGA-1920 case where `http://127.0.0.1:3100/invite/<token>` only resolves on the host machine, making it impossible to share invites with remote humans (e.g. over Tailscale). With `PAPERCLIP_PUBLIC_URL=https://desktop.tail-scale.ts.net` set on the server, "Copy invite link" now emits `https://desktop.tail-scale.ts.net/invite/<token>` directly.

Refs SAGA-1920 (board-approved via ask_user_questions interaction).

cc @cryppadotta @devinfoley for review (per repo routing convention).
