### PR TITLE
TEC-1857: CI maintenance — Node.js 24 opt-in and Docker concurrency fix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,13 @@ on:
     tags:
       - "v*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+concurrency:
+  group: docker-${{ github.sha }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write
@@ -15,9 +22,6 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    concurrency:
-      group: docker-${{ github.ref }}
-      cancel-in-progress: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,9 @@ on:
         type: boolean
         default: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -6,6 +6,9 @@ on:
       - master
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: refresh-lockfile-master
   cancel-in-progress: false

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -35,6 +35,9 @@ on:
         default: release-smoke
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ on:
         type: boolean
         default: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: release-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to all six workflow `env` blocks (pr, release, docker, e2e, refresh-lockfile, release-smoke) to opt into Node.js 24 for GitHub Actions runners before the June 2, 2026 forced migration
- Fix `docker.yml` concurrency: move from job-level `docker-${{ github.ref }}` to workflow-level `docker-${{ github.sha }}` so simultaneous branch + tag pushes for the same commit collapse into one run instead of producing a cancelled/failed workflow

## Motivation

GitHub Actions deprecation warning: *"Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026."* Affected actions: `actions/checkout@v4`, `actions/setup-node@v4`, `docker/*`, `pnpm/action-setup@v4`, `actions/upload-artifact@v4`.

The Docker concurrency issue: when a version tag is pushed alongside a master branch update, `docker.yml` fires twice with different `github.ref` values, causing one run to be cancelled. Keying on `github.sha` groups both events for the same commit.

## Paperclip

- Issue: TEC-1857

## AI tool disclosure

Implemented by Full-Stack Developer (Claude).

## Test plan

- [ ] PR CI passes with no Node.js 20 deprecation warnings
- [ ] Verify `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` appears in workflow env for all six files
- [ ] Confirm `docker.yml` concurrency is now workflow-level with `github.sha` key