### PR TITLE
fix(codex-local): symlink .credentials.json into managed CODEX_HOME

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -5,7 +5,7 @@ import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
-const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
+const SYMLINKED_SHARED_FILES = ["auth.json", ".credentials.json"] as const;
 const DEFAULT_PAPERCLIP_INSTANCE_ID = "default";
 
 function nonEmpty(value: string | undefined): string | null {


### PR DESCRIPTION
The codex_local adapter creates a per-company managed CODEX_HOME and seeds it from the host's ~/.codex by copying a fixed list of shared files (config.toml, etc.) and symlinking auth.json. MCP servers added via 'codex mcp add' work, but their OAuth tokens land in ~/.codex/.credentials.json, which was neither copied nor symlinked — so agents in the managed home saw 'No MCP servers configured yet' even when the URL was present in config.toml, because tokens for the OAuth handshake were missing.

Symlink .credentials.json (same pattern as auth.json) so MCP OAuth tokens stay in sync with the host. This is required for any HTTP-streamable MCP that uses 'codex mcp login <name>'.

Repro of the original failure (without this patch):
  codex mcp add canva --url https://mcp.canva.com/mcp     # on host
  codex mcp login canva                                   # on host (OAuth)
  CODEX_HOME=<managed-home> codex mcp list
  -> 'No MCP servers configured yet'

After this patch, the managed home sees canva/notion/etc. as 'enabled OAuth' immediately on next adapter prepareManagedCodexHome.

Existing managed homes still need a one-time backfill:
  ln -sfn ~/.codex/.credentials.json <managed-home>/.credentials.json

Discovered while wiring Canva and Notion MCPs to a marketing content-engine company on a self-hosted Paperclip instance.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
