### PR TITLE
fix: openclaw-gateway adapter — opt-in paperclip payload + document session isolation

### DIFF
--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -70,3 +70,26 @@ Structured gateway event logs use:
 - `[openclaw-gateway:event] run=<id> stream=<stream> data=<json>` for `event agent` frames
 
 UI/CLI parsers consume these lines to render transcript updates.
+
+## Multi-Organization Session Isolation
+
+When a single Paperclip instance manages multiple organizations through one OpenClaw gateway, each agent wake request includes a `sessionKey` (format: `agent:<agent-id>:<context>`) to isolate sessions per agent.
+
+By default, the OpenClaw gateway ignores this field and routes all requests into a shared default session. To enable per-agent session isolation, the following must be set in the gateway's `openclaw.json`:
+
+```json
+{
+  "hooks": {
+    "allowRequestSessionKey": true,
+    "allowedSessionKeyPrefixes": ["agent:", "hook:"]
+  }
+}
+```
+
+Without this configuration, multi-organization deployments will appear to work but sessions will not be isolated — all agents across all organizations share a single session context.
+
+## Gateway Schema Compatibility
+
+The adapter builds `agentParams` as the gateway request body. OpenClaw's `AgentParamsSchema` enforces `additionalProperties: false`, so only known fields are accepted: `message`, `sessionKey`, `idempotencyKey`, `agentId`, `timeout`.
+
+The `includePaperclipPayload` adapter config option (default: `false`) controls whether the full Paperclip context payload is included in `agentParams.paperclip`. Only enable this if your gateway has been configured to accept the `paperclip` property.

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1143,7 +1143,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   // but must not be sent in agentParams — OpenClaw's AgentParamsSchema
   // enforces additionalProperties: false and rejects unknown fields.
 
-  if (ctx.config.includePaperclipPayload) {
+  if (parseBoolean(ctx.config.includePaperclipPayload, false)) {
     agentParams.paperclip = paperclipPayload;
   }
 

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1139,13 +1139,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  // paperclipPayload is used internally for logging and adapter context,
-  // but must not be sent in agentParams — OpenClaw's AgentParamsSchema
-  // enforces additionalProperties: false and rejects unknown fields.
-
-  if (parseBoolean(ctx.config.includePaperclipPayload, false)) {
-    agentParams.paperclip = paperclipPayload;
-  }
+  agentParams.paperclip = paperclipPayload;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {
@@ -1319,7 +1313,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[openclaw-gateway] connected protocol=${asNumber(asRecord(hello)?.protocol, PROTOCOL_VERSION)}\n`,
       );
 
-      const acceptedPayload = await client.request<Record<string, unknown>>("agent", agentParams, {
+      // When a gateway enforces strict schema validation (e.g., OpenClaw's
+      // additionalProperties: false), the adapter-internal `paperclip` field on
+      // agentParams causes immediate rejection.  Strip it from the wire payload
+      // unless the operator has opted in via `includePaperclipPayload`.
+      // The wake context is already embedded in the message text for LLM
+      // consumption, so no information is lost on the wire.
+      const wireParams = { ...agentParams };
+      if (!parseBoolean(ctx.config.includePaperclipPayload, false)) {
+        delete wireParams.paperclip;
+      }
+      const acceptedPayload = await client.request<Record<string, unknown>>("agent", wireParams, {
         timeoutMs: connectTimeoutMs,
       });
 

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1139,7 +1139,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  // paperclipPayload is used internally for logging and adapter context,
+  // but must not be sent in agentParams — OpenClaw's AgentParamsSchema
+  // enforces additionalProperties: false and rejects unknown fields.
+
+  if (ctx.config.includePaperclipPayload) {
+    agentParams.paperclip = paperclipPayload;
+  }
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -841,6 +841,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includePaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -861,6 +862,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includePaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -1193,6 +1195,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includePaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -1213,6 +1216,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includePaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -1394,6 +1398,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includePaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },
@@ -1414,6 +1419,7 @@ describe("heartbeat comment wake batching", () => {
             headers: {
               "x-openclaw-token": "gateway-token",
             },
+            includePaperclipPayload: true,
             payloadTemplate: {
               message: "wake now",
             },

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -298,6 +298,7 @@ describe("heartbeat comment wake batching", () => {
           headers: {
             "x-openclaw-token": "gateway-token",
           },
+          includePaperclipPayload: true,
           payloadTemplate: {
             message: "wake now",
           },
@@ -491,6 +492,7 @@ describe("heartbeat comment wake batching", () => {
           headers: {
             "x-openclaw-token": "gateway-token",
           },
+          includePaperclipPayload: true,
           payloadTemplate: {
             message: "wake now",
           },
@@ -653,6 +655,7 @@ describe("heartbeat comment wake batching", () => {
           headers: {
             "x-openclaw-token": "gateway-token",
           },
+          includePaperclipPayload: true,
           payloadTemplate: {
             message: "wake now",
           },
@@ -1041,6 +1044,7 @@ describe("heartbeat comment wake batching", () => {
           headers: {
             "x-openclaw-token": "gateway-token",
           },
+          includePaperclipPayload: true,
           payloadTemplate: {
             message: "wake now",
           },
@@ -1546,6 +1550,7 @@ describe("heartbeat comment wake batching", () => {
           headers: {
             "x-openclaw-token": "gateway-token",
           },
+          includePaperclipPayload: true,
           payloadTemplate: {
             message: "wake now",
           },

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -412,6 +412,7 @@ describe("openclaw gateway adapter execute", () => {
               message: "wake now",
             },
             waitTimeoutMs: 2000,
+            includePaperclipPayload: true,
           },
           {
             onLog: async (_stream, chunk) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents can be connected to external gateways via adapters, including the openclaw-gateway adapter
> - The openclaw-gateway adapter builds an `agentParams` request body and sends it to the OpenClaw gateway over WebSocket
> - OpenClaw's `AgentParamsSchema` enforces `additionalProperties: false`, rejecting any unknown fields
> - The adapter injects `agentParams.paperclip = paperclipPayload` — a field no released OpenClaw version accepts
> - Every Paperclip-triggered wake request fails with "invalid agent params: unexpected property 'paperclip'"
> - Separately, multi-org deployments require undocumented gateway config for per-agent session isolation
> - This PR strips the paperclip field at the wire send point (preserving it for internal logging) and documents the session isolation requirements
> - The benefit is the adapter works out of the box with standard OpenClaw gateways, and multi-org deployments have clear setup guidance

## What Changed

**Code** (`packages/adapters/openclaw-gateway/src/server/execute.ts`):
- `agentParams.paperclip = paperclipPayload` remains unconditionally assigned — the field is used for internal adapter logging and the full `agentParams` object is the source of truth within the adapter lifecycle.
- At the wire send point (the `client.request("agent", ...)` call), a shallow copy `wireParams` is created and `paperclip` is stripped from it unless `includePaperclipPayload` is explicitly enabled via adapter config. Uses `parseBoolean` consistent with `disableDeviceAuth` and `autoPairOnFirstConnect` in the same file.
- Default behavior: `paperclip` is NOT sent on the wire. Gateways with strict schema validation (OpenClaw) work without config changes.
- Opt-in: set `includePaperclipPayload: true` in adapter config to send the structured payload to gateways that accept it.

**Tests** (`server/src/__tests__/`):
- 7 test configs that assert on the wire-level `payload.paperclip` now explicitly opt in via `includePaperclipPayload: true` — they are testing the paperclip payload feature and should enable it.
- Tests that do not check `payload.paperclip` use the default (stripped) behavior.

**Docs** (`packages/adapters/openclaw-gateway/README.md`):
- Added "Multi-Organization Session Isolation" section documenting the required `allowRequestSessionKey` and `allowedSessionKeyPrefixes` gateway config.
- Added "Gateway Schema Compatibility" section explaining the `additionalProperties: false` constraint and the `includePaperclipPayload` opt-in.

## Verification

1. Deploy a Paperclip instance with an openclaw-gateway agent connected to a standard OpenClaw gateway (v2026.4.22+)
2. Trigger a wake request — should succeed without `agentParams.paperclip` on the wire (default behavior)
3. Confirm `agentParams.paperclip` still appears in adapter logs (internal object preserved)
4. Set `includePaperclipPayload: true` in adapter config, trigger again — `agentParams.paperclip` should appear in the wire payload
5. Set `includePaperclipPayload: "false"` (string) — should correctly evaluate to false via `parseBoolean`, strip the field
6. For session isolation: configure `allowRequestSessionKey: true` + `allowedSessionKeyPrefixes: ["agent:", "hook:"]` in gateway `openclaw.json`, verify per-agent sessions are isolated in multi-org deployment

## Risks

- **Low (behavioral change):** Deployments where a custom gateway programmatically reads `agentParams.paperclip` from the wire will need to add `includePaperclipPayload: true` to their adapter config. However, no released OpenClaw version accepts this field (`additionalProperties: false` in `AgentParamsSchema`), and the same data is already embedded in the `message` text — so the wire-level structured copy was unreachable by standard gateways.
- **None (docs):** README additions are purely additive.
- **None (tests):** Test changes are additive config flags; no assertions removed.

## Model Used

- **Provider:** Anthropic
- **Model:** Claude Opus 4.6 (`claude-opus-4-6`)
- **Context window:** 1M tokens
- **Mode:** Extended thinking with tool use (Claude Code CLI)
- **Supervision:** Human-supervised session (Lucas Crown / LucidPaths)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A (no UI changes)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge