### PR TITLE
fix: scope wake-payload comment query to issueId (BLO-188)

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1485,6 +1485,116 @@ describe("heartbeat comment wake batching", () => {
       await gateway.close();
     }
   }, 120_000);
+  it("does not include comments from other issues in the wake payload even when their ids appear in context", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueAId = randomUUID();
+    const issueBId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: { "x-openclaw-token": "gateway-token" },
+          payloadTemplate: { message: "wake now" },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values([
+        {
+          id: issueAId,
+          companyId,
+          title: "Unrelated issue A",
+          status: "done",
+          priority: "low",
+          issueNumber: 1,
+          identifier: `${issuePrefix}-1`,
+        },
+        {
+          id: issueBId,
+          companyId,
+          title: "Active issue B",
+          status: "todo",
+          priority: "medium",
+          assigneeAgentId: agentId,
+          issueNumber: 2,
+          identifier: `${issuePrefix}-2`,
+        },
+      ]);
+
+      // A board comment is posted on issue A (the unrelated issue).
+      const commentOnIssueA = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId: issueAId,
+          authorUserId: "board-user",
+          body: "LEAKED: this comment belongs to issue A and must never appear in issue B's wake payload",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      // Wake agent for issue B with the issue A comment ID in the context snapshot.
+      // This replicates the reported bug: a board comment ID from one issue
+      // ends up referenced in the context snapshot of a different issue.
+      const run = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId: issueBId, commentId: commentOnIssueA.id },
+        contextSnapshot: {
+          issueId: issueBId,
+          taskId: issueBId,
+          commentId: commentOnIssueA.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "board-user",
+      });
+
+      expect(run).not.toBeNull();
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      const payload = gateway.getAgentPayloads()[0] ?? {};
+      const wake = (payload.paperclip as Record<string, unknown> | undefined)?.wake as
+        | Record<string, unknown>
+        | undefined;
+
+      // The comment ID is still listed (it was requested) …
+      expect(wake?.commentIds).toContain(commentOnIssueA.id);
+      // … but the comment body is absent because it belongs to issue A, not issue B.
+      const inlineComments = (wake?.comments as Array<Record<string, unknown>> | undefined) ?? [];
+      expect(inlineComments.find((c) => c.id === commentOnIssueA.id)).toBeUndefined();
+      expect(String(payload.message ?? "")).not.toContain("LEAKED:");
+      // The server signals that it could not resolve the comment so the agent
+      // knows to fall back to the API.
+      expect((wake?.commentWindow as Record<string, unknown> | undefined)?.missingCount).toBe(1);
+      expect(wake?.fallbackFetchNeeded).toBe(true);
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 30_000);
+
   it("treats the automatic run summary as fallback-only when the run already posted a comment", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1845,6 +1845,7 @@ async function buildPaperclipWakePayload(input: {
           .where(
             and(
               eq(issueComments.companyId, input.companyId),
+              issueId ? eq(issueComments.issueId, issueId) : undefined,
               inArray(issueComments.id, commentIds),
             ),
           );


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; each agent run is woken up by the heartbeat scheduler with a compact "wake payload" that includes inline comment bodies so the agent does not have to round-trip the API on startup.
> - The wake payload is assembled in `buildPaperclipWakePayload` inside `server/src/services/heartbeat.ts`.
> - That function resolves inline comment bodies from the DB using the comment IDs stored in the run's `contextSnapshot`.
> - The DB query filtered comments by `companyId` and `inArray(issueComments.id, commentIds)` — but **not** by `issueId`.
> - Because comment UUIDs are company-scoped in the query, a comment ID from issue A could be resolved and included in the wake payload built for issue B (same company), leaking the body of issue A's comment to an agent working on a completely different ticket.
> - This PR adds `eq(issueComments.issueId, issueId)` to the WHERE clause, restricting comment resolution to the issue the run is scoped to.
> - The benefit is that agents only ever see inline comments that belong to their assigned issue; cross-issue information leakage via the wake payload is eliminated.

## What Changed

- `server/src/services/heartbeat.ts` — added `issueId ? eq(issueComments.issueId, issueId) : undefined` to the WHERE clause of the comment-fetch query inside `buildPaperclipWakePayload` (one line).
- `server/src/__tests__/heartbeat-comment-wake-batching.test.ts` — new regression test: wakes an agent for issue B with a comment ID that belongs to issue A in the same company; asserts the comment body is absent from the inline payload, `missingCount === 1`, and `fallbackFetchNeeded === true`.

## Verification

```bash
npx vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts
```

All 10 tests pass (9 pre-existing + 1 new regression).

```
✓ |@paperclipai/server| src/__tests__/heartbeat-comment-wake-batching.test.ts (10 tests) 5194ms
Test Files  1 passed (1)
     Tests  10 passed (10)
```

Full typecheck also passes: `pnpm typecheck`.

## Risks

- **Low risk.** The change is a single additional equality predicate on a query that already filters by `companyId` and a list of known IDs. In correct operation, comment IDs in a run's context snapshot always belong to the run's issue, so the added filter is a no-op. It only changes behaviour in the bug case (cross-issue ID leakage), where it prevents the stray body from appearing.
- No migrations or schema changes. No API surface changes.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6 (Claude Sonnet 4.6)
- Mode: tool-use / agentic (Claude Code CLI)
- Context window: 200 k tokens

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only change)
- [x] I have updated relevant documentation to reflect my changes — no doc change needed for a one-line WHERE clause fix
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge