### PR TITLE
Skip worktrees for unscoped heartbeats

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -304,6 +304,45 @@ describe("ensureServerWorkspaceLinksCurrent", () => {
 });
 
 describe("realizeExecutionWorkspace", () => {
+  it("does not require a git checkout for unscoped git worktree runs", async () => {
+    const agentHome = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-agent-home-"));
+
+    const realized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: agentHome,
+        source: "agent_home",
+        projectId: null,
+        workspaceId: null,
+        repoUrl: null,
+        repoRef: null,
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: null,
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(realized).toMatchObject({
+      strategy: "project_primary",
+      cwd: agentHome,
+      source: "agent_home",
+      projectId: null,
+      workspaceId: null,
+      branchName: null,
+      worktreePath: null,
+      created: false,
+    });
+    expect(realized.warnings[0]).toContain("Skipping git worktree strategy");
+  });
+
   it("creates and reuses a git worktree for an issue-scoped branch", async () => {
     const repoRoot = await createTempRepo();
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -998,6 +998,19 @@ export async function realizeExecutionWorkspace(input: {
       created: false,
     };
   }
+  if (!input.issue && !input.base.projectId) {
+    return {
+      ...input.base,
+      strategy: "project_primary",
+      cwd: input.base.baseCwd,
+      branchName: null,
+      worktreePath: null,
+      warnings: [
+        "Skipping git worktree strategy because this run is not scoped to an issue or project.",
+      ],
+      created: false,
+    };
+  }
 
   const repoRoot = await resolveGitOwnerRepoRoot(input.base.baseCwd);
   const branchTemplate = asString(rawStrategy.branchTemplate, "{{issue.identifier}}-{{slug}}");


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Heartbeat runs are the control-plane path that wakes agents for timer, assignment, and continuation work.
> - Execution workspace realization can apply a git worktree strategy before the adapter process starts.
> - Unscoped timer heartbeats may not have an issue, project, or repo-backed cwd; they can resolve to an agent-home directory instead.
> - Applying git worktree setup to that non-repo cwd fails before the agent can inspect its inbox or decide there is no work.
> - This pull request keeps git worktrees for issue- and project-scoped runs, but lets unscoped runs continue in the resolved primary cwd.
> - The benefit is that idle/timer heartbeats no longer fail setup while preserving isolated worktrees for real scoped work.

## What Changed

- Added an early return in `realizeExecutionWorkspace` for runs with a `git_worktree` strategy but no issue and no project scope.
- Returns the resolved cwd as a `project_primary` workspace with a warning instead of calling `git rev-parse` from a non-repo directory.
- Added a regression test covering an unscoped `agent_home` cwd that is not a git checkout.

## Verification

- `pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts -t "does not require a git checkout"`
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check`

Note: I also ran the full `workspace-runtime.test.ts` file locally. The new regression and the existing non-provision worktree tests passed, but unrelated provision-worktree tests failed because this local checkout lacks the `local_encrypted` secrets master key under the temp Paperclip home.

## Risks

- Low risk: the new path only applies when there is no issue and no project scope.
- Issue-scoped and project-scoped runs still use the configured `git_worktree` strategy.
- The main behavior shift is that unscoped timer runs can start in the resolved fallback cwd instead of failing during workspace setup.

> Checked `ROADMAP.md`; this is a focused bugfix for existing heartbeat/worktree behavior and does not duplicate planned core roadmap work.

## Model Used

- OpenAI Codex, GPT-5-class coding model, with shell/GitHub CLI tool use for repo inspection, testing, commit, push, and PR updates.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge