### PR TITLE
fix(routines): isolate per-trigger errors so one bad cron does not freeze the batch (#5184)

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -1144,4 +1144,80 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run.source).toBe("webhook");
     expect(run.status).toBe("issue_created");
   });
+
+  // Regression for #5184: a single trigger row with a corrupted cron expression
+  // (or timezone) used to throw out of nextCronTickInTimeZone, killing the
+  // whole tick loop and freezing every other due trigger.
+  it("isolates per-trigger evaluation errors so one bad cron does not freeze the rest of the batch", async () => {
+    const { routine: goodRoutine, svc } = await seedFixture();
+    const { trigger: goodTrigger } = await svc.createTrigger(
+      goodRoutine.id,
+      {
+        kind: "schedule",
+        label: "every 15",
+        cronExpression: "*/15 * * * *",
+        timezone: "UTC",
+      },
+      {},
+    );
+    const goodNextRunAt = goodTrigger.nextRunAt!;
+
+    const { trigger: badTrigger } = await svc.createTrigger(
+      goodRoutine.id,
+      {
+        kind: "schedule",
+        label: "broken",
+        cronExpression: "*/30 * * * *",
+        timezone: "UTC",
+      },
+      {},
+    );
+    const badNextRunAt = badTrigger.nextRunAt!;
+
+    // Corrupt the second trigger's cron expression directly in the DB so it
+    // bypasses createTrigger's validateCron pass — this is how user data ends
+    // up in this state when an older row predates a validation tightening or
+    // a manual SQL change is made.
+    await db
+      .update(routineTriggers)
+      .set({ cronExpression: "this is not a cron expression" })
+      .where(eq(routineTriggers.id, badTrigger.id));
+
+    // Force both triggers to be due so the tick processes them in one batch.
+    const past = new Date(Date.now() - 60_000);
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: past })
+      .where(eq(routineTriggers.id, goodTrigger.id));
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: past })
+      .where(eq(routineTriggers.id, badTrigger.id));
+
+    const tickResult = await svc.tickScheduledTriggers(new Date());
+    expect(tickResult.failed).toBeGreaterThanOrEqual(1);
+
+    const [goodAfter, badAfter] = await Promise.all([
+      db
+        .select()
+        .from(routineTriggers)
+        .where(eq(routineTriggers.id, goodTrigger.id))
+        .then((rows) => rows[0]!),
+      db
+        .select()
+        .from(routineTriggers)
+        .where(eq(routineTriggers.id, badTrigger.id))
+        .then((rows) => rows[0]!),
+    ]);
+
+    // The good trigger advanced past the manually-rewound `past` timestamp.
+    expect(goodAfter.nextRunAt!.getTime()).toBeGreaterThan(past.getTime());
+    // The bad trigger stays frozen at the past timestamp — we don't silently
+    // null it out (which would hide the bad config) and we don't crash the
+    // whole batch trying to compute its next tick.
+    expect(badAfter.nextRunAt!.getTime()).toBe(past.getTime());
+    expect(badAfter.cronExpression).toBe("this is not a cron expression");
+    void goodNextRunAt;
+    void badNextRunAt;
+  });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -163,7 +163,7 @@ vi.mock("../services/index.js", () => ({
   })),
   reconcilePersistedRuntimeServicesOnStartup: vi.fn(async () => ({ reconciled: 0 })),
   routineService: vi.fn(() => ({
-    tickScheduledTriggers: vi.fn(async () => ({ triggered: 0 })),
+    tickScheduledTriggers: vi.fn(async () => ({ triggered: 0, failed: 0 })),
   })),
 }));
 

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1655,50 +1655,87 @@ export function routineService(
         .orderBy(asc(routineTriggers.nextRunAt), asc(routineTriggers.createdAt));
 
       let triggered = 0;
+      let failed = 0;
       for (const row of due) {
         if (!row.trigger.nextRunAt || !row.trigger.cronExpression || !row.trigger.timezone) continue;
 
-        let runCount = 1;
-        let claimedNextRunAt = nextCronTickInTimeZone(row.trigger.cronExpression, row.trigger.timezone, now);
+        // Per-trigger error isolation: a single bad cron expression or timezone
+        // would otherwise throw out of nextCronTickInTimeZone (via
+        // unprocessable()) and kill the whole batch — every other due trigger
+        // would stay frozen until the bad row is fixed. Catch and log instead.
+        try {
+          let runCount = 1;
+          let claimedNextRunAt = nextCronTickInTimeZone(row.trigger.cronExpression, row.trigger.timezone, now);
 
-        if (row.routine.catchUpPolicy === "enqueue_missed_with_cap") {
-          let cursor: Date | null = row.trigger.nextRunAt;
-          runCount = 0;
-          while (cursor && cursor <= now && runCount < MAX_CATCH_UP_RUNS) {
-            runCount += 1;
-            claimedNextRunAt = nextCronTickInTimeZone(row.trigger.cronExpression, row.trigger.timezone, cursor);
-            cursor = claimedNextRunAt;
+          if (row.routine.catchUpPolicy === "enqueue_missed_with_cap") {
+            let cursor: Date | null = row.trigger.nextRunAt;
+            runCount = 0;
+            while (cursor && cursor <= now && runCount < MAX_CATCH_UP_RUNS) {
+              runCount += 1;
+              claimedNextRunAt = nextCronTickInTimeZone(row.trigger.cronExpression, row.trigger.timezone, cursor);
+              cursor = claimedNextRunAt;
+            }
           }
-        }
 
-        const claimed = await db
-          .update(routineTriggers)
-          .set({
-            nextRunAt: claimedNextRunAt,
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(routineTriggers.id, row.trigger.id),
-              eq(routineTriggers.enabled, true),
-              eq(routineTriggers.nextRunAt, row.trigger.nextRunAt),
-            ),
-          )
-          .returning({ id: routineTriggers.id })
-          .then((rows) => rows[0] ?? null);
-        if (!claimed) continue;
+          if (!claimedNextRunAt) {
+            // The cron expression validated but produced no future tick within
+            // the lookahead horizon (impossible date combination, etc.). Don't
+            // null out nextRunAt — that would silently disable the trigger and
+            // hide the misconfiguration.
+            logger.warn(
+              { triggerId: row.trigger.id, routineId: row.routine.id, cronExpression: row.trigger.cronExpression, timezone: row.trigger.timezone },
+              "routine scheduler could not compute a next tick; leaving trigger nextRunAt untouched",
+            );
+            failed += 1;
+            continue;
+          }
 
-        for (let i = 0; i < runCount; i += 1) {
-          await dispatchRoutineRun({
-            routine: row.routine,
-            trigger: row.trigger,
-            source: "schedule",
-          });
-          triggered += 1;
+          const claimed = await db
+            .update(routineTriggers)
+            .set({
+              nextRunAt: claimedNextRunAt,
+              updatedAt: new Date(),
+            })
+            .where(
+              and(
+                eq(routineTriggers.id, row.trigger.id),
+                eq(routineTriggers.enabled, true),
+                eq(routineTriggers.nextRunAt, row.trigger.nextRunAt),
+              ),
+            )
+            .returning({ id: routineTriggers.id })
+            .then((rows) => rows[0] ?? null);
+          if (!claimed) continue;
+
+          for (let i = 0; i < runCount; i += 1) {
+            try {
+              await dispatchRoutineRun({
+                routine: row.routine,
+                trigger: row.trigger,
+                source: "schedule",
+              });
+              triggered += 1;
+            } catch (dispatchError) {
+              // The atomic claim above already advanced nextRunAt, so a dispatch
+              // failure here will not refire on the next tick. Surface the
+              // failure and let the next scheduled tick proceed.
+              logger.error(
+                { err: dispatchError, triggerId: row.trigger.id, routineId: row.routine.id },
+                "routine scheduler dispatch failed after advancing trigger",
+              );
+              failed += 1;
+            }
+          }
+        } catch (perTriggerError) {
+          logger.error(
+            { err: perTriggerError, triggerId: row.trigger.id, routineId: row.routine.id, cronExpression: row.trigger.cronExpression, timezone: row.trigger.timezone },
+            "routine scheduler skipped a trigger due to evaluation error",
+          );
+          failed += 1;
         }
       }
 
-      return { triggered };
+      return { triggered, failed };
     },
 
     syncRunStatusForIssue: async (issueId: string) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Scheduled Routines are a roadmap-✅ feature: cron-style triggers fire periodic agent work (PM triage, evals, governance loops)
> - The control plane ticks routines every \`heartbeatSchedulerIntervalMs\` (default 30s) via \`routineService.tickScheduledTriggers\`, which selects due triggers, advances their \`next_run_at\` atomically, and dispatches the run
> - One bad trigger row (invalid cron expression or timezone — possible via older rows, manual SQL, or a validation tightening that post-dated the row) made \`nextCronTickInTimeZone\` throw \`unprocessable()\` out of the for loop, killing the entire batch and freezing every other due trigger until the bad row was fixed by hand
> - This pull request adds per-trigger try/catch so a single bad row only fails itself, not every other routine in the company
> - The benefit is autonomous routines stay autonomous: a misconfigured cron in one routine no longer silently halts every other routine on the deployment

## What Changed

- \`server/src/services/routines.ts\` (\`tickScheduledTriggers\`):
  - Wrap each due-trigger iteration in try/catch; log \`triggerId\`, \`routineId\`, \`cronExpression\`, \`timezone\` on failure and skip just that row.
  - Wrap each \`dispatchRoutineRun\` call separately so a dispatch failure (the atomic \`next_run_at\` advance has already committed by then) doesn't unwind the loop either.
  - Treat a \`null\` return from \`nextCronTickInTimeZone\` (cron validates but produces no future tick within the lookahead horizon — impossible day/month combos, etc.) as a per-trigger failure; \`next_run_at\` is intentionally **not** nulled out, because that would silently disable the trigger and hide the misconfiguration.
  - Return \`{ triggered, failed }\` so the setInterval log line surfaces partial failures (currently only logs \"triggered enqueued runs\" when count > 0; \`failed\` is an additional observability signal).
- \`server/src/__tests__/server-startup-feedback-export.test.ts\` — update the one mock that asserts the return shape.
- \`server/src/__tests__/routines-service.test.ts\` (new test) — live-DB regression: create one valid \`*/15 * * * *\` schedule trigger and a second trigger whose \`cron_expression\` is then corrupted via raw \`db.update\` (simulating user data that bypassed \`createTrigger\` validation), force both due, call \`tickScheduledTriggers\`, and assert the good trigger advances past the rewound \`past\` timestamp while the bad trigger stays frozen and \`tickResult.failed >= 1\`.

## Verification

\`\`\`
npx vitest run --project @paperclipai/server server/src/__tests__/routines-service.test.ts -t \"isolates per-trigger\"
# Test Files  1 passed (1)
# Tests       1 passed (1)
\`\`\`

Sanity, server startup-feedback test still passes after updating the shape mock:
\`\`\`
npx vitest run --project @paperclipai/server server/src/__tests__/server-startup-feedback-export.test.ts
\`\`\`

## Risks

- **Low risk overall.** Behavior on the happy path (all triggers have valid cron + timezone) is unchanged — same SELECT, same atomic UPDATE, same dispatch.
- The previously-thrown error case used to surface as a single \`logger.error\` from the setInterval \`.catch\` per tick; it now surfaces as one \`logger.error\` per offending trigger per tick, with richer context (trigger/routine ids). On a deployment with one bad row, log volume is unchanged. On one with N bad rows, log volume is N per tick — bounded and addressable.
- Return-shape change: \`tickScheduledTriggers\` now returns \`{ triggered, failed }\` instead of \`{ triggered }\`. The only consumer in production code (the setInterval handler in \`server/src/index.ts\`) reads \`result.triggered\` and is forward-compatible. The mock that needed updating did so in this PR.
- No DB migration. No schema change.
- Deliberately conservative on \`null\` cron-tick: we leave the column unchanged and warn-log rather than nulling the trigger, so the bad config remains observable to the operator.

## Model Used

- Anthropic Claude Opus 4.7 (claude-opus-4-7), via Claude Code CLI with extended tool use (Read / Edit / Bash / Grep). No extended-thinking budget consumed beyond default.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — Scheduled Routines is roadmap-✅, this is a resilience fix to that feature
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only
- [x] I have updated relevant documentation to reflect my changes — inline comments at the new try/catch blocks explain the reasoning
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #5184.