### PR TITLE
HOM-197: dedupe productivity-review refresh comments

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -165,7 +165,7 @@ describeEmbeddedPostgres("productivity review service", () => {
       .orderBy(issues.createdAt);
   }
 
-  it("creates exactly one manager-assigned review for a no-comment run streak and refreshes it idempotently", async () => {
+  it("creates exactly one manager-assigned review for a no-comment run streak and skips unchanged refresh comments", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();
     await insertRuns({
@@ -181,7 +181,8 @@ describeEmbeddedPostgres("productivity review service", () => {
     const second = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
 
     expect(first.created).toBe(1);
-    expect(second.updated).toBe(1);
+    expect(second.updated).toBe(0);
+    expect(second.existing).toBe(1);
     const reviews = await listProductivityReviews(seeded.companyId);
     expect(reviews).toHaveLength(1);
     expect(reviews[0]?.parentId).toBe(seeded.issueId);
@@ -195,7 +196,83 @@ describeEmbeddedPostgres("productivity review service", () => {
       .select()
       .from(issueComments)
       .where(eq(issueComments.issueId, reviews[0]!.id));
-    expect(comments.some((comment) => comment.body.includes("Productivity review evidence refreshed"))).toBe(true);
+    expect(comments.some((comment) => comment.body.includes("Productivity review evidence refreshed"))).toBe(false);
+  });
+
+  it("dedupes legacy refresh comments when only long-active reason text drifts", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    const service = productivityReviewService(db);
+    const first = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    expect(first.created).toBe(1);
+
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review).toBeTruthy();
+
+    await db.insert(issueComments).values({
+      companyId: seeded.companyId,
+      issueId: review!.id,
+      body: [
+        "Productivity review evidence refreshed.",
+        "",
+        `- Source issue: [${seeded.issuePrefix}-1](/${seeded.issuePrefix}/issues/${seeded.issuePrefix}-1)`,
+        "- Trigger: `long_active_duration` (Long active duration)",
+        "- Reasons: current active episode has lasted 7h 0m",
+        "- No-comment streak: 0",
+        "- Runs/assignee comments: 0/0 in 1h, 0/0 in 6h",
+        "- Next action: none recorded",
+      ].join("\n"),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const second = await service.reconcileProductivityReviews({
+      now: new Date(now.getTime() + 60_000),
+      companyId: seeded.companyId,
+    });
+
+    expect(second.updated).toBe(0);
+    expect(second.existing).toBe(1);
+
+    const refreshComments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, review!.id));
+    expect(refreshComments).toHaveLength(1);
+  });
+
+  it("collapses concurrent refresh writes with the same evidence signature", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    const service = productivityReviewService(db);
+    const first = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    expect(first.created).toBe(1);
+
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review).toBeTruthy();
+
+    const refreshAt = new Date(now.getTime() + 60_000);
+    await Promise.all([
+      service.reconcileProductivityReviews({ now: refreshAt, companyId: seeded.companyId }),
+      service.reconcileProductivityReviews({ now: refreshAt, companyId: seeded.companyId }),
+    ]);
+
+    const refreshComments = await db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.issueId, review!.id),
+          sql`${issueComments.body} like ${"Productivity review evidence refreshed.%"}`,
+        ),
+      );
+    expect(refreshComments).toHaveLength(1);
   });
 
   it("creates a long-active review without enabling a continuation hold", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { and, asc, desc, eq, gt, inArray, isNull, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { clampIssueRequestDepth } from "@paperclipai/shared";
@@ -28,6 +29,8 @@ const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const MAX_CANDIDATE_ISSUES = 250;
 const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
+const PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX = "Productivity review evidence refreshed.";
+const PRODUCTIVITY_REVIEW_REFRESH_SIGNATURE_PREFIX = "productivity-review-refresh-signature:";
 
 type IssueRow = typeof issues.$inferSelect;
 type AgentRow = typeof agents.$inferSelect;
@@ -64,6 +67,16 @@ type ProductivityReviewEvidence = {
   nextAction: string | null;
   thresholds: ProductivityReviewThresholds;
   generatedAt: Date;
+};
+
+type ProductivityReviewRefreshSignature = {
+  trigger: ProductivityReviewTrigger;
+  noCommentStreak: number;
+  runCountLastHour: number;
+  commentCountLastHour: number;
+  runCountLastSixHours: number;
+  commentCountLastSixHours: number;
+  nextAction: string;
 };
 
 type EnqueueWakeup = (
@@ -164,6 +177,10 @@ function formatTrigger(trigger: ProductivityReviewTrigger) {
   if (trigger === "no_comment_streak") return "No-comment streak";
   if (trigger === "high_churn") return "High churn";
   return "Long active duration";
+}
+
+function refreshSignatureMarker(signature: string) {
+  return `<!-- ${PRODUCTIVITY_REVIEW_REFRESH_SIGNATURE_PREFIX}${signature} -->`;
 }
 
 export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: EnqueueWakeup }) {
@@ -460,6 +477,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   }
 
   function buildReviewMarkdown(evidence: ProductivityReviewEvidence, prefix: string) {
+    const refreshSignature = buildRefreshCommentSignature(evidence);
     const latestRuns = evidence.latestRuns.length > 0
       ? evidence.latestRuns.map((run) =>
         `- ${runUiLink(run, prefix)} \`${run.status}\` liveness \`${run.livenessState ?? "unknown"}\`, created ${run.createdAt.toISOString()}${run.nextAction ? `, next action: ${truncateInline(run.nextAction, 160)}` : ""}`,
@@ -520,20 +538,107 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       "- Close as productive if this pattern is expected.",
       "- Continue with a snooze window if the current work should keep running without repeat review spam.",
       "- Request decomposition, reroute, block with an unblock owner, or stop/cancel the source work if the work is inefficient.",
+      "",
+      refreshSignatureMarker(refreshSignature),
     ].join("\n");
   }
 
   function buildRefreshComment(evidence: ProductivityReviewEvidence, prefix: string) {
+    const nextAction = evidence.nextAction ? truncateInline(evidence.nextAction, 300) : "none recorded";
+    const refreshSignature = buildRefreshCommentSignature(evidence);
     return [
-      "Productivity review evidence refreshed.",
+      PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX,
       "",
       `- Source issue: ${issueUiLink(evidence.sourceIssue, prefix)}`,
       `- Trigger: \`${evidence.trigger}\` (${formatTrigger(evidence.trigger)})`,
       `- Reasons: ${evidence.triggerReasons.join("; ")}`,
       `- No-comment streak: ${evidence.noCommentStreak}`,
       `- Runs/assignee comments: ${evidence.runCountLastHour}/${evidence.commentCountLastHour} in 1h, ${evidence.runCountLastSixHours}/${evidence.commentCountLastSixHours} in 6h`,
-      `- Next action: ${evidence.nextAction ? truncateInline(evidence.nextAction, 300) : "none recorded"}`,
+      `- Next action: ${nextAction}`,
+      "",
+      refreshSignatureMarker(refreshSignature),
     ].join("\n");
+  }
+
+  function buildRefreshCommentSignature(evidence: ProductivityReviewEvidence) {
+    const signature: ProductivityReviewRefreshSignature = {
+      trigger: evidence.trigger,
+      noCommentStreak: evidence.noCommentStreak,
+      runCountLastHour: evidence.runCountLastHour,
+      commentCountLastHour: evidence.commentCountLastHour,
+      runCountLastSixHours: evidence.runCountLastSixHours,
+      commentCountLastSixHours: evidence.commentCountLastSixHours,
+      nextAction: evidence.nextAction ? truncateInline(evidence.nextAction, 300) : "none recorded",
+    };
+    return createHash("sha256").update(JSON.stringify(signature)).digest("hex");
+  }
+
+  function extractRefreshCommentSignature(commentBody: string) {
+    const match = commentBody.match(
+      new RegExp(`<!--\\s*${PRODUCTIVITY_REVIEW_REFRESH_SIGNATURE_PREFIX}([a-f0-9]{64})\\s*-->\\s*$`),
+    );
+    return match?.[1] ?? null;
+  }
+
+  function normalizeRefreshCommentForDedupe(commentBody: string) {
+    return commentBody
+      .replace(
+        new RegExp(`\\n<!--\\s*${PRODUCTIVITY_REVIEW_REFRESH_SIGNATURE_PREFIX}[a-f0-9]{64}\\s*-->\\s*$`),
+        "",
+      )
+      .split("\n")
+      .filter((line) => !line.startsWith("- Reasons:"))
+      .join("\n")
+      .trim();
+  }
+
+  async function getLatestRefreshComment(issueId: string) {
+    return db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.issueId, issueId),
+          sql`${issueComments.body} like ${`${PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX}%`}`,
+        ),
+      )
+      .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+      .limit(1)
+      .then((rows) => rows[0]?.body ?? null);
+  }
+
+  async function collapseDuplicateRefreshComments(
+    issueId: string,
+    refreshSignature: string,
+    insertedCommentId: string,
+  ) {
+    const signatureMarker = `${PRODUCTIVITY_REVIEW_REFRESH_SIGNATURE_PREFIX}${refreshSignature}`;
+    const matching = await db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.issueId, issueId),
+          sql`${issueComments.body} like ${`${PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX}%`}`,
+          sql`${issueComments.body} like ${`%${signatureMarker}%`}`,
+        ),
+      )
+      .orderBy(asc(issueComments.createdAt), asc(issueComments.id));
+
+    if (matching.length <= 1) {
+      return { removedCount: 0, insertedRemoved: false };
+    }
+
+    const [oldest, ...rest] = matching;
+    const duplicateIds = rest.map((row) => row.id);
+    if (duplicateIds.length > 0) {
+      await db.delete(issueComments).where(inArray(issueComments.id, duplicateIds));
+    }
+
+    return {
+      removedCount: duplicateIds.length,
+      insertedRemoved: oldest?.id !== insertedCommentId,
+    };
   }
 
   async function createOrUpdateReview(
@@ -542,7 +647,28 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   ) {
     const existing = await findOpenProductivityReview(evidence.sourceIssue.companyId, evidence.sourceIssue.id);
     if (existing) {
-      await issuesSvc.addComment(existing.id, buildRefreshComment(evidence, opts.prefix), {});
+      const refreshComment = buildRefreshComment(evidence, opts.prefix);
+      const refreshSignature = buildRefreshCommentSignature(evidence);
+      const latestRefreshComment = await getLatestRefreshComment(existing.id);
+      const latestSignature = latestRefreshComment
+        ? extractRefreshCommentSignature(latestRefreshComment)
+        : null;
+      const baselineDescriptionSignature = latestRefreshComment
+        ? null
+        : extractRefreshCommentSignature(existing.description ?? "");
+      const latestIsEquivalentWithoutReasons = latestRefreshComment
+        ? normalizeRefreshCommentForDedupe(latestRefreshComment) === normalizeRefreshCommentForDedupe(refreshComment)
+        : false;
+      const shouldSkipUsingBaselineSignature =
+        baselineDescriptionSignature === refreshSignature && isSoftStopTrigger(evidence.trigger);
+      if (latestSignature === refreshSignature || latestIsEquivalentWithoutReasons || shouldSkipUsingBaselineSignature) {
+        return { kind: "existing" as const, reviewIssueId: existing.id };
+      }
+      const insertedRefreshComment = await issuesSvc.addComment(existing.id, refreshComment, {});
+      const collapse = await collapseDuplicateRefreshComments(existing.id, refreshSignature, insertedRefreshComment.id);
+      if (collapse.insertedRemoved) {
+        return { kind: "existing" as const, reviewIssueId: existing.id };
+      }
       await logActivity(db, {
         companyId: evidence.sourceIssue.companyId,
         actorType: "system",
@@ -558,6 +684,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           noCommentStreak: evidence.noCommentStreak,
           runCountLastHour: evidence.runCountLastHour,
           commentCountLastHour: evidence.commentCountLastHour,
+          runCountLastSixHours: evidence.runCountLastSixHours,
+          commentCountLastSixHours: evidence.commentCountLastSixHours,
+          refreshSignature,
+          duplicateRefreshCommentsRemoved: collapse.removedCount,
         },
       });
       return { kind: "updated" as const, reviewIssueId: existing.id };


### PR DESCRIPTION
Closes #HOM-197\n\n## Summary\n- dedupe refresh comments using a stable evidence signature marker\n- skip unchanged refreshes (including legacy reason-text drift cases)\n- collapse concurrent same-signature refresh writes to a single comment\n- add regression coverage for unchanged and concurrent refresh behavior