### PR TITLE
Enforce assignee-change when agent transitions issue to in_review

### DIFF
--- a/server/src/__tests__/issue-in-review-assignee-enforcement-routes.test.ts
+++ b/server/src/__tests__/issue-in-review-assignee-enforcement-routes.test.ts
@@ -1,0 +1,306 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const issueId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const companyId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const agentId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const reviewerAgentId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const runId = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+
+const mockIssueService = vi.hoisted(() => ({
+  addComment: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+  getAttachmentById: vi.fn(),
+  getByIdentifier: vi.fn(),
+  getById: vi.fn(),
+  getRelationSummaries: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  listAttachments: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  remove: vi.fn(),
+  removeAttachment: vi.fn(),
+  update: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  getDependencyReadiness: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  list: vi.fn(),
+  resolveByReference: vi.fn(),
+}));
+
+const mockCompanyService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockStorageService = vi.hoisted(() => ({
+  provider: "local_disk",
+  putFile: vi.fn(),
+  getObject: vi.fn(),
+  headObject: vi.fn(),
+  deleteObject: vi.fn(),
+}));
+
+const mockIssueThreadInteractionService = vi.hoisted(() => ({
+  expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+  expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+}));
+
+function registerRouteMocks() {
+  vi.doMock("@paperclipai/shared/telemetry", () => ({
+    trackAgentTaskCompleted: vi.fn(),
+    trackErrorHandlerCrash: vi.fn(),
+  }));
+
+  vi.doMock("../telemetry.js", () => ({
+    getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+  }));
+
+  vi.doMock("../services/access.js", () => ({
+    accessService: () => mockAccessService,
+  }));
+
+  vi.doMock("../services/agents.js", () => ({
+    agentService: () => mockAgentService,
+  }));
+
+  vi.doMock("../services/activity-log.js", () => ({
+    logActivity: vi.fn(async () => undefined),
+  }));
+
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => mockAccessService,
+    agentService: () => mockAgentService,
+    companyService: () => mockCompanyService,
+    documentService: () => ({}),
+    executionWorkspaceService: () => ({}),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({}),
+    heartbeatService: () => ({
+      wakeup: vi.fn(async () => undefined),
+      reportRunActivity: vi.fn(async () => undefined),
+      getRun: vi.fn(async () => null),
+      getActiveRunForAgent: vi.fn(async () => null),
+      cancelRun: vi.fn(async () => null),
+    }),
+    instanceSettingsService: () => ({
+      get: vi.fn(async () => ({
+        id: "instance-settings-1",
+        general: {
+          censorUsernameInLogs: false,
+          feedbackDataSharingPreference: "prompt",
+        },
+      })),
+      listCompanyIds: vi.fn(async () => [companyId]),
+    }),
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: async () => undefined,
+      diffIssueReferenceSummary: () => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      }),
+      emptySummary: () => ({ outbound: [], inbound: [] }),
+      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+      syncComment: async () => undefined,
+      syncDocument: async () => undefined,
+      syncIssue: async () => undefined,
+    }),
+    issueService: () => mockIssueService,
+    issueThreadInteractionService: () => mockIssueThreadInteractionService,
+    logActivity: vi.fn(async () => undefined),
+    projectService: () => ({}),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({}),
+  }));
+
+  vi.doMock("../services/issues.js", () => ({
+    issueService: () => mockIssueService,
+  }));
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: issueId,
+    companyId,
+    status: "in_progress",
+    priority: "medium",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    assigneeAgentId: agentId,
+    assigneeUserId: null,
+    createdByUserId: "board-user",
+    identifier: "KFS-624",
+    title: "Test issue",
+    executionPolicy: null,
+    executionState: null,
+    hiddenAt: null,
+    ...overrides,
+  };
+}
+
+function makeAgent(id: string) {
+  return {
+    id,
+    companyId,
+    role: "engineer",
+    reportsTo: null,
+    status: "active",
+    permissions: { canCreateAgents: false },
+  };
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ errorHandler }, { issueRoutes }] = await Promise.all([
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, mockStorageService as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function agentActor(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "agent",
+    agentId,
+    companyId,
+    source: "agent_key",
+    runId,
+    ...overrides,
+  };
+}
+
+function boardActor() {
+  return {
+    type: "board",
+    userId: "board-user",
+    companyIds: [companyId],
+    source: "local_implicit",
+    isInstanceAdmin: false,
+  };
+}
+
+describe("in_review assignee-change enforcement", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@paperclipai/shared/telemetry");
+    vi.doUnmock("../telemetry.js");
+    vi.doUnmock("../services/access.js");
+    vi.doUnmock("../services/activity-log.js");
+    vi.doUnmock("../services/agents.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/issues.js");
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerRouteMocks();
+    vi.clearAllMocks();
+
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === agentId) return makeAgent(agentId);
+      if (id === reviewerAgentId) return makeAgent(reviewerAgentId);
+      return null;
+    });
+    mockAgentService.list.mockResolvedValue([makeAgent(agentId), makeAgent(reviewerAgentId)]);
+    mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: null });
+    mockCompanyService.getById.mockResolvedValue({ id: companyId, issuePrefix: "KFS" });
+    mockIssueService.getById.mockResolvedValue(makeIssue());
+    mockIssueService.getByIdentifier.mockResolvedValue(null);
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({ unresolvedBlockerCount: 0 });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue(),
+      ...patch,
+    }));
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-1",
+      issueId,
+      companyId,
+      body: "comment",
+    });
+    mockIssueService.listAttachments.mockResolvedValue([]);
+  });
+
+  it("rejects agent setting status=in_review while remaining the assignee (422)", async () => {
+    const app = await createApp(agentActor());
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "in_review" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("Cannot transition to in_review while remaining the assignee");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows agent setting status=in_review when simultaneously reassigning to a different agent (200)", async () => {
+    const app = await createApp(agentActor());
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "in_review", assigneeAgentId: reviewerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("allows agent setting status=in_review when clearing the assignee (200)", async () => {
+    const app = await createApp(agentActor());
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "in_review", assigneeAgentId: null });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("allows board user to set status=in_review without changing assignee (200)", async () => {
+    const app = await createApp(boardActor());
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "in_review" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("allows agent to make other patches without status=in_review while remaining assignee (200)", async () => {
+    const app = await createApp(agentActor());
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Updated title" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2252,6 +2252,19 @@ export function issueRoutes(
       }
     }
 
+    if (
+      updateFields.status === "in_review" &&
+      req.actor.type === "agent" &&
+      req.actor.agentId &&
+      nextAssigneeAgentId === req.actor.agentId
+    ) {
+      res.status(422).json({
+        error:
+          "Cannot transition to in_review while remaining the assignee. Set assigneeAgentId to a reviewer before moving to in_review.",
+      });
+      return;
+    }
+
     let issue;
     try {
       if (transition.decision && decisionId) {

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -737,6 +737,11 @@ Terminal states: `done`, `cancelled`
 - Use formal approvals for governed actions such as hires, budget overrides, or CEO strategy gates.
 - Use issue-thread interactions for issue-scoped board/user decisions such as plan acceptance, proposed task breakdowns, or missing-answer questions.
 - Use `blockedByIssueIds` for real work dependencies between issues so Paperclip can wake the blocked assignee when all blockers resolve.
+- **`in_review` handoff rule (agents only):** An agent cannot set `status=in_review` while remaining the `assigneeAgentId`. The API returns `422` if the requesting agent is still the assignee after the PATCH. To hand off correctly, include `assigneeAgentId` pointing to a reviewer (or `null`) in the same request:
+  ```json
+  PATCH /api/issues/:id
+  { "status": "in_review", "assigneeAgentId": "<reviewer-agent-id>", "comment": "Ready for review." }
+  ```
 
 ---
 
@@ -749,7 +754,7 @@ Terminal states: `done`, `cancelled`
 | 403  | Unauthorized       | You don't have permission for this action                            |
 | 404  | Not found          | Entity doesn't exist or isn't in your company                        |
 | 409  | Conflict           | Another agent owns the task. Pick a different one. **Do not retry.** |
-| 422  | Semantic violation | Invalid state transition (e.g. `backlog` -> `done`)                  |
+| 422  | Semantic violation | Invalid state transition (e.g. `backlog` -> `done`); or agent setting `status=in_review` without changing `assigneeAgentId` away from itself — include `assigneeAgentId` in the request |
 | 500  | Server error       | Transient failure. Comment on the task and move on.                  |
 
 ---


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and routes work via inbox/wakeup signals.
> - Issue status transitions control the flow of work between agents.
> - When an agent sets `status=in_review` while keeping itself as `assigneeAgentId`, no wakeup fires for a reviewer — the task silently stalls.
> - This was observed in practice (KFS-607): DevOps completed work, moved to `in_review`, but stayed assignee, so the issue sat unreviewed.
> - The root cause is that the API allowed this silent handoff violation with no error.
> - The fix gates the `in_review` transition in `routes/issues.ts`: if the requesting agent would still be the assignee after the patch, return `422` with an actionable message.
> - This pull request adds the guard, tests for each code path, and documents the rule in `skills/paperclip/references/api-reference.md`.
> - The benefit is that agents are forced to explicitly choose a reviewer before handing off, eliminating the silent-stall failure mode.

## What Changed

- **`server/src/routes/issues.ts`**: Added guard after `nextAssigneeAgentId` is resolved and before `svc.update()` — if actor is an agent and `nextAssigneeAgentId === actor.agentId` while `status === "in_review"`, returns `422` with a clear message directing the agent to set `assigneeAgentId` to a reviewer.
- **`server/src/__tests__/issue-in-review-assignee-enforcement-routes.test.ts`**: New test file covering: (1) blocked path → 422, (2) allowed path with simultaneous reassign → 200, (3) allowed path with `assigneeAgentId: null` → 200, (4) board user bypass → 200, (5) unrelated patch → 200.
- **`skills/paperclip/references/api-reference.md`**: Documents the `in_review` handoff rule with a code example, and updates the 422 error-handling table row.

## Verification

```bash
# Run the new test file
pnpm test -- server/src/__tests__/issue-in-review-assignee-enforcement-routes.test.ts

# Manual: PATCH with status=in_review and no assignee change → expect 422
curl -X PATCH http://localhost:3101/api/issues/<id> \
  -H "Authorization: Bearer <agent-key>" \
  -H "Content-Type: application/json" \
  -d '{"status":"in_review"}'
# Expected: {"error":"Cannot transition to in_review while remaining the assignee. Set assigneeAgentId to a reviewer before moving to in_review."}

# Manual: PATCH with status=in_review + assigneeAgentId changed → expect 200
curl -X PATCH http://localhost:3101/api/issues/<id> \
  -H "Authorization: Bearer <agent-key>" \
  -H "Content-Type: application/json" \
  -d '{"status":"in_review","assigneeAgentId":"<reviewer-id>"}'
# Expected: 200 with updated issue
```

## Risks

The guard only fires for agent actors (`req.actor.type === "agent"`). Board users are unaffected. The check is positioned after all assignee normalization and transition-policy calculation, so it reflects the true post-patch assignee — no edge cases with execution-policy transitions.

Low risk: this is a new validation on a previously-unchecked path. Any agent that was silently violating the handoff rule will now get a 422 and need to add `assigneeAgentId` to their PATCH. That is the intended behavior.

## Model Used

- Provider: Anthropic
- Model ID: `claude-sonnet-4-6`
- Context window: 200K
- Tool use: yes (file read/edit, bash, git)
- Reasoning: standard (no extended thinking)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge