### PR TITLE
feat(adapter-utils): stream-silence detection in runChildProcess (INF-80)

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -78,6 +78,7 @@ export interface AdapterExecutionTargetProcessOptions {
   stdin?: string;
   timeoutSec: number;
   graceSec: number;
+  silenceTimeoutSec?: number;
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
   terminalResultCleanup?: TerminalResultCleanupOptions;
@@ -342,6 +343,11 @@ export async function runAdapterExecutionTargetProcess(
   options: AdapterExecutionTargetProcessOptions,
 ): Promise<RunProcessResult> {
   if (target?.kind === "remote" && target.transport === "sandbox") {
+    // TODO(stream-silence-remote): silenceTimeoutSec is accepted but ignored on
+    // sandbox/remote paths in v1 — sandbox runners don't expose live data
+    // events the same way runChildProcess does. Plumbing silence detection
+    // here requires a separate change. The bug fix this option targets
+    // (claude_local CLI socket-stall) is local-only.
     const runner = requireSandboxRunner(target);
     const env = sanitizeRemoteExecutionEnv(options.env);
     return await runner.execute({
@@ -369,6 +375,7 @@ export async function runAdapterExecutionTargetProcess(
     stdin: options.stdin,
     timeoutSec: options.timeoutSec,
     graceSec: options.graceSec,
+    silenceTimeoutSec: options.silenceTimeoutSec,
     onLog: options.onLog,
     onSpawn: options.onSpawn,
     terminalResultCleanup: options.terminalResultCleanup,

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -350,6 +350,306 @@ describe("runChildProcess", () => {
     expect(result.stdout).toContain('"type":"result"');
   });
 
+  it.skipIf(process.platform === "win32")(
+    "kills a silent child via SIGTERM when silenceTimeoutSec elapses",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        ["-e", "setInterval(() => {}, 1000);"],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          silenceTimeoutSec: 0.3,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.timedOut).toBe(true);
+      expect(result.errorCode).toBe("stream_silence_timeout");
+      expect(result.stdout).toBe("");
+      expect(result.signal === "SIGTERM" || result.signal === "SIGKILL").toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "completes normally when output arrives well within silenceTimeoutSec",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        ["-e", "process.stdout.write('done');"],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          silenceTimeoutSec: 2,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.timedOut).toBe(false);
+      expect(result.errorCode ?? null).toBeNull();
+      expect(result.stdout).toBe("done");
+      expect(result.exitCode).toBe(0);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "intermittent output keeps the silence timer alive",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          [
+            "let n = 0;",
+            "const id = setInterval(() => {",
+            "  process.stdout.write('tick\\n');",
+            "  if (++n >= 8) { clearInterval(id); process.exit(0); }",
+            "}, 100);",
+          ].join(" "),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          silenceTimeoutSec: 0.3,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.timedOut).toBe(false);
+      expect(result.errorCode ?? null).toBeNull();
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.split("tick").length - 1).toBeGreaterThanOrEqual(4);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "escalates SIGTERM to SIGKILL when child traps SIGTERM",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          [
+            "process.on('SIGTERM', () => {});",
+            "setInterval(() => {}, 1000);",
+          ].join(" "),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          silenceTimeoutSec: 0.3,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.timedOut).toBe(true);
+      expect(result.errorCode).toBe("stream_silence_timeout");
+      expect(result.signal).toBe("SIGKILL");
+      if (result.pid != null) {
+        expect(await waitForPidExit(result.pid, 2_000)).toBe(true);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "wall-clock timeout wins the race when it fires before silence",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        ["-e", "setInterval(() => {}, 1000);"],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0.3,
+          graceSec: 1,
+          silenceTimeoutSec: 5,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.timedOut).toBe(true);
+      expect(result.errorCode).toBe("timeout");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "silence timer wins the race when it fires before wall-clock",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          [
+            "process.stdout.write('hi');",
+            "setInterval(() => {}, 1000);",
+          ].join(" "),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 5,
+          graceSec: 1,
+          silenceTimeoutSec: 0.3,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.timedOut).toBe(true);
+      expect(result.errorCode).toBe("stream_silence_timeout");
+      expect(result.stdout).toBe("hi");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "silenceTimeoutSec=0 leaves the run pending past the would-be threshold",
+    async () => {
+      const runId = randomUUID();
+      const resultPromise = runChildProcess(
+        runId,
+        process.execPath,
+        ["-e", "setInterval(() => {}, 1000);"],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          silenceTimeoutSec: 0,
+          onLog: async () => {},
+        },
+      );
+
+      const race = await Promise.race([
+        resultPromise.then(() => "settled" as const),
+        new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 600)),
+      ]);
+      expect(race).toBe("pending");
+
+      const running = runningProcesses.get(runId) as
+        | { child: { kill(signal: NodeJS.Signals): boolean }; processGroupId: number | null }
+        | undefined;
+      try {
+        if (running?.processGroupId) {
+          process.kill(-running.processGroupId, "SIGKILL");
+        } else {
+          running?.child.kill("SIGKILL");
+        }
+        await resultPromise;
+      } finally {
+        runningProcesses.delete(runId);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "omitting silenceTimeoutSec is a no-op",
+    async () => {
+      const runId = randomUUID();
+      const resultPromise = runChildProcess(
+        runId,
+        process.execPath,
+        ["-e", "setInterval(() => {}, 1000);"],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      );
+
+      const race = await Promise.race([
+        resultPromise.then(() => "settled" as const),
+        new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 600)),
+      ]);
+      expect(race).toBe("pending");
+
+      const running = runningProcesses.get(runId) as
+        | { child: { kill(signal: NodeJS.Signals): boolean }; processGroupId: number | null }
+        | undefined;
+      try {
+        if (running?.processGroupId) {
+          process.kill(-running.processGroupId, "SIGKILL");
+        } else {
+          running?.child.kill("SIGKILL");
+        }
+        await resultPromise;
+      } finally {
+        runningProcesses.delete(runId);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "terminal-result cleanup wins over the silence timer",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        [
+          "-e",
+          [
+            "process.stdout.write(`${JSON.stringify({ type: 'result', result: 'done' })}\\n`);",
+            "setTimeout(() => process.exit(0), 25);",
+          ].join(" "),
+        ],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          silenceTimeoutSec: 10,
+          onLog: async () => {},
+          terminalResultCleanup: {
+            graceMs: 50,
+            hasTerminalResult: ({ stdout }) => stdout.includes('"type":"result"'),
+          },
+        },
+      );
+
+      expect(result.timedOut).toBe(false);
+      expect(result.errorCode ?? null).toBeNull();
+      expect(result.stdout).toContain('"type":"result"');
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "spawn-time silence (zero bytes ever) is killed within silenceTimeoutSec",
+    async () => {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        ["-e", "setTimeout(() => process.exit(0), 1500);"],
+        {
+          cwd: process.cwd(),
+          env: {},
+          timeoutSec: 0,
+          graceSec: 1,
+          silenceTimeoutSec: 0.3,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.timedOut).toBe(true);
+      expect(result.errorCode).toBe("stream_silence_timeout");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+    },
+  );
+
   it.skipIf(process.platform === "win32")("does not clean up noisy runs that have no terminal output", async () => {
     const runId = randomUUID();
     let observed = "";

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -10,10 +10,13 @@ import type {
   AdapterSkillSnapshot,
 } from "./types.js";
 
+export type RunProcessTimeoutErrorCode = "timeout" | "stream_silence_timeout";
+
 export interface RunProcessResult {
   exitCode: number | null;
   signal: string | null;
   timedOut: boolean;
+  errorCode?: RunProcessTimeoutErrorCode | null;
   stdout: string;
   stderr: string;
   pid: number | null;
@@ -1784,6 +1787,7 @@ export async function runChildProcess(
     env: Record<string, string>;
     timeoutSec: number;
     graceSec: number;
+    silenceTimeoutSec?: number;
     onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
     onLogError?: (err: unknown, runId: string, message: string) => void;
     onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
@@ -1840,6 +1844,7 @@ export async function runChildProcess(
         runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
 
         let timedOut = false;
+        let timeoutErrorCode: RunProcessTimeoutErrorCode | null = null;
         let stdout = "";
         let stderr = "";
         let logChain: Promise<void> = Promise.resolve();
@@ -1849,12 +1854,41 @@ export async function runChildProcess(
         let terminalCleanupKillTimer: NodeJS.Timeout | null = null;
         let terminalResultStdoutScanOffset = 0;
         let terminalResultStderrScanOffset = 0;
+        let silenceTimer: NodeJS.Timeout | null = null;
+        let silenceKillTimer: NodeJS.Timeout | null = null;
 
         const clearTerminalCleanupTimers = () => {
           if (terminalCleanupTimer) clearTimeout(terminalCleanupTimer);
           if (terminalCleanupKillTimer) clearTimeout(terminalCleanupKillTimer);
           terminalCleanupTimer = null;
           terminalCleanupKillTimer = null;
+        };
+
+        const clearSilenceTimers = () => {
+          if (silenceTimer) clearTimeout(silenceTimer);
+          if (silenceKillTimer) clearTimeout(silenceKillTimer);
+          silenceTimer = null;
+          silenceKillTimer = null;
+        };
+
+        const armSilenceTimer = () => {
+          const sec = opts.silenceTimeoutSec;
+          if (!sec || sec <= 0) return;
+          if (timedOut || terminalCleanupStarted) return;
+          if (silenceTimer) clearTimeout(silenceTimer);
+          silenceTimer = setTimeout(() => {
+            silenceTimer = null;
+            if (timedOut || terminalCleanupStarted) return;
+            timedOut = true;
+            timeoutErrorCode = "stream_silence_timeout";
+            clearTerminalCleanupTimers();
+            if (timeout) clearTimeout(timeout);
+            signalRunningProcess({ child, processGroupId }, "SIGTERM");
+            silenceKillTimer = setTimeout(() => {
+              silenceKillTimer = null;
+              signalRunningProcess({ child, processGroupId }, "SIGKILL");
+            }, Math.max(1, opts.graceSec) * 1000);
+          }, sec * 1000);
         };
 
         const maybeArmTerminalResultCleanup = () => {
@@ -1896,7 +1930,9 @@ export async function runChildProcess(
           opts.timeoutSec > 0
             ? setTimeout(() => {
                 timedOut = true;
+                timeoutErrorCode = "timeout";
                 clearTerminalCleanupTimers();
+                clearSilenceTimers();
                 signalRunningProcess({ child, processGroupId }, "SIGTERM");
                 setTimeout(() => {
                   signalRunningProcess({ child, processGroupId }, "SIGKILL");
@@ -1904,12 +1940,15 @@ export async function runChildProcess(
               }, opts.timeoutSec * 1000)
             : null;
 
+        armSilenceTimer();
+
         child.stdout?.on("data", (chunk: unknown) => {
           const readable = child.stdout;
           if (!readable) return;
           readable.pause();
           const text = String(chunk);
           stdout = appendWithCap(stdout, text);
+          armSilenceTimer();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stdout", text))
@@ -1926,6 +1965,7 @@ export async function runChildProcess(
           readable.pause();
           const text = String(chunk);
           stderr = appendWithCap(stderr, text);
+          armSilenceTimer();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stderr", text))
@@ -1948,6 +1988,7 @@ export async function runChildProcess(
         child.on("error", (err: Error) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearSilenceTimers();
           runningProcesses.delete(runId);
           void target.cleanup?.();
           const errno = (err as NodeJS.ErrnoException).code;
@@ -1966,6 +2007,7 @@ export async function runChildProcess(
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearSilenceTimers();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
             void Promise.resolve()
@@ -1975,6 +2017,7 @@ export async function runChildProcess(
                 exitCode: code,
                 signal,
                 timedOut,
+                errorCode: timedOut ? timeoutErrorCode : null,
                 stdout,
                 stderr,
                 pid: child.pid ?? null,


### PR DESCRIPTION
## Summary

- Add optional `silenceTimeoutSec` to `runChildProcess` (and pass-through on `runAdapterExecutionTargetProcess`) so a child producing no stdout/stderr for N seconds is SIGTERM'd, then SIGKILL'd after `graceSec`.
- Add `errorCode: "timeout" | "stream_silence_timeout" | null` to the result. `timedOut: true` is preserved for both paths so existing branches that read `proc.timedOut` keep working.
- Sandbox/SSH paths accept the option but ignore it for now (`// TODO(stream-silence-remote)`).

Implements the platform-code half of the stream-silence detection work tracked in InfraLint as INF-77 / INF-80, per a board-accepted plan revision.

## Why

A claude_local heartbeat that produced 0 bytes after `system init` sat in a kernel-blocked socket read for ~65 minutes before the run was reaped. The wall-clock `timeoutSec` is "total runtime" (often 1h+ on long heartbeats), which is too coarse to catch this kind of socket stall. A separate stream-silence timer (single timer, reset on every `data` event, default off) closes the gap with ~50 LOC and zero behaviour change for callers that don't opt in. Adapter wire-ups follow in a sibling change so this PR can land on its own.

## Behaviour

| Path                                              | Result                                                     |
| ------------------------------------------------- | ---------------------------------------------------------- |
| `silenceTimeoutSec` undefined or `<= 0`           | No-op. Behaviour identical to before.                      |
| Child writes within threshold                     | Timer resets on every `data` event.                        |
| Silence > threshold                               | `timedOut: true`, `errorCode: "stream_silence_timeout"`, SIGTERM then SIGKILL after `graceSec`. |
| Wall-clock `timeoutSec` fires first               | `timedOut: true`, `errorCode: "timeout"` (silence timer cleared). |
| `terminalResultCleanup` fires first               | Existing path; silence timer suppressed via `terminalCleanupStarted` guard. |
| Child exits or errors                             | Silence timers cleared in `close`/`error` handlers.        |

## Files touched (+350 / -0)

- `packages/adapter-utils/src/server-utils.ts` — silence timer + result `errorCode`.
- `packages/adapter-utils/src/execution-target.ts` — opts pass-through; sandbox/SSH branch documented as accepted-but-ignored for v1.
- `packages/adapter-utils/src/server-utils.test.ts` — 10 new vitest cases.

## Test plan

- [x] `pnpm --filter @paperclipai/adapter-utils typecheck` clean.
- [x] `pnpm --filter @paperclipai/adapter-utils build` clean.
- [x] All 38 cases in `server-utils.test.ts` pass (28 baseline + 10 new), including:
  1. Silent child kill (`errorCode: "stream_silence_timeout"`)
  2. Normal completion within threshold
  3. Intermittent output keeps timer alive
  4. SIGTERM ignored → SIGKILL escalation
  5. Wall-clock fires first → `errorCode: "timeout"`
  6. Silence fires first → `errorCode: "stream_silence_timeout"`
  7. `silenceTimeoutSec=0` is a no-op (run stays pending past would-be threshold)
  8. Omitting `silenceTimeoutSec` is a no-op
  9. Terminal-result cleanup wins over silence timer
  10. Spawn-time silence (zero bytes ever) still kills within threshold
- [x] `execution-target.test.ts` + `execution-target-sandbox.test.ts` (19 cases) still green.
- [ ] Adapter wire-ups (claude_local + 5 others) follow in a sibling PR, blocked-on this one.

## Out of scope

- Adapter wire-ups (sibling subtask).
- Sandbox / SSH silence detection (TODO comment only).
- Recovery-service auto-terminate (separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)