### PR TITLE
Add Proxmox deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 .github
 .paperclip
 .pnpm-store
+._*
+**/._*
 node_modules
 **/node_modules
 coverage

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ tmp/
 .paperclip-local/
 /.idea/
 /.agents/
+deploy/proxmox/.env
 
 # Doc maintenance cursor
 .doc-review-cursor

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN pnpm install --frozen-lockfile
 
 FROM base AS build
 WORKDIR /app
+ENV NODE_OPTIONS=--max-old-space-size=3072
 COPY --from=deps /app /app
 COPY . .
 RUN pnpm --filter @paperclipai/ui build

--- a/deploy/proxmox/.env.example
+++ b/deploy/proxmox/.env.example
@@ -1,0 +1,37 @@
+# Public URL that users will open in the browser.
+PAPERCLIP_PUBLIC_URL=http://paperclip.local:3100
+
+# Host port exposed by Docker on the VM.
+PAPERCLIP_PORT=3100
+
+# Bind host for the published Paperclip port.
+# Use 127.0.0.1 when a reverse proxy terminates public traffic.
+PAPERCLIP_BIND_HOST=0.0.0.0
+
+# Persistent Paperclip data on the VM host.
+PAPERCLIP_DATA_DIR=/srv/paperclip
+
+# Generate with: openssl rand -hex 32
+BETTER_AUTH_SECRET=replace-me
+
+# Optional extra hostnames, comma separated.
+PAPERCLIP_ALLOWED_HOSTNAMES=
+
+# Reverse proxy mode: none, caddy, nginx
+PAPERCLIP_PROXY_MODE=none
+
+# Public hostname used by reverse proxies.
+PAPERCLIP_SERVER_NAME=paperclip.example.com
+
+# Reverse proxy state directories.
+CADDY_DATA_DIR=/srv/caddy/data
+CADDY_CONFIG_DIR=/srv/caddy/config
+NGINX_CERT_DIR=/srv/nginx/certs
+
+# Optional model provider keys for local adapters inside the container.
+OPENAI_API_KEY=
+ANTHROPIC_API_KEY=
+
+# Sensible defaults for a single-VM Proxmox install.
+PAPERCLIP_DEPLOYMENT_MODE=authenticated
+PAPERCLIP_DEPLOYMENT_EXPOSURE=private

--- a/deploy/proxmox/bootstrap-lxc.sh
+++ b/deploy/proxmox/bootstrap-lxc.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v systemd-detect-virt >/dev/null 2>&1; then
+  if ! systemd-detect-virt --quiet --container; then
+    echo "This script is intended to run inside a Proxmox LXC container." >&2
+    exit 1
+  fi
+fi
+
+cat <<'EOF'
+Before running Docker inside Proxmox LXC, the container should usually be configured with:
+  - features: nesting=1,keyctl=1
+  - privileged container preferred
+  - enough disk/RAM for image builds
+If Docker fails to start, check the matching guidance in doc/PROXMOX.md.
+EOF
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+exec "${SCRIPT_DIR}/bootstrap-ubuntu.sh"

--- a/deploy/proxmox/bootstrap-ubuntu.sh
+++ b/deploy/proxmox/bootstrap-ubuntu.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run this script with sudo or as root." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose.yml"
+COMPOSE_CADDY_FILE="${SCRIPT_DIR}/docker-compose.caddy.yml"
+COMPOSE_NGINX_FILE="${SCRIPT_DIR}/docker-compose.nginx.yml"
+EXAMPLE_ENV_FILE="${SCRIPT_DIR}/.env.example"
+ENV_FILE="${SCRIPT_DIR}/.env"
+
+if [[ ! -f "${COMPOSE_FILE}" ]]; then
+  echo "Missing ${COMPOSE_FILE}. Run this from a Paperclip checkout." >&2
+  exit 1
+fi
+
+if [[ ! -f "${EXAMPLE_ENV_FILE}" ]]; then
+  echo "Missing ${EXAMPLE_ENV_FILE}." >&2
+  exit 1
+fi
+
+. /etc/os-release
+case "${ID:-}" in
+  ubuntu|debian)
+    ;;
+  *)
+    echo "This script currently supports Ubuntu or Debian VMs on Proxmox." >&2
+    exit 1
+    ;;
+esac
+
+requested_public_url="${PAPERCLIP_PUBLIC_URL:-}"
+requested_port="${PAPERCLIP_PORT:-}"
+requested_bind_host="${PAPERCLIP_BIND_HOST:-}"
+requested_data_dir="${PAPERCLIP_DATA_DIR:-}"
+requested_secret="${BETTER_AUTH_SECRET:-}"
+requested_allowed_hostnames="${PAPERCLIP_ALLOWED_HOSTNAMES:-}"
+requested_proxy_mode="${PAPERCLIP_PROXY_MODE:-}"
+requested_server_name="${PAPERCLIP_SERVER_NAME:-}"
+requested_caddy_data_dir="${CADDY_DATA_DIR:-}"
+requested_caddy_config_dir="${CADDY_CONFIG_DIR:-}"
+requested_nginx_cert_dir="${NGINX_CERT_DIR:-}"
+requested_openai_key="${OPENAI_API_KEY:-}"
+requested_anthropic_key="${ANTHROPIC_API_KEY:-}"
+requested_mode="${PAPERCLIP_DEPLOYMENT_MODE:-}"
+requested_exposure="${PAPERCLIP_DEPLOYMENT_EXPOSURE:-}"
+
+if [[ -f "${ENV_FILE}" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "${ENV_FILE}"
+  set +a
+fi
+
+PAPERCLIP_PORT="${requested_port:-${PAPERCLIP_PORT:-3100}}"
+PAPERCLIP_BIND_HOST="${requested_bind_host:-${PAPERCLIP_BIND_HOST:-0.0.0.0}}"
+PAPERCLIP_DATA_DIR="${requested_data_dir:-${PAPERCLIP_DATA_DIR:-/srv/paperclip}}"
+PAPERCLIP_DEPLOYMENT_MODE="${requested_mode:-${PAPERCLIP_DEPLOYMENT_MODE:-authenticated}}"
+PAPERCLIP_DEPLOYMENT_EXPOSURE="${requested_exposure:-${PAPERCLIP_DEPLOYMENT_EXPOSURE:-private}}"
+PAPERCLIP_ALLOWED_HOSTNAMES="${requested_allowed_hostnames:-${PAPERCLIP_ALLOWED_HOSTNAMES:-}}"
+PAPERCLIP_PROXY_MODE="${requested_proxy_mode:-${PAPERCLIP_PROXY_MODE:-none}}"
+PAPERCLIP_SERVER_NAME="${requested_server_name:-${PAPERCLIP_SERVER_NAME:-}}"
+CADDY_DATA_DIR="${requested_caddy_data_dir:-${CADDY_DATA_DIR:-/srv/caddy/data}}"
+CADDY_CONFIG_DIR="${requested_caddy_config_dir:-${CADDY_CONFIG_DIR:-/srv/caddy/config}}"
+NGINX_CERT_DIR="${requested_nginx_cert_dir:-${NGINX_CERT_DIR:-/srv/nginx/certs}}"
+OPENAI_API_KEY="${requested_openai_key:-${OPENAI_API_KEY:-}}"
+ANTHROPIC_API_KEY="${requested_anthropic_key:-${ANTHROPIC_API_KEY:-}}"
+
+case "${PAPERCLIP_PROXY_MODE}" in
+  none|caddy|nginx)
+    ;;
+  *)
+    echo "Unsupported PAPERCLIP_PROXY_MODE=${PAPERCLIP_PROXY_MODE}. Use none, caddy, or nginx." >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${PAPERCLIP_PROXY_MODE}" != "none" ]]; then
+  if [[ -z "${requested_bind_host}" ]]; then
+    PAPERCLIP_BIND_HOST="127.0.0.1"
+  fi
+  if [[ -z "${PAPERCLIP_SERVER_NAME}" ]]; then
+    echo "PAPERCLIP_SERVER_NAME is required when PAPERCLIP_PROXY_MODE=${PAPERCLIP_PROXY_MODE}." >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "${requested_public_url}" ]]; then
+  PAPERCLIP_PUBLIC_URL="${requested_public_url}"
+elif [[ -z "${PAPERCLIP_PUBLIC_URL:-}" ]]; then
+  if [[ "${PAPERCLIP_PROXY_MODE}" == "none" ]]; then
+    primary_ip="$(hostname -I | awk '{print $1}')"
+    PAPERCLIP_PUBLIC_URL="http://${primary_ip}:${PAPERCLIP_PORT}"
+  else
+    PAPERCLIP_PUBLIC_URL="https://${PAPERCLIP_SERVER_NAME}"
+  fi
+fi
+
+if [[ -n "${requested_secret}" ]]; then
+  BETTER_AUTH_SECRET="${requested_secret}"
+elif [[ -z "${BETTER_AUTH_SECRET:-}" || "${BETTER_AUTH_SECRET}" == "replace-me" ]]; then
+  BETTER_AUTH_SECRET="$(openssl rand -hex 32)"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y ca-certificates curl git gnupg openssl
+
+if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL "https://download.docker.com/linux/${ID}/gpg" -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+  arch="$(dpkg --print-architecture)"
+  echo "deb [arch=${arch} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} ${VERSION_CODENAME} stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update
+  apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+fi
+
+install -d -m 0775 -o 1000 -g 1000 "${PAPERCLIP_DATA_DIR}"
+
+compose_args=(-f "${COMPOSE_FILE}")
+
+if [[ "${PAPERCLIP_PROXY_MODE}" == "caddy" ]]; then
+  install -d -m 0755 "${CADDY_DATA_DIR}" "${CADDY_CONFIG_DIR}"
+  compose_args+=(-f "${COMPOSE_CADDY_FILE}")
+fi
+
+if [[ "${PAPERCLIP_PROXY_MODE}" == "nginx" ]]; then
+  install -d -m 0755 "${NGINX_CERT_DIR}"
+  if [[ ! -f "${NGINX_CERT_DIR}/fullchain.pem" || ! -f "${NGINX_CERT_DIR}/privkey.pem" ]]; then
+    echo "NGINX_CERT_DIR must contain fullchain.pem and privkey.pem before nginx mode can start." >&2
+    exit 1
+  fi
+  compose_args+=(-f "${COMPOSE_NGINX_FILE}")
+fi
+
+cat > "${ENV_FILE}" <<EOF
+PAPERCLIP_PUBLIC_URL=${PAPERCLIP_PUBLIC_URL}
+PAPERCLIP_PORT=${PAPERCLIP_PORT}
+PAPERCLIP_BIND_HOST=${PAPERCLIP_BIND_HOST}
+PAPERCLIP_DATA_DIR=${PAPERCLIP_DATA_DIR}
+BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
+PAPERCLIP_ALLOWED_HOSTNAMES=${PAPERCLIP_ALLOWED_HOSTNAMES}
+PAPERCLIP_PROXY_MODE=${PAPERCLIP_PROXY_MODE}
+PAPERCLIP_SERVER_NAME=${PAPERCLIP_SERVER_NAME}
+CADDY_DATA_DIR=${CADDY_DATA_DIR}
+CADDY_CONFIG_DIR=${CADDY_CONFIG_DIR}
+NGINX_CERT_DIR=${NGINX_CERT_DIR}
+OPENAI_API_KEY=${OPENAI_API_KEY}
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+PAPERCLIP_DEPLOYMENT_MODE=${PAPERCLIP_DEPLOYMENT_MODE}
+PAPERCLIP_DEPLOYMENT_EXPOSURE=${PAPERCLIP_DEPLOYMENT_EXPOSURE}
+EOF
+
+docker compose "${compose_args[@]}" --env-file "${ENV_FILE}" up -d --build
+
+for _ in $(seq 1 40); do
+  if curl -fsS "http://127.0.0.1:${PAPERCLIP_PORT}/api/health" >/dev/null; then
+    echo "Paperclip is running at ${PAPERCLIP_PUBLIC_URL}"
+    echo "Data dir: ${PAPERCLIP_DATA_DIR}"
+    exit 0
+  fi
+  sleep 5
+done
+
+docker compose "${compose_args[@]}" --env-file "${ENV_FILE}" ps >&2
+docker compose "${compose_args[@]}" --env-file "${ENV_FILE}" logs --tail 120 >&2
+echo "Paperclip did not become healthy within the expected time window." >&2
+exit 1

--- a/deploy/proxmox/cloud-init/meta-data.yaml
+++ b/deploy/proxmox/cloud-init/meta-data.yaml
@@ -1,0 +1,2 @@
+instance-id: paperclip-proxmox
+local-hostname: paperclip

--- a/deploy/proxmox/cloud-init/user-data.yaml
+++ b/deploy/proxmox/cloud-init/user-data.yaml
@@ -1,0 +1,41 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+packages:
+  - git
+  - qemu-guest-agent
+
+users:
+  - default
+  - name: "__VM_USERNAME__"
+    gecos: Paperclip Admin
+    groups: [sudo]
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: true
+    ssh_authorized_keys:
+      - "__SSH_PUBLIC_KEY__"
+
+write_files:
+  - path: /usr/local/sbin/paperclip-firstboot.sh
+    permissions: '0755'
+    owner: root:root
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      if [[ ! -d /opt/paperclip/.git ]]; then
+        git clone "__PAPERCLIP_REPO__" /opt/paperclip
+      fi
+      cd /opt/paperclip
+      git fetch --all --tags
+      git checkout "__PAPERCLIP_GIT_REF__"
+      PAPERCLIP_PUBLIC_URL="__PAPERCLIP_PUBLIC_URL__" \
+      PAPERCLIP_PROXY_MODE="__PAPERCLIP_PROXY_MODE__" \
+      PAPERCLIP_SERVER_NAME="__PAPERCLIP_SERVER_NAME__" \
+      OPENAI_API_KEY="__OPENAI_API_KEY__" \
+      ANTHROPIC_API_KEY="__ANTHROPIC_API_KEY__" \
+      ./deploy/proxmox/bootstrap-ubuntu.sh
+
+runcmd:
+  - systemctl enable --now qemu-guest-agent || true
+  - /usr/local/sbin/paperclip-firstboot.sh

--- a/deploy/proxmox/docker-compose.caddy.yml
+++ b/deploy/proxmox/docker-compose.caddy.yml
@@ -1,0 +1,17 @@
+services:
+  caddy:
+    image: caddy:2.10-alpine
+    restart: unless-stopped
+    depends_on:
+      paperclip:
+        condition: service_started
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      PAPERCLIP_SERVER_NAME: "${PAPERCLIP_SERVER_NAME:?PAPERCLIP_SERVER_NAME must be set for caddy mode}"
+      PAPERCLIP_UPSTREAM: "paperclip:3100"
+    volumes:
+      - ./proxy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - "${CADDY_DATA_DIR:-/srv/caddy/data}:/data"
+      - "${CADDY_CONFIG_DIR:-/srv/caddy/config}:/config"

--- a/deploy/proxmox/docker-compose.nginx.yml
+++ b/deploy/proxmox/docker-compose.nginx.yml
@@ -1,0 +1,16 @@
+services:
+  nginx:
+    image: nginx:1.29-alpine
+    restart: unless-stopped
+    depends_on:
+      paperclip:
+        condition: service_started
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      PAPERCLIP_SERVER_NAME: "${PAPERCLIP_SERVER_NAME:?PAPERCLIP_SERVER_NAME must be set for nginx mode}"
+      PAPERCLIP_UPSTREAM: "paperclip:3100"
+    volumes:
+      - ./proxy/nginx.conf.template:/etc/nginx/templates/default.conf.template:ro
+      - "${NGINX_CERT_DIR:-/srv/nginx/certs}:/etc/nginx/certs:ro"

--- a/deploy/proxmox/docker-compose.yml
+++ b/deploy/proxmox/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  paperclip:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "${PAPERCLIP_BIND_HOST:-0.0.0.0}:${PAPERCLIP_PORT:-3100}:3100"
+    environment:
+      HOST: "0.0.0.0"
+      PAPERCLIP_HOME: "/paperclip"
+      PAPERCLIP_DEPLOYMENT_MODE: "${PAPERCLIP_DEPLOYMENT_MODE:-authenticated}"
+      PAPERCLIP_DEPLOYMENT_EXPOSURE: "${PAPERCLIP_DEPLOYMENT_EXPOSURE:-private}"
+      PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:?PAPERCLIP_PUBLIC_URL must be set}"
+      BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+      PAPERCLIP_ALLOWED_HOSTNAMES: "${PAPERCLIP_ALLOWED_HOSTNAMES:-}"
+      OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+    volumes:
+      - "${PAPERCLIP_DATA_DIR:-/srv/paperclip}:/paperclip"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:3100/api/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 10
+      start_period: 90s

--- a/deploy/proxmox/lxc/pve-container.conf.example
+++ b/deploy/proxmox/lxc/pve-container.conf.example
@@ -1,0 +1,19 @@
+# Example Proxmox LXC config for Docker-based Paperclip.
+# Adjust the VM/CT id-specific lines to match your node setup.
+
+arch: amd64
+cores: 4
+memory: 8192
+swap: 2048
+hostname: paperclip
+onboot: 1
+ostype: debian
+rootfs: local-lvm:8
+unprivileged: 0
+features: nesting=1,keyctl=1
+
+# Optional if your host profile blocks Docker storage/network setup.
+# Use only when required by your environment.
+# lxc.apparmor.profile: unconfined
+# lxc.cgroup2.devices.allow: a
+# lxc.cap.drop:

--- a/deploy/proxmox/proxy/Caddyfile
+++ b/deploy/proxmox/proxy/Caddyfile
@@ -1,0 +1,4 @@
+{$PAPERCLIP_SERVER_NAME} {
+	encode zstd gzip
+	reverse_proxy {$PAPERCLIP_UPSTREAM}
+}

--- a/deploy/proxmox/proxy/nginx.conf.template
+++ b/deploy/proxmox/proxy/nginx.conf.template
@@ -1,0 +1,33 @@
+server {
+  listen 80;
+  server_name ${PAPERCLIP_SERVER_NAME};
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl;
+  http2 on;
+  server_name ${PAPERCLIP_SERVER_NAME};
+
+  ssl_certificate /etc/nginx/certs/fullchain.pem;
+  ssl_certificate_key /etc/nginx/certs/privkey.pem;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 1d;
+  ssl_protocols TLSv1.2 TLSv1.3;
+
+  location / {
+    proxy_pass http://${PAPERCLIP_UPSTREAM};
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+  }
+}
+
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}

--- a/doc/PROXMOX.md
+++ b/doc/PROXMOX.md
@@ -1,0 +1,239 @@
+# Proxmox Deployment
+
+The most reliable Proxmox setup for Paperclip is:
+
+- a standard Ubuntu VM on Proxmox
+- Docker Compose inside the VM
+- Paperclip persistent data mounted at `/srv/paperclip`
+
+This avoids the extra Docker-in-LXC edge cases while keeping deployment simple.
+
+This repo now includes:
+
+- direct VM bootstrap assets
+- cloud-init templates for unattended first boot
+- reverse-proxy overlays for Caddy and Nginx
+- an LXC-oriented bootstrap path for advanced setups
+
+## Recommended VM Shape
+
+- Ubuntu Server 24.04 LTS
+- 4 vCPU
+- 8 GB RAM
+- 40 GB disk
+- bridged network interface
+- OpenSSH server enabled
+- QEMU guest agent enabled if you use it elsewhere in Proxmox
+
+## Quick Start
+
+From the new VM:
+
+```sh
+git clone https://github.com/paperclipai/paperclip.git
+cd paperclip
+sudo PAPERCLIP_PUBLIC_URL=http://<vm-ip>:3100 ./deploy/proxmox/bootstrap-ubuntu.sh
+```
+
+What the bootstrap script does:
+
+- installs Docker Engine and the Compose plugin
+- creates `deploy/proxmox/.env`
+- creates `/srv/paperclip` with write permissions for the container user
+- builds and starts Paperclip with `deploy/proxmox/docker-compose.yml`
+- waits for `http://127.0.0.1:<port>/api/health`
+
+After the script finishes, open `PAPERCLIP_PUBLIC_URL` in your browser.
+
+## Cloud-Init VM Provisioning
+
+Templates live in `deploy/proxmox/cloud-init/`.
+
+- `user-data.yaml`
+- `meta-data.yaml`
+
+Replace these placeholders in `user-data.yaml` before uploading it to a Proxmox snippet store or attaching it as cloud-init user data:
+
+- `__VM_USERNAME__`
+- `__SSH_PUBLIC_KEY__`
+- `__PAPERCLIP_REPO__`
+- `__PAPERCLIP_GIT_REF__`
+- `__PAPERCLIP_PUBLIC_URL__`
+- `__PAPERCLIP_PROXY_MODE__`
+- `__PAPERCLIP_SERVER_NAME__`
+- `__OPENAI_API_KEY__`
+- `__ANTHROPIC_API_KEY__`
+
+Typical values:
+
+- repo: `https://github.com/paperclipai/paperclip.git`
+- git ref: `master`
+- proxy mode: `none`, `caddy`, or `nginx`
+- server name: your public DNS name when using HTTPS proxying
+
+When the VM boots, cloud-init will:
+
+- install `git` and `qemu-guest-agent`
+- clone the repo into `/opt/paperclip`
+- check out the selected git ref
+- run `deploy/proxmox/bootstrap-ubuntu.sh`
+
+## Reverse Proxy / HTTPS
+
+The bootstrap script now supports three modes through `PAPERCLIP_PROXY_MODE`:
+
+- `none`: direct HTTP on `PAPERCLIP_PORT`
+- `caddy`: automatic HTTPS with Caddy and a public DNS hostname
+- `nginx`: HTTPS with Nginx and pre-provisioned certificate files
+
+In proxy mode, `PAPERCLIP_BIND_HOST` automatically defaults to `127.0.0.1` unless you override it.
+
+### Caddy
+
+For automatic HTTPS with Let's Encrypt, point your DNS name at the VM and run:
+
+```sh
+sudo \
+  PAPERCLIP_PROXY_MODE=caddy \
+  PAPERCLIP_SERVER_NAME=paperclip.example.com \
+  PAPERCLIP_PUBLIC_URL=https://paperclip.example.com \
+  ./deploy/proxmox/bootstrap-ubuntu.sh
+```
+
+This uses:
+
+- `deploy/proxmox/docker-compose.caddy.yml`
+- `deploy/proxmox/proxy/Caddyfile`
+
+Persistent Caddy state defaults to:
+
+- `/srv/caddy/data`
+- `/srv/caddy/config`
+
+### Nginx
+
+For Nginx, put these files on the VM first:
+
+- `${NGINX_CERT_DIR:-/srv/nginx/certs}/fullchain.pem`
+- `${NGINX_CERT_DIR:-/srv/nginx/certs}/privkey.pem`
+
+Then run:
+
+```sh
+sudo \
+  PAPERCLIP_PROXY_MODE=nginx \
+  PAPERCLIP_SERVER_NAME=paperclip.example.com \
+  PAPERCLIP_PUBLIC_URL=https://paperclip.example.com \
+  NGINX_CERT_DIR=/srv/nginx/certs \
+  ./deploy/proxmox/bootstrap-ubuntu.sh
+```
+
+This uses:
+
+- `deploy/proxmox/docker-compose.nginx.yml`
+- `deploy/proxmox/proxy/nginx.conf.template`
+
+## Optional Provider Keys
+
+Paperclip itself can boot without model-provider credentials, but local adapters inside the container need them.
+
+```sh
+sudo \
+  PAPERCLIP_PUBLIC_URL=http://<vm-ip>:3100 \
+  OPENAI_API_KEY=... \
+  ANTHROPIC_API_KEY=... \
+  ./deploy/proxmox/bootstrap-ubuntu.sh
+```
+
+If auth or callbacks must accept extra private names, add them as a comma-separated allowlist:
+
+```sh
+sudo \
+  PAPERCLIP_PUBLIC_URL=https://paperclip.example.com \
+  PAPERCLIP_ALLOWED_HOSTNAMES=paperclip.example.com,paperclip.lan \
+  ./deploy/proxmox/bootstrap-ubuntu.sh
+```
+
+## Files
+
+- `deploy/proxmox/docker-compose.yml`: Proxmox-oriented Compose file
+- `deploy/proxmox/docker-compose.caddy.yml`: Caddy HTTPS overlay
+- `deploy/proxmox/docker-compose.nginx.yml`: Nginx HTTPS overlay
+- `deploy/proxmox/.env.example`: environment template
+- `deploy/proxmox/bootstrap-ubuntu.sh`: Ubuntu/Debian VM bootstrap script
+- `deploy/proxmox/bootstrap-lxc.sh`: Proxmox LXC bootstrap entrypoint
+- `deploy/proxmox/cloud-init/user-data.yaml`: cloud-init template
+- `deploy/proxmox/cloud-init/meta-data.yaml`: cloud-init metadata template
+- `deploy/proxmox/lxc/pve-container.conf.example`: LXC config example
+
+## Operations
+
+Check container status:
+
+```sh
+docker compose -f deploy/proxmox/docker-compose.yml --env-file deploy/proxmox/.env ps
+```
+
+Watch logs:
+
+```sh
+docker compose -f deploy/proxmox/docker-compose.yml --env-file deploy/proxmox/.env logs -f
+```
+
+Rebuild after updating the repo:
+
+```sh
+git pull
+sudo ./deploy/proxmox/bootstrap-ubuntu.sh
+```
+
+Stop the stack:
+
+```sh
+docker compose -f deploy/proxmox/docker-compose.yml --env-file deploy/proxmox/.env down
+```
+
+If you use Caddy or Nginx mode, include the extra compose file on operational commands too:
+
+```sh
+docker compose \
+  -f deploy/proxmox/docker-compose.yml \
+  -f deploy/proxmox/docker-compose.caddy.yml \
+  --env-file deploy/proxmox/.env ps
+```
+
+## Proxmox LXC
+
+LXC is an advanced option. Prefer the VM path unless you specifically want container density.
+
+Recommended Proxmox CT settings:
+
+- Debian 12 or Ubuntu 24.04 template
+- privileged container
+- `features: nesting=1,keyctl=1`
+- 4 vCPU
+- 8 GB RAM
+- 40 GB disk
+
+An example config is included at `deploy/proxmox/lxc/pve-container.conf.example`.
+
+Inside the container:
+
+```sh
+git clone https://github.com/paperclipai/paperclip.git
+cd paperclip
+sudo PAPERCLIP_PUBLIC_URL=http://<ct-ip>:3100 ./deploy/proxmox/bootstrap-lxc.sh
+```
+
+Notes for LXC:
+
+- Docker inside LXC may require host-side allowance beyond `nesting=1,keyctl=1` on some Proxmox setups.
+- If Docker storage or iptables setup fails, try the optional AppArmor lines shown in `pve-container.conf.example`.
+- Keep persistent storage on a real Proxmox-backed volume, not a tiny rootfs.
+
+## Notes
+
+- Paperclip uses embedded PostgreSQL by default, so a separate database is not required for this VM-based setup.
+- Persistent state lives under `/srv/paperclip` unless you override `PAPERCLIP_DATA_DIR`.
+- `BETTER_AUTH_SECRET` is generated automatically when missing and then stored in `deploy/proxmox/.env`.
+- In `caddy` or `nginx` mode, set `PAPERCLIP_PUBLIC_URL` to the final external HTTPS URL.


### PR DESCRIPTION
## Summary
- Adds VM/LXC/cloud-init deployment assets and proxy configs (Caddy, nginx) so Paperclip can be stood up on Proxmox via a repeatable path.
- Bumps Docker build memory limits and ignores macOS metadata so constrained VM builds and embedded Postgres startup succeed.
- Adds `doc/PROXMOX.md` with an end-to-end deployment guide (recommended VM shape, quick start, cloud-init templates, reverse-proxy overlays).

## Test plan
- [ ] Verify ` ./deploy/proxmox/bootstrap-ubuntu.sh` runs cleanly on a fresh Ubuntu 24.04 VM with the documented inputs.
- [ ] Confirm `docker compose -f deploy/proxmox/docker-compose.yml` brings up the stack and `curl http://127.0.0.1:<port>/api/health` returns ok.
- [ ] Smoke-test cloud-init path with the templates in `deploy/proxmox/cloud-init/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)