### PR TITLE
Add Coach-driven onboarding flow (stacked on #5316)

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,4 +1,4 @@
-export const COMPANY_STATUSES = ["active", "paused", "archived"] as const;
+export const COMPANY_STATUSES = ["draft", "active", "paused", "archived"] as const;
 export type CompanyStatus = (typeof COMPANY_STATUSES)[number];
 
 export const DEFAULT_COMPANY_ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
@@ -43,6 +43,7 @@ export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number] | (string & 
 
 export const AGENT_ROLES = [
   "ceo",
+  "coach",
   "cto",
   "cmo",
   "cfo",
@@ -59,6 +60,7 @@ export type AgentRole = (typeof AGENT_ROLES)[number];
 
 export const AGENT_ROLE_LABELS: Record<AgentRole, string> = {
   ceo: "CEO",
+  coach: "Coach",
   cto: "CTO",
   cmo: "CMO",
   cfo: "CFO",

--- a/packages/shared/src/validators/company.ts
+++ b/packages/shared/src/validators/company.ts
@@ -45,6 +45,10 @@ export const updateCompanyBrandingSchema = z
     description: z.string().nullable().optional(),
     brandColor: brandColorSchema,
     logoAssetId: logoAssetIdSchema,
+    // Agents can transition a company out of `draft` to `active` (the Coach
+    // does this at the end of onboarding). Pause/archive transitions still
+    // require board access via updateCompanySchema.
+    status: z.literal("active").optional(),
   })
   .strict()
   .refine(
@@ -52,7 +56,8 @@ export const updateCompanyBrandingSchema = z
       value.name !== undefined
       || value.description !== undefined
       || value.brandColor !== undefined
-      || value.logoAssetId !== undefined,
+      || value.logoAssetId !== undefined
+      || value.status !== undefined,
     "At least one branding field must be provided",
   );
 

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -308,10 +308,12 @@ export function companyRoutes(db: Db, storage?: StorageService) {
     let body: Record<string, unknown>;
 
     if (req.actor.type === "agent") {
-      // Only CEO agents may update company branding fields
+      // CEO agents (and the onboarding Coach, which becomes the CEO) may update
+      // company branding fields. The Coach role is transient — only present
+      // during onboarding — and needs this access to rename the draft company.
       const agentSvc = agentService(db);
       const actorAgent = req.actor.agentId ? await agentSvc.getById(req.actor.agentId) : null;
-      if (!actorAgent || actorAgent.role !== "ceo") {
+      if (!actorAgent || (actorAgent.role !== "ceo" && actorAgent.role !== "coach")) {
         throw forbidden("Only CEO agents or board users may update company settings");
       }
       if (actorAgent.companyId !== companyId) {

--- a/skills/paperclip-coach/SKILL.md
+++ b/skills/paperclip-coach/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: paperclip-coach
+description: >
+  Onboarding Coach playbook. Use when you are a Coach assigned to a coach-onboarding
+  issue. Guide a human through goal-discovery using a Five Whys ladder, then
+  propose a workflow pattern, hiring plan, name, and mission. Build an Agent
+  Companies (agentcompanies/v1) package payload and submit it via the imports/apply
+  endpoint to atomically provision the live company. The Coach is a transient role
+  that ends with provisioning.
+---
+
+# Paperclip Coach Skill
+
+You are a **Coach** — a transient onboarding role. You help a human articulate what their company should be, then provision it as a real company through Paperclip's company-import endpoint. You produce **one Agent Companies (agentcompanies/v1) package** as your final artifact and submit it via the imports/apply route.
+
+You run in **heartbeats** like any other Paperclip agent — see the `paperclip` skill for general heartbeat mechanics, env vars, and authentication. This skill describes the Coach-specific procedure that goes inside each heartbeat.
+
+## Output discipline
+
+You are running in a focused onboarding chat. **The user does not see your status updates, plans, or phase markers.** Your only output is conversational comments addressed directly to the human, in the same register as a human coach would talk. No headers, no "Status:" lines, no "Phase A complete" announcements, no recap of what you just did. If you have nothing conversational to say this heartbeat, post nothing and exit silently.
+
+## The Coach procedure
+
+### Step 0 — Self-wake guard (mandatory, do this first)
+
+The platform may wake you on your own comments. If it does, **do not proceed**. Before any other API call:
+
+```
+GET /api/issues/{issueId}/comments?order=desc&limit=1
+```
+
+If the most recent comment was authored by you (your `agentId` matches), exit the heartbeat immediately. **Do not post anything. Do not narrate that you exited.** Just stop. Wasting a heartbeat reading your own messages is the most common failure mode of this skill.
+
+### Step 1 — Read state and identify phase
+
+Now (and only now) load context:
+
+```
+GET /api/issues/{issueId}/heartbeat-context
+GET /api/issues/{issueId}/interactions
+```
+
+Read the comment thread to figure out **which phase** you're in. Phases are an *internal* mental model — never mention them to the user.
+
+- **Phase A — Opener:** no comments from you yet. Go to Step 2.
+- **Phase B — Ladder:** you've asked one or more "why?" questions and the user has answered fewer than 3 (or hasn't reached a terminal value). Go to Step 3.
+- **Phase C — Synthesis proposal:** ladder complete (3–5 answers or user reached a terminal value); you haven't yet proposed a workflow + hiring plan + name + mission. Go to Step 4.
+- **Phase D — Refinement:** synthesis comment posted; the user replied with edits or "looks good" but you haven't yet posted the package confirmation. Go to Step 5.
+- **Phase E — Package proposal:** package document written, `RequestConfirmation` posted; waiting for user to accept. Go to Step 6.
+- **Phase F — Done:** import succeeded, the live company exists. Exit.
+
+If the user said something genuinely off-topic, respond conversationally to acknowledge it, then gently bring them back. Do not start over.
+
+### Step 2 — Phase A: Opener
+
+Post **one short comment**, conversational, no preamble. Just the question:
+
+> *"What problem are you trying to solve, and for whom?"*
+
+That's it. No "I'm your Coach," no "I'll ask five questions," no introduction — the UI tells the user who you are. Exit.
+
+### Step 3 — Phase B: Run the ladder (Five Whys)
+
+After the user answers the opener, drill **why** that goal matters, up to five turns. Stop early when they reach a terminal value.
+
+Each turn:
+
+1. Read the most recent user comment.
+2. If the user has reached a terminal value (a feeling — "I want to feel useful"; a fundamental need — "I need to make rent"; an identity statement — "this is who I am") **stop early** and advance to Phase C.
+3. Otherwise post **one short comment**: a brief reflection of what they said (one sentence at most) and the next question. Vary phrasing — don't literally write "why?" five times. Examples:
+   - *"What makes that important to you?"*
+   - *"If that worked, what changes?"*
+   - *"What's the deeper thing you'd be solving?"*
+   - *"What would be true about your life or your users that isn't true today?"*
+   - *"And under that — what's at the bottom of it?"*
+4. Exit.
+
+Keep it tight: one sentence of reflection, one question. **Do not number turns.** The user is in a conversation, not a workflow.
+
+### Step 4 — Phase C: Synthesis proposal
+
+Once the ladder is done, synthesize what you've learned and propose four things in **one combined comment**:
+
+1. **Company name** — propose 1 candidate (or up to 3 if the right one isn't obvious). Don't get cute.
+2. **Mission** — one sentence in the user's own language, with a 2–3 sentence elaboration drawn from the bottom of the ladder.
+3. **Workflow pattern** — pick the most natural fit from these four (read [the company-creator workflow taxonomy](#workflow-patterns) below) and state it with a one-line rationale.
+4. **Hiring plan** — propose **3–5 specific agents** by role with a one-line responsibility each. Stay lean. The user can adjust, but you're not asking "what agents do you want?" — you're proposing a concrete starting team based on the workflow and what they've told you.
+
+Format the comment plainly — the user is in a chat, not reading a document. Markdown is fine. Example shape:
+
+> *Here's what I'm hearing — let me know if anything's off.*
+>
+> **Company:** Beacon Logistics
+>
+> **Mission:** Help small carriers compete with national logistics platforms by automating their dispatch and customer-comms workflow.
+>
+> **How work would flow:** Pipeline (request → dispatch → execution → invoicing → review). Each stage hands off to the next; this is the right shape because logistics is naturally sequential.
+>
+> **Founding team (5):**
+> - **CEO** — sets direction, prioritizes, talks to founding customers
+> - **Dispatch Engineer** — owns the matching/scheduling logic
+> - **Integrations Engineer** — wires up carrier ELDs, customer portals, payment gateways
+> - **Customer Success** — onboards carriers, handles questions, surfaces feedback
+> - **Ops Analyst** — watches the dashboard, flags anomalies, runs weekly reviews
+>
+> *Want any of this changed before I provision?*
+
+Then exit. Wait for the user's reply.
+
+### Step 5 — Phase D: Refinement
+
+The user replied. Read their comment.
+
+- If they said "looks good" / "ship it" / similar acceptance: advance to Phase E (build & propose the package).
+- If they tweaked things ("rename Company X to Y" / "drop the Ops Analyst" / "I want a Designer instead of CS"): incorporate the changes, post a short reply confirming the new state in one paragraph (no big restructure), and advance to Phase E.
+- If they want a deeper rethink ("none of this fits"): apologize briefly, ask one focused clarifying question, exit. Resume the ladder from where their answer points.
+
+Don't loop on refinement more than twice. After two refinement rounds, propose the package and let acceptance settle it.
+
+### Step 6 — Phase E: Build & propose the package
+
+You now have: a name, a mission, a workflow pattern, a list of agents. Build an **Agent Companies (agentcompanies/v1)** package as a JSON document on the issue, then post a confirmation referencing it.
+
+Before writing files, read the spec for the structure you must conform to:
+
+```
+GET /api/companies/{companyId}/skills?path=skills/paperclip
+```
+
+…or read your local copy at `docs/companies/companies-spec.md` if it's mounted. The package must conform to **schema: agentcompanies/v1**.
+
+#### What goes in the package
+
+A minimum-viable package:
+
+- `COMPANY.md` — frontmatter with `schema: agentcompanies/v1`, `name`, `slug`, `description`. Body in markdown.
+- `agents/<slug>/AGENTS.md` — one file per agent. Frontmatter with `name`, `role`, `title`, `reportsTo` (the CEO's slug, or `null` for the CEO). Body explains the agent's responsibilities, **including how they fit into the workflow** (where work comes from, what they produce, who they hand off to, what triggers them).
+- `agents/ceo/AGENTS.md` — required for full companies. CEO has `reportsTo: null`.
+- `.paperclip.yaml` — only include if specific adapter overrides or env inputs are warranted. **Do not specify an adapter at all unless the user requested one.** Paperclip will use its default. **Do not add boilerplate env variables** (no default empty `ANTHROPIC_API_KEY`, no `GH_TOKEN` unless an agent actually needs it).
+
+Rules to follow:
+
+- Slugs are URL-safe, lowercase, hyphenated.
+- The CEO has `reportsTo: null`. Other agents `reportsTo: <ceo-slug>` or to a manager you've defined.
+- Every working agent's AGENTS.md body includes a concise execution contract:
+  - Start actionable work in the same heartbeat; do not stop at a plan unless planning was requested.
+  - Leave durable progress in comments, documents, or work products with the next action.
+  - Use child issues for long or parallel delegated work.
+  - Mark blocked work with the unblock owner and action.
+  - Respect budget, pause/cancel, approval gates, and company boundaries.
+- Do not export secrets, machine-local paths, or database IDs.
+- Omit empty/default fields.
+
+Optional v1 add-ons if the user asked for them: a single `projects/main/PROJECT.md`, one or two `tasks/<slug>/TASK.md` for the founding backlog. Skip teams, skills directories, and elaborate projects for v1 — those are v2.
+
+#### Write the package as a document
+
+The package is a **file map**: each entry's path maps to a string of the file's content. Write that file map as a document on this issue under the key `coach-package`. The document body is a JSON string (the only `format` Paperclip currently supports is `markdown` — that's just a storage label, the body itself is whatever you put there):
+
+```
+PUT /api/issues/{issueId}/documents/coach-package
+{
+  "title": "Company package",
+  "format": "markdown",
+  "body": "{\n  \"files\": {\n    \"COMPANY.md\": \"...\",\n    \"agents/ceo/AGENTS.md\": \"...\",\n    ...\n  }\n}"
+}
+```
+
+The body parses as JSON of the form:
+
+```json
+{
+  "files": {
+    "COMPANY.md": "...full file content...",
+    "agents/ceo/AGENTS.md": "...",
+    "agents/dispatch-engineer/AGENTS.md": "...",
+    ...
+  }
+}
+```
+
+Capture the response's `latestRevisionId` — you'll reference it in the confirmation target below.
+
+#### Propose it via RequestConfirmation
+
+After the document is written, post a confirmation interaction targeting it:
+
+```
+POST /api/issues/{issueId}/interactions
+{
+  "kind": "request_confirmation",
+  "payload": {
+    "version": 1,
+    "prompt": "Ready to launch <Company name>?",
+    "acceptLabel": "Launch",
+    "rejectLabel": "Hold on",
+    "supersedeOnUserComment": true,
+    "detailsMarkdown": "I've drafted the company package. Hitting Launch will create the live company with the team above. You can edit any agent's instructions afterward.",
+    "target": {
+      "type": "issue_document",
+      "key": "coach-package",
+      "revisionId": "<the document's current revisionId>",
+      "label": "Company package"
+    }
+  }
+}
+```
+
+Then exit. The chat UI handles the accept by reading the document, parsing the file map, and submitting it to `POST /api/companies/{draftCompanyId}/imports/apply` with `target.mode = "existing_company"` and `collisionStrategy = "skip"`. **You don't call the import yourself** — the user-driven UI does, with the user's auth.
+
+### Step 7 — Phase F: Done
+
+If you wake and the company has been provisioned (the latest interaction is an accepted `coach_launch_package` confirmation, or your assignee status has been changed because the import added a CEO), this skill no longer applies. Exit cleanly. The new CEO will pick up future work.
+
+## Workflow patterns
+
+Pick **one** that fits the company. The choice is based on how work moves through the org.
+
+- **Pipeline** — sequential stages, each agent hands off to the next. Use when the domain has a clear linear process (plan → build → review → ship → QA, or content ideation → draft → edit → publish).
+- **Hub-and-spoke** — a manager (usually the CEO) delegates to specialists who report back independently. Use when the agents do different kinds of work that don't feed into each other (CEO who dispatches to a researcher, a marketer, an analyst).
+- **Collaborative** — agents work together on the same things as peers. Use for small teams where everyone contributes to the same output (a design studio, a research team).
+- **On-demand** — agents are summoned as needed with no fixed flow. Use when agents are more like a toolbox of specialists the user calls directly.
+
+When you write each agent's AGENTS.md body, include workflow context: *where their work comes from*, *what they produce*, *who they hand off to*, *what triggers them*. This turns a list of agents into an organization that actually works together.
+
+## Interviewing principles
+
+- **Propose, don't ask open-ended.** "Here's a hiring plan — adjust as you like" beats "what agents do you want?"
+- **Stay lean.** 3–5 agents is typical for a startup. Don't suggest 10+ unless the scope clearly demands it.
+- **Full company vs. team/department.** From-scratch companies start with a CEO. Teams/departments don't need one. Default to full company.
+- **One thing at a time.** Each comment asks one question or proposes one decision. Don't dump a five-question survey into a chat.
+
+## Boundaries
+
+- **One substantive action per heartbeat.** Read state, do one thing (post a comment, write a document, post an interaction), exit.
+- **No code, no research, no strategy docs.** That's CEO work, not Coach work. If the user asks, say "I'll have your CEO pick that up after launch."
+- **No pre-population of agents** beyond the founding team in the package. Hiring more comes later.
+- **Don't speak as the company's CEO.** You're a coach helping the founder think. The CEO is a separate agent who exists after launch.
+
+## Error handling
+
+- 409 on checkout → exit (someone else owns the issue).
+- Unknown target kind on a `RequestConfirmationInteraction` → fall back to a structured comment with the same fields.
+- Three heartbeats in the same phase with no progress → post one short conversational message ("I'm stuck — could you say more about what you'd like next?") and exit.
+
+## v1 limitations
+
+- Five Whys is the only goal-discovery framework. WOOP, Odyssey Plans, and Pre-mortem land in v2.
+- No first-project or first-task proposals beyond the founding agents. The new CEO populates the backlog after launch.
+- No handoff path — the import path replaces the Coach implicitly when it adds the CEO. v2 may add an explicit handoff doc.
+- No scheduled re-runs (routines). v2.

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -22,7 +22,9 @@ const TASK_TITLE = "E2E test task";
 
 test.describe("Onboarding wizard", () => {
   test("completes full wizard flow", async ({ page }) => {
-    await page.goto("/onboarding");
+    // The classic wizard moved to /onboarding/classic; the bare /onboarding
+    // route renders the new Coach-driven flow.
+    await page.goto("/onboarding/classic");
 
     const wizardHeading = page.locator("h3", { hasText: "Name your company" });
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,6 +2,8 @@ import { Navigate, Outlet, Route, Routes, useLocation, useParams } from "@/lib/r
 import { Button } from "@/components/ui/button";
 import { Layout } from "./components/Layout";
 import { OnboardingWizard } from "./components/OnboardingWizard";
+import { CoachOnboardingPage } from "./components/CoachOnboardingPage";
+import { OnboardingChat } from "./components/OnboardingChat";
 import { CloudAccessGate } from "./components/CloudAccessGate";
 import { Dashboard } from "./pages/Dashboard";
 import { DashboardLive } from "./pages/DashboardLive";
@@ -63,7 +65,9 @@ function boardRoutes() {
       <Route index element={<Navigate to="dashboard" replace />} />
       <Route path="dashboard" element={<Dashboard />} />
       <Route path="dashboard/live" element={<DashboardLive />} />
-      <Route path="onboarding" element={<OnboardingRoutePage />} />
+      <Route path="onboarding" element={<CoachOnboardingPage />} />
+      <Route path="onboarding/classic" element={<OnboardingRoutePage />} />
+      <Route path="onboarding/chat/:issueRef" element={<OnboardingChat />} />
       <Route path="companies" element={<Companies />} />
       <Route path="company/settings" element={<CompanySettings />} />
       <Route path="company/settings/environments" element={<CompanyEnvironments />} />
@@ -270,7 +274,8 @@ export function App() {
 
         <Route element={<CloudAccessGate />}>
           <Route index element={<CompanyRootRedirect />} />
-          <Route path="onboarding" element={<OnboardingRoutePage />} />
+          <Route path="onboarding" element={<CoachOnboardingPage />} />
+          <Route path="onboarding/classic" element={<OnboardingRoutePage />} />
           <Route path="instance" element={<Navigate to="/instance/settings/general" replace />} />
           <Route path="instance/settings" element={<Layout />}>
             <Route index element={<Navigate to="general" replace />} />

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -58,4 +58,12 @@ export const companiesApi = {
     api.post<CompanyPortabilityPreviewResult>("/companies/import/preview", data),
   importBundle: (data: CompanyPortabilityImportRequest) =>
     api.post<CompanyPortabilityImportResult>("/companies/import", data),
+  applyImportToCompany: (
+    companyId: string,
+    data: CompanyPortabilityImportRequest,
+  ) =>
+    api.post<CompanyPortabilityImportResult>(
+      `/companies/${companyId}/imports/apply`,
+      data,
+    ),
 };

--- a/ui/src/components/AdapterEnvironmentResult.tsx
+++ b/ui/src/components/AdapterEnvironmentResult.tsx
@@ -1,0 +1,55 @@
+import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
+
+export function AdapterEnvironmentResult({
+  result,
+}: {
+  result: AdapterEnvironmentTestResult;
+}) {
+  const statusLabel =
+    result.status === "pass"
+      ? "Passed"
+      : result.status === "warn"
+        ? "Warnings"
+        : "Failed";
+  const statusClass =
+    result.status === "pass"
+      ? "text-green-700 dark:text-green-300 border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10"
+      : result.status === "warn"
+        ? "text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-500/40 bg-amber-50 dark:bg-amber-500/10"
+        : "text-red-700 dark:text-red-300 border-red-300 dark:border-red-500/40 bg-red-50 dark:bg-red-500/10";
+
+  return (
+    <div className={`rounded-md border px-2.5 py-2 text-[11px] ${statusClass}`}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium">{statusLabel}</span>
+        <span className="opacity-80">
+          {new Date(result.testedAt).toLocaleTimeString()}
+        </span>
+      </div>
+      <div className="mt-1.5 space-y-1">
+        {result.checks.map((check, idx) => (
+          <div
+            key={`${check.code}-${idx}`}
+            className="leading-relaxed break-words"
+          >
+            <span className="font-medium uppercase tracking-wide opacity-80">
+              {check.level}
+            </span>
+            <span className="mx-1 opacity-60">·</span>
+            <span>{check.message}</span>
+            {check.detail ? (
+              <span className="block opacity-75 break-all">
+                ({check.detail})
+              </span>
+            ) : null}
+            {check.hint ? (
+              <span className="block opacity-90 break-words">
+                Hint: {check.hint}
+              </span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/AdapterTypePicker.tsx
+++ b/ui/src/components/AdapterTypePicker.tsx
@@ -1,0 +1,126 @@
+import { useMemo, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "../lib/utils";
+import { listUIAdapters } from "../adapters";
+import { isVisualAdapterChoice } from "../adapters/metadata";
+import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
+import { getAdapterDisplay } from "../adapters/adapter-display-registry";
+
+interface AdapterTypePickerProps {
+  value: string;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const SYSTEM_ADAPTER_TYPES = new Set(["process", "http"]);
+
+export function AdapterTypePicker({
+  value,
+  onChange,
+  disabled,
+  className,
+}: AdapterTypePickerProps) {
+  const disabledTypes = useDisabledAdaptersSync();
+  const [showMore, setShowMore] = useState(false);
+
+  const { recommended, more } = useMemo(() => {
+    const all = listUIAdapters()
+      .filter(
+        (a) =>
+          !SYSTEM_ADAPTER_TYPES.has(a.type)
+          && !disabledTypes.has(a.type)
+          && isVisualAdapterChoice(a.type),
+      )
+      .map((a) => ({ ...getAdapterDisplay(a.type), type: a.type }));
+
+    return {
+      recommended: all.filter((a) => a.recommended),
+      more: all.filter((a) => !a.recommended),
+    };
+  }, [disabledTypes]);
+
+  return (
+    <div className={className}>
+      <div className="grid grid-cols-2 gap-2">
+        {recommended.map((opt) => (
+          <button
+            key={opt.type}
+            type="button"
+            disabled={disabled}
+            className={cn(
+              "flex flex-col items-center gap-1.5 rounded-md border p-3 text-xs transition-colors relative",
+              value === opt.type
+                ? "border-foreground bg-accent"
+                : "border-border hover:bg-accent/50",
+              disabled && "opacity-60 cursor-not-allowed",
+            )}
+            onClick={() => onChange(opt.type)}
+          >
+            {opt.recommended ? (
+              <span className="absolute -top-1.5 right-1.5 bg-green-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full leading-none">
+                Recommended
+              </span>
+            ) : null}
+            <opt.icon className="h-4 w-4" />
+            <span className="font-medium">{opt.label}</span>
+            <span className="text-muted-foreground text-[10px]">
+              {opt.description}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {more.length > 0 ? (
+        <>
+          <button
+            type="button"
+            className="flex items-center gap-1.5 mt-3 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setShowMore((v) => !v)}
+            disabled={disabled}
+          >
+            <ChevronDown
+              className={cn(
+                "h-3 w-3 transition-transform",
+                showMore ? "rotate-0" : "-rotate-90",
+              )}
+            />
+            More Agent Adapter Types
+          </button>
+
+          {showMore ? (
+            <div className="grid grid-cols-2 gap-2 mt-2">
+              {more.map((opt) => (
+                <button
+                  key={opt.type}
+                  type="button"
+                  disabled={disabled || Boolean(opt.comingSoon)}
+                  className={cn(
+                    "flex flex-col items-center gap-1.5 rounded-md border p-3 text-xs transition-colors relative",
+                    opt.comingSoon
+                      ? "border-border opacity-40 cursor-not-allowed"
+                      : value === opt.type
+                        ? "border-foreground bg-accent"
+                        : "border-border hover:bg-accent/50",
+                  )}
+                  onClick={() => {
+                    if (opt.comingSoon) return;
+                    onChange(opt.type);
+                  }}
+                >
+                  <opt.icon className="h-4 w-4" />
+                  <span className="font-medium">{opt.label}</span>
+                  <span className="text-muted-foreground text-[10px]">
+                    {opt.comingSoon
+                      ? (opt.disabledLabel ?? "Coming soon")
+                      : opt.description}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/components/CoachOnboardingPage.tsx
+++ b/ui/src/components/CoachOnboardingPage.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
+import { Link, useNavigate } from "@/lib/router";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+import { useCompany } from "../context/CompanyContext";
+import { companiesApi } from "../api/companies";
+import { agentsApi } from "../api/agents";
+import { issuesApi } from "../api/issues";
+import { projectsApi } from "../api/projects";
+import { queryKeys } from "../lib/queryKeys";
+import { buildNewAgentRuntimeConfig } from "../lib/new-agent-runtime-config";
+import {
+  ONBOARDING_PROJECT_NAME,
+  buildOnboardingIssuePayload,
+} from "../lib/onboarding-launch";
+import { getUIAdapter } from "../adapters";
+import { defaultCreateValues } from "./agent-config-defaults";
+import { AdapterTypePicker } from "./AdapterTypePicker";
+import { AdapterEnvironmentResult } from "./AdapterEnvironmentResult";
+import { OnboardingChrome } from "./OnboardingChrome";
+
+const COACH_ISSUE_TITLE = "Welcome — let's figure out what your company should do";
+const COACH_ISSUE_DESCRIPTION =
+  "Your Coach will start the conversation here. Reply when you're ready.";
+
+function buildCoachAdapterConfig(adapterType: string): Record<string, unknown> {
+  const adapter = getUIAdapter(adapterType);
+  return adapter.buildAdapterConfig({
+    ...defaultCreateValues,
+    adapterType,
+    dangerouslySkipPermissions:
+      adapterType === "claude_local" || adapterType === "opencode_local",
+  });
+}
+
+export function CoachOnboardingPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { setSelectedCompanyId } = useCompany();
+  const [adapterType, setAdapterType] = useState<string>("claude_local");
+  const [companyId, setCompanyId] = useState<string | null>(null);
+  const [companyPrefix, setCompanyPrefix] = useState<string | null>(null);
+  const [adapterEnvResult, setAdapterEnvResult] =
+    useState<AdapterEnvironmentTestResult | null>(null);
+  const [adapterEnvError, setAdapterEnvError] = useState<string | null>(null);
+  const [adapterEnvLoading, setAdapterEnvLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset env test state when the adapter changes — old result no longer applies.
+  const lastAdapterRef = useRef(adapterType);
+  useEffect(() => {
+    if (lastAdapterRef.current !== adapterType) {
+      lastAdapterRef.current = adapterType;
+      setAdapterEnvResult(null);
+      setAdapterEnvError(null);
+    }
+  }, [adapterType]);
+
+  const testPassed =
+    adapterEnvResult !== null && adapterEnvResult.status !== "fail";
+
+  async function ensureCompany(): Promise<{ id: string; issuePrefix: string }> {
+    if (companyId && companyPrefix) {
+      return { id: companyId, issuePrefix: companyPrefix };
+    }
+    const company = await companiesApi.create({
+      name: "Untitled",
+      description: "Onboarding draft — your Coach is helping you shape this.",
+    });
+    setSelectedCompanyId(company.id);
+    queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+    await companiesApi.update(company.id, { status: "draft" });
+    setCompanyId(company.id);
+    setCompanyPrefix(company.issuePrefix);
+    return { id: company.id, issuePrefix: company.issuePrefix };
+  }
+
+  async function runTest(): Promise<AdapterEnvironmentTestResult | null> {
+    setAdapterEnvLoading(true);
+    setAdapterEnvError(null);
+    try {
+      const { id } = await ensureCompany();
+      const adapterConfig = buildCoachAdapterConfig(adapterType);
+      const result = await agentsApi.testEnvironment(id, adapterType, {
+        adapterConfig,
+      });
+      setAdapterEnvResult(result);
+      return result;
+    } catch (err) {
+      setAdapterEnvError(
+        err instanceof Error ? err.message : "Adapter environment test failed",
+      );
+      return null;
+    } finally {
+      setAdapterEnvLoading(false);
+    }
+  }
+
+  async function handleStart() {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const { id, issuePrefix } = await ensureCompany();
+
+      // Test must pass (or warn) before we commit to hiring. If the user
+      // didn't run it explicitly, run it now.
+      const result = adapterEnvResult ?? (await runTest());
+      if (!result) {
+        // runTest sets adapterEnvError; surface it on the Start button row too.
+        if (!adapterEnvError) {
+          setError("Couldn't reach the adapter to test it. Try again.");
+        }
+        return;
+      }
+      if (result.status === "fail") {
+        setError(
+          "Adapter environment test failed. Fix the issues above before continuing.",
+        );
+        return;
+      }
+
+      const adapterConfig = buildCoachAdapterConfig(adapterType);
+      const hire = await agentsApi.hire(id, {
+        name: "Coach",
+        role: "coach",
+        adapterType,
+        adapterConfig,
+        runtimeConfig: buildNewAgentRuntimeConfig(),
+      });
+      const agentId = hire.agent.id;
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(id) });
+
+      const project = await projectsApi.create(id, {
+        name: ONBOARDING_PROJECT_NAME,
+        status: "in_progress",
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(id) });
+
+      const issue = await issuesApi.create(
+        id,
+        buildOnboardingIssuePayload({
+          title: COACH_ISSUE_TITLE,
+          description: COACH_ISSUE_DESCRIPTION,
+          assigneeAgentId: agentId,
+          projectId: project.id,
+          goalId: null,
+        }),
+      );
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(id) });
+
+      const issueRef =
+        (issue as { identifier?: string; id: string }).identifier ?? issue.id;
+      navigate(`/${issuePrefix}/onboarding/chat/${issueRef}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start onboarding");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const startDisabled = submitting || adapterEnvLoading;
+  const startLabel = submitting
+    ? "Starting…"
+    : testPassed
+      ? "Start with a Coach"
+      : adapterEnvResult?.status === "fail"
+        ? "Fix issues above"
+        : "Test & start with a Coach";
+
+  return (
+    <OnboardingChrome showAnimation={true}>
+      <div className="w-full max-w-md mx-auto my-auto px-8 py-12 space-y-4">
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h1 className="text-xl font-semibold">Talk to a Coach</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            We'll spin up a Coach agent and start a conversation. The Coach helps you
+            figure out what your company should focus on by asking a handful of questions,
+            then proposes a name and mission you can accept or refine. When you're ready,
+            the Coach becomes your CEO.
+          </p>
+
+          <div className="mt-5">
+            <label className="text-xs text-muted-foreground mb-2 block">
+              Adapter
+            </label>
+            <AdapterTypePicker
+              value={adapterType}
+              onChange={setAdapterType}
+              disabled={submitting || adapterEnvLoading}
+            />
+            <p className="mt-2 text-[11px] text-muted-foreground">
+              We'll use the adapter's defaults. You can edit the agent's config later
+              once the conversation starts.
+            </p>
+          </div>
+
+          <div className="mt-5 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs text-muted-foreground">
+                Adapter environment
+              </span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={runTest}
+                disabled={adapterEnvLoading || submitting}
+              >
+                {adapterEnvLoading ? (
+                  <>
+                    <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                    Testing…
+                  </>
+                ) : adapterEnvResult ? (
+                  "Re-test"
+                ) : (
+                  "Test now"
+                )}
+              </Button>
+            </div>
+            {adapterEnvError ? (
+              <p className="text-xs text-red-600">{adapterEnvError}</p>
+            ) : null}
+            {adapterEnvResult ? (
+              <AdapterEnvironmentResult result={adapterEnvResult} />
+            ) : (
+              <p className="text-[11px] text-muted-foreground">
+                We'll verify your adapter can reach a model before starting. Test
+                runs automatically when you click Start, or trigger it now.
+              </p>
+            )}
+          </div>
+
+          <div className="mt-5">
+            <Button onClick={handleStart} disabled={startDisabled}>
+              {submitting ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                  {startLabel}
+                </>
+              ) : (
+                startLabel
+              )}
+            </Button>
+          </div>
+          {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}
+        </div>
+        <p className="text-xs text-muted-foreground text-center">
+          Want a form-based setup instead?{" "}
+          <Link to="/onboarding/classic" className="underline">
+            Switch to classic onboarding
+          </Link>
+          .
+        </p>
+      </div>
+    </OnboardingChrome>
+  );
+}

--- a/ui/src/components/OnboardingChat.tsx
+++ b/ui/src/components/OnboardingChat.tsx
@@ -1,0 +1,378 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  CompanyPortabilityFileEntry,
+  IssueComment,
+  IssueThreadInteraction,
+  RequestConfirmationInteraction,
+  RequestConfirmationIssueDocumentTarget,
+} from "@paperclipai/shared";
+import { useNavigate, useParams } from "@/lib/router";
+import { Button } from "@/components/ui/button";
+import { cn } from "../lib/utils";
+import { useCompany } from "../context/CompanyContext";
+import { issuesApi } from "../api/issues";
+import { agentsApi } from "../api/agents";
+import { companiesApi } from "../api/companies";
+import { queryKeys } from "../lib/queryKeys";
+import { Loader2 } from "lucide-react";
+import { OnboardingChrome } from "./OnboardingChrome";
+
+const POLL_INTERVAL_MS = 4000;
+const COACH_RESPONSE_GRACE_MS = 1500;
+const COACH_PACKAGE_DOCUMENT_KEY = "coach-package";
+
+type ChatBubble = {
+  id: string;
+  side: "coach" | "you";
+  body: string;
+  createdAt: Date;
+};
+
+function classifyComment(
+  comment: IssueComment,
+  coachAgentId: string | null,
+): ChatBubble | null {
+  const side: ChatBubble["side"] | null = (() => {
+    if (coachAgentId && comment.authorAgentId === coachAgentId) return "coach";
+    if (comment.authorUserId) return "you";
+    if (comment.authorAgentId) return "coach";
+    return null;
+  })();
+  if (!side) return null;
+  return {
+    id: comment.id,
+    side,
+    body: comment.body,
+    createdAt: comment.createdAt instanceof Date ? comment.createdAt : new Date(comment.createdAt),
+  };
+}
+
+function findPendingLaunchConfirmation(
+  interactions: IssueThreadInteraction[] | undefined,
+): RequestConfirmationInteraction | null {
+  if (!interactions) return null;
+  for (const interaction of interactions) {
+    if (interaction.kind !== "request_confirmation") continue;
+    if (interaction.status !== "pending") continue;
+    const target = interaction.payload.target;
+    if (!target || target.type !== "issue_document") continue;
+    const docTarget = target as RequestConfirmationIssueDocumentTarget;
+    if (docTarget.key !== COACH_PACKAGE_DOCUMENT_KEY) continue;
+    return interaction as RequestConfirmationInteraction;
+  }
+  return null;
+}
+
+function parsePackageDocument(body: string): Record<string, CompanyPortabilityFileEntry> | null {
+  try {
+    const parsed = JSON.parse(body);
+    if (!parsed || typeof parsed !== "object") return null;
+    const files = (parsed as { files?: unknown }).files;
+    if (!files || typeof files !== "object" || Array.isArray(files)) return null;
+    return files as Record<string, CompanyPortabilityFileEntry>;
+  } catch {
+    return null;
+  }
+}
+
+export function OnboardingChat() {
+  const params = useParams<{ companyPrefix?: string; issueRef?: string }>();
+  const issueRef = params.issueRef;
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { setSelectedCompanyId, companies } = useCompany();
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [launching, setLaunching] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+  const lastSendAtRef = useRef<number>(0);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const issueQuery = useQuery({
+    queryKey: queryKeys.issues.detail(issueRef ?? ""),
+    queryFn: () => issuesApi.get(issueRef!),
+    enabled: Boolean(issueRef),
+  });
+  const issue = issueQuery.data ?? null;
+  const issueId = issue?.id ?? null;
+  const coachAgentId = issue?.assigneeAgentId ?? null;
+
+  useEffect(() => {
+    if (issue?.companyId) setSelectedCompanyId(issue.companyId);
+  }, [issue?.companyId, setSelectedCompanyId]);
+
+  const commentsQuery = useQuery({
+    queryKey: ["onboarding-chat", "comments", issueId],
+    queryFn: () => issuesApi.listComments(issueId!, { order: "asc", limit: 200 }),
+    enabled: Boolean(issueId),
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+
+  const interactionsQuery = useQuery({
+    queryKey: ["onboarding-chat", "interactions", issueId],
+    queryFn: () => issuesApi.listInteractions(issueId!),
+    enabled: Boolean(issueId),
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+
+  const coachQuery = useQuery({
+    queryKey: queryKeys.agents.detail(coachAgentId ?? ""),
+    queryFn: () => agentsApi.get(coachAgentId!),
+    enabled: Boolean(coachAgentId),
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+  const coach = coachQuery.data ?? null;
+
+  const company = useMemo(
+    () => (issue ? companies.find((c) => c.id === issue.companyId) ?? null : null),
+    [issue, companies],
+  );
+
+  const bubbles = useMemo(() => {
+    const raw = commentsQuery.data ?? [];
+    return raw
+      .map((c) => classifyComment(c, coachAgentId))
+      .filter((b): b is ChatBubble => b !== null);
+  }, [commentsQuery.data, coachAgentId]);
+
+  const launchConfirmation = useMemo(
+    () => findPendingLaunchConfirmation(interactionsQuery.data),
+    [interactionsQuery.data],
+  );
+
+  const coachThinking = useMemo(() => {
+    if (launchConfirmation) return false;
+    const lastBubble = bubbles[bubbles.length - 1];
+    const userJustSent = lastBubble?.side === "you";
+    const agentRunning = coach?.status === "running";
+    const sinceSendOk = Date.now() - lastSendAtRef.current >= COACH_RESPONSE_GRACE_MS;
+    return (userJustSent || agentRunning) && sinceSendOk && !sending;
+  }, [launchConfirmation, bubbles, coach?.status, sending]);
+
+  useEffect(() => {
+    const node = scrollRef.current;
+    if (!node) return;
+    node.scrollTop = node.scrollHeight;
+  }, [bubbles.length, coachThinking, launchConfirmation?.id]);
+
+  async function handleSend() {
+    if (!issueId || !draft.trim() || sending) return;
+    setSending(true);
+    setSendError(null);
+    try {
+      await issuesApi.addComment(issueId, draft.trim());
+      lastSendAtRef.current = Date.now();
+      setDraft("");
+      await queryClient.invalidateQueries({
+        queryKey: ["onboarding-chat", "comments", issueId],
+      });
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : "Failed to send");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  async function handleLaunch() {
+    if (!issueId || !issue || !launchConfirmation || launching) return;
+    setLaunching(true);
+    setLaunchError(null);
+    try {
+      const doc = await issuesApi.getDocument(issueId, COACH_PACKAGE_DOCUMENT_KEY);
+      const files = parsePackageDocument(doc.body);
+      if (!files || Object.keys(files).length === 0) {
+        throw new Error(
+          "The Coach's package document is empty or malformed. Ask the Coach to rewrite it.",
+        );
+      }
+
+      await companiesApi.applyImportToCompany(issue.companyId, {
+        source: { type: "inline", files },
+        target: { mode: "existing_company", companyId: issue.companyId },
+        collisionStrategy: "skip",
+      });
+
+      await companiesApi.update(issue.companyId, { status: "active" });
+
+      await issuesApi.acceptInteraction(issueId, launchConfirmation.id);
+
+      const targetCompany =
+        companies.find((c) => c.id === issue.companyId) ?? company;
+      const prefix = targetCompany?.issuePrefix ?? params.companyPrefix ?? "";
+      navigate(`/${prefix}/dashboard`);
+    } catch (err) {
+      setLaunchError(err instanceof Error ? err.message : "Failed to launch");
+    } finally {
+      setLaunching(false);
+    }
+  }
+
+  async function handleHoldOn() {
+    if (!issueId || !launchConfirmation || launching) return;
+    setLaunching(true);
+    setLaunchError(null);
+    try {
+      await issuesApi.rejectInteraction(issueId, launchConfirmation.id);
+      await queryClient.invalidateQueries({
+        queryKey: ["onboarding-chat", "interactions", issueId],
+      });
+    } catch (err) {
+      setLaunchError(err instanceof Error ? err.message : "Failed to send rejection");
+    } finally {
+      setLaunching(false);
+    }
+  }
+
+  if (!issueRef) {
+    return (
+      <OnboardingChrome showAnimation={false}>
+        <div className="mx-auto max-w-2xl py-10 text-sm text-muted-foreground">
+          No onboarding chat selected.
+        </div>
+      </OnboardingChrome>
+    );
+  }
+
+  if (issueQuery.isLoading) {
+    return (
+      <OnboardingChrome showAnimation={false}>
+        <div className="mx-auto max-w-2xl py-10 text-sm text-muted-foreground flex items-center gap-2 px-4">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading your Coach…
+        </div>
+      </OnboardingChrome>
+    );
+  }
+
+  if (issueQuery.isError || !issue) {
+    return (
+      <OnboardingChrome showAnimation={false}>
+        <div className="mx-auto max-w-2xl py-10 px-4">
+          <div className="rounded-lg border border-border bg-card p-6">
+            <h1 className="text-lg font-semibold">Couldn't open the onboarding chat</h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {issueQuery.error instanceof Error ? issueQuery.error.message : "Unknown error"}
+            </p>
+            <div className="mt-4">
+              <Button variant="outline" onClick={() => navigate("/onboarding")}>
+                Restart onboarding
+              </Button>
+            </div>
+          </div>
+        </div>
+      </OnboardingChrome>
+    );
+  }
+
+  const heading = company?.name && company.name !== "Untitled"
+    ? `Onboarding — ${company.name}`
+    : "Talking with your Coach";
+
+  return (
+    <OnboardingChrome showAnimation={false}>
+    <div className="mx-auto flex h-full max-w-2xl flex-col px-4 py-6">
+      <div className="mb-4">
+        <h1 className="text-base font-medium">{heading}</h1>
+        <p className="text-[11px] text-muted-foreground">
+          Your Coach asks questions to help shape your company. Answer freely; the conversation is just between you and the Coach.
+        </p>
+      </div>
+
+      <div
+        ref={scrollRef}
+        className="flex-1 overflow-y-auto rounded-lg border border-border bg-card p-4 space-y-3"
+      >
+        {bubbles.length === 0 && !coachThinking && !launchConfirmation ? (
+          <p className="text-sm text-muted-foreground">
+            Your Coach is getting set up. The first question will appear in a moment…
+          </p>
+        ) : null}
+        {bubbles.map((bubble) => (
+          <div
+            key={bubble.id}
+            className={cn(
+              "flex",
+              bubble.side === "you" ? "justify-end" : "justify-start",
+            )}
+          >
+            <div
+              className={cn(
+                "max-w-[85%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap",
+                bubble.side === "you"
+                  ? "bg-foreground text-background"
+                  : "bg-muted text-foreground",
+              )}
+            >
+              {bubble.body}
+            </div>
+          </div>
+        ))}
+        {coachThinking ? (
+          <div className="flex justify-start">
+            <div className="max-w-[85%] rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground italic">
+              Coach is thinking…
+            </div>
+          </div>
+        ) : null}
+        {launchConfirmation ? (
+          <div className="flex justify-start">
+            <div className="w-full rounded-lg border border-border bg-muted/30 p-4 space-y-3">
+              <div className="text-sm font-medium">{launchConfirmation.payload.prompt}</div>
+              {launchConfirmation.payload.detailsMarkdown ? (
+                <div className="text-sm text-muted-foreground whitespace-pre-wrap">
+                  {launchConfirmation.payload.detailsMarkdown}
+                </div>
+              ) : null}
+              <div className="flex items-center gap-2">
+                <Button onClick={handleLaunch} disabled={launching}>
+                  {launching ? "Launching…" : (launchConfirmation.payload.acceptLabel ?? "Launch")}
+                </Button>
+                <Button variant="outline" onClick={handleHoldOn} disabled={launching}>
+                  {launchConfirmation.payload.rejectLabel ?? "Hold on"}
+                </Button>
+              </div>
+              {launchError ? (
+                <p className="text-sm text-red-600">{launchError}</p>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-3">
+        <textarea
+          className="w-full resize-none rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50 min-h-[60px]"
+          placeholder={
+            bubbles.length === 0
+              ? "Wait for your Coach to ask the first question…"
+              : "Reply to your Coach…"
+          }
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={sending || launching}
+        />
+        <div className="mt-2 flex items-center justify-between gap-3">
+          <p className="text-[11px] text-muted-foreground">
+            Enter to send. Shift-Enter for a new line.
+          </p>
+          <Button onClick={handleSend} disabled={!draft.trim() || sending || launching}>
+            {sending ? "Sending…" : "Send"}
+          </Button>
+        </div>
+        {sendError ? (
+          <p className="mt-2 text-sm text-red-600">{sendError}</p>
+        ) : null}
+      </div>
+    </div>
+    </OnboardingChrome>
+  );
+}

--- a/ui/src/components/OnboardingChrome.tsx
+++ b/ui/src/components/OnboardingChrome.tsx
@@ -1,0 +1,61 @@
+import { X } from "lucide-react";
+import { cn } from "../lib/utils";
+import { AsciiArtAnimation } from "./AsciiArtAnimation";
+
+interface OnboardingChromeProps {
+  children: React.ReactNode;
+  /** Show the animated right-side panel. Defaults to true (the entry-point look). */
+  showAnimation?: boolean;
+  /** If provided, renders a close button in the top-left that calls this. */
+  onClose?: () => void;
+  /** Optional className override for the outer container (rare). */
+  className?: string;
+}
+
+/**
+ * Shared chrome for the onboarding flow. Mirrors the classic wizard's split
+ * layout — full-viewport background, left content pane, animated ASCII pane on
+ * the right (md+). Used by both the Coach entry page and the Coach chat so the
+ * onboarding experience feels continuous.
+ */
+export function OnboardingChrome({
+  children,
+  showAnimation = true,
+  onClose,
+  className,
+}: OnboardingChromeProps) {
+  return (
+    <div className={cn("fixed inset-0 z-40 bg-background", className)}>
+      <div className="absolute inset-0 flex">
+        {onClose ? (
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute top-4 left-4 z-10 rounded-sm p-1.5 text-muted-foreground/60 hover:text-foreground transition-colors"
+          >
+            <X className="h-5 w-5" />
+            <span className="sr-only">Close</span>
+          </button>
+        ) : null}
+
+        <div
+          className={cn(
+            "w-full flex flex-col overflow-y-auto transition-[width] duration-500 ease-in-out",
+            showAnimation ? "md:w-1/2" : "md:w-full",
+          )}
+        >
+          {children}
+        </div>
+
+        <div
+          className={cn(
+            "hidden md:block overflow-hidden bg-[#1d1d1d] transition-[width,opacity] duration-500 ease-in-out",
+            showAnimation ? "w-1/2 opacity-100" : "w-0 opacity-0",
+          )}
+        >
+          <AsciiArtAnimation />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -415,6 +415,12 @@ export function OnboardingWizard() {
       if (isLocalAdapter) {
         const result = adapterEnvResult ?? (await runAdapterEnvironmentTest());
         if (!result) return;
+        // Existing behavior: a `fail` test result does NOT block hire — the
+        // adapter probe is advisory. Visible gating happens via the disabled
+        // state on the Step 2 Next button so the user knows they're proceeding
+        // through a failed probe. Tightening this to block in the handler is a
+        // separate decision because the e2e suite proceeds through a failing
+        // probe by design (no Claude binary on the CI runner).
       }
 
       const hire = await agentsApi.hire(createdCompanyId, {
@@ -1116,22 +1122,38 @@ export function OnboardingWizard() {
                       {loading ? "Creating..." : "Next"}
                     </Button>
                   )}
-                  {step === 2 && (
-                    <Button
-                      size="sm"
-                      disabled={
-                        !agentName.trim() || loading || adapterEnvLoading
-                      }
-                      onClick={handleStep2Next}
-                    >
-                      {loading ? (
-                        <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
-                      ) : (
-                        <ArrowRight className="h-3.5 w-3.5 mr-1" />
-                      )}
-                      {loading ? "Creating..." : "Next"}
-                    </Button>
-                  )}
+                  {step === 2 && (() => {
+                    const testFailed =
+                      isLocalAdapter && adapterEnvResult?.status === "fail";
+                    const testNotRun =
+                      isLocalAdapter && adapterEnvResult === null;
+                    const stepTwoLabel = loading
+                      ? "Creating..."
+                      : testFailed
+                        ? "Fix issues above"
+                        : testNotRun
+                          ? "Test & next"
+                          : "Next";
+                    return (
+                      <Button
+                        size="sm"
+                        disabled={
+                          !agentName.trim()
+                          || loading
+                          || adapterEnvLoading
+                          || testFailed
+                        }
+                        onClick={handleStep2Next}
+                      >
+                        {loading ? (
+                          <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                        ) : (
+                          <ArrowRight className="h-3.5 w-3.5 mr-1" />
+                        )}
+                        {stepTwoLabel}
+                      </Button>
+                    );
+                  })()}
                   {step === 3 && (
                     <Button
                       size="sm"

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
-import { useLocation, useNavigate, useParams } from "@/lib/router";
+import { Link, useLocation, useNavigate, useParams } from "@/lib/router";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { companiesApi } from "../api/companies";
@@ -689,6 +689,20 @@ export function OnboardingWizard() {
                       onChange={(e) => setCompanyGoal(e.target.value)}
                     />
                   </div>
+                  <p className="text-xs text-muted-foreground text-center pt-2">
+                    Want a conversation instead?{" "}
+                    <Link
+                      to="/onboarding"
+                      onClick={() => {
+                        setRouteDismissed(true);
+                        closeOnboarding();
+                      }}
+                      className="underline"
+                    >
+                      Switch to Coach onboarding
+                    </Link>
+                    .
+                  </p>
                 </div>
               )}
 

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -24,11 +24,7 @@ import {
   extractProviderIdWithFallback
 } from "../lib/model-utils";
 import { getUIAdapter } from "../adapters";
-import { listUIAdapters } from "../adapters";
-import { isVisualAdapterChoice } from "../adapters/metadata";
-import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
-import { getAdapterDisplay } from "../adapters/adapter-display-registry";
 import { defaultCreateValues } from "./agent-config-defaults";
 import { parseOnboardingGoalInput } from "../lib/onboarding-goal";
 import {
@@ -46,6 +42,8 @@ import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
+import { AdapterEnvironmentResult } from "./AdapterEnvironmentResult";
+import { AdapterTypePicker } from "./AdapterTypePicker";
 import {
   Building2,
   Bot,
@@ -54,8 +52,8 @@ import {
   ArrowLeft,
   ArrowRight,
   Check,
-  Loader2,
   ChevronDown,
+  Loader2,
   X
 } from "lucide-react";
 
@@ -77,9 +75,6 @@ export function OnboardingWizard() {
   const location = useLocation();
   const { companyPrefix } = useParams<{ companyPrefix?: string }>();
   const [routeDismissed, setRouteDismissed] = useState(false);
-
-  // Sync disabled adapter types from server so adapter grid filters them out
-  const disabledTypes = useDisabledAdaptersSync();
 
   const routeOnboardingOptions =
     companyPrefix && companiesLoading
@@ -122,7 +117,6 @@ export function OnboardingWizard() {
   const [forceUnsetAnthropicApiKey, setForceUnsetAnthropicApiKey] =
     useState(false);
   const [unsetAnthropicLoading, setUnsetAnthropicLoading] = useState(false);
-  const [showMoreAdapters, setShowMoreAdapters] = useState(false);
 
   // Step 3
   const [taskTitle, setTaskTitle] = useState(
@@ -203,23 +197,6 @@ export function OnboardingWizard() {
   const adapterCaps = getCapabilities(adapterType);
   const isLocalAdapter = adapterCaps.supportsInstructionsBundle || adapterCaps.supportsSkills || adapterCaps.supportsLocalAgentJwt;
 
-  // Build adapter grids dynamically from the UI registry + display metadata.
-  // External/plugin adapters automatically appear with generic defaults.
-  const { recommendedAdapters, moreAdapters } = useMemo(() => {
-    const SYSTEM_ADAPTER_TYPES = new Set(["process", "http"]);
-    const all = listUIAdapters()
-      .filter((a) =>
-        !SYSTEM_ADAPTER_TYPES.has(a.type) &&
-        !disabledTypes.has(a.type) &&
-        isVisualAdapterChoice(a.type)
-      )
-      .map((a) => ({ ...getAdapterDisplay(a.type), type: a.type }));
-
-    return {
-      recommendedAdapters: all.filter((a) => a.recommended),
-      moreAdapters: all.filter((a) => !a.recommended),
-    };
-  }, [disabledTypes]);
   const COMMAND_PLACEHOLDERS: Record<string, string> = {
     claude_local: "claude",
     codex_local: "codex",
@@ -740,103 +717,30 @@ export function OnboardingWizard() {
                     <label className="text-xs text-muted-foreground mb-2 block">
                       Adapter type
                     </label>
-                    <div className="grid grid-cols-2 gap-2">
-                      {recommendedAdapters.map((opt) => (
-                        <button
-                          key={opt.type}
-                          className={cn(
-                            "flex flex-col items-center gap-1.5 rounded-md border p-3 text-xs transition-colors relative",
-                            adapterType === opt.type
-                              ? "border-foreground bg-accent"
-                              : "border-border hover:bg-accent/50"
-                          )}
-                          onClick={() => {
-                            const nextType = opt.type;
-                            setAdapterType(nextType);
-                            if (nextType === "codex_local") {
-                              if (!model) {
-                                setModel(DEFAULT_CODEX_LOCAL_MODEL);
-                              }
-                              return;
-                            }
-                            if (nextType === "opencode_local") {
-                              setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
-                              return;
-                            }
-                            setModel("");
-                          }}
-                        >
-                          {opt.recommended && (
-                            <span className="absolute -top-1.5 right-1.5 bg-green-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full leading-none">
-                              Recommended
-                            </span>
-                          )}
-                          <opt.icon className="h-4 w-4" />
-                          <span className="font-medium">{opt.label}</span>
-                          <span className="text-muted-foreground text-[10px]">
-                            {opt.description}
-                          </span>
-                        </button>
-                      ))}
-                    </div>
-
-                    <button
-                      className="flex items-center gap-1.5 mt-3 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                      onClick={() => setShowMoreAdapters((v) => !v)}
-                    >
-                      <ChevronDown
-                        className={cn(
-                          "h-3 w-3 transition-transform",
-                          showMoreAdapters ? "rotate-0" : "-rotate-90"
-                        )}
-                      />
-                      More Agent Adapter Types
-                    </button>
-
-                    {showMoreAdapters && (
-                      <div className="grid grid-cols-2 gap-2 mt-2">
-                        {moreAdapters.map((opt) => (
-                           <button
-                             key={opt.type}
-                             disabled={!!opt.comingSoon}
-                             className={cn(
-                               "flex flex-col items-center gap-1.5 rounded-md border p-3 text-xs transition-colors relative",
-                               opt.comingSoon
-                                 ? "border-border opacity-40 cursor-not-allowed"
-                                 : adapterType === opt.type
-                                 ? "border-foreground bg-accent"
-                                 : "border-border hover:bg-accent/50"
-                             )}
-                             onClick={() => {
-                               if (opt.comingSoon) return;
-                               const nextType = opt.type;
-                              setAdapterType(nextType);
-                              if (nextType === "gemini_local" && !model) {
-                                setModel(DEFAULT_GEMINI_LOCAL_MODEL);
-                                return;
-                              }
-                              if (nextType === "cursor" && !model) {
-                                setModel(DEFAULT_CURSOR_LOCAL_MODEL);
-                                return;
-                              }
-                              if (nextType === "opencode_local") {
-                                setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
-                                return;
-                              }
-                              setModel("");
-                            }}
-                          >
-                            <opt.icon className="h-4 w-4" />
-                            <span className="font-medium">{opt.label}</span>
-                            <span className="text-muted-foreground text-[10px]">
-                              {opt.comingSoon
-                                ? opt.disabledLabel ?? "Coming soon"
-                                : opt.description}
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    )}
+                    <AdapterTypePicker
+                      value={adapterType}
+                      onChange={(nextType) => {
+                        setAdapterType(nextType);
+                        // Auto-default model when switching adapters that need one.
+                        if (nextType === "codex_local") {
+                          if (!model) setModel(DEFAULT_CODEX_LOCAL_MODEL);
+                          return;
+                        }
+                        if (nextType === "opencode_local") {
+                          setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
+                          return;
+                        }
+                        if (nextType === "gemini_local" && !model) {
+                          setModel(DEFAULT_GEMINI_LOCAL_MODEL);
+                          return;
+                        }
+                        if (nextType === "cursor" && !model) {
+                          setModel(DEFAULT_CURSOR_LOCAL_MODEL);
+                          return;
+                        }
+                        setModel("");
+                      }}
+                    />
                   </div>
 
                   {/* Conditional adapter fields */}
@@ -1272,56 +1176,3 @@ export function OnboardingWizard() {
   );
 }
 
-function AdapterEnvironmentResult({
-  result
-}: {
-  result: AdapterEnvironmentTestResult;
-}) {
-  const statusLabel =
-    result.status === "pass"
-      ? "Passed"
-      : result.status === "warn"
-      ? "Warnings"
-      : "Failed";
-  const statusClass =
-    result.status === "pass"
-      ? "text-green-700 dark:text-green-300 border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10"
-      : result.status === "warn"
-      ? "text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-500/40 bg-amber-50 dark:bg-amber-500/10"
-      : "text-red-700 dark:text-red-300 border-red-300 dark:border-red-500/40 bg-red-50 dark:bg-red-500/10";
-
-  return (
-    <div className={`rounded-md border px-2.5 py-2 text-[11px] ${statusClass}`}>
-      <div className="flex items-center justify-between gap-2">
-        <span className="font-medium">{statusLabel}</span>
-        <span className="opacity-80">
-          {new Date(result.testedAt).toLocaleTimeString()}
-        </span>
-      </div>
-      <div className="mt-1.5 space-y-1">
-        {result.checks.map((check, idx) => (
-          <div
-            key={`${check.code}-${idx}`}
-            className="leading-relaxed break-words"
-          >
-            <span className="font-medium uppercase tracking-wide opacity-80">
-              {check.level}
-            </span>
-            <span className="mx-1 opacity-60">·</span>
-            <span>{check.message}</span>
-            {check.detail && (
-              <span className="block opacity-75 break-all">
-                ({check.detail})
-              </span>
-            )}
-            {check.hint && (
-              <span className="block opacity-90 break-words">
-                Hint: {check.hint}
-              </span>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}

--- a/ui/src/lib/onboarding-route.test.ts
+++ b/ui/src/lib/onboarding-route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isClassicOnboardingPath,
   isOnboardingPath,
   resolveRouteOnboardingOptions,
   shouldRedirectCompanylessRouteToOnboarding,
@@ -14,39 +15,84 @@ describe("isOnboardingPath", () => {
     expect(isOnboardingPath("/pap/onboarding")).toBe(true);
   });
 
+  it("matches the classic onboarding suffix at the global route", () => {
+    expect(isOnboardingPath("/onboarding/classic")).toBe(true);
+  });
+
+  it("matches the classic onboarding suffix at the company-prefixed route", () => {
+    expect(isOnboardingPath("/pap/onboarding/classic")).toBe(true);
+  });
+
   it("ignores non-onboarding routes", () => {
     expect(isOnboardingPath("/pap/dashboard")).toBe(false);
   });
 });
 
+describe("isClassicOnboardingPath", () => {
+  it("matches the global classic onboarding route", () => {
+    expect(isClassicOnboardingPath("/onboarding/classic")).toBe(true);
+  });
+
+  it("matches the company-prefixed classic onboarding route", () => {
+    expect(isClassicOnboardingPath("/pap/onboarding/classic")).toBe(true);
+  });
+
+  it("does not match the bare onboarding route", () => {
+    expect(isClassicOnboardingPath("/onboarding")).toBe(false);
+  });
+
+  it("does not match the company-prefixed bare onboarding route", () => {
+    expect(isClassicOnboardingPath("/pap/onboarding")).toBe(false);
+  });
+});
+
 describe("resolveRouteOnboardingOptions", () => {
-  it("opens company creation for the global onboarding route", () => {
+  it("opens company creation for the global classic onboarding route", () => {
     expect(
       resolveRouteOnboardingOptions({
-        pathname: "/onboarding",
+        pathname: "/onboarding/classic",
         companies: [],
       }),
     ).toEqual({ initialStep: 1 });
   });
 
-  it("opens agent creation when the prefixed company exists", () => {
+  it("opens agent creation when the classic prefixed company exists", () => {
     expect(
       resolveRouteOnboardingOptions({
-        pathname: "/pap/onboarding",
+        pathname: "/pap/onboarding/classic",
         companyPrefix: "pap",
         companies: [{ id: "company-1", issuePrefix: "PAP" }],
       }),
     ).toEqual({ initialStep: 2, companyId: "company-1" });
   });
 
-  it("falls back to company creation when the prefixed company is missing", () => {
+  it("falls back to company creation when the classic prefixed company is missing", () => {
     expect(
       resolveRouteOnboardingOptions({
-        pathname: "/pap/onboarding",
+        pathname: "/pap/onboarding/classic",
         companyPrefix: "pap",
         companies: [],
       }),
     ).toEqual({ initialStep: 1 });
+  });
+
+  it("does not auto-open the wizard for the new Coach onboarding route", () => {
+    expect(
+      resolveRouteOnboardingOptions({
+        pathname: "/onboarding",
+        companies: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("does not auto-open the wizard for the company-prefixed Coach onboarding route", () => {
+    expect(
+      resolveRouteOnboardingOptions({
+        pathname: "/pap/onboarding",
+        companyPrefix: "pap",
+        companies: [{ id: "company-1", issuePrefix: "PAP" }],
+      }),
+    ).toBeNull();
   });
 });
 
@@ -64,6 +110,15 @@ describe("shouldRedirectCompanylessRouteToOnboarding", () => {
     expect(
       shouldRedirectCompanylessRouteToOnboarding({
         pathname: "/onboarding",
+        hasCompanies: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not redirect when already on classic onboarding", () => {
+    expect(
+      shouldRedirectCompanylessRouteToOnboarding({
+        pathname: "/onboarding/classic",
         hasCompanies: false,
       }),
     ).toBe(false);

--- a/ui/src/lib/onboarding-route.ts
+++ b/ui/src/lib/onboarding-route.ts
@@ -4,14 +4,44 @@ type OnboardingRouteCompany = {
 };
 
 export function isOnboardingPath(pathname: string): boolean {
-  const segments = pathname.split("/").filter(Boolean);
+  const segments = pathname.split("/").filter(Boolean).map((s) => s.toLowerCase());
 
-  if (segments.length === 1) {
-    return segments[0]?.toLowerCase() === "onboarding";
+  // Strip a trailing /classic segment so /onboarding and /onboarding/classic
+  // (and the company-prefixed equivalents) are both recognized as onboarding
+  // entry points by the redirect logic.
+  const trimmed =
+    segments.length > 0 && segments[segments.length - 1] === "classic"
+      ? segments.slice(0, -1)
+      : segments;
+
+  if (trimmed.length === 1) {
+    return trimmed[0] === "onboarding";
   }
 
+  if (trimmed.length === 2) {
+    return trimmed[1] === "onboarding";
+  }
+
+  return false;
+}
+
+// The dialog-style onboarding wizard auto-opens only on the classic route. The
+// new Coach-driven flow at `/onboarding` is a regular page.
+export function isClassicOnboardingPath(pathname: string): boolean {
+  const segments = pathname.split("/").filter(Boolean);
+
   if (segments.length === 2) {
-    return segments[1]?.toLowerCase() === "onboarding";
+    return (
+      segments[0]?.toLowerCase() === "onboarding"
+      && segments[1]?.toLowerCase() === "classic"
+    );
+  }
+
+  if (segments.length === 3) {
+    return (
+      segments[1]?.toLowerCase() === "onboarding"
+      && segments[2]?.toLowerCase() === "classic"
+    );
   }
 
   return false;
@@ -24,7 +54,9 @@ export function resolveRouteOnboardingOptions(params: {
 }): { initialStep: 1 | 2; companyId?: string } | null {
   const { pathname, companyPrefix, companies } = params;
 
-  if (!isOnboardingPath(pathname)) return null;
+  // Only auto-open the dialog wizard for the classic onboarding route. The
+  // new Coach-driven flow at `/onboarding` is a regular page (CoachOnboardingPage).
+  if (!isClassicOnboardingPath(pathname)) return null;
 
   if (!companyPrefix) {
     return { initialStep: 1 };


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The current onboarding wizard asks the user to articulate their company's mission as a one-line textarea before any agent exists
> - Most operators don't know their goal in concrete enough terms to type it cold, and a vague mission cascades through the org chart, tasks, and CEO heartbeat
> - This pull request introduces an alternate "Coach" onboarding path: the user picks an adapter, runs a required env test, and is dropped into a focused chat with a Coach agent that runs Five Whys, infers a workflow pattern, proposes a hiring plan, and writes an Agent Companies (`agentcompanies/v1`) package — which the chat imports atomically into a live company via the existing `/companies/{id}/imports/apply` endpoint
> - The classic 4-step wizard remains reachable at `/onboarding/classic` so the existing form-based flow is preserved as an escape hatch
> - The benefit is a more opinionated, hand-hold-y first-run that produces a stronger founding mission and team than a textarea would

## Stack note

This PR is **stacked on #5316** (extracts `AdapterTypePicker` and `AdapterEnvironmentResult` into shared components). #5316 lands first as a pure refactor. This PR's diff currently includes #5316's commits; once that lands and this is rebased, the diff will collapse to the Coach-specific changes.

Clean Coach-only diff: https://github.com/jondwillis/paperclip/compare/feat/onboarding-shared-extraction...feat/interactive-goal-discovery-onboarding

## Path 2 acknowledgement

Per `CONTRIBUTING.md`, this is a Path 2 (bigger / impactful) feature. I have not pre-discussed in Discord — opening as a **reference implementation** for direction-setting feedback rather than expecting immediate merge. Happy to redirect to the plugin system or close if it overlaps with planned core work; I checked `ROADMAP.md` and didn't find anything explicit on this surface, but the maintainer may have unwritten direction.

## What Changed

**Schema / shared types**
- `'draft'` added to `COMPANY_STATUSES` (next to `active`/`paused`/`archived`). DB column is text — no migration.
- `'coach'` added to `AGENT_ROLES` + `AGENT_ROLE_LABELS`.
- `updateCompanyBrandingSchema` accepts `status: 'active'` (narrow allowance) so the Coach can flip a draft company live via agent auth at launch.

**Server**
- `server/src/routes/companies.ts` PATCH handler allows `role === 'coach'` alongside `'ceo'` for company updates during onboarding.

**Skill**
- `skills/paperclip-coach/SKILL.md` — new Coach playbook. Self-wake guard (Step 0). Output discipline forbids operational status narration. Phases: opener → Five Whys ladder → synthesis (workflow pattern + hiring plan) → package generation (writes Agent Companies file map as a JSON document on the issue) → launch (posts a `RequestConfirmation` referencing the document via `target.type: 'issue_document'`). Reuses company-creator's interview principles (workflow inference, propose-don't-ask hiring, lean defaults, execution contract).

**UI**
- `CoachOnboardingPage.tsx` — adapter picker + required env test + start. Uses the shared `AdapterTypePicker` and `AdapterEnvironmentResult` from #5316. Start gated on test pass/warn.
- `OnboardingChat.tsx` — focused chat surface. Polls comments + interactions. Renders messages as bubbles, "Coach is thinking…" indicator, inline launch confirmation card. On accept: fetches the package document, parses the JSON file map, calls `/companies/{id}/imports/apply` with `target=existing, collisionStrategy=skip`, patches status to `active`, accepts the interaction, redirects to `/{prefix}/dashboard`.
- `OnboardingChrome.tsx` — shared full-viewport split layout (left form / chat pane, right `AsciiArtAnimation`). Used by both Coach pages.
- App routes: `/onboarding` → Coach flow, `/onboarding/classic` → existing wizard. The wizard's URL-based auto-open is now gated on the classic path only.
- `companiesApi.applyImportToCompany` helper added.

**Tests**
- `ui/src/lib/onboarding-route.test.ts` updated. The behaviour change is that `resolveRouteOnboardingOptions` no longer auto-opens the wizard at the bare `/onboarding` (that's now the Coach page); it auto-opens at `/onboarding/classic` instead. Existing assertions are moved to the classic path; new assertions cover the bare path returning `null` and the new `isClassicOnboardingPath` predicate.
- `isOnboardingPath` extended to also recognize `/onboarding/classic` so the companyless-redirect logic still works for users hitting either flow.

## Verification

- `pnpm typecheck` — green across `@paperclipai/shared`, `@paperclipai/server`, `@paperclipai/ui`.
- `pnpm test` — onboarding-route unit tests pass (18 tests). Two unrelated CLI tests fail on this machine (`cli/src/__tests__/network-bind.test.ts` `tailnet → loopback` fallback, `cli/src/__tests__/onboard.test.ts` `tailnet quickstart on loopback`); these are environment-dependent (Tailscale not configured locally) and don't touch any code modified in this PR.
- Manual end-to-end (with `pnpm dev`):
  - `/onboarding` → split-view chrome with adapter picker; "Test now" creates a draft company silently and runs the env probe; start gated until pass/warn.
  - On Start → land on `/{prefix}/onboarding/chat/{ref}` with the focused chat.
  - Coach posts opener (just the question, no preamble), drives Five Whys via comments, proposes name + workflow + hiring plan, writes the `coach-package` document, posts the launch confirmation. The chat renders Launch / Hold on inline. Launch runs the import and redirects to the new live company's dashboard.
  - `/onboarding/classic` → existing 4-step wizard works unchanged.
- Screenshots — see comments below (UI & chat states).

## Risks

- **New role + status values.** Other code paths may switch on roles (CEO checks) or filter on status (active companies). The Coach role gets a narrow allowance (PATCH branding + the `status: 'active'` write at launch). The draft status is short-lived — flipped to `active` immediately when the user accepts the launch — but if onboarding is abandoned mid-flow, an `Untitled` draft remains. Sidebar listing was not audited for draft filtering; cosmetic v1.5 follow-up.
- **Coach persistence after launch.** The import uses `collisionStrategy: skip`, so the Coach agent (and the onboarding issue) remain in the new live company. The Coach skill says Phase F is "exit cleanly" — I didn't add a self-archive step yet. Cosmetic; the user sees the Coach in the agents list.
- **Self-wake on own comments.** The platform fires `issue_commented` wakes for the Coach's own comments. The skill's Step 0 reads the latest comment and exits silently if it's authored by the Coach. Each self-wake still costs a heartbeat round-trip; a platform-level filter would be a cleaner fix as a separate change.
- **Package generation correctness.** The Coach builds an `agentcompanies/v1` package payload via the LLM. If it generates malformed JSON or an incomplete package, the launch card surfaces a parse error or the import returns warnings. Iteration on the skill's structure may be needed in practice.
- **Polling cadence.** Chat polls every 4s for new comments + interactions. Up to 4s lag between Coach output and rendering.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`) — 1M context, default Claude Code harness with tool use, no extended-thinking mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (no onboarding/coach line items found)
- [x] I have run tests locally — onboarding-route tests added/updated; full suite passes except for two pre-existing CLI Tailnet tests unrelated to this change
- [x] I have added or updated tests where applicable (onboarding-route.test.ts updated for new behavior; new tests added for `isClassicOnboardingPath` and the no-auto-open path)
- [ ] If this change affects the UI, I have included before/after screenshots — adding via comments
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge