### PR TITLE
Fix active-run watchdog log progress

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -184,6 +184,72 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     return { companyId, managerId, coderId, issueId, runId, issuePrefix };
   }
 
+  async function seedInvokableIssue() {
+    const companyId = randomUUID();
+    const managerId = randomUUID();
+    const coderId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `W${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Watchdog Co",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: managerId,
+        companyId,
+        name: "CTO",
+        role: "cto",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: coderId,
+        companyId,
+        name: "Coder",
+        role: "engineer",
+        status: "idle",
+        reportsTo: managerId,
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Long running implementation",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: coderId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+    return { companyId, managerId, coderId, issueId, issuePrefix };
+  }
+
+  async function waitForRun(
+    runId: string,
+    predicate: (run: typeof heartbeatRuns.$inferSelect) => boolean,
+    timeoutMs = 2_000,
+  ) {
+    const deadline = Date.now() + timeoutMs;
+    let latest: typeof heartbeatRuns.$inferSelect | null = null;
+    while (Date.now() < deadline) {
+      latest = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId)).then((rows) => rows[0] ?? null);
+      if (latest && predicate(latest)) return latest;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error(`Timed out waiting for heartbeat run ${runId}`);
+  }
+
   it("creates one medium-priority evaluation issue for a suspicious silent run", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const { companyId, managerId, runId } = await seedRunningRun({
@@ -241,6 +307,89 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(evaluation?.description).not.toContain("json-secret-value");
     expect(evaluation?.description).not.toContain(leakedJwt);
     expect(evaluation?.description).not.toContain(leakedGithubToken);
+  });
+
+  it("uses lastOutputBytes to read active run-log evidence before finalization", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const store = getRunLogStore();
+    const handle = await store.begin({ companyId, agentId: coderId, runId });
+    const logBytes = await store.append(handle, {
+      stream: "stdout",
+      chunk: "boot complete\nready for next command\n",
+      ts: new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 60_000).toISOString(),
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({
+        logStore: handle.store,
+        logRef: handle.logRef,
+        logBytes: null,
+        lastOutputAt: new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 60_000),
+        lastOutputSeq: 7,
+        lastOutputStream: "stdout",
+        lastOutputBytes: logBytes,
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    const [evaluation] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation?.description).toContain("boot complete");
+    expect(evaluation?.description).toContain("ready for next command");
+    expect(evaluation?.description).toContain("- Last output sequence: 7");
+    expect(evaluation?.description).not.toContain("_No run-log tail was available._");
+  });
+
+  it("flushes burst output progress while the active run remains quiet", async () => {
+    let finishAdapterRun: (() => void) | null = null;
+    const logsWritten = new Promise<void>((resolveLogsWritten) => {
+      mockAdapterExecute.mockImplementationOnce(async (input: {
+        onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+      }) => {
+        await input.onLog?.("stdout", "first chunk\n");
+        await input.onLog?.("stdout", "second chunk\n");
+        resolveLogsWritten();
+        await new Promise<void>((resolve) => {
+          finishAdapterRun = resolve;
+        });
+        return {
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          errorMessage: null,
+          summary: "Acknowledged stale-run evaluation.",
+          provider: "test",
+          model: "test-model",
+        };
+      });
+    });
+    const { coderId, issueId } = await seedInvokableIssue();
+    const heartbeat = heartbeatService(db, { activeRunOutputProgressFlushIntervalMs: 25 });
+    const queued = await heartbeat.invoke(coderId, "assignment", { issueId }, "system");
+    expect(queued?.id).toBeTruthy();
+
+    await logsWritten;
+
+    const afterBurst = await waitForRun(queued!.id, (run) => run.status === "running" && (run.lastOutputSeq ?? 0) >= 1);
+    expect(afterBurst.lastOutputBytes ?? 0).toBeGreaterThan(0);
+
+    const afterIdleFlush = await waitForRun(
+      queued!.id,
+      (run) => run.status === "running" && (run.lastOutputSeq ?? 0) >= 2,
+    );
+    expect(afterIdleFlush.lastOutputSeq ?? 0).toBeGreaterThanOrEqual(2);
+    expect(afterIdleFlush.lastOutputBytes ?? 0).toBeGreaterThan(0);
+
+    finishAdapterRun?.();
+    await waitForRun(queued!.id, (run) => run.status === "succeeded");
   });
 
   it("raises critical stale-run evaluations and blocks the source issue", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2147,6 +2147,7 @@ export type HeartbeatEnvironmentRuntime = ReturnType<typeof environmentRuntimeSe
 export interface HeartbeatServiceOptions {
   pluginWorkerManager?: PluginWorkerManager;
   environmentRuntime?: HeartbeatEnvironmentRuntime;
+  activeRunOutputProgressFlushIntervalMs?: number;
 }
 
 export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) {
@@ -2177,6 +2178,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   const budgets = budgetService(db, budgetHooks);
   const recovery = recoveryService(db, { enqueueWakeup });
   const productivityReviews = productivityReviewService(db, { enqueueWakeup });
+  const activeRunOutputProgressFlushIntervalMs =
+    options.activeRunOutputProgressFlushIntervalMs ?? ACTIVE_RUN_OUTPUT_PROGRESS_FLUSH_INTERVAL_MS;
   let unsafeTextProjectionPromise: Promise<boolean> | null = null;
 
   async function releaseEnvironmentLeasesForRun(input: {
@@ -5537,20 +5540,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     let lastOutputFlushAt: Date | null = run.lastOutputAt ?? null;
     const outputProgressState: {
       pending: {
-      at: Date;
-      seq: number;
-      stream: "stdout" | "stderr";
-      bytes: number;
+        at: Date;
+        seq: number;
+        stream: "stdout" | "stderr";
+        bytes: number;
       } | null;
     } = { pending: null };
+    let outputProgressFlushTimer: ReturnType<typeof setTimeout> | null = null;
+    let outputProgressFlushInFlight: Promise<void> | null = null;
     let persistedLogBytes = Number(run.logBytes ?? 0);
+    const clearOutputProgressFlushTimer = () => {
+      if (!outputProgressFlushTimer) return;
+      clearTimeout(outputProgressFlushTimer);
+      outputProgressFlushTimer = null;
+    };
     const flushOutputProgress = async (opts?: { force?: boolean }) => {
       const pendingOutputProgress = outputProgressState.pending;
       if (!pendingOutputProgress) return;
       const shouldFlush =
         opts?.force === true ||
         !lastOutputFlushAt ||
-        pendingOutputProgress.at.getTime() - lastOutputFlushAt.getTime() >= ACTIVE_RUN_OUTPUT_PROGRESS_FLUSH_INTERVAL_MS;
+        pendingOutputProgress.at.getTime() - lastOutputFlushAt.getTime() >= activeRunOutputProgressFlushIntervalMs;
       if (!shouldFlush) return;
       await db
         .update(heartbeatRuns)
@@ -5563,7 +5573,39 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         })
         .where(eq(heartbeatRuns.id, run.id));
       lastOutputFlushAt = pendingOutputProgress.at;
-      outputProgressState.pending = null;
+      if (outputProgressState.pending === pendingOutputProgress) {
+        outputProgressState.pending = null;
+      }
+      clearOutputProgressFlushTimer();
+    };
+    const scheduleOutputProgressFlush = () => {
+      if (!outputProgressState.pending || !lastOutputFlushAt) {
+        clearOutputProgressFlushTimer();
+        return;
+      }
+      clearOutputProgressFlushTimer();
+      const flushDelayMs = Math.max(
+        0,
+        activeRunOutputProgressFlushIntervalMs -
+          (outputProgressState.pending.at.getTime() - lastOutputFlushAt.getTime()),
+      );
+      outputProgressFlushTimer = setTimeout(() => {
+        outputProgressFlushTimer = null;
+        outputProgressFlushInFlight = flushOutputProgress({ force: true })
+          .catch((err) => {
+            logger.warn({ err, runId: run.id }, "failed to flush idle run output progress");
+          })
+          .finally(() => {
+            outputProgressFlushInFlight = null;
+            if (outputProgressState.pending) scheduleOutputProgressFlush();
+          });
+      }, flushDelayMs);
+    };
+    const flushPendingOutputProgressBeforeStop = async () => {
+      clearOutputProgressFlushTimer();
+      if (outputProgressFlushInFlight) {
+        await outputProgressFlushInFlight;
+      }
     };
     try {
       const startedAt = run.startedAt ?? new Date();
@@ -5648,6 +5690,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           bytes: persistedLogBytes,
         };
         await flushOutputProgress();
+        scheduleOutputProgressFlush();
 
         const payloadChunk =
           sanitizedChunk.length > MAX_LIVE_LOG_CHUNK_BYTES
@@ -5881,6 +5924,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (handle) {
         logSummary = await runLogStore.finalize(handle);
       }
+      await flushPendingOutputProgressBeforeStop();
       const finalLogBytes = logSummary?.bytes;
       if (outputProgressState.pending && typeof finalLogBytes === "number") {
         outputProgressState.pending.bytes = finalLogBytes;
@@ -6040,6 +6084,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           logger.warn({ err: finalizeErr, runId }, "failed to finalize run log after error");
         }
       }
+      await flushPendingOutputProgressBeforeStop();
       const finalLogBytes = logSummary?.bytes;
       if (outputProgressState.pending && typeof finalLogBytes === "number") {
         outputProgressState.pending.bytes = finalLogBytes;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -678,10 +678,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return `${value.slice(value.length - maxChars)}\n[truncated earlier evidence]`;
   }
 
-  async function readRunLogTailForEvidence(run: typeof heartbeatRuns.$inferSelect) {
-    if (!run.logStore || !run.logRef || !run.logBytes) return "";
+  async function readRunLogTailForEvidence(
+    run: Pick<typeof heartbeatRuns.$inferSelect, "id" | "logStore" | "logRef" | "logBytes" | "lastOutputBytes">,
+  ) {
+    const readableBytes =
+      typeof run.logBytes === "number" && run.logBytes > 0
+        ? run.logBytes
+        : typeof run.lastOutputBytes === "number" && run.lastOutputBytes > 0
+          ? run.lastOutputBytes
+          : 0;
+    if (!run.logStore || !run.logRef || readableBytes <= 0) return "";
     try {
-      const offset = Math.max(0, run.logBytes - ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES);
+      const offset = Math.max(0, readableBytes - ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES);
       const result = await runLogStore.read(
         { store: run.logStore as "local_file", logRef: run.logRef },
         { offset, limitBytes: ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES },


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and records heartbeat runs as the operational evidence trail.
> - The heartbeat subsystem streams run logs and persists progress fields used by stale-run recovery.
> - Active runs can emit a startup burst and then go quiet before finalization.
> - Before this change, persisted output progress could stay pinned to an early chunk until another output event or finalization.
> - Stale-run watchdog evidence also read only finalized `logBytes`, so active unfinalized logs could show `_No run-log tail was available._`.
> - This pull request makes active-run watchdog evidence use the best known active output byte count and persists idle burst progress.
> - The benefit is clearer recovery evidence for silent active runs without changing watchdog thresholds or the stale-run pipeline.

## What Changed

- Persist pending active-run output progress after an idle/debounced burst so `lastOutputAt`, `lastOutputSeq`, and `lastOutputBytes` do not stay pinned to the first chunk until finalization.
- Read watchdog evidence tails using `logBytes ?? lastOutputBytes` so unfinalized runs with active `logStore` / `logRef` output can include the latest readable tail.
- Add focused coverage for active runs with unset final `logBytes` and burst-then-quiet output progress.

## Provenance

- Parent issue: [DEV-145](/DEV/issues/DEV-145)
- PR-owner issue: [DEV-146](/DEV/issues/DEV-146)
- Repo: `/Users/kmullaney/keegoid/repos/paperclip`
- Branch: `codex/dev-145-active-run-watchdog-evidence`
- Commit: `308b9a12ef40711ee4cd08a1d6f75d8c352a2ec8`
- Commit identity: `Codex <codex@keegoid.com>`
- Implementation handoff author: DEV Engineer (`3fc7f7c3-0a3d-4154-a256-3d507a9792ff`)

## Verification

- `pnpm run preflight:workspace-links`
- `PAPERCLIP_HOME=/tmp/paperclip-dev-145-vitest-home PAPERCLIP_INSTANCE_ID=dev-145-vitest TMPDIR=/tmp/paperclip-dev-145-vitest-tmp pnpm exec vitest run --project @paperclipai/server server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low migration risk: no schema changes and no watchdog threshold changes.
- Timer-ordering risk is contained by the force flush before run finalization and focused tests for burst-then-quiet output.
- Evidence-tail reads still use the existing log store and recovery description paths; this change only chooses `lastOutputBytes` when finalized `logBytes` is not available.
- The focused test uses short real-time polling for the debounced flush path; reviewer noted this as a possible CI-flake risk, but local verification passed.

## Model Used

- OpenAI GPT-5.5 via Codex local adapter, with repository/tool access for implementation handoff verification and PR ownership.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no UI change)
- [x] I have updated relevant documentation to reflect my changes (N/A: behavior fix covered by tests and issue/PR evidence)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
