### PR TITLE
feat(server): heartbeat summarizer service (THE-433, C2 of session compaction)

### DIFF
--- a/server/src/services/heartbeat-summarizer.test.ts
+++ b/server/src/services/heartbeat-summarizer.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MAX_INPUT_CHARS,
+  SUMMARY_MARKER,
+  summarizeHeartbeatTrail,
+  type SummarizerOptions,
+} from "./heartbeat-summarizer.js";
+
+const SAMPLE_INPUT = {
+  priorSummary: null,
+  newTrailTail: [
+    "Board: please ship X by Friday.",
+    "Agent: filed THE-123 to track.",
+    "Open question: which environment do we deploy to?",
+  ].join("\n"),
+};
+
+function makeFetchReturning(body: unknown, init: { ok?: boolean; status?: number } = {}): typeof fetch {
+  return vi.fn(async () => ({
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  })) as unknown as typeof fetch;
+}
+
+const baseOptions: SummarizerOptions = {
+  apiKey: "test-key",
+  fetchImpl: makeFetchReturning({}),
+};
+
+describe("summarizeHeartbeatTrail", () => {
+  it("returns the stripped summary on the happy path", async () => {
+    const fetchImpl = makeFetchReturning({
+      content: [
+        {
+          type: "text",
+          text: `${SUMMARY_MARKER}\n## Decisions\n- Ship X by Friday (board, 2026-05-08).\n## Commitments\n(none)\n## Unresolved questions\n- Which environment?\n## Open blockers\n(none)\n## Context\nFiled THE-123.`,
+        },
+      ],
+      usage: { input_tokens: 1234, output_tokens: 200 },
+    });
+
+    const result = await summarizeHeartbeatTrail(SAMPLE_INPUT, {
+      ...baseOptions,
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.summary.startsWith(SUMMARY_MARKER)).toBe(false);
+    expect(result.summary).toContain("Ship X by Friday");
+    expect(result.summary).toContain("Which environment?");
+    expect(result.truncated).toBe(false);
+    expect(result.usage).toEqual({ inputTokens: 1234, outputTokens: 200 });
+    expect(result.model).toBeTruthy();
+  });
+
+  it("sends prior summary into the user prompt when provided", async () => {
+    const fetchImpl = vi.fn(async (_url, init: RequestInit | undefined) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : null;
+      const userMessage = body?.messages?.[0]?.content ?? "";
+      expect(userMessage).toContain("PRIOR-DECISION-MARKER");
+      expect(userMessage).toContain("NEW-TRAIL-MARKER");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          content: [{ type: "text", text: `${SUMMARY_MARKER}\nok` }],
+        }),
+        text: async () => "",
+      };
+    }) as unknown as typeof fetch;
+
+    const result = await summarizeHeartbeatTrail(
+      {
+        priorSummary: "PRIOR-DECISION-MARKER body",
+        newTrailTail: "NEW-TRAIL-MARKER body",
+      },
+      { ...baseOptions, fetchImpl },
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns timeout fallback when the call exceeds the deadline", async () => {
+    // Slow fetch that respects abort via the supplied signal.
+    const slowFetch = vi.fn((_url, init: RequestInit | undefined) => {
+      return new Promise((_resolve, reject) => {
+        const sig = init?.signal;
+        if (!sig) return;
+        if (sig.aborted) {
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+          return;
+        }
+        sig.addEventListener("abort", () => {
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await summarizeHeartbeatTrail(SAMPLE_INPUT, {
+      apiKey: "test-key",
+      fetchImpl: slowFetch,
+      timeoutMs: 25,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("timeout");
+    expect(result.detail).toMatch(/25ms/);
+  });
+
+  it("returns malformed fallback when output lacks the SUMMARY-V1 marker", async () => {
+    const fetchImpl = makeFetchReturning({
+      content: [{ type: "text", text: "Sure! Here's the summary you asked for: ..." }],
+    });
+
+    const result = await summarizeHeartbeatTrail(SAMPLE_INPUT, {
+      ...baseOptions,
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("malformed");
+    expect(result.detail).toContain(SUMMARY_MARKER);
+  });
+
+  it("returns malformed fallback when the response body has no text block", async () => {
+    const fetchImpl = makeFetchReturning({
+      content: [{ type: "tool_use", id: "x" }],
+    });
+
+    const result = await summarizeHeartbeatTrail(SAMPLE_INPUT, {
+      ...baseOptions,
+      fetchImpl,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("malformed");
+  });
+
+  it("returns malformed fallback when schema validation fails", async () => {
+    const fetchImpl = makeFetchReturning({ unexpected: "shape" });
+    const result = await summarizeHeartbeatTrail(SAMPLE_INPUT, {
+      ...baseOptions,
+      fetchImpl,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("malformed");
+  });
+
+  it("returns api_error fallback on non-2xx response", async () => {
+    const fetchImpl = makeFetchReturning("upstream rate limit", { ok: false, status: 429 });
+    const result = await summarizeHeartbeatTrail(SAMPLE_INPUT, {
+      ...baseOptions,
+      fetchImpl,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("api_error");
+    expect(result.detail).toContain("429");
+  });
+
+  it("returns api_error fallback when fetch throws", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ENETDOWN");
+    }) as unknown as typeof fetch;
+    const result = await summarizeHeartbeatTrail(SAMPLE_INPUT, {
+      ...baseOptions,
+      fetchImpl,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("api_error");
+    expect(result.detail).toContain("ENETDOWN");
+  });
+
+  it("returns oversize_input fallback when combined input exceeds the char cap", async () => {
+    const big = "x".repeat(DEFAULT_MAX_INPUT_CHARS + 1);
+    const fetchImpl = vi.fn();
+    const result = await summarizeHeartbeatTrail(
+      { priorSummary: null, newTrailTail: big },
+      { apiKey: "test-key", fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("oversize_input");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns missing_api_key fallback when api key is empty", async () => {
+    const result = await summarizeHeartbeatTrail(SAMPLE_INPUT, {
+      apiKey: "",
+      fetchImpl: makeFetchReturning({}),
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe("missing_api_key");
+  });
+
+  it("does not throw when called repeatedly with failures (stable on the heartbeat path)", async () => {
+    const fetchImpl = makeFetchReturning("server crashed", { ok: false, status: 500 });
+    for (let i = 0; i < 5; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      const r = await summarizeHeartbeatTrail(SAMPLE_INPUT, { ...baseOptions, fetchImpl });
+      expect(r.ok).toBe(false);
+    }
+  });
+
+  it("defensively truncates pathologically long output bodies", async () => {
+    const huge = "y".repeat(20_000);
+    const fetchImpl = makeFetchReturning({
+      content: [{ type: "text", text: `${SUMMARY_MARKER}\n${huge}` }],
+    });
+    const result = await summarizeHeartbeatTrail(SAMPLE_INPUT, { ...baseOptions, fetchImpl });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.truncated).toBe(true);
+    expect(result.summary.length).toBeLessThan(huge.length);
+  });
+
+  it("forwards model + max_tokens overrides into the request body", async () => {
+    let captured: any = null;
+    const fetchImpl = vi.fn(async (_url, init: RequestInit | undefined) => {
+      captured = init?.body ? JSON.parse(String(init.body)) : null;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ content: [{ type: "text", text: `${SUMMARY_MARKER}\nok` }] }),
+        text: async () => "",
+      };
+    }) as unknown as typeof fetch;
+
+    await summarizeHeartbeatTrail(SAMPLE_INPUT, {
+      apiKey: "test-key",
+      fetchImpl,
+      model: "claude-haiku-4-6",
+      maxOutputTokens: 1500,
+    });
+
+    expect(captured.model).toBe("claude-haiku-4-6");
+    expect(captured.max_tokens).toBe(1500);
+    expect(captured.system).toContain("PRESERVE VERBATIM");
+  });
+
+  it("respects caller-supplied AbortSignal even before fetch resolves", async () => {
+    const controller = new AbortController();
+    const slowFetch = vi.fn((_url, init: RequestInit | undefined) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        });
+      });
+    }) as unknown as typeof fetch;
+    const promise = summarizeHeartbeatTrail(SAMPLE_INPUT, {
+      apiKey: "test-key",
+      fetchImpl: slowFetch,
+      signal: controller.signal,
+      timeoutMs: 60_000,
+    });
+    controller.abort();
+    const result = await promise;
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    // External abort returns api_error (not timeout — the timeout did not fire).
+    expect(result.reason).toBe("api_error");
+  });
+});

--- a/server/src/services/heartbeat-summarizer.ts
+++ b/server/src/services/heartbeat-summarizer.ts
@@ -1,0 +1,302 @@
+/**
+ * Standalone summarizer service for heartbeat session compaction.
+ *
+ * Plan reference: THE-429 (rev 2). C2 deliverable: THE-433.
+ *
+ * Contract:
+ *   `(priorSummary, newTrailTail) → newSummary` via Haiku.
+ *
+ * Failure modes (timeout, malformed output, API error, oversize input) MUST
+ * return a fallback signal — never throw into the heartbeat path. Callers
+ * (C3 prompt-builder) are expected to replay the full transcript verbatim
+ * when they receive `{ ok: false }` — reliability over cost on the failure
+ * path, per plan §4.
+ *
+ * The function is pure / harness-agnostic: caller supplies API key, model,
+ * timeouts, and (in tests) a `fetchImpl`. No platform globals are read here.
+ */
+import { z } from "zod";
+
+export const SUMMARY_MARKER = "SUMMARY-V1";
+
+/** Default model: Haiku 4.5 dated alias. v1 has no Sonnet escape hatch. */
+export const DEFAULT_SUMMARIZER_MODEL = "claude-haiku-4-5-20251001";
+
+/** Token cap on output (per plan §1). */
+export const DEFAULT_MAX_OUTPUT_TOKENS = 2_000;
+
+/** Wall-clock cap on a single summarizer call. */
+export const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Hard cap on combined input size (priorSummary + newTrailTail). Anything
+ * larger fails fast with `oversize_input` rather than burning a doomed API
+ * call. ~400K chars ≈ 100K tokens, comfortably under Haiku's context window
+ * but signals an upstream invariant break (checkpoint threshold should keep
+ * inputs far smaller than this).
+ */
+export const DEFAULT_MAX_INPUT_CHARS = 400_000;
+
+/** Defensive char cap on returned summary, in case the model exceeds max_tokens. */
+const SUMMARY_OUTPUT_CHAR_CAP = 8_800;
+
+export interface SummarizerInput {
+  /** Prior summary body (without marker), or null if this is the first checkpoint. */
+  priorSummary: string | null;
+  /** New trail tail (everything since the prior summary's checkpoint). */
+  newTrailTail: string;
+}
+
+export type SummarizerFailureReason =
+  | "timeout"
+  | "malformed"
+  | "api_error"
+  | "oversize_input"
+  | "missing_api_key";
+
+export interface SummarizerSuccess {
+  ok: true;
+  /** Summary body with the SUMMARY-V1 marker stripped. */
+  summary: string;
+  /** True if the model output was defensively truncated to fit the char cap. */
+  truncated: boolean;
+  /** Token usage reported by the API, when available. */
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+  } | null;
+  model: string;
+}
+
+export interface SummarizerFailure {
+  ok: false;
+  reason: SummarizerFailureReason;
+  /** Human-readable detail for logs. Never includes raw API key bytes. */
+  detail: string;
+}
+
+export type SummarizerResult = SummarizerSuccess | SummarizerFailure;
+
+export interface SummarizerOptions {
+  apiKey: string;
+  model?: string;
+  timeoutMs?: number;
+  maxOutputTokens?: number;
+  maxInputChars?: number;
+  fetchImpl?: typeof fetch;
+  /** Optional caller-supplied abort signal (composed with the timeout). */
+  signal?: AbortSignal;
+  /** Override the API URL (used by tests; default is api.anthropic.com). */
+  apiUrl?: string;
+}
+
+const SUMMARIZER_SYSTEM_PROMPT = [
+  "You are a context-compaction service for an AI agent. You receive (1) a prior",
+  "summary of the agent's work on a single issue and (2) the most recent trail tail",
+  "(new actions, comments, tool I/O) since that summary was written. Produce a NEW",
+  "summary that supersedes the prior one.",
+  "",
+  "PRESERVE VERBATIM (these MUST appear in the new summary, copied as-is from the source):",
+  "- Decisions made (and who made them).",
+  "- Commitments (what is owed to whom, with deadlines).",
+  "- Unresolved questions (open items awaiting an answer).",
+  "- Open blockers (with the unblock owner if known).",
+  "",
+  "COMPRESS:",
+  "- Tool output details, search results, intermediate reasoning, prior status transitions.",
+  "",
+  "RULES:",
+  "- Output a markdown document only. No prose framing, no apologies, no chain-of-thought.",
+  `- Begin every output with the literal line: ${SUMMARY_MARKER}`,
+  "- Use stable section headings: ## Decisions, ## Commitments, ## Unresolved questions, ## Open blockers, ## Context.",
+  "- If a section has no content, write the literal line: (none)",
+  "- Hard cap: keep the entire summary under 2000 tokens. If you must drop content to fit,",
+  "  drop compressible material first; never drop a decision, commitment, question, or blocker.",
+  "- Never invent facts. If something is unclear in the source, list it under Unresolved questions.",
+].join("\n");
+
+function buildUserPrompt(input: SummarizerInput): string {
+  const priorBlock = input.priorSummary?.trim()
+    ? `<prior-summary>\n${input.priorSummary.trim()}\n</prior-summary>`
+    : "<prior-summary>(none — this is the first checkpoint)</prior-summary>";
+  return [
+    priorBlock,
+    "",
+    "<new-trail-tail>",
+    input.newTrailTail,
+    "</new-trail-tail>",
+    "",
+    `Produce the new summary now. Begin with the literal line ${SUMMARY_MARKER}.`,
+  ].join("\n");
+}
+
+const messagesResponseSchema = z.object({
+  content: z
+    .array(
+      z.object({
+        type: z.string(),
+        text: z.string().optional(),
+      }),
+    )
+    .min(1),
+  usage: z
+    .object({
+      input_tokens: z.number().optional(),
+      output_tokens: z.number().optional(),
+    })
+    .optional(),
+  stop_reason: z.string().optional(),
+});
+
+function joinAbortSignals(signals: Array<AbortSignal | undefined>): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const handlers: Array<() => void> = [];
+  for (const s of signals) {
+    if (!s) continue;
+    if (s.aborted) {
+      controller.abort(s.reason);
+      break;
+    }
+    const onAbort = () => controller.abort(s.reason);
+    s.addEventListener("abort", onAbort, { once: true });
+    handlers.push(() => s.removeEventListener("abort", onAbort));
+  }
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      for (const h of handlers) h();
+    },
+  };
+}
+
+function failure(reason: SummarizerFailureReason, detail: string): SummarizerFailure {
+  return { ok: false, reason, detail };
+}
+
+function validateAndStripMarker(raw: string): { body: string; truncated: boolean } | null {
+  const trimmed = raw.trimStart();
+  if (!trimmed.startsWith(SUMMARY_MARKER)) return null;
+  let body = trimmed.slice(SUMMARY_MARKER.length).replace(/^\r?\n/, "");
+  let truncated = false;
+  if (body.length > SUMMARY_OUTPUT_CHAR_CAP) {
+    body = body.slice(0, SUMMARY_OUTPUT_CHAR_CAP);
+    truncated = true;
+  }
+  return { body, truncated };
+}
+
+export async function summarizeHeartbeatTrail(
+  input: SummarizerInput,
+  options: SummarizerOptions,
+): Promise<SummarizerResult> {
+  const apiKey = options.apiKey?.trim();
+  if (!apiKey) {
+    return failure("missing_api_key", "ANTHROPIC_API_KEY not configured for summarizer");
+  }
+
+  const model = options.model ?? DEFAULT_SUMMARIZER_MODEL;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxOutputTokens = options.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+  const maxInputChars = options.maxInputChars ?? DEFAULT_MAX_INPUT_CHARS;
+  const apiUrl = options.apiUrl ?? "https://api.anthropic.com/v1/messages";
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const inputCharCount = (input.priorSummary?.length ?? 0) + input.newTrailTail.length;
+  if (inputCharCount > maxInputChars) {
+    return failure(
+      "oversize_input",
+      `input chars ${inputCharCount} exceed cap ${maxInputChars}; checkpoint threshold should prevent this`,
+    );
+  }
+
+  const userPrompt = buildUserPrompt(input);
+
+  const timeoutController = new AbortController();
+  const timer = setTimeout(() => timeoutController.abort(new Error("summarizer-timeout")), timeoutMs);
+  const joined = joinAbortSignals([timeoutController.signal, options.signal]);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(apiUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: maxOutputTokens,
+        system: SUMMARIZER_SYSTEM_PROMPT,
+        messages: [{ role: "user", content: userPrompt }],
+      }),
+      signal: joined.signal,
+    });
+  } catch (err) {
+    const aborted =
+      timeoutController.signal.aborted ||
+      (err instanceof Error && (err.name === "AbortError" || /abort/i.test(err.message)));
+    if (aborted && timeoutController.signal.aborted) {
+      return failure("timeout", `summarizer exceeded ${timeoutMs}ms`);
+    }
+    if (aborted) {
+      return failure("api_error", "summarizer call aborted by caller");
+    }
+    return failure("api_error", err instanceof Error ? err.message : String(err));
+  } finally {
+    clearTimeout(timer);
+    joined.cleanup();
+  }
+
+  if (!response.ok) {
+    let detail = `status ${response.status}`;
+    try {
+      const text = await response.text();
+      if (text) detail += `: ${text.slice(0, 500)}`;
+    } catch {
+      // ignore — response body is best-effort for diagnostics
+    }
+    return failure("api_error", detail);
+  }
+
+  let parsedBody: unknown;
+  try {
+    parsedBody = await response.json();
+  } catch (err) {
+    return failure("api_error", `non-json response body: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const parsed = messagesResponseSchema.safeParse(parsedBody);
+  if (!parsed.success) {
+    return failure("malformed", `messages response did not match schema: ${parsed.error.message}`);
+  }
+
+  const textBlock = parsed.data.content.find((c) => c.type === "text" && typeof c.text === "string");
+  if (!textBlock?.text) {
+    return failure("malformed", "no text content block in messages response");
+  }
+
+  const validated = validateAndStripMarker(textBlock.text);
+  if (!validated) {
+    return failure(
+      "malformed",
+      `summary did not begin with ${SUMMARY_MARKER} marker; got: ${textBlock.text.slice(0, 80)}`,
+    );
+  }
+
+  return {
+    ok: true,
+    summary: validated.body,
+    truncated: validated.truncated,
+    usage: parsed.data.usage
+      ? {
+          inputTokens: parsed.data.usage.input_tokens ?? 0,
+          outputTokens: parsed.data.usage.output_tokens ?? 0,
+        }
+      : null,
+    model,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a standalone summarizer service to `@paperclipai/server` that compacts an issue's heartbeat trail via Haiku, with explicit timeout, structured-output validation, and a fallback signal on every failure mode. This is **C2** of the session-compaction plan ([THE-429](https://github.com/paperclipai/paperclip/issues/THE-429), rev 2 approved).

The function is callable in isolation — pure, harness-agnostic, no dependency on the runtime — so the heartbeat-builder swap (C3) can wire it in cleanly later.

## Files

- `server/src/services/heartbeat-summarizer.ts` — `summarizeHeartbeatTrail(input, options) → SummarizerResult` discriminated union (\`{ ok: true, summary, … } | { ok: false, reason, detail }\`).
- `server/src/services/heartbeat-summarizer.test.ts` — 14 vitest unit tests.

## Design

- **Model:** Default `claude-haiku-4-5-20251001` (overridable via options). No Sonnet escape hatch — explicitly out of v1 per the CEO edit on the plan.
- **Output cap:** `max_tokens: 2000` per plan §1, plus a defensive char-level cap if the model exceeds it.
- **Validation:** every successful summary must begin with the literal marker `SUMMARY-V1`. Drift in model output format is caught cheaply and routed to the fallback path. The marker is stripped before returning.
- **Verbatim preservation prompt:** the system prompt explicitly instructs the model to preserve decisions, commitments, unresolved questions, and open blockers verbatim, per Risk #1 in the plan. Stable section headings keep the summary's prompt-prefix bytes stable across checkpoints — load-bearing for prefix caching (Risk #3).
- **Failure path:** every error returns \`{ ok: false, reason }\` rather than throwing. Reasons: \`timeout\`, \`malformed\`, \`api_error\`, \`oversize_input\`, \`missing_api_key\`. Callers (C3) replay the full verbatim trail when \`ok\` is false — reliability over cost on the failure path, per plan §4.
- **No new dependencies.** Uses `fetch` against the Messages API directly, which keeps the surface small and lets tests inject a `fetchImpl` without spinning up the SDK.
- **Oversize input** (priorSummary + newTrailTail > 400K chars) fails fast without an API call. Indicates an upstream invariant break (the C0/C1 checkpoint threshold should keep inputs far smaller).

## Test plan

- [x] `vitest run server/src/services/heartbeat-summarizer.test.ts` — 14 / 14 pass locally.
- [x] `pnpm --filter @paperclipai/server typecheck` — clean.
- Tests cover: happy path, prior-summary plumbing, timer-driven timeout, caller AbortSignal, malformed output (no marker, no text block, schema mismatch), non-2xx response, network throw, oversize input, missing key, repeated-failure stability on the heartbeat path, defensive output truncation, and override forwarding.

## Out of scope (per issue spec)

- Wiring this into the heartbeat prompt-builder (that's **C3** / [THE-434](https://github.com/paperclipai/paperclip/issues/THE-434), which this PR blocks).
- Per-agent feature flag (C4 / [THE-435](https://github.com/paperclipai/paperclip/issues/THE-435)).
- Sonnet escape hatch (explicitly excluded from v1).

Tracked in Paperclip as THE-433.