### PR TITLE
Suppress @-mention wakes on done/cancelled issues for non-assignees

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1237,4 +1237,55 @@ describe.sequential("issue comment reopen routes", () => {
       }),
     ));
   });
+
+  it("suppresses non-assignee mention wakes when an assignee agent POSTs on its own done issue", async () => {
+    const MENTIONED_AGENT_ID = "55555555-5555-4555-8555-555555555555";
+    const issue = makeIssue("done");
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+    }));
+    mockIssueService.findMentionedAgents.mockResolvedValue([MENTIONED_AGENT_ID]);
+
+    const res = await request(
+      await installActor(createApp(), agentActor()),
+    )
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: `done — cc [@Other](agent://${MENTIONED_AGENT_ID})` });
+
+    expect(res.status).toBe(201);
+    // Agent self-comments do not implicitly reopen, and the issue stays done, so the
+    // mentioned non-assignee must NOT be woken.
+    await new Promise((r) => setTimeout(r, 25));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      MENTIONED_AGENT_ID,
+      expect.objectContaining({ reason: "issue_comment_mentioned" }),
+    );
+  });
+
+  it("still wakes mentioned agents when an assignee agent POSTs on its own in_progress issue", async () => {
+    const MENTIONED_AGENT_ID = "66666666-6666-4666-8666-666666666666";
+    const issue = makeIssue("in_progress");
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+    }));
+    mockIssueService.findMentionedAgents.mockResolvedValue([MENTIONED_AGENT_ID]);
+
+    const res = await request(
+      await installActor(createApp(), agentActor()),
+    )
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: `cc [@Other](agent://${MENTIONED_AGENT_ID})` });
+
+    expect(res.status).toBe(201);
+    await waitForWakeup(() =>
+      expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+        MENTIONED_AGENT_ID,
+        expect.objectContaining({ reason: "issue_comment_mentioned" }),
+      ),
+    );
+  });
 });

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -290,4 +290,94 @@ describe("issue update comment wakeups", () => {
       }),
     );
   });
+
+  it("still wakes mentioned agents when a board PATCH implicitly reopens a closed issue", async () => {
+    const MENTIONED_AGENT_ID = "33333333-3333-4333-8333-333333333333";
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "done",
+    });
+    const reopened = { ...existing, status: "todo" as const };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(reopened);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-3",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: `cc [@Other](agent://${MENTIONED_AGENT_ID})`,
+    });
+    mockIssueService.findMentionedAgents.mockResolvedValue([MENTIONED_AGENT_ID]);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ comment: `cc [@Other](agent://${MENTIONED_AGENT_ID})` });
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() =>
+      expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+        MENTIONED_AGENT_ID,
+        expect.objectContaining({ reason: "issue_comment_mentioned" }),
+      ),
+    );
+  });
+
+  it("suppresses mention wakes on closed issues with no agent assignee (PATCH)", async () => {
+    const MENTIONED_AGENT_ID = "44444444-4444-4444-8444-444444444444";
+    // No assignee → shouldImplicitlyMoveCommentedIssueToTodo returns false → reopened stays false.
+    const existing = makeIssue({
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+      status: "done",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(existing);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-4",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: `cc [@Other](agent://${MENTIONED_AGENT_ID})`,
+    });
+    mockIssueService.findMentionedAgents.mockResolvedValue([MENTIONED_AGENT_ID]);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ comment: `cc [@Other](agent://${MENTIONED_AGENT_ID})` });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      MENTIONED_AGENT_ID,
+      expect.objectContaining({ reason: "issue_comment_mentioned" }),
+    );
+  });
+
+  it("still wakes mentioned agents on open issues (PATCH regression)", async () => {
+    const MENTIONED_AGENT_ID = "55555555-5555-4555-8555-555555555555";
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(existing);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-5",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: `cc [@Other](agent://${MENTIONED_AGENT_ID})`,
+    });
+    mockIssueService.findMentionedAgents.mockResolvedValue([MENTIONED_AGENT_ID]);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ comment: `cc [@Other](agent://${MENTIONED_AGENT_ID})` });
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() =>
+      expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+        MENTIONED_AGENT_ID,
+        expect.objectContaining({ reason: "issue_comment_mentioned" }),
+      ),
+    );
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2783,6 +2783,7 @@ export function issueRoutes(
 
         for (const mentionedId of mentionedIds) {
           if (actor.actorType === "agent" && actor.actorId === mentionedId) continue;
+          if (isClosed && !reopened && mentionedId !== assigneeId) continue;
           addWakeup(mentionedId, {
             source: "automation",
             triggerDetail: "system",
@@ -3814,6 +3815,7 @@ export function issueRoutes(
       for (const mentionedId of mentionedIds) {
         if (wakeups.has(mentionedId)) continue;
         if (actorIsAgent && actor.actorId === mentionedId) continue;
+        if (isClosed && !reopened && mentionedId !== assigneeId) continue;
         wakeups.set(mentionedId, {
           source: "automation",
           triggerDetail: "system",

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -49,6 +49,7 @@ Overrides and special cases:
 - `PAPERCLIP_TASK_ID` set and assigned to you → prioritize that task first.
 - `PAPERCLIP_WAKE_REASON=issue_commented` with `PAPERCLIP_WAKE_COMMENT_ID` → read the comment, then checkout and address the feedback (applies to `in_review` too).
 - `PAPERCLIP_WAKE_REASON=issue_comment_mentioned` → read the comment thread first even if you're not the assignee. Self-assign (via checkout) only if the comment explicitly directs you to take the task. Otherwise respond in comments if useful and continue with your own assigned work; do not self-assign.
+- **Closed-issue mention dedup:** if the wake is `issue_comment_mentioned` on an issue whose status is `done` or `cancelled` AND you are not the assignee, exit the heartbeat without commenting. The dispatcher already suppresses these wakes server-side; this rule is the second-line guard for any wake that slips through. Re-engage only if the comment explicitly asks for your input or someone reassigns the issue.
 - Wake payload says `dependency-blocked interaction: yes` → the issue is still blocked for deliverable work. Do not try to unblock it. Read the comment, name the unresolved blocker(s), and respond/triage via comments or documents. Use the scoped wake context rather than treating a checkout failure as a blocker.
 - **Blocked-task dedup:** before touching a `blocked` task, check the thread. If your most recent comment was a blocked-status update and no one has replied since, skip entirely — do not checkout, do not re-comment. Only re-engage on new context (comment, status change, event wake).
 - Nothing assigned and no valid mention handoff → exit the heartbeat.
@@ -227,6 +228,7 @@ For commands, response fields, and MCP tools, read:
 - **Never cancel cross-team tasks.** Reassign to your manager with a comment.
 - **Use first-class blockers** (`blockedByIssueIds`) rather than free-text "blocked by X" comments.
 - **On a blocked task with no new context, don't re-comment** — see the blocked-task dedup rule in Step 4.
+- **On a `done` / `cancelled` mention wake where you are not the assignee, don't comment** — see the closed-issue mention dedup rule in Step 4. The dispatcher should already suppress these wakes; this rule is the second-line guard.
 - **@-mentions** trigger heartbeats — use sparingly, they cost budget. For machine-authored comments, resolve the target agent and emit a structured mention as `[@Agent Name](agent://<agent-id>)` instead of raw `@AgentName` text.
 - **Budget**: auto-paused at 100%. Above 80%, focus on critical tasks only.
 - **Escalate** via `chainOfCommand` when stuck. Reassign to manager or create a task for them.


### PR DESCRIPTION
## Summary

- Server: both mention-wake loops in `routes/issues.ts` (PATCH issue + POST `/comments`) now skip mentioned agents when the issue is closed (`done` / `cancelled`), the comment did not implicitly reopen it, and the mentioned agent is not the assignee. Stops the wasted heartbeats that fire when an agent gets `@`-mentioned in a closed-issue comment and exits at "no skills apply".

## Why now

We saw recurring no-op heartbeats on closed issues. The dispatcher should suppress the mention wake before it reaches the agent.

## Behaviour

- Closed issue + `@`-mention of a non-assignee: no wake. ✅
- Closed issue + `@`-mention of the assignee: still wakes (assignee can choose to re-engage on their own closed issue).
- Closed issue + board comment that implicitly reopens the issue and `@`-mentions a non-assignee: still wakes (`reopened` flips the suppress off because the issue is now open).
- Open issue + `@`-mention of a non-assignee: still wakes (no regression).