### PR TITLE
DEV-136 surface onboarding issue prefix

### DIFF
--- a/packages/shared/src/validators/company.ts
+++ b/packages/shared/src/validators/company.ts
@@ -13,16 +13,25 @@ const attachmentMaxBytesSchema = z
   .min(1)
   .max(MAX_COMPANY_ATTACHMENT_MAX_BYTES);
 
-export const createCompanySchema = z.object({
+export const companyIssuePrefixSchema = z
+  .string()
+  .trim()
+  .regex(/^[A-Z]{2,4}$/, "Issue prefix must be 2-4 uppercase letters");
+
+const createCompanyBaseSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional().nullable(),
   budgetMonthlyCents: z.number().int().nonnegative().optional().default(0),
   attachmentMaxBytes: attachmentMaxBytesSchema.optional(),
 });
 
+export const createCompanySchema = createCompanyBaseSchema.extend({
+  issuePrefix: companyIssuePrefixSchema.optional(),
+});
+
 export type CreateCompany = z.infer<typeof createCompanySchema>;
 
-export const updateCompanySchema = createCompanySchema
+export const updateCompanySchema = createCompanyBaseSchema
   .partial()
   .extend({
     status: z.enum(COMPANY_STATUSES).optional(),

--- a/server/src/__tests__/company-branding-route.test.ts
+++ b/server/src/__tests__/company-branding-route.test.ts
@@ -94,6 +94,44 @@ describe("PATCH /api/companies/:companyId/branding", () => {
     vi.clearAllMocks();
   });
 
+  it("accepts an explicit issue prefix when creating a company", async () => {
+    const company = { ...createCompany(), name: "Trading", issuePrefix: "TRD" };
+    mockCompanyService.create.mockResolvedValue(company);
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app)
+      .post("/api/companies")
+      .send({ name: "Trading", issuePrefix: "TRD" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.issuePrefix).toBe("TRD");
+    expect(mockCompanyService.create).toHaveBeenCalledWith({
+      name: "Trading",
+      issuePrefix: "TRD",
+      budgetMonthlyCents: 0,
+    });
+  });
+
+  it("rejects invalid explicit issue prefixes when creating a company", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "user-1",
+      source: "local_implicit",
+    });
+
+    const res = await request(app)
+      .post("/api/companies")
+      .send({ name: "Trading", issuePrefix: "trading" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Validation error");
+    expect(mockCompanyService.create).not.toHaveBeenCalled();
+  });
+
   it("rejects non-CEO agent callers", async () => {
     mockAgentService.getById.mockResolvedValue({
       id: "agent-1",

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -137,6 +137,24 @@ export function companyService(db: Db) {
       && constraint === "companies_issue_prefix_idx";
   }
 
+  async function createCompanyWithExplicitPrefix(
+    data: typeof companies.$inferInsert,
+    issuePrefix: string,
+  ) {
+    try {
+      const rows = await db
+        .insert(companies)
+        .values({ ...data, issuePrefix })
+        .returning();
+      return rows[0];
+    } catch (error) {
+      if (isIssuePrefixConflict(error)) {
+        throw unprocessable(`Issue prefix ${issuePrefix} is already in use`);
+      }
+      throw error;
+    }
+  }
+
   async function createCompanyWithUniquePrefix(data: typeof companies.$inferInsert) {
     const base = deriveIssuePrefixBase(data.name);
     let suffix = 1;
@@ -173,7 +191,19 @@ export function companyService(db: Db) {
     },
 
     create: async (data: typeof companies.$inferInsert) => {
-      const created = await createCompanyWithUniquePrefix(data);
+      const explicitIssuePrefix =
+        typeof data.issuePrefix === "string" && data.issuePrefix.length > 0
+          ? data.issuePrefix
+          : null;
+      if (
+        explicitIssuePrefix &&
+        !/^[A-Z]{2,4}$/.test(explicitIssuePrefix)
+      ) {
+        throw unprocessable("Issue prefix must be 2-4 uppercase letters");
+      }
+      const created = explicitIssuePrefix
+        ? await createCompanyWithExplicitPrefix(data, explicitIssuePrefix)
+        : await createCompanyWithUniquePrefix(data);
       await environmentsSvc.ensureLocalEnvironment(created.id);
       const row = await getCompanyQuery(db)
         .where(eq(companies.id, created.id))

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -16,6 +16,8 @@ import { test, expect } from "@playwright/test";
 
 const SKIP_LLM = process.env.PAPERCLIP_E2E_SKIP_LLM !== "false";
 
+// The default Playwright config creates a fresh PAPERCLIP_HOME per run, so
+// fixed fixtures are safe and assert DEV-136's explicit Trading/TRD path.
 const COMPANY_NAME = "Trading";
 const COMPANY_PREFIX = "TRD";
 const AGENT_NAME = "CEO";

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -16,7 +16,8 @@ import { test, expect } from "@playwright/test";
 
 const SKIP_LLM = process.env.PAPERCLIP_E2E_SKIP_LLM !== "false";
 
-const COMPANY_NAME = `E2E-Test-${Date.now()}`;
+const COMPANY_NAME = "Trading";
+const COMPANY_PREFIX = "TRD";
 const AGENT_NAME = "CEO";
 const TASK_TITLE = "E2E test task";
 
@@ -30,6 +31,10 @@ test.describe("Onboarding wizard", () => {
 
     const companyNameInput = page.locator('input[placeholder="Acme Corp"]');
     await companyNameInput.fill(COMPANY_NAME);
+    const companyPrefixInput = page.getByLabel("Issue prefix");
+    await expect(companyPrefixInput).toHaveValue("TRA");
+    await companyPrefixInput.fill(COMPANY_PREFIX);
+    await expect(companyPrefixInput).toHaveValue(COMPANY_PREFIX);
 
     const nextButton = page.getByRole("button", { name: "Next" });
     await nextButton.click();
@@ -120,6 +125,7 @@ test.describe("Onboarding wizard", () => {
       (c: { name: string }) => c.name === COMPANY_NAME
     );
     expect(company).toBeTruthy();
+    expect(company.issuePrefix).toBe(COMPANY_PREFIX);
 
     const agentsRes = await page.request.get(
       `${baseUrl}/api/companies/${company.id}/agents`
@@ -151,6 +157,7 @@ test.describe("Onboarding wizard", () => {
       (i: { title: string }) => i.title === TASK_TITLE
     );
     expect(task).toBeTruthy();
+    expect(task.identifier).toMatch(new RegExp(`^${COMPANY_PREFIX}-`));
     expect(task.assigneeAgentId).toBe(ceoAgent.id);
     expect(task.description).toContain(
       "You are the CEO. You set the direction for the company."

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -19,6 +19,7 @@ export const companiesApi = {
   stats: () => api.get<CompanyStats>("/companies/stats"),
   create: (data: {
     name: string;
+    issuePrefix?: string;
     description?: string | null;
     budgetMonthlyCents?: number;
   }) =>

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -36,6 +36,11 @@ import {
   buildOnboardingProjectPayload,
   selectDefaultCompanyGoalId
 } from "../lib/onboarding-launch";
+import {
+  deriveOnboardingIssuePrefix,
+  sanitizeOnboardingIssuePrefix,
+  validateOnboardingIssuePrefix
+} from "../lib/onboarding-company-prefix";
 import { buildNewAgentRuntimeConfig } from "../lib/new-agent-runtime-config";
 import {
   DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
@@ -105,6 +110,9 @@ export function OnboardingWizard() {
 
   // Step 1
   const [companyName, setCompanyName] = useState("");
+  const [companyIssuePrefix, setCompanyIssuePrefix] = useState("");
+  const [companyIssuePrefixTouched, setCompanyIssuePrefixTouched] =
+    useState(false);
   const [companyGoal, setCompanyGoal] = useState("");
 
   // Step 2
@@ -250,6 +258,10 @@ export function OnboardingWizard() {
     adapterType === "claude_local" &&
     adapterEnvResult?.status === "fail" &&
     hasAnthropicApiKeyOverrideCheck;
+  const companyIssuePrefixError = useMemo(() => {
+    if (!companyName.trim() && !companyIssuePrefix.trim()) return null;
+    return validateOnboardingIssuePrefix(companyIssuePrefix, companies);
+  }, [companies, companyIssuePrefix, companyName]);
   const filteredModels = useMemo(() => {
     const query = modelSearch.trim().toLowerCase();
     return (adapterModels ?? []).filter((entry) => {
@@ -291,6 +303,8 @@ export function OnboardingWizard() {
     setLoading(false);
     setError(null);
     setCompanyName("");
+    setCompanyIssuePrefix("");
+    setCompanyIssuePrefixTouched(false);
     setCompanyGoal("");
     setAgentName("CEO");
     setAdapterType("claude_local");
@@ -386,10 +400,23 @@ export function OnboardingWizard() {
   }
 
   async function handleStep1Next() {
+    const normalizedIssuePrefix = companyIssuePrefix.trim().toUpperCase();
+    const prefixError = validateOnboardingIssuePrefix(
+      normalizedIssuePrefix,
+      companies
+    );
+    if (prefixError) {
+      setError(prefixError);
+      return;
+    }
+
     setLoading(true);
     setError(null);
     try {
-      const company = await companiesApi.create({ name: companyName.trim() });
+      const company = await companiesApi.create({
+        name: companyName.trim(),
+        issuePrefix: normalizedIssuePrefix
+      });
       setCreatedCompanyId(company.id);
       setCreatedCompanyPrefix(company.issuePrefix);
       setSelectedCompanyId(company.id);
@@ -708,9 +735,54 @@ export function OnboardingWizard() {
                       className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
                       placeholder="Acme Corp"
                       value={companyName}
-                      onChange={(e) => setCompanyName(e.target.value)}
+                      onChange={(e) => {
+                        const nextName = e.target.value;
+                        setCompanyName(nextName);
+                        if (!companyIssuePrefixTouched) {
+                          setCompanyIssuePrefix(
+                            deriveOnboardingIssuePrefix(nextName)
+                          );
+                        }
+                      }}
                       autoFocus
                     />
+                  </div>
+                  <div className="group">
+                    <label
+                      htmlFor="onboarding-company-issue-prefix"
+                      className={cn(
+                        "text-xs mb-1 block transition-colors",
+                        companyIssuePrefix.trim()
+                          ? "text-foreground"
+                          : "text-muted-foreground group-focus-within:text-foreground"
+                      )}
+                    >
+                      Issue prefix
+                    </label>
+                    <input
+                      id="onboarding-company-issue-prefix"
+                      className={cn(
+                        "w-full rounded-md border bg-transparent px-3 py-2 text-sm font-mono uppercase outline-none focus:ring-1 placeholder:text-muted-foreground/50",
+                        companyIssuePrefixError
+                          ? "border-destructive focus:ring-destructive"
+                          : "border-border focus:ring-ring"
+                      )}
+                      placeholder="ACM"
+                      value={companyIssuePrefix}
+                      maxLength={4}
+                      aria-invalid={Boolean(companyIssuePrefixError)}
+                      onChange={(e) => {
+                        setCompanyIssuePrefixTouched(true);
+                        setCompanyIssuePrefix(
+                          sanitizeOnboardingIssuePrefix(e.target.value)
+                        );
+                      }}
+                    />
+                    {companyIssuePrefixError && (
+                      <p className="mt-1 text-xs text-destructive">
+                        {companyIssuePrefixError}
+                      </p>
+                    )}
                   </div>
                   <div className="group">
                     <label
@@ -1222,7 +1294,11 @@ export function OnboardingWizard() {
                   {step === 1 && (
                     <Button
                       size="sm"
-                      disabled={!companyName.trim() || loading}
+                      disabled={
+                        !companyName.trim() ||
+                        Boolean(companyIssuePrefixError) ||
+                        loading
+                      }
                       onClick={handleStep1Next}
                     >
                       {loading ? (

--- a/ui/src/context/CompanyContext.tsx
+++ b/ui/src/context/CompanyContext.tsx
@@ -27,6 +27,7 @@ interface CompanyContextValue {
   reloadCompanies: () => Promise<void>;
   createCompany: (data: {
     name: string;
+    issuePrefix?: string;
     description?: string | null;
     budgetMonthlyCents?: number;
   }) => Promise<Company>;
@@ -128,6 +129,7 @@ export function CompanyProvider({ children }: { children: ReactNode }) {
   const createMutation = useMutation({
     mutationFn: (data: {
       name: string;
+      issuePrefix?: string;
       description?: string | null;
       budgetMonthlyCents?: number;
     }) =>
@@ -141,6 +143,7 @@ export function CompanyProvider({ children }: { children: ReactNode }) {
   const createCompany = useCallback(
     async (data: {
       name: string;
+      issuePrefix?: string;
       description?: string | null;
       budgetMonthlyCents?: number;
     }) => {

--- a/ui/src/lib/onboarding-company-prefix.test.ts
+++ b/ui/src/lib/onboarding-company-prefix.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveOnboardingIssuePrefix,
+  sanitizeOnboardingIssuePrefix,
+  validateOnboardingIssuePrefix,
+} from "./onboarding-company-prefix";
+
+describe("onboarding company issue prefix helpers", () => {
+  it("derives the default prefix from the company name", () => {
+    expect(deriveOnboardingIssuePrefix("Trading")).toBe("TRA");
+    expect(deriveOnboardingIssuePrefix("TRD Trading")).toBe("TRD");
+    expect(deriveOnboardingIssuePrefix("123 Open-Pursuit")).toBe("OPE");
+  });
+
+  it("normalizes typed prefixes for the onboarding field", () => {
+    expect(sanitizeOnboardingIssuePrefix("trd")).toBe("TRD");
+    expect(sanitizeOnboardingIssuePrefix("op3n-long")).toBe("OPNL");
+  });
+
+  it("validates prefix length and uniqueness", () => {
+    expect(validateOnboardingIssuePrefix("TRD", [])).toBeNull();
+    expect(validateOnboardingIssuePrefix("T", [])).toContain("2-4");
+    expect(
+      validateOnboardingIssuePrefix("DEV", [{ issuePrefix: "DEV" }]),
+    ).toContain("already in use");
+  });
+});

--- a/ui/src/lib/onboarding-company-prefix.ts
+++ b/ui/src/lib/onboarding-company-prefix.ts
@@ -1,0 +1,27 @@
+export function deriveOnboardingIssuePrefix(companyName: string): string {
+  return companyName.toUpperCase().replace(/[^A-Z]/g, "").slice(0, 3);
+}
+
+export function sanitizeOnboardingIssuePrefix(value: string): string {
+  return value.toUpperCase().replace(/[^A-Z]/g, "").slice(0, 4);
+}
+
+export function validateOnboardingIssuePrefix(
+  issuePrefix: string,
+  companies: ReadonlyArray<{ issuePrefix: string }>,
+): string | null {
+  const normalized = issuePrefix.trim().toUpperCase();
+  if (!/^[A-Z]{2,4}$/.test(normalized)) {
+    return "Issue prefix must be 2-4 uppercase letters.";
+  }
+
+  if (
+    companies.some(
+      (company) => company.issuePrefix.toUpperCase() === normalized,
+    )
+  ) {
+    return `Issue prefix ${normalized} is already in use.`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Implements [DEV-136](/DEV/issues/DEV-136) by surfacing an explicit onboarding `issuePrefix` field and wiring it through company creation.

- Adds create-company validation and service support for caller-supplied `issuePrefix`, while preserving derived-prefix behavior when omitted.
- Adds an editable onboarding wizard issue prefix field with derived defaults, uppercase sanitization, 2-4 letter validation, and duplicate-prefix feedback.
- Passes `issuePrefix` through the onboarding API typing/context path.
- Covers the `Trading` + `TRD` onboarding flow and asserts the first issue uses `TRD-*`.

## Source

- Parent Paperclip issue: [DEV-136](/DEV/issues/DEV-136)
- PR owner handoff issue: [DEV-169](/DEV/issues/DEV-169)
- Repo/worktree: `/Users/kmullaney/keegoid/repos/paperclip-dev-136`
- Branch: `codex/dev-136-onboarding-issueprefix`
- Commit: `d5951ba09d9946edeefadca4f21912ca99adbb4c`
- Commit author/committer: `Fig <fig@keegoid.com>`
- Review route: Codex-model Fig PR path, independent review by `keegoid-cc`

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/lib/onboarding-company-prefix.test.ts`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/company-branding-route.test.ts`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm test:e2e tests/e2e/onboarding.spec.ts`

## Notes

The `/Users/kmullaney/keegoid/org` worktree is dirty, including `playbooks/paperclip_operations.md`, so the playbook cleanup is intentionally left out of this PR.
