### PR TITLE
fix(server): recognize future routine schedule as live execution path (DGG-5094)

### DIFF
--- a/docs/guides/agent-developer/external-dependency-issues.md
+++ b/docs/guides/agent-developer/external-dependency-issues.md
@@ -1,0 +1,66 @@
+# External-Dependency Issues and Routine-Based Wake-Up
+
+When an issue is `in_progress` and the next step depends on something external (a human approval, a slow pipeline, a third-party API, a scheduled data feed), the agent should register a **routine schedule** that targets the issue instead of busy-polling or leaving the issue stranded.
+
+## Why this matters (DGG-5094)
+
+Paperclip's heartbeat reconciler (`reconcileStrandedAssignedIssues`) periodically scans for `in_progress` issues that appear to have no live execution path.
+Before DGG-5094 it recognised only two live-path signals:
+
+| Signal | Description |
+|---|---|
+| Active heartbeat run | A `queued`, `running`, or `scheduled_retry` run referencing the issue |
+| Deferred issue execution wake | An `agentWakeupRequests` row with `status = deferred_issue_execution` |
+
+An issue waiting on an external dependency that had _neither_ of these was misclassified as stranded, triggering unnecessary recovery issues (the DGG-5074 wake-loop pattern).
+
+After DGG-5094 a **future routine schedule** is also recognised as a live execution path:
+a `routines` row with `parentIssueId = <issue id>`, `status = active`, joined to a `routineTriggers` row with `enabled = true` and `nextRunAt > now()`.
+
+## How to register a routine schedule
+
+Set the issue status to `in_progress` (or leave it there), then create a routine that targets it:
+
+```
+# 1. Create the routine
+POST /api/companies/{companyId}/routines
+{
+  "title": "Wait for external API readiness",
+  "description": "Polls once the dependency is expected to be ready",
+  "parentIssueId": "{issueId}",
+  "assigneeAgentId": "{yourAgentId}",
+  "status": "active"
+}
+# -> { "id": "{routineId}", ... }
+
+# 2. Attach a schedule trigger
+POST /api/routines/{routineId}/triggers
+{
+  "kind": "schedule",
+  "label": "daily-check",
+  "cronExpression": "0 9 * * *",
+  "timezone": "UTC",
+  "enabled": true
+}
+```
+
+Once the trigger's `nextRunAt` is in the future the reconciler will consider the issue _live_ and will not create a stranded-issue recovery ticket for it.
+
+When the routine fires it creates a new heartbeat run with the issue in context; the agent can then re-evaluate whether the dependency has been satisfied and advance or re-schedule accordingly.
+
+## What prevents the DGG-5074 wake-loop
+
+The wake-loop occurred because:
+
+1. An in_progress issue had a succeeded run but no queued/running follow-up run.
+2. The reconciler classified it as stranded and issued a recovery wake.
+3. The recovery wake produced another succeeded run with no follow-up.
+4. Repeat from step 2.
+
+Registering a future routine schedule (step above) breaks the loop at step 2: `hasActiveExecutionPath` returns `true` and the reconciler skips the issue entirely, producing zero recovery wakes until the scheduled run fires.
+
+## See also
+
+- `docs/guides/agent-developer/heartbeat-protocol.md` — heartbeat lifecycle overview
+- `server/src/services/recovery/service.ts` → `hasActiveExecutionPath` — implementation
+- DGG-5094 — original fix; DGG-5074 — wake-loop incident that motivated it

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -24,6 +24,8 @@ import {
   issueTreeHoldMembers,
   issueTreeHolds,
   issues,
+  routineTriggers,
+  routines,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -320,6 +322,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(issueRelations);
     await db.delete(issueTreeHoldMembers);
     await db.delete(issueTreeHolds);
+    await db.delete(routineTriggers);
+    await db.delete(routines);
     for (let attempt = 0; attempt < 5; attempt += 1) {
       await db.delete(issueComments);
       await db.delete(issueDocuments);
@@ -2337,6 +2341,84 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       retryOfRunId: runId,
       source: "issue.productive_terminal_continuation_recovery",
     });
+  });
+
+  it("skips reconcile when a future routine schedule targets the issue (live execution path)", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+    });
+
+    const routineId = randomUUID();
+    const triggerId = randomUUID();
+    const sevenDaysFromNow = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      parentIssueId: issueId,
+      title: "External-dep follow-up",
+      description: "Wakes the issue once the external dependency is expected to be ready",
+      assigneeAgentId: agentId,
+      priority: "medium",
+      status: "active",
+    });
+    await db.insert(routineTriggers).values({
+      id: triggerId,
+      companyId,
+      routineId,
+      kind: "schedule",
+      label: "daily-09",
+      enabled: true,
+      cronExpression: "0 9 * * *",
+      nextRunAt: sevenDaysFromNow,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const heartbeatRunsBefore = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.companyId, companyId));
+    const wakeupsBefore = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.assignmentDispatched).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+    expect(result.issueIds).toEqual([]);
+
+    const heartbeatRunsAfter = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.companyId, companyId));
+    const wakeupsAfter = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+    expect(heartbeatRunsAfter).toHaveLength(heartbeatRunsBefore.length);
+    expect(wakeupsAfter).toHaveLength(wakeupsBefore.length);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
   });
 
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNotNull, isNull, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -19,6 +19,8 @@ import {
   issueRelations,
   issueThreadInteractions,
   issues,
+  routines,
+  routineTriggers,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
 import { runningProcesses } from "../../adapters/index.js";
@@ -334,7 +336,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
-    const [run, deferredWake] = await Promise.all([
+    const [run, deferredWake, scheduledRoutine] = await Promise.all([
       db
         .select({ id: heartbeatRuns.id })
         .from(heartbeatRuns)
@@ -359,9 +361,25 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         )
         .limit(1)
         .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: routines.id })
+        .from(routines)
+        .innerJoin(routineTriggers, eq(routineTriggers.routineId, routines.id))
+        .where(
+          and(
+            eq(routines.companyId, companyId),
+            eq(routines.parentIssueId, issueId),
+            eq(routines.status, "active"),
+            eq(routineTriggers.enabled, true),
+            isNotNull(routineTriggers.nextRunAt),
+            gt(routineTriggers.nextRunAt, sql`now()`),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
     ]);
 
-    return Boolean(run || deferredWake);
+    return Boolean(run || deferredWake || scheduledRoutine);
   }
 
   async function hasQueuedIssueWake(companyId: string, issueId: string) {


### PR DESCRIPTION
## Summary

Fixes `hasActiveExecutionPath()` in the heartbeat recovery service to recognise a **future routine schedule** as a valid live execution path for an `in_progress` issue.

### Problem

`reconcileStrandedAssignedIssues` previously checked only two live-path signals:
- Active heartbeat run (`queued`/`running`/`scheduled_retry`)
- Deferred issue execution wake (`agentWakeupRequests.status = deferred_issue_execution`)

An `in_progress` issue waiting on an external dependency that had a future routine cron registered was nonetheless classified as stranded → recovery issue dispatched → wake loop (DGG-5074 pattern).

### Fix

Added a third check inside `hasActiveExecutionPath()`: a `routines` row with `parentIssueId = issueId`, `status = active`, joined to `routineTriggers` with `enabled = true` and `nextRunAt > now()` is now treated as a live execution path.

### Changes

| File | Change |
|---|---|
| `server/src/services/recovery/service.ts` | Import `routines`, `routineTriggers`, `isNotNull`; third Promise.all leg in `hasActiveExecutionPath()` |
| `server/src/__tests__/heartbeat-process-recovery.test.ts` | New regression test: _"skips reconcile when a future routine schedule targets the issue (live execution path)"_ |
| `docs/guides/agent-developer/external-dependency-issues.md` | New guide: routine-based external-dependency wake pattern, DGG-5074 wake-loop prevention |

## AC checklist

- [x] AC1: `hasActiveExecutionPath` returns `true` when a future-scheduled routine with `parentIssueId` matching the issue exists
- [x] AC2: Regression test passes — `result.skipped >= 1`, no new runs, no new wakes, no recovery issues
- [x] AC3: Existing tests pass — `heartbeat-process-recovery.test.ts` (38 tests) and `recovery-classifiers.test.ts` (6 tests) all PASS
- [x] AC4: `docs/guides/agent-developer/external-dependency-issues.md` added with routine-based wake pattern, DGG-5074 prevention explanation, and curl example
- [ ] AC5 (DGG-5074 hold release verification): Follow-up after merge — run DGG-5074 runbook to verify no new stranded-recovery wake-loops for the affected issue(s); unhold if confirmed stable

## Test results

```
Tests  38 passed (38)  — heartbeat-process-recovery.test.ts
Tests   6 passed (6)   — recovery-classifiers.test.ts
```