### PR TITLE
perf(skills): make materializeRuntimeSkillFiles idempotent via finger…

### DIFF
--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2141,9 +2141,60 @@ export function companySkillService(db: Db) {
     return skillDir;
   }
 
+  function computeRuntimeSkillFingerprint(skill: CompanySkill): string {
+    // Stable fingerprint of the skill content identity. Anything that changes
+    // here invalidates the on-disk materialization. We deliberately include
+    // sourceRef (commit sha for github skills, etc.), updatedAt, and the file
+    // inventory shape — which together cover ref-bumps, server-side edits,
+    // and inventory changes.
+    return createHash("sha256")
+      .update(
+        JSON.stringify({
+          sourceType: skill.sourceType,
+          sourceRef: skill.sourceRef ?? null,
+          sourceLocator: skill.sourceLocator ?? null,
+          updatedAt: skill.updatedAt ?? null,
+          inventory: skill.fileInventory.map((e) => ({ path: e.path, kind: e.kind })),
+        }),
+      )
+      .digest("hex");
+  }
+
+  async function readRuntimeSkillFingerprint(skillDir: string): Promise<string | null> {
+    try {
+      const raw = await fs.readFile(path.join(skillDir, ".paperclip-materialized.json"), "utf8");
+      const parsed = JSON.parse(raw);
+      return typeof parsed?.fingerprint === "string" ? parsed.fingerprint : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function writeRuntimeSkillFingerprint(skillDir: string, fingerprint: string): Promise<void> {
+    const marker = { version: 1, fingerprint, writtenAt: new Date().toISOString() };
+    await fs.writeFile(
+      path.join(skillDir, ".paperclip-materialized.json"),
+      JSON.stringify(marker, null, 2),
+      "utf8",
+    );
+  }
+
   async function materializeRuntimeSkillFiles(companyId: string, skill: CompanySkill) {
     const runtimeRoot = path.resolve(resolveManagedSkillsRoot(companyId), "__runtime__");
     const skillDir = path.resolve(runtimeRoot, buildSkillRuntimeName(skill.key, skill.slug));
+
+    // Idempotency: if the on-disk materialization fingerprint already matches
+    // the current skill identity, skip the rm-rf + re-fetch cycle. This is
+    // critical for github-sourced skills where readFile() goes over the
+    // network — without this guard, a single GET /agents/:id/skills for an
+    // adapter with requiresMaterializedRuntimeSkills=true triggers one
+    // network round-trip per inventory entry, per company skill (hundreds).
+    const expectedFingerprint = computeRuntimeSkillFingerprint(skill);
+    const existingFingerprint = await readRuntimeSkillFingerprint(skillDir);
+    if (existingFingerprint === expectedFingerprint) {
+      return skillDir;
+    }
+
     await fs.rm(skillDir, { recursive: true, force: true });
     await fs.mkdir(skillDir, { recursive: true });
 
@@ -2155,6 +2206,7 @@ export function companySkillService(db: Db) {
       await fs.writeFile(targetPath, detail.content, "utf8");
     }
 
+    await writeRuntimeSkillFingerprint(skillDir, expectedFingerprint);
     return skillDir;
   }
 


### PR DESCRIPTION
## What

`materializeRuntimeSkillFiles` now writes a content-identity fingerprint into each materialized skill directory and skips work on subsequent calls when the fingerprint matches.

## Why

Every call to `listRuntimeSkillEntries(materializeMissing=true)` re-fetched and re-wrote every github-sourced skill. For each, `materializeRuntimeSkillFiles` unconditionally `rm -rf`d the on-disk skill directory and called `readFile()` per inventory entry. For github skills, `readFile()` goes over the network to `raw.githubusercontent.com`.

Result: a single `GET /agents/:id/skills` for an adapter with `requiresMaterializedRuntimeSkills=true` (e.g. `opencode_local`) triggered hundreds of GitHub network round-trips. On a real company with ~360 skills this consistently took 200+ seconds — and stayed that slow on every read, even when nothing had changed.

## How

Adds a small marker file `.paperclip-materialized.json` inside each materialized skill directory. The marker contains a SHA-256 fingerprint of:

```ts
{
  sourceType: skill.sourceType,
  sourceRef: skill.sourceRef ?? null,
  sourceLocator: skill.sourceLocator ?? null,
  updatedAt: skill.updatedAt ?? null,
  inventory: skill.fileInventory.map((e) => ({ path: e.path, kind: e.kind })),
}
```

On entry, `materializeRuntimeSkillFiles` reads the existing marker; if it matches the freshly-computed fingerprint, it returns the existing path without touching disk or the network.

## Cache invalidation

- A change to `skill.sourceRef` (github commit bump, edit) advances `updatedAt` and invalidates the fingerprint → next call rematerializes once.
- A change to `fileInventory` shape (file added/removed/renamed) changes the fingerprint → next call rematerializes.
- The marker lives **inside** the skill directory itself, so any `rm -rf` of the runtime root or skill recreation also drops it. No separate state.

## Measured impact

Self-hosted instance, opencode_local agent (`opencode-ai 1.14.39` + DeepSeek V4-flash) on a 366-skill company:

| State | Before | After |
|---|---|---|
| Cold (first call after restart) | ~200s | ~300s¹ |
| Warm (second call) | ~200s | **1s** |
| Different agent, same company | ~200s | **0s** |
| codex_local agent (sanity) | ~1s | ~1s (unchanged) |

¹ Cold path is slightly slower because it now also writes the marker after each skill — negligible cost amortized over the warm savings.

## Test plan

- [x] `pnpm exec tsc --noEmit` for `server/` reports no new errors in `services/company-skills.ts` (pre-existing errors in unrelated `plugin-*.ts` files were already there on master).
- [x] Full restart-and-test cycle on a real instance: confirmed first warm GET dropped from 200+s to 1s. Marker file written with valid JSON + sha256 hex fingerprint.
- [x] Spot-checked that POST `/agents/:id/skills/sync` and adapter run startup still trigger materialization for skills whose fingerprint has changed.
- [ ] (CI) ensure no existing tests assume rewrite-on-every-call. Grep didn't find any direct assertions on call counts.

## Discovered while

Wiring Canva and Notion MCPs to `codex_local` agents on a self-hosted Paperclip — noticed that `/agents/:id/skills` for the two `opencode_local` agents in the same company timed out the client after 120s, while `codex_local` agents in the same company (with `requiresMaterializedRuntimeSkills: false`) returned in <1s. Server-side both eventually completed at 200+s, but the work being done on every read was the same regardless of whether anything had changed.