### PR TITLE
fix(workspaces): fetch origin before branching new worktrees

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1459,14 +1459,17 @@ describe("realizeExecutionWorkspace", () => {
 
     expect(operations.map((operation) => operation.phase)).toEqual([
       "worktree_prepare",
+      "worktree_prepare",
       "workspace_provision",
     ]);
-    expect(operations[0]?.command).toContain("git worktree add");
-    expect(operations[0]?.metadata).toMatchObject({
+    expect(operations[0]?.command).toBe("git fetch origin");
+    expect(operations[0]?.metadata).toMatchObject({ fetchOrigin: true });
+    expect(operations[1]?.command).toContain("git worktree add");
+    expect(operations[1]?.metadata).toMatchObject({
       branchName: "PAP-540-record-workspace-operations",
       created: true,
     });
-    expect(operations[1]?.command).toBe("bash ./scripts/provision.sh");
+    expect(operations[2]?.command).toBe("bash ./scripts/provision.sh");
   });
 
   it("truncates oversized provision command output before storing it in memory", async () => {
@@ -1847,6 +1850,214 @@ describe("realizeExecutionWorkspace", () => {
     expect(worktreeOp).toBeDefined();
     expect(worktreeOp!.metadata!.baseRef).toBe("master");
   }, 10_000);
+
+  it("fetches origin before branching a new worktree so the base ref is current", async () => {
+    // Set up a local repo + bare remote, push initial commit, then advance
+    // the remote independently so the local origin/master is stale.
+    // Provisioning a new worktree should fetch first and branch from the
+    // current remote tip, not the stale local copy.
+    // Using "master" (matching the auto-detect tests above) sidesteps
+    // init.defaultBranch portability issues across CI environments.
+    const repoRoot = await createTempRepo("master");
+    const bareRemote = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-worktree-bare-fetch-"));
+    await runGit(bareRemote, ["init", "--bare"]);
+    await runGit(repoRoot, ["remote", "add", "origin", bareRemote]);
+    await runGit(repoRoot, ["push", "-u", "origin", "master"]);
+    // The push above creates refs/heads/master on the bare repo but does not
+    // update its HEAD. Set HEAD explicitly so the subsequent `git clone`
+    // checks out master (otherwise it lands detached and the next push fails).
+    await runGit(bareRemote, ["symbolic-ref", "HEAD", "refs/heads/master"]);
+
+    // Advance the remote from a side clone so the local repo's origin/master
+    // remains pointing at the initial commit.
+    const sideClone = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-worktree-side-"));
+    await runGit(sideClone, ["clone", bareRemote, "."]);
+    await runGit(sideClone, ["config", "user.email", "side@example.com"]);
+    await runGit(sideClone, ["config", "user.name", "Side Author"]);
+    await fs.writeFile(path.join(sideClone, "DRIFT.md"), "advanced on remote\n", "utf8");
+    await runGit(sideClone, ["add", "DRIFT.md"]);
+    await runGit(sideClone, ["commit", "-m", "Advance remote master"]);
+    await runGit(sideClone, ["push", "origin", "master"]);
+    const remoteTip = (await execFileAsync("git", ["rev-parse", "master"], { cwd: sideClone })).stdout.trim();
+
+    // Sanity: the local repo has not seen the new commit yet.
+    const staleOriginMaster = (await execFileAsync("git", ["rev-parse", "origin/master"], { cwd: repoRoot })).stdout.trim();
+    expect(staleOriginMaster).not.toBe(remoteTip);
+
+    const { recorder, operations } = createWorkspaceOperationRecorderDouble();
+    const workspace = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "origin/master",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          baseRef: "origin/master",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-fetch",
+        title: "Fetch before branch",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+      recorder,
+    });
+
+    // The fetch must be recorded, and must come before the worktree-add.
+    const fetchOpIndex = operations.findIndex(op => op.metadata?.fetchOrigin === true);
+    const worktreeOpIndex = operations.findIndex(op => op.metadata?.created === true);
+    expect(fetchOpIndex).toBeGreaterThanOrEqual(0);
+    expect(worktreeOpIndex).toBeGreaterThan(fetchOpIndex);
+
+    // The new worktree's HEAD should match the current remote tip — proof
+    // that we branched from the freshly-fetched ref, not the stale local one.
+    const worktreeHead = (await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: workspace.cwd })).stdout.trim();
+    expect(worktreeHead).toBe(remoteTip);
+  }, 15_000);
+
+  it("proceeds with possibly-stale refs when fetch fails (best-effort)", async () => {
+    // No origin remote configured — git fetch origin will fail. Provisioning
+    // must still succeed using local refs, with a warning logged.
+    const repoRoot = await createTempRepo("main");
+
+    const { recorder, operations } = createWorkspaceOperationRecorderDouble();
+    const workspace = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "main",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          baseRef: "main",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-fetch-fail",
+        title: "Fetch failure tolerated",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+      recorder,
+    });
+
+    expect(workspace.strategy).toBe("git_worktree");
+    expect(workspace.created).toBe(true);
+    // The fetch attempt should be recorded but its result was a failure.
+    const fetchOp = operations.find(op => op.metadata?.fetchOrigin === true);
+    expect(fetchOp).toBeDefined();
+    expect(fetchOp!.result.status).toBe("failed");
+  }, 10_000);
+
+  it("fetches origin when ensurePersistedExecutionWorkspaceAvailable recreates a missing branch", async () => {
+    // Persisted workspace exists in DB-like state, but both the worktree
+    // directory AND the branch are gone (e.g., disk wipe + branch deleted).
+    // Reattach via `git worktree add path branchName` will fail with
+    // "invalid reference", and the recreate fall-through must fetch origin
+    // before running `git worktree add -b branchName path baseRef`.
+    const repoRoot = await createTempRepo("main");
+    const branchName = "PAP-recreate-feature";
+
+    // First, realize a workspace so the worktree + branch exist as state we
+    // can later remove.
+    const initial = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: branchName,
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-recreate",
+        title: "Recreate missing branch",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    // Tear down both the worktree directory and the branch so the reattach
+    // path fails and the recreate fall-through fires.
+    await execFileAsync("git", ["worktree", "remove", "--force", initial.cwd], { cwd: repoRoot });
+    await execFileAsync("git", ["branch", "-D", branchName], { cwd: repoRoot });
+
+    const { recorder, operations } = createWorkspaceOperationRecorderDouble();
+    const restored = await ensurePersistedExecutionWorkspaceAvailable({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      workspace: {
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        cwd: initial.cwd,
+        providerRef: initial.worktreePath,
+        projectId: "project-1",
+        projectWorkspaceId: "workspace-1",
+        repoUrl: null,
+        baseRef: "HEAD",
+        branchName,
+        config: {},
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-recreate",
+        title: "Recreate missing branch",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+      recorder,
+    });
+
+    expect(restored).not.toBeNull();
+    // Reattach attempt → fails. Fetch → recorded. Recreate (with -b) → succeeds.
+    const reattachOpIndex = operations.findIndex(
+      op => op.metadata?.restored === true && op.metadata?.created === false,
+    );
+    const fetchOpIndex = operations.findIndex(op => op.metadata?.fetchOrigin === true);
+    const recreateOpIndex = operations.findIndex(
+      op => op.metadata?.restored === true && op.metadata?.created === true,
+    );
+    expect(reattachOpIndex).toBeGreaterThanOrEqual(0);
+    expect(fetchOpIndex).toBeGreaterThan(reattachOpIndex);
+    expect(recreateOpIndex).toBeGreaterThan(fetchOpIndex);
+  }, 15_000);
 
   it("removes a created git worktree and branch during cleanup", async () => {
     const repoRoot = await createTempRepo();

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -829,6 +829,32 @@ async function recordGitOperation(
   return stdout.trim();
 }
 
+// Refresh remote-tracking refs before branching a new worktree off them.
+// Best-effort: fetch failures (no remote, network blip, GitHub outage, auth)
+// must not block provisioning — agents need to keep moving even when origin
+// is unreachable. We log a warning and proceed with possibly-stale local refs.
+async function fetchOriginBestEffort(
+  recorder: WorkspaceOperationRecorder | null | undefined,
+  repoRoot: string,
+): Promise<void> {
+  try {
+    await recordGitOperation(recorder, {
+      phase: "worktree_prepare",
+      args: ["fetch", "origin"],
+      cwd: repoRoot,
+      metadata: { repoRoot, fetchOrigin: true },
+      successMessage: `Fetched latest refs from origin in ${repoRoot}\n`,
+      failureLabel: `git fetch origin in ${repoRoot}`,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(
+      `[workspace-runtime] git fetch origin in ${repoRoot} failed; ` +
+        `proceeding with possibly-stale local refs: ${message}`,
+    );
+  }
+}
+
 async function recordWorkspaceCommandOperation(
   recorder: WorkspaceOperationRecorder | null | undefined,
   input: {
@@ -1099,6 +1125,8 @@ export async function realizeExecutionWorkspace(input: {
     throw new Error(`Registered worktree for branch "${branchName}" at "${registeredBranchWorktree}" is not reusable${reason}.`);
   }
 
+  await fetchOriginBestEffort(input.recorder, repoRoot);
+
   try {
     await recordGitOperation(input.recorder, {
       phase: "worktree_prepare",
@@ -1268,6 +1296,7 @@ export async function ensurePersistedExecutionWorkspaceAvailable(input: {
       throw error;
     }
     const baseRef = input.workspace.baseRef ?? await detectDefaultBranch(repoRoot) ?? "HEAD";
+    await fetchOriginBestEffort(input.recorder, repoRoot);
     await recordGitOperation(input.recorder, {
       phase: "worktree_prepare",
       args: ["worktree", "add", "-b", branchName, worktreePath, baseRef],


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each issue an agent picks up gets its own isolated git worktree, branched from the project's base ref (typically `origin/main`)
> - The worktree is created via `git worktree add -b <branch> <path> <baseRef>` against the project's primary checkout
> - But the primary checkout's local `origin/main` only updates when something does a `git fetch` — and nothing in the provisioning path does
> - So when an agent picks up a new issue after a quiet period, the new worktree silently branches from a stale local `origin/main` (could be hours/days old)
> - This pull request adds a best-effort `git fetch origin` before each `git worktree add -b`, so new worktrees branch from the current remote tip
> - The benefit is that agents get a fresh starting point for new work, PRs avoid avoidable rebases against drift, and the close panel's "merged into base" check (which uses the same local ref) returns correct results

## What Changed

- New helper `fetchOriginBestEffort(recorder, repoRoot)` in `server/src/services/workspace-runtime.ts` that runs `git fetch origin` and logs (without throwing) on failure
- Called at the two `git worktree add -b ... baseRef` sites: the fresh-create path and the recreate-missing-worktree path
- Two new tests in `server/src/__tests__/workspace-runtime.test.ts`:
  - **fetches origin before branching**: pushes an initial commit, advances the remote independently from a side clone, then verifies the new worktree branches from the current remote tip rather than the stale local `origin/main`
  - **proceeds with possibly-stale refs when fetch fails**: no origin remote configured, fetch fails, provisioning still succeeds (best-effort)
- One existing assertion (`records worktree setup and provision operations when a recorder is provided`) updated to include the new fetch operation in the expected sequence

## Verification

\`\`\`bash
pnpm run preflight:workspace-links
cd server && npx vitest run --no-coverage src/__tests__/workspace-runtime.test.ts
# 59 passed (59)
\`\`\`

The two new tests cover both the success and failure paths. The success test produces a verifiable result (worktree HEAD matches the post-advance remote tip), so a regression where the fetch is removed would fail it.

## Risks

- **Behavior change**: Existing deployments will see a small additional latency per provision (single-digit seconds for typical repos, scales with fetch payload). For correctness this seems clearly worth it, but flagging.
- **Best-effort failure handling**: If origin is unreachable (network blip, GitHub outage, auth misconfig), provisioning still proceeds with the stale local ref. The trade-off is preserving "agents can keep picking up issues even when GitHub is down" over "fail loudly when we can't refresh." A warning is logged for later inspection.
- **No new config surface**: Considered an opt-out flag (e.g., `skipFetchBeforeProvision`) but kept it out to stay Path 1 / minimal. If specific deployments need to suppress the fetch (offline, airgapped, deterministic-test), happy to follow up with a separate PR adding a config knob.
- **Non-`-b` worktree paths are not touched**: The reattach paths (`git worktree add path branch` without `-b`, attaching an existing branch) don't branch from a base ref, so don't need the fetch. Only the two `-b` paths get it.

## Model Used

- Provider: Anthropic
- Model ID: claude-opus-4-7
- Context window: 1M
- Capabilities: extended thinking, tool use, file editing, code execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-side only)
- [x] I have updated relevant documentation to reflect my changes (N/A — no doc references to the prior behavior)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge