### PR TITLE
fix(recovery + llm + ui): recovery notice validation, OPENAI_BASE_URL support, new-agent adapter defaults

### DIFF
--- a/cli/src/__tests__/llm-check.test.ts
+++ b/cli/src/__tests__/llm-check.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { llmCheck } from "../checks/llm-check.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe("llmCheck", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.OPENAI_BASE_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it("uses the OpenAI /v1 models endpoint by default", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    } as Response);
+
+    const result = await llmCheck({
+      llm: {
+        provider: "openai",
+        apiKey: "sk-test",
+      },
+    } as never);
+
+    expect(result).toEqual({
+      name: "LLM provider",
+      status: "pass",
+      message: "OpenAI API key is valid",
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/models",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer sk-test" },
+      }),
+    );
+  });
+});

--- a/cli/src/checks/llm-check.ts
+++ b/cli/src/checks/llm-check.ts
@@ -51,6 +51,10 @@ export async function llmCheck(config: PaperclipConfig): Promise<CheckResult> {
         message: `Claude API returned status ${res.status}`,
       };
     } else {
+      // OPENAI_BASE_URL support for proxies (e.g. OmniRoute, LiteLLM).
+      // Custom base URLs must include the /v1 prefix (e.g. http://127.0.0.1:20128/v1)
+      // so that we can safely append /models and get a working endpoint.
+      // The default hardcodes the full official path for the same reason.
       const baseUrl = process.env.OPENAI_BASE_URL
         ? process.env.OPENAI_BASE_URL.replace(/\/$/, "")
         : "https://api.openai.com/v1";

--- a/cli/src/checks/llm-check.ts
+++ b/cli/src/checks/llm-check.ts
@@ -51,7 +51,10 @@ export async function llmCheck(config: PaperclipConfig): Promise<CheckResult> {
         message: `Claude API returned status ${res.status}`,
       };
     } else {
-      const res = await fetch("https://api.openai.com/v1/models", {
+      const baseUrl = process.env.OPENAI_BASE_URL
+        ? process.env.OPENAI_BASE_URL.replace(/\/$/, "")
+        : "https://api.openai.com";
+      const res = await fetch(`${baseUrl}/models`, {
         headers: { Authorization: `Bearer ${config.llm.apiKey}` },
       });
       if (res.ok) {

--- a/cli/src/checks/llm-check.ts
+++ b/cli/src/checks/llm-check.ts
@@ -53,7 +53,7 @@ export async function llmCheck(config: PaperclipConfig): Promise<CheckResult> {
     } else {
       const baseUrl = process.env.OPENAI_BASE_URL
         ? process.env.OPENAI_BASE_URL.replace(/\/$/, "")
-        : "https://api.openai.com";
+        : "https://api.openai.com/v1";
       const res = await fetch(`${baseUrl}/models`, {
         headers: { Authorization: `Bearer ${config.llm.apiKey}` },
       });

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -2,6 +2,10 @@ import type { AdapterModel } from "./types.js";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { readConfigFile } from "../config-file.js";
 
+// OPENAI_BASE_URL support for proxies (e.g. OmniRoute, LiteLLM).
+// Custom base URLs must include the /v1 prefix (e.g. http://127.0.0.1:20128/v1)
+// so that we can safely append /models and get a working endpoint.
+// The default hardcodes the full official path for the same reason.
 const OPENAI_MODELS_ENDPOINT = process.env.OPENAI_BASE_URL
   ? `${process.env.OPENAI_BASE_URL.replace(/\/$/, "")}/models`
   : "https://api.openai.com/v1/models";

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -2,7 +2,9 @@ import type { AdapterModel } from "./types.js";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { readConfigFile } from "../config-file.js";
 
-const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
+const OPENAI_MODELS_ENDPOINT = process.env.OPENAI_BASE_URL
+  ? `${process.env.OPENAI_BASE_URL.replace(/\/$/, "")}/models`
+  : "https://api.openai.com/v1/models";
 const OPENAI_MODELS_TIMEOUT_MS = 5000;
 const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
 

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { issueCommentMetadataSchema } from "@paperclipai/shared";
 import {
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
@@ -244,6 +245,34 @@ describe("successful run handoff decision", () => {
         ]),
       }),
     ]));
+  });
+
+  it("truncates overlong issue titles to satisfy metadata validation", () => {
+    const longTitle = `${"A".repeat(300)} tail`;
+    const notice = buildSuccessfulRunHandoffRequiredNotice({
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        identifier: "PAP-1",
+        title: longTitle,
+        status: "in_progress",
+      } as any,
+      run: {
+        id: "22222222-2222-4222-8222-222222222222",
+        status: "succeeded",
+      } as any,
+      agent: {
+        id: "33333333-3333-4333-8333-333333333333",
+        name: "CodexCoder",
+      } as any,
+      detectedProgressSummary: "Run produced concrete action evidence: 1 issue comment(s)",
+    });
+
+    expect(() => issueCommentMetadataSchema.parse(notice.metadata)).not.toThrow();
+    const row = notice.metadata.sections[0].rows[0];
+    expect(row.type).toBe("issue_link");
+    if (row.type !== "issue_link") return;
+    expect(row.title).toHaveLength(240);
+    expect(row.title?.endsWith("...")).toBe(true);
   });
 
   it("builds the exhausted system notice with recovery metadata", () => {

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { issueCommentMetadataSchema } from "@paperclipai/shared";
 import {
   FINISH_SUCCESSFUL_RUN_HANDOFF_REASON,
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
@@ -237,6 +238,34 @@ describe("successful run handoff decision", () => {
         ]),
       }),
     ]));
+  });
+
+  it("truncates overlong issue titles to satisfy metadata validation", () => {
+    const longTitle = `${"A".repeat(300)} tail`;
+    const notice = buildSuccessfulRunHandoffRequiredNotice({
+      issue: {
+        id: "11111111-1111-4111-8111-111111111111",
+        identifier: "PAP-1",
+        title: longTitle,
+        status: "in_progress",
+      } as any,
+      run: {
+        id: "22222222-2222-4222-8222-222222222222",
+        status: "succeeded",
+      } as any,
+      agent: {
+        id: "33333333-3333-4333-8333-333333333333",
+        name: "CodexCoder",
+      } as any,
+      detectedProgressSummary: "Run produced concrete action evidence: 1 issue comment(s)",
+    });
+
+    expect(() => issueCommentMetadataSchema.parse(notice.metadata)).not.toThrow();
+    const row = notice.metadata.sections[0].rows[0];
+    expect(row.type).toBe("issue_link");
+    if (row.type !== "issue_link") return;
+    expect(row.title).toHaveLength(240);
+    expect(row.title?.endsWith("...")).toBe(true);
   });
 
   it("builds the exhausted system notice with recovery metadata", () => {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -93,6 +93,14 @@ function metadataText(value: unknown, fallback = "unknown") {
   return resolved.length > 2000 ? `${resolved.slice(0, 1997)}...` : resolved;
 }
 
+function boundedMetadataTitle(value: unknown, maxLength: number, fallback = "unknown") {
+  const text = typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
+  const resolved = text.length > 0 ? text : fallback;
+  if (resolved.length <= maxLength) return resolved;
+  if (maxLength <= 3) return resolved.slice(0, maxLength);
+  return `${resolved.slice(0, maxLength - 3)}...`;
+}
+
 function keyValueRow(label: string, value: unknown): IssueCommentMetadata["sections"][number]["rows"][number] {
   return { type: "key_value", label, value: metadataText(value) };
 }
@@ -107,7 +115,7 @@ function issueLinkRow(
     label,
     issueId: issue.id,
     identifier: issue.identifier,
-    title: issue.title,
+    title: boundedMetadataTitle(issue.title, 240),
   };
 }
 
@@ -116,7 +124,7 @@ function runLinkRow(
   run: NullableNoticeRun,
 ): IssueCommentMetadata["sections"][number]["rows"][number] {
   if (!run) return keyValueRow(label, "unknown");
-  return { type: "run_link", label, runId: run.id, title: run.status };
+  return { type: "run_link", label, runId: run.id, title: boundedMetadataTitle(run.status, 160) };
 }
 
 function agentLinkRow(
@@ -124,7 +132,7 @@ function agentLinkRow(
   agent: NullableNoticeAgent,
 ): IssueCommentMetadata["sections"][number]["rows"][number] {
   if (!agent) return keyValueRow(label, "unknown");
-  return { type: "agent_link", label, agentId: agent.id, name: agent.name };
+  return { type: "agent_link", label, agentId: agent.id, name: boundedMetadataTitle(agent.name, 160) };
 }
 
 function systemNoticePresentation(input: {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -80,6 +80,14 @@ function metadataText(value: unknown, fallback = "unknown") {
   return resolved.length > 2000 ? `${resolved.slice(0, 1997)}...` : resolved;
 }
 
+function boundedMetadataTitle(value: unknown, maxLength: number, fallback = "unknown") {
+  const text = typeof value === "string" ? value.trim() : value == null ? "" : String(value).trim();
+  const resolved = text.length > 0 ? text : fallback;
+  if (resolved.length <= maxLength) return resolved;
+  if (maxLength <= 3) return resolved.slice(0, maxLength);
+  return `${resolved.slice(0, maxLength - 3)}...`;
+}
+
 function keyValueRow(label: string, value: unknown): IssueCommentMetadata["sections"][number]["rows"][number] {
   return { type: "key_value", label, value: metadataText(value) };
 }
@@ -94,7 +102,7 @@ function issueLinkRow(
     label,
     issueId: issue.id,
     identifier: issue.identifier,
-    title: issue.title,
+    title: boundedMetadataTitle(issue.title, 240),
   };
 }
 
@@ -103,7 +111,7 @@ function runLinkRow(
   run: NullableNoticeRun,
 ): IssueCommentMetadata["sections"][number]["rows"][number] {
   if (!run) return keyValueRow(label, "unknown");
-  return { type: "run_link", label, runId: run.id, title: run.status };
+  return { type: "run_link", label, runId: run.id, title: boundedMetadataTitle(run.status, 160) };
 }
 
 function agentLinkRow(
@@ -111,7 +119,7 @@ function agentLinkRow(
   agent: NullableNoticeAgent,
 ): IssueCommentMetadata["sections"][number]["rows"][number] {
   if (!agent) return keyValueRow(label, "unknown");
-  return { type: "agent_link", label, agentId: agent.id, name: agent.name };
+  return { type: "agent_link", label, agentId: agent.id, name: boundedMetadataTitle(agent.name, 160) };
 }
 
 function systemNoticePresentation(input: {

--- a/ui/src/lib/new-agent-create-values.test.ts
+++ b/ui/src/lib/new-agent-create-values.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { defaultCreateValues } from "../components/agent-config-defaults";
+import {
+  buildNewAgentDefaultCreateValues,
+  createValuesForAdapterType,
+  resolveNewAgentDefaultAdapterType,
+} from "./new-agent-create-values";
+
+describe("new agent create values", () => {
+  it("inherits the CEO adapter type when no explicit preset is provided", () => {
+    expect(
+      resolveNewAgentDefaultAdapterType({
+        companyAgents: [
+          { role: "ceo", adapterType: "pi_local" },
+          { role: "engineer", adapterType: "codex_local" },
+        ],
+      }),
+    ).toBe("pi_local");
+  });
+
+  it("prefers an explicit preset adapter type over the CEO adapter type", () => {
+    expect(
+      resolveNewAgentDefaultAdapterType({
+        companyAgents: [{ role: "ceo", adapterType: "pi_local" }],
+        presetAdapterType: "codex_local",
+      }),
+    ).toBe("codex_local");
+  });
+
+  it("falls back to the global default when no CEO adapter is available", () => {
+    expect(resolveNewAgentDefaultAdapterType()).toBe(defaultCreateValues.adapterType);
+  });
+
+  it("builds pi-local create values without codex-specific defaults", () => {
+    const values = createValuesForAdapterType("pi_local");
+    expect(values.adapterType).toBe("pi_local");
+    expect(values.model).toBe("");
+    expect(values.dangerouslyBypassSandbox).toBe(defaultCreateValues.dangerouslyBypassSandbox);
+  });
+
+  it("builds new-agent defaults from the CEO adapter type", () => {
+    const values = buildNewAgentDefaultCreateValues({
+      companyAgents: [{ role: "ceo", adapterType: "pi_local" }],
+    });
+    expect(values.adapterType).toBe("pi_local");
+  });
+});

--- a/ui/src/lib/new-agent-create-values.ts
+++ b/ui/src/lib/new-agent-create-values.ts
@@ -1,0 +1,54 @@
+import type { Agent } from "@paperclipai/shared";
+import { isValidAdapterType } from "../adapters/metadata";
+import type { CreateConfigValues } from "../components/AgentConfigForm";
+import { defaultCreateValues } from "../components/agent-config-defaults";
+import {
+  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
+  DEFAULT_CODEX_LOCAL_MODEL,
+} from "@paperclipai/adapter-codex-local";
+import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
+import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { DEFAULT_OPENCODE_LOCAL_MODEL } from "@paperclipai/adapter-opencode-local";
+
+export function createValuesForAdapterType(
+  adapterType: CreateConfigValues["adapterType"],
+): CreateConfigValues {
+  const { adapterType: _discard, ...defaults } = defaultCreateValues;
+  const nextValues: CreateConfigValues = { ...defaults, adapterType };
+  if (adapterType === "codex_local") {
+    nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
+    nextValues.dangerouslyBypassSandbox =
+      DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
+  } else if (adapterType === "gemini_local") {
+    nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
+  } else if (adapterType === "cursor") {
+    nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
+  } else if (adapterType === "opencode_local") {
+    nextValues.model = DEFAULT_OPENCODE_LOCAL_MODEL;
+  }
+  return nextValues;
+}
+
+export function resolveNewAgentDefaultAdapterType(input?: {
+  companyAgents?: Pick<Agent, "adapterType" | "role">[] | null;
+  presetAdapterType?: string | null;
+}) {
+  const presetAdapterType = input?.presetAdapterType;
+  if (typeof presetAdapterType === "string" && isValidAdapterType(presetAdapterType)) {
+    return presetAdapterType as CreateConfigValues["adapterType"];
+  }
+
+  const ceoAdapterType = input?.companyAgents?.find((agent) => agent.role === "ceo")?.adapterType ?? null;
+  if (typeof ceoAdapterType === "string" && isValidAdapterType(ceoAdapterType)) {
+    return ceoAdapterType as CreateConfigValues["adapterType"];
+  }
+
+  return defaultCreateValues.adapterType;
+}
+
+export function buildNewAgentDefaultCreateValues(input?: {
+  companyAgents?: Pick<Agent, "adapterType" | "role">[] | null;
+  presetAdapterType?: string | null;
+}) {
+  return createValuesForAdapterType(resolveNewAgentDefaultAdapterType(input));
+}

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearchParams } from "@/lib/router";
 import { useCompany } from "../context/CompanyContext";
@@ -29,31 +29,11 @@ import { isValidAdapterType } from "../adapters/metadata";
 import { ReportsToPicker } from "../components/ReportsToPicker";
 import { buildNewAgentHirePayload } from "../lib/new-agent-hire-payload";
 import {
-  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
-  DEFAULT_CODEX_LOCAL_MODEL,
-} from "@paperclipai/adapter-codex-local";
-import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
-import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
-import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
-
-function createValuesForAdapterType(
-  adapterType: CreateConfigValues["adapterType"],
-): CreateConfigValues {
-  const { adapterType: _discard, ...defaults } = defaultCreateValues;
-  const nextValues: CreateConfigValues = { ...defaults, adapterType };
-  if (adapterType === "codex_local") {
-    nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
-    nextValues.dangerouslyBypassSandbox =
-      DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
-  } else if (adapterType === "gemini_local") {
-    nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
-  } else if (adapterType === "cursor") {
-    nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
-  } else if (adapterType === "opencode_local") {
-    nextValues.model = DEFAULT_OPENCODE_LOCAL_MODEL;
-  }
-  return nextValues;
-}
+  buildNewAgentDefaultCreateValues,
+  createValuesForAdapterType,
+  resolveNewAgentDefaultAdapterType,
+} from "../lib/new-agent-create-values";
+import { isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
 
 export function NewAgent() {
   const { selectedCompanyId } = useCompany();
@@ -69,6 +49,7 @@ export function NewAgent() {
   const [reportsTo, setReportsTo] = useState<string | null>(null);
   const [configValues, setConfigValues] = useState<CreateConfigValues>(defaultCreateValues);
   const [selectedSkillKeys, setSelectedSkillKeys] = useState<string[]>([]);
+  const adapterTouchedRef = useRef(false);
   const [roleOpen, setRoleOpen] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [testAgentAction, setTestAgentAction] = useState<(() => void) | null>(null);
@@ -95,6 +76,10 @@ export function NewAgent() {
 
   const isFirstAgent = !agents || agents.length === 0;
   const effectiveRole = isFirstAgent ? "ceo" : role;
+  const defaultAdapterType = resolveNewAgentDefaultAdapterType({
+    companyAgents: agents ?? null,
+    presetAdapterType,
+  });
 
   useEffect(() => {
     setBreadcrumbs([
@@ -114,11 +99,25 @@ export function NewAgent() {
     const requested = presetAdapterType;
     if (!requested) return;
     if (!isValidAdapterType(requested)) return;
+    adapterTouchedRef.current = true;
     setConfigValues((prev) => {
       if (prev.adapterType === requested) return prev;
       return createValuesForAdapterType(requested as CreateConfigValues["adapterType"]);
     });
   }, [presetAdapterType]);
+
+  useEffect(() => {
+    if (presetAdapterType) return;
+    if (adapterTouchedRef.current) return;
+    if (!agents) return;
+    if (defaultAdapterType === defaultCreateValues.adapterType) return;
+    setConfigValues((prev) => {
+      if (prev.adapterType === defaultAdapterType) return prev;
+      return buildNewAgentDefaultCreateValues({
+        companyAgents: agents,
+      });
+    });
+  }, [agents, defaultAdapterType, presetAdapterType]);
 
   const createAgent = useMutation({
     mutationFn: (data: Record<string, unknown>) =>
@@ -260,7 +259,12 @@ export function NewAgent() {
         <AgentConfigForm
           mode="create"
           values={configValues}
-          onChange={(patch) => setConfigValues((prev) => ({ ...prev, ...patch }))}
+          onChange={(patch) => {
+            if (Object.keys(patch).length > 0) {
+              adapterTouchedRef.current = true;
+            }
+            setConfigValues((prev) => ({ ...prev, ...patch }));
+          }}
           onTestActionChange={handleTestAgentActionChange}
           onTestActionStateChange={handleTestAgentStateChange}
           onTestFeedbackChange={handleTestAgentFeedbackChange}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Successful runs that leave issues in `in_progress` without a clear disposition trigger a corrective "handoff" wake to force the agent to pick done/cancelled/in_review/blocked/delegated/etc.
> - The handoff constructs structured system notices (with `issueCommentMetadataSchema`) containing `issue_link`, `run_link`, and `agent_link` rows that embed titles/names/statuses
> - Those fields have strict length caps in the schema (240 for issue titles, 160 for run status and agent names) to keep metadata compact and valid
> - Real issues often have titles longer than 240 chars; the handoff code was passing raw strings, causing `too_big` validation failures, aborted handoffs, and stuck issues
> - Independently, CLI `llmCheck` and server Codex model discovery hardcoded the OpenAI models endpoint and did not honor `OPENAI_BASE_URL` (used for OmniRoute proxies, LiteLLM etc), and the two paths had inconsistent handling of the `/v1` suffix
> - This pull request adds safe truncation helpers, applies them to all three link row builders used by both handoff notice types, adds a regression test that exercises the schema, wires `OPENAI_BASE_URL` support with matching convention + clarifying comments in both LLM paths, and extracts/refactors new-agent create value logic (with CEO adapter defaulting) into shared lib for reuse
> - The benefit is recovery handoffs no longer blow up on long titles, OpenAI config works correctly behind proxies for both CLI validation and model lists, new agent form correctly seeds from company CEO adapter, and convention is documented to avoid future drift

## What Changed

- Introduced `boundedMetadataTitle(value, maxLength, fallback)` helper in `server/src/services/recovery/successful-run-handoff.ts` (sibling to existing `metadataText`) that safely truncates to the exact schema limit + "..." suffix
- Refactored `issueLinkRow`, `runLinkRow`, `agentLinkRow` helpers to use the bounded title fn (issue.title → 240, run.status → 160, agent.name → 160)
- Updated `buildSuccessfulRunHandoffRequiredNotice` and `buildSuccessfulRunHandoffExhaustedNotice` to go through the link row helpers (so they now truncate)
- Added end-to-end regression test `"truncates overlong issue titles to satisfy metadata validation"` that builds a notice with 300+ char title, asserts `issueCommentMetadataSchema.parse` succeeds, and that the title is exactly 240 chars ending in `...`
- Added `OPENAI_BASE_URL` support (with trailing-slash strip + `/models` append) to `cli/src/checks/llm-check.ts` + unit test verifying default uses `/v1/models`
- Added `OPENAI_BASE_URL` support to `server/src/adapters/codex-models.ts` (module const for endpoint) with same logic
- Added identical clarifying comments in both LLM files: "Custom base URLs must include the /v1 prefix ... so that we can safely append /models..."
- Extracted `createValuesForAdapterType`, `resolveNewAgentDefaultAdapterType`, `buildNewAgentDefaultCreateValues` into new `ui/src/lib/new-agent-create-values.ts` (and matching test)
- Refactored `ui/src/pages/NewAgent.tsx` to import the shared functions, added `adapterTouchedRef` guard + effect to auto-seed default adapter from CEO agent when no preset, plus touched tracking on form changes so user selections are not clobbered
- Squashed/rebased the Greptile address commit for clean history on this branch

## Verification

- `pnpm exec vitest run cli/src/__tests__/llm-check.test.ts` (1 test, verifies default `/v1` endpoint)
- `pnpm exec vitest run server/src/services/recovery/successful-run-handoff.test.ts` (15 tests, including the new overlong title truncation + schema parse + all notice builders)
- `pnpm --filter @paperclipai/ui exec vitest run src/lib/new-agent-create-values.test.ts` (5 tests)
- `pnpm -r typecheck`
- `pnpm test:run` (relevant suites)
- `pnpm build`
- Manual: constructed long-title handoff notice and confirmed no schema error; confirmed custom OPENAI_BASE_URL=http://127.0.0.1:20128/v1 produces correct /models URL in both paths; new agent form seeds from CEO adapter and respects manual override

## Risks

- Low risk for the truncation: the `...` suffix is only used when exceeding limit; existing callers of the notice builders continue to receive valid metadata; the test exercises the exact schema used in prod.
- Low risk for OPENAI_BASE_URL: defaults unchanged for users without the env var; custom users were already expected to provide full base (now documented); the change makes CLI match what Codex already intended.
- The new-agent refactor moves code that was inline into shared lib; behavior is preserved + enhanced with CEO defaulting. Risk of regression in agent creation flow is mitigated by the dedicated test and the fact that NewAgent.tsx now delegates to it.
- No breaking changes to public APIs or DB.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected. See `CONTRIBUTING.md`.

## Model Used

- None — human-authored (Apostol Apostolov). Greptile provided automated review feedback that was manually addressed in follow-up commit.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots or confirmed screenshots are not applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #7594
