### PR TITLE
fix: add context: fork to nested skill reference files to prevent token blowup

### DIFF
--- a/skills/paperclip-create-agent/references/agent-instruction-templates.md
+++ b/skills/paperclip-create-agent/references/agent-instruction-templates.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Agent Instruction Templates
 
 Use this reference from step 4 of the hiring workflow. It lists the current role templates, when to use each, and how to decide between an exact template, an adjacent template, or the generic fallback.

--- a/skills/paperclip-create-agent/references/agents/coder.md
+++ b/skills/paperclip-create-agent/references/agents/coder.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Coder Agent Template
 
 Use this template when hiring software engineers who implement code, debug issues, write tests, and coordinate with QA or engineering leadership.

--- a/skills/paperclip-create-agent/references/agents/qa.md
+++ b/skills/paperclip-create-agent/references/agents/qa.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # QA Agent Template
 
 Use this template when hiring QA engineers who reproduce bugs, validate fixes, capture screenshots, and report actionable findings.

--- a/skills/paperclip-create-agent/references/agents/securityengineer.md
+++ b/skills/paperclip-create-agent/references/agents/securityengineer.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # SecurityEngineer Agent Template
 
 Use this template when hiring security engineers who own security posture: threat-model systems, review auth/crypto/input handling, triage supply-chain and LLM-agent risk, and drive concrete remediations.

--- a/skills/paperclip-create-agent/references/agents/uxdesigner.md
+++ b/skills/paperclip-create-agent/references/agents/uxdesigner.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # UX Designer Agent Template
 
 Use this template when hiring product designers who produce UX specs, review interface quality, identify usability risks, and evolve the design system.

--- a/skills/paperclip-create-agent/references/api-reference.md
+++ b/skills/paperclip-create-agent/references/api-reference.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Paperclip Create Agent API Reference
 
 ## Core Endpoints

--- a/skills/paperclip-create-agent/references/baseline-role-guide.md
+++ b/skills/paperclip-create-agent/references/baseline-role-guide.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Baseline Role Guide (No-Template Fallback)
 
 Use this guide when no template under `references/agents/` is a close fit for the role you are hiring. It gives you a concrete structure for drafting a new `AGENTS.md` from scratch without asking the board for prompt-writing help.

--- a/skills/paperclip-create-agent/references/draft-review-checklist.md
+++ b/skills/paperclip-create-agent/references/draft-review-checklist.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Draft-Review Checklist
 
 Walk this checklist before submitting any `agent-hires` request. Fix each item that does not pass — do not submit a draft with open failures.

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Paperclip API Reference
 
 Detailed reference for the Paperclip control plane API. For the core heartbeat procedure and critical rules, see the main `SKILL.md`.

--- a/skills/paperclip/references/company-skills.md
+++ b/skills/paperclip/references/company-skills.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Company Skills Workflow
 
 Use this reference when a board user, CEO, or manager asks you to find a skill, install it into the company library, or assign it to an agent.

--- a/skills/paperclip/references/issue-workspaces.md
+++ b/skills/paperclip/references/issue-workspaces.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Issue Workspace Runtime Controls
 
 Use this reference when an issue has an isolated execution workspace and you need to inspect or run that workspace's services, especially for QA/browser verification.

--- a/skills/paperclip/references/routines.md
+++ b/skills/paperclip/references/routines.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Paperclip Routines
 
 Routines are recurring tasks. Each time a routine fires it creates an execution issue assigned to the routine's agent — the agent picks it up in the normal heartbeat flow.

--- a/skills/paperclip/references/workflows.md
+++ b/skills/paperclip/references/workflows.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Paperclip Workflow Playbooks
 
 Reference material for niche workflows that are pointed to from `SKILL.md`. Load only when the task matches.

--- a/skills/para-memory-files/references/schemas.md
+++ b/skills/para-memory-files/references/schemas.md
@@ -1,3 +1,6 @@
+---
+context: fork
+---
 # Schemas and Memory Decay
 
 ## Atomic Fact Schema (items.yaml)


### PR DESCRIPTION
## Problem

When agents load nested skill reference files, the files expand inline into the calling agent's main context window. With deeply nested skill trees (e.g., `paperclip` → `paperclip-create-agent` → `para-memory-files`), this causes unbounded token blowup — the entire reference file is duplicated in context for each nested call.

This was discovered in production. The symptom is that heartbeats consuming multiple skills blow past context limits and either fail or produce degraded output.

## Fix

Add `context: fork` frontmatter to 14 nested skill reference files. With this directive, the skill loader forks context when loading these files instead of expanding them inline into the calling agent's main context window.

**Commit:** `bc434be8`
**Branch:** `claude/gifted-bouman-044afd`

## Files changed (14)

### `skills/paperclip-create-agent/references/`
- `agent-instruction-templates.md`
- `agents/coder.md`
- `agents/qa.md`
- `agents/securityengineer.md`
- `agents/uxdesigner.md`
- `api-reference.md`
- `baseline-role-guide.md`
- `draft-review-checklist.md`

### `skills/paperclip/references/`
- `api-reference.md`
- `company-skills.md`
- `issue-workspaces.md`
- `routines.md`
- `workflows.md`

### `skills/para-memory-files/references/`
- `schemas.md`

## Verification

Before this fix, loading the paperclip skill with nested agent creation would expand all 14 reference files into the active context window — easily 20,000+ tokens of repeated content.

After this fix, each reference file is loaded in a forked context, keeping the calling agent's context window clean.

## Notes

- This fix was developed and tested on the ShredTech production instance
- No behavioral changes — only the context loading strategy is modified
- The maintainers have not responded on Discord; submitting as a PR for upstream consideration
