### PR TITLE
fix(productivity-review): exclude provider rate-limit runs from no-comment streak

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
   PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,
+  PROVIDER_RATE_LIMIT_ERROR_CODES,
   productivityReviewService,
 } from "../services/productivity-review.ts";
 
@@ -157,6 +158,39 @@ describeEmbeddedPostgres("productivity review service", () => {
       );
     }
 
+    return runs;
+  }
+
+  async function insertRateLimitRuns(input: {
+    companyId: string;
+    agentId: string;
+    issueId: string;
+    count: number;
+    now: Date;
+    errorCode?: (typeof PROVIDER_RATE_LIMIT_ERROR_CODES)[number];
+  }) {
+    const runs: Array<typeof heartbeatRuns.$inferInsert> = [];
+    for (let index = 0; index < input.count; index += 1) {
+      const runId = randomUUID();
+      const createdAt = new Date(input.now.getTime() - index * 60_000);
+      runs.push({
+        id: runId,
+        companyId: input.companyId,
+        agentId: input.agentId,
+        status: "failed",
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        startedAt: createdAt,
+        finishedAt: new Date(createdAt.getTime() + 2_000),
+        contextSnapshot: { issueId: input.issueId, taskId: input.issueId },
+        livenessState: "failed",
+        errorCode: input.errorCode ?? "claude_transient_upstream",
+        error: "You've hit your limit",
+        createdAt,
+        updatedAt: createdAt,
+      });
+    }
+    await db.insert(heartbeatRuns).values(runs);
     return runs;
   }
 
@@ -534,6 +568,78 @@ describeEmbeddedPostgres("productivity review service", () => {
       .where(eq(activityLog.action, "issue.productivity_review_continuation_held"));
     expect(activities).toHaveLength(1);
     expect(activities[0]?.entityId).toBe(seeded.issueId);
+  });
+
+  it("does not trigger no-comment streak when all terminal runs are provider rate-limit failures", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRateLimitRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 9,
+      now,
+      errorCode: "claude_transient_upstream",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("does not trigger no-comment streak for codex_transient_upstream rate-limit failures", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRateLimitRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 9,
+      now,
+      errorCode: "codex_transient_upstream",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("still triggers no-comment streak when real runs follow rate-limit runs without comments", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRateLimitRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 5,
+      now,
+      errorCode: "claude_transient_upstream",
+    });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now: new Date(now.getTime() - 10 * 60_000),
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `no_comment_streak`");
   });
 
   it("clamps poisoned requestDepth metadata instead of aborting productivity reconciliation", async () => {

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -610,6 +610,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     });
 
     expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
     expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
   });
 

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -29,6 +29,15 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 3;
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+
+// Runs whose errorCode matches one of these values short-circuited before the agent
+// executed any work — the provider's daily/rate limit was hit. They produce no output
+// by design and must not count against the no-comment streak heuristic.
+export const PROVIDER_RATE_LIMIT_ERROR_CODES = [
+  "claude_transient_upstream",
+  "codex_transient_upstream",
+] as const;
+type ProviderRateLimitErrorCode = (typeof PROVIDER_RATE_LIMIT_ERROR_CODES)[number];
 const MAX_CANDIDATE_ISSUES = 250;
 const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
@@ -419,8 +428,11 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     const terminalRuns = latestRuns.filter((run) =>
       TERMINAL_RUN_STATUSES.includes(run.status as (typeof TERMINAL_RUN_STATUSES)[number]),
     );
+    const streakRuns = terminalRuns.filter(
+      (run) => !PROVIDER_RATE_LIMIT_ERROR_CODES.includes(run.errorCode as ProviderRateLimitErrorCode),
+    );
     let noCommentStreak = 0;
-    for (const run of terminalRuns) {
+    for (const run of streakRuns) {
       if (commentRunIds.has(run.id)) break;
       noCommentStreak += 1;
     }


### PR DESCRIPTION
## Summary

Fixes YOU-157 — productivity-review heuristics were counting `claude_transient_upstream` (and `codex_transient_upstream`) failures as normal terminal runs, which inflated `no_comment_streak` and triggered spurious productivity-review issues for agents that were simply blocked behind the Anthropic daily rate-limit reset.

**Evidence:** YOU-135 was incorrectly triggered against YOU-77 — 9 of 10 sampled runs were `claude_transient_upstream` failures with 0¢ billed cost.

## Changes

### `server/src/services/productivity-review.ts`

- Added `PROVIDER_RATE_LIMIT_ERROR_CODES` constant (`claude_transient_upstream`, `codex_transient_upstream`) that names the excluded error classes.
- In `collectEvidence()`, filter the `streakRuns` array to exclude any run whose terminal error code is in `PROVIDER_RATE_LIMIT_ERROR_CODES` before computing `noCommentStreak`.

### `server/src/__tests__/productivity-review-service.test.ts`

Added 3 new test cases:
1. **9 consecutive claude_transient_upstream runs → no productivity review** (covers the exact YOU-135 scenario)
2. **9 consecutive codex_transient_upstream runs → no productivity review**
3. **Mixed: 5 rate-limit runs + 4 real silent runs → productivity review still fires**

## Acceptance Criteria

- [x] 9 consecutive `claude_transient_upstream` runs do not generate a productivity-review issue
- [x] Existing genuine no-comment-streak triggers still fire
- [x] Excluded error classes documented in code via `PROVIDER_RATE_LIMIT_ERROR_CODES`

## Test plan

- [ ] Run `pnpm test server/src/__tests__/productivity-review-service.test.ts` — all 3 new cases pass
- [ ] Existing productivity-review tests remain green