### PR TITLE
fix: respect ANTHROPIC_BASE_URL in LLM doctor check and onboarding validation

### DIFF
--- a/cli/src/checks/llm-check.ts
+++ b/cli/src/checks/llm-check.ts
@@ -20,7 +20,8 @@ export async function llmCheck(config: PaperclipConfig): Promise<CheckResult> {
 
   try {
     if (config.llm.provider === "claude") {
-      const res = await fetch("https://api.anthropic.com/v1/messages", {
+      const anthropicBaseUrl = process.env.ANTHROPIC_BASE_URL?.replace(/\/$/, "") ?? "https://api.anthropic.com";
+      const res = await fetch(`${anthropicBaseUrl}/v1/messages`, {
         method: "POST",
         headers: {
           "x-api-key": config.llm.apiKey,

--- a/cli/src/commands/onboard.ts
+++ b/cli/src/commands/onboard.ts
@@ -509,7 +509,8 @@ export async function onboard(opts: OnboardOptions): Promise<void> {
       s.start("Validating API key...");
       try {
         if (llm.provider === "claude") {
-          const res = await fetch("https://api.anthropic.com/v1/messages", {
+          const anthropicBaseUrl = process.env.ANTHROPIC_BASE_URL?.replace(/\/$/, "") ?? "https://api.anthropic.com";
+          const res = await fetch(`${anthropicBaseUrl}/v1/messages`, {
             method: "POST",
             headers: {
               "x-api-key": llm.apiKey,


### PR DESCRIPTION
## What changed

The doctor check (`cli/src/checks/llm-check.ts`) and onboarding wizard (`cli/src/commands/onboard.ts`) were hardcoding `https://api.anthropic.com` for API key validation, ignoring the `ANTHROPIC_BASE_URL` environment variable.

## Why

Users running Paperclip with a custom Anthropic-compatible API gateway (e.g. a proxy or enterprise endpoint) set `ANTHROPIC_BASE_URL` to point Claude Code at their gateway. The doctor would always validate against the real Anthropic endpoint, causing a 401 failure and blocking server startup — even when the key is valid for the configured gateway.

## How

Both validation calls now read `ANTHROPIC_BASE_URL` from the environment and fall back to `https://api.anthropic.com` when it is not set. A trailing-slash strip is applied so URLs like `https://my-gateway.example.com/` don't produce double slashes in the path.