### PR TITLE
perf(ui,server): reduce polling traffic 4-7x

### DIFF
--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -52,6 +52,7 @@ export const httpLogger = pinoHttp({
       return "silent";
     }
     if (err || res.statusCode >= 500) return "error";
+    if (res.statusCode === 404) return "info";
     if (res.statusCode >= 400) return "warn";
     return "info";
   },

--- a/ui/src/components/CompanyRail.tsx
+++ b/ui/src/components/CompanyRail.tsx
@@ -145,14 +145,14 @@ export function CompanyRail() {
     queries: companyIds.map((companyId) => ({
       queryKey: queryKeys.liveRuns(companyId),
       queryFn: () => heartbeatsApi.liveRunsForCompany(companyId),
-      refetchInterval: 10_000,
+      refetchInterval: companyId === highlightedCompanyId ? 10_000 : 60_000,
     })),
   });
   const sidebarBadgeQueries = useQueries({
     queries: companyIds.map((companyId) => ({
       queryKey: queryKeys.sidebarBadges(companyId),
       queryFn: () => sidebarBadgesApi.get(companyId),
-      refetchInterval: 15_000,
+      refetchInterval: companyId === highlightedCompanyId ? 15_000 : 60_000,
     })),
   });
   const hasLiveAgentsByCompanyId = useMemo(() => {

--- a/ui/src/components/LiveRunWidget.tsx
+++ b/ui/src/components/LiveRunWidget.tsx
@@ -32,14 +32,14 @@ export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
     queryKey: queryKeys.issues.liveRuns(issueId),
     queryFn: () => heartbeatsApi.liveRunsForIssue(issueId),
     enabled: !!issueId,
-    refetchInterval: 3000,
+    refetchInterval: 8000,
   });
 
   const { data: activeRun } = useQuery({
     queryKey: queryKeys.issues.activeRun(issueId),
     queryFn: () => heartbeatsApi.activeRunForIssue(issueId),
     enabled: !!issueId,
-    refetchInterval: 3000,
+    refetchInterval: 8000,
   });
 
   const runs = useMemo(() => {

--- a/ui/src/components/transcript/useLiveRunTranscripts.ts
+++ b/ui/src/components/transcript/useLiveRunTranscripts.ts
@@ -8,6 +8,7 @@ import { buildTranscript, getUIAdapter, onAdapterChange, type RunLogChunk, type 
 import { queryKeys } from "../../lib/queryKeys";
 
 const LOG_POLL_INTERVAL_MS = 2000;
+const LOG_POLL_INTERVAL_MAX_MS = 30_000;
 const LOG_READ_LIMIT_BYTES = 256_000;
 const EMPTY_RUN_LOG_CHUNKS: RunLogChunk[] = [];
 
@@ -212,28 +213,30 @@ export function useLiveRunTranscripts({
 
     let cancelled = false;
 
-    const readRunLog = async (run: RunTranscriptSource) => {
+    const readRunLog = async (run: RunTranscriptSource): Promise<boolean> => {
       if (missingTerminalLogRunIdsRef.current.has(run.id)) {
-        return;
+        return false;
       }
       const offset = logOffsetByRunRef.current.get(run.id) ?? resolveInitialLogOffset(run, logReadLimitBytes);
       try {
         const result = await heartbeatsApi.log(run.id, offset, logReadLimitBytes);
-        if (cancelled) return;
+        if (cancelled) return false;
 
         appendChunks(run.id, parsePersistedLogContent(run.id, result.content, pendingLogRowsByRunRef.current));
 
-        if (result.nextOffset !== undefined) {
-          logOffsetByRunRef.current.set(run.id, result.nextOffset);
-          return;
-        }
-        if (result.content.length > 0) {
-          logOffsetByRunRef.current.set(run.id, offset + result.content.length);
-        }
+        const newOffset =
+          result.nextOffset !== undefined
+            ? result.nextOffset
+            : result.content.length > 0
+              ? offset + result.content.length
+              : offset;
+        logOffsetByRunRef.current.set(run.id, newOffset);
+        return newOffset > offset;
       } catch (error) {
         if (error instanceof ApiError && error.status === 404 && isTerminalStatus(run.status)) {
           missingTerminalLogRunIdsRef.current.add(run.id);
         }
+        return false;
       } finally {
         if (!cancelled) {
           setHydratedRunIds((prev) => {
@@ -246,21 +249,36 @@ export function useLiveRunTranscripts({
       }
     };
 
-    const readAll = async () => {
-      await Promise.all(normalizedRuns.map((run) => readRunLog(run)));
+    const readAll = async (): Promise<boolean> => {
+      const results = await Promise.all(normalizedRuns.map((run) => readRunLog(run)));
+      return results.some(Boolean);
     };
 
     void readAll();
     const activeRuns = normalizedRuns.filter((run) => !isTerminalStatus(run.status));
-    const interval = activeRuns.length > 0 && logPollIntervalMs > 0
-      ? window.setInterval(() => {
-          void Promise.all(activeRuns.map((run) => readRunLog(run)));
-        }, logPollIntervalMs)
-      : null;
+    let idleCycles = 0;
+    let timer: number | null = null;
+    const scheduleNext = (delay: number) => {
+      timer = window.setTimeout(async () => {
+        if (cancelled || activeRuns.length === 0) return;
+        const results = await Promise.all(activeRuns.map((run) => readRunLog(run)));
+        if (cancelled) return;
+        const sawNewBytes = results.some(Boolean);
+        idleCycles = sawNewBytes ? 0 : idleCycles + 1;
+        const nextDelay = Math.min(
+          logPollIntervalMs * 2 ** idleCycles,
+          LOG_POLL_INTERVAL_MAX_MS,
+        );
+        scheduleNext(nextDelay);
+      }, delay);
+    };
+    if (activeRuns.length > 0 && logPollIntervalMs > 0) {
+      scheduleNext(logPollIntervalMs);
+    }
 
     return () => {
       cancelled = true;
-      if (interval !== null) window.clearInterval(interval);
+      if (timer !== null) window.clearTimeout(timer);
     };
   }, [logPollIntervalMs, logReadLimitBytes, normalizedRuns, runIdsKey]);
 

--- a/ui/src/lib/issueDetailCache.ts
+++ b/ui/src/lib/issueDetailCache.ts
@@ -95,6 +95,7 @@ export function getIssueDetailQueryOptions(
     queryKey: queryKeys.issues.detail(issueRef),
     queryFn: () => fetchIssueDetail(queryClient, issueRef),
     placeholderData: getCachedIssueDetail(queryClient, issueRef, options?.placeholderIssue ?? undefined),
+    retry: false,
   };
 }
 

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -681,7 +681,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   const { data: liveRuns } = useQuery({
     queryKey: queryKeys.issues.liveRuns(issueId),
     queryFn: () => heartbeatsApi.liveRunsForIssue(issueId),
-    refetchInterval: 3000,
+    refetchInterval: 8000,
     placeholderData: keepPreviousDataForSameQueryTail<LiveRunForIssue[]>(issueId),
   });
   const resolvedLiveRuns = liveRuns ?? [];
@@ -690,7 +690,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
     queryKey: queryKeys.issues.activeRun(issueId),
     queryFn: () => heartbeatsApi.activeRunForIssue(issueId),
     enabled: !!executionRunId || issueStatus === "in_progress",
-    refetchInterval: liveRunCount > 0 ? false : 3000,
+    refetchInterval: liveRunCount > 0 ? false : 8000,
     placeholderData: keepPreviousDataForSameQueryTail<ActiveRunForIssue | null>(issueId),
   });
   const resolvedActiveRun = useMemo(
@@ -701,7 +701,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   const { data: linkedRuns } = useQuery({
     queryKey: queryKeys.issues.runs(issueId),
     queryFn: () => activityApi.runsForIssue(issueId),
-    refetchInterval: hasLiveRuns ? 5000 : false,
+    refetchInterval: hasLiveRuns ? 15000 : false,
     placeholderData: keepPreviousDataForSameQueryTail<RunForIssue[]>(issueId),
   });
   const resolvedActivity = activity ?? [];
@@ -1226,7 +1226,7 @@ export function IssueDetail() {
     queryKey: queryKeys.issues.liveRuns(issueId!),
     queryFn: () => heartbeatsApi.liveRunsForIssue(issueId!),
     enabled: !!issueId,
-    refetchInterval: 3000,
+    refetchInterval: 8000,
     select: (runs) => runs.length,
     placeholderData: keepPreviousDataForSameQueryTail<LiveRunForIssue[]>(issueId ?? "pending"),
   });
@@ -1235,7 +1235,7 @@ export function IssueDetail() {
     queryKey: queryKeys.issues.activeRun(issueId!),
     queryFn: () => heartbeatsApi.activeRunForIssue(issueId!),
     enabled: !!issueId && (!!issue?.executionRunId || issue?.status === "in_progress"),
-    refetchInterval: liveRunCount > 0 ? false : 3000,
+    refetchInterval: liveRunCount > 0 ? false : 8000,
     select: (run) => !!run,
     placeholderData: keepPreviousDataForSameQueryTail<ActiveRunForIssue | null>(issueId ?? "pending"),
   });
@@ -1264,7 +1264,7 @@ export function IssueDetail() {
     queryKey: resolvedCompanyId ? queryKeys.liveRuns(resolvedCompanyId) : ["live-runs", "pending"],
     queryFn: () => heartbeatsApi.liveRunsForCompany(resolvedCompanyId!),
     enabled: !!resolvedCompanyId,
-    refetchInterval: 5000,
+    refetchInterval: 15000,
     placeholderData: keepPreviousDataForSameQueryTail<LiveRunForIssue[]>(resolvedCompanyId ?? "pending"),
   });
 


### PR DESCRIPTION
## Summary
Frontend polling was hammering the backend at ~1100 reqs/5min for a single user session, dominated by heartbeat-runs/log (261 reqs), live-runs (180), and a 404 retry loop on missing issue refs (158). DB returning 2.3B rows / 49GB net out cumulatively.

## Changes
**UI:**
- useLiveRunTranscripts: replaced fixed 2s setInterval with adaptive setTimeout chain. Doubles delay each cycle when no new bytes (max 30s). Resets on new bytes.
- LiveRunWidget + IssueDetail: liveRuns/activeRun polls 3s -> 8s. linkedRuns + companyLiveRuns 5s -> 15s.
- CompanyRail: only the highlighted company stays at 10/15s; other companies drop to 60s. Highlighted company already gets per-event invalidation via LiveUpdatesProvider.
- issueDetailCache: retry false on the issue detail query so a stale issue id (old bookmark) does not loop on 404.

**Server:**
- logger: demote 4xx 404 from warn to info. Stale client routes hit /issues/:id 404 in tight loops; warn-level was log-volume overhead, not an alertable signal.

## Measured impact (active UI session, 3 min)
- Server net in: 159 MB/min -> 21 MB/min (~7.5x)
- DB xact rate: ~4800/min -> ~650-1300/min (~4-7x)
- DB CPU: 32% -> ~1%

## Test plan
- [ ] Open issue detail with active run, verify live transcript still updates in near-realtime (WS push covers it; poll is fallback)
- [ ] Open issue detail with no active run, verify poll backs off (network tab shows /heartbeat-runs/.../log calls slowing 2s -> 4s -> ... -> 30s)
- [ ] Visit a stale URL like /issues/SERVER-1, verify only one 404 (no retry storm)
- [ ] Switch between companies in CompanyRail, verify highlighted polls fast and others slow