### PR TITLE
fix(entrypoint): ensure /data/productioncity is owned by node user on UID/GID remap

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -24,6 +24,19 @@ fi
 
 if [ "$changed" = "1" ]; then
     chown -R node:node /paperclip
+    # Fix ownership on bind-mounted tenant directories so they remain writable
+    # after a UID/GID remap (e.g. /data/productioncity -> /data/paperclip/productioncity).
+    for extra_dir in /data/productioncity; do
+        if [ -d "$extra_dir" ]; then
+            chown "$PUID:$PGID" "$extra_dir"
+        fi
+    done
+fi
+
+# Ensure /data/productioncity exists even if the bind mount is not configured.
+# The node process requires this path to be writable before the upstream call.
+if [ ! -d /data/productioncity ]; then
+    mkdir -p /data/productioncity && chown "$PUID:$PGID" /data/productioncity
 fi
 
 exec gosu node "$@"


### PR DESCRIPTION
## Problem

After a UID/GID remap the entrypoint chowns `/paperclip` but misses bind-mounted tenant directories such as `/data/productioncity`. This caused `EACCES: permission denied, mkdir "/data/productioncity"` errors when workspace paths were resolved after a container restart (2026-05-02 incident, PRO-3134).

## Changes

- On UID/GID remap (`changed=1`), also `chown` `/data/productioncity` if the directory exists (handles the normal bind-mount case).
- If `/data/productioncity` does not exist at all (no bind mount), `mkdir -p` and `chown` it so the node process can always write workspace sub-paths there (guards against a missing compose bind mount).

## Test plan

- [ ] Container starts normally with `USER_UID=999`, `USER_GID=989` — `/data/productioncity` owned by node
- [ ] Container starts with no `/data/productioncity` bind mount — directory created and owned by node, no EACCES on workspace paths
- [ ] Existing `/paperclip` chown still fires on UID/GID remap

Relates to: PRO-3134 (immediate volume ownership fix, no approval needed per CTO comment on PRO-3127)

🤖 Generated with [Claude Code](https://claude.com/claude-code)