### PR TITLE
ELEAAA-461: add hand-rolled Prometheus metrics endpoint

### DIFF
--- a/server/src/__tests__/metrics-endpoint.test.ts
+++ b/server/src/__tests__/metrics-endpoint.test.ts
@@ -1,0 +1,42 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { recordPlaceholderCapHit } from "../observability/prom.js";
+import { metricsRoutes } from "../routes/metrics.js";
+
+function createApp() {
+  const app = express();
+  app.use(metricsRoutes());
+  return app;
+}
+
+describe("GET /metrics", () => {
+  it("returns Prometheus text format", async () => {
+    const res = await request(createApp()).get("/metrics");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toBe("text/plain; version=0.0.4; charset=utf-8");
+  });
+
+  it("emits placeholder cap counter HELP and TYPE lines before increments", async () => {
+    const res = await request(createApp()).get("/metrics");
+
+    expect(res.text).toContain(
+      "# HELP paperclip_placeholder_cap_hits_total Times the placeholder-comment cap blocked an agent comment post.",
+    );
+    expect(res.text).toContain("# TYPE paperclip_placeholder_cap_hits_total counter");
+    expect(res.text).toContain(
+      "# HELP paperclip_placeholder_cap_overrides_total Times a board override bypassed the placeholder-comment cap.",
+    );
+    expect(res.text).toContain("# TYPE paperclip_placeholder_cap_overrides_total counter");
+  });
+
+  it("emits agent_id-labelled samples after a placeholder cap hit", async () => {
+    recordPlaceholderCapHit("test-agent");
+
+    const res = await request(createApp()).get("/metrics");
+
+    expect(res.text).toContain('paperclip_placeholder_cap_hits_total{agent_id="test-agent"} 1');
+    expect(res.text).not.toContain("issue_id");
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -41,6 +41,7 @@ import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
+import { metricsRoutes } from "./routes/metrics.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
@@ -160,6 +161,9 @@ export async function createApp(
       bindHost: opts.bindHost,
     }),
   );
+  // Intentionally before actor middleware so Prometheus can scrape without a Paperclip identity.
+  // Operators should restrict exposure at the same host/network boundary used for health checks.
+  app.use(metricsRoutes());
   app.use(
     actorMiddleware(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/observability/prom.ts
+++ b/server/src/observability/prom.ts
@@ -1,0 +1,60 @@
+const LABEL_NAME = "agent_id";
+
+const METRIC_DEFINITIONS = [
+  {
+    name: "paperclip_placeholder_cap_hits_total",
+    help: "Times the placeholder-comment cap blocked an agent comment post.",
+  },
+  {
+    name: "paperclip_placeholder_cap_overrides_total",
+    help: "Times a board override bypassed the placeholder-comment cap.",
+  },
+] as const;
+
+type MetricName = typeof METRIC_DEFINITIONS[number]["name"];
+
+const counters = new Map<MetricName, Map<string, number>>(
+  METRIC_DEFINITIONS.map((metric) => [metric.name, new Map<string, number>()]),
+);
+
+export function recordPlaceholderCapHit(agentId: string): void {
+  incrementCounter("paperclip_placeholder_cap_hits_total", agentId);
+}
+
+export function recordPlaceholderCapOverride(agentId: string): void {
+  incrementCounter("paperclip_placeholder_cap_overrides_total", agentId);
+}
+
+export function renderMetrics(): string {
+  const lines: string[] = [];
+
+  for (const metric of METRIC_DEFINITIONS) {
+    lines.push(`# HELP ${metric.name} ${metric.help}`);
+    lines.push(`# TYPE ${metric.name} counter`);
+
+    const samples = counters.get(metric.name);
+    if (!samples) continue;
+
+    for (const [agentId, count] of [...samples.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+      lines.push(`${metric.name}{${LABEL_NAME}="${escapeLabelValue(agentId)}"} ${count}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function incrementCounter(metricName: MetricName, agentId: string): void {
+  const samples = counters.get(metricName);
+  if (!samples) {
+    throw new Error(`Unknown counter: ${metricName}`);
+  }
+
+  samples.set(agentId, (samples.get(agentId) ?? 0) + 1);
+}
+
+function escapeLabelValue(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n")
+    .replace(/"/g, "\\\"");
+}

--- a/server/src/routes/metrics.ts
+++ b/server/src/routes/metrics.ts
@@ -1,0 +1,17 @@
+import { Router } from "express";
+import { renderMetrics } from "../observability/prom.js";
+
+const PROMETHEUS_TEXT_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8";
+
+export function metricsRoutes() {
+  const router = Router();
+
+  router.get("/metrics", (_req, res) => {
+    res
+      .status(200)
+      .set("Content-Type", PROMETHEUS_TEXT_CONTENT_TYPE)
+      .end(renderMetrics());
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The server needs a small observability surface for agent comment guard behavior.
> - ELEAAA-461 originally planned a prom-client dependency, but the upstream lockfile branch stalled review.
> - The ratified Plan B keeps the same Prometheus endpoint contract without introducing a runtime dependency.
> - This pull request adds a hand-rolled Prometheus text exposition route for placeholder cap counters.
> - The benefit is one small PR with no manifest or lockfile delta, while preserving the metric names and bounded `agent_id` label required by the follow-on guard work.

## What Changed

- Added `server/src/observability/prom.ts` with in-memory placeholder cap hit/override counters and Prometheus text rendering.
- Added `GET /metrics` via a small metrics route mounted before actor middleware so scrape jobs do not need a Paperclip identity.
- Added endpoint tests covering content type, cold-start HELP/TYPE lines, and `agent_id`-only samples after increment.
- Left `server/package.json` and `pnpm-lock.yaml` unchanged; no `prom-client` dependency is introduced.

## Verification

- PASS: `pnpm install --frozen-lockfile` to refresh workspace links after rebasing onto current `origin/master`.
- PASS: `pnpm --filter @paperclipai/server exec vitest run metrics-endpoint`.
- PASS: `pnpm --filter @paperclipai/server typecheck`.
- ATTEMPTED: `pnpm --filter @paperclipai/server exec vitest run` ran 221 server files; metrics passed, 220 files passed, and 1 untouched file failed with 2 worktree-config port assertions: expected embedded Postgres port `54335`, received `54331` at `server/src/__tests__/worktree-config.test.ts:520` and `:602`.
- NOT RUN: `promtool check metrics`; `promtool` is not installed in this local environment. The emitted content type, HELP/TYPE lines, and labelled sample format are covered by the new Vitest endpoint tests.

## Risks

- Low runtime risk: this is a process-local counter and text renderer with no persistence, network calls, migrations, or new dependency.
- The `/metrics` route is intentionally unauthenticated, matching the ratified Plan B and existing health-endpoint-style scrape expectation; operators should restrict exposure at the host/network boundary.
- Rollback before merge: `git revert dc8eacba 63048cca`. After merge, revert the PR merge commit.

## Model Used

- OpenAI Codex, GPT-5.5 coding agent, tool-enabled shell/git/Vitest workflow, with repository-local instructions and Paperclip issue context.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and documented the full-suite environment failures above
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable)
- [x] I have updated relevant documentation to reflect my changes (not applicable; server-only scaffold covered by tests)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge