### PR TITLE
Fix company delete with heartbeat cost history

### DIFF
--- a/server/src/__tests__/cleanup-removal-service.test.ts
+++ b/server/src/__tests__/cleanup-removal-service.test.ts
@@ -6,9 +6,11 @@ import {
   agents,
   companies,
   companySkills,
+  costEvents,
   createDb,
   documents,
   documentRevisions,
+  financeEvents,
   heartbeatRuns,
   issueComments,
   issueDocuments,
@@ -49,6 +51,8 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await db.delete(documentRevisions);
     await db.delete(documents);
     await db.delete(companySkills);
+    await db.delete(financeEvents);
+    await db.delete(costEvents);
     await db.delete(heartbeatRuns);
     await db.delete(issues);
     await db.delete(agents);
@@ -227,5 +231,47 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await expect(db.select().from(documentRevisions).where(eq(documentRevisions.id, revisionId))).resolves.toHaveLength(0);
     await expect(db.select().from(issueReadStates).where(eq(issueReadStates.companyId, companyId))).resolves.toHaveLength(0);
     await expect(db.select().from(activityLog).where(eq(activityLog.companyId, companyId))).resolves.toHaveLength(0);
+  });
+
+  it("removes finance and cost rows before deleting company heartbeat runs", async () => {
+    const { agentId, companyId, runId } = await seedFixture();
+    const costEventId = randomUUID();
+
+    await db.insert(costEvents).values({
+      id: costEventId,
+      companyId,
+      agentId,
+      heartbeatRunId: runId,
+      provider: "openai",
+      biller: "openai",
+      billingType: "tokens",
+      model: "gpt-5",
+      inputTokens: 10,
+      outputTokens: 5,
+      costCents: 3,
+      occurredAt: new Date("2026-05-04T12:00:00Z"),
+    });
+
+    await db.insert(financeEvents).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      heartbeatRunId: runId,
+      costEventId,
+      eventKind: "llm_usage",
+      direction: "debit",
+      biller: "openai",
+      provider: "openai",
+      model: "gpt-5",
+      amountCents: 3,
+      occurredAt: new Date("2026-05-04T12:00:00Z"),
+    });
+
+    const removed = await companyService(db).remove(companyId);
+
+    expect(removed?.id).toBe(companyId);
+    await expect(db.select().from(financeEvents).where(eq(financeEvents.companyId, companyId))).resolves.toHaveLength(0);
+    await expect(db.select().from(costEvents).where(eq(costEvents.companyId, companyId))).resolves.toHaveLength(0);
+    await expect(db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId))).resolves.toHaveLength(0);
   });
 });

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -268,13 +268,13 @@ export function companyService(db: Db) {
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.companyId, id));
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.companyId, id));
         await tx.delete(activityLog).where(eq(activityLog.companyId, id));
+        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
+        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, id));
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.companyId, id));
         await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.companyId, id));
         await tx.delete(issueComments).where(eq(issueComments.companyId, id));
-        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
-        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
         await tx.delete(approvals).where(eq(approvals.companyId, id));
         await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));


### PR DESCRIPTION
## Summary

- Fixes [DEV-134](/DEV/issues/DEV-134) by deleting finance/cost history before heartbeat run rows during company cleanup.
- Keeps the change in the service-layer delete order instead of adding a schema migration, because company deletion already performs explicit ordered cleanup and the missing dependency edge was cost history linked to heartbeat runs.
- Adds an embedded-Postgres regression that creates heartbeat-linked cost history, deletes the company, and verifies cleanup succeeds without orphans.

## Implementation choice

This uses explicit service-layer delete ordering rather than a migration. The company deletion path already coordinates dependent cleanup inside the removal service; the broken case was that cost history rows still referenced heartbeat runs when heartbeat runs were deleted. Removing finance/cost rows first keeps the existing cleanup model coherent and avoids changing database cascade semantics globally.

## Verification

- `pnpm exec vitest run server/src/__tests__/cleanup-removal-service.test.ts`
- Result: passed, 1 test file, 3 tests.

## PR ownership

- Parent issue: [DEV-134](/DEV/issues/DEV-134)
- PR owner handoff issue: [DEV-160](/DEV/issues/DEV-160)
- Source branch: `codex/dev-134-company-delete-heartbeats`
- Source commit: `7ead3b8453e1bec843be1034e03184bcffae60d9`
