### PR TITLE
feat(issues): add blockReason field to distinguish stale-heartbeat from upstream blocks

### DIFF
--- a/packages/db/src/migrations/0060_block_reason.sql
+++ b/packages/db/src/migrations/0060_block_reason.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "issues" ADD COLUMN "block_reason" text;
+--> statement-breakpoint
+UPDATE "issues" i
+SET block_reason = CASE
+  WHEN EXISTS (
+    SELECT 1 FROM issue_relations ir
+    WHERE ir.related_issue_id = i.id
+    AND ir.type = 'blocks'
+  ) THEN 'upstream'
+  ELSE 'manual'
+END
+WHERE i.status = 'blocked';

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1776542246000,
       "tag": "0059_plugin_database_namespaces",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1746579161000,
+      "tag": "0060_block_reason",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -425,7 +425,7 @@
     {
       "idx": 60,
       "version": "7",
-      "when": 1746579161000,
+      "when": 1776579161000,
       "tag": "0060_block_reason",
       "breakpoints": true
     }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -30,6 +30,7 @@ export const issues = pgTable(
     title: text("title").notNull(),
     description: text("description"),
     status: text("status").notNull().default("backlog"),
+    blockReason: text("block_reason"),
     priority: text("priority").notNull().default("medium"),
     assigneeAgentId: uuid("assignee_agent_id").references(() => agents.id),
     assigneeUserId: text("assignee_user_id"),

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -147,6 +147,9 @@ export type IssueOriginKind = BuiltInIssueOriginKind | PluginIssueOriginKind;
 export const ISSUE_RELATION_TYPES = ["blocks"] as const;
 export type IssueRelationType = (typeof ISSUE_RELATION_TYPES)[number];
 
+export const ISSUE_BLOCK_REASONS = ["upstream", "stale_heartbeat", "manual"] as const;
+export type IssueBlockReason = (typeof ISSUE_BLOCK_REASONS)[number];
+
 export const ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY = "continuation-summary" as const;
 export const SYSTEM_ISSUE_DOCUMENT_KEYS = [ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY] as const;
 export type SystemIssueDocumentKey = (typeof SYSTEM_ISSUE_DOCUMENT_KEYS)[number];

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  ISSUE_BLOCK_REASONS,
   ISSUE_EXECUTION_DECISION_OUTCOMES,
   ISSUE_EXECUTION_POLICY_MODES,
   ISSUE_EXECUTION_STAGE_TYPES,
@@ -123,6 +124,7 @@ export const createIssueSchema = z.object({
   title: z.string().min(1),
   description: z.string().optional().nullable(),
   status: z.enum(ISSUE_STATUSES).optional().default("backlog"),
+  blockReason: z.enum(ISSUE_BLOCK_REASONS).optional().nullable(),
   priority: z.enum(ISSUE_PRIORITIES).optional().default("medium"),
   assigneeAgentId: z.string().uuid().optional().nullable(),
   assigneeUserId: z.string().optional().nullable(),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3630,6 +3630,7 @@ export function heartbeatService(db: Db) {
   }) {
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
+      blockReason: "stale_heartbeat",
     });
     if (!updated) return null;
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1857,9 +1857,16 @@ export function issueService(db: Db) {
       }
 
       applyStatusSideEffects(issueData.status, patch);
-      if (issueData.status === "blocked" && !issueData.blockReason) {
-        patch.blockReason =
-          blockedByIssueIds !== undefined && blockedByIssueIds.length > 0 ? "upstream" : "manual";
+      const finalStatus = issueData.status ?? existing.status;
+      if (finalStatus === "blocked" && !issueData.blockReason) {
+        if (blockedByIssueIds !== undefined) {
+          // blockedByIssueIds is being synced — re-derive reason from the incoming list
+          patch.blockReason = blockedByIssueIds.length > 0 ? "upstream" : "manual";
+        } else if (issueData.status === "blocked") {
+          // Transitioning to blocked with no blockers provided
+          patch.blockReason = "manual";
+        }
+        // Already blocked with no relevant changes → leave blockReason unchanged
       }
       if (issueData.status && issueData.status !== "blocked") {
         patch.blockReason = null;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1857,6 +1857,13 @@ export function issueService(db: Db) {
       }
 
       applyStatusSideEffects(issueData.status, patch);
+      if (issueData.status === "blocked" && !issueData.blockReason) {
+        patch.blockReason =
+          blockedByIssueIds !== undefined && blockedByIssueIds.length > 0 ? "upstream" : "manual";
+      }
+      if (issueData.status && issueData.status !== "blocked") {
+        patch.blockReason = null;
+      }
       if (issueData.status && issueData.status !== "done") {
         patch.completedAt = null;
       }


### PR DESCRIPTION
## Summary

- Adds `blockReason` column (`upstream | stale_heartbeat | manual`) to the `issues` table
- Heartbeat retry-exhaustion path now sets `blockReason=stale_heartbeat` automatically
- PATCH with non-empty `blockedByIssueIds` auto-sets `blockReason=upstream`; explicit `status=blocked` with no blockers defaults to `manual`
- Field clears to `null` when status leaves `blocked`
- Migration 0060 backfills existing blocked rows: rows with blocker relations → `upstream`, others → `manual`

## Changed files

| File | Change |
|---|---|
| `packages/shared/src/constants.ts` | Add `ISSUE_BLOCK_REASONS` enum + `IssueBlockReason` type |
| `packages/db/src/schema/issues.ts` | Add `blockReason text` column |
| `packages/shared/src/validators/issue.ts` | Add optional `blockReason` field to create/update schemas |
| `server/src/services/issues.ts` | Auto-set `blockReason` in `update()` based on status + blockedByIssueIds |
| `server/src/services/heartbeat.ts` | Pass `blockReason: "stale_heartbeat"` in `escalateStrandedAssignedIssue` |
| `packages/db/src/migrations/0060_block_reason.sql` | Migration + backfill |
| `packages/db/src/migrations/meta/_journal.json` | Register migration entry |

Resolves: FIN-1457

🤖 Generated with [Claude Code](https://claude.com/claude-code)