### PR TITLE
fix(platform): bundled UUID validation hardening (ZERA-521/526/527/528/530/532)

### DIFF
--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -186,4 +186,118 @@ describe.sequential("activity routes", () => {
     expect(mockHeartbeatService.getRun).not.toHaveBeenCalled();
     expect(mockActivityService.issuesForRun).not.toHaveBeenCalled();
   });
+
+  describe("GET /api/companies/:companyId/activity pagination + window (ZERA-526/527)", () => {
+    it("applies the service-side default when no limit is provided", async () => {
+      mockActivityService.list.mockResolvedValue([]);
+      const app = await createApp();
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get("/api/companies/company-1/activity"),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockActivityService.list).toHaveBeenCalledTimes(1);
+      const filters = mockActivityService.list.mock.calls[0][0];
+      expect(filters).toMatchObject({ companyId: "company-1", limit: 100 });
+      expect(filters.since).toBeUndefined();
+      expect(filters.until).toBeUndefined();
+    });
+
+    it("rejects a non-integer or non-positive limit with 400", async () => {
+      const app = await createApp();
+      const cases = ["abc", "0", "-1", "1.5"];
+      for (const value of cases) {
+        const res = await requestApp(app, (baseUrl) =>
+          request(baseUrl).get(`/api/companies/company-1/activity?limit=${value}`),
+        );
+        expect(res.status).toBe(400);
+      }
+      expect(mockActivityService.list).not.toHaveBeenCalled();
+    });
+
+    it("forwards a valid since timestamp as a Date", async () => {
+      mockActivityService.list.mockResolvedValue([]);
+      const app = await createApp();
+      const since = "2026-05-01T00:00:00.000Z";
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get(
+          `/api/companies/company-1/activity?since=${encodeURIComponent(since)}`,
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      const filters = mockActivityService.list.mock.calls[0][0];
+      expect(filters.since).toBeInstanceOf(Date);
+      expect(filters.since.toISOString()).toBe(since);
+    });
+
+    it("forwards a valid until timestamp as a Date", async () => {
+      mockActivityService.list.mockResolvedValue([]);
+      const app = await createApp();
+      const until = "2026-05-06T00:00:00.000Z";
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get(
+          `/api/companies/company-1/activity?until=${encodeURIComponent(until)}`,
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      const filters = mockActivityService.list.mock.calls[0][0];
+      expect(filters.until).toBeInstanceOf(Date);
+      expect(filters.until.toISOString()).toBe(until);
+    });
+
+    it("rejects malformed since/until with 400", async () => {
+      const app = await createApp();
+      const sinceRes = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get("/api/companies/company-1/activity?since=not-a-date"),
+      );
+      expect(sinceRes.status).toBe(400);
+
+      const untilRes = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get("/api/companies/company-1/activity?until=also-not-a-date"),
+      );
+      expect(untilRes.status).toBe(400);
+
+      expect(mockActivityService.list).not.toHaveBeenCalled();
+    });
+
+    it("composes limit clamp with since/until window", async () => {
+      mockActivityService.list.mockResolvedValue([]);
+      const app = await createApp();
+      const since = "2026-05-01T00:00:00.000Z";
+      const until = "2026-05-06T00:00:00.000Z";
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get(
+          `/api/companies/company-1/activity?limit=10&since=${encodeURIComponent(since)}&until=${encodeURIComponent(until)}`,
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      const filters = mockActivityService.list.mock.calls[0][0];
+      expect(filters).toMatchObject({ companyId: "company-1", limit: 10 });
+      expect(filters.since).toBeInstanceOf(Date);
+      expect(filters.since.toISOString()).toBe(since);
+      expect(filters.until).toBeInstanceOf(Date);
+      expect(filters.until.toISOString()).toBe(until);
+    });
+
+    it("preserves existing agentId / entityType filters", async () => {
+      mockActivityService.list.mockResolvedValue([]);
+      const app = await createApp();
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).get(
+          "/api/companies/company-1/activity?agentId=agent-x&entityType=issue&limit=10",
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockActivityService.list.mock.calls[0][0]).toMatchObject({
+        companyId: "company-1",
+        agentId: "agent-x",
+        entityType: "issue",
+        limit: 10,
+      });
+    });
+  });
 });

--- a/server/src/__tests__/goals-service-uuid-validation.test.ts
+++ b/server/src/__tests__/goals-service-uuid-validation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { goalService } from "../services/goals.ts";
+
+function makeExplodingDb() {
+  const explode = () => {
+    throw new Error("db should not be queried for malformed UUIDs");
+  };
+  const handler: ProxyHandler<object> = {
+    get() {
+      return explode;
+    },
+  };
+  return new Proxy({}, handler) as never;
+}
+
+const MALFORMED_IDS = ["not-a-uuid", "", "   ", "1234", "abc-def"];
+
+describe("goalService.getById UUID guard (ZERA-527)", () => {
+  const svc = goalService(makeExplodingDb());
+
+  for (const value of MALFORMED_IDS) {
+    it(`returns null without hitting the DB for "${value}"`, async () => {
+      await expect(svc.getById(value)).resolves.toBeNull();
+    });
+  }
+});

--- a/server/src/__tests__/heartbeat-service-uuid-validation.test.ts
+++ b/server/src/__tests__/heartbeat-service-uuid-validation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { heartbeatService } from "../services/heartbeat.ts";
+
+function makeExplodingDb() {
+  const explode = () => {
+    throw new Error("db should not be queried for malformed UUIDs");
+  };
+  const handler: ProxyHandler<object> = {
+    get() {
+      return explode;
+    },
+  };
+  return new Proxy({}, handler) as never;
+}
+
+const MALFORMED_IDS = ["not-a-uuid", "", "   ", "1234", "abc-def"];
+
+describe("heartbeatService.getRun UUID guard (ZERA-528)", () => {
+  const svc = heartbeatService(makeExplodingDb());
+
+  for (const value of MALFORMED_IDS) {
+    it(`returns null without hitting the DB for "${value}"`, async () => {
+      await expect(svc.getRun(value)).resolves.toBeNull();
+    });
+  }
+});

--- a/server/src/__tests__/issue-attachment-service-uuid-validation.test.ts
+++ b/server/src/__tests__/issue-attachment-service-uuid-validation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { issueService } from "../services/issues.ts";
+
+function makeExplodingDb() {
+  const explode = () => {
+    throw new Error("db should not be queried for malformed UUIDs");
+  };
+  const handler: ProxyHandler<object> = {
+    get() {
+      return explode;
+    },
+  };
+  return new Proxy({}, handler) as never;
+}
+
+const MALFORMED_IDS = ["not-a-uuid", "", "   ", "1234", "abc-def"];
+
+describe("issueService.getAttachmentById UUID guard (ZERA-530)", () => {
+  const svc = issueService(makeExplodingDb());
+
+  for (const value of MALFORMED_IDS) {
+    it(`returns null without hitting the DB for "${value}"`, async () => {
+      await expect(svc.getAttachmentById(value)).resolves.toBeNull();
+    });
+  }
+});

--- a/server/src/__tests__/uuid-validation-services.test.ts
+++ b/server/src/__tests__/uuid-validation-services.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { approvalService } from "../services/approvals.ts";
+import { projectService } from "../services/projects.ts";
+import { routineService } from "../services/routines.ts";
+
+vi.mock("../services/agents.js", () => ({
+  agentService: vi.fn(() => ({})),
+}));
+
+vi.mock("../services/hire-hook.js", () => ({
+  notifyHireApproved: vi.fn(),
+}));
+
+vi.mock("../services/budgets.js", () => ({
+  budgetService: vi.fn(() => ({})),
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: vi.fn(() => ({})),
+}));
+
+vi.mock("../services/heartbeat.js", () => ({
+  heartbeatService: vi.fn(() => ({})),
+}));
+
+vi.mock("../services/issues.js", () => ({
+  issueService: vi.fn(() => ({ getById: vi.fn() })),
+}));
+
+vi.mock("../services/workspace-runtime-read-model.js", () => ({
+  listCurrentRuntimeServicesForProjectWorkspaces: vi.fn(),
+}));
+
+function makeExplodingDb() {
+  const explode = () => {
+    throw new Error("db should not be queried for malformed UUIDs");
+  };
+  const handler: ProxyHandler<object> = {
+    get() {
+      return explode;
+    },
+  };
+  return new Proxy({}, handler) as never;
+}
+
+const MALFORMED_IDS = ["not-a-uuid", "", "   ", "1234", "abc-def"];
+
+describe("UUID validation guards (ZERA-521)", () => {
+  describe("projectService.getById", () => {
+    const svc = projectService(makeExplodingDb());
+
+    for (const value of MALFORMED_IDS) {
+      it(`returns null without hitting the DB for "${value}"`, async () => {
+        await expect(svc.getById(value)).resolves.toBeNull();
+      });
+    }
+  });
+
+  describe("approvalService.getById", () => {
+    const svc = approvalService(makeExplodingDb());
+
+    for (const value of MALFORMED_IDS) {
+      it(`returns null without hitting the DB for "${value}"`, async () => {
+        await expect(svc.getById(value)).resolves.toBeNull();
+      });
+    }
+  });
+
+  describe("routineService.get / getDetail / getTrigger", () => {
+    const svc = routineService(makeExplodingDb());
+
+    for (const value of MALFORMED_IDS) {
+      it(`routine get returns null without hitting the DB for "${value}"`, async () => {
+        await expect(svc.get(value)).resolves.toBeNull();
+      });
+
+      it(`routine getDetail returns null without hitting the DB for "${value}"`, async () => {
+        await expect(svc.getDetail(value)).resolves.toBeNull();
+      });
+
+      it(`routine getTrigger returns null without hitting the DB for "${value}"`, async () => {
+        await expect(svc.getTrigger(value)).resolves.toBeNull();
+      });
+    }
+  });
+});

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -8,6 +8,13 @@ import { assertAuthenticated, assertBoard, assertCompanyAccess } from "./authz.j
 import { heartbeatService, issueService } from "../services/index.js";
 import { sanitizeRecord } from "../redaction.js";
 
+function parseIsoDate(raw: unknown): Date | undefined | null {
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  const parsed = new Date(raw);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
 const createActivitySchema = z.object({
   actorType: z.enum(["agent", "user", "system", "plugin"]).optional().default("system"),
   actorId: z.string().min(1),
@@ -36,12 +43,38 @@ export function activityRoutes(db: Db) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
 
+    const rawLimit = req.query.limit;
+    let limit: number | undefined;
+    if (typeof rawLimit === "string" && rawLimit.length > 0) {
+      const parsed = Number(rawLimit);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        res
+          .status(400)
+          .json({ error: "limit must be a positive integer" });
+        return;
+      }
+      limit = parsed;
+    }
+
+    const since = parseIsoDate(req.query.since);
+    if (since === null) {
+      res.status(400).json({ error: "since must be a valid ISO 8601 timestamp" });
+      return;
+    }
+    const until = parseIsoDate(req.query.until);
+    if (until === null) {
+      res.status(400).json({ error: "until must be a valid ISO 8601 timestamp" });
+      return;
+    }
+
     const filters = {
       companyId,
       agentId: req.query.agentId as string | undefined,
       entityType: req.query.entityType as string | undefined,
       entityId: req.query.entityId as string | undefined,
-      limit: normalizeActivityLimit(Number(req.query.limit)),
+      limit: normalizeActivityLimit(limit),
+      since: since ?? undefined,
+      until: until ?? undefined,
     };
     const result = await svc.list(filters);
     res.json(result);

--- a/server/src/services/activity.ts
+++ b/server/src/services/activity.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, isNull, lte, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -24,6 +24,8 @@ export interface ActivityFilters {
   entityType?: string;
   entityId?: string;
   limit?: number;
+  since?: Date;
+  until?: Date;
 }
 
 const DEFAULT_ACTIVITY_LIMIT = 100;
@@ -337,6 +339,12 @@ export function activityService(db: Db) {
       }
       if (filters.entityId) {
         conditions.push(eq(activityLog.entityId, filters.entityId));
+      }
+      if (filters.since) {
+        conditions.push(gte(activityLog.createdAt, filters.since));
+      }
+      if (filters.until) {
+        conditions.push(lte(activityLog.createdAt, filters.until));
       }
 
       return db

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, inArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { approvalComments, approvals } from "@paperclipai/db";
+import { isUuidLike } from "@paperclipai/shared";
 import { notFound, unprocessable } from "../errors.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { agentService } from "./agents.js";
@@ -85,12 +86,14 @@ export function approvalService(db: Db) {
       return db.select().from(approvals).where(and(...conditions));
     },
 
-    getById: (id: string) =>
-      db
+    getById: (id: string) => {
+      if (!isUuidLike(id)) return Promise.resolve(null);
+      return db
         .select()
         .from(approvals)
         .where(eq(approvals.id, id))
-        .then((rows) => rows[0] ?? null),
+        .then((rows) => rows[0] ?? null);
+    },
 
     create: (companyId: string, data: Omit<typeof approvals.$inferInsert, "companyId">) =>
       db

--- a/server/src/services/goals.ts
+++ b/server/src/services/goals.ts
@@ -1,6 +1,7 @@
 import { and, asc, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { goals } from "@paperclipai/db";
+import { isUuidLike } from "@paperclipai/shared";
 
 type GoalReader = Pick<Db, "select">;
 
@@ -46,12 +47,14 @@ export function goalService(db: Db) {
   return {
     list: (companyId: string) => db.select().from(goals).where(eq(goals.companyId, companyId)),
 
-    getById: (id: string) =>
-      db
+    getById: (id: string) => {
+      if (!isUuidLike(id)) return Promise.resolve(null);
+      return db
         .select()
         .from(goals)
         .where(eq(goals.id, id))
-        .then((rows) => rows[0] ?? null),
+        .then((rows) => rows[0] ?? null);
+    },
 
     getDefaultCompanyGoal: (companyId: string) => getDefaultCompanyGoal(db, companyId),
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2265,7 +2265,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function getRun(runId: string, opts?: { unsafeFullResultJson?: boolean }) {
-    if (!isUuidLike(runId)) return null;
     const safeForLegacyEncoding = !opts?.unsafeFullResultJson && await hasUnsafeTextProjectionDatabase();
     return db
       .select(
@@ -8832,7 +8831,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
     },
 
-    getRun,
+    getRun: async (runId: string, opts?: { unsafeFullResultJson?: boolean }) => {
+      if (!isUuidLike(runId)) return null;
+      return getRun(runId, opts);
+    },
 
     getRunLogAccess,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10,6 +10,7 @@ import {
   ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
   MODEL_PROFILE_KEYS,
   isEnvironmentDriverSupportedForAdapter,
+  isUuidLike,
   type BillingType,
   type EnvironmentLeaseStatus,
   type ExecutionWorkspace,
@@ -2264,6 +2265,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   }
 
   async function getRun(runId: string, opts?: { unsafeFullResultJson?: boolean }) {
+    if (!isUuidLike(runId)) return null;
     const safeForLegacyEncoding = !opts?.unsafeFullResultJson && await hasUnsafeTextProjectionDatabase();
     return db
       .select(

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3878,8 +3878,9 @@ export function issueService(db: Db) {
         .where(eq(issueAttachments.issueId, issueId))
         .orderBy(desc(issueAttachments.createdAt)),
 
-    getAttachmentById: async (id: string) =>
-      db
+    getAttachmentById: async (id: string) => {
+      if (!isUuidLike(id)) return null;
+      return db
         .select({
           id: issueAttachments.id,
           companyId: issueAttachments.companyId,
@@ -3900,7 +3901,8 @@ export function issueService(db: Db) {
         .from(issueAttachments)
         .innerJoin(assets, eq(issueAttachments.assetId, assets.id))
         .where(eq(issueAttachments.id, id))
-        .then((rows) => rows[0] ?? null),
+        .then((rows) => rows[0] ?? null);
+    },
 
     removeAttachment: async (id: string) =>
       db.transaction(async (tx) => {

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -496,6 +496,7 @@ export function projectService(db: Db) {
   };
 
   const getProjectById = async (id: string): Promise<ProjectWithGoals | null> => {
+    if (!isUuidLike(id)) return null;
     const row = await db
       .select()
       .from(projects)

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -41,6 +41,7 @@ import {
   getBuiltinRoutineVariableValues,
   extractRoutineVariableNames,
   interpolateRoutineTemplate,
+  isUuidLike,
   pluginOperationIssueOriginKind,
   stringifyRoutineVariableValue,
   syncRoutineVariablesWithTemplate,
@@ -470,6 +471,7 @@ export function routineService(
   });
 
   async function getRoutineById(id: string) {
+    if (!isUuidLike(id)) return null;
     return db
       .select()
       .from(routines)
@@ -535,6 +537,7 @@ export function routineService(
   }
 
   async function getTriggerById(id: string) {
+    if (!isUuidLike(id)) return null;
     return db
       .select()
       .from(routineTriggers)


### PR DESCRIPTION
## Summary

Bundled fix for the cycle 11 dogfooding sweep on UUID-validation gaps. All six fixes follow the same pattern: an `isUuidLike` short-circuit at the service-export boundary so malformed path params 404 cleanly instead of 500ing on an invalid Postgres UUID cast.

## Bundle contents (5 commits, master→HEAD)

| Commit  | Ticket(s)                                                  | What it does                                                                                                                          |
| ------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
| 1719cbe | [ZERA-526](/ZERA/issues/ZERA-526) + [ZERA-527](/ZERA/issues/ZERA-527) | `GET /api/companies/:companyId/activity` now applies `limit` / `since` / `until` instead of returning full company history; `goalService.getById` short-circuits to 404 on malformed UUIDs |
| 93128ae | [ZERA-528](/ZERA/issues/ZERA-528)                         | `isUuidLike` guard on `heartbeat.getRun` (was 500ing on `GET /api/heartbeat-runs/{not-a-uuid}/issues`)                                |
| 61e0af5 | [ZERA-530](/ZERA/issues/ZERA-530)                         | `isUuidLike` guard on `issueService.getAttachmentById` (was 500ing on attachment GET/DELETE with malformed id)                        |
| 3d34a96 | [ZERA-532](/ZERA/issues/ZERA-532)                         | Typecheck regression fix — hoist UUID guard onto the service-export boundary so internal `getRun` callers retain inferred return type |
| a1684e1 | [ZERA-521](/ZERA/issues/ZERA-521)                         | `isUuidLike` guard on `projectService.getById`, `approvalService.getById`, `routineService.getRoutineById`, `routineService.getTriggerById` (was 500ing on malformed UUIDs) |

Umbrella tracker: [ZERA-529](/ZERA/issues/ZERA-529).

## Pattern

Every fix is the same minimal shape at the service-export boundary:

```ts
if (!isUuidLike(id)) return null;
```

Route layer already 404s on `null`. No route-level changes were needed.

## Verification

- UUID-validation vitest suites green (40/40 across heartbeat, goals, attachment, and project/approval/routine services)
- Engineer's done-comment with full diff walkthrough: [ZERA-532#comment-668f4cd8](/ZERA/issues/ZERA-532#comment-668f4cd8-2fef-4f84-8aea-3858855d29d6)
- COO ack: [ZERA-532#comment-6d9a2c17](/ZERA/issues/ZERA-532#comment-6d9a2c17-0e37-48d2-be8b-be04ea6d4124)
- ZERA-521 cherry-pick: [ZERA-537](/ZERA/issues/ZERA-537)

## Scope notes

- **Global Zod-route-param validator is out of scope.** The structural one-shot fix (route-boundary UUID validator, [ZERA-531](/ZERA/issues/ZERA-531)) is intentionally NOT in this PR per the parent issue's release-scope decision. It exists as a separate commit on the engineer's local branch (`fix/zera-531-route-boundary-uuid-validator`) and can be released independently if/when the CEO authorizes.

## Model used

Claude Opus 4.7 (1M context).

## Test plan

- [ ] Security-researcher review of the `isUuidLike` short-circuit pattern (sibling subtask under [ZERA-533](/ZERA/issues/ZERA-533))
- [ ] CI green on PR
