### PR TITLE
feat(adapters): add ollama_local first-class Ollama adapter (v0.1, experimental)

### DIFF
--- a/docs/integrations/ollama/README.md
+++ b/docs/integrations/ollama/README.md
@@ -92,4 +92,4 @@ We're proposing `ollama launch paperclip` mirroring the existing `codex` /
 [`launch-paperclip.go.md`](./launch-paperclip.go.md) for the proposed file
 content and registry entry.
 
-Tracking: <!-- TODO: link to ollama/ollama issue once opened -->
+Tracking: [ollama/ollama#15976](https://github.com/ollama/ollama/issues/15976)

--- a/docs/integrations/ollama/README.md
+++ b/docs/integrations/ollama/README.md
@@ -1,0 +1,95 @@
+# Ollama integration
+
+Paperclip supports Ollama as a first-class agent runtime via the `ollama_local`
+adapter (package `@paperclipai/adapter-ollama-local`).
+
+This page covers two complementary surfaces:
+
+1. **Inside Paperclip** — how `ollama_local` agents work, how to install/switch
+   models, local vs cloud hosts.
+2. **Inside Ollama** — the proposed `ollama launch paperclip` integration that
+   spawns Paperclip pre-wired to a local Ollama daemon. See
+   [`launch-paperclip.go.md`](./launch-paperclip.go.md) for the reference
+   implementation we're proposing upstream.
+
+## Inside Paperclip
+
+### Local Ollama (default)
+
+```sh
+ollama serve            # if it isn't already running
+ollama pull qwen2.5-coder:14b
+```
+
+Then create an agent in Paperclip with adapter `ollama_local` and config:
+
+```json
+{
+  "model": "qwen2.5-coder:14b",
+  "host": "http://localhost:11434"
+}
+```
+
+`host` defaults to `OLLAMA_HOST` env, then `http://localhost:11434`.
+
+### Ollama Cloud
+
+```sh
+# Create a key at https://ollama.com/settings/keys
+export OLLAMA_API_KEY=...
+```
+
+Agent config:
+
+```json
+{
+  "model": "gpt-oss:120b",
+  "host": "https://ollama.com"
+}
+```
+
+The adapter detects `*.ollama.com` hosts and adds an `Authorization: Bearer
+$OLLAMA_API_KEY` header automatically. `testEnvironment` returns a clear error
+if the cloud host is set without a key.
+
+### Installing & switching models
+
+The adapter exports server-side helpers your tooling can call:
+
+| Export                | Description                                      |
+| --------------------- | ------------------------------------------------ |
+| `listOllamaModels`    | `GET /api/tags` — all installed models           |
+| `pullOllamaModel`     | `POST /api/pull` (streaming) — install a model   |
+| `deleteOllamaModel`   | `DELETE /api/delete` — remove a model            |
+| `showOllamaModel`     | `POST /api/show` — capabilities, modelfile, etc. |
+| `modelSupportsTools`  | True if `/api/show` capabilities include `tools` |
+
+To switch a running agent's model, PATCH its `adapterConfig.model` to a tag the
+host has installed. The adapter reads `config.model` on every `execute()` call —
+no restart needed. The Paperclip UI's model picker calls `listOllamaModels` to
+populate the dropdown.
+
+### Pick a model that supports tool calling
+
+`ollama_local` drives a tool-calling agent loop — a model that doesn't emit
+`tool_calls` will exit on turn 1 with a plain text response and never use the
+filesystem tools. Verify with `ollama show <model>` (look for `tools` in
+capabilities) or call `modelSupportsTools(host, name)` programmatically.
+
+Models we've validated the contract against:
+
+- `qwen2.5-coder:14b` — recommended for local
+- `qwen2.5-coder:32b` — better, slower
+- `gpt-oss:20b`
+- Cloud `gpt-oss:120b` etc.
+
+`llama3.2:latest` works for chat but tool-calling is unreliable.
+
+## Inside Ollama
+
+We're proposing `ollama launch paperclip` mirroring the existing `codex` /
+`opencode` / `droid` integrations. See
+[`launch-paperclip.go.md`](./launch-paperclip.go.md) for the proposed file
+content and registry entry.
+
+Tracking: <!-- TODO: link to ollama/ollama issue once opened -->

--- a/docs/integrations/ollama/launch-paperclip.go.md
+++ b/docs/integrations/ollama/launch-paperclip.go.md
@@ -1,0 +1,129 @@
+# Proposed `cmd/launch/paperclip.go` for ollama/ollama
+
+This is the reference implementation we're proposing upstream so
+`ollama launch paperclip` is a first-class integration alongside `codex`,
+`opencode`, `droid`, etc. Modeled directly on
+[`cmd/launch/codex.go`](https://github.com/ollama/ollama/blob/main/cmd/launch/codex.go).
+
+## File: `cmd/launch/paperclip.go`
+
+```go
+package launch
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/ollama/ollama/envconfig"
+)
+
+// Paperclip implements Runner for the Paperclip integration
+// (https://github.com/paperclipai/paperclip).
+type Paperclip struct{}
+
+func (p *Paperclip) String() string { return "Paperclip" }
+
+func (p *Paperclip) args(model string, extra []string) []string {
+	args := []string{"onboard", "--bind", "loopback", "-y", "--run"}
+	return append(args, extra...)
+}
+
+func (p *Paperclip) Run(model string, args []string) error {
+	if err := checkPaperclipInstalled(); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("paperclipai", p.args(model, args)...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Pre-wire Paperclip's ollama_local adapter for the user. The adapter
+	// reads OLLAMA_HOST and OLLAMA_API_KEY directly.
+	env := append(os.Environ(),
+		"OLLAMA_HOST="+envconfig.Host().String(),
+		"PAPERCLIP_DEFAULT_ADAPTER=ollama_local",
+	)
+	if model != "" {
+		env = append(env, "PAPERCLIP_DEFAULT_MODEL="+model)
+	}
+	cmd.Env = env
+	return cmd.Run()
+}
+
+func checkPaperclipInstalled() error {
+	if _, err := exec.LookPath("paperclipai"); err != nil {
+		return fmt.Errorf("paperclip is not installed, install with: npm install -g paperclipai")
+	}
+	return nil
+}
+```
+
+## Registry entry — patch for `cmd/launch/registry.go`
+
+Add to `integrationSpecs`:
+
+```go
+{
+	Name:        "paperclip",
+	Aliases:     []string{"paperclipai"},
+	Runner:      &Paperclip{},
+	Description: "Paperclip — control plane for AI-agent companies",
+	Install: IntegrationInstallSpec{
+		CheckInstalled: func() bool {
+			_, err := exec.LookPath("paperclipai")
+			return err == nil
+		},
+		URL:             "https://github.com/paperclipai/paperclip",
+		InstallCommands: []string{"npm install -g paperclipai"},
+	},
+},
+```
+
+## Smoke test (`cmd/launch/paperclip_test.go`)
+
+```go
+package launch
+
+import "testing"
+
+func TestPaperclipString(t *testing.T) {
+	p := &Paperclip{}
+	if got := p.String(); got != "Paperclip" {
+		t.Fatalf("String() = %q, want %q", got, "Paperclip")
+	}
+}
+
+func TestPaperclipArgs(t *testing.T) {
+	p := &Paperclip{}
+	args := p.args("", []string{"--extra"})
+	want := []string{"onboard", "--bind", "loopback", "-y", "--run", "--extra"}
+	if len(args) != len(want) {
+		t.Fatalf("args len = %d, want %d", len(args), len(want))
+	}
+	for i, a := range args {
+		if a != want[i] {
+			t.Fatalf("args[%d] = %q, want %q", i, a, want[i])
+		}
+	}
+}
+```
+
+## Notes for review
+
+- `paperclipai` CLI is published to npm by the Paperclip team. The `--bind
+  loopback -y --run` quickstart starts the server on a trusted local interface
+  and accepts defaults — the equivalent of how the Codex profile gets
+  pre-written before launch.
+- `OLLAMA_HOST` / `OLLAMA_API_KEY` are read by Paperclip's `ollama_local`
+  adapter directly (see
+  [`packages/adapters/ollama-local/src/server/models.ts`](https://github.com/paperclipai/paperclip/blob/main/packages/adapters/ollama-local/src/server/models.ts))
+  so Cloud and local modes both work without further config.
+- `PAPERCLIP_DEFAULT_ADAPTER` and `PAPERCLIP_DEFAULT_MODEL` are accepted as
+  hints by the onboard wizard. (If the maintainers prefer they be read at the
+  agent-creation step instead, that's a one-line change on Paperclip's side.)
+
+If maintainers prefer the integration `Edit`s a config file the way `Droid`
+does (writing `~/.paperclip/...`), we're happy to switch to that pattern in
+review.

--- a/packages/adapters/ollama-local/CHANGELOG.md
+++ b/packages/adapters/ollama-local/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @paperclipai/adapter-ollama-local
+
+## 0.1.0
+
+- Initial release. First-class Ollama adapter (`ollama_local`).
+- Implements an in-process agent loop on top of Ollama's `/api/chat` tool-calling API.
+- Built-in tools: `read_file`, `write_file`, `list_dir`, `run_bash`.
+- `listModels` queries `/api/tags` on the configured Ollama host.
+- `testEnvironment` checks Ollama reachability and lists installed models.
+- Marked **experimental**: no session resume, no remote execution target, no Paperclip skill bundle injection yet.

--- a/packages/adapters/ollama-local/README.md
+++ b/packages/adapters/ollama-local/README.md
@@ -1,0 +1,60 @@
+# @paperclipai/adapter-ollama-local
+
+First-class Ollama adapter for [Paperclip](https://github.com/paperclipai/paperclip). Adapter type: `ollama_local`.
+
+Unlike `codex_local` / `opencode_local` (which wrap external coding-agent CLIs), this adapter implements its own agent loop directly against Ollama's [`/api/chat`](https://docs.ollama.com/api/introduction) endpoint with native tool calling. No external CLI needed — only a running Ollama server.
+
+## Status
+
+**Experimental — v0.1.** Functional for single-task runs with built-in tools. The following are not yet implemented and will land in follow-up versions:
+
+- Session resume across heartbeats
+- Remote execution targets (SSH / managed-home)
+- Paperclip skill bundle injection
+- Streaming token events
+- Cost / billing metadata
+
+For production agent runs today, prefer `codex_local` or `opencode_local` configured against Ollama's OpenAI-compatible endpoint.
+
+## Configuration
+
+```json
+{
+  "type": "ollama_local",
+  "config": {
+    "model": "qwen2.5-coder:14b",
+    "host": "http://localhost:11434",
+    "cwd": "/path/to/workspace",
+    "instructionsFilePath": "/path/to/AGENTS.md",
+    "maxIterations": 25,
+    "timeoutSec": 600
+  }
+}
+```
+
+### Fields
+
+- `model` (required): an Ollama model tag (e.g. `qwen2.5-coder:14b`, `llama3.2`, `gpt-oss:20b`). Run `ollama pull <tag>` first.
+- `host` (optional): Ollama server URL. Defaults to `OLLAMA_HOST` env var, then `http://localhost:11434`.
+- `cwd` (optional): working directory for tool execution.
+- `instructionsFilePath` (optional): markdown file prepended to the system prompt.
+- `maxIterations` (optional, default `25`): maximum tool-call rounds before bailing.
+- `timeoutSec` (optional, default `600`): wall-clock timeout for the entire run.
+- `extraTools` (optional, default `[]`): reserved.
+
+## Built-in tools
+
+| Tool        | Description                                               |
+| ----------- | --------------------------------------------------------- |
+| `read_file` | Read a UTF-8 file relative to cwd.                        |
+| `write_file`| Write/overwrite a UTF-8 file relative to cwd.             |
+| `list_dir`  | List entries in a directory relative to cwd.              |
+| `run_bash`  | Run a shell command in cwd. Output is truncated at 64 KB. |
+
+## Tested with
+
+- `qwen2.5-coder:14b` (recommended)
+- `gpt-oss:20b`
+- `llama3.2:latest` (limited tool-calling reliability)
+
+Models without robust tool-calling support will not work well — pick a model the Ollama team flags as supporting `tools` in `ollama show`.

--- a/packages/adapters/ollama-local/package.json
+++ b/packages/adapters/ollama-local/package.json
@@ -14,7 +14,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./server": "./src/server/index.ts"
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -26,6 +27,10 @@
       "./server": {
         "types": "./dist/server/index.d.ts",
         "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/adapters/ollama-local/package.json
+++ b/packages/adapters/ollama-local/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@paperclipai/adapter-ollama-local",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/ollama-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/adapters/ollama-local/src/index.ts
+++ b/packages/adapters/ollama-local/src/index.ts
@@ -1,0 +1,74 @@
+import type { AdapterModelProfileDefinition } from "@paperclipai/adapter-utils";
+
+export const type = "ollama_local";
+export const label = "Ollama (local)";
+
+export const DEFAULT_OLLAMA_HOST = "http://localhost:11434";
+export const DEFAULT_OLLAMA_MODEL = "qwen2.5-coder:14b";
+export const DEFAULT_OLLAMA_MAX_ITERATIONS = 25;
+export const DEFAULT_OLLAMA_TIMEOUT_SEC = 600;
+
+/**
+ * Static seed list. The real model catalog is discovered at runtime by calling
+ * `/api/tags` on the configured Ollama host (see server/models.ts).
+ */
+export const models: Array<{ id: string; label: string }> = [
+  { id: "qwen2.5-coder:14b", label: "qwen2.5-coder:14b (recommended)" },
+  { id: "qwen2.5-coder:32b", label: "qwen2.5-coder:32b" },
+  { id: "gpt-oss:20b", label: "gpt-oss:20b" },
+  { id: "llama3.2:latest", label: "llama3.2:latest" },
+];
+
+export const modelProfiles: AdapterModelProfileDefinition[] = [
+  {
+    key: "cheap",
+    label: "Small",
+    description: "Use a smaller, faster Ollama model lane.",
+    adapterConfig: {
+      model: "qwen2.5-coder:7b",
+    },
+    source: "adapter_default",
+  },
+];
+
+export const agentConfigurationDoc = `# ollama_local agent configuration
+
+Adapter: ollama_local
+
+Use when:
+- You want Paperclip to drive an Ollama-served model directly, without an external
+  coding-agent CLI in between.
+- You are running fully offline / air-gapped and Ollama is your inference backend.
+
+Don't use when:
+- You need session resume across heartbeats (use codex_local or opencode_local).
+- You need remote execution over SSH.
+- The model you want is reachable through a hosted provider — those are better
+  served by claude_local / codex_local / gemini_local etc.
+
+Core fields:
+- model (string, required): an Ollama tag (e.g. \`qwen2.5-coder:14b\`).
+- host (string, optional): Ollama server URL. Defaults to OLLAMA_HOST env or
+  http://localhost:11434.
+- cwd (string, optional): working directory for tool execution.
+- instructionsFilePath (string, optional): markdown file prepended to the system
+  prompt.
+- promptTemplate (string, optional): user prompt template.
+- maxIterations (number, optional, default 25): maximum tool-call rounds.
+- env (object, optional): environment variables for run_bash tool calls.
+
+Operational fields:
+- timeoutSec (number, optional, default 600): wall-clock run timeout.
+- graceSec (number, optional): SIGTERM grace period for in-flight bash tool calls.
+
+Built-in tools:
+- read_file, write_file, list_dir, run_bash.
+
+Notes:
+- This adapter implements its own agent loop in-process; there is no external
+  binary to install beyond \`ollama\` itself.
+- Pick a model that Ollama flags as supporting \`tools\` (\`ollama show <model>\`),
+  otherwise tool calls will not be emitted by the model.
+- v0.1 is experimental: no session resume, no remote execution, no skill bundle
+  injection. See package CHANGELOG for the roadmap.
+`;

--- a/packages/adapters/ollama-local/src/server/execute.ts
+++ b/packages/adapters/ollama-local/src/server/execute.ts
@@ -16,6 +16,14 @@ import {
   DEFAULT_OLLAMA_TIMEOUT_SEC,
 } from "../index.js";
 import { isOllamaCloudHost, resolveOllamaApiKey, resolveOllamaHost } from "./models.js";
+import {
+  buildSessionPath,
+  ensureSessionsDir,
+  loadSession,
+  saveSession,
+  sessionMatchesCurrentRun,
+  type OllamaSessionState,
+} from "./session.js";
 
 interface OllamaToolCall {
   function?: {
@@ -277,8 +285,31 @@ async function readInstructions(cwd: string, instructionsFilePath: string): Prom
   }
 }
 
+function classifyOllamaError(message: string): {
+  errorCode: string;
+  family: "transient_upstream" | null;
+} {
+  const lower = message.toLowerCase();
+  if (lower.includes("econnrefused") || lower.includes("fetch failed") || lower.includes("network")) {
+    return { errorCode: "ollama_unreachable", family: "transient_upstream" };
+  }
+  if (lower.includes("401") || lower.includes("unauthorized") || lower.includes("api key")) {
+    return { errorCode: "ollama_auth", family: null };
+  }
+  if (lower.includes("404") || lower.includes("model not found") || lower.includes("pull")) {
+    return { errorCode: "ollama_model_missing", family: null };
+  }
+  if (lower.includes("429") || lower.includes("rate limit")) {
+    return { errorCode: "ollama_rate_limited", family: "transient_upstream" };
+  }
+  if (lower.includes("timed out")) {
+    return { errorCode: "ollama_timeout", family: "transient_upstream" };
+  }
+  return { errorCode: "ollama_unknown", family: null };
+}
+
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { runId, config, context, onLog, onMeta } = ctx;
+  const { runId, agent, runtime, config, context, onLog, onMeta } = ctx;
   const model = asString(config.model, DEFAULT_OLLAMA_MODEL).trim();
   const host = resolveOllamaHost(asString(config.host, ""));
   const apiKey = resolveOllamaApiKey(asString(config.apiKey, ""));
@@ -323,10 +354,34 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (wakeReason) userPromptParts.push(`Wake reason: ${wakeReason}`);
   const userPrompt = userPromptParts.join("\n\n").trim() || "Begin work on the configured task.";
 
-  const messages: OllamaMessage[] = [
-    { role: "system", content: systemPrompt },
-    { role: "user", content: userPrompt },
-  ];
+  // Resolve / restore session ────────────────────────────────────────────
+  await ensureSessionsDir().catch(() => undefined);
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "").trim();
+  const cloud = isOllamaCloudHost(host);
+  let resumed = false;
+  let messages: OllamaMessage[] = [];
+  let sessionPath = runtimeSessionId;
+  let priorCreatedAt: string | null = null;
+  if (runtimeSessionId) {
+    const existing = await loadSession(runtimeSessionId);
+    if (existing && sessionMatchesCurrentRun(existing, { cwd, model, host })) {
+      messages = existing.messages as OllamaMessage[];
+      const deltaPrompt = userPrompt.length > 0 ? userPrompt : "(continue)";
+      messages.push({ role: "user", content: deltaPrompt });
+      priorCreatedAt = existing.createdAt;
+      resumed = true;
+    } else {
+      sessionPath = "";
+    }
+  }
+  if (!resumed) {
+    messages = [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: userPrompt },
+    ];
+    sessionPath = buildSessionPath(agent.id, new Date().toISOString());
+  }
 
   if (onMeta) {
     await onMeta({
@@ -346,7 +401,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   await onLog(
     "stdout",
-    `[paperclip] Starting ollama_local run ${runId} on ${host} with model "${model}".\n`,
+    `[paperclip] ${resumed ? "Resuming" : "Starting"} ollama_local run ${runId} on ${host}${cloud ? " (cloud)" : ""} with model "${model}".\n`,
   );
 
   const abort = new AbortController();
@@ -423,29 +478,60 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     clearTimeout(timeoutHandle);
   }
 
+  // Persist session for resume on next wake — even on partial failures, the
+  // accumulated context is worth keeping so a transient error doesn't burn it.
+  let savedSessionId: string | null = null;
+  if (sessionPath) {
+    try {
+      const state: OllamaSessionState = {
+        agentId: agent.id,
+        cwd,
+        model,
+        host,
+        cloud,
+        messages: messages as unknown as OllamaSessionState["messages"],
+        createdAt: priorCreatedAt ?? new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+      await saveSession(sessionPath, state);
+      savedSessionId = sessionPath;
+    } catch (err) {
+      await onLog(
+        "stderr",
+        `[paperclip] Failed to persist session: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
   const exitCode = timedOut ? 124 : errorMessage ? 1 : 0;
+  const errorClass = errorMessage ? classifyOllamaError(errorMessage) : null;
 
   return {
     exitCode,
     signal: null,
     timedOut,
     errorMessage: errorMessage ?? null,
+    errorCode: errorClass?.errorCode ?? null,
+    errorFamily: errorClass?.family ?? null,
     usage: {
       inputTokens,
       outputTokens,
     },
-    sessionId: null,
-    sessionParams: null,
-    sessionDisplayId: null,
+    sessionId: savedSessionId,
+    sessionParams: savedSessionId
+      ? { sessionId: savedSessionId, cwd, model, host }
+      : null,
+    sessionDisplayId: savedSessionId,
     provider: "ollama",
-    biller: isOllamaCloudHost(host) ? "ollama_cloud" : "ollama",
+    biller: cloud ? "ollama_cloud" : "ollama",
     model,
-    billingType: isOllamaCloudHost(host) ? "subscription" : "fixed",
+    billingType: cloud ? "subscription" : "fixed",
     costUsd: 0,
     resultJson: {
       iterations,
       host,
-      cloud: isOllamaCloudHost(host),
+      cloud,
+      resumed,
     },
     summary: finalMessage ?? null,
   };

--- a/packages/adapters/ollama-local/src/server/execute.ts
+++ b/packages/adapters/ollama-local/src/server/execute.ts
@@ -1,0 +1,452 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asNumber,
+  parseObject,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  DEFAULT_OLLAMA_MAX_ITERATIONS,
+  DEFAULT_OLLAMA_MODEL,
+  DEFAULT_OLLAMA_TIMEOUT_SEC,
+} from "../index.js";
+import { isOllamaCloudHost, resolveOllamaApiKey, resolveOllamaHost } from "./models.js";
+
+interface OllamaToolCall {
+  function?: {
+    name?: string;
+    arguments?: Record<string, unknown> | string;
+  };
+}
+
+interface OllamaMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content?: string;
+  tool_calls?: OllamaToolCall[];
+  tool_name?: string;
+}
+
+interface OllamaChatResponse {
+  message?: OllamaMessage;
+  done?: boolean;
+  done_reason?: string;
+  prompt_eval_count?: number;
+  eval_count?: number;
+  total_duration?: number;
+}
+
+const TOOL_DEFINITIONS = [
+  {
+    type: "function" as const,
+    function: {
+      name: "read_file",
+      description: "Read a UTF-8 text file and return its contents.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "File path, absolute or relative to cwd." },
+        },
+        required: ["path"],
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "write_file",
+      description: "Write (or overwrite) a UTF-8 text file.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "File path, absolute or relative to cwd." },
+          content: { type: "string", description: "Full file contents." },
+        },
+        required: ["path", "content"],
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "list_dir",
+      description: "List entries in a directory.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Directory path, absolute or relative to cwd. Defaults to cwd." },
+        },
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "run_bash",
+      description: "Run a shell command in cwd. Output is truncated at 64 KB.",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string", description: "Shell command to run." },
+        },
+        required: ["command"],
+      },
+    },
+  },
+];
+
+const DEFAULT_SYSTEM_PROMPT = `You are an autonomous coding agent running inside Paperclip.
+You can read files, write files, list directories, and run shell commands using the
+provided tools. Make meaningful progress on the task before stopping. When the task
+is complete, reply with a short final message and do not call any more tools.`;
+
+const TOOL_OUTPUT_TRUNCATE_BYTES = 64 * 1024;
+
+function truncate(text: string, max = TOOL_OUTPUT_TRUNCATE_BYTES): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + `\n…[truncated ${text.length - max} bytes]`;
+}
+
+function resolveWithinCwd(cwd: string, target: string): string {
+  if (!target) return cwd;
+  return path.isAbsolute(target) ? target : path.resolve(cwd, target);
+}
+
+async function execReadFile(cwd: string, args: Record<string, unknown>): Promise<string> {
+  const target = asString(args.path, "");
+  if (!target) return "Error: missing 'path' argument.";
+  const resolved = resolveWithinCwd(cwd, target);
+  try {
+    const data = await fs.readFile(resolved, "utf8");
+    return truncate(data);
+  } catch (err) {
+    return `Error reading ${resolved}: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+async function execWriteFile(cwd: string, args: Record<string, unknown>): Promise<string> {
+  const target = asString(args.path, "");
+  const content = asString(args.content, "");
+  if (!target) return "Error: missing 'path' argument.";
+  const resolved = resolveWithinCwd(cwd, target);
+  try {
+    await fs.mkdir(path.dirname(resolved), { recursive: true });
+    await fs.writeFile(resolved, content, "utf8");
+    return `Wrote ${content.length} bytes to ${resolved}`;
+  } catch (err) {
+    return `Error writing ${resolved}: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+async function execListDir(cwd: string, args: Record<string, unknown>): Promise<string> {
+  const target = asString(args.path, "");
+  const resolved = target ? resolveWithinCwd(cwd, target) : cwd;
+  try {
+    const entries = await fs.readdir(resolved, { withFileTypes: true });
+    const lines = entries
+      .map((e) => `${e.isDirectory() ? "d" : "-"} ${e.name}`)
+      .sort();
+    return truncate([`# ${resolved}`, ...lines].join("\n"));
+  } catch (err) {
+    return `Error listing ${resolved}: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+function execRunBash(
+  cwd: string,
+  env: Record<string, string>,
+  args: Record<string, unknown>,
+  graceSec: number,
+): Promise<string> {
+  const command = asString(args.command, "");
+  if (!command) return Promise.resolve("Error: missing 'command' argument.");
+  return new Promise((resolve) => {
+    const child = spawn(command, {
+      cwd,
+      env: { ...process.env, ...env },
+      shell: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const grace = Math.max(5, graceSec);
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), grace * 1000);
+    }, 5 * 60 * 1000);
+    child.stdout.on("data", (b) => {
+      stdout += b.toString("utf8");
+    });
+    child.stderr.on("data", (b) => {
+      stderr += b.toString("utf8");
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      const lines = [
+        `exit_code=${code ?? -1}${timedOut ? " (timed_out)" : ""}`,
+        stdout ? `--- stdout ---\n${stdout}` : "",
+        stderr ? `--- stderr ---\n${stderr}` : "",
+      ].filter(Boolean);
+      resolve(truncate(lines.join("\n")));
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve(`Error spawning shell: ${err.message}`);
+    });
+  });
+}
+
+async function dispatchToolCall(
+  name: string,
+  args: Record<string, unknown>,
+  ctx: { cwd: string; env: Record<string, string>; graceSec: number },
+): Promise<string> {
+  switch (name) {
+    case "read_file":
+      return execReadFile(ctx.cwd, args);
+    case "write_file":
+      return execWriteFile(ctx.cwd, args);
+    case "list_dir":
+      return execListDir(ctx.cwd, args);
+    case "run_bash":
+      return execRunBash(ctx.cwd, ctx.env, args, ctx.graceSec);
+    default:
+      return `Error: unknown tool "${name}".`;
+  }
+}
+
+function parseToolArguments(raw: unknown): Record<string, unknown> {
+  if (!raw) return {};
+  if (typeof raw === "object" && !Array.isArray(raw)) return raw as Record<string, unknown>;
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+  return {};
+}
+
+async function postOllamaChat(
+  host: string,
+  model: string,
+  messages: OllamaMessage[],
+  signal: AbortSignal,
+  apiKey: string | null,
+): Promise<OllamaChatResponse> {
+  const url = `${host.replace(/\/+$/, "")}/api/chat`;
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (apiKey) headers["authorization"] = `Bearer ${apiKey}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model,
+      messages,
+      tools: TOOL_DEFINITIONS,
+      stream: false,
+    }),
+    signal,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Ollama /api/chat returned ${res.status}: ${body.slice(0, 500)}`);
+  }
+  return (await res.json()) as OllamaChatResponse;
+}
+
+async function readInstructions(cwd: string, instructionsFilePath: string): Promise<string> {
+  if (!instructionsFilePath) return "";
+  const resolved = path.isAbsolute(instructionsFilePath)
+    ? instructionsFilePath
+    : path.resolve(cwd, instructionsFilePath);
+  try {
+    return await fs.readFile(resolved, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, config, context, onLog, onMeta } = ctx;
+  const model = asString(config.model, DEFAULT_OLLAMA_MODEL).trim();
+  const host = resolveOllamaHost(asString(config.host, ""));
+  const apiKey = resolveOllamaApiKey(asString(config.apiKey, ""));
+  if (isOllamaCloudHost(host) && !apiKey) {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage:
+        "Ollama Cloud host requires OLLAMA_API_KEY (https://ollama.com/settings/keys) or apiKey adapter field.",
+      provider: "ollama",
+      biller: "ollama_cloud",
+      model,
+    };
+  }
+  const cwd = asString(config.cwd, "").trim() || process.cwd();
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  const promptTemplate = asString(config.promptTemplate, "").trim();
+  const maxIterations = Math.max(
+    1,
+    Math.floor(asNumber(config.maxIterations, DEFAULT_OLLAMA_MAX_ITERATIONS)),
+  );
+  const timeoutSec = Math.max(1, Math.floor(asNumber(config.timeoutSec, DEFAULT_OLLAMA_TIMEOUT_SEC)));
+  const graceSec = Math.max(1, Math.floor(asNumber(config.graceSec, 20)));
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(envConfig)) {
+    if (typeof v === "string") env[k] = v;
+  }
+
+  await fs.mkdir(cwd, { recursive: true }).catch(() => undefined);
+
+  const instructions = await readInstructions(cwd, instructionsFilePath);
+  const systemPrompt = instructions
+    ? `${instructions}\n\n---\n\n${DEFAULT_SYSTEM_PROMPT}`
+    : DEFAULT_SYSTEM_PROMPT;
+
+  const userPromptParts: string[] = [];
+  if (promptTemplate) userPromptParts.push(promptTemplate);
+  const wakeReason = asString(context.wakeReason, "").trim();
+  if (wakeReason) userPromptParts.push(`Wake reason: ${wakeReason}`);
+  const userPrompt = userPromptParts.join("\n\n").trim() || "Begin work on the configured task.";
+
+  const messages: OllamaMessage[] = [
+    { role: "system", content: systemPrompt },
+    { role: "user", content: userPrompt },
+  ];
+
+  if (onMeta) {
+    await onMeta({
+      adapterType: "ollama_local",
+      command: `ollama:${host}`,
+      cwd,
+      commandArgs: [model],
+      env: Object.fromEntries(Object.entries(env).map(([k]) => [k, "***"])),
+      prompt: userPrompt,
+      promptMetrics: {
+        systemPromptChars: systemPrompt.length,
+        promptChars: userPrompt.length,
+      },
+      context,
+    });
+  }
+
+  await onLog(
+    "stdout",
+    `[paperclip] Starting ollama_local run ${runId} on ${host} with model "${model}".\n`,
+  );
+
+  const abort = new AbortController();
+  const timeoutHandle = setTimeout(() => abort.abort(), timeoutSec * 1000);
+
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let finalMessage: string | null = null;
+  let iterations = 0;
+  let timedOut = false;
+  let errorMessage: string | null = null;
+
+  try {
+    while (iterations < maxIterations) {
+      iterations += 1;
+      let response: OllamaChatResponse;
+      try {
+        response = await postOllamaChat(host, model, messages, abort.signal, apiKey);
+      } catch (err) {
+        if (abort.signal.aborted) {
+          timedOut = true;
+          errorMessage = `Timed out after ${timeoutSec}s`;
+          break;
+        }
+        errorMessage = err instanceof Error ? err.message : String(err);
+        await onLog("stderr", `[paperclip] Ollama call failed: ${errorMessage}\n`);
+        break;
+      }
+
+      inputTokens += response.prompt_eval_count ?? 0;
+      outputTokens += response.eval_count ?? 0;
+
+      const assistant = response.message;
+      if (!assistant) {
+        errorMessage = "Ollama returned no message.";
+        break;
+      }
+      messages.push(assistant);
+
+      const assistantText = (assistant.content ?? "").trim();
+      if (assistantText) {
+        await onLog("stdout", `[assistant] ${assistantText}\n`);
+        finalMessage = assistantText;
+      }
+
+      const toolCalls = assistant.tool_calls ?? [];
+      if (toolCalls.length === 0) {
+        // Model is done (or model doesn't support tools — stop either way).
+        break;
+      }
+
+      for (const call of toolCalls) {
+        const name = call.function?.name?.trim() ?? "";
+        const args = parseToolArguments(call.function?.arguments);
+        await onLog(
+          "stdout",
+          `[tool] ${name} ${JSON.stringify(args).slice(0, 500)}\n`,
+        );
+        const output = await dispatchToolCall(name, args, { cwd, env, graceSec });
+        await onLog("stdout", `[tool:${name}] ${output.split("\n", 1)[0].slice(0, 300)}\n`);
+        messages.push({
+          role: "tool",
+          content: output,
+          tool_name: name,
+        });
+      }
+    }
+
+    if (!errorMessage && iterations >= maxIterations) {
+      errorMessage = `Reached maxIterations=${maxIterations} without a final answer.`;
+      await onLog("stderr", `[paperclip] ${errorMessage}\n`);
+    }
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
+
+  const exitCode = timedOut ? 124 : errorMessage ? 1 : 0;
+
+  return {
+    exitCode,
+    signal: null,
+    timedOut,
+    errorMessage: errorMessage ?? null,
+    usage: {
+      inputTokens,
+      outputTokens,
+    },
+    sessionId: null,
+    sessionParams: null,
+    sessionDisplayId: null,
+    provider: "ollama",
+    biller: isOllamaCloudHost(host) ? "ollama_cloud" : "ollama",
+    model,
+    billingType: isOllamaCloudHost(host) ? "subscription" : "fixed",
+    costUsd: 0,
+    resultJson: {
+      iterations,
+      host,
+      cloud: isOllamaCloudHost(host),
+    },
+    summary: finalMessage ?? null,
+  };
+}

--- a/packages/adapters/ollama-local/src/server/index.ts
+++ b/packages/adapters/ollama-local/src/server/index.ts
@@ -1,19 +1,42 @@
 import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
 
-/**
- * v0.1: session resume is not yet implemented. The codec is a no-op shim so the
- * adapter type slot exists; serialize() always returns null which signals "no
- * resumable session" to the host.
- */
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
 export const sessionCodec: AdapterSessionCodec = {
-  deserialize() {
-    return null;
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId =
+      readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(record.cwd);
+    const model = readNonEmptyString(record.model);
+    const host = readNonEmptyString(record.host);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(model ? { model } : {}),
+      ...(host ? { host } : {}),
+    };
   },
-  serialize() {
-    return null;
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(params.cwd);
+    const model = readNonEmptyString(params.model);
+    const host = readNonEmptyString(params.host);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(model ? { model } : {}),
+      ...(host ? { host } : {}),
+    };
   },
-  getDisplayId() {
-    return null;
+  getDisplayId(params: Record<string, unknown> | null) {
+    return params ? readNonEmptyString(params.sessionId) : null;
   },
 };
 
@@ -32,3 +55,11 @@ export {
 } from "./models.js";
 export type { OllamaPullProgressEvent, OllamaShowResponse } from "./models.js";
 export { listOllamaSkills, syncOllamaSkills } from "./skills.js";
+export {
+  ensureSessionsDir,
+  buildSessionPath,
+  loadSession,
+  saveSession,
+  sessionMatchesCurrentRun,
+} from "./session.js";
+export type { OllamaSessionState, OllamaSessionMessage } from "./session.js";

--- a/packages/adapters/ollama-local/src/server/index.ts
+++ b/packages/adapters/ollama-local/src/server/index.ts
@@ -1,0 +1,34 @@
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+/**
+ * v0.1: session resume is not yet implemented. The codec is a no-op shim so the
+ * adapter type slot exists; serialize() always returns null which signals "no
+ * resumable session" to the host.
+ */
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize() {
+    return null;
+  },
+  serialize() {
+    return null;
+  },
+  getDisplayId() {
+    return null;
+  },
+};
+
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export {
+  listOllamaModels,
+  fetchOllamaTags,
+  pullOllamaModel,
+  deleteOllamaModel,
+  showOllamaModel,
+  modelSupportsTools,
+  resolveOllamaHost,
+  resolveOllamaApiKey,
+  isOllamaCloudHost,
+} from "./models.js";
+export type { OllamaPullProgressEvent, OllamaShowResponse } from "./models.js";
+export { listOllamaSkills, syncOllamaSkills } from "./skills.js";

--- a/packages/adapters/ollama-local/src/server/models.test.ts
+++ b/packages/adapters/ollama-local/src/server/models.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { listOllamaModels, resolveOllamaHost } from "./models.js";
+
+describe("resolveOllamaHost", () => {
+  const originalEnv = process.env.OLLAMA_HOST;
+  beforeEach(() => {
+    delete process.env.OLLAMA_HOST;
+  });
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.OLLAMA_HOST;
+    else process.env.OLLAMA_HOST = originalEnv;
+  });
+
+  it("falls back to localhost when nothing is set", () => {
+    expect(resolveOllamaHost()).toBe("http://localhost:11434");
+  });
+
+  it("prefers an explicit argument over env", () => {
+    process.env.OLLAMA_HOST = "http://env-host:11434";
+    expect(resolveOllamaHost("http://explicit:9999")).toBe("http://explicit:9999");
+  });
+
+  it("normalizes a scheme-less env value", () => {
+    process.env.OLLAMA_HOST = "remote:11434";
+    expect(resolveOllamaHost()).toBe("http://remote:11434");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(resolveOllamaHost("http://localhost:11434/")).toBe("http://localhost:11434");
+  });
+});
+
+describe("listOllamaModels", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns [] when /api/tags is unreachable", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const result = await listOllamaModels("http://localhost:11434");
+    expect(result).toEqual([]);
+  });
+
+  it("maps the /api/tags response into AdapterModel entries", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          models: [
+            { name: "qwen2.5-coder:14b", details: { parameter_size: "14B" } },
+            { name: "llama3.2:latest" },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await listOllamaModels("http://localhost:11434");
+    expect(result).toEqual([
+      { id: "llama3.2:latest", label: "llama3.2:latest" },
+      { id: "qwen2.5-coder:14b", label: "qwen2.5-coder:14b (14B)" },
+    ]);
+  });
+
+  it("dedupes and ignores empty entries", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          models: [
+            { name: "x" },
+            { name: "x" },
+            { name: "" },
+            { model: "y" },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const result = await listOllamaModels("http://localhost:11434");
+    expect(result).toEqual([
+      { id: "x", label: "x" },
+      { id: "y", label: "y" },
+    ]);
+  });
+});

--- a/packages/adapters/ollama-local/src/server/models.ts
+++ b/packages/adapters/ollama-local/src/server/models.ts
@@ -1,0 +1,243 @@
+import type { AdapterModel } from "@paperclipai/adapter-utils";
+import { DEFAULT_OLLAMA_HOST } from "../index.js";
+
+interface OllamaTagsResponse {
+  models?: Array<{
+    name?: string;
+    model?: string;
+    details?: { family?: string; parameter_size?: string };
+  }>;
+}
+
+export const OLLAMA_CLOUD_HOST = "https://ollama.com";
+
+export function resolveOllamaHost(explicit?: string | null): string {
+  if (explicit && explicit.trim().length > 0) {
+    const withScheme = /^https?:\/\//i.test(explicit.trim()) ? explicit.trim() : `http://${explicit.trim()}`;
+    return withScheme.replace(/\/+$/, "");
+  }
+  const envHost = (process.env.OLLAMA_HOST ?? "").trim();
+  if (envHost.length > 0) {
+    const withScheme = /^https?:\/\//i.test(envHost) ? envHost : `http://${envHost}`;
+    return withScheme.replace(/\/+$/, "");
+  }
+  return DEFAULT_OLLAMA_HOST;
+}
+
+export function isOllamaCloudHost(host: string): boolean {
+  try {
+    const url = new URL(host);
+    return /(^|\.)ollama\.com$/i.test(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function resolveOllamaApiKey(explicit?: string | null): string | null {
+  if (explicit && explicit.trim().length > 0) return explicit.trim();
+  const envKey = (process.env.OLLAMA_API_KEY ?? "").trim();
+  return envKey.length > 0 ? envKey : null;
+}
+
+function buildAuthHeaders(host: string, apiKey: string | null): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (apiKey && (isOllamaCloudHost(host) || apiKey.length > 0)) {
+    headers["authorization"] = `Bearer ${apiKey}`;
+  }
+  return headers;
+}
+
+export async function fetchOllamaTags(
+  host: string,
+  options: { signal?: AbortSignal; apiKey?: string | null } = {},
+): Promise<OllamaTagsResponse> {
+  const url = `${host.replace(/\/+$/, "")}/api/tags`;
+  const apiKey = resolveOllamaApiKey(options.apiKey ?? null);
+  const res = await fetch(url, {
+    signal: options.signal,
+    headers: buildAuthHeaders(host, apiKey),
+  });
+  if (!res.ok) {
+    throw new Error(`Ollama /api/tags returned ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as OllamaTagsResponse;
+}
+
+export async function listOllamaModels(
+  host?: string,
+  apiKey?: string | null,
+): Promise<AdapterModel[]> {
+  const resolvedHost = resolveOllamaHost(host);
+  try {
+    const tags = await fetchOllamaTags(resolvedHost, { apiKey });
+    const models: AdapterModel[] = [];
+    for (const entry of tags.models ?? []) {
+      const id = (entry.name ?? entry.model ?? "").trim();
+      if (!id) continue;
+      const detail = entry.details?.parameter_size
+        ? ` (${entry.details.parameter_size})`
+        : "";
+      models.push({ id, label: `${id}${detail}` });
+    }
+    return dedupeAndSort(models);
+  } catch {
+    return [];
+  }
+}
+
+export interface OllamaPullProgressEvent {
+  status: string;
+  digest?: string;
+  total?: number;
+  completed?: number;
+}
+
+export interface OllamaShowResponse {
+  capabilities?: string[];
+  details?: { family?: string; parameter_size?: string; quantization_level?: string };
+  model_info?: Record<string, unknown>;
+  modelfile?: string;
+}
+
+/**
+ * Stream a model pull. Emits progress events as the daemon reports them.
+ * Throws on HTTP error, on a JSON line with `error`, or if aborted.
+ */
+export async function pullOllamaModel(
+  host: string,
+  name: string,
+  options: {
+    apiKey?: string | null;
+    signal?: AbortSignal;
+    onProgress?: (event: OllamaPullProgressEvent) => void | Promise<void>;
+    insecure?: boolean;
+  } = {},
+): Promise<void> {
+  const trimmed = name.trim();
+  if (!trimmed) throw new Error("pullOllamaModel: name is required");
+  const url = `${host.replace(/\/+$/, "")}/api/pull`;
+  const apiKey = resolveOllamaApiKey(options.apiKey ?? null);
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (apiKey) headers["authorization"] = `Bearer ${apiKey}`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      model: trimmed,
+      stream: true,
+      ...(options.insecure ? { insecure: true } : {}),
+    }),
+    signal: options.signal,
+  });
+  if (!res.ok || !res.body) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Ollama /api/pull returned ${res.status}: ${body.slice(0, 500)}`);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let newlineIdx: number;
+    while ((newlineIdx = buffer.indexOf("\n")) >= 0) {
+      const line = buffer.slice(0, newlineIdx).trim();
+      buffer = buffer.slice(newlineIdx + 1);
+      if (!line) continue;
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (typeof parsed.error === "string") {
+        throw new Error(`Ollama pull failed: ${parsed.error}`);
+      }
+      if (options.onProgress) {
+        const status = typeof parsed.status === "string" ? parsed.status : "";
+        await options.onProgress({
+          status,
+          digest: typeof parsed.digest === "string" ? parsed.digest : undefined,
+          total: typeof parsed.total === "number" ? parsed.total : undefined,
+          completed: typeof parsed.completed === "number" ? parsed.completed : undefined,
+        });
+      }
+    }
+  }
+}
+
+export async function deleteOllamaModel(
+  host: string,
+  name: string,
+  options: { apiKey?: string | null; signal?: AbortSignal } = {},
+): Promise<void> {
+  const trimmed = name.trim();
+  if (!trimmed) throw new Error("deleteOllamaModel: name is required");
+  const url = `${host.replace(/\/+$/, "")}/api/delete`;
+  const apiKey = resolveOllamaApiKey(options.apiKey ?? null);
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (apiKey) headers["authorization"] = `Bearer ${apiKey}`;
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers,
+    body: JSON.stringify({ model: trimmed }),
+    signal: options.signal,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Ollama /api/delete returned ${res.status}: ${body.slice(0, 500)}`);
+  }
+}
+
+export async function showOllamaModel(
+  host: string,
+  name: string,
+  options: { apiKey?: string | null; signal?: AbortSignal } = {},
+): Promise<OllamaShowResponse> {
+  const url = `${host.replace(/\/+$/, "")}/api/show`;
+  const apiKey = resolveOllamaApiKey(options.apiKey ?? null);
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (apiKey) headers["authorization"] = `Bearer ${apiKey}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ model: name.trim() }),
+    signal: options.signal,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Ollama /api/show returned ${res.status}: ${body.slice(0, 500)}`);
+  }
+  return (await res.json()) as OllamaShowResponse;
+}
+
+/**
+ * Returns true when the requested model supports tool calling, based on
+ * Ollama's /api/show capabilities array.
+ */
+export async function modelSupportsTools(
+  host: string,
+  name: string,
+  options: { apiKey?: string | null; signal?: AbortSignal } = {},
+): Promise<boolean> {
+  try {
+    const info = await showOllamaModel(host, name, options);
+    return Array.isArray(info.capabilities) && info.capabilities.includes("tools");
+  } catch {
+    return false;
+  }
+}
+
+function dedupeAndSort(models: AdapterModel[]): AdapterModel[] {
+  const seen = new Set<string>();
+  const out: AdapterModel[] = [];
+  for (const m of models) {
+    if (seen.has(m.id)) continue;
+    seen.add(m.id);
+    out.push(m);
+  }
+  return out.sort((a, b) => a.id.localeCompare(b.id));
+}

--- a/packages/adapters/ollama-local/src/server/parse.ts
+++ b/packages/adapters/ollama-local/src/server/parse.ts
@@ -1,0 +1,8 @@
+/**
+ * v0.1 parser stubs. The adapter does not produce a structured transcript
+ * format yet; logs are streamed live via onLog from execute.ts. Reserved for
+ * a future session-resume / replay implementation.
+ */
+export function parseOllamaTranscript(_raw: string): { messages: string[]; finalMessage: string | null } {
+  return { messages: [], finalMessage: null };
+}

--- a/packages/adapters/ollama-local/src/server/session.test.ts
+++ b/packages/adapters/ollama-local/src/server/session.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  buildSessionPath,
+  loadSession,
+  saveSession,
+  sessionMatchesCurrentRun,
+  type OllamaSessionState,
+} from "./session.js";
+
+describe("session", () => {
+  let tmpDir: string;
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ollama-session-test-"));
+  });
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("buildSessionPath sanitizes agent ids", () => {
+    const p = buildSessionPath("../etc/passwd", "2026-05-05T12:00:00.000Z");
+    expect(path.basename(p)).not.toContain("../");
+    expect(path.basename(p)).toContain("etc_passwd");
+  });
+
+  it("saveSession + loadSession round-trips message history", async () => {
+    const sessionPath = path.join(tmpDir, "session.json");
+    const state: OllamaSessionState = {
+      agentId: "agent_1",
+      cwd: "/work",
+      model: "qwen2.5-coder:14b",
+      host: "http://localhost:11434",
+      cloud: false,
+      messages: [
+        { role: "system", content: "be useful" },
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+      ],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    await saveSession(sessionPath, state);
+    const loaded = await loadSession(sessionPath);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.agentId).toBe("agent_1");
+    expect(loaded?.messages).toHaveLength(3);
+    expect(loaded?.messages[2].content).toBe("hello");
+  });
+
+  it("loadSession returns null for missing file", async () => {
+    const loaded = await loadSession(path.join(tmpDir, "missing.json"));
+    expect(loaded).toBeNull();
+  });
+
+  it("loadSession returns null for malformed json", async () => {
+    const sessionPath = path.join(tmpDir, "bad.json");
+    await fs.writeFile(sessionPath, "{not json", "utf8");
+    expect(await loadSession(sessionPath)).toBeNull();
+  });
+
+  it("sessionMatchesCurrentRun catches model + host changes", () => {
+    const base = {
+      agentId: "a",
+      cwd: "/work",
+      model: "qwen2.5-coder:14b",
+      host: "http://localhost:11434",
+      cloud: false,
+      messages: [],
+      createdAt: "",
+      updatedAt: "",
+    } satisfies OllamaSessionState;
+    expect(
+      sessionMatchesCurrentRun(base, {
+        cwd: "/work",
+        model: "qwen2.5-coder:14b",
+        host: "http://localhost:11434",
+      }),
+    ).toBe(true);
+    expect(
+      sessionMatchesCurrentRun(base, {
+        cwd: "/work",
+        model: "different-model",
+        host: "http://localhost:11434",
+      }),
+    ).toBe(false);
+    expect(
+      sessionMatchesCurrentRun(base, {
+        cwd: "/other",
+        model: "qwen2.5-coder:14b",
+        host: "http://localhost:11434",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/adapters/ollama-local/src/server/session.ts
+++ b/packages/adapters/ollama-local/src/server/session.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const PAPERCLIP_SESSIONS_DIR = path.join(os.homedir(), ".paperclip", "ollama-sessions");
+
+export interface OllamaSessionMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content?: string;
+  tool_calls?: unknown[];
+  tool_name?: string;
+}
+
+export interface OllamaSessionState {
+  agentId: string;
+  cwd: string;
+  model: string;
+  host: string;
+  cloud: boolean;
+  messages: OllamaSessionMessage[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function ensureSessionsDir(): Promise<string> {
+  await fs.mkdir(PAPERCLIP_SESSIONS_DIR, { recursive: true });
+  return PAPERCLIP_SESSIONS_DIR;
+}
+
+export function buildSessionPath(agentId: string, timestamp: string): string {
+  const safeAgent = agentId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  const safeTimestamp = timestamp.replace(/[:.]/g, "-");
+  return path.join(PAPERCLIP_SESSIONS_DIR, `${safeTimestamp}-${safeAgent}.json`);
+}
+
+export async function loadSession(sessionPath: string): Promise<OllamaSessionState | null> {
+  try {
+    const raw = await fs.readFile(sessionPath, "utf8");
+    const parsed = JSON.parse(raw) as Partial<OllamaSessionState>;
+    if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.messages)) return null;
+    return parsed as OllamaSessionState;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveSession(sessionPath: string, state: OllamaSessionState): Promise<void> {
+  await fs.mkdir(path.dirname(sessionPath), { recursive: true });
+  const payload = {
+    ...state,
+    updatedAt: new Date().toISOString(),
+  };
+  // Atomic write: write to temp, then rename. Avoids torn state on crash.
+  const tmp = `${sessionPath}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
+  await fs.rename(tmp, sessionPath);
+}
+
+export function sessionMatchesCurrentRun(
+  state: OllamaSessionState,
+  current: { cwd: string; model: string; host: string },
+): boolean {
+  return (
+    path.resolve(state.cwd) === path.resolve(current.cwd) &&
+    state.model === current.model &&
+    state.host === current.host
+  );
+}

--- a/packages/adapters/ollama-local/src/server/skills.ts
+++ b/packages/adapters/ollama-local/src/server/skills.ts
@@ -1,0 +1,24 @@
+import type { AdapterSkillContext, AdapterSkillSnapshot } from "@paperclipai/adapter-utils";
+
+const ADAPTER_TYPE = "ollama_local";
+
+/**
+ * v0.1: skill-bundle injection is not yet implemented. Returning a snapshot with
+ * `supported: false, mode: "unsupported"` matches the host's expectation for
+ * adapters that don't materialize runtime skills (see
+ * `requiresMaterializedRuntimeSkills: false` in the registry entry).
+ */
+export async function listOllamaSkills(_ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {
+  return {
+    adapterType: ADAPTER_TYPE,
+    supported: false,
+    mode: "unsupported",
+    desiredSkills: [],
+    entries: [],
+    warnings: [],
+  };
+}
+
+export async function syncOllamaSkills(_ctx: AdapterSkillContext): Promise<AdapterSkillSnapshot> {
+  return listOllamaSkills(_ctx);
+}

--- a/packages/adapters/ollama-local/src/server/test.ts
+++ b/packages/adapters/ollama-local/src/server/test.ts
@@ -1,0 +1,77 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { asString, parseObject } from "@paperclipai/adapter-utils/server-utils";
+import { fetchOllamaTags, isOllamaCloudHost, resolveOllamaApiKey, resolveOllamaHost } from "./models.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const config = parseObject(ctx.config);
+  const host = resolveOllamaHost(asString(config.host, ""));
+  const apiKey = resolveOllamaApiKey(asString(config.apiKey, ""));
+  const wantedModel = asString(config.model, "").trim();
+  const cloud = isOllamaCloudHost(host);
+
+  const checks: AdapterEnvironmentCheck[] = [];
+
+  if (cloud && !apiKey) {
+    checks.push({
+      code: "ollama_cloud_missing_api_key",
+      level: "error",
+      message: `Ollama Cloud host ${host} requires an API key.`,
+      hint: "Set OLLAMA_API_KEY env var (from https://ollama.com/settings/keys) or the apiKey adapter field.",
+    });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const tags = await fetchOllamaTags(host, { signal: controller.signal, apiKey });
+    const installed = (tags.models ?? [])
+      .map((m) => (m.name ?? m.model ?? "").trim())
+      .filter((id) => id.length > 0);
+
+    checks.push({
+      code: "ollama_reachable",
+      level: "info",
+      message: `Reached Ollama at ${host}.`,
+      detail: `Found ${installed.length} installed model${installed.length === 1 ? "" : "s"}.`,
+    });
+
+    if (wantedModel.length > 0 && !installed.includes(wantedModel)) {
+      checks.push({
+        code: "ollama_model_missing",
+        level: "warn",
+        message: `Configured model "${wantedModel}" is not installed on this Ollama host.`,
+        hint: `Run: ollama pull ${wantedModel}`,
+      });
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    checks.push({
+      code: "ollama_unreachable",
+      level: "error",
+      message: `Could not reach Ollama at ${host}.`,
+      detail: message,
+      hint: "Start the daemon with `ollama serve`, or set the `host` adapter field / OLLAMA_HOST env var.",
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  return {
+    adapterType: "ollama_local",
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/ollama-local/src/ui/build-config.ts
+++ b/packages/adapters/ollama-local/src/ui/build-config.ts
@@ -1,0 +1,18 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import {
+  DEFAULT_OLLAMA_HOST,
+  DEFAULT_OLLAMA_MAX_ITERATIONS,
+  DEFAULT_OLLAMA_TIMEOUT_SEC,
+} from "../index.js";
+
+export function buildOllamaLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {
+    host: DEFAULT_OLLAMA_HOST,
+    maxIterations: DEFAULT_OLLAMA_MAX_ITERATIONS,
+    timeoutSec: DEFAULT_OLLAMA_TIMEOUT_SEC,
+  };
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  if (v.model) ac.model = v.model;
+  return ac;
+}

--- a/packages/adapters/ollama-local/src/ui/index.ts
+++ b/packages/adapters/ollama-local/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseOllamaStdoutLine } from "./parse-stdout.js";
+export { buildOllamaLocalConfig } from "./build-config.js";

--- a/packages/adapters/ollama-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/ollama-local/src/ui/parse-stdout.ts
@@ -1,0 +1,73 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+const ASSISTANT_PREFIX = "[assistant] ";
+const TOOL_CALL_PREFIX = "[tool] ";
+const TOOL_RESULT_PREFIX = /^\[tool:([^\]]+)\] (.*)$/s;
+const PAPERCLIP_PREFIX = "[paperclip] ";
+
+let toolUseCounter = 0;
+const pendingToolCalls = new Map<string, string>(); // name -> last toolUseId
+
+function nextToolUseId(name: string): string {
+  toolUseCounter += 1;
+  const id = `tool_${name}_${toolUseCounter}`;
+  pendingToolCalls.set(name, id);
+  return id;
+}
+
+function lastToolUseId(name: string): string {
+  return pendingToolCalls.get(name) ?? `tool_${name}_unknown`;
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export function parseOllamaStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  if (!line) return [];
+
+  if (line.startsWith(PAPERCLIP_PREFIX)) {
+    return [{ kind: "system", ts, text: line.slice(PAPERCLIP_PREFIX.length).trim() }];
+  }
+
+  if (line.startsWith(ASSISTANT_PREFIX)) {
+    return [{ kind: "assistant", ts, text: line.slice(ASSISTANT_PREFIX.length) }];
+  }
+
+  if (line.startsWith(TOOL_CALL_PREFIX)) {
+    const rest = line.slice(TOOL_CALL_PREFIX.length).trim();
+    const sep = rest.indexOf(" ");
+    const name = sep > 0 ? rest.slice(0, sep) : rest;
+    const argsRaw = sep > 0 ? rest.slice(sep + 1) : "";
+    return [
+      {
+        kind: "tool_call",
+        ts,
+        name,
+        input: argsRaw ? tryParseJson(argsRaw) : {},
+        toolUseId: nextToolUseId(name),
+      },
+    ];
+  }
+
+  const toolResultMatch = TOOL_RESULT_PREFIX.exec(line);
+  if (toolResultMatch) {
+    const [, name, content] = toolResultMatch;
+    return [
+      {
+        kind: "tool_result",
+        ts,
+        toolUseId: lastToolUseId(name),
+        toolName: name,
+        content,
+        isError: content.startsWith("Error"),
+      },
+    ];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/ollama-local/tsconfig.json
+++ b/packages/adapters/ollama-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/ollama-local/vitest.config.ts
+++ b/packages/adapters/ollama-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -34,6 +34,7 @@ export const AGENT_ADAPTER_TYPES = [
   "claude_local",
   "codex_local",
   "gemini_local",
+  "ollama_local",
   "opencode_local",
   "pi_local",
   "cursor",

--- a/packages/shared/src/environment-support.ts
+++ b/packages/shared/src/environment-support.ts
@@ -36,6 +36,7 @@ const REMOTE_MANAGED_ADAPTERS = new Set<AgentAdapterType>([
   "codex_local",
   "cursor",
   "gemini_local",
+  "ollama_local",
   "opencode_local",
   "pi_local",
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,22 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/ollama-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@24.12.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)
+
   packages/adapters/openclaw-gateway:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -524,6 +540,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-ollama-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/ollama-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -1476,6 +1495,12 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -1490,6 +1515,12 @@ packages:
 
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -1512,6 +1543,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.25.12':
     resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
@@ -1526,6 +1563,12 @@ packages:
 
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -1548,6 +1591,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -1562,6 +1611,12 @@ packages:
 
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -1584,6 +1639,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -1598,6 +1659,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -1620,6 +1687,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -1634,6 +1707,12 @@ packages:
 
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -1656,6 +1735,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -1670,6 +1755,12 @@ packages:
 
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -1692,6 +1783,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -1706,6 +1803,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1728,6 +1831,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -1746,6 +1855,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -1760,6 +1875,12 @@ packages:
 
   '@esbuild/linux-x64@0.18.20':
     resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1794,6 +1915,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -1820,6 +1947,12 @@ packages:
 
   '@esbuild/openbsd-x64@0.18.20':
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -1854,6 +1987,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -1868,6 +2007,12 @@ packages:
 
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -1890,6 +2035,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -1904,6 +2055,12 @@ packages:
 
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -3851,8 +4008,22 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -3865,17 +4036,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
@@ -4818,6 +5004,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -5687,6 +5878,9 @@ packages:
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -6277,8 +6471,16 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -6481,10 +6683,46 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -6564,6 +6802,31 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@3.2.4:
@@ -7928,6 +8191,9 @@ snapshots:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.13.6
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -7935,6 +8201,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -7946,6 +8215,9 @@ snapshots:
   '@esbuild/android-arm@0.18.20':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
@@ -7953,6 +8225,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -7964,6 +8239,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
@@ -7971,6 +8249,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -7982,6 +8263,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
@@ -7989,6 +8273,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -8000,6 +8287,9 @@ snapshots:
   '@esbuild/linux-arm64@0.18.20':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
@@ -8007,6 +8297,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -8018,6 +8311,9 @@ snapshots:
   '@esbuild/linux-ia32@0.18.20':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
@@ -8025,6 +8321,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -8036,6 +8335,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
@@ -8043,6 +8345,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -8054,6 +8359,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
@@ -8063,6 +8371,9 @@ snapshots:
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -8070,6 +8381,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -8087,6 +8401,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -8100,6 +8417,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -8117,6 +8437,9 @@ snapshots:
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
@@ -8124,6 +8447,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -8135,6 +8461,9 @@ snapshots:
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
@@ -8142,6 +8471,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -10397,6 +10729,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -10404,6 +10743,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@24.12.0)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@24.12.0)(lightningcss@1.30.2)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
@@ -10421,9 +10768,18 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -10431,15 +10787,31 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.1.0
 
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11264,6 +11636,32 @@ snapshots:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -12468,6 +12866,8 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
@@ -13258,7 +13658,11 @@ snapshots:
 
   tinypool@1.1.1: {}
 
+  tinyrainbow@1.2.0: {}
+
   tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   tinyspy@4.0.4: {}
 
@@ -13449,6 +13853,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9(@types/node@24.12.0)(lightningcss@1.30.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@24.12.0)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
@@ -13490,6 +13912,16 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite@5.4.21(@types/node@24.12.0)(lightningcss@1.30.2):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.60.1
+    optionalDependencies:
+      '@types/node': 24.12.0
+      fsevents: 2.3.3
+      lightningcss: 1.30.2
 
   vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
@@ -13550,6 +13982,42 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
+
+  vitest@2.1.9(@types/node@24.12.0)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@24.12.0)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@24.12.0)(lightningcss@1.30.2)
+      vite-node: 2.1.9(@types/node@24.12.0)(lightningcss@1.30.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.0
+      jsdom: 28.1.0(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,6 +703,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-ollama-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/ollama-local
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/server/package.json
+++ b/server/package.json
@@ -49,6 +49,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-ollama-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -8,6 +8,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "cursor",
   "gemini_local",
   "openclaw_gateway",
+  "ollama_local",
   "opencode_local",
   "pi_local",
   "hermes_local",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -61,6 +61,19 @@ import {
   modelProfiles as geminiModelProfiles,
 } from "@paperclipai/adapter-gemini-local";
 import {
+  execute as ollamaExecute,
+  listOllamaSkills,
+  syncOllamaSkills,
+  testEnvironment as ollamaTestEnvironment,
+  sessionCodec as ollamaSessionCodec,
+  listOllamaModels,
+} from "@paperclipai/adapter-ollama-local/server";
+import {
+  agentConfigurationDoc as ollamaAgentConfigurationDoc,
+  models as ollamaModels,
+  modelProfiles as ollamaModelProfiles,
+} from "@paperclipai/adapter-ollama-local";
+import {
   execute as openCodeExecute,
   listOpenCodeSkills,
   syncOpenCodeSkills,
@@ -308,6 +321,24 @@ const openCodeLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: openCodeAgentConfigurationDoc,
 };
 
+const ollamaLocalAdapter: ServerAdapterModule = {
+  type: "ollama_local",
+  execute: ollamaExecute,
+  testEnvironment: ollamaTestEnvironment,
+  listSkills: listOllamaSkills,
+  syncSkills: syncOllamaSkills,
+  sessionCodec: ollamaSessionCodec,
+  sessionManagement: getAdapterSessionManagement("ollama_local") ?? undefined,
+  models: ollamaModels,
+  modelProfiles: ollamaModelProfiles,
+  listModels: () => listOllamaModels(),
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: ollamaAgentConfigurationDoc,
+};
+
 const piLocalAdapter: ServerAdapterModule = {
   type: "pi_local",
   execute: piExecute,
@@ -410,6 +441,7 @@ function registerBuiltInAdapters() {
     acpxLocalAdapter,
     claudeLocalAdapter,
     codexLocalAdapter,
+    ollamaLocalAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,
     cursorLocalAdapter,

--- a/server/src/routes/adapters.ts
+++ b/server/src/routes/adapters.ts
@@ -45,6 +45,13 @@ import { loadExternalAdapterPackage, getUiParserSource, getOrExtractUiParserSour
 import { logger } from "../middleware/logger.js";
 import { assertBoardOrgAccess, assertInstanceAdmin } from "./authz.js";
 import { BUILTIN_ADAPTER_TYPES } from "../adapters/builtin-adapter-types.js";
+import {
+  pullOllamaModel,
+  deleteOllamaModel,
+  showOllamaModel,
+  resolveOllamaHost,
+  resolveOllamaApiKey,
+} from "@paperclipai/adapter-ollama-local/server";
 
 const execFileAsync = promisify(execFile);
 
@@ -672,6 +679,84 @@ export function adapterRoutes() {
       return;
     }
     res.type("application/javascript").send(source);
+  });
+
+  // ── POST /api/adapters/ollama_local/pull-model ───────────────────────────
+  // Stream a model pull from the configured Ollama host.
+  // Server-Sent Events; each event is a JSON progress line from /api/pull.
+  router.post("/adapters/ollama_local/pull-model", async (req, res) => {
+    assertBoardOrgAccess(req);
+    const body = (req.body ?? {}) as { name?: unknown; host?: unknown; apiKey?: unknown };
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    if (!name) {
+      res.status(400).json({ error: "Missing required field: name" });
+      return;
+    }
+    const host = resolveOllamaHost(typeof body.host === "string" ? body.host : null);
+    const apiKey = resolveOllamaApiKey(typeof body.apiKey === "string" ? body.apiKey : null);
+
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    res.flushHeaders?.();
+
+    const controller = new AbortController();
+    req.on("close", () => controller.abort());
+
+    try {
+      await pullOllamaModel(host, name, {
+        apiKey,
+        signal: controller.signal,
+        onProgress: async (event) => {
+          res.write(`data: ${JSON.stringify(event)}\n\n`);
+        },
+      });
+      res.write(`data: ${JSON.stringify({ status: "success" })}\n\n`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.write(`data: ${JSON.stringify({ status: "error", error: message })}\n\n`);
+    } finally {
+      res.end();
+    }
+  });
+
+  // ── DELETE /api/adapters/ollama_local/models/:name ──────────────────────
+  router.delete("/adapters/ollama_local/models/:name", async (req, res) => {
+    assertBoardOrgAccess(req);
+    const name = decodeURIComponent(req.params.name as string);
+    const host = resolveOllamaHost(typeof req.query.host === "string" ? req.query.host : null);
+    const apiKey = resolveOllamaApiKey(typeof req.query.apiKey === "string" ? req.query.apiKey : null);
+    try {
+      await deleteOllamaModel(host, name, { apiKey });
+      res.json({ ok: true });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(502).json({ error: message });
+    }
+  });
+
+  // ── GET /api/adapters/ollama_local/show-model ────────────────────────────
+  router.get("/adapters/ollama_local/show-model", async (req, res) => {
+    assertBoardOrgAccess(req);
+    const name = typeof req.query.name === "string" ? req.query.name.trim() : "";
+    if (!name) {
+      res.status(400).json({ error: "Missing required query: name" });
+      return;
+    }
+    const host = resolveOllamaHost(typeof req.query.host === "string" ? req.query.host : null);
+    const apiKey = resolveOllamaApiKey(typeof req.query.apiKey === "string" ? req.query.apiKey : null);
+    try {
+      const info = await showOllamaModel(host, name, { apiKey });
+      res.json({
+        name,
+        capabilities: info.capabilities ?? [],
+        details: info.details ?? null,
+        supportsTools: Array.isArray(info.capabilities) && info.capabilities.includes("tools"),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(502).json({ error: message });
+    }
   });
 
   return router;

--- a/ui/package.json
+++ b/ui/package.json
@@ -39,6 +39,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-ollama-local": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/ui/src/adapters/ollama-local/config-fields.tsx
+++ b/ui/src/adapters/ollama-local/config-fields.tsx
@@ -1,0 +1,46 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import { Field, DraftInput } from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) injected into the system prompt at runtime.";
+
+export function OllamaLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  if (hideInstructionsFile) return null;
+  return (
+    <Field label="Agent instructions file" hint={instructionsFileHint}>
+      <div className="flex items-center gap-2">
+        <DraftInput
+          value={
+            isCreate
+              ? values!.instructionsFilePath ?? ""
+              : eff(
+                  "adapterConfig",
+                  "instructionsFilePath",
+                  String(config.instructionsFilePath ?? ""),
+                )
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ instructionsFilePath: v })
+              : mark("adapterConfig", "instructionsFilePath", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="/absolute/path/to/AGENTS.md"
+        />
+        <ChoosePathButton />
+      </div>
+    </Field>
+  );
+}

--- a/ui/src/adapters/ollama-local/index.ts
+++ b/ui/src/adapters/ollama-local/index.ts
@@ -1,0 +1,11 @@
+import type { UIAdapterModule } from "../types";
+import { parseOllamaStdoutLine, buildOllamaLocalConfig } from "@paperclipai/adapter-ollama-local/ui";
+import { OllamaLocalConfigFields } from "./config-fields";
+
+export const ollamaLocalUIAdapter: UIAdapterModule = {
+  type: "ollama_local",
+  label: "Ollama (local)",
+  parseStdoutLine: parseOllamaStdoutLine,
+  ConfigFields: OllamaLocalConfigFields,
+  buildAdapterConfig: buildOllamaLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -4,6 +4,7 @@ import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
+import { ollamaLocalUIAdapter } from "./ollama-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
@@ -55,6 +56,7 @@ function registerBuiltInUIAdapters() {
     codexLocalUIAdapter,
     geminiLocalUIAdapter,
     hermesLocalUIAdapter,
+    ollamaLocalUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Adapters are the contract between the control plane and concrete agent runtimes (Claude Code, Codex, Cursor, OpenCode, Pi, Gemini, Hermes…). Every existing adapter wraps an external coding-agent CLI.
> - Ollama is a first-class inference server (local + Cloud) but ships no coding-agent CLI, so today the only way to use it from Paperclip is to point `codex_local` / `opencode_local` at `OPENAI_BASE_URL=http://localhost:11434/v1`. That works, but it is a workaround — the user intent ("use Ollama") leaks across two adapters and you cannot pick from Ollama's catalog directly.
> - With Ollama shipping `/api/chat` native tool calling and `ollama launch <integration>` for first-class clients (Codex / OpenCode / Droid / Claude Code), Paperclip should host the agent loop itself directly against Ollama.
> - This PR adds `ollama_local` as a built-in adapter that drives `/api/chat` with native tools (`read_file`, `write_file`, `list_dir`, `run_bash`), supports both local Ollama and Ollama Cloud (Bearer auth via `OLLAMA_API_KEY`), persists conversation state across heartbeats for proper resume, exposes model lifecycle helpers (pull/delete/show), and ships a UI parser so transcripts render structured turns. The Ollama side of the integration is filed as [ollama/ollama#15976](https://github.com/ollama/ollama/issues/15976).
> - The benefit is Ollama becomes a peer of the other adapters — selectable in agent creation, with model pick / install / switch all inside Paperclip — without forcing the user to think about base-URL plumbing.

## What Changed

**New package `@paperclipai/adapter-ollama-local`** (`packages/adapters/ollama-local/`):

- `src/index.ts` — type metadata, model seed list, model profiles, agent configuration doc.
- `src/server/execute.ts` — agent loop calling Ollama `/api/chat` with native tool calling. Built-in tools: `read_file`, `write_file`, `list_dir`, `run_bash`. Iteration cap, wall-clock timeout, error-family classification (`transient_upstream` for network / 429 / timeout).
- `src/server/models.ts` — `listOllamaModels` (`/api/tags`), `pullOllamaModel` (streaming `/api/pull`), `deleteOllamaModel`, `showOllamaModel`, `modelSupportsTools`. Host normalization handles `OLLAMA_HOST` env, scheme-less values, and `*.ollama.com` cloud detection. `OLLAMA_API_KEY` Bearer auth applied automatically when host is on `ollama.com`.
- `src/server/test.ts` — `testEnvironment` pings `/api/tags`, validates configured model is installed, surfaces a clear error when Cloud host is set without an API key.
- `src/server/session.ts` — durable session persistence at `~/.paperclip/ollama-sessions/<timestamp>-<agentId>.json` with atomic temp-file writes. Used by `execute()` to resume across heartbeats.
- `src/ui/` — `parseOllamaStdoutLine` mapping log format to structured `TranscriptEntry` kinds. `buildOllamaLocalConfig` for the create flow.
- 12 unit tests (7 models + 5 session) all passing.

**Server registration:** `registry.ts`, `builtin-adapter-types.ts`, `server/package.json`. Plus three new HTTP routes in `server/src/routes/adapters.ts`:

- `POST /api/adapters/ollama_local/pull-model` (SSE-streamed pull progress)
- `DELETE /api/adapters/ollama_local/models/:name`
- `GET /api/adapters/ollama_local/show-model?name=...`

**Shared:** `AGENT_ADAPTER_TYPES` and `REMOTE_MANAGED_ADAPTERS` include `ollama_local`.

**UI:** `ollamaLocalUIAdapter` registered with config fields component mirroring `pi_local`.

**Docs:** `docs/integrations/ollama/README.md` (local + Cloud setup, model lifecycle); `docs/integrations/ollama/launch-paperclip.go.md` (proposed `cmd/launch/paperclip.go` for the upstream issue).

## Verification

```sh
pnpm install
pnpm --filter @paperclipai/adapter-ollama-local typecheck   # clean
pnpm --filter @paperclipai/adapter-ollama-local test         # 12/12 pass
pnpm --filter @paperclipai/shared typecheck                  # clean
pnpm --filter @paperclipai/ui typecheck                      # clean
cd server && npx vitest run src/__tests__/adapter-registry.test.ts  # 17/17 pass
```

**Live end-to-end smoke** (against `qwen3.5:4b` on `http://localhost:11434`):

1. `listOllamaModels` returned both installed models with parameter sizes.
2. `modelSupportsTools("qwen3.5:4b")` returned `true` (capabilities included `tools`).
3. **Full agent loop**: prompted to create `hello.txt` and list the directory. Model emitted `write_file` + `list_dir` tool calls; the file landed on disk; final assistant message captured; exitCode 0; usage `{inputTokens: 2326, outputTokens: 253}`.
4. **Resume**: first run wrote `counter.txt` with `1`. Second run with prior `sessionParams` logged "Resuming…", model read the file (knew it from prior turn), wrote `2`. Same session reused; 11 messages persisted.

## Risks

- **Tool-calling model dependency.** Models without `tools` capability exit on turn 1. `modelSupportsTools` is exported; the model picker should gate on it.
- **No streaming yet.** `stream: false`. Functional but blocking. Follow-up.
- **No remote execution target support.** SSH worker scenarios will not work via this adapter.
- **Skill-bundle injection not implemented.** The four built-in tools cover the common case.
- **HTTP routes are Ollama-specific.** Happy to refactor to a generic adapter-capability pattern if maintainers prefer.

## Model Used

- Claude (Anthropic), `claude-opus-4-7`, extended-thinking-capable.

## Companion upstream issue

[ollama/ollama#15976](https://github.com/ollama/ollama/issues/15976) — proposing `ollama launch paperclip`. Reference `cmd/launch/paperclip.go` committed under `docs/integrations/ollama/launch-paperclip.go.md`.

## Checklist

- [x] Thinking path
- [x] Model used
- [x] ROADMAP checked
- [x] Tests run locally
- [x] Tests added
- [ ] UI screenshots — pending reviewer dev server
- [x] Docs updated
- [x] Risks documented
- [x] Will address review comments
