### PR TITLE
Default new hires to the CEO adapter

### DIFF
--- a/ui/src/lib/new-agent-create-values.test.ts
+++ b/ui/src/lib/new-agent-create-values.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { defaultCreateValues } from "../components/agent-config-defaults";
+import {
+  buildNewAgentDefaultCreateValues,
+  createValuesForAdapterType,
+  resolveNewAgentDefaultAdapterType,
+} from "./new-agent-create-values";
+
+describe("new agent create values", () => {
+  it("inherits the CEO adapter type when no explicit preset is provided", () => {
+    expect(
+      resolveNewAgentDefaultAdapterType({
+        companyAgents: [
+          { role: "ceo", adapterType: "pi_local" },
+          { role: "engineer", adapterType: "codex_local" },
+        ],
+      }),
+    ).toBe("pi_local");
+  });
+
+  it("prefers an explicit preset adapter type over the CEO adapter type", () => {
+    expect(
+      resolveNewAgentDefaultAdapterType({
+        companyAgents: [{ role: "ceo", adapterType: "pi_local" }],
+        presetAdapterType: "codex_local",
+      }),
+    ).toBe("codex_local");
+  });
+
+  it("falls back to the global default when no CEO adapter is available", () => {
+    expect(resolveNewAgentDefaultAdapterType()).toBe(defaultCreateValues.adapterType);
+  });
+
+  it("builds pi-local create values without codex-specific defaults", () => {
+    const values = createValuesForAdapterType("pi_local");
+    expect(values.adapterType).toBe("pi_local");
+    expect(values.model).toBe("");
+    expect(values.dangerouslyBypassSandbox).toBe(defaultCreateValues.dangerouslyBypassSandbox);
+  });
+
+  it("builds new-agent defaults from the CEO adapter type", () => {
+    const values = buildNewAgentDefaultCreateValues({
+      companyAgents: [{ role: "ceo", adapterType: "pi_local" }],
+    });
+    expect(values.adapterType).toBe("pi_local");
+  });
+});

--- a/ui/src/lib/new-agent-create-values.ts
+++ b/ui/src/lib/new-agent-create-values.ts
@@ -1,0 +1,54 @@
+import type { Agent } from "@paperclipai/shared";
+import { isValidAdapterType } from "../adapters/metadata";
+import type { CreateConfigValues } from "../components/AgentConfigForm";
+import { defaultCreateValues } from "../components/agent-config-defaults";
+import {
+  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
+  DEFAULT_CODEX_LOCAL_MODEL,
+} from "@paperclipai/adapter-codex-local";
+import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
+import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { DEFAULT_OPENCODE_LOCAL_MODEL } from "@paperclipai/adapter-opencode-local";
+
+export function createValuesForAdapterType(
+  adapterType: CreateConfigValues["adapterType"],
+): CreateConfigValues {
+  const { adapterType: _discard, ...defaults } = defaultCreateValues;
+  const nextValues: CreateConfigValues = { ...defaults, adapterType };
+  if (adapterType === "codex_local") {
+    nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
+    nextValues.dangerouslyBypassSandbox =
+      DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
+  } else if (adapterType === "gemini_local") {
+    nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
+  } else if (adapterType === "cursor") {
+    nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
+  } else if (adapterType === "opencode_local") {
+    nextValues.model = DEFAULT_OPENCODE_LOCAL_MODEL;
+  }
+  return nextValues;
+}
+
+export function resolveNewAgentDefaultAdapterType(input?: {
+  companyAgents?: Pick<Agent, "adapterType" | "role">[] | null;
+  presetAdapterType?: string | null;
+}) {
+  const presetAdapterType = input?.presetAdapterType;
+  if (typeof presetAdapterType === "string" && isValidAdapterType(presetAdapterType)) {
+    return presetAdapterType as CreateConfigValues["adapterType"];
+  }
+
+  const ceoAdapterType = input?.companyAgents?.find((agent) => agent.role === "ceo")?.adapterType ?? null;
+  if (typeof ceoAdapterType === "string" && isValidAdapterType(ceoAdapterType)) {
+    return ceoAdapterType as CreateConfigValues["adapterType"];
+  }
+
+  return defaultCreateValues.adapterType;
+}
+
+export function buildNewAgentDefaultCreateValues(input?: {
+  companyAgents?: Pick<Agent, "adapterType" | "role">[] | null;
+  presetAdapterType?: string | null;
+}) {
+  return createValuesForAdapterType(resolveNewAgentDefaultAdapterType(input));
+}

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -22,38 +22,18 @@ import {
   AdapterEnvironmentResult,
   type CreateConfigValues,
 } from "../components/AgentConfigForm";
-import { defaultCreateValues } from "../components/agent-config-defaults";
 import { getUIAdapter, listUIAdapters } from "../adapters";
 import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { isValidAdapterType } from "../adapters/metadata";
 import { ReportsToPicker } from "../components/ReportsToPicker";
 import { buildNewAgentHirePayload } from "../lib/new-agent-hire-payload";
 import {
-  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
-  DEFAULT_CODEX_LOCAL_MODEL,
-} from "@paperclipai/adapter-codex-local";
-import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
-import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+  buildNewAgentDefaultCreateValues,
+  createValuesForAdapterType,
+  resolveNewAgentDefaultAdapterType,
+} from "../lib/new-agent-create-values";
+import { defaultCreateValues } from "../components/agent-config-defaults";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
-
-function createValuesForAdapterType(
-  adapterType: CreateConfigValues["adapterType"],
-): CreateConfigValues {
-  const { adapterType: _discard, ...defaults } = defaultCreateValues;
-  const nextValues: CreateConfigValues = { ...defaults, adapterType };
-  if (adapterType === "codex_local") {
-    nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
-    nextValues.dangerouslyBypassSandbox =
-      DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
-  } else if (adapterType === "gemini_local") {
-    nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
-  } else if (adapterType === "cursor") {
-    nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
-  } else if (adapterType === "opencode_local") {
-    nextValues.model = DEFAULT_OPENCODE_LOCAL_MODEL;
-  }
-  return nextValues;
-}
 
 export function NewAgent() {
   const { selectedCompanyId } = useCompany();
@@ -95,6 +75,10 @@ export function NewAgent() {
 
   const isFirstAgent = !agents || agents.length === 0;
   const effectiveRole = isFirstAgent ? "ceo" : role;
+  const defaultAdapterType = resolveNewAgentDefaultAdapterType({
+    companyAgents: agents ?? null,
+    presetAdapterType,
+  });
 
   useEffect(() => {
     setBreadcrumbs([
@@ -119,6 +103,18 @@ export function NewAgent() {
       return createValuesForAdapterType(requested as CreateConfigValues["adapterType"]);
     });
   }, [presetAdapterType]);
+
+  useEffect(() => {
+    if (presetAdapterType) return;
+    if (!agents) return;
+    setConfigValues((prev) => {
+      if (prev.adapterType !== defaultCreateValues.adapterType) return prev;
+      if (prev.adapterType === defaultAdapterType) return prev;
+      return buildNewAgentDefaultCreateValues({
+        companyAgents: agents,
+      });
+    });
+  }, [agents, defaultAdapterType, presetAdapterType]);
 
   const createAgent = useMutation({
     mutationFn: (data: Record<string, unknown>) =>


### PR DESCRIPTION
## Thinking Path
I traced the hire-flow defaulting path from the UI into the hire payload, found that new-agent creation was seeding from the generic defaults instead of the company CEO's adapter type, and split the logic into a shared helper so the default can be derived from company state without duplicating adapter-specific model defaults.

## Model Used
- Provider: OpenAI
- Model: GPT-5.5
- Reasoning mode: medium

## Risks
- The seeding effect must not override an explicit adapter choice after the user touches the field.
- The helper must preserve adapter-specific defaults for `codex_local`, `gemini_local`, `cursor`, and `opencode_local`.
- The default should still fall back to the global create default when there is no CEO adapter to inherit.

## Checklist
- [x] CEO adapter type is inherited for new hires when no explicit preset is provided.
- [x] Explicit `?adapterType=` presets still win.
- [x] User-touched adapter state is not overwritten by refetches.
- [x] Unit tests cover default resolution and create-value generation.
- [x] `pnpm --dir /home/apoapostolov/git/paperclip exec vitest run ui/src/lib/new-agent-create-values.test.ts ui/src/lib/new-agent-hire-payload.test.ts ui/src/lib/new-agent-runtime-config.test.ts`
- [x] `pnpm --dir /home/apoapostolov/git/paperclip exec tsc -p ui/tsconfig.json --noEmit`

## Screenshots
Not captured in this terminal session.
