### PR TITLE
fix(server): prevent ELB-445 stale executionRunId stamp on cross-issue PATCH

### DIFF
--- a/server/src/__tests__/heartbeat-elb-445-cross-assignee-reattach.test.ts
+++ b/server/src/__tests__/heartbeat-elb-445-cross-assignee-reattach.test.ts
@@ -1,0 +1,330 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.ts";
+
+async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
+  await db?.$client?.end?.({ timeout: 0 });
+}
+
+// ELB-445 regression: an orphan queued heartbeat run owned by a *prior* assignee
+// must not be re-stamped onto an issue after the issue has been reassigned to a
+// new agent. Before the fix at services/heartbeat.ts (legacy-run reattach), the
+// reattach scan matched runs by issueId only and ignored agentId, so the next
+// wake on the issue would silently restamp executionRunId with the orphan run id
+// — blocking the new assignee's checkout with a 409 ~1s after a bare PATCH.
+describe("heartbeat ELB-445 cross-assignee reattach guard", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    const started = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-elb-445-");
+    db = createDb(started.connectionString);
+    tempDb = started;
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeDbClient(db);
+    await tempDb?.cleanup();
+  });
+
+  it("does not reattach an orphan queued run from the prior assignee after reassignment", async () => {
+    const companyId = randomUUID();
+    const priorAssigneeAgentId = randomUUID();
+    const newAssigneeAgentId = randomUUID();
+    const orphanQueuedRunId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: priorAssigneeAgentId,
+        companyId,
+        name: "GameDeveloper",
+        role: "engineer",
+        status: "active",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: newAssigneeAgentId,
+        companyId,
+        name: "Architect",
+        role: "engineer",
+        status: "active",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    // Orphan queued run for the prior assignee, with contextSnapshot.issueId
+    // pointing at the issue. Simulates a leftover wake from a sweep PATCH-with-
+    // comment cross-issue assignment that was later released and reassigned.
+    await db.insert(heartbeatRuns).values({
+      id: orphanQueuedRunId,
+      companyId,
+      agentId: priorAssigneeAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+    });
+
+    // Issue is freshly reassigned to the new agent. executionRunId is null
+    // (just-cleared by the bare PATCH path). Status todo, not in_progress.
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Reassigned target",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: newAssigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    // Trigger an issue-scoped wake for the NEW assignee, which exercises the
+    // legacy-run reattach path inside enqueueWakeup.
+    await heartbeat.wakeup(newAssigneeAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId, mutation: "update" },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+        source: "issue.update",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "local-board",
+    });
+
+    const issueAfter = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+        assigneeAgentId: issues.assigneeAgentId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+
+    expect(issueAfter?.assigneeAgentId).toBe(newAssigneeAgentId);
+
+    // Core assertion: the orphan run owned by the *prior* assignee must NOT be
+    // reattached to the issue. If executionRunId is set at all, it must belong
+    // to a run owned by the current assignee (e.g. the freshly-queued wake run
+    // promoted by Fix A lazy locking).
+    expect(issueAfter?.executionRunId).not.toBe(orphanQueuedRunId);
+    if (issueAfter?.executionRunId) {
+      const stampedRun = await db
+        .select({ agentId: heartbeatRuns.agentId })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, issueAfter.executionRunId))
+        .then((rows) => rows[0]);
+      expect(stampedRun?.agentId).toBe(newAssigneeAgentId);
+    }
+
+    // The orphan run is left in place — cleanup is the responsibility of the
+    // run-cancellation path, not the reattach guard. We only assert that the
+    // legacy reattach did not restamp it onto the issue.
+    const orphan = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, orphanQueuedRunId))
+      .then((rows) => rows[0]);
+    expect(orphan?.status).toBe("queued");
+  });
+
+  it("does not stamp the requesting run R onto target B when PATCH crosses checkout boundary", async () => {
+    // Acceptance scenario from the ELB-445 wake comment:
+    //   "Server fix: PATCH on issue B from run R-on-A leaves B's
+    //    executionRunId/executionLockedAt untouched (or null)."
+    // Setup: CPO holds checkout on issue A with running run R. Sweep flow then
+    // PATCH-with-comments issue B reassigning it to X. The async wake fired by
+    // the PATCH targets X on B. The legacy reattach in enqueueWakeup must filter
+    // by issue.assigneeAgentId so CPO's R (a running run with contextSnapshot
+    // issueId = A) is never matched as a "legacy run" for issue B.
+    const companyId = randomUUID();
+    const cpoAgentId = randomUUID();
+    const newAssigneeAgentId = randomUUID();
+    const cpoRunningRunId = randomUUID();
+    const issueAId = randomUUID();
+    const issueBId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: cpoAgentId,
+        companyId,
+        name: "CPO",
+        role: "executive",
+        status: "active",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: newAssigneeAgentId,
+        companyId,
+        name: "GameDeveloper",
+        role: "engineer",
+        status: "active",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    // CPO's *running* sweep run on issue A — this is the "R-on-A" run id.
+    const startedAt = new Date();
+    await db.insert(heartbeatRuns).values({
+      id: cpoRunningRunId,
+      companyId,
+      agentId: cpoAgentId,
+      invocationSource: "on_demand",
+      triggerDetail: "sweep",
+      status: "running",
+      startedAt,
+      contextSnapshot: {
+        issueId: issueAId,
+        taskId: issueAId,
+        wakeReason: "sweep",
+      },
+    });
+
+    // Issue A is checked out by CPO under run R.
+    await db.insert(issues).values({
+      id: issueAId,
+      companyId,
+      title: "CPO sweep run holder",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: cpoAgentId,
+      checkoutRunId: cpoRunningRunId,
+      executionRunId: cpoRunningRunId,
+      executionAgentNameKey: "cpo",
+      executionLockedAt: startedAt,
+      startedAt,
+      issueNumber: 3,
+      identifier: `${issuePrefix}-3`,
+    });
+
+    // Issue B simulates the post-PATCH state: assignee already swapped to the
+    // new assignee, executionRunId already cleared by issueService.update.
+    await db.insert(issues).values({
+      id: issueBId,
+      companyId,
+      title: "Sweep reassignment target",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: newAssigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+      issueNumber: 4,
+      identifier: `${issuePrefix}-4`,
+    });
+
+    // Mimic the async wake the PATCH route fires after addComment.
+    await heartbeat.wakeup(newAssigneeAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: issueBId, mutation: "update", commentId: randomUUID() },
+      contextSnapshot: {
+        issueId: issueBId,
+        taskId: issueBId,
+        wakeReason: "issue_assigned",
+        source: "issue.update",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: cpoAgentId,
+    });
+
+    const issueBAfter = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+        assigneeAgentId: issues.assigneeAgentId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueBId))
+      .then((rows) => rows[0]);
+
+    // Core acceptance: B.executionRunId is never CPO's run R.
+    expect(issueBAfter?.executionRunId).not.toBe(cpoRunningRunId);
+    expect(issueBAfter?.assigneeAgentId).toBe(newAssigneeAgentId);
+
+    if (issueBAfter?.executionRunId) {
+      // Anything stamped on B must be a run owned by the new assignee.
+      const stampedRun = await db
+        .select({ agentId: heartbeatRuns.agentId, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, issueBAfter.executionRunId))
+        .then((rows) => rows[0]);
+      expect(stampedRun?.agentId).toBe(newAssigneeAgentId);
+    } else {
+      expect(issueBAfter?.executionLockedAt).toBeNull();
+      expect(issueBAfter?.executionAgentNameKey).toBeNull();
+    }
+
+    // PATCH on the run's own checkout — current behavior preserved.
+    // Issue A (CPO's checkout) must remain stamped with R; the cross-issue wake
+    // on B must not disturb A.
+    const issueAAfter = await db
+      .select({
+        executionRunId: issues.executionRunId,
+        checkoutRunId: issues.checkoutRunId,
+        assigneeAgentId: issues.assigneeAgentId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueAId))
+      .then((rows) => rows[0]);
+    expect(issueAAfter?.executionRunId).toBe(cpoRunningRunId);
+    expect(issueAAfter?.checkoutRunId).toBe(cpoRunningRunId);
+    expect(issueAAfter?.assigneeAgentId).toBe(cpoAgentId);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6682,13 +6682,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .where(eq(issues.id, issue.id));
         }
 
-        if (!activeExecutionRun) {
+        if (!activeExecutionRun && issue.assigneeAgentId) {
+          // ELB-445: legacy reattach must be scoped to the issue's current assignee.
+          // Without the agentId guard, orphan queued/scheduled runs from a prior
+          // assignee — left over after PATCH-with-comment cross-issue reassignments
+          // — get re-stamped onto the issue ~1s after a bare PATCH lands, blocking
+          // the new assignee's checkout with a 409.
           const legacyRun = await tx
             .select()
             .from(heartbeatRuns)
             .where(
               and(
                 eq(heartbeatRuns.companyId, issue.companyId),
+                eq(heartbeatRuns.agentId, issue.assigneeAgentId),
                 inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
                 sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
               ),
@@ -6703,7 +6709,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           if (legacyRun) {
             if (await cancelStaleScheduledRetry(legacyRun)) {
               activeExecutionRun = null;
-            } else {
+            } else if (legacyRun.status === "running") {
+              // Only a *running* legacy run owns the issue execution lock right now.
+              // Queued/scheduled_retry legacy runs must defer the stamp to claimQueuedRun
+              // (Fix A: lazy locking). Stamping at queue time here re-introduces ELB-445:
+              // a queued legacy run gets stamped onto the issue ~1s after the wake fires,
+              // and the next checkout — whose actorRunId is a different live run — fails
+              // the executionLockCondition with a 409.
               activeExecutionRun = legacyRun;
               const legacyAgent = await tx
                 .select({ name: agents.name })
@@ -6719,6 +6731,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                   updatedAt: new Date(),
                 })
                 .where(eq(issues.id, issue.id));
+            } else {
+              // Treat the queued/scheduled_retry legacy run as the active execution path
+              // so the new wake coalesces/defers against it, but do NOT eagerly stamp
+              // executionRunId. The lazy stamp in claimQueuedRun will take over once the
+              // legacy run actually transitions to "running".
+              activeExecutionRun = legacyRun;
             }
           }
         }


### PR DESCRIPTION
## Summary

- Fixes [ELB-445](https://elbe.app/ELB/issues/ELB-445): `PATCH /api/issues/{id}` with both `assigneeAgentId` + `comment` from inside an active checkout run on a *different* issue stamped a non-running run id onto the target's `executionRunId`/`executionLockedAt` ~1s after the wake fired, causing the new assignee's downstream checkout to 409 on `executionLockCondition`.
- `claimQueuedRun` already used Fix A (lazy locking) — only stamp `executionRunId` when a run transitions to `running`. The legacy-run reattach branch inside `enqueueWakeup` was violating that contract by eagerly stamping any matching queued/`scheduled_retry` run.
- Two leak paths closed:
  1. **Cross-assignee leak**: legacy-run lookup now filters by `heartbeatRuns.agentId == issue.assigneeAgentId`. Orphan queued/scheduled runs from a prior assignee can no longer be reattached after reassignment.
  2. **Eager-stamp leak**: when a same-assignee legacy run is matched, only stamp `executionRunId/executionAgentNameKey/executionLockedAt` if its status is `running`. Queued/scheduled_retry legacy runs still drive coalesce/defer routing via `activeExecutionRun`, but defer the stamp to `claimQueuedRun`.

## Test plan

- [x] New `server/src/__tests__/heartbeat-elb-445-cross-assignee-reattach.test.ts` covers:
  - (a) prior-assignee orphan queued run is not reattached after reassignment
  - (b) PATCH from inside CPO's running run R-on-A targeting issue B for new assignee X does not propagate R onto B; A's checkout state remains intact
- [x] Adjacent suites green locally: `heartbeat-comment-wake-batching` (9), `heartbeat-retry-scheduling` (8), `heartbeat-dependency-scheduling` (5), `issue-stale-execution-lock-routes` (3) — 25 passing.
- [ ] CI matrix.
- [ ] Manual verify on staging: run sweep with combined PATCH+comment on a low-stakes target after merge; confirm `executionRunId` is null or owned-by-new-assignee on the target post-PATCH.

## Follow-ups

- [ELB-485](https://elbe.app/ELB/issues/ELB-485) — CPO sweep v2.5: drop release+bare-PATCH workaround once this ships.
- [ELB-397](https://elbe.app/ELB/issues/ELB-397), [ELB-398](https://elbe.app/ELB/issues/ELB-398) — auto-resume on `issue_blockers_resolved` when this lands `done` (containment endorsed by board).