### PR TITLE
fix(server): treat */* as allow-all in matchesContentType (#5215)

### DIFF
--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -97,6 +97,15 @@ describe("matchesContentType", () => {
     expect(matchesContentType("text/plain", patterns)).toBe(true);
     expect(matchesContentType("application/zip", patterns)).toBe(true);
   });
+
+  it("handles */* as allow-all wildcard (HTTP Accept syntax)", () => {
+    const patterns = ["*/*"];
+    expect(matchesContentType("image/png", patterns)).toBe(true);
+    expect(matchesContentType("image/jpeg", patterns)).toBe(true);
+    expect(matchesContentType("application/pdf", patterns)).toBe(true);
+    expect(matchesContentType("application/zip", patterns)).toBe(true);
+    expect(matchesContentType("text/plain", patterns)).toBe(true);
+  });
 });
 
 describe("normalizeContentType", () => {

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -66,7 +66,7 @@ export function parseAllowedTypes(raw: string | undefined): string[] {
 export function matchesContentType(contentType: string, allowedPatterns: string[]): boolean {
   const ct = contentType.toLowerCase();
   return allowedPatterns.some((pattern) => {
-    if (pattern === "*") return true;
+    if (pattern === "*" || pattern === "*/*") return true;
     if (pattern.endsWith("/*") || pattern.endsWith(".*")) {
       return ct.startsWith(pattern.slice(0, -1));
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Operators upload images and documents into companies (e.g. paste-into-issue, asset uploads); the server gates these by MIME type via \`PAPERCLIP_ALLOWED_ATTACHMENT_TYPES\`
> - The intent of \`PAPERCLIP_ALLOWED_ATTACHMENT_TYPES=*/*\` is "allow everything" — that's the standard HTTP \`Accept\` allow-all syntax
> - But \`matchesContentType\` only short-circuited on the bare \`"*"\` wildcard. \`"*/*"\` fell through to the prefix-match branch, where \`"*/*".slice(0, -1)\` is \`"*/"\` and no real MIME type starts with that → every upload was silently rejected with 422
> - This pull request makes \`"*/*"\` behave the same as \`"*"\` and adds a regression test
> - The benefit is operators who set the documented allow-all pattern actually get allow-all behavior, instead of a confusing 422 with no obvious cause

## What Changed

- \`server/src/attachment-types.ts\`: in \`matchesContentType\`, extend the short-circuit from \`pattern === "*"\` to \`pattern === "*" || pattern === "*/*"\`. One-line change at the documented bug site (line 69).
- \`server/src/__tests__/attachment-types.test.ts\`: add a \`"handles */* as allow-all wildcard (HTTP Accept syntax)"\` test alongside the existing \`"handles plain * as allow-all wildcard"\` test, asserting that \`*/*\` accepts \`image/*\`, \`application/*\`, and \`text/*\` types.

## Verification

\`\`\`
npx vitest run --project @paperclipai/server server/src/__tests__/attachment-types.test.ts
# Test Files  1 passed (1)
# Tests       17 passed (17)   <-- includes new */* test
\`\`\`

Repro from the original issue:
\`\`\`
PAPERCLIP_ALLOWED_ATTACHMENT_TYPES="*/*" node -e "
import('./server/dist/attachment-types.js').then(({ isAllowedContentType }) => {
  console.log(isAllowedContentType('image/png')); // before: false → after: true
});
"
\`\`\`

## Risks

- **Low risk.** The change only widens the allow-all short-circuit; nothing new can be blocked. Anyone who set \`*/*\` already intended allow-all and was hitting the silent-reject bug.
- No DB / migration / schema impact. No public-API shape change.
- The companion \`isAllowedContentType\` (default-export wrapper) inherits the fix automatically because it delegates to \`matchesContentType\`.

## Model Used

- Anthropic Claude Opus 4.7 (claude-opus-4-7), via Claude Code CLI with extended tool use (Read / Edit / Bash). No extended-thinking budget consumed beyond default.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only
- [x] I have updated relevant documentation to reflect my changes — N/A, the existing module-level docstring already documents wildcard syntax; \`*/*\` now works as users would expect
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #5215.