### PR TITLE
fix: routine execution zombie gap — constraint + skip_if_active + force-terminate

### DIFF
--- a/packages/db/src/migrations/0076_routine_execution_constraint_zombie_gap.sql
+++ b/packages/db/src/migrations/0076_routine_execution_constraint_zombie_gap.sql
@@ -1,0 +1,15 @@
+-- Fix: zombie routine execution issues (open but executionRunId=null) were excluded
+-- from the unique index because of the `execution_run_id IS NOT NULL` predicate.
+-- When a heartbeat exits without completing an issue the heartbeat service clears
+-- executionRunId, evicting the zombie from the index.  The next scheduled fire then
+-- passes the skip_if_active check (findLiveExecutionIssue finds nothing) and creates
+-- a second open execution issue.  Recovery is then blocked: checkout sets executionRunId
+-- on the zombie, which conflicts with the new live issue already in the index.
+--
+-- Fix: drop the execution_run_id IS NOT NULL guard.  Zombie issues stay in the index
+-- and correctly block duplicate creation regardless of their executionRunId state.
+DROP INDEX IF EXISTS "issues_open_routine_execution_uq";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "issues_open_routine_execution_uq" ON "issues" USING btree ("company_id","origin_kind","origin_id","origin_fingerprint") WHERE "issues"."origin_kind" = 'routine_execution'
+          and "issues"."origin_id" is not null
+          and "issues"."hidden_at" is null
+          and "issues"."status" in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked');

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1777572332006,
       "tag": "0075_cultured_sebastian_shaw",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1777954601938,
+      "tag": "0076_routine_execution_constraint_zombie_gap",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -95,7 +95,6 @@ export const issues = pgTable(
         sql`${table.originKind} = 'routine_execution'
           and ${table.originId} is not null
           and ${table.hiddenAt} is null
-          and ${table.executionRunId} is not null
           and ${table.status} in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked')`,
       ),
     activeLivenessRecoveryIncidentIdx: uniqueIndex("issues_active_liveness_recovery_incident_uq")

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -303,6 +303,36 @@ export function routineRoutes(
     res.status(202).json(run);
   });
 
+  router.post("/routines/:id/force-terminate", async (req, res) => {
+    const routine = await assertCanManageExistingRoutine(req, req.params.id as string);
+    if (!routine) {
+      res.status(404).json({ error: "Routine not found" });
+      return;
+    }
+    if (req.actor.type !== "board") {
+      res.status(403).json({ error: "Only board users can force-terminate routine executions" });
+      return;
+    }
+    const result = await svc.forceTerminateExecution(routine.id, routine.companyId);
+    const actor = getActorInfo(req);
+    await logActivity(db, {
+      companyId: routine.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "routine.force_terminated",
+      entityType: "routine",
+      entityId: routine.id,
+      details: {
+        routineId: routine.id,
+        terminatedCount: result.terminatedCount,
+        terminatedIssueIds: result.terminatedIssueIds,
+      },
+    });
+    res.json(result);
+  });
+
   router.post("/routine-triggers/public/:publicId/fire", async (req, res) => {
     const result = await svc.firePublicTrigger(req.params.publicId as string, {
       authorizationHeader: req.header("authorization"),

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -717,6 +717,33 @@ export function routineService(
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  // Broader than findLiveExecutionIssue: returns any open issue for the routine regardless
+  // of whether it has a live heartbeat run. Used for the concurrency-policy gate so that
+  // zombie issues (open but executionRunId cleared after heartbeat exit) are still detected.
+  async function findOpenExecutionIssue(
+    routine: typeof routines.$inferSelect,
+    executor: Db = db,
+    dispatchFingerprint?: string | null,
+  ) {
+    const fingerprintCondition = routineExecutionFingerprintCondition(dispatchFingerprint);
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.originId, routine.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+          ...(fingerprintCondition ? [fingerprintCondition] : []),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -902,7 +929,9 @@ export function routineService(
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
-        const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint);
+        // Use findOpenExecutionIssue (not findLiveExecutionIssue) so zombie issues
+        // (open but executionRunId=null after heartbeat exit) are also detected.
+        const activeIssue = await findOpenExecutionIssue(input.routine, txDb, dispatchFingerprint);
         if (activeIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
           const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
           if (manualRunnerUserId) {
@@ -966,7 +995,7 @@ export function routineService(
             throw error;
           }
 
-          const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint);
+          const existingIssue = await findOpenExecutionIssue(input.routine, txDb, dispatchFingerprint);
           if (!existingIssue) throw error;
           const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
           if (manualRunnerUserId) {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -945,7 +945,11 @@ export function routineService(
             originKind: "routine_execution",
             originId: input.routine.id,
             originRunId: createdRun.id,
-            originFingerprint: dispatchFingerprint,
+            // always_enqueue must bypass the open-execution uniqueness constraint.
+            // Using the run ID as originFingerprint guarantees uniqueness per dispatch.
+            originFingerprint: input.routine.concurrencyPolicy === "always_enqueue"
+              ? createdRun.id
+              : dispatchFingerprint,
             executionWorkspaceId: input.executionWorkspaceId ?? null,
             executionWorkspacePreference: input.executionWorkspacePreference ?? null,
             executionWorkspaceSettings: input.executionWorkspaceSettings ?? null,

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1705,6 +1705,63 @@ export function routineService(
       return { triggered };
     },
 
+    forceTerminateExecution: async (routineId: string, companyId: string) => {
+      const openIssues = await db
+        .select({
+          id: issues.id,
+          identifier: issues.identifier,
+          originRunId: issues.originRunId,
+          executionRunId: issues.executionRunId,
+        })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.originKind, "routine_execution"),
+            eq(issues.originId, routineId),
+            inArray(issues.status, OPEN_ISSUE_STATUSES),
+            isNull(issues.hiddenAt),
+          ),
+        )
+        .orderBy(asc(issues.createdAt));
+
+      if (openIssues.length === 0) return { terminatedIssueIds: [], terminatedCount: 0 };
+
+      const now = new Date();
+      const terminatedIssueIds: string[] = [];
+
+      for (const issue of openIssues) {
+        await db.transaction(async (tx) => {
+          await tx.execute(
+            sql`select id from ${issues} where id = ${issue.id} for update`,
+          );
+          await tx
+            .update(issues)
+            .set({
+              status: "cancelled",
+              cancelledAt: now,
+              executionRunId: null,
+              checkoutRunId: null,
+              executionAgentNameKey: null,
+              executionLockedAt: null,
+              updatedAt: now,
+            })
+            .where(eq(issues.id, issue.id));
+
+          if (issue.originRunId) {
+            await finalizeRun(issue.originRunId, {
+              status: "failed",
+              failureReason: "Force-terminated by admin via force-terminate endpoint",
+              completedAt: now,
+            }, tx as unknown as Db);
+          }
+        });
+        terminatedIssueIds.push(issue.id);
+      }
+
+      return { terminatedIssueIds, terminatedCount: terminatedIssueIds.length };
+    },
+
     syncRunStatusForIssue: async (issueId: string) => {
       const issue = await db
         .select({


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agent heartbeats and tracks each agent task as an issue; routine dispatches create routine execution issues
> - The `issues_open_routine_execution_uq` partial unique index prevents two open execution issues for the same routine + fingerprint — a correct constraint in theory
> - The index predicate included `execution_run_id IS NOT NULL`; when a heartbeat exits without completing an issue the heartbeat service clears `executionRunId` on the zombie, which evicts it from the index
> - With the zombie evicted, `findLiveExecutionIssue` (which requires a live heartbeat join) returns null; `skip_if_active` passes silently; a duplicate open issue is created with the same fingerprint
> - Recovery is then blocked: checkout sets `executionRunId` on the zombie, which conflicts with the new live issue now in the index — HTTP 500
> - This PR closes the full bug chain: (A) fix the index predicate, (B) fix the concurrency gate query, (C) add a break-glass endpoint for future stuck executions
> - The benefit is that duplicate routine execution issues cannot form and, if they somehow do, can be force-terminated without DB surgery

## What Changed

- **Fix A — migration `0076_routine_execution_constraint_zombie_gap`**: removes `execution_run_id IS NOT NULL` from the `issues_open_routine_execution_uq` partial index predicate. Zombie issues (open, `executionRunId=null`) now stay in the index, correctly blocking duplicate creation. Also includes an `always_enqueue` compat fix: `always_enqueue` dispatches now use `createdRun.id` as `originFingerprint` to guarantee uniqueness per dispatch and avoid conflicting with the expanded constraint.
- **Fix B — `findOpenExecutionIssue`**: new function in `routines.ts` that finds open execution issues without requiring a live heartbeat run join. Replaces `findLiveExecutionIssue` at the two `dispatchRoutineRun` concurrency-gate call sites (pre-check and constraint-violation catch fallback). `findLiveExecutionIssue` is retained for display/coalescing run-link purposes.
- **Fix C — `POST /api/routines/:id/force-terminate`**: board-only endpoint that cancels all open execution issues for a routine without going through checkout, bypassing the constraint conflict. Clears `executionRunId`/`checkoutRunId`, sets `status = 'cancelled'`, finalizes associated `routine_runs` as failed, activity-logs the result.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean (all three changes)
- `pnpm --filter @paperclipai/db typecheck` — clean (migration + journal + schema)
- `routines-e2e.test.ts` (4 tests) ✓ and `routines-routes.test.ts` (9 tests) ✓
- Migration applied to a local primary instance; index verified in-DB: `execution_run_id` clause absent from `pg_indexes.indexdef`
- Pre-migration: cancelled one pre-existing zombie duplicate (`DEN-824`, same fingerprint as live `DEN-871`) that would have blocked the migration — confirms the fix addresses a real live state

## Risks

- **`always_enqueue` behavior change**: dispatches now get `createdRun.id` as `originFingerprint` instead of `dispatchFingerprint`. Issues created by `always_enqueue` are no longer fingerprint-coalesceable with each other. This is correct — `always_enqueue` is supposed to always create new issues. If anything was relying on fingerprint matching across `always_enqueue` dispatches for display/deduplication, that assumption is now broken.
- **Index rebuild**: the migration drops and recreates the unique index. On large deployments this acquires an `ACCESS EXCLUSIVE` lock on `issues` during index creation. Duration proportional to table size. For hosted instances, schedule during low-traffic window.
- **Force-terminate audit trail**: the endpoint logs to the activity log but does not create issue comments. Future operators debugging a cancellation may not see why the issue was cancelled unless they check the activity log.

## Model Used

- Provider: Anthropic
- Model ID: claude-sonnet-4-6
- Context window: 200k tokens
- Capabilities: tool use, code execution, multi-step reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge