### PR TITLE
[AGE-12812] Restrict harness_liveness fallback rungs to executive roles

### DIFF
--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -452,8 +452,12 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     await db.insert(agents).values({
       id: managerId,
       companyId,
-      name: "Root Operator",
-      role: "operator",
+      name: "Company CTO",
+      // Recovery fallback rungs require executive role (cto/ceo). Without this,
+      // resolveEscalationOwnerAgentId finds no candidate and the escalation is
+      // not created. Mirrors the production fleet precondition: every company
+      // must have at least one cto/ceo agent.
+      role: "cto",
       status: "idle",
       adapterType: "codex_local",
       adapterConfig: {},

--- a/server/src/__tests__/issue-liveness.test.ts
+++ b/server/src/__tests__/issue-liveness.test.ts
@@ -77,16 +77,18 @@ describe("issue graph liveness classifier", () => {
     });
   });
 
-  it("does not use free-form executive role or name matching for recovery ownership", () => {
+  it("does not use agent name or title for recovery ownership", () => {
+    // Asserts the resolver does not read free-form fields like agent.name or
+    // agent.title when picking a recovery owner. agent.role IS load-bearing for
+    // the fallback rungs (mirrors resolveStaleRunOwnerAgentId), so this test
+    // uses a non-executive operator with the misleading title "CEO" to confirm
+    // the title is ignored.
     const rootAgentId = "root-agent";
-    const spoofedExecutiveId = "spoofed-executive";
+    const ctoAgentId = "real-cto";
 
     const findings = classifyIssueGraphLiveness({
       issues: [
-        issue({
-          assigneeAgentId: null,
-          createdByAgentId: null,
-        }),
+        issue({ assigneeAgentId: null, createdByAgentId: null }),
         issue({
           id: blockerId,
           identifier: "PAP-1704",
@@ -99,16 +101,16 @@ describe("issue graph liveness classifier", () => {
       relations: blocks,
       agents: [
         agent({
-          id: spoofedExecutiveId,
-          name: "Chief Executive Recovery",
-          role: "cto",
-          title: "CEO",
-          reportsTo: rootAgentId,
-        }),
-        agent({
           id: rootAgentId,
           name: "Root Operator",
           role: "operator",
+          title: "CEO", // misleading title; should be ignored
+          reportsTo: null,
+        }),
+        agent({
+          id: ctoAgentId,
+          name: "Real CTO",
+          role: "cto",
           title: null,
           reportsTo: null,
         }),
@@ -116,16 +118,86 @@ describe("issue graph liveness classifier", () => {
     });
 
     expect(findings).toHaveLength(1);
-    expect(findings[0]?.recommendedOwnerAgentId).toBe(rootAgentId);
-    expect(findings[0]?.recommendedOwnerCandidates[0]).toMatchObject({
-      agentId: rootAgentId,
-      reason: "root_agent",
-      sourceIssueId: blockerId,
+    // The operator has no reportsTo and a misleading "CEO" title, but role is
+    // "operator" — so it is excluded from both fallback rungs. The real CTO
+    // (role=cto, no reportsTo) is the only valid candidate.
+    expect(findings[0]?.recommendedOwnerAgentId).toBe(ctoAgentId);
+    expect(findings[0]?.recommendedOwnerCandidateAgentIds).toEqual([ctoAgentId]);
+  });
+
+  it("restricts root_agent and ordered_invokable_fallback rungs to executive roles", () => {
+    // Without this filter, escalations route to whichever invokable agent has
+    // the lowest UUID (e.g. process-adapter scripts that ignore issue context).
+    // Mirrors resolveStaleRunOwnerAgentId / resolveStrandedIssueRecoveryOwnerAgentId
+    // in services/recovery/service.ts.
+    const ceoId = "00000000-ceo";
+    const ctoId = "11111111-cto";
+    const processAgentId = "22222222-process"; // non-executive, would-be UUID winner
+
+    const findings = classifyIssueGraphLiveness({
+      issues: [
+        issue({ assigneeAgentId: null, createdByAgentId: null }),
+        issue({
+          id: blockerId,
+          identifier: "PAP-1704",
+          title: "Missing unblock work",
+          status: "todo",
+          assigneeAgentId: null,
+          createdByAgentId: null,
+        }),
+      ],
+      relations: blocks,
+      agents: [
+        agent({ id: ceoId, name: "CEO", role: "ceo", reportsTo: null }),
+        agent({ id: ctoId, name: "CTO", role: "cto", reportsTo: ceoId }),
+        agent({ id: processAgentId, name: "Script", role: "general", reportsTo: null }),
+      ],
     });
-    expect(findings[0]?.recommendedOwnerCandidateAgentIds).toEqual([
-      rootAgentId,
-      spoofedExecutiveId,
-    ]);
+
+    expect(findings).toHaveLength(1);
+    const candidates = findings[0]?.recommendedOwnerCandidates ?? [];
+    const candidateAgentIds = candidates.map((c) => c.agentId);
+    expect(candidateAgentIds).not.toContain(processAgentId);
+    expect(candidateAgentIds).toContain(ceoId); // root_agent rung (no reportsTo + executive)
+    expect(candidateAgentIds).toContain(ctoId); // ordered_invokable_fallback rung
+    expect(findings[0]?.recommendedOwnerAgentId).toBe(ceoId); // root_agent first
+  });
+
+  it("preserves non-executive ownership via chain-based reasons (assignee_reporting_chain)", () => {
+    // The role filter only affects fallback rungs. Chain-based candidates that
+    // surface a non-executive manager (e.g. devops lead) via reportsTo
+    // traversal must still be selectable.
+    const ceoId = "ceo-1";
+    const opsLeadId = "ops-lead";
+    const opsEngineerId = "ops-engineer";
+    const blockerAssigneeId = "blocker-agent";
+
+    const findings = classifyIssueGraphLiveness({
+      issues: [
+        issue({ assigneeAgentId: opsEngineerId, createdByAgentId: null }),
+        issue({
+          id: blockerId,
+          identifier: "PAP-1704",
+          title: "Cancelled unblock work",
+          status: "cancelled",
+          assigneeAgentId: blockerAssigneeId,
+        }),
+      ],
+      relations: blocks,
+      agents: [
+        agent({ id: ceoId, name: "CEO", role: "ceo", reportsTo: null }),
+        agent({ id: opsLeadId, name: "Ops Lead", role: "devops", reportsTo: ceoId }),
+        agent({ id: opsEngineerId, name: "Ops Engineer", role: "devops", reportsTo: opsLeadId }),
+        agent({ id: blockerAssigneeId, name: "Blocker", role: "general", reportsTo: opsLeadId }),
+      ],
+    });
+
+    expect(findings).toHaveLength(1);
+    const candidates = findings[0]?.recommendedOwnerCandidates ?? [];
+    // The ops lead (non-executive devops role) is reachable via the
+    // assignee_reporting_chain — confirms chain-based reasons are unaffected
+    // by the role filter on the fallback rungs.
+    expect(candidates.some((c) => c.agentId === opsLeadId && c.reason === "assignee_reporting_chain")).toBe(true);
   });
 
   it("does not flag a live blocked chain with an active assignee and wake path", () => {

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -107,6 +107,16 @@ export interface IssueGraphLivenessInput {
 
 const INVOKABLE_AGENT_STATUSES = new Set(["active", "idle", "running", "error"]);
 const BLOCKING_AGENT_STATUSES = new Set(["paused", "terminated", "pending_approval"]);
+// Recovery fallback rungs (root_agent, ordered_invokable_fallback) restrict to
+// executive roles. Mirrors resolveStaleRunOwnerAgentId / resolveStrandedIssueRecoveryOwnerAgentId
+// in services/recovery/service.ts which already filter to ["cto","ceo"]. Without this filter,
+// the fallback degenerates into a UUID-sort lottery and routes triage work to non-executive
+// agents (notably process adapters that ignore issue context).
+const EXECUTIVE_ROLES = new Set(["cto", "ceo"]);
+
+function isExecutiveRole(role: string | null | undefined): boolean {
+  return typeof role === "string" && EXECUTIVE_ROLES.has(role);
+}
 
 function issueLabel(issue: IssueLivenessIssueInput) {
   return issue.identifier ?? issue.id;
@@ -285,11 +295,12 @@ function ownerCandidatesForRecoveryIssue(
 
   const invokableAgents = orderedInvokableAgents(agents, issue.companyId);
   for (const agent of invokableAgents) {
-    if (!agent.reportsTo) {
+    if (!agent.reportsTo && isExecutiveRole(agent.role)) {
       addOwnerCandidate(candidates, seen, agentsById, issue.companyId, agent.id, "root_agent", issue.id);
     }
   }
   for (const agent of invokableAgents) {
+    if (!isExecutiveRole(agent.role)) continue;
     addOwnerCandidate(
       candidates,
       seen,


### PR DESCRIPTION
## Summary

The `harness_liveness_escalation` candidate selector has two fallback rungs that bypass the executive role filter used by the rest of the recovery system:

- `root_agent` rung — picks any invokable agent with no `reportsTo`, regardless of role
- `ordered_invokable_fallback` rung — picks every invokable agent in the company sorted by UUID lexicographically, regardless of role

These rungs feed `resolveEscalationOwnerAgentId` (`services/recovery/service.ts:1750-1788`), which selects the first candidate not blocked by budget. With no role filter, the lowest-UUID invokable agent wins — including pure `process` adapters (Python scripts) that have no awareness of issue context.

## Why this is inconsistent

The two other recovery owner-resolvers already restrict to executive roles:

- `resolveStaleRunOwnerAgentId` (`service.ts:512-516`) — `inArray(agents.role, [\"cto\", \"ceo\"])`
- `resolveStrandedIssueRecoveryOwnerAgentId` (`service.ts:983-987`) — same filter

Only `harness_liveness_escalation` was missing it. This PR closes that gap.

## Real-world impact (uncovered 2026-05-05 in AGE)

| Agent | Adapter | UUID sort | Outcome |
|-------|---------|-----------|---------|
| Deep Scanner | `process` (Python) | `36ab8148...` | 65 failed runs, 0 successful since 2026-04-30. 20 escalations routed, all loud-failed because the script path was misconfigured (separate ops fix). |
| Email Groomer | `process` (Python) | `c100eed9...` | 23 escalations silently routed. Script ran successfully (47 succeeded), exited 0 — and 23 escalations got marked `in_progress` with **zero actual triage**. Silent escalation sinkhole. |

After pausing both, the bug shifted to the next UUID-sorted process agent. Pausing isn't a fix; this PR is.

## Change

- New helper `isExecutiveRole(role)` + `EXECUTIVE_ROLES` set near the existing `INVOKABLE_AGENT_STATUSES` constant
- `root_agent` rung now requires `!agent.reportsTo && isExecutiveRole(agent.role)`
- `ordered_invokable_fallback` rung now requires `isExecutiveRole(agent.role)`
- Chain-based reasons (`stalled_blocker_assignee`, `assignee_reporting_chain`, `creator_reporting_chain`) are **unchanged** — non-executive owners reachable via `reportsTo` traversal are still selectable.

## Tests

- Updated `issue-liveness.test.ts` test that asserted operator-with-no-reportsTo wins — operators are no longer eligible. The renamed test now confirms the resolver still ignores `agent.name` and `agent.title` (those have never been read; only `role` is).
- Added 2 new tests:
  - `restricts root_agent and ordered_invokable_fallback rungs to executive roles` — process agent with low UUID is excluded; CEO + CTO are the only candidates
  - `preserves non-executive ownership via chain-based reasons` — devops manager is still reachable via `assignee_reporting_chain`
- Updated `heartbeat-issue-liveness-escalation.test.ts` fixture to use `role: \"cto\"` for the company's sole agent (was `operator`) — required for the test's escalation to find a fallback owner under the new policy.

All 21 tests in both files pass.

## Fleet precondition

The patch makes every company need at least one `cto` or `ceo` agent for the fallback to remain autonomous. AGE pre-deployed this:

- Juno is registered as CEO in all 8 companies (was `general` in 6 of them)
- 5 new CTOs added: Hale (AGE), Wren (KAL), Tate (WEE), Vale (DIA), Ren (Personal). Existing CTOs Willa (FON), Finn (PIX), Rue (STU) unchanged.
- All 8 companies now have CEO + CTO coverage

## Test plan

- [x] `pnpm exec vitest run src/__tests__/issue-liveness.test.ts src/__tests__/heartbeat-issue-liveness-escalation.test.ts` — 21/21 pass
- [x] `tsc --noEmit` clean on the 3 modified files
- [ ] Reviewer to confirm chain-based reasons still cover the common case (most escalations should resolve via assignee/creator chains; the executive fallback is the safety net)
- [ ] CI pass

## Reviewer

Requesting Ellis (AGE platform). Per AGE SDLC, the implementer (me, Otis) cannot self-merge.

## Related

- AGE-12812 — investigation transcript and rollout plan