### PR TITLE
fix(server): drop non-UUID X-Paperclip-Run-Id at the boundary (#5229)

### DIFF
--- a/server/src/__tests__/actor-middleware-run-id.test.ts
+++ b/server/src/__tests__/actor-middleware-run-id.test.ts
@@ -1,0 +1,55 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { actorMiddleware } from "../middleware/auth.js";
+
+// In local_trusted mode without an Authorization header, actorMiddleware
+// short-circuits before touching the DB. We can pass a sentinel and trust the
+// middleware never calls into it on this path.
+const sentinelDb = {} as never;
+
+function buildApp() {
+  const app = express();
+  app.use(actorMiddleware(sentinelDb, { deploymentMode: "local_trusted" }));
+  app.get("/probe", (req, res) => {
+    res.json({ runId: req.actor.runId ?? null });
+  });
+  return app;
+}
+
+describe("actorMiddleware — X-Paperclip-Run-Id sanitization (#5229)", () => {
+  it("propagates a valid v4 UUID run-id", async () => {
+    const validUuid = "11111111-2222-4333-8444-555555555555";
+    const res = await request(buildApp())
+      .get("/probe")
+      .set("X-Paperclip-Run-Id", validUuid);
+    expect(res.status).toBe(200);
+    expect(res.body.runId).toBe(validUuid);
+  });
+
+  it("drops a non-UUID run-id instead of forwarding it to UUID-typed FK columns", async () => {
+    const res = await request(buildApp())
+      .get("/probe")
+      .set("X-Paperclip-Run-Id", "subagent:cleanup-2026-05-04");
+    expect(res.status).toBe(200);
+    expect(res.body.runId).toBeNull();
+  });
+
+  it("drops an empty run-id", async () => {
+    const res = await request(buildApp())
+      .get("/probe")
+      .set("X-Paperclip-Run-Id", "   ");
+    expect(res.status).toBe(200);
+    expect(res.body.runId).toBeNull();
+  });
+
+  it("drops a UUID-shaped value with the wrong version digit", async () => {
+    // Right-shape but version 6 — Postgres uuid type is permissive about version,
+    // but we keep parity with isUuidLike (RFC 4122 v1-v5).
+    const res = await request(buildApp())
+      .get("/probe")
+      .set("X-Paperclip-Run-Id", "11111111-2222-6333-8444-555555555555");
+    expect(res.status).toBe(200);
+    expect(res.body.runId).toBeNull();
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -4,7 +4,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agentApiKeys, agents, authUsers, companies, companyMemberships, instanceUserRoles } from "@paperclipai/db";
 import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
-import type { DeploymentMode } from "@paperclipai/shared";
+import { isUuidLike, type DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
@@ -33,7 +33,21 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
           }
         : { type: "none", source: "none" };
 
-    const runIdHeader = req.header("x-paperclip-run-id");
+    const rawRunIdHeader = req.header("x-paperclip-run-id");
+    // activity_log.run_id and the FK columns it points at are UUIDs. If a caller
+    // sends a descriptive value (e.g. "subagent:cleanup-..."), passing it through
+    // turns every mutation that calls logActivity / addComment into a Postgres
+    // 22P02 "invalid input syntax for type uuid" — which surfaces as a confusing
+    // 500 and, on the comment INSERT path, silently loses the row. Drop the
+    // attribution rather than poison the request.
+    const runIdHeader =
+      rawRunIdHeader && isUuidLike(rawRunIdHeader) ? rawRunIdHeader : undefined;
+    if (rawRunIdHeader && !runIdHeader) {
+      logger.warn(
+        { runIdHeader: rawRunIdHeader, method: req.method, url: req.originalUrl },
+        "Ignoring non-UUID X-Paperclip-Run-Id header",
+      );
+    }
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Mutating API endpoints (\`/comments\`, \`/issues\`, status patches) write to the activity_log, which has a UUID-typed run_id with a FK to heartbeat_runs.id; the actor middleware reads X-Paperclip-Run-Id and stores whatever it finds on req.actor.runId
> - Heartbeat runs supply real UUIDs there, but any other client (subagent, manual script, CLI tool) that follows the docs and sends a descriptive run-id like \"subagent:cleanup-2026-05-04\" hits Postgres 22P02 invalid_text_representation
> - The 500 is bad enough on its own; on POST /comments the row never lands (silent comment loss), and on POST /issues the issue commits before logActivity throws so the client gets a 500 with no clue the resource was actually created
> - This pull request validates the header at the actor-middleware boundary using the existing isUuidLike helper and drops non-UUID values rather than poisoning every downstream UUID column with them
> - The benefit is non-heartbeat callers stop hitting confusing 500s and stop losing comments — and the contract is now \"if you want activity-log attribution, send a UUID; otherwise the mutation still works\"

## What Changed

- \`server/src/middleware/auth.ts\` — read \`x-paperclip-run-id\` into a \`rawRunIdHeader\`, validate with \`isUuidLike(rawRunIdHeader)\` (already exported from \`@paperclipai/shared\`), and only forward the value if it passes. Non-UUID values are dropped and a single warn-level log entry is emitted with method/url for debuggability. All six existing call sites (\`runIdHeader\` references in the local-trusted, cloud-tenant, session, board-key, agent-jwt, and agent-key branches) consume the validated value.
- \`server/src/__tests__/actor-middleware-run-id.test.ts\` (new) — four supertest cases: valid v4 UUID propagates, descriptive string is dropped, whitespace-only value is dropped, wrong-version UUID is dropped. Uses local_trusted mode so the test can run without a real DB.

## Verification

\`\`\`
npx vitest run --project @paperclipai/server server/src/__tests__/actor-middleware-run-id.test.ts
# Test Files  1 passed (1)
# Tests       4 passed (4)
\`\`\`

Manual repro from the issue:
\`\`\`
curl -X POST http://127.0.0.1:3100/api/issues/<id>/comments \
  -H 'Authorization: Bearer ...' \
  -H 'X-Paperclip-Run-Id: subagent:cleanup-2026-05-04' \
  -H 'Content-Type: application/json' \
  -d '{\"body\":\"hello\"}'
# before: HTTP 500, comment row never inserted
# after:  HTTP 201, comment lands; server log emits a single warn line
#         \"Ignoring non-UUID X-Paperclip-Run-Id header\"
\`\`\`

## Risks

- **Low risk.** Only behavior change is for callers who were already getting a 500 — they now get the success they expected, minus activity-log attribution. Heartbeat-issued UUIDs remain unaffected.
- The validator (\`isUuidLike\`) accepts RFC 4122 v1-v5; \`gen_random_uuid()\` is v4, so all server-issued run-ids continue to flow through. If someone is relying on a custom \`run_id\` claim in an agent JWT that isn't a UUID, that branch (line 166 in auth.ts) now also drops the bogus value — but that claim was already going to 22P02 the moment they tried to comment, so this is strictly an improvement.
- Logger emits one warn per offending request, so the volume is bounded by client traffic (no log amplification).
- No DB migration. No public-API shape change.

## Model Used

- Anthropic Claude Opus 4.7 (claude-opus-4-7), via Claude Code CLI with extended tool use (Read / Edit / Bash / Grep). No extended-thinking budget consumed beyond default.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only
- [x] I have updated relevant documentation to reflect my changes — the inline comment at the new validator block explains the why
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #5229.