### PR TITLE
fix(DGG-5210): cap stranded recovery retries + same-source dedup

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2339,6 +2339,213 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  // DGG-5210: Helper that adds N additional automatic stranded-recovery runs
+  // to an issue, anchored to wall-clock now so they fall inside the
+  // STRANDED_RECOVERY_RETRY_BUDGET_WINDOW_MS (24h) used by reconcile.
+  // seedStrandedIssueFixture seeds the canonical run with default `createdAt`
+  // (now via Postgres `defaultNow()`) so we mirror that here — otherwise the
+  // earlier hard-coded 2026-03 anchor would land outside the window and the
+  // cap would never trigger in tests.
+  async function appendAutomaticRecoveryRuns(input: {
+    companyId: string;
+    agentId: string;
+    issueId: string;
+    runs: Array<{
+      retryReason: "assignment_recovery" | "issue_continuation_needed";
+      runStatus: "failed" | "timed_out" | "cancelled" | "succeeded";
+      runErrorCode?: string | null;
+      runError?: string | null;
+      livenessState?: "completed" | "advanced" | "plan_only" | "empty_response" | "blocked" | "failed" | "needs_followup" | null;
+      runSource?: string | null;
+      // Minutes before the wall-clock anchor (now). Must stay within the 24h
+      // window so the cap counts the run as recent.
+      minutesBefore: number;
+    }>;
+  }) {
+    const anchor = Date.now();
+    for (const run of input.runs) {
+      const startedAt = new Date(anchor - run.minutesBefore * 60 * 1000);
+      const finishedAt = new Date(startedAt.getTime() + 30 * 1000);
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId: input.companyId,
+        agentId: input.agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: run.runStatus,
+        contextSnapshot: {
+          issueId: input.issueId,
+          taskId: input.issueId,
+          wakeReason: run.retryReason === "assignment_recovery" ? "issue_assignment_recovery" : "issue_continuation_needed",
+          retryReason: run.retryReason,
+          ...(run.runSource ? { source: run.runSource } : {}),
+        },
+        startedAt,
+        finishedAt,
+        createdAt: startedAt,
+        updatedAt: finishedAt,
+        errorCode: run.runStatus === "succeeded" ? null : run.runErrorCode ?? "process_lost",
+        error: run.runStatus === "succeeded" ? null : run.runError ?? "run failed before issue advanced",
+        livenessState: run.livenessState ?? null,
+      });
+    }
+  }
+
+  // DGG-5210 AC-2: cap automatic stranded-recovery retries at 3 inside the 24h budget.
+  it("escalates stranded work to blocked once the 24h automatic recovery budget is exhausted", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.continuation_recovery",
+      runErrorCode: "openclaw_gateway_wait_error",
+      runError: "ChatGPT usage limit",
+    });
+    // Two earlier automatic retries (different fingerprints so dedup doesn't trip)
+    // plus the seeded current run = 3 total automatic attempts -> cap reached.
+    await appendAutomaticRecoveryRuns({
+      companyId,
+      agentId,
+      issueId,
+      runs: [
+        {
+          retryReason: "issue_continuation_needed",
+          runStatus: "failed",
+          runErrorCode: "adapter_timeout",
+          runError: "adapter timed out",
+          minutesBefore: 600,
+        },
+        {
+          retryReason: "issue_continuation_needed",
+          runStatus: "failed",
+          runErrorCode: "process_lost",
+          runError: "adapter process lost",
+          minutesBefore: 300,
+        },
+      ],
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.capEscalated).toBe(1);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("paused automatic stranded-work recovery");
+    expect(comments[0]?.body).toContain("3 automatic recovery attempts");
+
+    // The cap path escalates via escalateStrandedAssignedIssue — no
+    // *retry* run is queued (would carry retryReason), but the recovery
+    // child issue is created and triggers an `issue_assigned` wake. The
+    // resulting heartbeat run has wakeReason `issue_assigned`, not a retry
+    // reason, so it does not loop back into automatic recovery.
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs.map((row) => row.id)).toContain(runId);
+    const retryRuns = runs.filter((row) => {
+      const ctx = row.contextSnapshot as { retryReason?: unknown } | null;
+      return Boolean(ctx?.retryReason);
+    });
+    // The two seeded retries + the original seeded current run = 3 retry
+    // runs. Critically, the cap path must not enqueue *another* retry on
+    // top of those.
+    expect(retryRuns).toHaveLength(3);
+  });
+
+  // DGG-5210 AC-1: same-source 1h dedup. A retry that fails with the same
+  // errorCode as a previous automatic recovery within the dedup window must not
+  // trigger another retry on the next reconcile tick.
+  it("deduplicates same-source automatic recovery retries inside the 1h fingerprint window", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.continuation_recovery",
+      runErrorCode: "openclaw_gateway_wait_error",
+      runError: "ChatGPT usage limit",
+    });
+    // One earlier automatic retry that already failed with the same errorCode
+    // 30 minutes before the seeded current run -> same-source dedup must trip.
+    await appendAutomaticRecoveryRuns({
+      companyId,
+      agentId,
+      issueId,
+      runs: [
+        {
+          retryReason: "issue_continuation_needed",
+          runStatus: "failed",
+          runErrorCode: "openclaw_gateway_wait_error",
+          runError: "ChatGPT usage limit",
+          minutesBefore: 30,
+        },
+      ],
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    // Cap is not yet reached (only 2 recent attempts) so no escalation; dedup
+    // should suppress the next retry instead.
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.sameSourceDedupSkipped).toBe(1);
+    expect(result.skipped).toBeGreaterThanOrEqual(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    // No new retry comment, no new retry run.
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(0);
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    // Only the original seeded run + the 1 we appended; no new retry was queued.
+    expect(runs).toHaveLength(2);
+  });
+
+  // DGG-5210 AC-1 negative path: when the latest run's failure fingerprint
+  // differs from earlier automatic recovery attempts, dedup must NOT trip.
+  // We can only assert the dedup *counter* directly because the downstream
+  // path is governed by the existing reconcile logic (escalate on repeated
+  // continuation failure), which is unrelated to AC-1.
+  it("does not dedup retries when the failure fingerprint changes between attempts", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.continuation_recovery",
+      runErrorCode: "openclaw_gateway_wait_error",
+      runError: "ChatGPT usage limit",
+    });
+    await appendAutomaticRecoveryRuns({
+      companyId,
+      agentId,
+      issueId,
+      runs: [
+        {
+          retryReason: "issue_continuation_needed",
+          runStatus: "failed",
+          runErrorCode: "adapter_timeout",
+          runError: "adapter timed out",
+          minutesBefore: 30,
+        },
+      ],
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    // The dedup gate must not fire because fingerprints differ. Whether the
+    // downstream path re-queues or escalates is the existing reconcile
+    // contract — the AC-1 gate just shouldn't suppress this.
+    expect(result.sameSourceDedupSkipped).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+  });
+
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {
     const { issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -53,6 +53,20 @@ const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
+// DGG-5210: bound automatic stranded recovery so a single stalled issue cannot
+// loop indefinitely. The 24h window is the lifecycle horizon for an automated
+// retry — anything beyond that is a different incident, not the same retry
+// stream. The cap of 3 attempts in that window matches the COO recovery
+// policy: each retry must surface a distinct failure source, otherwise it is
+// dedup'd by the same-source guard below before counting against the budget.
+const STRANDED_RECOVERY_RETRY_BUDGET_WINDOW_MS = 24 * 60 * 60 * 1000;
+const STRANDED_RECOVERY_RETRY_BUDGET_MAX_ATTEMPTS = 3;
+// DGG-5210: same-source retry dedup window. If the most recent automatic
+// recovery attempt for an issue failed with the same error fingerprint inside
+// this window, skip re-issuing another attempt — let it surface to manual
+// intervention through the cap path instead of comment-spamming the issue
+// with another identical retry note.
+const STRANDED_RECOVERY_SAME_SOURCE_DEDUP_WINDOW_MS = 60 * 60 * 1000;
 
 type RecoveryWakeupOptions = {
   source?: "timer" | "assignment" | "on_demand" | "automation";
@@ -72,7 +86,7 @@ type RecoveryWakeup = (
 
 type LatestIssueRun = Pick<
   typeof heartbeatRuns.$inferSelect,
-  "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState"
+  "id" | "agentId" | "status" | "error" | "errorCode" | "contextSnapshot" | "livenessState" | "createdAt" | "finishedAt"
 > | null;
 type SuccessfulLatestIssueRun = NonNullable<LatestIssueRun> & { status: "succeeded" };
 
@@ -320,6 +334,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        createdAt: heartbeatRuns.createdAt,
+        finishedAt: heartbeatRuns.finishedAt,
       })
       .from(heartbeatRuns)
       .where(
@@ -331,6 +347,117 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
       .limit(1)
       .then((rows) => rows[0] ?? null);
+  }
+
+  // DGG-5210: pull recent runs for an issue so the stranded-recovery cap and
+  // same-source dedup gate can both reason over them without re-querying. The
+  // window is bounded to STRANDED_RECOVERY_RETRY_BUDGET_WINDOW_MS so old
+  // unrelated retries from a previous incident never count against the cap.
+  async function getRecentIssueRuns(
+    companyId: string,
+    issueId: string,
+    since: Date,
+  ): Promise<NonNullable<LatestIssueRun>[]> {
+    return db
+      .select({
+        id: heartbeatRuns.id,
+        agentId: heartbeatRuns.agentId,
+        status: heartbeatRuns.status,
+        error: heartbeatRuns.error,
+        errorCode: heartbeatRuns.errorCode,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+        livenessState: heartbeatRuns.livenessState,
+        createdAt: heartbeatRuns.createdAt,
+        finishedAt: heartbeatRuns.finishedAt,
+      })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          gt(heartbeatRuns.createdAt, since),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
+      .limit(100);
+  }
+
+  function isAutomaticStrandedRecoveryRetryReason(value: unknown) {
+    return value === "assignment_recovery" || value === "issue_continuation_needed";
+  }
+
+  // DGG-5210: count automatic stranded-recovery attempts for an issue inside
+  // STRANDED_RECOVERY_RETRY_BUDGET_WINDOW_MS. Used to enforce the
+  // STRANDED_RECOVERY_RETRY_BUDGET_MAX_ATTEMPTS cap before issuing another
+  // retry. Successful runs still count: a productive run that got us back
+  // here means the recovery loop is alive but not making forward progress.
+  async function countRecentAutomaticStrandedRecoveryAttempts(
+    companyId: string,
+    issueId: string,
+    now = new Date(),
+  ) {
+    const since = new Date(now.getTime() - STRANDED_RECOVERY_RETRY_BUDGET_WINDOW_MS);
+    const rows = await getRecentIssueRuns(companyId, issueId, since);
+    return rows.filter((run) => {
+      const ctx = parseObject(run.contextSnapshot);
+      return isAutomaticStrandedRecoveryRetryReason(readNonEmptyString(ctx.retryReason));
+    }).length;
+  }
+
+  // DGG-5210: classify a run's failure source so two retries that fail with
+  // the same root cause can be dedup'd inside
+  // STRANDED_RECOVERY_SAME_SOURCE_DEDUP_WINDOW_MS. The fingerprint prefers the
+  // structured `errorCode` (e.g. `openclaw_gateway_wait_error`) and falls back
+  // to the first line of the human-readable `error` text so loosely-typed
+  // adapter failures still group. Successful runs return `null` so they don't
+  // dedup retries: a productive run that the loop ignored should still be
+  // allowed to bump into the cap on the next failure.
+  function recoveryFailureFingerprint(run: NonNullable<LatestIssueRun>): string | null {
+    if (
+      !UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
+        run.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
+      )
+    ) {
+      return null;
+    }
+    const code = readNonEmptyString(run.errorCode);
+    if (code) return `code:${code}`;
+    const message = readNonEmptyString(run.error);
+    if (message) {
+      const firstLine = message.split(/\r?\n/)[0]?.trim() ?? "";
+      if (firstLine.length > 0) return `msg:${firstLine.slice(0, 200)}`;
+    }
+    return `status:${run.status}`;
+  }
+
+  // DGG-5210: returns true when the most recent automatic stranded-recovery
+  // run for this issue failed with the same fingerprint as `latestRun` inside
+  // the same-source dedup window. Caller should suppress another retry in
+  // that case — the cap path will eventually escalate to `blocked` once the
+  // 3-attempt budget is exhausted, but we shouldn't comment-spam in the
+  // meantime with identical retry notes.
+  async function isSameSourceRetryDuplicate(
+    companyId: string,
+    issueId: string,
+    latestRun: LatestIssueRun,
+    now = new Date(),
+  ) {
+    if (!latestRun) return false;
+    const fingerprint = recoveryFailureFingerprint(latestRun);
+    if (!fingerprint) return false;
+    const since = new Date(now.getTime() - STRANDED_RECOVERY_SAME_SOURCE_DEDUP_WINDOW_MS);
+    const rows = await getRecentIssueRuns(companyId, issueId, since);
+    let matches = 0;
+    for (const run of rows) {
+      if (run.id === latestRun.id) continue;
+      const ctx = parseObject(run.contextSnapshot);
+      if (!isAutomaticStrandedRecoveryRetryReason(readNonEmptyString(ctx.retryReason))) continue;
+      if (recoveryFailureFingerprint(run) === fingerprint) {
+        matches += 1;
+        if (matches >= 1) return true;
+      }
+    }
+    return false;
   }
 
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
@@ -1578,6 +1705,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   async function reconcileStrandedAssignedIssues() {
+    // DGG-5210: capture a single "now" so cap counting and same-source dedup
+    // both reason against the same instant for every candidate in this run.
+    const now = new Date();
     const candidates = await db
       .select()
       .from(issues)
@@ -1598,6 +1728,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       orphanBlockersAssigned: 0,
       escalated: 0,
       skipped: 0,
+      sameSourceDedupSkipped: 0,
+      capEscalated: 0,
       issueIds: [] as string[],
     };
 
@@ -1625,6 +1757,51 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
+
+      // DGG-5210 (AC-2): cap automatic stranded-recovery retries inside the
+      // 24h budget window. When the cap is exhausted the issue must escalate
+      // to `blocked` and stop participating in the retry loop — otherwise
+      // each cron tick comments "Paperclip retried..." indefinitely. We
+      // evaluate the cap *before* the same-source dedup gate so a hot loop
+      // failing on one fingerprint still surfaces an explicit recovery issue
+      // once the budget is exhausted.
+      const recentRecoveryAttempts = await countRecentAutomaticStrandedRecoveryAttempts(
+        issue.companyId,
+        issue.id,
+        now,
+      );
+      if (recentRecoveryAttempts >= STRANDED_RECOVERY_RETRY_BUDGET_MAX_ATTEMPTS) {
+        const updated = await escalateStrandedAssignedIssue({
+          issue,
+          previousStatus: issue.status as "todo" | "in_progress",
+          latestRun,
+          comment:
+            "Paperclip paused automatic stranded-work recovery for this issue because the same source issue " +
+            `already consumed ${recentRecoveryAttempts} automatic recovery attempts inside 24h. ` +
+            "Moving it to `blocked` for manual/COO intervention instead of continuing the retry loop.",
+        });
+        if (updated) {
+          result.escalated += 1;
+          result.capEscalated += 1;
+          result.issueIds.push(issue.id);
+        } else {
+          result.skipped += 1;
+        }
+        continue;
+      }
+
+      // DGG-5210 (AC-1): same-source dedup. If the latest failed run shares
+      // an error fingerprint with another automatic recovery run inside the
+      // 1h dedup window, suppress another retry and let the cap path catch
+      // it on the next loop. The cap above only escalates after
+      // STRANDED_RECOVERY_RETRY_BUDGET_MAX_ATTEMPTS, so this guard prevents
+      // bursty back-to-back duplicate retries between cap evaluations.
+      if (await isSameSourceRetryDuplicate(issue.companyId, issue.id, latestRun, now)) {
+        result.skipped += 1;
+        result.sameSourceDedupSkipped += 1;
+        continue;
+      }
+
       if (isStrandedIssueRecoveryIssue(issue) && isUnsuccessfulTerminalIssueRun(latestRun)) {
         const updated = await escalateStrandedRecoveryIssueInPlace({
           issue,


### PR DESCRIPTION
## Why

`reconcileStrandedAssignedIssues` re-issues automatic recovery for stalled assigned issues on every cron tick. When the same root cause keeps failing (e.g. `openclaw_gateway_wait_error`, ChatGPT usage limit, repeated adapter timeouts), the loop currently:

1. Posts an identical `Paperclip automatically retried…` comment on each tick.
2. Only escalates after a one-shot productivity gate upstream, so back-to-back attempts on the same fingerprint pile up before any `blocked` transition.

In production we observed DGG-4980 receive 3 automatic recovery comments back-to-back for the same `openclaw_gateway_wait_error` and `timeout - OpenClaw gateway` source before the 4th finally landed it in `todo`. That is too noisy and too slow.

## What

Adds two governance gates inside the reconcile loop:

1. **Same-source dedup (AC-1)** — every automatic recovery run gets a failure fingerprint (`errorCode`, falling back to the first line of `error`). If the latest run shares a fingerprint with another automatic recovery inside a 1h window, the next reconcile tick suppresses another retry. New result key: `sameSourceDedupSkipped`.
2. **24h budget cap (AC-2)** — once an issue consumes 3 automatic recovery attempts inside 24h, escalate it to `blocked` via the existing `escalateStrandedAssignedIssue` path (which creates the `Recover stalled issue …` child issue). The cap is evaluated *before* dedup so a hot loop that varies fingerprints still terminates after 3 attempts. New result key: `capEscalated`.

Both gates only act on automatic recovery runs (`retryReason` is `assignment_recovery` or `issue_continuation_needed`). Productive runs and unrelated heartbeats are unaffected.

## Tests

Added 3 vitest cases against the embedded Postgres harness:

- `escalates stranded work to blocked once the 24h automatic recovery budget is exhausted` — drives the cap with 2 historical retries + 1 seeded current run, asserts `capEscalated`, `blocked` status, and that no extra retry run is queued on top of the cap escalation.
- `deduplicates same-source automatic recovery retries inside the 1h fingerprint window` — asserts dedup fires when fingerprints match.
- `does not dedup retries when the failure fingerprint changes between attempts` — asserts dedup does *not* fire when fingerprints differ.

`pnpm exec vitest run src/__tests__/heartbeat-process-recovery.test.ts` → 40/40 pass on this branch (37 prior tests + 3 new).

## Out of scope

Tracked as follow-ups against DGG-5210:

- AC-3 — auto-done for the `Recover stalled issue …` recovery child once the source issue resumes or is intentionally resolved.
- AC-4 — 24h post-deploy monitoring grep + evidence comment.
- AC-2 `#0_standup` notification — requires Slack/notifier wiring beyond the existing recovery comment.

## Risk / rollout

- Pure server-side change in recovery service. No DB schema, no API surface, no UI.
- Cap is bounded to *automatic* recovery attempts \u2014 manual reassignment, board-driven retries, and external dispatches don't count against it.
- Dedup window (1h) is conservative: a different fingerprint immediately bypasses dedup, so legit transient failures aren't blocked.