### PR TITLE
fix(api): echo execution lock fields on heartbeat-context (COP-242)

### DIFF
--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -156,6 +156,10 @@ const legacyProjectLinkedIssue = {
   assigneeUserId: null,
   updatedAt: new Date("2026-03-24T12:00:00Z"),
   executionWorkspaceId: null,
+  checkoutRunId: null,
+  executionRunId: null,
+  executionAgentNameKey: null,
+  executionLockedAt: null,
   labels: [],
   labelIds: [],
 };
@@ -368,5 +372,27 @@ describe.sequential("issue goal context routes", () => {
         }),
       ],
     }));
+  });
+
+  it("echoes execution lock fields on heartbeat-context issue snapshot same as GET /issues/:id", async () => {
+    const lockedAt = new Date("2026-05-06T12:00:00.000Z");
+    mockIssueService.getById.mockResolvedValue({
+      ...legacyProjectLinkedIssue,
+      checkoutRunId: "run-checkout-lock",
+      executionRunId: "run-exec-lock",
+      executionAgentNameKey: "founding-engineer",
+      executionLockedAt: lockedAt,
+    });
+    const app = createApp();
+    const hb = await request(app).get("/api/issues/11111111-1111-4111-8111-111111111111/heartbeat-context");
+    const full = await request(app).get("/api/issues/11111111-1111-4111-8111-111111111111");
+    expect(hb.status).toBe(200);
+    expect(full.status).toBe(200);
+    const fields = ["checkoutRunId", "executionRunId", "executionAgentNameKey", "executionLockedAt"] as const;
+    for (const field of fields) {
+      expect(hb.body.issue[field]).toEqual(full.body[field]);
+    }
+    expect(hb.body.issue.executionRunId).toBe("run-exec-lock");
+    expect(hb.body.issue.checkoutRunId).toBe("run-checkout-lock");
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1533,6 +1533,10 @@ export function issueRoutes(
         blocks: relations.blocks,
         assigneeAgentId: issue.assigneeAgentId,
         assigneeUserId: issue.assigneeUserId,
+        checkoutRunId: issue.checkoutRunId,
+        executionRunId: issue.executionRunId,
+        executionLockedAt: issue.executionLockedAt,
+        executionAgentNameKey: issue.executionAgentNameKey,
         originKind: issue.originKind,
         originId: issue.originId,
         updatedAt: issue.updatedAt,
@@ -3345,6 +3349,13 @@ export function issueRoutes(
     res.json(issue);
   });
 
+  // Agent checkout: `requireAgentRunId` resolves the current heartbeat run from `req.actor.runId`
+  // (typically propagated from `X-Paperclip-Run-Id` on the request or embedded in the agent JWT).
+  // That run id is passed through as `checkoutRunId` into `issueService.checkout`, which persists it
+  // on the row as both `checkoutRunId` and `executionRunId` while the execution lock is active.
+  // For lock state, prefer `GET /api/issues/:id` or `GET .../heartbeat-context` (`issue` snapshot);
+  // clients should not infer locks from headers alone after checkout, because the stored ids must
+  // match when re-entering or adopting an existing checkout for the same run.
   router.post("/issues/:id/checkout", validate(checkoutIssueSchema), async (req, res) => {
     const id = req.params.id as string;
     const issue = await svc.getById(id);

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -783,10 +783,10 @@ Terminal states: `done`, `cancelled`
 | ------ | ---------------------------------- | ---------------------------------------------------------------------------------------- |
 | GET    | `/api/companies/:companyId/issues` | List issues, sorted by priority. Filters: `?status=`, `?assigneeAgentId=`, `?assigneeUserId=`, `?projectId=`, `?labelId=`, `?q=` (full-text search across title, identifier, description, comments) |
 | GET    | `/api/issues/:issueId`             | Issue details + ancestors                                                                |
-| GET    | `/api/issues/:issueId/heartbeat-context` | Compact context for heartbeat: issue state, ancestor summaries, comment cursor  |
+| GET    | `/api/issues/:issueId/heartbeat-context` | Compact context for heartbeat: issue state, ancestor summaries, comment cursor, `currentExecutionWorkspace` when linked. Nested `issue` includes the same execution-lock fields as `GET /api/issues/:issueId` (`checkoutRunId`, `executionRunId`, `executionLockedAt`, `executionAgentNameKey`). |
 | POST   | `/api/companies/:companyId/issues` | Create issue (supports `blockedByIssueIds: string[]` for dependencies)                   |
 | PATCH  | `/api/issues/:issueId`             | Update issue (optional `comment` field; `blockedByIssueIds` replaces blocker set)        |
-| POST   | `/api/issues/:issueId/checkout`    | Atomic checkout (claim + start). Idempotent if you already own it.                       |
+| POST   | `/api/issues/:issueId/checkout`    | Atomic checkout (claim + start). Idempotent if you already own it. Agent actors must send the current heartbeat run as `X-Paperclip-Run-Id` (surfaced as `req.actor.runId`); the service stores that id on the issue as `checkoutRunId` / `executionRunId` for the active lock. Compare stored ids from `GET /api/issues/:issueId` or `.../heartbeat-context` rather than assuming the header alone matches persisted state. |
 | POST   | `/api/issues/:issueId/release`     | Release task ownership                                                                   |
 | GET    | `/api/issues/:issueId/comments`    | List comments                                                                            |
 | GET    | `/api/issues/:issueId/comments/:commentId` | Get a specific comment by ID                                                     |
@@ -804,7 +804,6 @@ Terminal states: `done`, `cancelled`
 | GET    | `/api/issues/:issueId/approvals`   | List approvals linked to issue                                                           |
 | POST   | `/api/issues/:issueId/approvals`   | Link approval to issue                                                                   |
 | DELETE | `/api/issues/:issueId/approvals/:approvalId` | Unlink approval from issue                                                     |
-| GET    | `/api/issues/:issueId/heartbeat-context` | Compact issue context including `currentExecutionWorkspace` when one is linked |
 | GET    | `/api/execution-workspaces/:workspaceId` | Execution workspace detail including runtime services and service URLs |
 | POST   | `/api/execution-workspaces/:workspaceId/runtime-services/start` | Start configured workspace services |
 | POST   | `/api/execution-workspaces/:workspaceId/runtime-services/restart` | Restart configured workspace services |


### PR DESCRIPTION
## Summary
Aligns `GET /api/issues/:id/heartbeat-context` nested `issue` snapshot with execution-lock fields from `GET /api/issues/:id` (`checkoutRunId`, `executionRunId`, `executionLockedAt`, `executionAgentNameKey`).

## Acceptance
- Same lock field values on both endpoints
- Code comment on `POST /checkout` re: `X-Paperclip-Run-Id` vs persisted ids
- Agent API reference updated
- Regression test: heartbeat-context vs full GET issue

Closes COP-242 (Paperclip control plane).

Made with [Cursor](https://cursor.com)