### PR TITLE
adapter-utils: add silenceTimeoutSec stream-silence watchdog to runChildProcess

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -78,6 +78,12 @@ export interface AdapterExecutionTargetProcessOptions {
   stdin?: string;
   timeoutSec: number;
   graceSec: number;
+  /**
+   * Stdout/stderr silence watchdog (seconds). Local target: passed through to
+   * `runChildProcess`. Sandbox / SSH targets accept the option but ignore it
+   * for now — see TODO(stream-silence-remote) below.
+   */
+  silenceTimeoutSec?: number;
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
   terminalResultCleanup?: TerminalResultCleanupOptions;
@@ -342,6 +348,10 @@ export async function runAdapterExecutionTargetProcess(
   options: AdapterExecutionTargetProcessOptions,
 ): Promise<RunProcessResult> {
   if (target?.kind === "remote" && target.transport === "sandbox") {
+    // TODO(stream-silence-remote): the sandbox runner does not expose live
+    // stdout/stderr `data` events the same way `runChildProcess` does. Wiring
+    // silence detection into this path requires a separate change; the option
+    // is accepted but ignored for sandbox/SSH targets in v1.
     const runner = requireSandboxRunner(target);
     const env = sanitizeRemoteExecutionEnv(options.env);
     return await runner.execute({
@@ -363,12 +373,16 @@ export async function runAdapterExecutionTargetProcess(
       ? sanitizeRemoteExecutionEnv(options.env)
       : options.env;
 
+  // TODO(stream-silence-remote): SSH path also goes through `runChildProcess`,
+  // but the child is `ssh`, not the remote command. Silence on the local SSH
+  // pipe is a coarse proxy for remote silence; behaves like local for now.
   return await runChildProcess(runId, command, args, {
     cwd: options.cwd,
     env,
     stdin: options.stdin,
     timeoutSec: options.timeoutSec,
     graceSec: options.graceSec,
+    silenceTimeoutSec: options.silenceTimeoutSec,
     onLog: options.onLog,
     onSpawn: options.onSpawn,
     terminalResultCleanup: options.terminalResultCleanup,

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -414,6 +414,264 @@ describe("runChildProcess", () => {
   });
 });
 
+describe("runChildProcess silenceTimeoutSec watchdog", () => {
+  it.skipIf(process.platform === "win32")("kills a silent child and reports stream_silence_timeout", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      ["-e", "setTimeout(() => process.stdout.write('late'), 5000);"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0,
+        graceSec: 1,
+        silenceTimeoutSec: 0.3,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorCode).toBe("stream_silence_timeout");
+    expect(result.signal === "SIGTERM" || result.signal === "SIGKILL").toBe(true);
+    expect(result.stdout).toBe("");
+  });
+
+  it("returns normally when the child completes within the silence threshold", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      ["-e", "process.stdout.write('done');"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0,
+        graceSec: 1,
+        silenceTimeoutSec: 2,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+    expect(result.errorCode ?? null).toBeNull();
+    expect(result.stdout).toBe("done");
+  });
+
+  it.skipIf(process.platform === "win32")("intermittent output keeps the silence timer alive", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      [
+        "-e",
+        [
+          "let n = 0;",
+          "const t = setInterval(() => {",
+          "  process.stdout.write('tick\\n');",
+          "  if (++n >= 10) { clearInterval(t); process.exit(0); }",
+          "}, 100);",
+        ].join(" "),
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0,
+        graceSec: 1,
+        silenceTimeoutSec: 0.3,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.timedOut).toBe(false);
+    expect(result.errorCode ?? null).toBeNull();
+    expect(result.stdout.match(/tick/g)?.length ?? 0).toBeGreaterThanOrEqual(5);
+  });
+
+  it.skipIf(process.platform === "win32")("escalates SIGTERM to SIGKILL when the child traps SIGTERM", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      [
+        "-e",
+        [
+          "process.on('SIGTERM', () => {});",
+          "setInterval(() => {}, 1000);",
+        ].join(" "),
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0,
+        graceSec: 1,
+        silenceTimeoutSec: 0.3,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorCode).toBe("stream_silence_timeout");
+    expect(result.signal).toBe("SIGKILL");
+    expect(result.pid != null && !isPidAlive(result.pid)).toBe(true);
+  });
+
+  it.skipIf(process.platform === "win32")("wall-clock timeout wins the race against silence", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      ["-e", "setInterval(() => {}, 5000);"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0.3,
+        graceSec: 1,
+        silenceTimeoutSec: 2,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorCode).toBe("timeout");
+  });
+
+  it.skipIf(process.platform === "win32")("silence wins the race against wall-clock when child stalls early", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      [
+        "-e",
+        [
+          "process.stdout.write('hi');",
+          "setInterval(() => {}, 5000);",
+        ].join(" "),
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 5,
+        graceSec: 1,
+        silenceTimeoutSec: 0.3,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorCode).toBe("stream_silence_timeout");
+  });
+
+  it.skipIf(process.platform === "win32")("silenceTimeoutSec=0 disables the watchdog", async () => {
+    const runId = randomUUID();
+    const resultPromise = runChildProcess(
+      runId,
+      process.execPath,
+      ["-e", "setInterval(() => {}, 1000);"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0,
+        graceSec: 1,
+        silenceTimeoutSec: 0,
+        onLog: async () => {},
+      },
+    );
+
+    const race = await Promise.race([
+      resultPromise.then(() => "settled" as const),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 500)),
+    ]);
+    expect(race).toBe("pending");
+
+    const running = runningProcesses.get(runId);
+    if (running?.processGroupId) {
+      process.kill(-running.processGroupId, "SIGKILL");
+    } else {
+      running?.child.kill("SIGKILL");
+    }
+    await resultPromise;
+  });
+
+  it.skipIf(process.platform === "win32")("undefined silenceTimeoutSec disables the watchdog", async () => {
+    const runId = randomUUID();
+    const resultPromise = runChildProcess(
+      runId,
+      process.execPath,
+      ["-e", "setInterval(() => {}, 1000);"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0,
+        graceSec: 1,
+        onLog: async () => {},
+      },
+    );
+
+    const race = await Promise.race([
+      resultPromise.then(() => "settled" as const),
+      new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 500)),
+    ]);
+    expect(race).toBe("pending");
+
+    const running = runningProcesses.get(runId);
+    if (running?.processGroupId) {
+      process.kill(-running.processGroupId, "SIGKILL");
+    } else {
+      running?.child.kill("SIGKILL");
+    }
+    await resultPromise;
+  });
+
+  it.skipIf(process.platform === "win32")("terminal-result cleanup wins; silence timer never fires", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      [
+        "-e",
+        [
+          "process.stdout.write(`${JSON.stringify({ type: 'result', result: 'done' })}\\n`);",
+          "setInterval(() => process.stdout.write(''), 5000);",
+        ].join(" "),
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0,
+        graceSec: 1,
+        silenceTimeoutSec: 10,
+        onLog: async () => {},
+        terminalResultCleanup: {
+          graceMs: 50,
+          hasTerminalResult: ({ stdout }) => stdout.includes('"type":"result"'),
+        },
+      },
+    );
+
+    expect(result.timedOut).toBe(false);
+    expect(result.errorCode ?? null).toBeNull();
+    expect(result.signal).toBe("SIGTERM");
+    expect(result.stdout).toContain('"type":"result"');
+  });
+
+  it.skipIf(process.platform === "win32")("kills a child that produces zero bytes ever", async () => {
+    const result = await runChildProcess(
+      randomUUID(),
+      process.execPath,
+      ["-e", "setTimeout(() => process.exit(0), 1000);"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0,
+        graceSec: 1,
+        silenceTimeoutSec: 0.3,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorCode).toBe("stream_silence_timeout");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+  });
+});
+
 describe("renderPaperclipWakePrompt", () => {
   it("keeps the default local-agent prompt action-oriented", () => {
     expect(DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE).toContain("Start actionable work in this heartbeat");

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -10,10 +10,20 @@ import type {
   AdapterSkillSnapshot,
 } from "./types.js";
 
+export type RunProcessTimeoutErrorCode = "timeout" | "stream_silence_timeout";
+
 export interface RunProcessResult {
   exitCode: number | null;
   signal: string | null;
   timedOut: boolean;
+  /**
+   * Populated when `timedOut === true`. `"timeout"` for the wall-clock
+   * `timeoutSec` path; `"stream_silence_timeout"` for the stdout/stderr
+   * silence-watchdog path. `null` otherwise. Optional so existing
+   * `RunProcessResult` literals across the codebase keep type-checking;
+   * `runChildProcess` always sets it to a concrete value.
+   */
+  errorCode?: RunProcessTimeoutErrorCode | null;
   stdout: string;
   stderr: string;
   pid: number | null;
@@ -1784,6 +1794,15 @@ export async function runChildProcess(
     env: Record<string, string>;
     timeoutSec: number;
     graceSec: number;
+    /**
+     * Watchdog: kill the child if no stdout/stderr `data` event arrives within
+     * `silenceTimeoutSec * 1000` ms. Timer arms at spawn (so a child that
+     * produces zero bytes is also killed) and resets on every data event.
+     * `undefined` or `<= 0` disables the watchdog (current behavior).
+     * On expiry: SIGTERM, then SIGKILL after `graceSec` seconds.
+     * Result has `timedOut: true` + `errorCode: "stream_silence_timeout"`.
+     */
+    silenceTimeoutSec?: number;
     onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
     onLogError?: (err: unknown, runId: string, message: string) => void;
     onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
@@ -1840,6 +1859,7 @@ export async function runChildProcess(
         runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
 
         let timedOut = false;
+        let timeoutErrorCode: RunProcessTimeoutErrorCode | null = null;
         let stdout = "";
         let stderr = "";
         let logChain: Promise<void> = Promise.resolve();
@@ -1855,6 +1875,39 @@ export async function runChildProcess(
           if (terminalCleanupKillTimer) clearTimeout(terminalCleanupKillTimer);
           terminalCleanupTimer = null;
           terminalCleanupKillTimer = null;
+        };
+
+        const silenceTimeoutSec =
+          typeof opts.silenceTimeoutSec === "number" && opts.silenceTimeoutSec > 0
+            ? opts.silenceTimeoutSec
+            : 0;
+        let silenceTimer: NodeJS.Timeout | null = null;
+        let silenceKillTimer: NodeJS.Timeout | null = null;
+
+        const clearSilenceTimers = () => {
+          if (silenceTimer) clearTimeout(silenceTimer);
+          if (silenceKillTimer) clearTimeout(silenceKillTimer);
+          silenceTimer = null;
+          silenceKillTimer = null;
+        };
+
+        const armSilenceTimer = () => {
+          if (silenceTimeoutSec <= 0) return;
+          if (timedOut || terminalCleanupStarted) return;
+          if (silenceTimer) clearTimeout(silenceTimer);
+          silenceTimer = setTimeout(() => {
+            silenceTimer = null;
+            if (timedOut || terminalCleanupStarted) return;
+            timedOut = true;
+            timeoutErrorCode = "stream_silence_timeout";
+            clearTerminalCleanupTimers();
+            if (timeout) clearTimeout(timeout);
+            signalRunningProcess({ child, processGroupId }, "SIGTERM");
+            silenceKillTimer = setTimeout(() => {
+              silenceKillTimer = null;
+              signalRunningProcess({ child, processGroupId }, "SIGKILL");
+            }, Math.max(1, opts.graceSec) * 1000);
+          }, silenceTimeoutSec * 1000);
         };
 
         const maybeArmTerminalResultCleanup = () => {
@@ -1896,7 +1949,9 @@ export async function runChildProcess(
           opts.timeoutSec > 0
             ? setTimeout(() => {
                 timedOut = true;
+                timeoutErrorCode = "timeout";
                 clearTerminalCleanupTimers();
+                clearSilenceTimers();
                 signalRunningProcess({ child, processGroupId }, "SIGTERM");
                 setTimeout(() => {
                   signalRunningProcess({ child, processGroupId }, "SIGKILL");
@@ -1904,12 +1959,15 @@ export async function runChildProcess(
               }, opts.timeoutSec * 1000)
             : null;
 
+        armSilenceTimer();
+
         child.stdout?.on("data", (chunk: unknown) => {
           const readable = child.stdout;
           if (!readable) return;
           readable.pause();
           const text = String(chunk);
           stdout = appendWithCap(stdout, text);
+          armSilenceTimer();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stdout", text))
@@ -1926,6 +1984,7 @@ export async function runChildProcess(
           readable.pause();
           const text = String(chunk);
           stderr = appendWithCap(stderr, text);
+          armSilenceTimer();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stderr", text))
@@ -1948,6 +2007,7 @@ export async function runChildProcess(
         child.on("error", (err: Error) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearSilenceTimers();
           runningProcesses.delete(runId);
           void target.cleanup?.();
           const errno = (err as NodeJS.ErrnoException).code;
@@ -1966,6 +2026,7 @@ export async function runChildProcess(
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          clearSilenceTimers();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
             void Promise.resolve()
@@ -1975,6 +2036,7 @@ export async function runChildProcess(
                 exitCode: code,
                 signal,
                 timedOut,
+                errorCode: timedOut ? timeoutErrorCode : null,
                 stdout,
                 stderr,
                 pid: child.pid ?? null,


### PR DESCRIPTION
## Summary

Adds an opt-in stdout/stderr silence watchdog to `runChildProcess` in `@paperclipai/adapter-utils`, with the option threaded through `runAdapterExecutionTargetProcess` for local + SSH adapters. Sandbox path accepts and ignores the option for now (`TODO(stream-silence-remote)`).

This is the platform half of an internal incident-response fix (INF-77 / INF-80). It addresses a failure mode where a spawned CLI's OS process stays alive while its stdout/stderr go silent — the existing wall-clock `timeoutSec` only fires on overall runtime, not on stream silence. The fix is **default-off**: callers must explicitly pass `silenceTimeoutSec` to opt in, and adapter-level enablement is a sibling task (INF-81).

Plan reference (internal): plan rev 2, board-accepted (revision id `8ad7199d-a1c5-42d4-a947-d0c1709b88fa`). Full design + sequence diagrams + race matrix + research findings live in the internal tracker; this PR implements §3.1 and §3.2 verbatim.

## What changed

| File | Δ | What |
|---|---|---|
| `packages/adapter-utils/src/server-utils.ts` | +62 | `silenceTimeoutSec?: number` opt on `runChildProcess`; `errorCode?: "timeout" \| "stream_silence_timeout" \| null` on `RunProcessResult`; arm-at-spawn watchdog with reset-on-data and SIGTERM→SIGKILL after `graceSec`. |
| `packages/adapter-utils/src/execution-target.ts` | +14 | `silenceTimeoutSec?` on `AdapterExecutionTargetProcessOptions`, threaded to `runChildProcess` on local + SSH paths. Sandbox path accepts and ignores with `TODO(stream-silence-remote)`. |
| `packages/adapter-utils/src/server-utils.test.ts` | +258 | 10 new vitest cases covering silent kill, normal completion, intermittent output, SIGTERM→SIGKILL escalation, both race directions, 0/undefined no-op, terminal-cleanup precedence, zero-byte spawn-time silence. |

### Behavior

- `silenceTimeoutSec` undefined or `<= 0` → watchdog disabled, **byte-for-byte identical to current behavior**. The 5 existing `runChildProcess` test cases pass unchanged.
- `silenceTimeoutSec > 0` → arm a single timer at spawn for `silenceTimeoutSec * 1000` ms. Reset on every `child.stdout` / `child.stderr` `data` event. On expiry: SIGTERM the process group, then SIGKILL after `graceSec` seconds.
- `errorCode` is populated only when `timedOut === true`: `"timeout"` for the wall-clock path, `"stream_silence_timeout"` for the new path. `timedOut: true` is preserved for both paths so existing branches that read `proc.timedOut` keep working. `errorCode` is **optional** on `RunProcessResult` so existing `RunProcessResult` literals across the codebase continue to type-check.
- Race resolution: all three terminal paths (silence-fire / wall-clock-fire / `terminalResultCleanup`) guard on `timedOut || terminalCleanupStarted` before acting, and `clearSilenceTimers()` is called from `error`, `close`, and the wall-clock timeout body. No leak window.

## Test plan

- [x] `pnpm exec vitest run packages/adapter-utils/` — 81/81 pass (10 new cases + 71 existing).
- [x] `pnpm typecheck` clean across `adapter-utils`, `server`, and the 8 local-adapter packages (`adapter-{claude,codex,cursor,gemini,opencode,pi,acpx}-local`, `adapter-openclaw-gateway`).
- [x] Default-off invariant: existing `runChildProcess` tests don't set `silenceTimeoutSec` and pass without modification.
- [x] POSIX-only tests skipped on Windows (the watchdog uses POSIX process-group signaling).

```
$ pnpm exec vitest run packages/adapter-utils/
 Test Files  8 passed (8)
      Tests  81 passed (81)
   Duration  7.68s
```

## Out of scope

- **Adapter wire-ups** — sibling task INF-81; default `silenceTimeoutSec` per local adapter (recommend 300s, aligned with the Claude CLI's own 5-minute SSE idle watchdog) is added there. INF-81 is blocked-on this PR.
- **Sandbox / SSH remote-side silence detection** — the sandbox runner doesn't expose `data` events the same way; piping silence detection requires a separate change. Tracked via `TODO(stream-silence-remote)` in `execution-target.ts`.
- **Recovery service auto-terminate** — separate ticket (INF-78).

## Reviewer notes

Internal review by Staff Engineer (audit findings, "ship-with-followups" verdict) covered architecture, default-off invariant, race handling, type safety, grace consistency, and test coverage. Two non-blocking nits were raised:

1. The `silenceTimeoutSec=0` / `undefined` no-op tests use a behavioral proxy (`Promise.race` sentinel + cleanup) rather than asserting "no timer was armed" directly. Adequate given the trivial control flow.
2. No structured log/metric emitted when the watchdog fires. Consumers see `errorCode: "stream_silence_timeout"` and can log it themselves; richer signal will be added when the recovery service (INF-78) needs it.
