### PR TITLE
fix(productivity-review): suppress long_active_duration on pending wake_assignee request_confirmation

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -8,6 +8,7 @@ import {
   createDb,
   heartbeatRuns,
   issueComments,
+  issueThreadInteractions,
   issues,
 } from "@paperclipai/db";
 import {
@@ -16,9 +17,11 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { MAX_ISSUE_REQUEST_DEPTH } from "@paperclipai/shared";
 import {
+  DEFAULT_PRODUCTIVITY_REVIEW_LONG_ACTIVE_HOURS,
   DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS,
   DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
   DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
+  PRODUCTIVITY_REVIEW_LONG_ACTIVE_SUPPRESSION_MULTIPLIER,
   PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,
   productivityReviewService,
@@ -561,5 +564,197 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(result.failed).toBe(0);
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.requestDepth).toBe(MAX_ISSUE_REQUEST_DEPTH);
+  });
+
+  async function insertWakeAssigneeConfirmation(input: {
+    companyId: string;
+    issueId: string;
+    createdAt: Date;
+    status?: "pending" | "accepted" | "rejected" | "expired";
+    continuationPolicy?: "wake_assignee" | "none";
+    kind?: "request_confirmation" | "ask_user_questions" | "suggest_tasks";
+  }) {
+    const id = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id,
+      companyId: input.companyId,
+      issueId: input.issueId,
+      kind: input.kind ?? "request_confirmation",
+      status: input.status ?? "pending",
+      continuationPolicy: input.continuationPolicy ?? "wake_assignee",
+      payload: { kind: "request_confirmation", body: "Confirm before continuing." } as never,
+      createdAt: input.createdAt,
+      updatedAt: input.createdAt,
+    });
+    return id;
+  }
+
+  it("suppresses long_active_duration when a fresh pending wake_assignee request_confirmation exists", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    await insertWakeAssigneeConfirmation({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      createdAt: new Date(now.getTime() - 30 * 60 * 1000),
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("still fires long_active_duration when the only pending wake_assignee request_confirmation is older than the freshness bound", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    const longActiveMs = DEFAULT_PRODUCTIVITY_REVIEW_LONG_ACTIVE_HOURS * 60 * 60 * 1000;
+    await insertWakeAssigneeConfirmation({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      createdAt: new Date(
+        now.getTime() - longActiveMs * PRODUCTIVITY_REVIEW_LONG_ACTIVE_SUPPRESSION_MULTIPLIER - 60 * 60 * 1000,
+      ),
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
+  });
+
+  it("does not suppress long_active_duration for non-pending or non-wake_assignee request_confirmation interactions", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    await insertWakeAssigneeConfirmation({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      createdAt: new Date(now.getTime() - 30 * 60 * 1000),
+      status: "accepted",
+    });
+    await insertWakeAssigneeConfirmation({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      createdAt: new Date(now.getTime() - 30 * 60 * 1000),
+      status: "pending",
+      continuationPolicy: "none",
+    });
+    await insertWakeAssigneeConfirmation({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      createdAt: new Date(now.getTime() - 30 * 60 * 1000),
+      kind: "ask_user_questions",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
+  });
+
+  it("still fires no_comment_streak when a fresh pending wake_assignee request_confirmation exists", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+    await insertWakeAssigneeConfirmation({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      createdAt: new Date(now.getTime() - 30 * 60 * 1000),
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `no_comment_streak`");
+  });
+
+  it("still fires high_churn when a fresh pending wake_assignee request_confirmation exists", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 10,
+      now,
+      withRunComments: true,
+    });
+    await insertWakeAssigneeConfirmation({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      createdAt: new Date(now.getTime() - 30 * 60 * 1000),
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `high_churn`");
+  });
+
+  it("still applies the resolved-review snooze when a fresh pending wake_assignee request_confirmation exists", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const [review] = await listProductivityReviews(seeded.companyId);
+    await db
+      .update(issues)
+      .set({ status: "done", updatedAt: now })
+      .where(eq(issues.id, review!.id));
+    await insertWakeAssigneeConfirmation({
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      createdAt: new Date(now.getTime() - 30 * 60 * 1000),
+    });
+
+    const result = await service.reconcileProductivityReviews({
+      now: new Date(now.getTime() + 30 * 60 * 1000),
+      companyId: seeded.companyId,
+    });
+
+    expect(result.snoozed).toBe(1);
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(1);
   });
 });

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -7,6 +7,7 @@ import {
   costEvents,
   heartbeatRuns,
   issueComments,
+  issueThreadInteractions,
   issues,
   projects,
 } from "@paperclipai/db";
@@ -26,6 +27,15 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS = 3;
 export const DEFAULT_PRODUCTIVITY_REVIEW_CREATION_WINDOW_MS = 24 * 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 3;
+// Freshness window for the long_active_duration suppression check, expressed as
+// a multiple of the long_active threshold. A pending wake_assignee
+// request_confirmation older than this is treated as stale and no longer
+// suppresses the heuristic, so a forgotten interaction cannot silently disable
+// productivity review on an issue forever. With the default 6h threshold this
+// yields a 24h window — wide enough to cover overnight / weekend decision
+// delays on a board that responds within a day, while still bounded enough that
+// a wake_assignee left pending for multiple days no longer hides the issue.
+export const PRODUCTIVITY_REVIEW_LONG_ACTIVE_SUPPRESSION_MULTIPLIER = 4;
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
@@ -342,6 +352,28 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     return comment;
   }
 
+  async function hasFreshPendingWakeAssigneeConfirmation(
+    companyId: string,
+    issueId: string,
+    freshnessCutoff: Date,
+  ) {
+    const rows = await db
+      .select({ id: issueThreadInteractions.id })
+      .from(issueThreadInteractions)
+      .where(
+        and(
+          eq(issueThreadInteractions.companyId, companyId),
+          eq(issueThreadInteractions.issueId, issueId),
+          eq(issueThreadInteractions.kind, "request_confirmation"),
+          eq(issueThreadInteractions.status, "pending"),
+          eq(issueThreadInteractions.continuationPolicy, "wake_assignee"),
+          sql`${issueThreadInteractions.createdAt} >= ${freshnessCutoff.toISOString()}::timestamptz`,
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
   async function countIssueRunsSince(companyId: string, agentId: string, issueId: string, since: Date) {
     return db
       .select({ count: sql<number>`count(*)::int` })
@@ -472,7 +504,18 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       : null;
 
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    let longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    if (longActive) {
+      const freshnessCutoff = new Date(
+        now.getTime() - thresholds.longActiveMs * PRODUCTIVITY_REVIEW_LONG_ACTIVE_SUPPRESSION_MULTIPLIER,
+      );
+      const suppressed = await hasFreshPendingWakeAssigneeConfirmation(
+        sourceIssue.companyId,
+        sourceIssue.id,
+        freshnessCutoff,
+      );
+      if (suppressed) longActive = false;
+    }
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -356,7 +356,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     companyId: string,
     issueId: string,
     freshnessCutoff: Date,
-  ) {
+  ): Promise<boolean> {
     const rows = await db
       .select({ id: issueThreadInteractions.id })
       .from(issueThreadInteractions)
@@ -457,6 +457,15 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       noCommentStreak += 1;
     }
 
+    const activeStartedAt = sourceIssue.startedAt ?? sourceIssue.executionLockedAt ?? null;
+    const elapsedMs = sourceIssue.status === "in_progress" && activeStartedAt
+      ? Math.max(0, now.getTime() - activeStartedAt.getTime())
+      : null;
+    const longActiveCandidate = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    const longActiveSuppressionCutoff = longActiveCandidate
+      ? new Date(now.getTime() - thresholds.longActiveMs * PRODUCTIVITY_REVIEW_LONG_ACTIVE_SUPPRESSION_MULTIPLIER)
+      : null;
+
     const [
       runCountLastHour,
       runCountLastSixHours,
@@ -465,6 +474,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       assigneeRunCommentCountLastSixHours,
       latestComments,
       costRow,
+      longActiveSuppressed,
     ] = await Promise.all([
       countIssueRunsSince(sourceIssue.companyId, sourceAgent.id, sourceIssue.id, oneHourAgo),
       countIssueRunsSince(sourceIssue.companyId, sourceAgent.id, sourceIssue.id, sixHoursAgo),
@@ -493,29 +503,17 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         .from(costEvents)
         .where(and(eq(costEvents.companyId, sourceIssue.companyId), eq(costEvents.issueId, sourceIssue.id)))
         .then((rows) => rows[0] ?? { costCents: 0 }),
+      longActiveSuppressionCutoff
+        ? hasFreshPendingWakeAssigneeConfirmation(sourceIssue.companyId, sourceIssue.id, longActiveSuppressionCutoff)
+        : Promise.resolve(false),
     ]);
 
     const activeRunCount = latestRuns.filter((run) =>
       ACTIVE_RUN_STATUSES.includes(run.status as (typeof ACTIVE_RUN_STATUSES)[number]),
     ).length;
-    const activeStartedAt = sourceIssue.startedAt ?? sourceIssue.executionLockedAt ?? null;
-    const elapsedMs = sourceIssue.status === "in_progress" && activeStartedAt
-      ? Math.max(0, now.getTime() - activeStartedAt.getTime())
-      : null;
 
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    let longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
-    if (longActive) {
-      const freshnessCutoff = new Date(
-        now.getTime() - thresholds.longActiveMs * PRODUCTIVITY_REVIEW_LONG_ACTIVE_SUPPRESSION_MULTIPLIER,
-      );
-      const suppressed = await hasFreshPendingWakeAssigneeConfirmation(
-        sourceIssue.companyId,
-        sourceIssue.id,
-        freshnessCutoff,
-      );
-      if (suppressed) longActive = false;
-    }
+    const longActive = longActiveCandidate && !longActiveSuppressed;
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The productivity-review service watches assigned issues and creates a manager-review issue when an agent is suspected of spinning, no-progress, or long-stalled execution.
> - One of its heuristics, `long_active_duration`, fires after an issue has been continuously `in_progress` for ≥6h regardless of *why* it has been active.
> - This conflicts with the `request_confirmation` interaction pattern: an agent that emits a `wake_assignee` `request_confirmation` is paused waiting on the board / user to respond, not spinning. The heuristic currently treats this as inactivity and creates a productivity-review issue with status `in_progress` and zero recent runs — a false positive.
> - The fix: short-circuit `long_active_duration` when the source issue has a fresh pending `wake_assignee` `request_confirmation`, with a freshness bound so a forgotten interaction cannot silently disable the heuristic forever.
> - This pull request adds that suppression and tests for it.
> - The benefit is fewer false-positive productivity reviews on issues whose agents are legitimately paused.

## Minimal repro

1. Create an issue, assign it to an agent, mark it `in_progress`, set `startedAt` to ≥6 hours ago.
2. Insert one row into `issue_thread_interactions` with `kind = 'request_confirmation'`, `status = 'pending'`, `continuationPolicy = 'wake_assignee'`, `createdAt = now`.
3. Run `productivityReviewService(db).reconcileProductivityReviews({ now, companyId })`.

Before this patch: a productivity-review issue is created with `Primary trigger: long_active_duration`, even though there are no active runs and the agent is paused on a pending board confirmation.

After this patch: the heuristic is suppressed for that source issue and no review is created. Stale wake_assignee interactions (older than the freshness bound) and other heuristics (`no_comment_streak`, `high_churn`, the resolved-review snooze) are unaffected.

## What Changed

- `server/src/services/productivity-review.ts`: added a parallelized suppression query in `collectEvidence`. Pre-compute `longActiveCandidate` from `sourceIssue.startedAt`, then in the existing `Promise.all` batch include a query against `issue_thread_interactions` for any `request_confirmation` with `status = pending`, `continuationPolicy = wake_assignee`, and `createdAt` within `longActiveMs * 4` (24h with the default 6h threshold). When that query finds a match, `longActive` is set to `false` before trigger selection. Non-candidates short-circuit with `Promise.resolve(false)` and incur no additional roundtrip.
- Exposed a new constant `PRODUCTIVITY_REVIEW_LONG_ACTIVE_SUPPRESSION_MULTIPLIER = 4` so the freshness multiplier is documented and tunable from one place.
- Added 6 unit tests in `server/src/__tests__/productivity-review-service.test.ts`:
  1. Suppresses `long_active_duration` when a fresh pending `wake_assignee` `request_confirmation` exists (reproduces the false-positive case).
  2. Still fires `long_active_duration` when the only pending `wake_assignee` interaction is older than the freshness bound.
  3. Does not suppress for non-pending or non-`wake_assignee` interactions, or for other interaction kinds (e.g. `ask_user_questions`).
  4. `no_comment_streak` still fires under the new conditions.
  5. `high_churn` still fires under the new conditions.
  6. The resolved-review snooze still applies under the new conditions.
- Deliberate design choice: the predicate does **not** require `payload.target.revisionId` to match the latest plan revision. Agents emit valid `wake_assignee` interactions whose `payload.target` is omitted entirely, and `wake_assignee` semantically already means "agent is paused waiting" — that's the activity signal we want to honor. Requiring a target binding would silently skip those legitimately untargeted interactions.
- `request_confirmation` itself is not modified — read-only access only.

## Verification

- `pnpm --filter @paperclipai/server vitest run src/__tests__/productivity-review-service.test.ts` → **17 / 17 tests pass** (11 pre-existing + 6 new).
- `pnpm --filter @paperclipai/server typecheck` → clean.
- Backfill sanity check against 14 days of historical productivity-review records under the patched predicate: **6 / 9** would have been suppressed. The 3 not suppressed are exactly the cases the freshness bound is designed to allow through — 1 source issue had no `request_confirmation` interactions at all, and 2 reviews fired against a wake_assignee that had already been pending for >24h by the review's creation time.

## Risks

- **Low — query cost.** One additional `issue_thread_interactions` `LIMIT 1` lookup per candidate that hit the `longActive` flag (i.e. only on issues that have been in_progress ≥6h). The query overlaps with the existing run/comment/cost batch via `Promise.all`, so it does not serialize an extra roundtrip on candidates. Indexes `issue_thread_interactions_company_issue_status_idx` and `issue_thread_interactions_company_issue_created_at_idx` cover the predicate.
- **Low — interaction kind / state coupling.** Reads `kind`, `status`, `continuationPolicy`, `createdAt` only; no writes. If the interaction state machine changes (e.g. a new pending-equivalent status), the suppression will under-fire (heuristic still creates a review) — never silently over-fire.
- **None — other heuristics.** `no_comment_streak`, `high_churn`, and the resolved-review snooze paths are not modified; the only flag mutated is `longActive`.
- **Bounded — stale-interaction footgun.** The 24h freshness window prevents an abandoned wake_assignee from disabling the heuristic indefinitely. Reviewers can tune `PRODUCTIVITY_REVIEW_LONG_ACTIVE_SUPPRESSION_MULTIPLIER` (currently 4 = 24h with the default 6h threshold) without restructuring the patch.

## Model Used

- Claude Opus 4.7, 1M context window, extended thinking off, tool use on.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-side only
- [x] I have updated relevant documentation to reflect my changes (constant exported and inline-commented)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
