### PR TITLE
fix: add per-company-per-hour rate cap to stranded issue recovery reaper

### DIFF
--- a/server/src/__tests__/recovery-rate-cap.test.ts
+++ b/server/src/__tests__/recovery-rate-cap.test.ts
@@ -1,0 +1,317 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  budgetPolicies,
+  companies,
+  companySkills,
+  costEvents,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueDocuments,
+  documentRevisions,
+  documents,
+  issueRelations,
+  issueTreeHoldMembers,
+  issueTreeHolds,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../telemetry.ts", () => ({
+  getTelemetryClient: () => mockTelemetryClient,
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return { ...actual, trackAgentFirstHeartbeat: vi.fn() };
+});
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: vi.fn(async () => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "ok",
+        provider: "test",
+        model: "test-model",
+      })),
+    })),
+  };
+});
+
+import { recoveryService } from "../services/recovery/service.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres recovery rate cap tests: ${embeddedPostgresSupport.reason ?? "unsupported"}`,
+  );
+}
+
+describeEmbeddedPostgres("stranded issue recovery rate cap", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-recovery-rate-cap-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(issueComments);
+    await db.delete(issueDocuments);
+    await db.delete(documentRevisions);
+    await db.delete(documents);
+    await db.delete(issueRelations);
+    await db.delete(issueTreeHoldMembers);
+    await db.delete(issueTreeHolds);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      try {
+        await db.delete(issues);
+        break;
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+    }
+    await db.delete(budgetPolicies);
+    await db.delete(costEvents);
+    await db.delete(agentRuntimeState);
+    await db.delete(companySkills);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompanyAndAgents() {
+    const companyId = randomUUID();
+    const ctoAgentId = randomUUID();
+    const engineerAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "RateCapTestCo",
+      issuePrefix: "RCT",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: ctoAgentId,
+        companyId,
+        name: "CTO",
+        role: "cto",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: engineerAgentId,
+        companyId,
+        name: "Engineer",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+        reportsTo: ctoAgentId,
+      },
+    ]);
+
+    await db.insert(budgetPolicies).values({
+      id: randomUUID(),
+      companyId,
+      agentId: ctoAgentId,
+      maxDailyCostCents: 100_000,
+      maxMonthlyCostCents: 1_000_000,
+    });
+
+    return { companyId, ctoAgentId, engineerAgentId };
+  }
+
+  async function seedSourceIssue(companyId: string, assigneeAgentId: string) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stranded source issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId,
+      originKind: "manual",
+      originFingerprint: "default",
+    });
+    return issueId;
+  }
+
+  async function seedRecoveryIssues(companyId: string, count: number, assigneeAgentId: string) {
+    const now = Date.now();
+    for (let i = 0; i < count; i++) {
+      await db.insert(issues).values({
+        id: randomUUID(),
+        companyId,
+        title: `Recovery issue ${i}`,
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId,
+        originKind: "stranded_issue_recovery",
+        originId: randomUUID(),
+        originFingerprint: `stranded_issue_recovery:${companyId}:${randomUUID()}:no-run`,
+        createdAt: new Date(now - i * 60_000),
+      });
+    }
+  }
+
+  it("allows recovery creation when below the per-company-per-hour cap", async () => {
+    const { companyId, ctoAgentId, engineerAgentId } = await seedCompanyAndAgents();
+    const sourceIssueId = await seedSourceIssue(companyId, engineerAgentId);
+
+    await seedRecoveryIssues(companyId, 10, ctoAgentId);
+
+    const mockEnqueueWakeup = vi.fn(async () => null);
+    const svc = recoveryService(db, { enqueueWakeup: mockEnqueueWakeup });
+
+    const sourceIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, sourceIssueId))
+      .then((rows) => rows[0]!);
+
+    await svc.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: null,
+      comment: "Issue is stranded (test).",
+    });
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, "stranded_issue_recovery"),
+          eq(issues.originId, sourceIssueId),
+        ),
+      );
+
+    expect(recoveryIssues.length).toBe(1);
+  });
+
+  it("blocks recovery creation when at or above the per-company-per-hour cap", async () => {
+    const { companyId, ctoAgentId, engineerAgentId } = await seedCompanyAndAgents();
+    const sourceIssueId = await seedSourceIssue(companyId, engineerAgentId);
+
+    await seedRecoveryIssues(companyId, 50, ctoAgentId);
+
+    const mockEnqueueWakeup = vi.fn(async () => null);
+    const svc = recoveryService(db, { enqueueWakeup: mockEnqueueWakeup });
+
+    const sourceIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, sourceIssueId))
+      .then((rows) => rows[0]!);
+
+    await svc.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: null,
+      comment: "Issue is stranded (test).",
+    });
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, "stranded_issue_recovery"),
+          eq(issues.originId, sourceIssueId),
+        ),
+      );
+
+    expect(recoveryIssues.length).toBe(0);
+    expect(mockEnqueueWakeup).not.toHaveBeenCalled();
+  });
+
+  it("does not count recovery issues older than one hour toward the cap", async () => {
+    const { companyId, ctoAgentId, engineerAgentId } = await seedCompanyAndAgents();
+    const sourceIssueId = await seedSourceIssue(companyId, engineerAgentId);
+
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    for (let i = 0; i < 60; i++) {
+      await db.insert(issues).values({
+        id: randomUUID(),
+        companyId,
+        title: `Old recovery issue ${i}`,
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: ctoAgentId,
+        originKind: "stranded_issue_recovery",
+        originId: randomUUID(),
+        originFingerprint: `stranded_issue_recovery:${companyId}:${randomUUID()}:no-run`,
+        createdAt: new Date(twoHoursAgo - i * 60_000),
+      });
+    }
+
+    const mockEnqueueWakeup = vi.fn(async () => null);
+    const svc = recoveryService(db, { enqueueWakeup: mockEnqueueWakeup });
+
+    const sourceIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, sourceIssueId))
+      .then((rows) => rows[0]!);
+
+    await svc.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: null,
+      comment: "Issue is stranded (test).",
+    });
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, "stranded_issue_recovery"),
+          eq(issues.originId, sourceIssueId),
+        ),
+      );
+
+    expect(recoveryIssues.length).toBe(1);
+  });
+});

--- a/server/src/__tests__/recovery-rate-cap.test.ts
+++ b/server/src/__tests__/recovery-rate-cap.test.ts
@@ -149,11 +149,14 @@ describeEmbeddedPostgres("stranded issue recovery rate cap", () => {
     ]);
 
     await db.insert(budgetPolicies).values({
-      id: randomUUID(),
       companyId,
-      agentId: ctoAgentId,
-      maxDailyCostCents: 100_000,
-      maxMonthlyCostCents: 1_000_000,
+      scopeType: "agent",
+      scopeId: ctoAgentId,
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      amount: 1_000_000_00,
+      hardStopEnabled: true,
+      isActive: true,
     });
 
     return { companyId, ctoAgentId, engineerAgentId };

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -52,6 +52,7 @@ export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+export const STRANDED_ISSUE_RECOVERY_RATE_CAP_PER_HOUR = 50;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 
 type RecoveryWakeupOptions = {
@@ -1336,6 +1337,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;
+
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    const recentCount = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, input.issue.companyId),
+          eq(issues.originKind, STRANDED_ISSUE_RECOVERY_ORIGIN_KIND),
+          gt(issues.createdAt, oneHourAgo),
+        ),
+      )
+      .then((rows) => Number(rows[0]?.count ?? 0));
+
+    if (recentCount >= STRANDED_ISSUE_RECOVERY_RATE_CAP_PER_HOUR) {
+      logger.warn(
+        { companyId: input.issue.companyId, recentCount, cap: STRANDED_ISSUE_RECOVERY_RATE_CAP_PER_HOUR },
+        "stranded issue recovery rate cap reached, skipping creation",
+      );
+      return null;
+    }
 
     const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
     if (!ownerAgentId) return null;


### PR DESCRIPTION
## Thinking Path

> - After the SupportFlow recovery-of-recovery cascade (~27,800 issues in one company), upstream shipped two guards in v2026.428.0: skip-self and per-target dedup
> - The third guard from the original spec — a per-company-per-hour rate cap — was not included in that release
> - Without it, any future code path that bypasses the existing guards (or a similarly-shaped reaper) can still flood a company with unbounded recovery issues
> - The rate cap is defense-in-depth: even if guards 1 and 2 hold, this provides an upper bound on issue creation velocity per company

## Linked Issues or Issue Description

Refs #5413

## What Changed

- `server/src/services/recovery/service.ts` (`ensureStrandedIssueRecoveryIssue`): added a count query after the existing per-target dedup check — when 50+ `stranded_issue_recovery` issues already exist for the company within the last hour, log a warning and return null instead of creating another
- `server/src/services/recovery/service.ts`: exported `STRANDED_ISSUE_RECOVERY_RATE_CAP_PER_HOUR = 50` for visibility and test reference
- `server/src/__tests__/recovery-rate-cap.test.ts`: integration test (embedded Postgres) verifying below-cap creates, at/above-cap skips, and old (>1h) issues don't count

## Verification

```bash
pnpm test -- --run "recovery-rate-cap"
```

Below cap (10 recent issues): recovery issue is created normally.
At/above cap (50 recent issues): recovery issue creation is skipped.
Old issues (>1 hour): do not count toward the cap.

## Risks

Low: the count query adds one `SELECT count(*)` per recovery attempt — negligible in normal operation. The cap is per-company, not per-source-issue; this is intentional — 50 recovery issues per hour is pathological.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`) — tool-use / agentic code editing, 200k context window

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge