### PR TITLE
BRAA-1076: reset timer heartbeat sessions

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -299,8 +299,8 @@ describe("shouldResetTaskSessionForWake", () => {
     expect(shouldResetTaskSessionForWake({ wakeReason: "execution_changes_requested" })).toBe(true);
   });
 
-  it("preserves session context on timer heartbeats", () => {
-    expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(false);
+  it("resets session context on timer heartbeats", () => {
+    expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(true);
   });
 
   it("preserves session context on manual on-demand invokes by default", () => {
@@ -367,11 +367,11 @@ describe("deriveTaskKeyWithHeartbeatFallback", () => {
     expect(deriveTaskKeyWithHeartbeatFallback({ issueId: "issue-456" }, null)).toBe("issue-456");
   });
 
-  it("returns __heartbeat__ for timer wakes with no explicit key", () => {
-    expect(deriveTaskKeyWithHeartbeatFallback({ wakeSource: "timer" }, null)).toBe("__heartbeat__");
+  it("does not invent a synthetic key for timer wakes with no explicit key", () => {
+    expect(deriveTaskKeyWithHeartbeatFallback({ wakeSource: "timer" }, null)).toBeNull();
   });
 
-  it("prefers explicit key over heartbeat fallback even on timer wakes", () => {
+  it("prefers explicit key on timer wakes", () => {
     expect(
       deriveTaskKeyWithHeartbeatFallback({ wakeSource: "timer", taskKey: "issue-789" }, null),
     ).toBe("issue-789");

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -303,6 +303,15 @@ describe("shouldResetTaskSessionForWake", () => {
     expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(true);
   });
 
+  it("resets session context on timer heartbeats even with an explicit task key", () => {
+    expect(
+      shouldResetTaskSessionForWake({
+        wakeSource: "timer",
+        taskKey: "issue-789",
+      }),
+    ).toBe(true);
+  });
+
   it("preserves session context on manual on-demand invokes by default", () => {
     expect(
       shouldResetTaskSessionForWake({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1276,8 +1276,6 @@ function parseIssueAssigneeAdapterOverrides(
  * and benefit from robust session resume, instead of relying solely on the
  * simpler `agentRuntimeState.sessionId` fallback.
  */
-const HEARTBEAT_TASK_KEY = "__heartbeat__";
-
 function deriveTaskKey(
   contextSnapshot: Record<string, unknown> | null | undefined,
   payload: Record<string, unknown> | null | undefined,
@@ -1293,32 +1291,20 @@ function deriveTaskKey(
   );
 }
 
-/**
- * Extended task key derivation that falls back to a stable synthetic key
- * for timer/heartbeat wakes. This ensures timer wakes can resume their
- * previous session via `agentTaskSessions` instead of starting fresh.
- *
- * The synthetic key is only used when:
- * - No explicit task/issue key exists in the context
- * - The wake source is "timer" (scheduled heartbeat)
- */
 export function deriveTaskKeyWithHeartbeatFallback(
   contextSnapshot: Record<string, unknown> | null | undefined,
   payload: Record<string, unknown> | null | undefined,
 ) {
-  const explicit = deriveTaskKey(contextSnapshot, payload);
-  if (explicit) return explicit;
-
-  const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
-  if (wakeSource === "timer") return HEARTBEAT_TASK_KEY;
-
-  return null;
+  return deriveTaskKey(contextSnapshot, payload);
 }
 
 export function shouldResetTaskSessionForWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
   if (contextSnapshot?.forceFreshSession === true) return true;
+
+  const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
+  if (wakeSource === "timer") return true;
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1271,10 +1271,9 @@ function parseIssueAssigneeAdapterOverrides(
 }
 
 /**
- * Synthetic task key for timer/heartbeat wakes that have no issue context.
- * This allows timer wakes to participate in the `agentTaskSessions` system
- * and benefit from robust session resume, instead of relying solely on the
- * simpler `agentRuntimeState.sessionId` fallback.
+ * Derives the issue/task key that scopes `agentTaskSessions` for a wake.
+ * Timer wakes deliberately avoid inventing a synthetic key so scheduler-driven
+ * runs can force a fresh session unless they carry an explicit task binding.
  */
 function deriveTaskKey(
   contextSnapshot: Record<string, unknown> | null | undefined,
@@ -1295,6 +1294,7 @@ export function deriveTaskKeyWithHeartbeatFallback(
   contextSnapshot: Record<string, unknown> | null | undefined,
   payload: Record<string, unknown> | null | undefined,
 ) {
+  // Keep the public helper name stable for tests and downstream callers.
   return deriveTaskKey(contextSnapshot, payload);
 }
 


### PR DESCRIPTION
## Summary
- stop timer heartbeat wakes from inventing a synthetic `__heartbeat__` task key
- force fresh sessions for scheduler-driven timer wakes instead of resuming saved task-session state
- update heartbeat session tests to lock the new timer-wake contract

## Production evidence
- post-deploy Kali timer runs `51737837-8980-4716-9dd7-3fdd0d95e6d4` and `d27e9aa0-811a-4803-8231-a25325880d84` both ran on live image `ts-20260505145622`
- both runs invoked Codex with `resume 019d4bda-8818-7c70-a35d-58cc17eafce2 -`
- both runs had `wakeReason=heartbeat_timer`, `wakeSource=timer`, and `paperclipWorkspace.source=task_session`
- both emitted stale queue output for completed/blocked `BRAA-755`

## Verification
- `pnpm exec vitest run server/src/__tests__/heartbeat-workspace-session.test.ts`
