### PR TITLE
fix(heartbeat): use OUTPUT cap for result/message/error in resultJson projections (#5197)

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -694,10 +694,14 @@ const heartbeatRunListContextColumns = {
 } as const;
 
 const heartbeatRunListResultColumns = {
+  // The substantive output fields (result, message, error) get the larger
+  // OUTPUT cap so eval graders, briefing routines, and other consumers see the
+  // full agent response instead of a mid-sentence cutoff at 500 chars (#5197).
+  // `summary` is a brief description by design and stays at the 500-char cap.
   resultSummary: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'summary', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultSummary"),
-  resultResult: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'result', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultResult"),
-  resultMessage: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'message', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultMessage"),
-  resultError: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'error', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS})`.as("resultError"),
+  resultResult: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'result', ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS})`.as("resultResult"),
+  resultMessage: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'message', ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS})`.as("resultMessage"),
+  resultError: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'error', ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS})`.as("resultError"),
   resultTotalCostUsd: sql<string | null>`${heartbeatRuns.resultJson} ->> 'total_cost_usd'`.as("resultTotalCostUsd"),
   resultCostUsd: sql<string | null>`${heartbeatRuns.resultJson} ->> 'cost_usd'`.as("resultCostUsd"),
   resultCostUsdCamel: sql<string | null>`${heartbeatRuns.resultJson} ->> 'costUsd'`.as("resultCostUsdCamel"),
@@ -711,9 +715,9 @@ const heartbeatRunSafeResultJsonColumn = sql<Record<string, unknown> | null>`
     else jsonb_strip_nulls(
       jsonb_build_object(
         'summary', left(${heartbeatRuns.resultJson} ->> 'summary', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS}),
-        'result', left(${heartbeatRuns.resultJson} ->> 'result', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS}),
-        'message', left(${heartbeatRuns.resultJson} ->> 'message', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS}),
-        'error', left(${heartbeatRuns.resultJson} ->> 'error', ${HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS}),
+        'result', left(${heartbeatRuns.resultJson} ->> 'result', ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}),
+        'message', left(${heartbeatRuns.resultJson} ->> 'message', ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}),
+        'error', left(${heartbeatRuns.resultJson} ->> 'error', ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}),
         'stdout', left(${heartbeatRuns.resultJson} ->> 'stdout', ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}),
         'stderr', left(${heartbeatRuns.resultJson} ->> 'stderr', ${HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS}),
         'stdoutTruncated', case


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Every agent run ends in a heartbeat_runs row whose \`resultJson\` carries the agent's text output (\`result\`), human-facing summary (\`summary\`), and any error/message metadata; consumers fetch this via the heartbeat-runs API to display run output, score evals, and feed deterministic graders
> - The list-projection and the safe-large-row projection both use Postgres \`left(... ->> 'field', N)\` to cap each text field at the DB level — \`summary\` legitimately wants a 500-char cap (it's a brief description), but \`result\` / \`message\` / \`error\` were also being capped at 500, which silently truncates substantive agent output mid-sentence
> - The constant \`HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS = 4096\` was already defined (and already used for \`stdout\`/\`stderr\` in the safe-row projection), but the four other text fields were wired to the smaller \`SUMMARY\` cap by mistake
> - This pull request bumps \`result\` / \`message\` / \`error\` to the OUTPUT cap in both projections; \`summary\` stays at 500 by design
> - The benefit is eval graders no longer see truncated \`BOUNDARY_CHECK:\` labels, briefing routines display their full content, and operators inspecting a run see the agent's actual response instead of a preview

## What Changed

- \`server/src/services/heartbeat.ts\`:
  - \`heartbeatRunListResultColumns\` (used by list endpoints, line ~696): \`resultResult\`, \`resultMessage\`, \`resultError\` switch from \`HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS\` (500) to \`HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS\` (4096). \`resultSummary\` stays at the SUMMARY cap.
  - \`heartbeatRunSafeResultJsonColumn\` (used for single-run fetches when \`pg_column_size(resultJson) > 64KB\`, line ~710): same swap for \`result\` / \`message\` / \`error\`. \`summary\` stays at the SUMMARY cap. Note that \`stdout\` / \`stderr\` in this projection already use the OUTPUT cap; this brings the rest of the text fields into parity.
  - One inline comment at the projection block explaining which fields use which cap and why.

## Verification

\`\`\`
# Repro from the issue (paste a routine that produces >500 char output):
curl -s -H 'Authorization: Bearer ...' \
  http://127.0.0.1:3100/api/heartbeat-runs/<run-id> \
  | jq '.resultJson.result | length'
# before: 500   (cut mid-sentence)
# after:  full length up to 4096
\`\`\`

The change is mechanical (constant swap inside a SQL template literal) and there are no in-process consumers that depend on the 500-char limit for these fields. No tests reference the constants by name.

## Risks

- **Low risk overall.** The only behavior change is response-payload size for runs whose \`resultJson.result\` (or \`message\` / \`error\`) was longer than 500 chars. Bandwidth ceiling per row goes from ~3 × 500 + 500 = 2KB of text to ~3 × 4096 + 500 ≈ 12.5KB. Both list and single-run endpoints already paginate / cap row counts; the row-level bump is well under the existing 64KB safe-result-json threshold.
- The safe-large-row projection's \`originalSizeBytes\` and \`truncated: true\` markers continue to fire when the underlying row exceeds 64KB; downstream code that checks for those markers is unaffected.
- No DB migration. No schema change. No public-API shape change (just longer string values in existing fields).
- \`summary\` truncation behavior is unchanged on purpose — it's a brief field and consumers rely on its bounded length.

## Model Used

- Anthropic Claude Opus 4.7 (claude-opus-4-7), via Claude Code CLI with extended tool use (Read / Edit / Bash / Grep). No extended-thinking budget consumed beyond default.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass — pre-existing typecheck noise in plugin-host-services and plugin-worker-manager is unchanged on master
- [x] I have added or updated tests where applicable — no existing tests reference these constants; the change is a constant swap inside a SQL template literal with no logic
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only, downstream UIs receive longer strings
- [x] I have updated relevant documentation to reflect my changes — inline comment at the projection block explains the cap choice
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #5197.