### PR TITLE
fix(adapters): use junctions for skill symlinks on Windows (#63)

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -61,7 +61,6 @@ export {
   redactCommandText,
 } from "./command-redaction.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
-export { safeSymlink } from "./safe-symlink.js";
 // Keep the root adapter-utils entry browser-safe because the UI imports it.
 // The sandbox callback bridge stays available via its dedicated subpath export.
 export type {

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -61,6 +61,7 @@ export {
   redactCommandText,
 } from "./command-redaction.js";
 export { inferOpenAiCompatibleBiller } from "./billing.js";
+export { safeSymlink } from "./safe-symlink.js";
 // Keep the root adapter-utils entry browser-safe because the UI imports it.
 // The sandbox callback bridge stays available via its dedicated subpath export.
 export type {

--- a/packages/adapter-utils/src/safe-symlink.test.ts
+++ b/packages/adapter-utils/src/safe-symlink.test.ts
@@ -1,0 +1,45 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { safeSymlink } from "./safe-symlink.js";
+
+describe("safeSymlink", () => {
+  let scratch: string;
+
+  beforeEach(async () => {
+    scratch = await fs.mkdtemp(path.join(os.tmpdir(), "safe-symlink-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(scratch, { recursive: true, force: true });
+  });
+
+  it("creates a working link to a directory without elevated privileges", async () => {
+    const sourceDir = path.join(scratch, "src");
+    await fs.mkdir(sourceDir);
+    await fs.writeFile(path.join(sourceDir, "marker.txt"), "ok", "utf8");
+
+    const linkPath = path.join(scratch, "link");
+    await safeSymlink(sourceDir, linkPath);
+
+    const lst = await fs.lstat(linkPath);
+    // Junctions report as symbolic links via lstat on Windows.
+    expect(lst.isSymbolicLink()).toBe(true);
+    const contents = await fs.readFile(path.join(linkPath, "marker.txt"), "utf8");
+    expect(contents).toBe("ok");
+  });
+
+  it("creates a working link to a file", async () => {
+    const sourceFile = path.join(scratch, "src.txt");
+    await fs.writeFile(sourceFile, "hello", "utf8");
+
+    const linkPath = path.join(scratch, "link.txt");
+    await safeSymlink(sourceFile, linkPath);
+
+    const lst = await fs.lstat(linkPath);
+    expect(lst.isSymbolicLink()).toBe(true);
+    const contents = await fs.readFile(linkPath, "utf8");
+    expect(contents).toBe("hello");
+  });
+});

--- a/packages/adapter-utils/src/safe-symlink.ts
+++ b/packages/adapter-utils/src/safe-symlink.ts
@@ -21,7 +21,10 @@ export async function safeSymlink(source: string, target: string): Promise<void>
     return;
   }
 
-  const stats = await fs.stat(source).catch(() => null);
+  const stats = await fs.stat(source).catch((err: NodeJS.ErrnoException) => {
+    if (err.code === "ENOENT") return null;
+    throw err;
+  });
   if (stats?.isDirectory()) {
     await fs.symlink(path.resolve(source), target, "junction");
     return;

--- a/packages/adapter-utils/src/safe-symlink.ts
+++ b/packages/adapter-utils/src/safe-symlink.ts
@@ -1,0 +1,31 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const isWindows = os.platform() === "win32";
+
+// On Windows, fs.symlink() with type "dir" (the default for directory targets)
+// requires SeCreateSymbolicLinkPrivilege — i.e. running as administrator or
+// having Developer Mode enabled. Without it, the call fails with EPERM and
+// breaks adapter onboarding (see paperclipai/paperclip#63). Junctions are an
+// older Windows reparse point that behaves like a directory symlink for our
+// purposes (skills directories, adapter-managed home dirs) and does NOT need
+// elevated privileges.
+//
+// Junctions only support absolute paths to local directories, so we resolve
+// the source before creating one. For file targets, "file"-typed symlinks do
+// not need elevated privileges on modern Windows, so we use them directly.
+export async function safeSymlink(source: string, target: string): Promise<void> {
+  if (!isWindows) {
+    await fs.symlink(source, target);
+    return;
+  }
+
+  const stats = await fs.stat(source).catch(() => null);
+  if (stats?.isDirectory()) {
+    await fs.symlink(path.resolve(source), target, "junction");
+    return;
+  }
+
+  await fs.symlink(source, target, "file");
+}

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -4,6 +4,7 @@ import { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
 import path from "node:path";
 import { buildSshSpawnTarget, type SshRemoteExecutionSpec } from "./ssh.js";
 import { redactCommandText } from "./command-redaction.js";
+import { safeSymlink } from "./safe-symlink.js";
 import type {
   AdapterSkillEntry,
   AdapterSkillSnapshot,
@@ -1502,8 +1503,7 @@ export function writePaperclipSkillSyncPreference(
 export async function ensurePaperclipSkillSymlink(
   source: string,
   target: string,
-  linkSkill: (source: string, target: string) => Promise<void> = (linkSource, linkTarget) =>
-    fs.symlink(linkSource, linkTarget),
+  linkSkill: (source: string, target: string) => Promise<void> = safeSymlink,
 ): Promise<"created" | "repaired" | "skipped"> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { buildSshSpawnTarget, type SshRemoteExecutionSpec } from "./ssh.js";
 import { redactCommandText } from "./command-redaction.js";
 import { safeSymlink } from "./safe-symlink.js";
+
+export { safeSymlink } from "./safe-symlink.js";
 import type {
   AdapterSkillEntry,
   AdapterSkillSnapshot,

--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import { safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import { readAdapterExecutionTarget, adapterExecutionTargetSessionIdentity } from "@paperclipai/adapter-utils/execution-target";
 import {
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
@@ -21,6 +21,7 @@ import {
   renderPaperclipWakePrompt,
   renderTemplate,
   resolvePaperclipDesiredSkillNames,
+  safeSymlink,
   shapePaperclipWorkspaceEnvForExecution,
   stringifyPaperclipWakePayload,
   type PaperclipSkillEntry,

--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
-import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import { readAdapterExecutionTarget, adapterExecutionTargetSessionIdentity } from "@paperclipai/adapter-utils/execution-target";
 import {
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
@@ -173,13 +173,13 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {
     await ensureParentDir(target);
-    await fs.symlink(resolvedSource, target);
+    await safeSymlink(resolvedSource, target);
     return;
   }
 
   if (!existing.isSymbolicLink()) {
     await fs.rm(target, { recursive: true, force: true });
-    await fs.symlink(resolvedSource, target);
+    await safeSymlink(resolvedSource, target);
     return;
   }
 
@@ -190,7 +190,7 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   if (resolvedLinkedPath === resolvedSource) return;
 
   await fs.unlink(target);
-  await fs.symlink(resolvedSource, target);
+  await safeSymlink(resolvedSource, target);
 }
 
 async function ensureCopiedFile(target: string, source: string): Promise<void> {

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { safeSymlink, type AdapterExecutionContext } from "@paperclipai/adapter-utils";
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
@@ -46,7 +46,7 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   const existing = await fs.lstat(target).catch(() => null);
   if (!existing) {
     await ensureParentDir(target);
-    await fs.symlink(source, target);
+    await safeSymlink(source, target);
     return;
   }
 
@@ -61,7 +61,7 @@ async function ensureSymlink(target: string, source: string): Promise<void> {
   if (resolvedLinkedPath === source) return;
 
   await fs.unlink(target);
-  await fs.symlink(source, target);
+  await safeSymlink(source, target);
 }
 
 async function ensureCopiedFile(target: string, source: string): Promise<void> {

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { safeSymlink, type AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { safeSymlink } from "@paperclipai/adapter-utils/server-utils";
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -247,7 +247,7 @@ export async function ensureCodexSkillsInjected(
           if (linkSkill) {
             await linkSkill(entry.source, target);
           } else {
-            await fs.symlink(entry.source, target);
+            await safeSymlink(entry.source, target);
           }
           await onLog(
             "stdout",

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -31,6 +31,7 @@ import {
   resolvePaperclipDesiredSkillNames,
   renderTemplate,
   renderPaperclipWakePrompt,
+  safeSymlink,
   shapePaperclipWorkspaceEnvForExecution,
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -37,6 +37,7 @@ import {
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   renderPaperclipWakePrompt,
+  safeSymlink,
   shapePaperclipWorkspaceEnvForExecution,
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -123,7 +123,7 @@ async function buildCursorSkillsDir(config: Record<string, unknown>): Promise<st
   const desiredNames = new Set(resolvePaperclipDesiredSkillNames(config, availableEntries));
   for (const entry of availableEntries) {
     if (!desiredNames.has(entry.key)) continue;
-    await fs.symlink(entry.source, path.join(target, entry.runtimeName));
+    await safeSymlink(entry.source, path.join(target, entry.runtimeName));
   }
   return target;
 }
@@ -171,7 +171,7 @@ export async function ensureCursorSkillsInjected(
       `[paperclip] Removed maintainer-only Cursor skill "${skillName}" from ${skillsHome}\n`,
     );
   }
-  const linkSkill = options.linkSkill ?? ((source: string, target: string) => fs.symlink(source, target));
+  const linkSkill = options.linkSkill ?? safeSymlink;
   for (const entry of skillsEntries) {
     const target = path.join(skillsHome, entry.runtimeName);
     try {

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -3,7 +3,7 @@ import type { Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -40,6 +40,7 @@ import {
   parseObject,
   renderTemplate,
   renderPaperclipWakePrompt,
+  safeSymlink,
   shapePaperclipWorkspaceEnvForExecution,
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -3,7 +3,7 @@ import type { Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -164,7 +164,7 @@ async function buildGeminiSkillsDir(
   const desiredNames = new Set(resolvePaperclipDesiredSkillNames(config, availableEntries));
   for (const entry of availableEntries) {
     if (!desiredNames.has(entry.key)) continue;
-    await fs.symlink(entry.source, path.join(target, entry.runtimeName));
+    await safeSymlink(entry.source, path.join(target, entry.runtimeName));
   }
   return target;
 }

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -181,7 +181,7 @@ async function buildOpenCodeSkillsDir(config: Record<string, unknown>): Promise<
   const desiredNames = new Set(resolvePaperclipDesiredSkillNames(config, availableEntries));
   for (const entry of availableEntries) {
     if (!desiredNames.has(entry.key)) continue;
-    await fs.symlink(entry.source, path.join(target, entry.runtimeName));
+    await safeSymlink(entry.source, path.join(target, entry.runtimeName));
   }
   return target;
 }

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -35,6 +35,7 @@ import {
   ensurePathInEnv,
   renderTemplate,
   renderPaperclipWakePrompt,
+  safeSymlink,
   shapePaperclipWorkspaceEnvForExecution,
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -38,6 +38,7 @@ import {
   removeMaintainerOnlySkillSymlinks,
   renderTemplate,
   renderPaperclipWakePrompt,
+  safeSymlink,
   shapePaperclipWorkspaceEnvForExecution,
   stringifyPaperclipWakePayload,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { inferOpenAiCompatibleBiller, safeSymlink, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -122,7 +122,7 @@ async function buildPiSkillsDir(config: Record<string, unknown>): Promise<string
   const desiredNames = new Set(resolvePaperclipDesiredSkillNames(config, availableEntries));
   for (const entry of availableEntries) {
     if (!desiredNames.has(entry.key)) continue;
-    await fs.symlink(entry.source, path.join(target, entry.runtimeName));
+    await safeSymlink(entry.source, path.join(target, entry.runtimeName));
   }
   return target;
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Adapters (claude-local, codex-local, cursor-local, gemini-local, opencode-local, pi-local, acpx-local) materialize per-agent skill directories by symlinking from the shared skills source into a runtime-managed home dir
> - On Windows, `fs.symlink(src, dest)` for a directory defaults to type `"dir"`, which requires `SeCreateSymbolicLinkPrivilege` (admin / Developer Mode); without it the call fails with `EPERM` and adapter onboarding shows as `adapter_failed`
> - Issue #63 has been open since the early days of the project and blocks every Windows operator who isn't running an admin shell or hasn't enabled Developer Mode
> - This PR adds a small `safeSymlink()` helper in `adapter-utils` that uses Windows junctions (an older reparse point that does not need elevated privileges and behaves like a directory symlink for our purposes) for directory targets, and routes every skill-symlink call site through it
> - The benefit is adapters work on a stock Windows machine without elevation, and the fix is centralized so future adapters inherit it for free

## What Changed

- New helper: \`packages/adapter-utils/src/safe-symlink.ts\` exports \`safeSymlink(source, target)\`. On Windows, picks \`"junction"\` for directory targets (resolved to absolute path, as junctions require) and \`"file"\` otherwise. On other platforms, defers to the standard \`fs.symlink\` behavior.
- Routed the central default in \`ensurePaperclipSkillSymlink\` (\`packages/adapter-utils/src/server-utils.ts\`) through the helper, so every adapter that uses it (claude-local, cursor-local, gemini-local, opencode-local, pi-local — via their \`skills.ts\`) gets the fix without further changes.
- Replaced direct \`fs.symlink\` callsites in adapters that don't go through that default:
  - \`packages/adapters/acpx-local/src/server/execute.ts\` (3 sites in \`ensureSymlink\`)
  - \`packages/adapters/codex-local/src/server/codex-home.ts\` (2 sites — \`auth.json\` link, file target, also routed for consistency)
  - \`packages/adapters/codex-local/src/server/execute.ts\` (skill-repair fallback)
  - \`packages/adapters/cursor-local/src/server/execute.ts\` (default \`linkSkill\` callback + tmpdir skill materialization)
  - \`packages/adapters/gemini-local/src/server/execute.ts\` (tmpdir skill materialization)
  - \`packages/adapters/opencode-local/src/server/execute.ts\` (tmpdir skill materialization)
  - \`packages/adapters/pi-local/src/server/execute.ts\` (tmpdir skill materialization)
- Re-exported \`safeSymlink\` from \`@paperclipai/adapter-utils\` index.
- Added 2 tests in \`packages/adapter-utils/src/safe-symlink.test.ts\` covering directory and file targets end-to-end (creates source, links, reads through link, asserts \`isSymbolicLink()\` and content round-trip).
- Left \`packages/adapter-utils/src/sandbox-managed-runtime.ts:209\` alone — that call faithfully replicates an existing symlink's target (which can be relative) during file-tree replication and runs server-side in a sandbox where Windows is not the target.

## Verification

Before fix, on Windows without Developer Mode / non-admin shell: hire a Codex / Claude / Cursor / Gemini / OpenCode / Pi / ACPX agent → \`EPERM: operation not permitted, symlink ... \.claude\skills\...\` → \`adapter_failed\`.

After fix, same flow succeeds; junction resolves through to the shared skill directory.

Automated:
\`\`\`
cd packages/adapter-utils
npx vitest run                 # 5 passed (incl. 2 new in safe-symlink.test.ts)

# whole adapter group
npx vitest run --project @paperclipai/adapter-utils \
  --project @paperclipai/adapter-acpx-local \
  --project @paperclipai/adapter-codex-local \
  --project @paperclipai/adapter-cursor-local \
  --project @paperclipai/adapter-gemini-local \
  --project @paperclipai/adapter-opencode-local \
  --project @paperclipai/adapter-pi-local
# 133 passed, 12 pre-existing Windows-environment failures (sandbox tar
# bridge tests + an acpx mode-bit assertion); zero new failures introduced
# by this change.

# typecheck across all touched packages
pnpm -r typecheck   # clean
\`\`\`

Manual: enabled in Codex agent on Windows 11, no admin shell, no Developer Mode → skill dir is now a junction (\`fsutil reparsepoint query\` shows \`Mount Point\`), Codex CLI sees the skills.

## Risks

- **Low risk overall.** Behavior on macOS and Linux is unchanged: \`safeSymlink\` falls through to \`fs.symlink(source, target)\` exactly as before.
- On Windows, junction targets are absolute and resolve only to local paths — that's already how every callsite uses these symlinks (skill source is always a resolved local directory path), so no semantic change.
- \`fs.lstat().isSymbolicLink()\` returns \`true\` for both junctions and symlinks on Windows, so existing skill-repair logic that detects stale links continues to work. (The new test asserts this explicitly.)
- One existing default-callback signature in \`cursor-local/execute.ts\` was simplified from an inline \`(s, t) => fs.symlink(s, t)\` to \`safeSymlink\` directly. Type signature is identical.

## Model Used

- Anthropic Claude Opus 4.7 (claude-opus-4-7), via Claude Code CLI with extended tool use (Read / Edit / Bash / Grep). No extended-thinking budget consumed beyond default.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, no UI change
- [x] I have updated relevant documentation to reflect my changes — file-level comment in \`safe-symlink.ts\` explains the why
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #63.