### PR TITLE
Fix project issue sort order

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -356,6 +356,97 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(result.map((issue) => issue.id)).toEqual([commentMatchId, descriptionMatchId]);
   });
 
+  it("orders project issues by newest creation time with issue number as a tie breaker", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const otherProjectId = randomUUID();
+    const olderHighPriorityIssueId = randomUUID();
+    const sameCreatedLowerNumberIssueId = randomUUID();
+    const sameCreatedHigherNumberIssueId = randomUUID();
+    const otherProjectIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(projects).values([
+      {
+        id: projectId,
+        companyId,
+        name: "Target project",
+        status: "in_progress",
+      },
+      {
+        id: otherProjectId,
+        companyId,
+        name: "Other project",
+        status: "in_progress",
+      },
+    ]);
+
+    await db.insert(issues).values([
+      {
+        id: olderHighPriorityIssueId,
+        companyId,
+        projectId,
+        title: "Older high priority issue",
+        status: "todo",
+        priority: "critical",
+        issueNumber: 41,
+        identifier: "T-41",
+        createdAt: new Date("2026-03-26T09:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T13:00:00.000Z"),
+      },
+      {
+        id: sameCreatedLowerNumberIssueId,
+        companyId,
+        projectId,
+        title: "Same created lower issue number",
+        status: "todo",
+        priority: "low",
+        issueNumber: 42,
+        identifier: "T-42",
+        createdAt: new Date("2026-03-26T10:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T10:00:00.000Z"),
+      },
+      {
+        id: sameCreatedHigherNumberIssueId,
+        companyId,
+        projectId,
+        title: "Same created higher issue number",
+        status: "todo",
+        priority: "low",
+        issueNumber: 43,
+        identifier: "T-43",
+        createdAt: new Date("2026-03-26T10:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T09:00:00.000Z"),
+      },
+      {
+        id: otherProjectIssueId,
+        companyId,
+        projectId: otherProjectId,
+        title: "Other project issue",
+        status: "todo",
+        priority: "low",
+        issueNumber: 44,
+        identifier: "T-44",
+        createdAt: new Date("2026-03-26T11:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T11:00:00.000Z"),
+      },
+    ]);
+
+    const result = await svc.list(companyId, { projectId });
+
+    expect(result.map((issue) => issue.id)).toEqual([
+      sameCreatedHigherNumberIssueId,
+      sameCreatedLowerNumberIssueId,
+      olderHighPriorityIssueId,
+    ]);
+  });
+
   it("filters issue lists to the full descendant tree for a root issue", async () => {
     const companyId = randomUUID();
     const rootId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2257,17 +2257,28 @@ export function issueService(db: Db) {
         END
       `;
       const canonicalLastActivityAt = issueCanonicalLastActivityAtExpr(companyId);
+      const defaultOrderBy = filters?.projectId
+        ? [desc(issues.createdAt), desc(issues.issueNumber)]
+        : [
+            asc(priorityOrder),
+            desc(canonicalLastActivityAt),
+            desc(issues.updatedAt),
+            desc(issues.id),
+          ];
+      const orderBy = hasSearch
+        ? [
+            asc(searchOrder),
+            asc(priorityOrder),
+            desc(canonicalLastActivityAt),
+            desc(issues.updatedAt),
+            desc(issues.id),
+          ]
+        : defaultOrderBy;
       const baseQuery = db
         .select(issueListSelect)
         .from(issues)
         .where(and(...conditions))
-        .orderBy(
-          hasSearch ? asc(searchOrder) : asc(priorityOrder),
-          asc(priorityOrder),
-          desc(canonicalLastActivityAt),
-          desc(issues.updatedAt),
-          desc(issues.id),
-        );
+        .orderBy(...orderBy);
       const pageQuery = offset > 0
         ? (limit === undefined ? baseQuery.offset(offset) : baseQuery.limit(limit).offset(offset))
         : (limit === undefined ? baseQuery : baseQuery.limit(limit));

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -120,9 +120,9 @@ export type IssueViewState = IssueFilterState & {
   collapsedParents: string[];
 };
 
-const defaultViewState: IssueViewState = {
+export const defaultViewState: IssueViewState = {
   ...defaultIssueFilterState,
-  sortField: "updated",
+  sortField: "created",
   sortDir: "desc",
   groupBy: "none",
   viewMode: "list",
@@ -214,7 +214,14 @@ function saveIssueColumns(key: string, columns: InboxIssueColumn[]) {
   }
 }
 
-function sortIssues(issues: Issue[], state: IssueViewState): Issue[] {
+function tieBreakIssues(a: Issue, b: Issue): number {
+  if (a.issueNumber != null && b.issueNumber != null) return b.issueNumber - a.issueNumber;
+  if (a.issueNumber != null) return -1;
+  if (b.issueNumber != null) return 1;
+  return (b.identifier ?? "").localeCompare(a.identifier ?? "");
+}
+
+export function sortIssues(issues: Issue[], state: IssueViewState): Issue[] {
   if (state.sortField === "workflow") {
     const ordered = workflowSort(issues);
     return state.sortDir === "desc" ? [...ordered].reverse() : ordered;
@@ -222,20 +229,28 @@ function sortIssues(issues: Issue[], state: IssueViewState): Issue[] {
   const sorted = [...issues];
   const dir = state.sortDir === "asc" ? 1 : -1;
   sorted.sort((a, b) => {
+    let result = 0;
     switch (state.sortField) {
       case "status":
-        return dir * (issueStatusOrder.indexOf(a.status) - issueStatusOrder.indexOf(b.status));
+        result = issueStatusOrder.indexOf(a.status) - issueStatusOrder.indexOf(b.status);
+        break;
       case "priority":
-        return dir * (issuePriorityOrder.indexOf(a.priority) - issuePriorityOrder.indexOf(b.priority));
+        result = issuePriorityOrder.indexOf(a.priority) - issuePriorityOrder.indexOf(b.priority);
+        break;
       case "title":
-        return dir * a.title.localeCompare(b.title);
+        result = a.title.localeCompare(b.title);
+        break;
       case "created":
-        return dir * (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+        result = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+        break;
       case "updated":
-        return dir * (new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime());
+        result = new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();
+        break;
       default:
-        return 0;
+        result = 0;
     }
+    if (result !== 0) return dir * result;
+    return tieBreakIssues(a, b);
   });
   return sorted;
 }


### PR DESCRIPTION
## Summary
- order project-scoped issue API results by newest creation time with issue number as a deterministic tie breaker
- make the issue list default sort newest-created first and use the same issue-number tie breaker locally
- add a regression test for project issue ordering

## Verification
- pnpm --filter @paperclipai/ui exec tsc --noEmit
- pnpm --filter @paperclipai/server typecheck
- pnpm exec vitest run --project @paperclipai/server server/src/__tests__/issues-service.test.ts --pool=forks --poolOptions.forks.isolate=true

Note: `pnpm test:run -- issues-service.test` currently fails before running tests because scripts/run-vitest-stable.mjs rejects unknown positional arguments.