### PR TITLE
fix(auth): keep human invite signup flow usable

### DIFF
--- a/server/src/__tests__/invite-accept-auto-approval.test.ts
+++ b/server/src/__tests__/invite-accept-auto-approval.test.ts
@@ -1,0 +1,215 @@
+import { createHash, randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  authUsers,
+  companies,
+  companyMemberships,
+  createDb,
+  invites,
+  joinRequests,
+  principalPermissionGrants,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { accessRoutes } from "../routes/access.js";
+import { errorHandler } from "../middleware/index.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+function hashToken(token: string) {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+describeEmbeddedPostgres("POST /invites/:token/accept human auto approval", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-invite-auto-approval-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(principalPermissionGrants);
+    await db.delete(joinRequests);
+    await db.delete(invites);
+    await db.delete(companyMemberships);
+    await db.delete(companies);
+    await db.delete(authUsers);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("auto-approves explicit owner human invites and grants the role permissions", async () => {
+    const now = new Date();
+    const inviterId = `inviter-${randomUUID()}`;
+    const invitedUserId = `invited-${randomUUID()}`;
+    const token = `pcp_invite_${randomUUID().replaceAll("-", "")}`;
+    await db.insert(authUsers).values([
+      {
+        id: inviterId,
+        name: "Inviter Admin",
+        email: "admin@example.com",
+        emailVerified: true,
+        image: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: invitedUserId,
+        name: "Invited Owner",
+        email: "owner@example.com",
+        emailVerified: true,
+        image: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    const company = await db
+      .insert(companies)
+      .values({
+        name: "Invite Auto Approval Co",
+        issuePrefix: `IA${randomUUID().slice(0, 6).toUpperCase()}`,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    await db.insert(invites).values({
+      companyId: company.id,
+      inviteType: "company_join",
+      tokenHash: hashToken(token),
+      allowedJoinTypes: "human",
+      defaultsPayload: {
+        human: {
+          role: "owner",
+          grants: [
+            { permissionKey: "agents:create", scope: null },
+            { permissionKey: "users:invite", scope: null },
+            { permissionKey: "users:manage_permissions", scope: null },
+            { permissionKey: "tasks:assign", scope: null },
+            { permissionKey: "joins:approve", scope: null },
+          ],
+        },
+      },
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      invitedByUserId: inviterId,
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        source: "session",
+        userId: invitedUserId,
+        companyIds: [],
+        memberships: [],
+      };
+      next();
+    });
+    app.use(
+      "/api",
+      accessRoutes(db, {
+        deploymentMode: "authenticated",
+        deploymentExposure: "private",
+        bindHost: "127.0.0.1",
+        allowedHostnames: [],
+      }),
+    );
+    app.use(errorHandler);
+
+    const res = await request(app)
+      .post(`/api/invites/${token}/accept`)
+      .send({ requestType: "human" });
+
+    expect(res.status).toBe(202);
+    expect(res.body.status).toBe("approved");
+    expect(res.body.approvedByUserId).toBe(inviterId);
+
+    const membership = await db
+      .select()
+      .from(companyMemberships)
+      .where(eq(companyMemberships.principalId, invitedUserId))
+      .then((rows) => rows[0]!);
+    expect(membership.companyId).toBe(company.id);
+    expect(membership.membershipRole).toBe("owner");
+    expect(membership.status).toBe("active");
+
+    const grants = await db
+      .select()
+      .from(principalPermissionGrants)
+      .where(eq(principalPermissionGrants.principalId, invitedUserId));
+    expect(grants.map((grant) => grant.permissionKey).sort()).toEqual([
+      "agents:create",
+      "joins:approve",
+      "tasks:assign",
+      "users:invite",
+      "users:manage_permissions",
+    ]);
+  }, 20_000);
+
+  it("leaves agent invites in the existing pending approval flow", async () => {
+    const token = `pcp_invite_${randomUUID().replaceAll("-", "")}`;
+    const company = await db
+      .insert(companies)
+      .values({
+        name: "Agent Invite Co",
+        issuePrefix: `AI${randomUUID().slice(0, 6).toUpperCase()}`,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    await db.insert(invites).values({
+      companyId: company.id,
+      inviteType: "company_join",
+      tokenHash: hashToken(token),
+      allowedJoinTypes: "agent",
+      defaultsPayload: {
+        agent: {
+          grants: [{ permissionKey: "tasks:assign", scope: null }],
+        },
+      },
+      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      invitedByUserId: null,
+    });
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "anonymous",
+        source: "none",
+      };
+      next();
+    });
+    app.use(
+      "/api",
+      accessRoutes(db, {
+        deploymentMode: "authenticated",
+        deploymentExposure: "private",
+        bindHost: "127.0.0.1",
+        allowedHostnames: [],
+      }),
+    );
+    app.use(errorHandler);
+
+    const res = await request(app)
+      .post(`/api/invites/${token}/accept`)
+      .send({ requestType: "agent", agentName: "Research Agent" });
+
+    expect(res.status).toBe(202);
+    expect(res.body.status).toBe("pending_approval");
+    expect(res.body.requestType).toBe("agent");
+
+    const memberships = await db.select().from(companyMemberships);
+    expect(memberships).toEqual([]);
+  }, 20_000);
+});

--- a/server/src/__tests__/invite-accept-auto-approval.test.ts
+++ b/server/src/__tests__/invite-accept-auto-approval.test.ts
@@ -155,6 +155,12 @@ describeEmbeddedPostgres("POST /invites/:token/accept human auto approval", () =
       "users:invite",
       "users:manage_permissions",
     ]);
+
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, res.body.id));
+    expect(activity.map((entry) => entry.action)).toEqual(["join.auto_approved"]);
   }, 20_000);
 
   it("leaves agent invites in the existing pending approval flow", async () => {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -3497,7 +3497,11 @@ export function accessRoutes(
       }
 
       let autoApprovedJoinRequest = false;
-      const requestingUserId = created.requestingUserId;
+      const requestingUserId =
+        req.actor.userId &&
+        created.requestingUserId === req.actor.userId
+          ? req.actor.userId
+          : null;
 
       if (
         requestType === "human" &&

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -3497,51 +3497,104 @@ export function accessRoutes(
       }
 
       let autoApprovedJoinRequest = false;
+      const requestingUserId = created.requestingUserId;
 
       if (
         requestType === "human" &&
         autoApproveHumanRole &&
-        created.requestingUserId
+        requestingUserId
       ) {
-        await access.ensureMembership(
-          companyId,
-          "user",
-          created.requestingUserId,
-          autoApproveHumanRole,
-          "active"
-        );
         const grants = humanJoinGrantsFromDefaults(
           invite.defaultsPayload as Record<string, unknown> | null,
           autoApproveHumanRole
         );
-        await access.setPrincipalGrants(
-          companyId,
-          "user",
-          created.requestingUserId,
-          grants,
-          invite.invitedByUserId ?? req.actor.userId ?? null
-        );
-        if (created.status !== "approved") {
-          created = await db
-            .update(joinRequests)
-            .set({
-              status: "approved",
-              approvedByUserId: invite.invitedByUserId ?? req.actor.userId ?? null,
-              approvedAt: new Date(),
-              updatedAt: new Date()
-            })
-            .where(eq(joinRequests.id, created.id))
-            .returning()
-            .then((rows) => rows[0] ?? created);
-        }
-        await logActivity(db, {
-          companyId,
-          actorType: "user",
-          actorId: invite.invitedByUserId ?? req.actor.userId ?? "board",
-          action: "join.auto_approved",
-          entityType: "join_request",
-          entityId: created.id,
-          details: { requestType: "human", membershipRole: autoApproveHumanRole }
+        const approvedByUserId = invite.invitedByUserId ?? req.actor.userId ?? null;
+        created = await db.transaction(async (tx) => {
+          const existingMembership = await tx
+            .select()
+            .from(companyMemberships)
+            .where(
+              and(
+                eq(companyMemberships.companyId, companyId),
+                eq(companyMemberships.principalType, "user"),
+                eq(companyMemberships.principalId, requestingUserId)
+              )
+            )
+            .then((rows) => rows[0] ?? null);
+
+          if (existingMembership) {
+            if (
+              existingMembership.status !== "active" ||
+              existingMembership.membershipRole !== autoApproveHumanRole
+            ) {
+              await tx
+                .update(companyMemberships)
+                .set({
+                  status: "active",
+                  membershipRole: autoApproveHumanRole,
+                  updatedAt: new Date()
+                })
+                .where(eq(companyMemberships.id, existingMembership.id));
+            }
+          } else {
+            await tx.insert(companyMemberships).values({
+              companyId,
+              principalType: "user",
+              principalId: requestingUserId,
+              status: "active",
+              membershipRole: autoApproveHumanRole
+            });
+          }
+
+          await tx
+            .delete(principalPermissionGrants)
+            .where(
+              and(
+                eq(principalPermissionGrants.companyId, companyId),
+                eq(principalPermissionGrants.principalType, "user"),
+                eq(principalPermissionGrants.principalId, requestingUserId)
+              )
+            );
+          if (grants.length > 0) {
+            await tx.insert(principalPermissionGrants).values(
+              grants.map((grant) => ({
+                companyId,
+                principalType: "user" as const,
+                principalId: requestingUserId,
+                permissionKey: grant.permissionKey,
+                scope: grant.scope ?? null,
+                grantedByUserId: approvedByUserId,
+                createdAt: new Date(),
+                updatedAt: new Date()
+              }))
+            );
+          }
+
+          let nextCreated = created;
+          if (created.status !== "approved") {
+            nextCreated = await tx
+              .update(joinRequests)
+              .set({
+                status: "approved",
+                approvedByUserId,
+                approvedAt: new Date(),
+                updatedAt: new Date()
+              })
+              .where(eq(joinRequests.id, created.id))
+              .returning()
+              .then((rows) => rows[0] ?? created);
+          }
+          await logActivity(tx as unknown as Db, {
+            companyId,
+            actorType: "user",
+            actorId: approvedByUserId ?? "board",
+            action: "join.auto_approved",
+            entityType: "join_request",
+            entityId: nextCreated.id,
+            details: { requestType: "human", membershipRole: autoApproveHumanRole }
+          });
+
+          return nextCreated;
         });
         autoApprovedJoinRequest = true;
       }

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -67,6 +67,7 @@ import {
 import {
   grantsForHumanRole,
   normalizeHumanRole,
+  parseExplicitHumanRole,
   resolveHumanInviteRole,
 } from "../services/company-member-roles.js";
 import { humanJoinGrantsFromDefaults } from "../services/invite-grants.js";
@@ -1916,21 +1917,6 @@ function extractInviteHumanRole(invite: typeof invites.$inferSelect) {
   );
 }
 
-function explicitHumanInviteRole(
-  defaultsPayload: Record<string, unknown> | null | undefined
-) {
-  if (!defaultsPayload || typeof defaultsPayload !== "object") return null;
-  const scoped = defaultsPayload.human;
-  if (!scoped || typeof scoped !== "object" || Array.isArray(scoped)) {
-    return null;
-  }
-  const role = (scoped as Record<string, unknown>).role;
-  if (!["owner", "admin", "operator", "viewer", "member"].includes(role as string)) {
-    return null;
-  }
-  return normalizeHumanRole(role, "operator");
-}
-
 function isLocalImplicit(req: Request) {
   return req.actor.type === "board" && req.actor.source === "local_implicit";
 }
@@ -3401,7 +3387,7 @@ export function accessRoutes(
         requestType === "human" ? await resolveActorEmail(db, req) : null;
       const autoApproveHumanRole =
         requestType === "human"
-          ? explicitHumanInviteRole(
+          ? parseExplicitHumanRole(
               invite.defaultsPayload as Record<string, unknown> | null
             )
           : null;
@@ -3510,6 +3496,8 @@ export function accessRoutes(
         throw conflict("Join request not found");
       }
 
+      let autoApprovedJoinRequest = false;
+
       if (
         requestType === "human" &&
         autoApproveHumanRole &&
@@ -3555,6 +3543,7 @@ export function accessRoutes(
           entityId: created.id,
           details: { requestType: "human", membershipRole: autoApproveHumanRole }
         });
+        autoApprovedJoinRequest = true;
       }
 
       if (
@@ -3658,27 +3647,29 @@ export function accessRoutes(
         }
       }
 
-      await logActivity(db, {
-        companyId,
-        actorType: req.actor.type === "agent" ? "agent" : "user",
-        actorId:
-          req.actor.type === "agent"
-            ? req.actor.agentId ?? "invite-agent"
-            : req.actor.userId ??
-              (requestType === "agent" ? "invite-anon" : "board"),
-        action: inviteAlreadyAccepted
-          ? "join.request_replayed"
-          : "join.requested",
-        entityType: "join_request",
-        entityId: created.id,
-        details: {
-          requestType,
-          requestIp: requestIp(req),
-          inviteReplay: inviteAlreadyAccepted,
-          reusedExistingJoinRequest:
-            Boolean(existingHumanJoinRequest) && !inviteAlreadyAccepted
-        }
-      });
+      if (!autoApprovedJoinRequest) {
+        await logActivity(db, {
+          companyId,
+          actorType: req.actor.type === "agent" ? "agent" : "user",
+          actorId:
+            req.actor.type === "agent"
+              ? req.actor.agentId ?? "invite-agent"
+              : req.actor.userId ??
+                (requestType === "agent" ? "invite-anon" : "board"),
+          action: inviteAlreadyAccepted
+            ? "join.request_replayed"
+            : "join.requested",
+          entityType: "join_request",
+          entityId: created.id,
+          details: {
+            requestType,
+            requestIp: requestIp(req),
+            inviteReplay: inviteAlreadyAccepted,
+            reusedExistingJoinRequest:
+              Boolean(existingHumanJoinRequest) && !inviteAlreadyAccepted
+          }
+        });
+      }
 
       const response = toJoinRequestResponse(created);
       if (claimSecret) {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1916,6 +1916,21 @@ function extractInviteHumanRole(invite: typeof invites.$inferSelect) {
   );
 }
 
+function explicitHumanInviteRole(
+  defaultsPayload: Record<string, unknown> | null | undefined
+) {
+  if (!defaultsPayload || typeof defaultsPayload !== "object") return null;
+  const scoped = defaultsPayload.human;
+  if (!scoped || typeof scoped !== "object" || Array.isArray(scoped)) {
+    return null;
+  }
+  const role = (scoped as Record<string, unknown>).role;
+  if (!["owner", "admin", "operator", "viewer", "member"].includes(role as string)) {
+    return null;
+  }
+  return normalizeHumanRole(role, "operator");
+}
+
 function isLocalImplicit(req: Request) {
   return req.actor.type === "board" && req.actor.source === "local_implicit";
 }
@@ -3384,6 +3399,12 @@ export function accessRoutes(
 
       const actorEmail =
         requestType === "human" ? await resolveActorEmail(db, req) : null;
+      const autoApproveHumanRole =
+        requestType === "human"
+          ? explicitHumanInviteRole(
+              invite.defaultsPayload as Record<string, unknown> | null
+            )
+          : null;
       const existingHumanJoinRequest =
         requestType === "human"
           ? findReusableHumanJoinRequest(
@@ -3403,7 +3424,7 @@ export function accessRoutes(
               }
             )
           : null;
-      const created = !inviteAlreadyAccepted
+      let created = !inviteAlreadyAccepted
         ? existingHumanJoinRequest
           ? await db.transaction(async (tx) => {
               await tx
@@ -3487,6 +3508,53 @@ export function accessRoutes(
 
       if (!created) {
         throw conflict("Join request not found");
+      }
+
+      if (
+        requestType === "human" &&
+        autoApproveHumanRole &&
+        created.requestingUserId
+      ) {
+        await access.ensureMembership(
+          companyId,
+          "user",
+          created.requestingUserId,
+          autoApproveHumanRole,
+          "active"
+        );
+        const grants = humanJoinGrantsFromDefaults(
+          invite.defaultsPayload as Record<string, unknown> | null,
+          autoApproveHumanRole
+        );
+        await access.setPrincipalGrants(
+          companyId,
+          "user",
+          created.requestingUserId,
+          grants,
+          invite.invitedByUserId ?? req.actor.userId ?? null
+        );
+        if (created.status !== "approved") {
+          created = await db
+            .update(joinRequests)
+            .set({
+              status: "approved",
+              approvedByUserId: invite.invitedByUserId ?? req.actor.userId ?? null,
+              approvedAt: new Date(),
+              updatedAt: new Date()
+            })
+            .where(eq(joinRequests.id, created.id))
+            .returning()
+            .then((rows) => rows[0] ?? created);
+        }
+        await logActivity(db, {
+          companyId,
+          actorType: "user",
+          actorId: invite.invitedByUserId ?? req.actor.userId ?? "board",
+          action: "join.auto_approved",
+          entityType: "join_request",
+          entityId: created.id,
+          details: { requestType: "human", membershipRole: autoApproveHumanRole }
+        });
       }
 
       if (

--- a/server/src/services/company-member-roles.ts
+++ b/server/src/services/company-member-roles.ts
@@ -47,13 +47,21 @@ export function grantsForHumanRole(
   }
 }
 
+export function parseExplicitHumanRole(
+  defaultsPayload: Record<string, unknown> | null | undefined
+): HumanCompanyMembershipRole | null {
+  if (!defaultsPayload || typeof defaultsPayload !== "object") return null;
+  const scoped = defaultsPayload.human;
+  if (!scoped || typeof scoped !== "object" || Array.isArray(scoped)) {
+    return null;
+  }
+  const role = (scoped as Record<string, unknown>).role;
+  const normalized = normalizeHumanRole(role, "operator");
+  return role === "member" || normalized === role ? normalized : null;
+}
+
 export function resolveHumanInviteRole(
   defaultsPayload: Record<string, unknown> | null | undefined
 ): HumanCompanyMembershipRole {
-  if (!defaultsPayload || typeof defaultsPayload !== "object") return "operator";
-  const scoped = defaultsPayload.human;
-  if (!scoped || typeof scoped !== "object" || Array.isArray(scoped)) {
-    return "operator";
-  }
-  return normalizeHumanRole((scoped as Record<string, unknown>).role, "operator");
+  return parseExplicitHumanRole(defaultsPayload) ?? "operator";
 }

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -9,9 +9,11 @@ import type {
   CompanyPortabilityPreviewResult,
   UpdateCompanyBranding,
 } from "@paperclipai/shared";
-import { api } from "./client";
+import { ApiError, api } from "./client";
 
 export type CompanyStats = Record<string, { agentCount: number; issueCount: number }>;
+
+export type CompanyListResult = { companies: Company[]; unauthorized: boolean };
 
 export const companiesApi = {
   list: () => api.get<Company[]>("/companies"),
@@ -59,3 +61,14 @@ export const companiesApi = {
   importBundle: (data: CompanyPortabilityImportRequest) =>
     api.post<CompanyPortabilityImportResult>("/companies/import", data),
 };
+
+export async function fetchCompanyListWithAuth(): Promise<CompanyListResult> {
+  try {
+    return { companies: await companiesApi.list(), unauthorized: false };
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) {
+      return { companies: [], unauthorized: true };
+    }
+    throw err;
+  }
+}

--- a/ui/src/context/CompanyContext.test.tsx
+++ b/ui/src/context/CompanyContext.test.tsx
@@ -20,6 +20,10 @@ const mockCompaniesApi = vi.hoisted(() => ({
 
 vi.mock("../api/companies", () => ({
   companiesApi: mockCompaniesApi,
+  fetchCompanyListWithAuth: async () => ({
+    companies: await mockCompaniesApi.list(),
+    unauthorized: false,
+  }),
 }));
 
 const activeCompany = { id: "company-1" };

--- a/ui/src/context/CompanyContext.tsx
+++ b/ui/src/context/CompanyContext.tsx
@@ -9,12 +9,14 @@ import {
 } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { Company } from "@paperclipai/shared";
-import { companiesApi } from "../api/companies";
-import { ApiError } from "../api/client";
+import {
+  companiesApi,
+  fetchCompanyListWithAuth,
+  type CompanyListResult,
+} from "../api/companies";
 import { queryKeys } from "../lib/queryKeys";
 import type { CompanySelectionSource } from "../lib/company-selection";
 type CompanySelectionOptions = { source?: CompanySelectionSource };
-type CompanyListResult = { companies: Company[]; unauthorized: boolean };
 
 interface CompanyContextValue {
   companies: Company[];
@@ -71,16 +73,7 @@ export function CompanyProvider({ children }: { children: ReactNode }) {
 
   const { data: companiesResult = { companies: [], unauthorized: false }, isLoading, error } = useQuery<CompanyListResult>({
     queryKey: queryKeys.companies.all,
-    queryFn: async () => {
-      try {
-        return { companies: await companiesApi.list(), unauthorized: false };
-      } catch (err) {
-        if (err instanceof ApiError && err.status === 401) {
-          return { companies: [], unauthorized: true };
-        }
-        throw err;
-      }
-    },
+    queryFn: fetchCompanyListWithAuth,
     retry: false,
   });
   const companies = companiesResult.companies;

--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -41,6 +41,17 @@ vi.mock("../api/companies", () => ({
   companiesApi: {
     list: () => listCompaniesMock(),
   },
+  fetchCompanyListWithAuth: async () => {
+    try {
+      return { companies: await listCompaniesMock(), unauthorized: false };
+    } catch (err) {
+      const status = (err as { status?: unknown })?.status;
+      if (status === 401) {
+        return { companies: [], unauthorized: true };
+      }
+      throw err;
+    }
+  },
 }));
 
 vi.mock("@/context/CompanyContext", () => ({
@@ -558,7 +569,7 @@ describe("InviteLandingPage", () => {
     });
   });
 
-  it("accepts signed-in human invites when the companies response uses the wrapped shape", async () => {
+  it("accepts signed-in human invites without colliding with the shared CompanyContext cache shape", async () => {
     getSessionMock.mockResolvedValue({
       session: { id: "session-1", userId: "user-1" },
       user: {
@@ -568,7 +579,7 @@ describe("InviteLandingPage", () => {
         image: null,
       },
     });
-    listCompaniesMock.mockResolvedValue({ companies: [] });
+    listCompaniesMock.mockResolvedValue([]);
     acceptInviteMock.mockResolvedValue({
       id: "join-1",
       companyId: "company-1",
@@ -598,6 +609,8 @@ describe("InviteLandingPage", () => {
 
     expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
     expect(container.textContent).toContain("Request to join Acme Robotics");
+    const cached = queryClient.getQueryData(["companies"]);
+    expect(cached).toEqual({ companies: [], unauthorized: false });
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/InviteLanding.test.tsx
+++ b/ui/src/pages/InviteLanding.test.tsx
@@ -558,6 +558,52 @@ describe("InviteLandingPage", () => {
     });
   });
 
+  it("accepts signed-in human invites when the companies response uses the wrapped shape", async () => {
+    getSessionMock.mockResolvedValue({
+      session: { id: "session-1", userId: "user-1" },
+      user: {
+        id: "user-1",
+        name: "Jane Example",
+        email: "jane@example.com",
+        image: null,
+      },
+    });
+    listCompaniesMock.mockResolvedValue({ companies: [] });
+    acceptInviteMock.mockResolvedValue({
+      id: "join-1",
+      companyId: "company-1",
+      requestType: "human",
+      status: "pending_approval",
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={["/invite/pcp_invite_test"]}>
+          <QueryClientProvider client={queryClient}>
+            <Routes>
+              <Route path="/invite/:token" element={<InviteLandingPage />} />
+            </Routes>
+          </QueryClientProvider>
+        </MemoryRouter>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+    await flushReact();
+
+    expect(acceptInviteMock).toHaveBeenCalledWith("pcp_invite_test", { requestType: "human" });
+    expect(container.textContent).toContain("Request to join Acme Robotics");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
   it("falls back to the generated company icon when the invite logo fails to load", async () => {
     const root = createRoot(container);
     const queryClient = new QueryClient({

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AGENT_ADAPTER_TYPES } from "@paperclipai/shared";
-import type { AgentAdapterType, JoinRequest } from "@paperclipai/shared";
+import type { AgentAdapterType, Company, JoinRequest } from "@paperclipai/shared";
 import { Button } from "@/components/ui/button";
 import { CompanyPatternIcon } from "@/components/CompanyPatternIcon";
 import { useCompany } from "@/context/CompanyContext";
@@ -35,6 +35,13 @@ function readNestedString(value: unknown, path: string[]): string | null {
     current = (current as Record<string, unknown>)[segment];
   }
   return typeof current === "string" && current.trim().length > 0 ? current : null;
+}
+
+function normalizeCompaniesResponse(value: unknown): Company[] {
+  if (Array.isArray(value)) return value as Company[];
+  if (!value || typeof value !== "object") return [];
+  const companies = (value as { companies?: unknown }).companies;
+  return Array.isArray(companies) ? (companies as Company[]) : [];
 }
 
 const fieldClassName =
@@ -254,6 +261,11 @@ export function InviteLandingPage() {
     retry: false,
   });
 
+  const companies = useMemo(
+    () => normalizeCompaniesResponse(companiesQuery.data),
+    [companiesQuery.data],
+  );
+
   useEffect(() => {
     if (token) rememberPendingInviteToken(token);
   }, [token]);
@@ -264,14 +276,14 @@ export function InviteLandingPage() {
 
   useEffect(() => {
     if (!companiesQuery.data || !inviteQuery.data?.companyId) return;
-    const isMember = companiesQuery.data.some(
+    const isMember = companies.some(
       (c) => c.id === inviteQuery.data!.companyId
     );
     if (isMember) {
       clearPendingInviteToken(token);
       navigate("/", { replace: true });
     }
-  }, [companiesQuery.data, inviteQuery.data, token, navigate]);
+  }, [companies, inviteQuery.data, token, navigate]);
 
   const invite = inviteQuery.data;
   const isCheckingExistingMembership =
@@ -280,9 +292,7 @@ export function InviteLandingPage() {
     companiesQuery.isLoading;
   const isCurrentMember =
     Boolean(invite?.companyId) &&
-    Boolean(
-      companiesQuery.data?.some((company) => company.id === invite?.companyId),
-    );
+    companies.some((company) => company.id === invite?.companyId);
   const companyName = invite?.companyName?.trim() || null;
   const companyDisplayName = companyName || "this Paperclip company";
   const companyLogoUrl = invite?.companyLogoUrl?.trim() || null;
@@ -375,13 +385,15 @@ export function InviteLandingPage() {
       setAuthFeedback(null);
       rememberPendingInviteToken(token);
       await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
-      const companies = await queryClient.fetchQuery({
-        queryKey: queryKeys.companies.all,
-        queryFn: () => companiesApi.list(),
-        retry: false,
-      });
+      const fetchedCompanies = normalizeCompaniesResponse(
+        await queryClient.fetchQuery({
+          queryKey: queryKeys.companies.all,
+          queryFn: () => companiesApi.list(),
+          retry: false,
+        }),
+      );
 
-      if (invite?.companyId && companies.some((company) => company.id === invite.companyId)) {
+      if (invite?.companyId && fetchedCompanies.some((company) => company.id === invite.companyId)) {
         clearPendingInviteToken(token);
         setSelectedCompanyId(invite.companyId, { source: "manual" });
         navigate("/", { replace: true });

--- a/ui/src/pages/InviteLanding.tsx
+++ b/ui/src/pages/InviteLanding.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AGENT_ADAPTER_TYPES } from "@paperclipai/shared";
-import type { AgentAdapterType, Company, JoinRequest } from "@paperclipai/shared";
+import type { AgentAdapterType, JoinRequest } from "@paperclipai/shared";
 import { Button } from "@/components/ui/button";
 import { CompanyPatternIcon } from "@/components/CompanyPatternIcon";
 import { useCompany } from "@/context/CompanyContext";
 import { Link, useNavigate, useParams } from "@/lib/router";
 import { accessApi } from "../api/access";
 import { authApi } from "../api/auth";
-import { companiesApi } from "../api/companies";
+import {
+  fetchCompanyListWithAuth,
+  type CompanyListResult,
+} from "../api/companies";
 import { healthApi } from "../api/health";
 import { getAdapterLabel } from "../adapters/adapter-display-registry";
 import { clearPendingInviteToken, rememberPendingInviteToken } from "../lib/invite-memory";
@@ -35,13 +38,6 @@ function readNestedString(value: unknown, path: string[]): string | null {
     current = (current as Record<string, unknown>)[segment];
   }
   return typeof current === "string" && current.trim().length > 0 ? current : null;
-}
-
-function normalizeCompaniesResponse(value: unknown): Company[] {
-  if (Array.isArray(value)) return value as Company[];
-  if (!value || typeof value !== "object") return [];
-  const companies = (value as { companies?: unknown }).companies;
-  return Array.isArray(companies) ? (companies as Company[]) : [];
 }
 
 const fieldClassName =
@@ -254,15 +250,15 @@ export function InviteLandingPage() {
     retry: false,
   });
 
-  const companiesQuery = useQuery({
+  const companiesQuery = useQuery<CompanyListResult>({
     queryKey: queryKeys.companies.all,
-    queryFn: () => companiesApi.list(),
+    queryFn: fetchCompanyListWithAuth,
     enabled: !!sessionQuery.data && !!inviteQuery.data?.companyId,
     retry: false,
   });
 
   const companies = useMemo(
-    () => normalizeCompaniesResponse(companiesQuery.data),
+    () => companiesQuery.data?.companies ?? [],
     [companiesQuery.data],
   );
 
@@ -385,13 +381,12 @@ export function InviteLandingPage() {
       setAuthFeedback(null);
       rememberPendingInviteToken(token);
       await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
-      const fetchedCompanies = normalizeCompaniesResponse(
-        await queryClient.fetchQuery({
-          queryKey: queryKeys.companies.all,
-          queryFn: () => companiesApi.list(),
-          retry: false,
-        }),
-      );
+      const fetchedResult = await queryClient.fetchQuery<CompanyListResult>({
+        queryKey: queryKeys.companies.all,
+        queryFn: fetchCompanyListWithAuth,
+        retry: false,
+      });
+      const fetchedCompanies = fetchedResult.companies;
 
       if (invite?.companyId && fetchedCompanies.some((company) => company.id === invite.companyId)) {
         clearPendingInviteToken(token);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for autonomous companies, with humans operating the board where governance and access decisions happen.
> - The multi-user/company access subsystem lets humans join an existing Paperclip company through invite links.
> - A signed-in user with no company membership is exactly the user who needs the invite route, but the current flow can crash or fall through to the generic “No company access” screen before the invite is accepted.
> - Role-based human invites already carry the intended human role/default grants, so requiring a second manual approval step can leave users stuck when the UI does not surface a join request.
> - The invite route also assumed the companies query result was always an array, which made the page fragile when query state/shape differed during post-signup access checks.
> - This pull request keeps human invite signup/sign-in flows usable by making role-based human invites complete into active memberships with the same grants as manual approval, while keeping agent invites on the existing pending-approval path.
> - The benefit is that invited human users can get into the company reliably across authenticated deployments without weakening non-human invite governance.

## What Changed

- Auto-approve explicit role-based **human** company invites during `POST /api/invites/:token/accept`.
  - Creates/ensures an active user membership with the explicit invite role.
  - Applies the same role/default grants via `humanJoinGrantsFromDefaults(...)` and `access.setPrincipalGrants(...)`.
  - Marks the join request as `approved` and logs `join.auto_approved` activity.
- Restricts the auto-approval trigger to explicit valid human roles only (`owner`, `admin`, `operator`, `viewer`, `member`). Missing/invalid role defaults stay on the existing join-request flow.
- Preserves non-human invite behavior: agent invites still create pending join requests and do not create memberships automatically.
- Hardens `InviteLandingPage` so company membership checks normalize the companies query response before calling `.some(...)`, preventing the invite page from crashing on wrapped/empty/transient response shapes.
- Adds regression tests for:
  - explicit owner human invite auto-approval + owner grants,
  - agent invite remaining pending approval with no membership,
  - wrapped companies response on the invite landing page.

## Verification

- `corepack pnpm@9.15.4 --filter @paperclipai/plugin-sdk build`
- `corepack pnpm@9.15.4 --filter @paperclipai/server exec tsc --noEmit --pretty false`
- `corepack pnpm@9.15.4 --filter @paperclipai/ui exec tsc --noEmit --pretty false`
- `corepack pnpm@9.15.4 --filter @paperclipai/server exec vitest --run src/__tests__/invite-accept-auto-approval.test.ts src/__tests__/invite-accept-existing-member.test.ts src/__tests__/invite-create-route.test.ts src/__tests__/invite-summary-route.test.ts`
- `corepack pnpm@9.15.4 --filter @paperclipai/ui exec vitest --run src/pages/InviteLanding.test.tsx`

Manual reproduction covered by the fix:

1. Create a human invite with an explicit role, e.g. owner/viewer.
2. Sign up or sign in with a user that has no active company membership.
3. Open `/invite/:token` and accept the invite.
4. Confirm the user receives an active company membership and role grants instead of seeing the generic “No company access” screen.
5. Create an agent invite and accept it as an agent; confirm it remains `pending_approval` and no human membership is created.

## Risks

- Medium behavioral change for explicit role-based human invites: they now complete directly into active memberships instead of waiting for approval. This is limited to invites that already encode an explicit human role and were created by an authorized inviter.
- Permission safety depends on `humanJoinGrantsFromDefaults(...)` staying aligned with manual approval behavior; the new test covers owner grants specifically.
- Agent invite governance should remain unchanged; a regression test asserts agent invites still produce pending join requests and no membership.
- Deployment/auth mode risk is low: the accept route still uses the existing actor/session resolution path, and the change is scoped to authenticated human actors plus the existing invite token validation. It does not alter host/exposure checks for local trusted, private/Tailscale, or public deployments.
- No database migration is required.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex / GPT-5.5 via Hermes Agent, with tool use for repository inspection, editing, git/GitHub operations, and local test execution. Context included the live Paperclip invite failure, related GitHub issue #5242, CONTRIBUTING.md, the PR template, and repository docs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
  - No screenshots included because this is a behavioral invite-flow hardening with no intended visual layout change; covered by `InviteLanding.test.tsx`.
- [x] I have updated relevant documentation to reflect my changes
  - No docs update needed; no public command/API contract changed beyond fixing existing invite behavior.
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #5242
