### PR TITLE
fix(cli): recover stale board auth cache on re-onboard

### DIFF
--- a/cli/src/__tests__/board-auth-check.test.ts
+++ b/cli/src/__tests__/board-auth-check.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { boardAuthCheck } from "../checks/board-auth-check.js";
+import { getStoredBoardCredential, setStoredBoardCredential } from "../client/board-auth.js";
+import type { PaperclipConfig } from "../config/schema.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function createTempAuthPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-board-auth-check-"));
+  return path.join(dir, "auth.json");
+}
+
+function config(): PaperclipConfig {
+  return {
+    $meta: {
+      version: 1,
+      updatedAt: "2026-05-05T00:00:00.000Z",
+      source: "doctor",
+    },
+    database: {
+      mode: "embedded-postgres",
+      embeddedPostgresDataDir: "/tmp/paperclip/db",
+      embeddedPostgresPort: 54329,
+      backup: {
+        enabled: true,
+        intervalMinutes: 60,
+        retentionDays: 30,
+        dir: "/tmp/paperclip/backups",
+      },
+    },
+    logging: {
+      mode: "file",
+      logDir: "/tmp/paperclip/logs",
+    },
+    server: {
+      deploymentMode: "authenticated",
+      exposure: "private",
+      host: "0.0.0.0",
+      port: 3100,
+      allowedHostnames: [],
+      serveUi: true,
+    },
+    auth: {
+      baseUrlMode: "auto",
+      disableSignUp: false,
+    },
+    telemetry: {
+      enabled: true,
+    },
+    storage: {
+      provider: "local_disk",
+      localDisk: {
+        baseDir: "/tmp/paperclip/storage",
+      },
+      s3: {
+        bucket: "paperclip",
+        region: "us-east-1",
+        prefix: "",
+        forcePathStyle: false,
+      },
+    },
+    secrets: {
+      provider: "local_encrypted",
+      strictMode: false,
+      localEncrypted: {
+        keyFilePath: "/tmp/paperclip/secrets/master.key",
+      },
+    },
+  };
+}
+
+describe("boardAuthCheck", () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it("fails repairably when the current instance rejects the cached board credential", async () => {
+    const authPath = createTempAuthPath();
+    process.env.PAPERCLIP_AUTH_STORE = authPath;
+    process.env.PAPERCLIP_API_URL = "http://localhost:3100";
+    setStoredBoardCredential({
+      apiBase: "http://localhost:3100",
+      token: "stale-token",
+      storePath: authPath,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "Board authentication required" }), { status: 403 }),
+      ),
+    );
+
+    const result = await boardAuthCheck(config());
+    expect(result).toMatchObject({
+      name: "CLI board auth cache",
+      status: "fail",
+      canRepair: true,
+    });
+
+    await result.repair?.();
+    expect(getStoredBoardCredential("http://localhost:3100", authPath)).toBeNull();
+  });
+});

--- a/cli/src/__tests__/board-auth.test.ts
+++ b/cli/src/__tests__/board-auth.test.ts
@@ -1,12 +1,14 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  clearInvalidStoredBoardCredential,
   getStoredBoardCredential,
   readBoardAuthStore,
   removeStoredBoardCredential,
   setStoredBoardCredential,
+  validateStoredBoardCredential,
 } from "../client/board-auth.js";
 
 function createTempAuthPath(): string {
@@ -15,6 +17,10 @@ function createTempAuthPath(): string {
 }
 
 describe("board auth store", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("returns an empty store when the file does not exist", () => {
     const authPath = createTempAuthPath();
     expect(readBoardAuthStore(authPath)).toEqual({
@@ -48,6 +54,62 @@ describe("board auth store", () => {
     });
 
     expect(removeStoredBoardCredential("http://localhost:3100", authPath)).toBe(true);
+    expect(getStoredBoardCredential("http://localhost:3100", authPath)).toBeNull();
+  });
+
+  it("validates a cached credential against the current API", async () => {
+    const authPath = createTempAuthPath();
+    setStoredBoardCredential({
+      apiBase: "http://localhost:3100",
+      token: "token-123",
+      storePath: authPath,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            userId: "user-1",
+            user: { id: "user-1", name: "Ada" },
+            keyId: "key-1",
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    await expect(validateStoredBoardCredential({
+      apiBase: "http://localhost:3100",
+      storePath: authPath,
+    })).resolves.toMatchObject({
+      status: "valid",
+      userId: "user-1",
+      userName: "Ada",
+      keyId: "key-1",
+    });
+  });
+
+  it("clears a stale cached credential when the current API rejects it", async () => {
+    const authPath = createTempAuthPath();
+    setStoredBoardCredential({
+      apiBase: "http://localhost:3100",
+      token: "stale-token",
+      storePath: authPath,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "Board authentication required" }), { status: 401 }),
+      ),
+    );
+
+    await expect(clearInvalidStoredBoardCredential({
+      apiBase: "http://localhost:3100",
+      storePath: authPath,
+    })).resolves.toMatchObject({
+      status: "invalid",
+      removed: true,
+    });
     expect(getStoredBoardCredential("http://localhost:3100", authPath)).toBeNull();
   });
 });

--- a/cli/src/__tests__/common.test.ts
+++ b/cli/src/__tests__/common.test.ts
@@ -1,11 +1,14 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getStoredBoardCredential, setStoredBoardCredential } from "../client/board-auth.js";
 import { writeContext } from "../client/context.js";
 import { resolveCommandContext } from "../commands/client/common.js";
 
 const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_STDIN_IS_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+const ORIGINAL_STDOUT_IS_TTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 
 function createTempPath(name: string): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-cli-common-"));
@@ -17,11 +20,15 @@ describe("resolveCommandContext", () => {
     process.env = { ...ORIGINAL_ENV };
     delete process.env.PAPERCLIP_API_URL;
     delete process.env.PAPERCLIP_API_KEY;
+    delete process.env.PAPERCLIP_AUTH_STORE;
     delete process.env.PAPERCLIP_COMPANY_ID;
   });
 
   afterEach(() => {
     process.env = { ...ORIGINAL_ENV };
+    restorePropertyDescriptor(process.stdin, "isTTY", ORIGINAL_STDIN_IS_TTY);
+    restorePropertyDescriptor(process.stdout, "isTTY", ORIGINAL_STDOUT_IS_TTY);
+    vi.restoreAllMocks();
   });
 
   it("uses profile defaults when options/env are not provided", () => {
@@ -95,4 +102,46 @@ describe("resolveCommandContext", () => {
       resolveCommandContext({ context: contextPath, apiBase: "http://localhost:3100" }, { requireCompany: true }),
     ).toThrow(/Company ID is required/);
   });
+
+  it("removes a stale stored board credential when a non-interactive request is rejected", async () => {
+    const authPath = createTempPath("auth.json");
+    process.env.PAPERCLIP_AUTH_STORE = authPath;
+    setStoredBoardCredential({
+      apiBase: "http://localhost:3100",
+      token: "stale-token",
+      storePath: authPath,
+    });
+    setTty(false);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "Board access required" }), { status: 403 }),
+      ),
+    );
+
+    const resolved = resolveCommandContext({ apiBase: "http://localhost:3100" });
+    expect(resolved.api.apiKey).toBe("stale-token");
+
+    await expect(resolved.api.get("/api/companies")).rejects.toThrow(
+      /Removed stale board credential for http:\/\/localhost:3100/,
+    );
+    expect(getStoredBoardCredential("http://localhost:3100", authPath)).toBeNull();
+  });
 });
+
+function setTty(value: boolean): void {
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value });
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value });
+}
+
+function restorePropertyDescriptor<T extends object, K extends keyof T>(
+  target: T,
+  property: K,
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(target, property, descriptor);
+  } else {
+    delete target[property];
+  }
+}

--- a/cli/src/checks/board-auth-check.ts
+++ b/cli/src/checks/board-auth-check.ts
@@ -1,0 +1,68 @@
+import type { PaperclipConfig } from "../config/schema.js";
+import {
+  removeStoredBoardCredential,
+  validateStoredBoardCredential,
+} from "../client/board-auth.js";
+import type { CheckResult } from "./index.js";
+
+export async function boardAuthCheck(config: PaperclipConfig): Promise<CheckResult> {
+  const apiBase = resolveBoardAuthCheckApiBase(config);
+  const result = await validateStoredBoardCredential({ apiBase });
+
+  if (result.status === "missing") {
+    return {
+      name: "CLI board auth cache",
+      status: "pass",
+      message: `No cached board credential for ${apiBase}`,
+    };
+  }
+
+  if (result.status === "valid") {
+    return {
+      name: "CLI board auth cache",
+      status: "pass",
+      message: `Cached credential for ${apiBase} resolves as ${result.userName ?? result.userId}`,
+    };
+  }
+
+  if (result.status === "invalid") {
+    return {
+      name: "CLI board auth cache",
+      status: "fail",
+      message: `Cached credential for ${apiBase} was rejected (${result.statusCode}: ${result.message})`,
+      canRepair: true,
+      repair: () => {
+        removeStoredBoardCredential(apiBase);
+      },
+      repairHint: `Run \`paperclipai doctor --repair\` to remove the stale entry from ${result.authPath}, then run \`paperclipai auth login\` if board access is needed.`,
+    };
+  }
+
+  if (result.status === "unreachable") {
+    return {
+      name: "CLI board auth cache",
+      status: "warn",
+      message: `Could not verify cached credential for ${apiBase}: ${result.message}`,
+      repairHint: "Start Paperclip or set PAPERCLIP_API_URL to the running instance, then re-run `paperclipai doctor`.",
+    };
+  }
+
+  return {
+    name: "CLI board auth cache",
+    status: "warn",
+    message: `Could not verify cached credential for ${apiBase}: ${result.statusCode}: ${result.message}`,
+    repairHint: "Verify the Paperclip API is healthy, then re-run `paperclipai doctor`.",
+  };
+}
+
+function resolveBoardAuthCheckApiBase(config: PaperclipConfig): string {
+  const explicit =
+    process.env.PAPERCLIP_API_URL?.trim() ||
+    process.env.PAPERCLIP_RUNTIME_API_URL?.trim() ||
+    (config.auth.baseUrlMode === "explicit" ? config.auth.publicBaseUrl?.trim() : undefined);
+  if (explicit) return explicit.replace(/\/+$/, "");
+
+  const host = process.env.PAPERCLIP_SERVER_HOST?.trim() || "localhost";
+  const port = Number(process.env.PAPERCLIP_SERVER_PORT || config.server.port || 3100);
+  return `http://${host}:${Number.isFinite(port) && port > 0 ? port : 3100}`;
+}

--- a/cli/src/checks/index.ts
+++ b/cli/src/checks/index.ts
@@ -8,6 +8,7 @@ export interface CheckResult {
 }
 
 export { agentJwtSecretCheck } from "./agent-jwt-secret-check.js";
+export { boardAuthCheck } from "./board-auth-check.js";
 export { configCheck } from "./config-check.js";
 export { deploymentAuthCheck } from "./deployment-auth-check.js";
 export { databaseCheck } from "./database-check.js";

--- a/cli/src/client/board-auth.ts
+++ b/cli/src/client/board-auth.ts
@@ -7,7 +7,7 @@ import { resolveDefaultCliAuthPath } from "../config/home.js";
 
 type RequestedAccess = "board" | "instance_admin_required";
 
-interface BoardAuthCredential {
+export interface BoardAuthCredential {
   apiBase: string;
   token: string;
   createdAt: string;
@@ -15,10 +15,45 @@ interface BoardAuthCredential {
   userId?: string | null;
 }
 
-interface BoardAuthStore {
+export interface BoardAuthStore {
   version: 1;
   credentials: Record<string, BoardAuthCredential>;
 }
+
+export type StoredBoardCredentialValidation =
+  | {
+      status: "missing";
+      apiBase: string;
+      authPath: string;
+    }
+  | {
+      status: "valid";
+      apiBase: string;
+      authPath: string;
+      userId: string;
+      userName?: string | null;
+      keyId?: string | null;
+    }
+  | {
+      status: "invalid";
+      apiBase: string;
+      authPath: string;
+      statusCode: number;
+      message: string;
+    }
+  | {
+      status: "unreachable";
+      apiBase: string;
+      authPath: string;
+      message: string;
+    }
+  | {
+      status: "error";
+      apiBase: string;
+      authPath: string;
+      statusCode: number;
+      message: string;
+    };
 
 interface CreateChallengeResponse {
   id: string;
@@ -139,6 +174,87 @@ export function removeStoredBoardCredential(apiBase: string, storePath?: string)
   return true;
 }
 
+export async function validateStoredBoardCredential(params: {
+  apiBase: string;
+  storePath?: string;
+}): Promise<StoredBoardCredentialValidation> {
+  const apiBase = normalizeApiBase(params.apiBase);
+  const authPath = resolveBoardAuthStorePath(params.storePath);
+  const credential = getStoredBoardCredential(apiBase, params.storePath);
+  if (!credential) {
+    return { status: "missing", apiBase, authPath };
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(`${apiBase}/api/cli-auth/me`, {
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${credential.token}`,
+      },
+    });
+  } catch (err) {
+    return {
+      status: "unreachable",
+      apiBase,
+      authPath,
+      message: formatErrorMessage(err),
+    };
+  }
+
+  const body = await response.text();
+  const parsed = safeParseJson(body);
+  const message = extractResponseMessage(parsed) ?? `Request failed with status ${response.status}`;
+
+  if (response.ok) {
+    const record = typeof parsed === "object" && parsed !== null ? parsed as Record<string, unknown> : {};
+    const user = typeof record.user === "object" && record.user !== null
+      ? record.user as Record<string, unknown>
+      : null;
+    const userId = toStringOrNull(record.userId) ?? toStringOrNull(user?.id) ?? credential.userId ?? "unknown";
+    return {
+      status: "valid",
+      apiBase,
+      authPath,
+      userId,
+      userName: toStringOrNull(user?.name),
+      keyId: toStringOrNull(record.keyId),
+    };
+  }
+
+  if (response.status === 401 || response.status === 403) {
+    return {
+      status: "invalid",
+      apiBase,
+      authPath,
+      statusCode: response.status,
+      message,
+    };
+  }
+
+  return {
+    status: "error",
+    apiBase,
+    authPath,
+    statusCode: response.status,
+    message,
+  };
+}
+
+export async function clearInvalidStoredBoardCredential(params: {
+  apiBase: string;
+  storePath?: string;
+}): Promise<StoredBoardCredentialValidation & { removed: boolean }> {
+  const result = await validateStoredBoardCredential(params);
+  if (result.status !== "invalid") {
+    return { ...result, removed: false };
+  }
+  return {
+    ...result,
+    removed: removeStoredBoardCredential(params.apiBase, params.storePath),
+  };
+}
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -167,6 +283,31 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
   }
 
   return response.json() as Promise<T>;
+}
+
+function safeParseJson(text: string): unknown {
+  if (!text.trim()) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function extractResponseMessage(body: unknown): string | null {
+  if (typeof body === "object" && body !== null && !Array.isArray(body)) {
+    const record = body as Record<string, unknown>;
+    const error = toStringOrNull(record.error);
+    if (error) return error;
+    const message = toStringOrNull(record.message);
+    if (message) return message;
+  }
+  return typeof body === "string" && body.trim() ? body.trim() : null;
+}
+
+function formatErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message.trim() || err.name;
+  return String(err);
 }
 
 export function openUrl(url: string): boolean {

--- a/cli/src/commands/client/common.ts
+++ b/cli/src/commands/client/common.ts
@@ -1,6 +1,11 @@
 import pc from "picocolors";
 import type { Command } from "commander";
-import { getStoredBoardCredential, loginBoardCli } from "../../client/board-auth.js";
+import {
+  getStoredBoardCredential,
+  loginBoardCli,
+  removeStoredBoardCredential,
+  resolveBoardAuthStorePath,
+} from "../../client/board-auth.js";
 import { buildCliCommandLabel } from "../../client/command-label.js";
 import { readConfig } from "../../config/store.js";
 import { readContext, resolveProfile, type ClientContextProfile } from "../../client/context.js";
@@ -76,13 +81,29 @@ export function resolveCommandContext(
   const api = new PaperclipApiClient({
     apiBase,
     apiKey,
-    recoverAuth: explicitApiKey || !canAttemptInteractiveBoardAuth()
+    recoverAuth: explicitApiKey || !storedBoardCredential
       ? undefined
       : async ({ error }) => {
+          if (!shouldRecoverBoardAuth(error)) {
+            return null;
+          }
+          const staleCredential = isStaleBoardCredentialError(error);
+          if (staleCredential) {
+            removeStoredBoardCredential(apiBase);
+          }
           const requestedAccess = error.message.includes("Instance admin required")
             ? "instance_admin_required"
             : "board";
-          if (!shouldRecoverBoardAuth(error)) {
+          if (!canAttemptInteractiveBoardAuth()) {
+            if (staleCredential) {
+              throw new Error(
+                [
+                  `Removed stale board credential for ${apiBase} from ${resolveBoardAuthStorePath()}.`,
+                  "The current Paperclip instance rejected the cached token.",
+                  "Run `paperclipai auth login` in an interactive terminal if board access is needed.",
+                ].join("\n"),
+              );
+            }
             return null;
           }
           const login = await loginBoardCli({
@@ -104,9 +125,14 @@ export function resolveCommandContext(
 }
 
 function shouldRecoverBoardAuth(error: ApiRequestError): boolean {
+  if (isStaleBoardCredentialError(error)) return true;
+  return error.status === 403 && error.message.includes("Instance admin required");
+}
+
+function isStaleBoardCredentialError(error: ApiRequestError): boolean {
   if (error.status === 401) return true;
   if (error.status !== 403) return false;
-  return error.message.includes("Board access required") || error.message.includes("Instance admin required");
+  return error.message.includes("Board access required");
 }
 
 function canAttemptInteractiveBoardAuth(): boolean {

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -4,6 +4,7 @@ import type { PaperclipConfig } from "../config/schema.js";
 import { readConfig, resolveConfigPath } from "../config/store.js";
 import {
   agentJwtSecretCheck,
+  boardAuthCheck,
   configCheck,
   databaseCheck,
   deploymentAuthCheck,
@@ -65,7 +66,16 @@ export async function doctor(opts: {
   results.push(deploymentAuthResult);
   printResult(deploymentAuthResult);
 
-  // 3. Agent JWT check
+  // 3. CLI board auth cache check
+  results.push(
+    await runRepairableCheck({
+      run: () => boardAuthCheck(config),
+      configPath,
+      opts,
+    }),
+  );
+
+  // 4. Agent JWT check
   results.push(
     await runRepairableCheck({
       run: () => agentJwtSecretCheck(opts.config),
@@ -74,7 +84,7 @@ export async function doctor(opts: {
     }),
   );
 
-  // 4. Secrets adapter check
+  // 5. Secrets adapter check
   results.push(
     await runRepairableCheck({
       run: () => secretsCheck(config, configPath),
@@ -83,7 +93,7 @@ export async function doctor(opts: {
     }),
   );
 
-  // 5. Storage check
+  // 6. Storage check
   results.push(
     await runRepairableCheck({
       run: () => storageCheck(config, configPath),
@@ -92,7 +102,7 @@ export async function doctor(opts: {
     }),
   );
 
-  // 6. Database check
+  // 7. Database check
   results.push(
     await runRepairableCheck({
       run: () => databaseCheck(config, configPath),
@@ -101,12 +111,12 @@ export async function doctor(opts: {
     }),
   );
 
-  // 7. LLM check
+  // 8. LLM check
   const llmResult = await llmCheck(config);
   results.push(llmResult);
   printResult(llmResult);
 
-  // 8. Log directory check
+  // 9. Log directory check
   results.push(
     await runRepairableCheck({
       run: () => logCheck(config, configPath),
@@ -115,7 +125,7 @@ export async function doctor(opts: {
     }),
   );
 
-  // 9. Port check
+  // 10. Port check
   const portResult = await portCheck(config);
   results.push(portResult);
   printResult(portResult);

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -83,7 +83,11 @@ export async function runCommand(opts: RunOptions): Promise<void> {
 
   p.log.step("Starting Paperclip server...");
   const startedServer = await importServerEntry();
-  await checkStartedServerBoardAuthCache(startedServer.apiUrl);
+  try {
+    await checkStartedServerBoardAuthCache(startedServer.apiUrl);
+  } catch (err) {
+    p.log.warn(`Could not check cached CLI board auth for ${startedServer.apiUrl}: ${formatError(err)}`);
+  }
 
   if (shouldGenerateBootstrapInviteAfterStart(config)) {
     p.log.step("Generating bootstrap CEO invite");
@@ -122,7 +126,13 @@ async function checkStartedServerBoardAuthCache(apiBase: string): Promise<void> 
     return;
   }
 
-  p.log.warn(`Could not verify cached CLI board auth for ${apiBase}: ${result.statusCode}: ${result.message}`);
+  if (result.status === "error") {
+    p.log.warn(`Could not verify cached CLI board auth for ${apiBase}: ${result.statusCode}: ${result.message}`);
+    return;
+  }
+
+  const _exhaustive: never = result;
+  return _exhaustive;
 }
 
 function resolveBootstrapInviteBaseUrl(

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -16,6 +16,7 @@ import {
   resolvePaperclipHomeDir,
   resolvePaperclipInstanceId,
 } from "../config/home.js";
+import { clearInvalidStoredBoardCredential } from "../client/board-auth.js";
 
 interface RunOptions {
   config?: string;
@@ -82,6 +83,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
 
   p.log.step("Starting Paperclip server...");
   const startedServer = await importServerEntry();
+  await checkStartedServerBoardAuthCache(startedServer.apiUrl);
 
   if (shouldGenerateBootstrapInviteAfterStart(config)) {
     p.log.step("Generating bootstrap CEO invite");
@@ -91,6 +93,36 @@ export async function runCommand(opts: RunOptions): Promise<void> {
       baseUrl: resolveBootstrapInviteBaseUrl(config, startedServer),
     });
   }
+}
+
+async function checkStartedServerBoardAuthCache(apiBase: string): Promise<void> {
+  const result = await clearInvalidStoredBoardCredential({ apiBase });
+
+  if (result.status === "missing") return;
+
+  if (result.status === "valid") {
+    p.log.message(pc.dim(`Cached CLI board auth verified for ${apiBase} (${result.userName ?? result.userId}).`));
+    return;
+  }
+
+  if (result.status === "invalid") {
+    const action = result.removed ? "Removed" : "Could not remove";
+    p.log.warn(
+      [
+        `${action} stale CLI board auth for ${apiBase} from ${result.authPath}.`,
+        `The current instance rejected the cached token (${result.statusCode}: ${result.message}).`,
+        `Run ${pc.cyan("paperclipai auth login")} if board-user CLI access is needed.`,
+      ].join("\n"),
+    );
+    return;
+  }
+
+  if (result.status === "unreachable") {
+    p.log.warn(`Could not verify cached CLI board auth for ${apiBase}: ${result.message}`);
+    return;
+  }
+
+  p.log.warn(`Could not verify cached CLI board auth for ${apiBase}: ${result.statusCode}: ${result.message}`);
 }
 
 function resolveBootstrapInviteBaseUrl(


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The CLI is the operator entrypoint for local instance onboarding, doctor checks, and board-scoped API access.
> - The board-auth cache in `~/.paperclip/auth.json` can outlive a wiped/re-onboarded instance.
> - A stale cached token made the CLI repeatedly hit 403 until the operator manually moved the auth file aside.
> - This pull request validates cached board auth against the current instance, clears rejected cache entries, and makes stale-cache recovery visible through doctor/run/client paths.
> - The benefit is a re-onboard flow that recovers locally and reports actionable cache state instead of failing silently.

## What Changed

- Validate cached board auth against `/api/cli-auth/me`.
- Clear stale `~/.paperclip/auth.json` entries rejected by the current instance.
- Add a doctor check and repair path for stale CLI board auth cache.
- Add post-start validation in `paperclipai run`, including the `paperclipai onboard --yes` startup path.
- Convert stale cached auth into an actionable local-cache error instead of repeated silent 403s.
- Address Greptile review feedback in `16ce6552` by keeping post-start board-auth validation advisory-only and adding an explicit `error` status guard.

Fixes [DEV-135](/DEV/issues/DEV-135).

## Verification

- `pnpm exec vitest run cli/src/__tests__/board-auth.test.ts cli/src/__tests__/board-auth-check.test.ts cli/src/__tests__/common.test.ts cli/src/__tests__/http.test.ts --config cli/vitest.config.ts`
- `pnpm --filter paperclipai typecheck`
- `git diff --check`

## Risks

- Low residual risk: `keegoid-cc` flagged low-severity follow-ups around fetch timeout, first-run interactive login behavior, and test global cleanup. These are not merge blockers, but they are worth human judgment during final review.
- The playbook/manual-workaround documentation update is intentionally split to [DEV-162](/DEV/issues/DEV-162) and remains blocked until this PR lands.

## Model Used

- OpenAI GPT-5.5 via Codex local adapter, tool-using coding mode, medium reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge