### PR TITLE
Fix company removal workspace operations cleanup

### DIFF
--- a/server/src/__tests__/cleanup-removal-service.test.ts
+++ b/server/src/__tests__/cleanup-removal-service.test.ts
@@ -15,6 +15,7 @@ import {
   issueExecutionDecisions,
   issueReadStates,
   issues,
+  workspaceOperations,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -49,6 +50,7 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await db.delete(documentRevisions);
     await db.delete(documents);
     await db.delete(companySkills);
+    await db.delete(workspaceOperations);
     await db.delete(heartbeatRuns);
     await db.delete(issues);
     await db.delete(agents);
@@ -227,5 +229,25 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await expect(db.select().from(documentRevisions).where(eq(documentRevisions.id, revisionId))).resolves.toHaveLength(0);
     await expect(db.select().from(issueReadStates).where(eq(issueReadStates.companyId, companyId))).resolves.toHaveLength(0);
     await expect(db.select().from(activityLog).where(eq(activityLog.companyId, companyId))).resolves.toHaveLength(0);
+  });
+
+  it("removes workspace operations before deleting the company", async () => {
+    const { companyId, runId } = await seedFixture();
+    const operationId = randomUUID();
+
+    await db.insert(workspaceOperations).values({
+      id: operationId,
+      companyId,
+      heartbeatRunId: runId,
+      phase: "exec",
+      command: "pnpm test",
+      status: "completed",
+    });
+
+    const removed = await companyService(db).remove(companyId);
+
+    expect(removed?.id).toBe(companyId);
+    await expect(db.select().from(companies).where(eq(companies.id, companyId))).resolves.toHaveLength(0);
+    await expect(db.select().from(workspaceOperations).where(eq(workspaceOperations.id, operationId))).resolves.toHaveLength(0);
   });
 });

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -28,6 +28,7 @@ import {
   companyMemberships,
   companySkills,
   documents,
+  workspaceOperations,
 } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { environmentService } from "./environments.js";
@@ -275,6 +276,7 @@ export function companyService(db: Db) {
         await tx.delete(issueComments).where(eq(issueComments.companyId, id));
         await tx.delete(costEvents).where(eq(costEvents.companyId, id));
         await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
+        await tx.delete(workspaceOperations).where(eq(workspaceOperations.companyId, id));
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
         await tx.delete(approvals).where(eq(approvals.companyId, id));
         await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));


### PR DESCRIPTION
Fixes [DEV-208](/DEV/issues/DEV-208). Deletes workspace_operations rows during company removal and adds the embedded Postgres regression. Verified with: pnpm exec vitest run --project @paperclipai/server server/src/__tests__/cleanup-removal-service.test.ts --pool=forks --poolOptions.forks.isolate=true