### PR TITLE
[LOX-506] Terminal routine_execution reopen requires explicit resume

### DIFF
--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -282,6 +282,8 @@ export type IssueExecutionWorkspaceSettings = z.infer<typeof issueExecutionWorks
 export const checkoutIssueSchema = z.object({
   agentId: z.string().uuid(),
   expectedStatuses: z.array(z.enum(ISSUE_STATUSES)).nonempty(),
+  /** Required to reopen a terminal routine_execution issue via checkout */
+  resume: z.boolean().optional(),
 });
 
 export type CheckoutIssue = z.infer<typeof checkoutIssueSchema>;

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eq, sql } from "drizzle-orm";
+import { asc, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -465,6 +465,76 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(wakeup?.status).toBe("skipped");
     expect(mockAdapterExecute).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["issue_children_completed"],
+    ["issue_reopened_via_comment"],
+    ["issue_continuation_needed"],
+  ] as const)(
+    "cancels queued runs for routine_execution done issues on synthetic continuation wake %s without resume intent",
+    async (wakeReason) => {
+      const { companyId, agentId } = await seedCompanyAndAgent();
+      const issueId = randomUUID();
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Routine synthetic wake",
+        status: "done",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        originKind: "routine_execution",
+        originId: randomUUID(),
+      });
+
+      const { runId, wakeupRequestId } = await seedQueuedRun({
+        companyId,
+        agentId,
+        issueId,
+        wakeReason,
+        contextExtras: {
+          wakeCommentId: randomUUID(),
+        },
+      });
+
+      await heartbeat.resumeQueuedRuns();
+
+      await waitForCondition(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "cancelled";
+      });
+
+      const [run, events, wakeup] = await Promise.all([
+        db
+          .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null),
+        db
+          .select({ eventType: heartbeatRunEvents.eventType, payload: heartbeatRunEvents.payload })
+          .from(heartbeatRunEvents)
+          .where(eq(heartbeatRunEvents.runId, runId))
+          .orderBy(asc(heartbeatRunEvents.seq)),
+        db
+          .select({ status: agentWakeupRequests.status })
+          .from(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.id, wakeupRequestId))
+          .then((rows) => rows[0] ?? null),
+      ]);
+
+      expect(run?.status).toBe("cancelled");
+      expect(run?.errorCode).toBe("routine_terminal_requires_resume_intent");
+      expect(wakeup?.status).toBe("skipped");
+      expect(mockAdapterExecute).not.toHaveBeenCalled();
+      const staleLifecycle = events.find((row) => row.eventType === "lifecycle");
+      const detail = staleLifecycle?.payload as Record<string, unknown> | undefined;
+      expect(detail?.routineTerminalSyntheticContinuationWake).toBe(true);
+      expect(detail?.routineTerminalGuardOutcome).toBe("rejected_synthetic_continuation_without_resume");
+    },
+  );
 
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -412,6 +412,60 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(countExecuteCallsForRun(runId)).toBe(0);
   });
 
+  it("cancels queued runs for routine_execution done issues when the wake only references a comment (no resume intent)", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Routine already complete",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      originKind: "routine_execution",
+      originId: randomUUID(),
+    });
+
+    const { runId, wakeupRequestId } = await seedQueuedRun({
+      companyId,
+      agentId,
+      issueId,
+      wakeReason: "issue_commented",
+      contextExtras: {
+        wakeCommentId: randomUUID(),
+      },
+    });
+
+    await heartbeat.resumeQueuedRuns();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "cancelled";
+    });
+
+    const [run, wakeup] = await Promise.all([
+      db
+        .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ status: agentWakeupRequests.status })
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("routine_terminal_requires_resume_intent");
+    expect(wakeup?.status).toBe("skipped");
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+  });
+
   it("cancels queued max-turn continuations when the issue is no longer in_progress before the run starts", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2004,6 +2004,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRuns);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -2254,6 +2255,62 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await expect(
       svc.checkout(blockedId, assigneeAgentId, ["todo", "blocked"], null),
     ).rejects.toMatchObject({ status: 422 });
+  });
+
+  it("rejects checkout of a terminal routine_execution issue without resume: true", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const runId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: assigneeAgentId,
+      status: "failed",
+      invocationSource: "manual",
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Weekly routine output",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId,
+      originKind: "routine_execution",
+    });
+
+    await expect(
+      svc.checkout(issueId, assigneeAgentId, ["todo", "blocked", "done", "in_review"], runId),
+    ).rejects.toMatchObject({ status: 422 });
+
+    const checkedOut = await svc.checkout(
+      issueId,
+      assigneeAgentId,
+      ["todo", "blocked", "done", "in_review"],
+      runId,
+      true,
+    );
+    expect(checkedOut?.status).toBe("in_progress");
+    expect(checkedOut?.checkoutRunId).toBe(runId);
   });
 
   it("wakes parents only when all direct children are terminal", async () => {

--- a/server/src/lib/routine-terminal-continuation.test.ts
+++ b/server/src/lib/routine-terminal-continuation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyWakeReasonFromContext,
+  isRoutineTerminalSyntheticContinuationWake,
+  resumeIntentFromIssueWakeContext,
+} from "./routine-terminal-continuation.js";
+
+describe("routine-terminal-continuation helpers", () => {
+  it("resumeIntentFromIssueWakeContext honors structured resume / resumeIntent flags", () => {
+    expect(resumeIntentFromIssueWakeContext({ resume: true })).toBe(true);
+    expect(resumeIntentFromIssueWakeContext({ resumeIntent: true })).toBe(true);
+    expect(resumeIntentFromIssueWakeContext({ followUpRequested: true })).toBe(true);
+    expect(resumeIntentFromIssueWakeContext({ wakeReason: "issue_commented" })).toBe(false);
+  });
+
+  it("classifyWakeReasonFromContext prefers wakeReason then reason", () => {
+    expect(classifyWakeReasonFromContext({ wakeReason: "issue_children_completed", reason: "ignored" })).toBe(
+      "issue_children_completed",
+    );
+    expect(classifyWakeReasonFromContext({ reason: "issue_continuation_needed" })).toBe("issue_continuation_needed");
+  });
+
+  it("isRoutineTerminalSyntheticContinuationWake enumerates continuation envelope reasons", () => {
+    expect(isRoutineTerminalSyntheticContinuationWake("issue_children_completed")).toBe(true);
+    expect(isRoutineTerminalSyntheticContinuationWake("issue_reopened_via_comment")).toBe(true);
+    expect(isRoutineTerminalSyntheticContinuationWake("issue_continuation_needed")).toBe(true);
+    expect(isRoutineTerminalSyntheticContinuationWake("issue_assigned")).toBe(false);
+  });
+});

--- a/server/src/lib/routine-terminal-continuation.ts
+++ b/server/src/lib/routine-terminal-continuation.ts
@@ -1,0 +1,32 @@
+/**
+ * Central definitions for guarding routine_execution issues in terminal statuses
+ * against synthetic continuation wakes (children completed, comment-driven reopen envelopes,
+ * recovery continuation) without structured resume intent.
+ */
+
+/** Wake envelope reasons tied to automation/continuation paths that must never reopen routine terminal output casually. */
+export const ROUTINE_TERMINAL_SYNTHETIC_CONTINUATION_WAKE_REASONS: ReadonlySet<string> = new Set([
+  "issue_children_completed",
+  "issue_reopened_via_comment",
+  "issue_continuation_needed",
+]);
+
+function readTrimmedString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function classifyWakeReasonFromContext(context: Record<string, unknown>): string | null {
+  return readTrimmedString(context, "wakeReason") ?? readTrimmedString(context, "reason") ?? null;
+}
+
+/** Matches PATCH/POST semantics: structured `resume: true` stamps resumeIntent/followUpRequested on snapshots. */
+export function resumeIntentFromIssueWakeContext(context: Record<string, unknown>): boolean {
+  return (
+    context.resume === true || context.resumeIntent === true || context.followUpRequested === true
+  );
+}
+
+export function isRoutineTerminalSyntheticContinuationWake(wakeReason: string | null | undefined): boolean {
+  return typeof wakeReason === "string" && ROUTINE_TERMINAL_SYNTHETIC_CONTINUATION_WAKE_REASONS.has(wakeReason);
+}

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -559,7 +559,10 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   assigneeAgentId: string | null | undefined;
   actorType: "agent" | "user";
   actorId: string;
+  originKind?: string | null | undefined;
 }) {
+  // Routine output must not be revived by a plain human comment; use resume: true.
+  if (input.originKind === "routine_execution" && isClosedIssueStatus(input.issueStatus)) return false;
   // Only human comments should implicitly reopen finished work.
   // Agent-authored comments remain communicative unless reopen was explicit.
   if (input.actorType !== "user") return false;
@@ -2577,6 +2580,7 @@ export function issueRoutes(
           assigneeAgentId: requestedAssigneeAgentId,
           actorType: actor.actorType,
           actorId: actor.actorId,
+          originKind: existing.originKind,
         }));
     const updateReferenceSummaryBefore = titleOrDescriptionChanged
       ? await issueReferencesSvc.listIssueReferenceSummary(existing.id)
@@ -2588,6 +2592,24 @@ export function issueRoutes(
     if (resumeRequested === true && isBlocked && hasUnresolvedFirstClassBlockers) {
       res.status(409).json({ error: "Issue follow-up blocked by unresolved blockers" });
       return;
+    }
+    const routineTerminal = existing.originKind === "routine_execution" && isClosedIssueStatus(existing.status);
+    if (routineTerminal && resumeRequested !== true) {
+      const patchedStatus = typeof updateFields.status === "string" ? updateFields.status : undefined;
+      const leavesTerminalViaExplicitStatus =
+        patchedStatus !== undefined && !isClosedIssueStatus(patchedStatus);
+      const leavesTerminalViaCommentOrReopen =
+        reopenRequested === true ||
+        (!!commentBody &&
+          effectiveMoveToTodoRequested &&
+          (isClosed || (isBlocked && !hasUnresolvedFirstClassBlockers)));
+      if (leavesTerminalViaExplicitStatus || leavesTerminalViaCommentOrReopen) {
+        res.status(422).json({
+          error:
+            "routine_execution issues in done or cancelled status require resume: true (and eligibility rules) to leave that terminal state",
+        });
+        return;
+      }
     }
     let interruptedRunId: string | null = null;
     const closedExecutionWorkspace = await getClosedIssueExecutionWorkspace(existing);
@@ -3465,7 +3487,13 @@ export function issueRoutes(
 
     const checkoutRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !checkoutRunId) return;
-    const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId);
+    const updated = await svc.checkout(
+      id,
+      req.body.agentId,
+      req.body.expectedStatuses,
+      checkoutRunId,
+      req.body.resume === true,
+    );
     const actor = getActorInfo(req);
 
     await logActivity(db, {
@@ -4126,6 +4154,18 @@ export function issueRoutes(
     if (resumeRequested !== true && reopenRequested === true && req.actor.type === "agent") {
       if (!(await assertExplicitResumeIntentAllowed(req, res, issue))) return;
     }
+    if (
+      issue.originKind === "routine_execution" &&
+      isClosedIssueStatus(issue.status) &&
+      resumeRequested !== true &&
+      reopenRequested === true
+    ) {
+      res.status(422).json({
+        error:
+          "routine_execution issues in done or cancelled status require resume: true (and eligibility rules) to leave that terminal state",
+      });
+      return;
+    }
     const isClosed = isClosedIssueStatus(issue.status);
     const isBlocked = issue.status === "blocked";
     const explicitMoveToTodoRequested = reopenRequested || resumeRequested === true;
@@ -4136,6 +4176,7 @@ export function issueRoutes(
         assigneeAgentId: issue.assigneeAgentId,
         actorType: actor.actorType,
         actorId: actor.actorId,
+        originKind: issue.originKind,
       });
     const hasUnresolvedFirstClassBlockers =
       isBlocked && effectiveMoveToTodoRequested

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8301,7 +8301,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           await tx
             .update(agentWakeupRequests)
             .set({
-              status: "failed",
+              status: "cancelled",
               finishedAt: new Date(),
               error: `${wakeTag} Deferred wake not promoted: terminal routine_execution issue has no audited comment/user reopen and no explicit resume metadata (requires context.resume / resumeIntent from structured resume: true)`,
               updatedAt: new Date(),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -81,6 +81,12 @@ import {
 } from "./run-liveness.js";
 import { logActivity, publishPluginDomainEvent, type LogActivityInput } from "./activity-log.js";
 import {
+  classifyWakeReasonFromContext,
+  isRoutineTerminalSyntheticContinuationWake,
+  resumeIntentFromIssueWakeContext,
+  ROUTINE_TERMINAL_SYNTHETIC_CONTINUATION_WAKE_REASONS,
+} from "../lib/routine-terminal-continuation.js";
+import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
   ensureRuntimeServicesForRun,
@@ -6013,8 +6019,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const wakeCommentId = deriveCommentId(context, null);
     const isInteractionWake = allowsIssueInteractionWake(context);
-    const resumeIntent = context.resumeIntent === true || context.followUpRequested === true;
+    const resumeIntent = resumeIntentFromIssueWakeContext(context);
     const wakeReason = readNonEmptyString(context.wakeReason);
+    const classifiedWakeReason = classifyWakeReasonFromContext(context);
     const retryReason = readNonEmptyString(context.retryReason) ?? run.scheduledRetryReason ?? null;
 
     if (
@@ -6064,13 +6071,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const routineTerminalMissingResume =
         issue.originKind === "routine_execution" && !resumeIntent;
       if (routineTerminalMissingResume) {
+        const syntheticWake = isRoutineTerminalSyntheticContinuationWake(classifiedWakeReason);
         return {
           stale: true,
           errorCode: "routine_terminal_requires_resume_intent",
           reason:
             `Cancelled because routine_execution issue is ${issue.status} and the queued wake lacks explicit resume intent ` +
-            "(context.resumeIntent / context.followUpRequested from resume: true); comment-only wakes must not revive routine output",
-          details: { issueId, currentStatus: issue.status, originKind: issue.originKind },
+            "(context.resume / context.resumeIntent / context.followUpRequested from structured resume: true); comment-only wakes must not revive routine output",
+          details: {
+            issueId,
+            currentStatus: issue.status,
+            originKind: issue.originKind,
+            classifiedWakeReason: classifiedWakeReason ?? null,
+            routineTerminalSyntheticContinuationWake: syntheticWake,
+            routineTerminalGuardOutcome: syntheticWake
+              ? "rejected_synthetic_continuation_without_resume"
+              : "rejected_routine_terminal_without_resume",
+          },
         };
       }
       if (!resumeIntent && !wakeCommentId) {
@@ -8253,11 +8270,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           };
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
-        const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
-        const deferredResumeIntent =
-          deferredContextSeed.resume === true ||
-          deferredContextSeed.resumeIntent === true ||
-          deferredContextSeed.followUpRequested === true;
+        const deferredWakeReason = classifyWakeReasonFromContext(deferredContextSeed);
+        const deferredResumeIntent = resumeIntentFromIssueWakeContext(deferredContextSeed);
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.
         let shouldReopenDeferredCommentWake =
@@ -8280,13 +8294,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           !shouldReopenDeferredCommentWake &&
           !deferredResumeIntent
         ) {
+          const wakeTag =
+            deferredWakeReason && ROUTINE_TERMINAL_SYNTHETIC_CONTINUATION_WAKE_REASONS.has(deferredWakeReason)
+              ? `[routine_terminal_guard:synthetic_continuation:${deferredWakeReason}]`
+              : "[routine_terminal_guard:terminal_routine]";
           await tx
             .update(agentWakeupRequests)
             .set({
               status: "failed",
               finishedAt: new Date(),
-              error:
-                "Deferred wake not promoted: terminal routine_execution issue has no audited comment/user reopen and no explicit resume metadata",
+              error: `${wakeTag} Deferred wake not promoted: terminal routine_execution issue has no audited comment/user reopen and no explicit resume metadata (requires context.resume / resumeIntent from structured resume: true)`,
               updatedAt: new Date(),
             })
             .where(eq(agentWakeupRequests.id, deferred.id));

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -5976,6 +5976,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           | "issue_not_found"
           | "issue_assignee_changed"
           | "issue_terminal_status"
+          | "routine_terminal_requires_resume_intent"
           | "issue_not_in_progress"
           | "issue_execution_lock_changed"
           | "issue_review_participant_changed"
@@ -5992,6 +5993,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .select({
         id: issues.id,
         status: issues.status,
+        originKind: issues.originKind,
         assigneeAgentId: issues.assigneeAgentId,
         executionRunId: issues.executionRunId,
         executionState: issues.executionState,
@@ -6059,6 +6061,18 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
 
     if (issue.status === "done" || issue.status === "cancelled") {
+      const routineTerminalMissingResume =
+        issue.originKind === "routine_execution" && !resumeIntent;
+      if (routineTerminalMissingResume) {
+        return {
+          stale: true,
+          errorCode: "routine_terminal_requires_resume_intent",
+          reason:
+            `Cancelled because routine_execution issue is ${issue.status} and the queued wake lacks explicit resume intent ` +
+            "(context.resumeIntent / context.followUpRequested from resume: true); comment-only wakes must not revive routine output",
+          details: { issueId, currentStatus: issue.status, originKind: issue.originKind },
+        };
+      }
       if (!resumeIntent && !wakeCommentId) {
         return {
           stale: true,
@@ -8240,15 +8254,44 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        const deferredResumeIntent =
+          deferredContextSeed.resume === true ||
+          deferredContextSeed.resumeIntent === true ||
+          deferredContextSeed.followUpRequested === true;
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.
-        const shouldReopenDeferredCommentWake =
+        let shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
           (issue.status === "done" || issue.status === "cancelled") &&
           (
             deferred.requestedByActorType === "user" ||
             deferredWakeReason === "issue_reopened_via_comment"
           );
+        if (
+          shouldReopenDeferredCommentWake &&
+          issue.originKind === "routine_execution" &&
+          !deferredResumeIntent
+        ) {
+          shouldReopenDeferredCommentWake = false;
+        }
+        if (
+          (issue.status === "done" || issue.status === "cancelled") &&
+          issue.originKind === "routine_execution" &&
+          !shouldReopenDeferredCommentWake &&
+          !deferredResumeIntent
+        ) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "failed",
+              finishedAt: new Date(),
+              error:
+                "Deferred wake not promoted: terminal routine_execution issue has no audited comment/user reopen and no explicit resume metadata",
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
         let reopenedActivity: LogActivityInput | null = null;
 
         if (shouldReopenDeferredCommentWake) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3374,7 +3374,13 @@ export function issueService(db: Db) {
         return enriched;
       }),
 
-    checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
+    checkout: async (
+      id: string,
+      agentId: string,
+      expectedStatuses: string[],
+      checkoutRunId: string | null,
+      resume: boolean | undefined = undefined,
+    ) => {
       const issueCompany = await db
         .select({ companyId: issues.companyId })
         .from(issues)
@@ -3399,6 +3405,30 @@ export function issueService(db: Db) {
       }
 
       await clearExecutionRunIfTerminal(id);
+
+      const checkoutTarget = await db
+        .select({ status: issues.status, originKind: issues.originKind })
+        .from(issues)
+        .where(eq(issues.id, id))
+        .then((rows) => rows[0] ?? null);
+      if (!checkoutTarget) throw notFound("Issue not found");
+
+      const isTerminalStatus =
+        checkoutTarget.status === "done" || checkoutTarget.status === "cancelled";
+      if (
+        isTerminalStatus &&
+        checkoutTarget.originKind === "routine_execution" &&
+        resume !== true
+      ) {
+        throw unprocessable(
+          "Terminal routine_execution issues cannot be checked out unless the request sets resume: true",
+          {
+            issueId: id,
+            status: checkoutTarget.status,
+            originKind: checkoutTarget.originKind,
+          },
+        );
+      }
 
       const dependencyReadiness = await listIssueDependencyReadinessMap(db, issueCompany.companyId, [id]);
       const unresolvedBlockerIssueIds = dependencyReadiness.get(id)?.unresolvedBlockerIssueIds ?? [];


### PR DESCRIPTION
Implements terminal reopen/checkout/deferred-wake guards for routine_execution issues unless context carries structured resume intent (resume / resumeIntent / followUpRequested). Adds Vitest coverage for stale-queue cancellation and checkout. Paperclip assignment anchor: Git base: main — upstream currently has only master as default trunk (no origin/main yet), so PR targets master echoing that contract. Local verification: vitest issues-service.test.ts + heartbeat-stale-queue-invalidation.test.ts (53 passed).

Made with [Cursor](https://cursor.com)