### PR TITLE
fix(heartbeat): include hermes_local in SESSIONED_LOCAL_ADAPTERS

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -82,6 +82,7 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "codex_local",
   "cursor",
   "gemini_local",
+  "hermes_local",
   "opencode_local",
   "pi_local",
 ]);


### PR DESCRIPTION
## Summary

The heartbeat reaper's `isTrackedLocalChildProcessAdapter` check returned `false` for `hermes_local`, so `reapOrphanedRuns` skipped the `isProcessAlive(processPid)` guard and reaped live runs once they crossed the staleness threshold. The run was marked failed in the API but the OS process was not killed; the heartbeat scheduler then re-dispatched and the same agent ended up running twice in parallel.

Adding `hermes_local` to the set lets the reaper tag detached-but-alive runs with `DETACHED_PROCESS_ERROR_CODE` and keep them running, matching the behavior already in place for `claude_local`, `codex_local`, `cursor`, `gemini_local`, `opencode_local`, and `pi_local`.

## Reproduction

1. Configure an agent with `adapterType: "hermes_local"` and a long-running task (e.g. a triage workload that takes >5 minutes).
2. Dispatch the agent. The Hermes child process starts work.
3. Wait for `reapOrphanedRuns` to fire with the default 5-minute stale threshold.
4. Observe: API marks the run `failed` with `errorCode: "process_lost"` despite `processPid` still being alive. The OS process continues running (zombie). A new dispatch is then spawned for the same assignment, resulting in concurrent runs of the same agent on the same issue.

## Fix

One-line addition to `SESSIONED_LOCAL_ADAPTERS`. The PID-alive check at `heartbeat.ts:2322` only runs when the adapter is in this set; without it, reaping is unconditional.

## Test plan

- [ ] Spawn a `hermes_local` dispatch that exceeds the stale threshold
- [ ] Confirm the run is tagged `DETACHED_PROCESS_ERROR_CODE` rather than reaped
- [ ] Confirm no duplicate dispatch is spawned
- [ ] Existing tests for the other six adapters remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)