### PR TITLE
Fix timer wake task-session workspace fallback

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -484,10 +484,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     adapterExecutionTargetSessionMatches(runtimeRemoteExecution, executionTarget);
   const codexTransientFallbackMode = readCodexTransientFallbackMode(context);
   const forceSaferInvocation = fallbackModeUsesSaferInvocation(codexTransientFallbackMode);
+  const legacySchedulerTimerWake =
+    asString(context.source, "") === "scheduler" &&
+    asString(context.reason, "") === "interval_elapsed";
   const timerWakeRequiresFreshSession =
     context.forceFreshSession === true ||
     wakeReason === "heartbeat_timer" ||
-    asString(context.wakeSource, "") === "timer";
+    asString(context.wakeSource, "") === "timer" ||
+    legacySchedulerTimerWake;
   const forceFreshSession =
     timerWakeRequiresFreshSession || fallbackModeUsesFreshSession(codexTransientFallbackMode);
   const sessionId = canResumeSession && !forceFreshSession ? runtimeSessionId : null;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -484,7 +484,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     adapterExecutionTargetSessionMatches(runtimeRemoteExecution, executionTarget);
   const codexTransientFallbackMode = readCodexTransientFallbackMode(context);
   const forceSaferInvocation = fallbackModeUsesSaferInvocation(codexTransientFallbackMode);
-  const forceFreshSession = fallbackModeUsesFreshSession(codexTransientFallbackMode);
+  const timerWakeRequiresFreshSession =
+    context.forceFreshSession === true ||
+    wakeReason === "heartbeat_timer" ||
+    asString(context.wakeSource, "") === "timer";
+  const forceFreshSession =
+    timerWakeRequiresFreshSession || fallbackModeUsesFreshSession(codexTransientFallbackMode);
   const sessionId = canResumeSession && !forceFreshSession ? runtimeSessionId : null;
   if (executionTargetIsRemote && runtimeSessionId && !canResumeSession) {
     await onLog(

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -378,6 +378,65 @@ describe("codex execute", () => {
     }
   });
 
+  it("forces a fresh Codex session for timer wakes even when runtime session state exists", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-timer-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-timer-fresh",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: "codex-session-stale",
+          sessionParams: {
+            sessionId: "codex-session-stale",
+            cwd: workspace,
+          },
+          sessionDisplayId: "codex-session-stale",
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          wakeReason: "heartbeat_timer",
+          wakeSource: "timer",
+          forceFreshSession: true,
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.argv).not.toContain("resume");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("classifies remote-compaction high-demand failures as retryable transient upstream errors", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-transient-"));
     const workspace = path.join(root, "workspace");

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -437,6 +437,64 @@ describe("codex execute", () => {
     }
   });
 
+  it("forces a fresh Codex session for legacy scheduler timer wakes even without wakeSource", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-legacy-timer-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "codex");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeCodexCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-legacy-timer-fresh",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Codex Coder",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: "codex-session-stale",
+          sessionParams: {
+            sessionId: "codex-session-stale",
+            cwd: workspace,
+          },
+          sessionDisplayId: "codex-session-stale",
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          source: "scheduler",
+          reason: "interval_elapsed",
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.argv).not.toContain("resume");
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("classifies remote-compaction high-demand failures as retryable transient upstream errors", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-transient-"));
     const workspace = path.join(root, "workspace");

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -181,7 +181,12 @@ describe("heartbeat comment wake batching", () => {
       status: "idle",
       adapterType: "process",
       adapterConfig: {},
-      runtimeConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec: 3600,
+        },
+      },
       permissions: {},
     });
 
@@ -243,7 +248,12 @@ describe("heartbeat comment wake batching", () => {
       status: "idle",
       adapterType: "process",
       adapterConfig: {},
-      runtimeConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec: 3600,
+        },
+      },
       permissions: {},
     });
 

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -186,9 +186,9 @@ describe("heartbeat comment wake batching", () => {
     });
 
     const run = await heartbeat.wakeup(agentId, {
-      source: "scheduler",
+      source: "timer",
       triggerDetail: "system",
-      reason: "interval_elapsed",
+      reason: "heartbeat_timer",
       contextSnapshot: {
         source: "scheduler",
         reason: "interval_elapsed",
@@ -251,7 +251,7 @@ describe("heartbeat comment wake batching", () => {
       id: runId,
       companyId,
       agentId,
-      invocationSource: "scheduler",
+      invocationSource: "timer",
       triggerDetail: "system",
       status: "queued",
       contextSnapshot: {
@@ -267,9 +267,9 @@ describe("heartbeat comment wake batching", () => {
     });
 
     const mergedRun = await heartbeat.wakeup(agentId, {
-      source: "scheduler",
+      source: "timer",
       triggerDetail: "system",
-      reason: "interval_elapsed",
+      reason: "heartbeat_timer",
       contextSnapshot: {
         source: "scheduler",
         reason: "interval_elapsed",

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -160,6 +160,148 @@ describe("heartbeat comment wake batching", () => {
     await tempDb?.cleanup();
   });
 
+  it("persists sanitized context for newly queued generic timer wakes", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Timer Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "scheduler",
+      triggerDetail: "system",
+      reason: "interval_elapsed",
+      contextSnapshot: {
+        source: "scheduler",
+        reason: "interval_elapsed",
+        resumeFromRunId: "run-1",
+        resumeSessionDisplayId: "session-1",
+        resumeSessionParams: {
+          sessionId: "session-1",
+          cwd: "/tmp/stale-workspace",
+        },
+      },
+    });
+
+    expect(run).not.toBeNull();
+
+    const persistedRun = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, run!.id))
+      .then((rows) => rows[0]);
+
+    expect(persistedRun?.contextSnapshot).toMatchObject({
+      source: "scheduler",
+      reason: "interval_elapsed",
+      wakeSource: "timer",
+      wakeReason: "heartbeat_timer",
+      forceFreshSession: true,
+    });
+    expect((persistedRun?.contextSnapshot as Record<string, unknown>).resumeFromRunId).toBeUndefined();
+    expect((persistedRun?.contextSnapshot as Record<string, unknown>).resumeSessionDisplayId).toBeUndefined();
+    expect((persistedRun?.contextSnapshot as Record<string, unknown>).resumeSessionParams).toBeUndefined();
+  });
+
+  it("persists sanitized context when coalescing generic timer wakes into a queued run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Timer Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "scheduler",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: {
+        source: "scheduler",
+        reason: "interval_elapsed",
+        resumeFromRunId: "run-old",
+        resumeSessionDisplayId: "session-old",
+        resumeSessionParams: {
+          sessionId: "session-old",
+          cwd: "/tmp/stale-workspace",
+        },
+      },
+    });
+
+    const mergedRun = await heartbeat.wakeup(agentId, {
+      source: "scheduler",
+      triggerDetail: "system",
+      reason: "interval_elapsed",
+      contextSnapshot: {
+        source: "scheduler",
+        reason: "interval_elapsed",
+        resumeFromRunId: "run-new",
+        resumeSessionDisplayId: "session-new",
+        resumeSessionParams: {
+          sessionId: "session-new",
+          cwd: "/tmp/other-stale-workspace",
+        },
+      },
+    });
+
+    expect(mergedRun?.id).toBe(runId);
+
+    const persistedRun = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]);
+
+    expect(persistedRun?.contextSnapshot).toMatchObject({
+      source: "scheduler",
+      reason: "interval_elapsed",
+      wakeSource: "timer",
+      wakeReason: "heartbeat_timer",
+      forceFreshSession: true,
+    });
+    expect((persistedRun?.contextSnapshot as Record<string, unknown>).resumeFromRunId).toBeUndefined();
+    expect((persistedRun?.contextSnapshot as Record<string, unknown>).resumeSessionDisplayId).toBeUndefined();
+    expect((persistedRun?.contextSnapshot as Record<string, unknown>).resumeSessionParams).toBeUndefined();
+  });
+
   it("defers approval-approved wakes for a running issue so the assignee resumes after the run", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -223,6 +223,47 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     return { runId, wakeupRequestId };
   }
 
+  async function seedRunningRun(input: {
+    companyId: string;
+    agentId: string;
+    contextSnapshot: Record<string, unknown>;
+    invocationSource?: "timer" | "assignment" | "automation" | "on_demand";
+  }) {
+    const wakeupRequestId = randomUUID();
+    const runId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      source: input.invocationSource ?? "on_demand",
+      triggerDetail: "system",
+      reason: readReason(input.contextSnapshot),
+      payload: null,
+      status: "coalesced",
+      finishedAt: new Date(),
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: input.companyId,
+      agentId: input.agentId,
+      invocationSource: input.invocationSource ?? "on_demand",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId,
+      contextSnapshot: input.contextSnapshot,
+      startedAt: new Date(),
+    });
+    return { runId, wakeupRequestId };
+  }
+
+  function readReason(contextSnapshot: Record<string, unknown>) {
+    return typeof contextSnapshot.wakeReason === "string"
+      ? contextSnapshot.wakeReason
+      : typeof contextSnapshot.reason === "string"
+        ? contextSnapshot.reason
+        : null;
+  }
+
   it("cancels queued runs when the issue assignee changes before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent({ agentName: "OriginalCoder" });
     const replacementAgentId = randomUUID();
@@ -343,6 +384,53 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(run?.errorCode).toBe("issue_terminal_status");
     expect(wakeup?.status).toBe("skipped");
     expect(mockAdapterExecute).not.toHaveBeenCalled();
+  });
+
+  it("re-sanitizes coalesced generic timer wakes before persisting merged run context", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const { runId } = await seedRunningRun({
+      companyId,
+      agentId,
+      contextSnapshot: {
+        wakeSource: "on_demand",
+        wakeReason: "issue_commented",
+        issueId: "BRAA-755",
+        taskId: "BRAA-755",
+        taskKey: "BRAA-755",
+        resumeFromRunId: "run-1",
+        resumeSessionDisplayId: "019d4bda-8818-7c70-a35d-58cc17eafce2",
+        resumeSessionParams: {
+          sessionId: "019d4bda-8818-7c70-a35d-58cc17eafce2",
+          cwd: "/tmp/stale-workspace",
+        },
+      },
+    });
+
+    const coalesced = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "system",
+      reason: "heartbeat_timer",
+      contextSnapshot: {
+        source: "scheduler",
+        reason: "interval_elapsed",
+      },
+    });
+
+    expect(coalesced?.id).toBe(runId);
+
+    const run = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+
+    expect(run?.contextSnapshot).toEqual({
+      wakeSource: "timer",
+      wakeReason: "heartbeat_timer",
+      source: "scheduler",
+      reason: "interval_elapsed",
+      forceFreshSession: true,
+    });
   });
 
   it("cancels queued in_review runs when the current participant changes before the run starts", async () => {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -299,8 +299,8 @@ describe("shouldResetTaskSessionForWake", () => {
     expect(shouldResetTaskSessionForWake({ wakeReason: "execution_changes_requested" })).toBe(true);
   });
 
-  it("preserves session context on timer heartbeats", () => {
-    expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(false);
+  it("resets session context on timer heartbeats", () => {
+    expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(true);
   });
 
   it("preserves session context on manual on-demand invokes by default", () => {
@@ -367,11 +367,11 @@ describe("deriveTaskKeyWithHeartbeatFallback", () => {
     expect(deriveTaskKeyWithHeartbeatFallback({ issueId: "issue-456" }, null)).toBe("issue-456");
   });
 
-  it("returns __heartbeat__ for timer wakes with no explicit key", () => {
-    expect(deriveTaskKeyWithHeartbeatFallback({ wakeSource: "timer" }, null)).toBe("__heartbeat__");
+  it("does not invent a synthetic key for timer wakes with no explicit key", () => {
+    expect(deriveTaskKeyWithHeartbeatFallback({ wakeSource: "timer" }, null)).toBeNull();
   });
 
-  it("prefers explicit key over heartbeat fallback even on timer wakes", () => {
+  it("prefers explicit key on timer wakes", () => {
     expect(
       deriveTaskKeyWithHeartbeatFallback({ wakeSource: "timer", taskKey: "issue-789" }, null),
     ).toBe("issue-789");

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -4,6 +4,7 @@ import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-lo
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
   applyPersistedExecutionWorkspaceConfig,
+  applyFreshSessionPolicyToWakeContext,
   buildRealizedExecutionWorkspaceFromPersisted,
   buildExplicitResumeSessionOverride,
   deriveTaskKeyWithHeartbeatFallback,
@@ -452,6 +453,41 @@ describe("shouldResetTaskSessionForWake", () => {
         wakeTriggerDetail: "callback",
       }),
     ).toBe(false);
+  });
+});
+
+describe("applyFreshSessionPolicyToWakeContext", () => {
+  it("forces a fresh session and strips resume fields for timer wakes", () => {
+    const result = applyFreshSessionPolicyToWakeContext({
+      wakeSource: "timer",
+      wakeReason: "heartbeat_timer",
+      resumeFromRunId: "run-1",
+      resumeSessionDisplayId: "session-1",
+      resumeSessionParams: {
+        sessionId: "session-1",
+        cwd: "/tmp/workspace",
+      },
+    });
+
+    expect(result).toEqual({
+      wakeSource: "timer",
+      wakeReason: "heartbeat_timer",
+      forceFreshSession: true,
+    });
+  });
+
+  it("preserves resume fields for comment wakes that may continue an active session", () => {
+    const result = applyFreshSessionPolicyToWakeContext({
+      wakeReason: "issue_commented",
+      resumeFromRunId: "run-1",
+      resumeSessionDisplayId: "session-1",
+    });
+
+    expect(result).toEqual({
+      wakeReason: "issue_commented",
+      resumeFromRunId: "run-1",
+      resumeSessionDisplayId: "session-1",
+    });
   });
 });
 

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -14,6 +14,7 @@ import {
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
   resolveRuntimeSessionParamsForWorkspace,
+  resolveTaskSessionWorkspaceFallbackForRun,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForWake,
   type ResolvedWorkspaceForRun,
@@ -124,6 +125,48 @@ describe("resolveRuntimeSessionParamsForWorkspace", () => {
       workspaceId: "workspace-1",
     });
     expect(result.warning).toBeNull();
+  });
+});
+
+describe("resolveTaskSessionWorkspaceFallbackForRun", () => {
+  it("reuses the saved task-session workspace when allowed and present", async () => {
+    const result = await resolveTaskSessionWorkspaceFallbackForRun({
+      agentId: "agent-123",
+      previousSessionParams: {
+        sessionId: "session-1",
+        cwd: process.cwd(),
+        workspaceId: "workspace-1",
+        repoUrl: "https://example.com/repo.git",
+        repoRef: "main",
+      },
+      resolvedProjectId: null,
+      workspaceHints: [],
+      allowTaskSessionWorkspace: true,
+    });
+
+    expect(result.source).toBe("task_session");
+    expect(result.cwd).toBe(process.cwd());
+    expect(result.workspaceId).toBe("workspace-1");
+  });
+
+  it("ignores the saved task-session workspace for timer/fresh-session wakes", async () => {
+    const result = await resolveTaskSessionWorkspaceFallbackForRun({
+      agentId: "agent-123",
+      previousSessionParams: {
+        sessionId: "session-1",
+        cwd: process.cwd(),
+        workspaceId: "workspace-1",
+      },
+      resolvedProjectId: null,
+      workspaceHints: [],
+      allowTaskSessionWorkspace: false,
+    });
+
+    expect(result.source).toBe("agent_home");
+    expect(result.cwd).toBe(resolveDefaultAgentWorkspaceDir("agent-123"));
+    expect(result.warnings).toContain(
+      `Saved session workspace "${process.cwd()}" is being ignored for this run. Using fallback workspace "${resolveDefaultAgentWorkspaceDir("agent-123")}" instead.`,
+    );
   });
 });
 

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -497,6 +497,9 @@ describe("applyFreshSessionPolicyToWakeContext", () => {
     const result = applyFreshSessionPolicyToWakeContext({
       source: "scheduler",
       reason: "interval_elapsed",
+      issueId: "BRAA-755",
+      taskId: "BRAA-755",
+      taskKey: "BRAA-755",
       resumeSessionDisplayId: "session-1",
     });
 
@@ -573,6 +576,38 @@ describe("comment wake batching", () => {
     expect(merged.commentId).toBe("comment-2");
     expect(merged.wakeCommentId).toBe("comment-2");
     expect(merged.paperclipWake).toBeUndefined();
+  });
+
+  it("re-sanitizes coalesced generic timer wakes so stale session and task fields cannot survive the merge", () => {
+    const merged = mergeCoalescedContextSnapshot(
+      {
+        wakeSource: "on_demand",
+        wakeReason: "issue_commented",
+        issueId: "BRAA-755",
+        taskId: "BRAA-755",
+        taskKey: "BRAA-755",
+        resumeFromRunId: "run-1",
+        resumeSessionDisplayId: "session-1",
+        resumeSessionParams: {
+          sessionId: "session-1",
+          cwd: "/tmp/workspace",
+        },
+      },
+      {
+        wakeSource: "timer",
+        wakeReason: "heartbeat_timer",
+        source: "scheduler",
+        reason: "interval_elapsed",
+      },
+    );
+
+    expect(merged).toEqual({
+      wakeSource: "timer",
+      wakeReason: "heartbeat_timer",
+      source: "scheduler",
+      reason: "interval_elapsed",
+      forceFreshSession: true,
+    });
   });
 });
 

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -401,6 +401,23 @@ describe("shouldResetTaskSessionForWake", () => {
     ).toBe(true);
   });
 
+  it("resets session context on legacy scheduler timer wakes", () => {
+    expect(
+      shouldResetTaskSessionForWake({
+        source: "scheduler",
+        reason: "interval_elapsed",
+      }),
+    ).toBe(true);
+  });
+
+  it("resets session context when wakeReason is heartbeat_timer", () => {
+    expect(
+      shouldResetTaskSessionForWake({
+        wakeReason: "heartbeat_timer",
+      }),
+    ).toBe(true);
+  });
+
   it("preserves session context on manual on-demand invokes by default", () => {
     expect(
       shouldResetTaskSessionForWake({
@@ -472,6 +489,20 @@ describe("applyFreshSessionPolicyToWakeContext", () => {
     expect(result).toEqual({
       wakeSource: "timer",
       wakeReason: "heartbeat_timer",
+      forceFreshSession: true,
+    });
+  });
+
+  it("forces a fresh session for legacy scheduler timer wakes", () => {
+    const result = applyFreshSessionPolicyToWakeContext({
+      source: "scheduler",
+      reason: "interval_elapsed",
+      resumeSessionDisplayId: "session-1",
+    });
+
+    expect(result).toEqual({
+      source: "scheduler",
+      reason: "interval_elapsed",
       forceFreshSession: true,
     });
   });

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -13,6 +13,7 @@ import {
   mergeCoalescedContextSnapshot,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
+  resolveExplicitResumeSessionForRun,
   resolveRuntimeSessionParamsForWorkspace,
   resolveTaskSessionWorkspaceFallbackForRun,
   stripWorkspaceRuntimeFromExecutionRunConfig,
@@ -167,6 +168,50 @@ describe("resolveTaskSessionWorkspaceFallbackForRun", () => {
     expect(result.warnings).toContain(
       `Saved session workspace "${process.cwd()}" is being ignored for this run. Using fallback workspace "${resolveDefaultAgentWorkspaceDir("agent-123")}" instead.`,
     );
+  });
+});
+
+describe("resolveExplicitResumeSessionForRun", () => {
+  it("preserves explicit resume session params when resume is allowed", () => {
+    const result = resolveExplicitResumeSessionForRun({
+      contextSnapshot: {
+        resumeSessionDisplayId: "session-1",
+        resumeSessionParams: {
+          sessionId: "session-1",
+          cwd: "/tmp/workspace",
+        },
+      },
+      sessionCodec: codexSessionCodec,
+      allowResume: true,
+    });
+
+    expect(result).toEqual({
+      sessionDisplayId: "session-1",
+      sessionParams: {
+        sessionId: "session-1",
+        cwd: "/tmp/workspace",
+      },
+    });
+  });
+
+  it("drops explicit resume session params for timer/fresh-session wakes", () => {
+    const result = resolveExplicitResumeSessionForRun({
+      contextSnapshot: {
+        resumeFromRunId: "run-1",
+        resumeSessionDisplayId: "session-1",
+        resumeSessionParams: {
+          sessionId: "session-1",
+          cwd: "/tmp/workspace",
+        },
+      },
+      sessionCodec: codexSessionCodec,
+      allowResume: false,
+    });
+
+    expect(result).toEqual({
+      sessionDisplayId: null,
+      sessionParams: null,
+    });
   });
 });
 

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -303,6 +303,15 @@ describe("shouldResetTaskSessionForWake", () => {
     expect(shouldResetTaskSessionForWake({ wakeSource: "timer" })).toBe(true);
   });
 
+  it("resets session context on timer heartbeats even with an explicit task key", () => {
+    expect(
+      shouldResetTaskSessionForWake({
+        wakeSource: "timer",
+        taskKey: "issue-789",
+      }),
+    ).toBe(true);
+  });
+
   it("preserves session context on manual on-demand invokes by default", () => {
     expect(
       shouldResetTaskSessionForWake({

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1404,8 +1404,13 @@ export function shouldResetTaskSessionForWake(
   const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
   if (wakeSource === "timer") return true;
 
+  const legacySource = readNonEmptyString(contextSnapshot?.source);
+  const legacyReason = readNonEmptyString(contextSnapshot?.reason);
+  if (legacySource === "scheduler" && legacyReason === "interval_elapsed") return true;
+
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (
+    wakeReason === "heartbeat_timer" ||
     wakeReason === "issue_assigned" ||
     wakeReason === "execution_review_requested" ||
     wakeReason === "execution_approval_requested" ||
@@ -4739,7 +4744,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     const runtime = await ensureRuntimeState(agent);
-    const context = parseObject(run.contextSnapshot);
+    const context = applyFreshSessionPolicyToWakeContext(parseObject(run.contextSnapshot));
     const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
     const issueId = readNonEmptyString(context.issueId);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1252,6 +1252,77 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
   };
 }
 
+export async function resolveTaskSessionWorkspaceFallbackForRun(input: {
+  agentId: string;
+  previousSessionParams: Record<string, unknown> | null;
+  resolvedProjectId: string | null;
+  workspaceHints: Array<{
+    workspaceId: string | null;
+    cwd: string | null;
+    repoUrl: string | null;
+    repoRef: string | null;
+  }>;
+  allowTaskSessionWorkspace: boolean;
+}): Promise<ResolvedWorkspaceForRun> {
+  const {
+    agentId,
+    previousSessionParams,
+    resolvedProjectId,
+    workspaceHints,
+    allowTaskSessionWorkspace,
+  } = input;
+  const sessionCwd = readNonEmptyString(previousSessionParams?.cwd);
+  if (allowTaskSessionWorkspace && sessionCwd) {
+    const sessionCwdExists = await fs
+      .stat(sessionCwd)
+      .then((stats) => stats.isDirectory())
+      .catch(() => false);
+    if (sessionCwdExists) {
+      return {
+        cwd: sessionCwd,
+        source: "task_session" as const,
+        projectId: resolvedProjectId,
+        workspaceId: readNonEmptyString(previousSessionParams?.workspaceId),
+        repoUrl: readNonEmptyString(previousSessionParams?.repoUrl),
+        repoRef: readNonEmptyString(previousSessionParams?.repoRef),
+        workspaceHints,
+        warnings: [],
+      };
+    }
+  }
+
+  const cwd = resolveDefaultAgentWorkspaceDir(agentId);
+  await fs.mkdir(cwd, { recursive: true });
+  const warnings: string[] = [];
+  if (sessionCwd && allowTaskSessionWorkspace) {
+    warnings.push(
+      `Saved session workspace "${sessionCwd}" is not available. Using fallback workspace "${cwd}" for this run.`,
+    );
+  } else if (sessionCwd) {
+    warnings.push(
+      `Saved session workspace "${sessionCwd}" is being ignored for this run. Using fallback workspace "${cwd}" instead.`,
+    );
+  } else if (resolvedProjectId) {
+    warnings.push(
+      `No project workspace directory is currently available for this issue. Using fallback workspace "${cwd}" for this run.`,
+    );
+  } else {
+    warnings.push(
+      `No project or prior session workspace was available. Using fallback workspace "${cwd}" for this run.`,
+    );
+  }
+  return {
+    cwd,
+    source: "agent_home" as const,
+    projectId: resolvedProjectId,
+    workspaceId: null,
+    repoUrl: null,
+    repoRef: null,
+    workspaceHints,
+    warnings,
+  };
+}
+
 function parseIssueAssigneeAdapterOverrides(
   raw: unknown,
 ): ParsedIssueAssigneeAdapterOverrides | null {
@@ -2356,7 +2427,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     agent: typeof agents.$inferSelect,
     context: Record<string, unknown>,
     previousSessionParams: Record<string, unknown> | null,
-    opts?: { useProjectWorkspace?: boolean | null },
+    opts?: {
+      useProjectWorkspace?: boolean | null;
+      allowTaskSessionWorkspace?: boolean | null;
+    },
   ): Promise<ResolvedWorkspaceForRun> {
     const issueId = readNonEmptyString(context.issueId);
     const contextProjectId = readNonEmptyString(context.projectId);
@@ -2507,52 +2581,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    const sessionCwd = readNonEmptyString(previousSessionParams?.cwd);
-    if (sessionCwd) {
-      const sessionCwdExists = await fs
-        .stat(sessionCwd)
-        .then((stats) => stats.isDirectory())
-        .catch(() => false);
-      if (sessionCwdExists) {
-        return {
-          cwd: sessionCwd,
-          source: "task_session" as const,
-          projectId: resolvedProjectId,
-          workspaceId: readNonEmptyString(previousSessionParams?.workspaceId),
-          repoUrl: readNonEmptyString(previousSessionParams?.repoUrl),
-          repoRef: readNonEmptyString(previousSessionParams?.repoRef),
-          workspaceHints,
-          warnings: [],
-        };
-      }
-    }
-
-    const cwd = resolveDefaultAgentWorkspaceDir(agent.id);
-    await fs.mkdir(cwd, { recursive: true });
-    const warnings: string[] = [];
-    if (sessionCwd) {
-      warnings.push(
-        `Saved session workspace "${sessionCwd}" is not available. Using fallback workspace "${cwd}" for this run.`,
-      );
-    } else if (resolvedProjectId) {
-      warnings.push(
-        `No project workspace directory is currently available for this issue. Using fallback workspace "${cwd}" for this run.`,
-      );
-    } else {
-      warnings.push(
-        `No project or prior session workspace was available. Using fallback workspace "${cwd}" for this run.`,
-      );
-    }
-    return {
-      cwd,
-      source: "agent_home" as const,
-      projectId: resolvedProjectId,
-      workspaceId: null,
-      repoUrl: null,
-      repoRef: null,
+    return resolveTaskSessionWorkspaceFallbackForRun({
+      agentId: agent.id,
+      previousSessionParams,
+      resolvedProjectId,
       workspaceHints,
-      warnings,
-    };
+      allowTaskSessionWorkspace: opts?.allowTaskSessionWorkspace !== false,
+    });
   }
 
   async function upsertTaskSession(input: {
@@ -4760,7 +4795,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       agent,
       context,
       previousSessionParams,
-      { useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default" },
+      {
+        useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default",
+        allowTaskSessionWorkspace: !resetTaskSession,
+      },
     );
     const issueRef = issueContext
       ? {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1252,6 +1252,33 @@ export function resolveRuntimeSessionParamsForWorkspace(input: {
   };
 }
 
+export function resolveExplicitResumeSessionForRun(input: {
+  contextSnapshot: Record<string, unknown> | null | undefined;
+  sessionCodec: AdapterSessionCodec;
+  allowResume: boolean;
+}) {
+  if (!input.allowResume) {
+    return {
+      sessionParams: null as Record<string, unknown> | null,
+      sessionDisplayId: null as string | null,
+    };
+  }
+
+  const sessionParams = normalizeSessionParams(
+    input.sessionCodec.deserialize(parseObject(input.contextSnapshot?.resumeSessionParams)),
+  );
+  const sessionDisplayId = truncateDisplayId(
+    readNonEmptyString(input.contextSnapshot?.resumeSessionDisplayId) ??
+      (input.sessionCodec.getDisplayId ? input.sessionCodec.getDisplayId(sessionParams) : null) ??
+      readNonEmptyString(sessionParams?.sessionId),
+  );
+
+  return {
+    sessionParams,
+    sessionDisplayId,
+  };
+}
+
 export async function resolveTaskSessionWorkspaceFallbackForRun(input: {
   agentId: string;
   previousSessionParams: Record<string, unknown> | null;
@@ -4773,14 +4800,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const resetTaskSession = shouldResetTaskSessionForWake(context);
     const sessionResetReason = describeSessionResetReason(context);
     const taskSessionForRun = resetTaskSession ? null : taskSession;
-    const explicitResumeSessionParams = normalizeSessionParams(
-      sessionCodec.deserialize(parseObject(context.resumeSessionParams)),
-    );
-    const explicitResumeSessionDisplayId = truncateDisplayId(
-      readNonEmptyString(context.resumeSessionDisplayId) ??
-        (sessionCodec.getDisplayId ? sessionCodec.getDisplayId(explicitResumeSessionParams) : null) ??
-        readNonEmptyString(explicitResumeSessionParams?.sessionId),
-    );
+    const explicitResumeSession = resolveExplicitResumeSessionForRun({
+      contextSnapshot: context,
+      sessionCodec,
+      allowResume: !resetTaskSession,
+    });
+    const explicitResumeSessionParams = explicitResumeSession.sessionParams;
+    const explicitResumeSessionDisplayId = explicitResumeSession.sessionDisplayId;
+    if (resetTaskSession) {
+      delete context.resumeFromRunId;
+      delete context.resumeSessionDisplayId;
+      delete context.resumeSessionParams;
+    }
     const previousSessionParams =
       explicitResumeSessionParams ??
       (explicitResumeSessionDisplayId ? { sessionId: explicitResumeSessionDisplayId } : null) ??

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1257,7 +1257,7 @@ export async function resolveTaskSessionWorkspaceFallbackForRun(input: {
   previousSessionParams: Record<string, unknown> | null;
   resolvedProjectId: string | null;
   workspaceHints: Array<{
-    workspaceId: string | null;
+    workspaceId: string;
     cwd: string | null;
     repoUrl: string | null;
     repoRef: string | null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1416,6 +1416,21 @@ export function shouldResetTaskSessionForWake(
   return false;
 }
 
+export function applyFreshSessionPolicyToWakeContext(
+  contextSnapshot: Record<string, unknown> | null | undefined,
+) {
+  const nextContext = { ...(contextSnapshot ?? {}) };
+  if (!shouldResetTaskSessionForWake(nextContext)) {
+    return nextContext;
+  }
+
+  nextContext.forceFreshSession = true;
+  delete nextContext.resumeFromRunId;
+  delete nextContext.resumeSessionDisplayId;
+  delete nextContext.resumeSessionParams;
+  return nextContext;
+}
+
 function shouldRequireIssueCommentForWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
@@ -6387,31 +6402,34 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       triggerDetail,
       payload,
     });
-    let issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload;
+    const wakeContextSnapshot = applyFreshSessionPolicyToWakeContext(enrichedContextSnapshot);
+    let issueId = readNonEmptyString(wakeContextSnapshot.issueId) ?? issueIdFromPayload;
 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
-    const explicitResumeSession = await resolveExplicitResumeSessionOverride(agent, payload, taskKey);
+    const explicitResumeSession = shouldResetTaskSessionForWake(wakeContextSnapshot)
+      ? null
+      : await resolveExplicitResumeSessionOverride(agent, payload, taskKey);
     if (explicitResumeSession) {
-      enrichedContextSnapshot.resumeFromRunId = explicitResumeSession.resumeFromRunId;
-      enrichedContextSnapshot.resumeSessionDisplayId = explicitResumeSession.sessionDisplayId;
-      enrichedContextSnapshot.resumeSessionParams = explicitResumeSession.sessionParams;
-      if (!readNonEmptyString(enrichedContextSnapshot.issueId) && explicitResumeSession.issueId) {
-        enrichedContextSnapshot.issueId = explicitResumeSession.issueId;
+      wakeContextSnapshot.resumeFromRunId = explicitResumeSession.resumeFromRunId;
+      wakeContextSnapshot.resumeSessionDisplayId = explicitResumeSession.sessionDisplayId;
+      wakeContextSnapshot.resumeSessionParams = explicitResumeSession.sessionParams;
+      if (!readNonEmptyString(wakeContextSnapshot.issueId) && explicitResumeSession.issueId) {
+        wakeContextSnapshot.issueId = explicitResumeSession.issueId;
       }
-      if (!readNonEmptyString(enrichedContextSnapshot.taskId) && explicitResumeSession.taskId) {
-        enrichedContextSnapshot.taskId = explicitResumeSession.taskId;
+      if (!readNonEmptyString(wakeContextSnapshot.taskId) && explicitResumeSession.taskId) {
+        wakeContextSnapshot.taskId = explicitResumeSession.taskId;
       }
-      if (!readNonEmptyString(enrichedContextSnapshot.taskKey) && explicitResumeSession.taskKey) {
-        enrichedContextSnapshot.taskKey = explicitResumeSession.taskKey;
+      if (!readNonEmptyString(wakeContextSnapshot.taskKey) && explicitResumeSession.taskKey) {
+        wakeContextSnapshot.taskKey = explicitResumeSession.taskKey;
       }
-      issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueId;
+      issueId = readNonEmptyString(wakeContextSnapshot.issueId) ?? issueId;
     }
-    const effectiveTaskKey = readNonEmptyString(enrichedContextSnapshot.taskKey) ?? taskKey;
+    const effectiveTaskKey = readNonEmptyString(wakeContextSnapshot.taskKey) ?? taskKey;
     const sessionBefore =
       explicitResumeSession?.sessionDisplayId ??
       await resolveSessionBeforeForWakeup(agent, effectiveTaskKey);
-    const continuationAttempt = readContinuationAttempt(enrichedContextSnapshot.livenessContinuationAttempt);
+    const continuationAttempt = readContinuationAttempt(wakeContextSnapshot.livenessContinuationAttempt);
 
     const writeSkippedRequest = async (skipReason: string) => {
       await db.insert(agentWakeupRequests).values({
@@ -6429,7 +6447,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
     };
 
-    let projectId = readNonEmptyString(enrichedContextSnapshot.projectId);
+    let projectId = readNonEmptyString(wakeContextSnapshot.projectId);
     if (!projectId && issueId) {
       projectId = await db
         .select({ projectId: issues.projectId })
@@ -7028,7 +7046,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         triggerDetail,
         status: "queued",
         wakeupRequestId: wakeupRequest.id,
-        contextSnapshot: enrichedContextSnapshot,
+        contextSnapshot: wakeContextSnapshot,
         sessionIdBefore: sessionBefore,
         continuationAttempt,
       })

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1276,8 +1276,6 @@ function parseIssueAssigneeAdapterOverrides(
  * and benefit from robust session resume, instead of relying solely on the
  * simpler `agentRuntimeState.sessionId` fallback.
  */
-const HEARTBEAT_TASK_KEY = "__heartbeat__";
-
 function deriveTaskKey(
   contextSnapshot: Record<string, unknown> | null | undefined,
   payload: Record<string, unknown> | null | undefined,
@@ -1293,32 +1291,20 @@ function deriveTaskKey(
   );
 }
 
-/**
- * Extended task key derivation that falls back to a stable synthetic key
- * for timer/heartbeat wakes. This ensures timer wakes can resume their
- * previous session via `agentTaskSessions` instead of starting fresh.
- *
- * The synthetic key is only used when:
- * - No explicit task/issue key exists in the context
- * - The wake source is "timer" (scheduled heartbeat)
- */
 export function deriveTaskKeyWithHeartbeatFallback(
   contextSnapshot: Record<string, unknown> | null | undefined,
   payload: Record<string, unknown> | null | undefined,
 ) {
-  const explicit = deriveTaskKey(contextSnapshot, payload);
-  if (explicit) return explicit;
-
-  const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
-  if (wakeSource === "timer") return HEARTBEAT_TASK_KEY;
-
-  return null;
+  return deriveTaskKey(contextSnapshot, payload);
 }
 
 export function shouldResetTaskSessionForWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
   if (contextSnapshot?.forceFreshSession === true) return true;
+
+  const wakeSource = readNonEmptyString(contextSnapshot?.wakeSource);
+  if (wakeSource === "timer") return true;
 
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6547,8 +6547,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           return null;
         }
 
-        enrichedContextSnapshot.treeHoldInteraction = true;
-        enrichedContextSnapshot.activeTreeHold = {
+        wakeContextSnapshot.treeHoldInteraction = true;
+        wakeContextSnapshot.activeTreeHold = {
           holdId: activePauseHold.holdId,
           rootIssueId: activePauseHold.rootIssueId,
           mode: activePauseHold.mode,
@@ -6768,13 +6768,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const blockedInteractionWake =
           dependencyReadiness &&
           !dependencyReadiness.isDependencyReady &&
-          allowsIssueInteractionWake(enrichedContextSnapshot);
+          allowsIssueInteractionWake(wakeContextSnapshot);
 
         if (blockedInteractionWake) {
-          enrichedContextSnapshot.dependencyBlockedInteraction = true;
-          enrichedContextSnapshot.unresolvedBlockerIssueIds = dependencyReadiness.unresolvedBlockerIssueIds;
-          enrichedContextSnapshot.unresolvedBlockerCount = dependencyReadiness.unresolvedBlockerCount;
-          enrichedContextSnapshot.unresolvedBlockerSummaries = await listUnresolvedBlockerSummaries(
+          wakeContextSnapshot.dependencyBlockedInteraction = true;
+          wakeContextSnapshot.unresolvedBlockerIssueIds = dependencyReadiness.unresolvedBlockerIssueIds;
+          wakeContextSnapshot.unresolvedBlockerCount = dependencyReadiness.unresolvedBlockerCount;
+          wakeContextSnapshot.unresolvedBlockerSummaries = await listUnresolvedBlockerSummaries(
             tx,
             issue.companyId,
             issue.id,
@@ -6815,7 +6815,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           const isSameExecutionAgent =
             Boolean(executionAgentNameKey) && executionAgentNameKey === agentNameKey;
           const shouldQueueFollowupForRunningWake =
-            shouldQueueFollowupForRunningIssueWake({ contextSnapshot: enrichedContextSnapshot, wakeCommentId }) &&
+            shouldQueueFollowupForRunningIssueWake({ contextSnapshot: wakeContextSnapshot, wakeCommentId }) &&
             activeExecutionRun.status === "running" &&
             isSameExecutionAgent;
 
@@ -6856,7 +6856,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           const deferredPayload = {
             ...(payload ?? {}),
             issueId,
-            [DEFERRED_WAKE_CONTEXT_KEY]: enrichedContextSnapshot,
+            [DEFERRED_WAKE_CONTEXT_KEY]: wakeContextSnapshot,
           };
 
           const existingDeferred = await tx
@@ -7005,7 +7005,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const shouldQueueFollowupForRunningWake =
       Boolean(sameScopeRunningRun) &&
       !sameScopeQueuedRun &&
-      shouldQueueFollowupForRunningIssueWake({ contextSnapshot: enrichedContextSnapshot, wakeCommentId });
+      shouldQueueFollowupForRunningIssueWake({ contextSnapshot: wakeContextSnapshot, wakeCommentId });
 
     const coalescedTargetRun =
       sameScopeQueuedRun ??

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1271,10 +1271,9 @@ function parseIssueAssigneeAdapterOverrides(
 }
 
 /**
- * Synthetic task key for timer/heartbeat wakes that have no issue context.
- * This allows timer wakes to participate in the `agentTaskSessions` system
- * and benefit from robust session resume, instead of relying solely on the
- * simpler `agentRuntimeState.sessionId` fallback.
+ * Derives the issue/task key that scopes `agentTaskSessions` for a wake.
+ * Timer wakes deliberately avoid inventing a synthetic key so scheduler-driven
+ * runs can force a fresh session unless they carry an explicit task binding.
  */
 function deriveTaskKey(
   contextSnapshot: Record<string, unknown> | null | undefined,
@@ -1295,6 +1294,7 @@ export function deriveTaskKeyWithHeartbeatFallback(
   contextSnapshot: Record<string, unknown> | null | undefined,
   payload: Record<string, unknown> | null | undefined,
 ) {
+  // Keep the public helper name stable for tests and downstream callers.
   return deriveTaskKey(contextSnapshot, payload);
 }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1429,10 +1429,27 @@ export function applyFreshSessionPolicyToWakeContext(
     return nextContext;
   }
 
+  const isHeartbeatTimerWake =
+    readNonEmptyString(nextContext.wakeSource) === "timer" ||
+    readNonEmptyString(nextContext.wakeReason) === "heartbeat_timer" ||
+    (
+      readNonEmptyString(nextContext.source) === "scheduler" &&
+      readNonEmptyString(nextContext.reason) === "interval_elapsed"
+    );
+
   nextContext.forceFreshSession = true;
   delete nextContext.resumeFromRunId;
   delete nextContext.resumeSessionDisplayId;
   delete nextContext.resumeSessionParams;
+  delete nextContext[PAPERCLIP_WAKE_PAYLOAD_KEY];
+  if (isHeartbeatTimerWake) {
+    delete nextContext.issueId;
+    delete nextContext.taskId;
+    delete nextContext.taskKey;
+    delete nextContext.commentId;
+    delete nextContext.wakeCommentId;
+    delete nextContext[WAKE_COMMENT_IDS_KEY];
+  }
   return nextContext;
 }
 
@@ -1681,7 +1698,7 @@ export function mergeCoalescedContextSnapshot(
     // regenerate any structured payload from those ids.
     delete merged[PAPERCLIP_WAKE_PAYLOAD_KEY];
   }
-  return merged;
+  return applyFreshSessionPolicyToWakeContext(merged);
 }
 
 async function buildPaperclipWakePayload(input: {
@@ -6805,7 +6822,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           if (isSameExecutionAgent && !shouldQueueFollowupForRunningWake) {
             const mergedContextSnapshot = mergeCoalescedContextSnapshot(
               activeExecutionRun.contextSnapshot,
-              enrichedContextSnapshot,
+              wakeContextSnapshot,
             );
             const mergedRun = await tx
               .update(heartbeatRuns)
@@ -6862,7 +6879,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             const existingDeferredContext = parseObject(existingDeferredPayload[DEFERRED_WAKE_CONTEXT_KEY]);
             const mergedDeferredContext = mergeCoalescedContextSnapshot(
               existingDeferredContext,
-              enrichedContextSnapshot,
+              wakeContextSnapshot,
             );
             const mergedDeferredPayload = {
               ...existingDeferredPayload,
@@ -6925,7 +6942,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             triggerDetail,
             status: "queued",
             wakeupRequestId: wakeupRequest.id,
-            contextSnapshot: enrichedContextSnapshot,
+            contextSnapshot: wakeContextSnapshot,
             sessionIdBefore: sessionBefore,
             continuationAttempt,
           })
@@ -6998,7 +7015,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (coalescedTargetRun) {
       const mergedContextSnapshot = mergeCoalescedContextSnapshot(
         coalescedTargetRun.contextSnapshot,
-        contextSnapshot,
+        wakeContextSnapshot,
       );
       const mergedRun = await db
         .update(heartbeatRuns)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4833,6 +4833,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       delete context.resumeSessionParams;
     }
     const previousSessionParams =
+      resetTaskSession
+        ? null
+        :
       explicitResumeSessionParams ??
       (explicitResumeSessionDisplayId ? { sessionId: explicitResumeSessionDisplayId } : null) ??
       normalizeSessionParams(sessionCodec.deserialize(taskSessionForRun?.sessionParamsJson ?? null));


### PR DESCRIPTION
## Summary
- stop timer/fresh-session wakes from realizing a saved task-session workspace
- ignore stale previous session cwd when a wake requires a fresh session
- add a regression test for the exact task-session fallback branch

## Verification
- pnpm exec vitest run server/src/__tests__/heartbeat-workspace-session.test.ts
