### PR TITLE
[cto] Suppress blockers_resolved sweep when an active executive hold marker is present

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -24,7 +24,14 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { instanceSettingsService } from "../services/instance-settings.ts";
-import { clampIssueListLimit, ISSUE_LIST_MAX_LIMIT, issueService } from "../services/issues.ts";
+import {
+  clampIssueListLimit,
+  extractExecutiveHoldMarker,
+  findActiveExecutiveHold,
+  ISSUE_LIST_MAX_LIMIT,
+  issueService,
+  parseExecutiveHoldMarkerTimestamp,
+} from "../services/issues.ts";
 import { buildProjectMentionHref, MAX_ISSUE_REQUEST_DEPTH } from "@paperclipai/shared";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
@@ -35,6 +42,97 @@ describe("issue list limit helpers", () => {
     expect(clampIssueListLimit(0)).toBe(1);
     expect(clampIssueListLimit(25.9)).toBe(25);
     expect(clampIssueListLimit(ISSUE_LIST_MAX_LIMIT + 10)).toBe(ISSUE_LIST_MAX_LIMIT);
+  });
+});
+
+describe("executive hold marker parsing", () => {
+  it("parses strict ISO-8601 with Z", () => {
+    const date = parseExecutiveHoldMarkerTimestamp("2026-05-07T03:00:00Z");
+    expect(date?.toISOString()).toBe("2026-05-07T03:00:00.000Z");
+  });
+
+  it("parses loose `YYYY-MM-DD HH:MM UTC` form", () => {
+    const date = parseExecutiveHoldMarkerTimestamp("2026-05-07 03:00 UTC");
+    expect(date?.toISOString()).toBe("2026-05-07T03:00:00.000Z");
+  });
+
+  it("returns null for unparseable strings", () => {
+    expect(parseExecutiveHoldMarkerTimestamp("tomorrow")).toBeNull();
+    expect(parseExecutiveHoldMarkerTimestamp("")).toBeNull();
+  });
+
+  it("extracts strict ISO timestamp from a comment body", () => {
+    const date = extractExecutiveHoldMarker(
+      "Pausing this — do not retry before 2026-05-07T03:00:00Z, see thread.",
+    );
+    expect(date?.toISOString()).toBe("2026-05-07T03:00:00.000Z");
+  });
+
+  it("extracts loose timestamp from a comment body", () => {
+    const date = extractExecutiveHoldMarker(
+      "Hold this until tomorrow. Do not retry before 2026-05-07 03:00 UTC.",
+    );
+    expect(date?.toISOString()).toBe("2026-05-07T03:00:00.000Z");
+  });
+
+  it("returns null when body has no marker", () => {
+    expect(extractExecutiveHoldMarker("Just a regular comment.")).toBeNull();
+    expect(extractExecutiveHoldMarker(null)).toBeNull();
+  });
+
+  it("treats newest matching executive comment as authoritative", () => {
+    const now = new Date("2026-05-06T00:00:00Z");
+    const hold = findActiveExecutiveHold(
+      [
+        {
+          id: "old",
+          body: "do not retry before 2026-05-04T00:00:00Z",
+          createdAt: new Date("2026-05-03T00:00:00Z"),
+          authorRole: "ceo",
+        },
+        {
+          id: "new",
+          body: "do not retry before 2026-05-07 03:00 UTC",
+          createdAt: new Date("2026-05-05T23:00:00Z"),
+          authorRole: "cto",
+        },
+      ],
+      now,
+    );
+    expect(hold).toMatchObject({ commentId: "new" });
+    expect(hold?.until.toISOString()).toBe("2026-05-07T03:00:00.000Z");
+  });
+
+  it("ignores hold markers from non-executive authors", () => {
+    const now = new Date("2026-05-06T00:00:00Z");
+    const hold = findActiveExecutiveHold(
+      [
+        {
+          id: "engineer-comment",
+          body: "do not retry before 2026-05-07T03:00:00Z",
+          createdAt: new Date("2026-05-05T23:00:00Z"),
+          authorRole: "engineer",
+        },
+      ],
+      now,
+    );
+    expect(hold).toBeNull();
+  });
+
+  it("releases the hold when the newest match has an expired timestamp", () => {
+    const now = new Date("2026-05-08T00:00:00Z");
+    const hold = findActiveExecutiveHold(
+      [
+        {
+          id: "expired",
+          body: "do not retry before 2026-05-07T03:00:00Z",
+          createdAt: new Date("2026-05-05T23:00:00Z"),
+          authorRole: "ceo",
+        },
+      ],
+      now,
+    );
+    expect(hold).toBeNull();
   });
 });
 
@@ -2171,6 +2269,204 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
         blockerIssueIds: expect.arrayContaining([blockerA, blockerB]),
       }),
     ]);
+  });
+
+  describe("listWakeableBlockedDependents executive hold suppression (BLO-3496)", () => {
+    async function setupBlockedDependentWithExecutive(opts: {
+      ctoRole?: string;
+    } = {}) {
+      const companyId = randomUUID();
+      const assigneeAgentId = randomUUID();
+      const ctoAgentId = randomUUID();
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      });
+      await db.insert(agents).values([
+        {
+          id: assigneeAgentId,
+          companyId,
+          name: "CodexCoder",
+          role: "engineer",
+          status: "active",
+          adapterType: "codex_local",
+          adapterConfig: {},
+          runtimeConfig: {},
+          permissions: {},
+        },
+        {
+          id: ctoAgentId,
+          companyId,
+          name: "CTO",
+          role: opts.ctoRole ?? "cto",
+          status: "active",
+          adapterType: "claude_k8s",
+          adapterConfig: {},
+          runtimeConfig: {},
+          permissions: {},
+        },
+      ]);
+
+      const blockerId = randomUUID();
+      const blockedIssueId = randomUUID();
+      await db.insert(issues).values([
+        { id: blockerId, companyId, title: "Recovery", status: "done", priority: "critical" },
+        {
+          id: blockedIssueId,
+          companyId,
+          title: "Source under hold",
+          status: "blocked",
+          priority: "critical",
+          assigneeAgentId,
+        },
+      ]);
+      await svc.update(blockedIssueId, { blockedByIssueIds: [blockerId] });
+
+      return { companyId, ctoAgentId, assigneeAgentId, blockerId, blockedIssueId };
+    }
+
+    async function insertComment(opts: {
+      companyId: string;
+      issueId: string;
+      authorAgentId: string | null;
+      body: string;
+      createdAt: Date;
+    }) {
+      await db.insert(issueComments).values({
+        id: randomUUID(),
+        companyId: opts.companyId,
+        issueId: opts.issueId,
+        authorAgentId: opts.authorAgentId,
+        body: opts.body,
+        createdAt: opts.createdAt,
+        updatedAt: opts.createdAt,
+      });
+    }
+
+    it("suppresses the wake when an executive `do not retry before <future ts>` hold is active (strict ISO)", async () => {
+      const ctx = await setupBlockedDependentWithExecutive();
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      await insertComment({
+        companyId: ctx.companyId,
+        issueId: ctx.blockedIssueId,
+        authorAgentId: ctx.ctoAgentId,
+        body: `Pausing — do not retry before ${future}.`,
+        createdAt: new Date(),
+      });
+
+      await expect(svc.listWakeableBlockedDependents(ctx.blockerId)).resolves.toEqual([]);
+
+      const after = await db
+        .select({ status: issues.status })
+        .from(issues)
+        .where(eq(issues.id, ctx.blockedIssueId))
+        .then((rows) => rows[0]);
+      expect(after?.status).toBe("blocked");
+    });
+
+    it("suppresses the wake for the loose `YYYY-MM-DD HH:MM UTC` form too", async () => {
+      const ctx = await setupBlockedDependentWithExecutive();
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000);
+      const yyyy = future.getUTCFullYear();
+      const mm = String(future.getUTCMonth() + 1).padStart(2, "0");
+      const dd = String(future.getUTCDate()).padStart(2, "0");
+      const hh = String(future.getUTCHours()).padStart(2, "0");
+      const minute = String(future.getUTCMinutes()).padStart(2, "0");
+      await insertComment({
+        companyId: ctx.companyId,
+        issueId: ctx.blockedIssueId,
+        authorAgentId: ctx.ctoAgentId,
+        body: `Hold this — do not retry before ${yyyy}-${mm}-${dd} ${hh}:${minute} UTC.`,
+        createdAt: new Date(),
+      });
+
+      await expect(svc.listWakeableBlockedDependents(ctx.blockerId)).resolves.toEqual([]);
+    });
+
+    it("does NOT suppress when the executive hold timestamp is in the past", async () => {
+      const ctx = await setupBlockedDependentWithExecutive();
+      const past = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      await insertComment({
+        companyId: ctx.companyId,
+        issueId: ctx.blockedIssueId,
+        authorAgentId: ctx.ctoAgentId,
+        body: `Hold expired — do not retry before ${past}.`,
+        createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+      });
+
+      await expect(svc.listWakeableBlockedDependents(ctx.blockerId)).resolves.toEqual([
+        expect.objectContaining({
+          id: ctx.blockedIssueId,
+          assigneeAgentId: ctx.assigneeAgentId,
+        }),
+      ]);
+    });
+
+    it("does NOT suppress when the hold marker is from a non-executive author", async () => {
+      const ctx = await setupBlockedDependentWithExecutive({ ctoRole: "engineer" });
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      await insertComment({
+        companyId: ctx.companyId,
+        issueId: ctx.blockedIssueId,
+        authorAgentId: ctx.ctoAgentId,
+        body: `Trying to hold — do not retry before ${future}.`,
+        createdAt: new Date(),
+      });
+
+      await expect(svc.listWakeableBlockedDependents(ctx.blockerId)).resolves.toEqual([
+        expect.objectContaining({
+          id: ctx.blockedIssueId,
+          assigneeAgentId: ctx.assigneeAgentId,
+        }),
+      ]);
+    });
+
+    it("does NOT suppress when there is no hold marker at all", async () => {
+      const ctx = await setupBlockedDependentWithExecutive();
+      await insertComment({
+        companyId: ctx.companyId,
+        issueId: ctx.blockedIssueId,
+        authorAgentId: ctx.ctoAgentId,
+        body: "Just a status update from the CTO, no hold marker here.",
+        createdAt: new Date(),
+      });
+
+      await expect(svc.listWakeableBlockedDependents(ctx.blockerId)).resolves.toEqual([
+        expect.objectContaining({
+          id: ctx.blockedIssueId,
+          assigneeAgentId: ctx.assigneeAgentId,
+        }),
+      ]);
+    });
+
+    it("uses the newest matching executive comment when multiple holds are present", async () => {
+      const ctx = await setupBlockedDependentWithExecutive();
+      const oldFuture = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      const newPast = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      await insertComment({
+        companyId: ctx.companyId,
+        issueId: ctx.blockedIssueId,
+        authorAgentId: ctx.ctoAgentId,
+        body: `Initial hold — do not retry before ${oldFuture}.`,
+        createdAt: new Date(Date.now() - 60 * 60 * 1000),
+      });
+      await insertComment({
+        companyId: ctx.companyId,
+        issueId: ctx.blockedIssueId,
+        authorAgentId: ctx.ctoAgentId,
+        body: `Override — do not retry before ${newPast}.`,
+        createdAt: new Date(),
+      });
+
+      await expect(svc.listWakeableBlockedDependents(ctx.blockerId)).resolves.toEqual([
+        expect.objectContaining({
+          id: ctx.blockedIssueId,
+          assigneeAgentId: ctx.assigneeAgentId,
+        }),
+      ]);
+    });
   });
 
   it("reports dependency readiness for blocked issue chains", async () => {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -47,6 +47,7 @@ import {
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
 } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
+import { logger } from "../middleware/logger.js";
 import { parseObject } from "../adapters/utils.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -1660,6 +1661,59 @@ async function blockedByMapForIssues(
   return map;
 }
 
+export const EXECUTIVE_AGENT_ROLES_FOR_HOLDS = new Set(["ceo", "cto"]);
+
+const EXECUTIVE_HOLD_MARKER_REGEX =
+  /do\s+not\s+retry\s+before\s+(\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2})?(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?(?:\s+(?:UTC|GMT))?)/i;
+
+export function parseExecutiveHoldMarkerTimestamp(raw: string): Date | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const direct = /Z$|[+-]\d{2}:?\d{2}$/.test(trimmed) ? new Date(trimmed) : null;
+  if (direct && !Number.isNaN(direct.getTime())) return direct;
+  const looseMatch = trimmed.match(
+    /^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}(?::\d{2})?)\s*(?:UTC|GMT)?$/i,
+  );
+  if (looseMatch) {
+    const time = looseMatch[2].length === 5 ? `${looseMatch[2]}:00` : looseMatch[2];
+    const date = new Date(`${looseMatch[1]}T${time}Z`);
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    const date = new Date(`${trimmed}T00:00:00Z`);
+    if (!Number.isNaN(date.getTime())) return date;
+  }
+  return null;
+}
+
+export function extractExecutiveHoldMarker(body: string | null | undefined): Date | null {
+  if (!body) return null;
+  const match = body.match(EXECUTIVE_HOLD_MARKER_REGEX);
+  if (!match) return null;
+  return parseExecutiveHoldMarkerTimestamp(match[1]);
+}
+
+export function findActiveExecutiveHold(
+  comments: Array<{
+    id: string;
+    body: string | null;
+    createdAt: Date;
+    authorRole: string | null;
+  }>,
+  now: Date = new Date(),
+): { until: Date; commentId: string } | null {
+  const sorted = [...comments].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  for (const comment of sorted) {
+    if (!comment.authorRole || !EXECUTIVE_AGENT_ROLES_FOR_HOLDS.has(comment.authorRole)) continue;
+    const until = extractExecutiveHoldMarker(comment.body);
+    if (!until) continue;
+    return until.getTime() > now.getTime()
+      ? { until, commentId: comment.id }
+      : null;
+  }
+  return null;
+}
+
 export function issueService(db: Db) {
   const instanceSettings = instanceSettingsService(db);
   const treeControlSvc = issueTreeControlService(db);
@@ -2593,7 +2647,7 @@ export function issueService(db: Db) {
         blockersByIssueId.set(row.issueId, list);
       }
 
-      return candidates
+      const wakeable = candidates
         .filter((candidate) => candidate.assigneeAgentId && !["backlog", "done", "cancelled"].includes(candidate.status))
         .map((candidate) => {
           const blockers = blockersByIssueId.get(candidate.id) ?? [];
@@ -2603,7 +2657,55 @@ export function issueService(db: Db) {
             allBlockersDone: blockers.length > 0 && blockers.every((blocker) => blocker.blockerStatus === "done"),
           };
         })
-        .filter((candidate) => candidate.allBlockersDone)
+        .filter((candidate) => candidate.allBlockersDone);
+
+      const blockedCandidateIds = wakeable
+        .filter((candidate) => candidate.status === "blocked")
+        .map((candidate) => candidate.id);
+
+      const suppressedIssueIds = new Set<string>();
+      if (blockedCandidateIds.length > 0) {
+        const commentRows = await db
+          .select({
+            id: issueComments.id,
+            issueId: issueComments.issueId,
+            body: issueComments.body,
+            createdAt: issueComments.createdAt,
+            authorRole: agents.role,
+          })
+          .from(issueComments)
+          .leftJoin(agents, eq(agents.id, issueComments.authorAgentId))
+          .where(
+            and(
+              eq(issueComments.companyId, blockerIssue.companyId),
+              inArray(issueComments.issueId, blockedCandidateIds),
+            ),
+          )
+          .orderBy(desc(issueComments.createdAt));
+
+        const commentsByIssueId = new Map<string, typeof commentRows>();
+        for (const row of commentRows) {
+          const list = commentsByIssueId.get(row.issueId) ?? [];
+          list.push(row);
+          commentsByIssueId.set(row.issueId, list);
+        }
+
+        const now = new Date();
+        for (const issueId of blockedCandidateIds) {
+          const candidateComments = commentsByIssueId.get(issueId) ?? [];
+          const hold = findActiveExecutiveHold(candidateComments, now);
+          if (hold) {
+            suppressedIssueIds.add(issueId);
+            logger.debug(
+              { issueId, until: hold.until.toISOString(), holdCommentId: hold.commentId },
+              `blockers_resolved_sweep: suppressed for issue=${issueId} until=${hold.until.toISOString()} hold_comment=${hold.commentId}`,
+            );
+          }
+        }
+      }
+
+      return wakeable
+        .filter((candidate) => !suppressedIssueIds.has(candidate.id))
         .map((candidate) => ({
           id: candidate.id,
           assigneeAgentId: candidate.assigneeAgentId!,


### PR DESCRIPTION
## Summary

Slice 1 of BLO-3322. Adds executive-hold-marker suppression to \`listWakeableBlockedDependents\` so blocker-resolved sweeps don't auto-wake issues that an executive (CEO/CTO) has explicitly held until a future timestamp. Implemented + tested by the Staff Engineer agent on Blockcast/paperclip; cross-fork PR.

## What changed

- \`server/src/services/issues.ts\`: in \`listWakeableBlockedDependents\`, after the existing \`allBlockersDone\` filter, scan each \`status="blocked"\` candidate's comments newest-first for an executive hold marker (regex \`/do\\s+not\\s+retry\\s+before\\s+<ts>/i\`, author \`role ∈ {ceo, cto}\`). If the parsed timestamp is in the future, drop the candidate from the wake set and emit \`logger.debug({...}, "blockers_resolved_sweep: suppressed for issue=<id> until=<ts> hold_comment=<commentId>")\`. No new comments are posted on the source.
- Module-level helpers (\`parseExecutiveHoldMarkerTimestamp\`, \`extractExecutiveHoldMarker\`, \`findActiveExecutiveHold\`) exported so they can be tested without DB.

## Tests

All green locally — \`pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-service.test.ts\` → **59 passed**.

- Pure unit: \`describe("executive hold marker parsing", ...)\` — strict ISO + loose \`YYYY-MM-DD HH:MM UTC\` parsing, newest-match-wins, executive-only author check, expired-ts release.
- Embedded-postgres integration: \`describe("listWakeableBlockedDependents executive hold suppression (BLO-3496)", ...)\` — one test per acceptance case (future strict-ISO hold suppresses, loose-form hold suppresses, past-ts does not, non-executive author does not, no marker does not) plus a newest-match-wins test using two stacked CTO comments.
- Confirmed \`heartbeat-dependency-scheduling.test.ts\` (5) and \`issue-dependency-wakeups-routes.test.ts\` (2) still green.

## Out of scope (deferred to slice 2/3)

- \`terminal_run_recovery\` deferral on quota-bounce errors
- Recovery-issue dedup within a reset window
- Structured \`executionHold\` field on the issue model
- Optional \`blockers_resolved_sweep_suppressed_total\` counter — skipped because there's no existing prom-client wiring in this service and slice 1 should stay minimal; the \`logger.debug\` line is enough to drive the dashboard rollup once a counter is added.

## Live signal

The current BLO-3182 hold (\`do not retry before 2026-05-07 03:00 UTC\`) is exactly the loose-form regression the integration tests cover. Once this lands and deploys, no further \`Recover stalled issue BLO-3182\` siblings should appear before that timestamp.

## PR provenance

Authored by Blockcast/paperclip Staff Engineer agent (run \`266f6a81-05f8-4692-8838-d7a29adec115\`) at 2026-05-05 23:32Z. Couldn't self-create due to a since-fixed GH_PAT revocation; opened on the agent's behalf by the operator after provisioning the durable GitHub App auth path (PCL-601).

🤖 Generated with [Claude Code](https://claude.com/claude-code)