### PR TITLE
Coach-driven onboarding: conversational entry + agent-companies package import

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,4 +1,4 @@
-export const COMPANY_STATUSES = ["active", "paused", "archived"] as const;
+export const COMPANY_STATUSES = ["draft", "active", "paused", "archived"] as const;
 export type CompanyStatus = (typeof COMPANY_STATUSES)[number];
 
 export const DEFAULT_COMPANY_ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
@@ -43,6 +43,7 @@ export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number] | (string & 
 
 export const AGENT_ROLES = [
   "ceo",
+  "coach",
   "cto",
   "cmo",
   "cfo",
@@ -59,6 +60,7 @@ export type AgentRole = (typeof AGENT_ROLES)[number];
 
 export const AGENT_ROLE_LABELS: Record<AgentRole, string> = {
   ceo: "CEO",
+  coach: "Coach",
   cto: "CTO",
   cmo: "CMO",
   cfo: "CFO",

--- a/packages/shared/src/validators/company.ts
+++ b/packages/shared/src/validators/company.ts
@@ -45,6 +45,10 @@ export const updateCompanyBrandingSchema = z
     description: z.string().nullable().optional(),
     brandColor: brandColorSchema,
     logoAssetId: logoAssetIdSchema,
+    // Agents can transition a company out of `draft` to `active` (the Coach
+    // does this at the end of onboarding). Pause/archive transitions still
+    // require board access via updateCompanySchema.
+    status: z.literal("active").optional(),
   })
   .strict()
   .refine(
@@ -52,7 +56,8 @@ export const updateCompanyBrandingSchema = z
       value.name !== undefined
       || value.description !== undefined
       || value.brandColor !== undefined
-      || value.logoAssetId !== undefined,
+      || value.logoAssetId !== undefined
+      || value.status !== undefined,
     "At least one branding field must be provided",
   );
 

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -308,10 +308,12 @@ export function companyRoutes(db: Db, storage?: StorageService) {
     let body: Record<string, unknown>;
 
     if (req.actor.type === "agent") {
-      // Only CEO agents may update company branding fields
+      // CEO agents (and the onboarding Coach, which becomes the CEO) may update
+      // company branding fields. The Coach role is transient — only present
+      // during onboarding — and needs this access to rename the draft company.
       const agentSvc = agentService(db);
       const actorAgent = req.actor.agentId ? await agentSvc.getById(req.actor.agentId) : null;
-      if (!actorAgent || actorAgent.role !== "ceo") {
+      if (!actorAgent || (actorAgent.role !== "ceo" && actorAgent.role !== "coach")) {
         throw forbidden("Only CEO agents or board users may update company settings");
       }
       if (actorAgent.companyId !== companyId) {

--- a/skills/paperclip-coach/SKILL.md
+++ b/skills/paperclip-coach/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: paperclip-coach
+description: >
+  Onboarding Coach playbook. Use when you are a Coach assigned to a coach-onboarding
+  issue. Guide a human through goal-discovery using a Five Whys ladder, then
+  propose a workflow pattern, hiring plan, name, and mission. Build an Agent
+  Companies (agentcompanies/v1) package payload and submit it via the imports/apply
+  endpoint to atomically provision the live company. The Coach is a transient role
+  that ends with provisioning.
+---
+
+# Paperclip Coach Skill
+
+You are a **Coach** — a transient onboarding role. You help a human articulate what their company should be, then provision it as a real company through Paperclip's company-import endpoint. You produce **one Agent Companies (agentcompanies/v1) package** as your final artifact and submit it via the imports/apply route.
+
+You run in **heartbeats** like any other Paperclip agent — see the `paperclip` skill for general heartbeat mechanics, env vars, and authentication. This skill describes the Coach-specific procedure that goes inside each heartbeat.
+
+## Output discipline
+
+You are running in a focused onboarding chat. **The user does not see your status updates, plans, or phase markers.** Your only output is conversational comments addressed directly to the human, in the same register as a human coach would talk. No headers, no "Status:" lines, no "Phase A complete" announcements, no recap of what you just did. If you have nothing conversational to say this heartbeat, post nothing and exit silently.
+
+## The Coach procedure
+
+### Step 0 — Self-wake guard (mandatory, do this first)
+
+The platform may wake you on your own comments. If it does, **do not proceed**. Before any other API call:
+
+```
+GET /api/issues/{issueId}/comments?order=desc&limit=1
+```
+
+If the most recent comment was authored by you (your `agentId` matches), exit the heartbeat immediately. **Do not post anything. Do not narrate that you exited.** Just stop. Wasting a heartbeat reading your own messages is the most common failure mode of this skill.
+
+### Step 1 — Read state and identify phase
+
+Now (and only now) load context:
+
+```
+GET /api/issues/{issueId}/heartbeat-context
+GET /api/issues/{issueId}/interactions
+```
+
+Read the comment thread to figure out **which phase** you're in. Phases are an *internal* mental model — never mention them to the user.
+
+- **Phase A — Opener:** no comments from you yet. Go to Step 2.
+- **Phase B — Ladder:** you've asked one or more "why?" questions and the user has answered fewer than 3 (or hasn't reached a terminal value). Go to Step 3.
+- **Phase C — Synthesis proposal:** ladder complete (3–5 answers or user reached a terminal value); you haven't yet proposed a workflow + hiring plan + name + mission. Go to Step 4.
+- **Phase D — Refinement:** synthesis comment posted; the user replied with edits or "looks good" but you haven't yet posted the package confirmation. Go to Step 5.
+- **Phase E — Package proposal:** package document written, `RequestConfirmation` posted; waiting for user to accept. Go to Step 6.
+- **Phase F — Done:** import succeeded, the live company exists. Exit.
+
+If the user said something genuinely off-topic, respond conversationally to acknowledge it, then gently bring them back. Do not start over.
+
+### Step 2 — Phase A: Opener
+
+Post **one short comment**, conversational, no preamble. Just the question:
+
+> *"What problem are you trying to solve, and for whom?"*
+
+That's it. No "I'm your Coach," no "I'll ask five questions," no introduction — the UI tells the user who you are. Exit.
+
+### Step 3 — Phase B: Run the ladder (Five Whys)
+
+After the user answers the opener, drill **why** that goal matters, up to five turns. Stop early when they reach a terminal value.
+
+Each turn:
+
+1. Read the most recent user comment.
+2. If the user has reached a terminal value (a feeling — "I want to feel useful"; a fundamental need — "I need to make rent"; an identity statement — "this is who I am") **stop early** and advance to Phase C.
+3. Otherwise post **one short comment**: a brief reflection of what they said (one sentence at most) and the next question. Vary phrasing — don't literally write "why?" five times. Examples:
+   - *"What makes that important to you?"*
+   - *"If that worked, what changes?"*
+   - *"What's the deeper thing you'd be solving?"*
+   - *"What would be true about your life or your users that isn't true today?"*
+   - *"And under that — what's at the bottom of it?"*
+4. Exit.
+
+Keep it tight: one sentence of reflection, one question. **Do not number turns.** The user is in a conversation, not a workflow.
+
+### Step 4 — Phase C: Synthesis proposal
+
+Once the ladder is done, synthesize what you've learned and propose four things in **one combined comment**:
+
+1. **Company name** — propose 1 candidate (or up to 3 if the right one isn't obvious). Don't get cute.
+2. **Mission** — one sentence in the user's own language, with a 2–3 sentence elaboration drawn from the bottom of the ladder.
+3. **Workflow pattern** — pick the most natural fit from these four (read [the company-creator workflow taxonomy](#workflow-patterns) below) and state it with a one-line rationale.
+4. **Hiring plan** — propose **3–5 specific agents** by role with a one-line responsibility each. Stay lean. The user can adjust, but you're not asking "what agents do you want?" — you're proposing a concrete starting team based on the workflow and what they've told you.
+
+Format the comment plainly — the user is in a chat, not reading a document. Markdown is fine. Example shape:
+
+> *Here's what I'm hearing — let me know if anything's off.*
+>
+> **Company:** Beacon Logistics
+>
+> **Mission:** Help small carriers compete with national logistics platforms by automating their dispatch and customer-comms workflow.
+>
+> **How work would flow:** Pipeline (request → dispatch → execution → invoicing → review). Each stage hands off to the next; this is the right shape because logistics is naturally sequential.
+>
+> **Founding team (5):**
+> - **CEO** — sets direction, prioritizes, talks to founding customers
+> - **Dispatch Engineer** — owns the matching/scheduling logic
+> - **Integrations Engineer** — wires up carrier ELDs, customer portals, payment gateways
+> - **Customer Success** — onboards carriers, handles questions, surfaces feedback
+> - **Ops Analyst** — watches the dashboard, flags anomalies, runs weekly reviews
+>
+> *Want any of this changed before I provision?*
+
+Then exit. Wait for the user's reply.
+
+### Step 5 — Phase D: Refinement
+
+The user replied. Read their comment.
+
+- If they said "looks good" / "ship it" / similar acceptance: advance to Phase E (build & propose the package).
+- If they tweaked things ("rename Company X to Y" / "drop the Ops Analyst" / "I want a Designer instead of CS"): incorporate the changes, post a short reply confirming the new state in one paragraph (no big restructure), and advance to Phase E.
+- If they want a deeper rethink ("none of this fits"): apologize briefly, ask one focused clarifying question, exit. Resume the ladder from where their answer points.
+
+Don't loop on refinement more than twice. After two refinement rounds, propose the package and let acceptance settle it.
+
+### Step 6 — Phase E: Build & propose the package
+
+You now have: a name, a mission, a workflow pattern, a list of agents. Build an **Agent Companies (agentcompanies/v1)** package as a JSON document on the issue, then post a confirmation referencing it.
+
+Before writing files, read the spec for the structure you must conform to:
+
+```
+GET /api/companies/{companyId}/skills?path=skills/paperclip
+```
+
+…or read your local copy at `docs/companies/companies-spec.md` if it's mounted. The package must conform to **schema: agentcompanies/v1**.
+
+#### What goes in the package
+
+A minimum-viable package:
+
+- `COMPANY.md` — frontmatter with `schema: agentcompanies/v1`, `name`, `slug`, `description`. Body in markdown.
+- `agents/<slug>/AGENTS.md` — one file per agent. Frontmatter with `name`, `role`, `title`, `reportsTo` (the CEO's slug, or `null` for the CEO). Body explains the agent's responsibilities, **including how they fit into the workflow** (where work comes from, what they produce, who they hand off to, what triggers them).
+- `agents/ceo/AGENTS.md` — required for full companies. CEO has `reportsTo: null`.
+- `.paperclip.yaml` — only include if specific adapter overrides or env inputs are warranted. **Do not specify an adapter at all unless the user requested one.** Paperclip will use its default. **Do not add boilerplate env variables** (no default empty `ANTHROPIC_API_KEY`, no `GH_TOKEN` unless an agent actually needs it).
+
+Rules to follow:
+
+- Slugs are URL-safe, lowercase, hyphenated.
+- The CEO has `reportsTo: null`. Other agents `reportsTo: <ceo-slug>` or to a manager you've defined.
+- Every working agent's AGENTS.md body includes a concise execution contract:
+  - Start actionable work in the same heartbeat; do not stop at a plan unless planning was requested.
+  - Leave durable progress in comments, documents, or work products with the next action.
+  - Use child issues for long or parallel delegated work.
+  - Mark blocked work with the unblock owner and action.
+  - Respect budget, pause/cancel, approval gates, and company boundaries.
+- Do not export secrets, machine-local paths, or database IDs.
+- Omit empty/default fields.
+
+Optional v1 add-ons if the user asked for them: a single `projects/main/PROJECT.md`, one or two `tasks/<slug>/TASK.md` for the founding backlog. Skip teams, skills directories, and elaborate projects for v1 — those are v2.
+
+#### Write the package as a document
+
+The package is a **file map**: each entry's path maps to a string of the file's content. Write that file map as a document on this issue under the key `coach-package`. The document body is a JSON string (the only `format` Paperclip currently supports is `markdown` — that's just a storage label, the body itself is whatever you put there):
+
+```
+PUT /api/issues/{issueId}/documents/coach-package
+{
+  "title": "Company package",
+  "format": "markdown",
+  "body": "{\n  \"files\": {\n    \"COMPANY.md\": \"...\",\n    \"agents/ceo/AGENTS.md\": \"...\",\n    ...\n  }\n}"
+}
+```
+
+The body parses as JSON of the form:
+
+```json
+{
+  "files": {
+    "COMPANY.md": "...full file content...",
+    "agents/ceo/AGENTS.md": "...",
+    "agents/dispatch-engineer/AGENTS.md": "...",
+    ...
+  }
+}
+```
+
+Capture the response's `latestRevisionId` — you'll reference it in the confirmation target below.
+
+#### Propose it via RequestConfirmation
+
+After the document is written, post a confirmation interaction targeting it:
+
+```
+POST /api/issues/{issueId}/interactions
+{
+  "kind": "request_confirmation",
+  "payload": {
+    "version": 1,
+    "prompt": "Ready to launch <Company name>?",
+    "acceptLabel": "Launch",
+    "rejectLabel": "Hold on",
+    "supersedeOnUserComment": true,
+    "detailsMarkdown": "I've drafted the company package. Hitting Launch will create the live company with the team above. You can edit any agent's instructions afterward.",
+    "target": {
+      "type": "issue_document",
+      "key": "coach-package",
+      "revisionId": "<the document's current revisionId>",
+      "label": "Company package"
+    }
+  }
+}
+```
+
+Then exit. The chat UI handles the accept by reading the document, parsing the file map, and submitting it to `POST /api/companies/{draftCompanyId}/imports/apply` with `target.mode = "existing_company"` and `collisionStrategy = "skip"`. **You don't call the import yourself** — the user-driven UI does, with the user's auth.
+
+### Step 7 — Phase F: Done
+
+If you wake and the company has been provisioned (the latest interaction is an accepted `coach_launch_package` confirmation, or your assignee status has been changed because the import added a CEO), this skill no longer applies. Exit cleanly. The new CEO will pick up future work.
+
+## Workflow patterns
+
+Pick **one** that fits the company. The choice is based on how work moves through the org.
+
+- **Pipeline** — sequential stages, each agent hands off to the next. Use when the domain has a clear linear process (plan → build → review → ship → QA, or content ideation → draft → edit → publish).
+- **Hub-and-spoke** — a manager (usually the CEO) delegates to specialists who report back independently. Use when the agents do different kinds of work that don't feed into each other (CEO who dispatches to a researcher, a marketer, an analyst).
+- **Collaborative** — agents work together on the same things as peers. Use for small teams where everyone contributes to the same output (a design studio, a research team).
+- **On-demand** — agents are summoned as needed with no fixed flow. Use when agents are more like a toolbox of specialists the user calls directly.
+
+When you write each agent's AGENTS.md body, include workflow context: *where their work comes from*, *what they produce*, *who they hand off to*, *what triggers them*. This turns a list of agents into an organization that actually works together.
+
+## Interviewing principles
+
+- **Propose, don't ask open-ended.** "Here's a hiring plan — adjust as you like" beats "what agents do you want?"
+- **Stay lean.** 3–5 agents is typical for a startup. Don't suggest 10+ unless the scope clearly demands it.
+- **Full company vs. team/department.** From-scratch companies start with a CEO. Teams/departments don't need one. Default to full company.
+- **One thing at a time.** Each comment asks one question or proposes one decision. Don't dump a five-question survey into a chat.
+
+## Boundaries
+
+- **One substantive action per heartbeat.** Read state, do one thing (post a comment, write a document, post an interaction), exit.
+- **No code, no research, no strategy docs.** That's CEO work, not Coach work. If the user asks, say "I'll have your CEO pick that up after launch."
+- **No pre-population of agents** beyond the founding team in the package. Hiring more comes later.
+- **Don't speak as the company's CEO.** You're a coach helping the founder think. The CEO is a separate agent who exists after launch.
+
+## Error handling
+
+- 409 on checkout → exit (someone else owns the issue).
+- Unknown target kind on a `RequestConfirmationInteraction` → fall back to a structured comment with the same fields.
+- Three heartbeats in the same phase with no progress → post one short conversational message ("I'm stuck — could you say more about what you'd like next?") and exit.
+
+## v1 limitations
+
+- Five Whys is the only goal-discovery framework. WOOP, Odyssey Plans, and Pre-mortem land in v2.
+- No first-project or first-task proposals beyond the founding agents. The new CEO populates the backlog after launch.
+- No handoff path — the import path replaces the Coach implicitly when it adds the CEO. v2 may add an explicit handoff doc.
+- No scheduled re-runs (routines). v2.

--- a/skills/paperclip-coach/SKILL.md
+++ b/skills/paperclip-coach/SKILL.md
@@ -19,6 +19,35 @@ You run in **heartbeats** like any other Paperclip agent — see the `paperclip`
 
 You are running in a focused onboarding chat. **The user does not see your status updates, plans, or phase markers.** Your only output is conversational comments addressed directly to the human, in the same register as a human coach would talk. No headers, no "Status:" lines, no "Phase A complete" announcements, no recap of what you just did. If you have nothing conversational to say this heartbeat, post nothing and exit silently.
 
+### What a comment is
+
+A comment is **something the human reads in a chat bubble.** Before you call the post-comment tool, run this check:
+
+> If a stranger opened this chat and read only this comment, would they recognize it as a question, proposal, or warm reply directed at them?
+
+If the answer is no, **do not post it.** That's a tool-use error, not a chat message.
+
+### Never post any of these as a comment
+
+- Reasoning about heartbeat plumbing, self-wake guards, comment IDs, run IDs, agent IDs, phase letters, or system state. Examples of forbidden content (do **not** echo or paraphrase these):
+  - *"The 'new' comment that triggered this wake (efd33ace…) is the Coach opening message I posted in the previous heartbeat — not a user reply."*
+  - *"Disposition unchanged: in_review, real unblock path is the user replying to the Coach prompt. Exiting silently."*
+  - *"UNTAAA-2 has flipped back to in_progress as an unresolved blocker on UNTAAA-1."*
+- Recovery-flow / dispatcher / scheduler observations of any kind.
+- Numbered explanations of what you decided not to do and why.
+- Apologies or status notes addressed to "the system" or "future me."
+
+If the LLM in you wants to write any of the above, that's a signal to **exit silently**, not to post. Self-narration belongs in your private reasoning, not in the user's chat.
+
+### What you can post
+
+- A single short conversational question or reflection addressed to the user.
+- A combined synthesis comment (Phase C) that proposes a name, mission, workflow, and hiring plan.
+- A short refinement reply (Phase D) confirming changes the user asked for.
+- The launch-confirmation interaction (Phase E) — that's an *interaction*, not a comment, but it's user-facing.
+
+If a heartbeat would not produce one of those, post nothing. Exiting silently is the correct outcome more often than posting.
+
 ## The Coach procedure
 
 ### Step 0 — Self-wake guard (mandatory, do this first)

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -22,7 +22,9 @@ const TASK_TITLE = "E2E test task";
 
 test.describe("Onboarding wizard", () => {
   test("completes full wizard flow", async ({ page }) => {
-    await page.goto("/onboarding");
+    // The classic wizard moved to /onboarding/classic; the bare /onboarding
+    // route renders the new Coach-driven flow.
+    await page.goto("/onboarding/classic");
 
     const wizardHeading = page.locator("h3", { hasText: "Name your company" });
 

--- a/tests/e2e/planning-mode-visual-verification.spec.ts
+++ b/tests/e2e/planning-mode-visual-verification.spec.ts
@@ -10,7 +10,9 @@ test("captures planning mode UI for desktop and mobile", async ({ page }) => {
   const companyName = `PAP-3413-${timestamp}`;
   const screenshotDir = "test-results/planning-mode";
 
-  await page.goto("/onboarding");
+  // The classic wizard moved to /onboarding/classic; the bare /onboarding
+  // route renders the new Coach-driven flow.
+  await page.goto("/onboarding/classic");
   await expect(page.locator("h3", { hasText: "Name your company" })).toBeVisible({ timeout: 5_000 });
 
   await page.locator('input[placeholder="Acme Corp"]').fill(companyName);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,6 +2,8 @@ import { Navigate, Outlet, Route, Routes, useLocation, useParams } from "@/lib/r
 import { Button } from "@/components/ui/button";
 import { Layout } from "./components/Layout";
 import { OnboardingWizard } from "./components/OnboardingWizard";
+import { CoachOnboardingPage } from "./components/CoachOnboardingPage";
+import { OnboardingChat } from "./components/OnboardingChat";
 import { CloudAccessGate } from "./components/CloudAccessGate";
 import { Dashboard } from "./pages/Dashboard";
 import { DashboardLive } from "./pages/DashboardLive";
@@ -63,7 +65,9 @@ function boardRoutes() {
       <Route index element={<Navigate to="dashboard" replace />} />
       <Route path="dashboard" element={<Dashboard />} />
       <Route path="dashboard/live" element={<DashboardLive />} />
-      <Route path="onboarding" element={<OnboardingRoutePage />} />
+      <Route path="onboarding" element={<CoachOnboardingPage />} />
+      <Route path="onboarding/classic" element={<OnboardingRoutePage />} />
+      <Route path="onboarding/chat/:issueRef" element={<OnboardingChat />} />
       <Route path="companies" element={<Companies />} />
       <Route path="company/settings" element={<CompanySettings />} />
       <Route path="company/settings/environments" element={<CompanyEnvironments />} />
@@ -270,7 +274,8 @@ export function App() {
 
         <Route element={<CloudAccessGate />}>
           <Route index element={<CompanyRootRedirect />} />
-          <Route path="onboarding" element={<OnboardingRoutePage />} />
+          <Route path="onboarding" element={<CoachOnboardingPage />} />
+          <Route path="onboarding/classic" element={<OnboardingRoutePage />} />
           <Route path="instance" element={<Navigate to="/instance/settings/general" replace />} />
           <Route path="instance/settings" element={<Layout />}>
             <Route index element={<Navigate to="general" replace />} />

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -58,4 +58,12 @@ export const companiesApi = {
     api.post<CompanyPortabilityPreviewResult>("/companies/import/preview", data),
   importBundle: (data: CompanyPortabilityImportRequest) =>
     api.post<CompanyPortabilityImportResult>("/companies/import", data),
+  applyImportToCompany: (
+    companyId: string,
+    data: CompanyPortabilityImportRequest,
+  ) =>
+    api.post<CompanyPortabilityImportResult>(
+      `/companies/${companyId}/imports/apply`,
+      data,
+    ),
 };

--- a/ui/src/components/AdapterEnvironmentResult.tsx
+++ b/ui/src/components/AdapterEnvironmentResult.tsx
@@ -1,0 +1,55 @@
+import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
+
+export function AdapterEnvironmentResult({
+  result,
+}: {
+  result: AdapterEnvironmentTestResult;
+}) {
+  const statusLabel =
+    result.status === "pass"
+      ? "Passed"
+      : result.status === "warn"
+        ? "Warnings"
+        : "Failed";
+  const statusClass =
+    result.status === "pass"
+      ? "text-green-700 dark:text-green-300 border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10"
+      : result.status === "warn"
+        ? "text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-500/40 bg-amber-50 dark:bg-amber-500/10"
+        : "text-red-700 dark:text-red-300 border-red-300 dark:border-red-500/40 bg-red-50 dark:bg-red-500/10";
+
+  return (
+    <div className={`rounded-md border px-2.5 py-2 text-[11px] ${statusClass}`}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium">{statusLabel}</span>
+        <span className="opacity-80">
+          {new Date(result.testedAt).toLocaleTimeString()}
+        </span>
+      </div>
+      <div className="mt-1.5 space-y-1">
+        {result.checks.map((check, idx) => (
+          <div
+            key={`${check.code}-${idx}`}
+            className="leading-relaxed break-words"
+          >
+            <span className="font-medium uppercase tracking-wide opacity-80">
+              {check.level}
+            </span>
+            <span className="mx-1 opacity-60">·</span>
+            <span>{check.message}</span>
+            {check.detail ? (
+              <span className="block opacity-75 break-all">
+                ({check.detail})
+              </span>
+            ) : null}
+            {check.hint ? (
+              <span className="block opacity-90 break-words">
+                Hint: {check.hint}
+              </span>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/AdapterStepFields.tsx
+++ b/ui/src/components/AdapterStepFields.tsx
@@ -1,0 +1,382 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { Check, ChevronDown } from "lucide-react";
+import { cn } from "../lib/utils";
+import { agentsApi } from "../api/agents";
+import { queryKeys } from "../lib/queryKeys";
+import {
+  extractModelName,
+  extractProviderIdWithFallback,
+} from "../lib/model-utils";
+import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
+import { AdapterTypePicker } from "./AdapterTypePicker";
+import { AdapterEnvironmentResult } from "./AdapterEnvironmentResult";
+
+const COMMAND_PLACEHOLDERS: Record<string, string> = {
+  claude_local: "claude",
+  codex_local: "codex",
+  gemini_local: "gemini",
+  pi_local: "pi",
+  cursor: "agent",
+  opencode_local: "opencode",
+};
+
+export function resolveEffectiveAdapterCommand(
+  adapterType: string,
+  command: string,
+): string {
+  return (
+    command.trim()
+    || COMMAND_PLACEHOLDERS[adapterType]
+    || adapterType.replace(/_local$/, "")
+  );
+}
+
+export interface AdapterStepFieldsProps {
+  companyId: string | null;
+
+  adapterType: string;
+  onAdapterTypeChange: (next: string) => void;
+
+  model: string;
+  onModelChange: (next: string) => void;
+
+  url: string;
+  onUrlChange: (next: string) => void;
+
+  envResult: AdapterEnvironmentTestResult | null;
+  envError: string | null;
+  envLoading: boolean;
+  onRunProbe: () => Promise<void> | void;
+
+  forceUnsetAnthropicApiKey: boolean;
+  unsetAnthropicLoading: boolean;
+  onUnsetAnthropicApiKey: () => Promise<void> | void;
+
+  effectiveAdapterCommand: string;
+
+  enabled?: boolean;
+}
+
+export function AdapterStepFields({
+  companyId,
+  adapterType,
+  onAdapterTypeChange,
+  model,
+  onModelChange,
+  url,
+  onUrlChange,
+  envResult,
+  envError,
+  envLoading,
+  onRunProbe,
+  unsetAnthropicLoading,
+  onUnsetAnthropicApiKey,
+  effectiveAdapterCommand,
+  enabled = true,
+}: AdapterStepFieldsProps) {
+  const [modelOpen, setModelOpen] = useState(false);
+  const [modelSearch, setModelSearch] = useState("");
+
+  const getCapabilities = useAdapterCapabilities();
+  const adapterCaps = getCapabilities(adapterType);
+  const isLocalAdapter =
+    adapterCaps.supportsInstructionsBundle
+    || adapterCaps.supportsSkills
+    || adapterCaps.supportsLocalAgentJwt;
+
+  const { data: adapterModels } = useQuery({
+    queryKey: companyId
+      ? queryKeys.agents.adapterModels(companyId, adapterType, null)
+      : ["agents", "none", "adapter-models", adapterType, null],
+    queryFn: () =>
+      agentsApi.adapterModels(companyId!, adapterType, { environmentId: null }),
+    enabled: Boolean(companyId) && enabled && isLocalAdapter,
+  });
+
+  const selectedModel = (adapterModels ?? []).find((m) => m.id === model);
+
+  const filteredModels = useMemo(() => {
+    const query = modelSearch.trim().toLowerCase();
+    return (adapterModels ?? []).filter((entry) => {
+      if (!query) return true;
+      const provider = extractProviderIdWithFallback(entry.id, "");
+      return (
+        entry.id.toLowerCase().includes(query)
+        || entry.label.toLowerCase().includes(query)
+        || provider.toLowerCase().includes(query)
+      );
+    });
+  }, [adapterModels, modelSearch]);
+
+  const groupedModels = useMemo(() => {
+    if (adapterType !== "opencode_local") {
+      return [
+        {
+          provider: "models",
+          entries: [...filteredModels].sort((a, b) =>
+            a.id.localeCompare(b.id),
+          ),
+        },
+      ];
+    }
+    const groups = new Map<string, Array<{ id: string; label: string }>>();
+    for (const entry of filteredModels) {
+      const provider = extractProviderIdWithFallback(entry.id);
+      const bucket = groups.get(provider) ?? [];
+      bucket.push(entry);
+      groups.set(provider, bucket);
+    }
+    return Array.from(groups.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([provider, entries]) => ({
+        provider,
+        entries: [...entries].sort((a, b) => a.id.localeCompare(b.id)),
+      }));
+  }, [filteredModels, adapterType]);
+
+  const hasAnthropicApiKeyOverrideCheck =
+    envResult?.checks.some(
+      (check) =>
+        check.code === "claude_anthropic_api_key_overrides_subscription",
+    ) ?? false;
+  const shouldSuggestUnsetAnthropicApiKey =
+    adapterType === "claude_local"
+    && envResult?.status === "fail"
+    && hasAnthropicApiKeyOverrideCheck;
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <label className="text-xs text-muted-foreground mb-2 block">
+          Adapter type
+        </label>
+        <AdapterTypePicker value={adapterType} onChange={onAdapterTypeChange} />
+      </div>
+
+      {isLocalAdapter ? (
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">
+            Model
+          </label>
+          <Popover
+            open={modelOpen}
+            onOpenChange={(next) => {
+              setModelOpen(next);
+              if (!next) setModelSearch("");
+            }}
+          >
+            <PopoverTrigger asChild>
+              <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm hover:bg-accent/50 transition-colors w-full justify-between">
+                <span className={cn(!model && "text-muted-foreground")}>
+                  {selectedModel
+                    ? selectedModel.label
+                    : model
+                      || (adapterType === "opencode_local"
+                        ? "Select model (required)"
+                        : "Default")}
+                </span>
+                <ChevronDown className="h-3 w-3 text-muted-foreground" />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-[var(--radix-popover-trigger-width)] p-1"
+              align="start"
+            >
+              <input
+                className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
+                placeholder="Search models..."
+                value={modelSearch}
+                onChange={(e) => setModelSearch(e.target.value)}
+                autoFocus
+              />
+              {adapterType !== "opencode_local" ? (
+                <button
+                  className={cn(
+                    "flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50",
+                    !model && "bg-accent",
+                  )}
+                  onClick={() => {
+                    onModelChange("");
+                    setModelOpen(false);
+                  }}
+                >
+                  Default
+                </button>
+              ) : null}
+              <div className="max-h-[240px] overflow-y-auto">
+                {groupedModels.map((group) => (
+                  <div key={group.provider} className="mb-1 last:mb-0">
+                    {adapterType === "opencode_local" ? (
+                      <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                        {group.provider} ({group.entries.length})
+                      </div>
+                    ) : null}
+                    {group.entries.map((m) => (
+                      <button
+                        key={m.id}
+                        className={cn(
+                          "flex items-center w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50",
+                          m.id === model && "bg-accent",
+                        )}
+                        onClick={() => {
+                          onModelChange(m.id);
+                          setModelOpen(false);
+                        }}
+                      >
+                        <span
+                          className="block w-full text-left truncate"
+                          title={m.id}
+                        >
+                          {adapterType === "opencode_local"
+                            ? extractModelName(m.id)
+                            : m.label}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                ))}
+              </div>
+              {filteredModels.length === 0 ? (
+                <p className="px-2 py-1.5 text-xs text-muted-foreground">
+                  No models discovered.
+                </p>
+              ) : null}
+            </PopoverContent>
+          </Popover>
+        </div>
+      ) : null}
+
+      {isLocalAdapter ? (
+        <div className="space-y-2 rounded-md border border-border p-3">
+          <div className="flex items-center justify-between gap-2">
+            <div>
+              <p className="text-xs font-medium">Adapter environment check</p>
+              <p className="text-[11px] text-muted-foreground">
+                Runs a live probe that asks the adapter CLI to respond with hello.
+              </p>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 px-2.5 text-xs"
+              disabled={envLoading}
+              onClick={() => void onRunProbe()}
+            >
+              {envLoading ? "Testing..." : envResult ? "Re-test" : "Test now"}
+            </Button>
+          </div>
+
+          {envError ? (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-2 text-[11px] text-destructive">
+              {envError}
+            </div>
+          ) : null}
+
+          {envResult?.status === "pass" ? (
+            <div className="flex items-center gap-2 rounded-md border border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10 px-3 py-2 text-xs text-green-700 dark:text-green-300 animate-in fade-in slide-in-from-bottom-1 duration-300">
+              <Check className="h-3.5 w-3.5 shrink-0" />
+              <span className="font-medium">Passed</span>
+            </div>
+          ) : envResult ? (
+            <AdapterEnvironmentResult result={envResult} />
+          ) : null}
+
+          {shouldSuggestUnsetAnthropicApiKey ? (
+            <div className="rounded-md border border-amber-300/60 bg-amber-50/40 px-2.5 py-2 space-y-2">
+              <p className="text-[11px] text-amber-900/90 leading-relaxed">
+                Claude failed while{" "}
+                <span className="font-mono">ANTHROPIC_API_KEY</span> is set. You
+                can clear it in this CEO adapter config and retry the probe.
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 px-2.5 text-xs"
+                disabled={envLoading || unsetAnthropicLoading}
+                onClick={() => void onUnsetAnthropicApiKey()}
+              >
+                {unsetAnthropicLoading
+                  ? "Retrying..."
+                  : "Unset ANTHROPIC_API_KEY"}
+              </Button>
+            </div>
+          ) : null}
+
+          {envResult?.status === "fail" ? (
+            <div className="rounded-md border border-border/70 bg-muted/20 px-2.5 py-2 text-[11px] space-y-1.5">
+              <p className="font-medium">Manual debug</p>
+              <p className="text-muted-foreground font-mono break-all">
+                {adapterType === "cursor"
+                  ? `${effectiveAdapterCommand} -p --mode ask --output-format json "Respond with hello."`
+                  : adapterType === "codex_local"
+                    ? `${effectiveAdapterCommand} exec --json -`
+                    : adapterType === "gemini_local"
+                      ? `${effectiveAdapterCommand} --output-format json "Respond with hello."`
+                      : adapterType === "opencode_local"
+                        ? `${effectiveAdapterCommand} run --format json "Respond with hello."`
+                        : `${effectiveAdapterCommand} --print - --output-format stream-json --verbose`}
+              </p>
+              <p className="text-muted-foreground">
+                Prompt:{" "}
+                <span className="font-mono">Respond with hello.</span>
+              </p>
+              {adapterType === "cursor"
+                || adapterType === "codex_local"
+                || adapterType === "gemini_local"
+                || adapterType === "opencode_local" ? (
+                <p className="text-muted-foreground">
+                  If auth fails, set{" "}
+                  <span className="font-mono">
+                    {adapterType === "cursor"
+                      ? "CURSOR_API_KEY"
+                      : adapterType === "gemini_local"
+                        ? "GEMINI_API_KEY"
+                        : "OPENAI_API_KEY"}
+                  </span>{" "}
+                  in env or run{" "}
+                  <span className="font-mono">
+                    {adapterType === "cursor"
+                      ? "agent login"
+                      : adapterType === "codex_local"
+                        ? "codex login"
+                        : adapterType === "gemini_local"
+                          ? "gemini auth"
+                          : "opencode auth login"}
+                  </span>
+                  .
+                </p>
+              ) : (
+                <p className="text-muted-foreground">
+                  If login is required, run{" "}
+                  <span className="font-mono">claude login</span> and retry.
+                </p>
+              )}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {adapterType === "http" || adapterType === "openclaw_gateway" ? (
+        <div>
+          <label className="text-xs text-muted-foreground mb-1 block">
+            {adapterType === "openclaw_gateway" ? "Gateway URL" : "Webhook URL"}
+          </label>
+          <input
+            className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+            placeholder={
+              adapterType === "openclaw_gateway"
+                ? "ws://127.0.0.1:18789"
+                : "https://..."
+            }
+            value={url}
+            onChange={(e) => onUrlChange(e.target.value)}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/components/AdapterTypePicker.tsx
+++ b/ui/src/components/AdapterTypePicker.tsx
@@ -1,0 +1,126 @@
+import { useMemo, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "../lib/utils";
+import { listUIAdapters } from "../adapters";
+import { isVisualAdapterChoice } from "../adapters/metadata";
+import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
+import { getAdapterDisplay } from "../adapters/adapter-display-registry";
+
+interface AdapterTypePickerProps {
+  value: string;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const SYSTEM_ADAPTER_TYPES = new Set(["process", "http"]);
+
+export function AdapterTypePicker({
+  value,
+  onChange,
+  disabled,
+  className,
+}: AdapterTypePickerProps) {
+  const disabledTypes = useDisabledAdaptersSync();
+  const [showMore, setShowMore] = useState(false);
+
+  const { recommended, more } = useMemo(() => {
+    const all = listUIAdapters()
+      .filter(
+        (a) =>
+          !SYSTEM_ADAPTER_TYPES.has(a.type)
+          && !disabledTypes.has(a.type)
+          && isVisualAdapterChoice(a.type),
+      )
+      .map((a) => ({ ...getAdapterDisplay(a.type), type: a.type }));
+
+    return {
+      recommended: all.filter((a) => a.recommended),
+      more: all.filter((a) => !a.recommended),
+    };
+  }, [disabledTypes]);
+
+  return (
+    <div className={className}>
+      <div className="grid grid-cols-2 gap-2">
+        {recommended.map((opt) => (
+          <button
+            key={opt.type}
+            type="button"
+            disabled={disabled}
+            className={cn(
+              "flex flex-col items-center gap-1.5 rounded-md border p-3 text-xs transition-colors relative",
+              value === opt.type
+                ? "border-foreground bg-accent"
+                : "border-border hover:bg-accent/50",
+              disabled && "opacity-60 cursor-not-allowed",
+            )}
+            onClick={() => onChange(opt.type)}
+          >
+            {opt.recommended ? (
+              <span className="absolute -top-1.5 right-1.5 bg-green-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full leading-none">
+                Recommended
+              </span>
+            ) : null}
+            <opt.icon className="h-4 w-4" />
+            <span className="font-medium">{opt.label}</span>
+            <span className="text-muted-foreground text-[10px]">
+              {opt.description}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {more.length > 0 ? (
+        <>
+          <button
+            type="button"
+            className="flex items-center gap-1.5 mt-3 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            onClick={() => setShowMore((v) => !v)}
+            disabled={disabled}
+          >
+            <ChevronDown
+              className={cn(
+                "h-3 w-3 transition-transform",
+                showMore ? "rotate-0" : "-rotate-90",
+              )}
+            />
+            More Agent Adapter Types
+          </button>
+
+          {showMore ? (
+            <div className="grid grid-cols-2 gap-2 mt-2">
+              {more.map((opt) => (
+                <button
+                  key={opt.type}
+                  type="button"
+                  disabled={disabled || Boolean(opt.comingSoon)}
+                  className={cn(
+                    "flex flex-col items-center gap-1.5 rounded-md border p-3 text-xs transition-colors relative",
+                    opt.comingSoon
+                      ? "border-border opacity-40 cursor-not-allowed"
+                      : value === opt.type
+                        ? "border-foreground bg-accent"
+                        : "border-border hover:bg-accent/50",
+                  )}
+                  onClick={() => {
+                    if (opt.comingSoon) return;
+                    onChange(opt.type);
+                  }}
+                >
+                  <opt.icon className="h-4 w-4" />
+                  <span className="font-medium">{opt.label}</span>
+                  <span className="text-muted-foreground text-[10px]">
+                    {opt.comingSoon
+                      ? (opt.disabledLabel ?? "Coming soon")
+                      : opt.description}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/components/CoachOnboardingPage.tsx
+++ b/ui/src/components/CoachOnboardingPage.tsx
@@ -29,6 +29,8 @@ import {
   resolveEffectiveAdapterCommand,
 } from "./AdapterStepFields";
 import { OnboardingChrome } from "./OnboardingChrome";
+import { OnboardingStepTabs } from "./OnboardingStepTabs";
+import { COACH_STEP_TABS } from "./onboarding-coach-steps";
 
 const COACH_ISSUE_TITLE = "Welcome — let's figure out what your company should do";
 const COACH_ISSUE_DESCRIPTION =
@@ -290,6 +292,12 @@ export function CoachOnboardingPage() {
   return (
     <OnboardingChrome showAnimation={true}>
       <div className="w-full max-w-md mx-auto my-auto px-8 py-12 space-y-4">
+        <OnboardingStepTabs
+          items={COACH_STEP_TABS.map((item) =>
+            item.id === "chat" ? { ...item, disabled: true } : item,
+          )}
+          activeId="configure"
+        />
         <div className="rounded-lg border border-border bg-card p-6">
           <h1 className="text-xl font-semibold">Talk to a Coach</h1>
           <p className="mt-2 text-sm text-muted-foreground">

--- a/ui/src/components/CoachOnboardingPage.tsx
+++ b/ui/src/components/CoachOnboardingPage.tsx
@@ -16,23 +16,64 @@ import {
   buildOnboardingIssuePayload,
 } from "../lib/onboarding-launch";
 import { getUIAdapter } from "../adapters";
+import {
+  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
+  DEFAULT_CODEX_LOCAL_MODEL,
+} from "@paperclipai/adapter-codex-local";
+import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
+import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
+import { DEFAULT_OPENCODE_LOCAL_MODEL } from "@paperclipai/adapter-opencode-local";
 import { defaultCreateValues } from "./agent-config-defaults";
-import { AdapterTypePicker } from "./AdapterTypePicker";
-import { AdapterEnvironmentResult } from "./AdapterEnvironmentResult";
+import {
+  AdapterStepFields,
+  resolveEffectiveAdapterCommand,
+} from "./AdapterStepFields";
 import { OnboardingChrome } from "./OnboardingChrome";
 
 const COACH_ISSUE_TITLE = "Welcome — let's figure out what your company should do";
 const COACH_ISSUE_DESCRIPTION =
   "Your Coach will start the conversation here. Reply when you're ready.";
 
-function buildCoachAdapterConfig(adapterType: string): Record<string, unknown> {
+function buildCoachAdapterConfig(args: {
+  adapterType: string;
+  model: string;
+  url: string;
+  forceUnsetAnthropicApiKey: boolean;
+}): Record<string, unknown> {
+  const { adapterType, model, url, forceUnsetAnthropicApiKey } = args;
   const adapter = getUIAdapter(adapterType);
-  return adapter.buildAdapterConfig({
+  const config = adapter.buildAdapterConfig({
     ...defaultCreateValues,
     adapterType,
+    model:
+      adapterType === "codex_local"
+        ? model || DEFAULT_CODEX_LOCAL_MODEL
+        : adapterType === "gemini_local"
+          ? model || DEFAULT_GEMINI_LOCAL_MODEL
+          : adapterType === "cursor"
+            ? model || DEFAULT_CURSOR_LOCAL_MODEL
+            : adapterType === "opencode_local"
+              ? model || DEFAULT_OPENCODE_LOCAL_MODEL
+              : model,
+    url,
     dangerouslySkipPermissions:
       adapterType === "claude_local" || adapterType === "opencode_local",
+    dangerouslyBypassSandbox:
+      adapterType === "codex_local"
+        ? DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX
+        : defaultCreateValues.dangerouslyBypassSandbox,
   });
+  if (adapterType === "claude_local" && forceUnsetAnthropicApiKey) {
+    const env =
+      typeof config.env === "object"
+        && config.env !== null
+        && !Array.isArray(config.env)
+        ? { ...(config.env as Record<string, unknown>) }
+        : {};
+    env.ANTHROPIC_API_KEY = { type: "plain", value: "" };
+    config.env = env;
+  }
+  return config;
 }
 
 export function CoachOnboardingPage() {
@@ -40,6 +81,11 @@ export function CoachOnboardingPage() {
   const queryClient = useQueryClient();
   const { setSelectedCompanyId } = useCompany();
   const [adapterType, setAdapterType] = useState<string>("claude_local");
+  const [model, setModel] = useState("");
+  const [url, setUrl] = useState("");
+  const [forceUnsetAnthropicApiKey, setForceUnsetAnthropicApiKey] =
+    useState(false);
+  const [unsetAnthropicLoading, setUnsetAnthropicLoading] = useState(false);
   const [companyId, setCompanyId] = useState<string | null>(null);
   const [companyPrefix, setCompanyPrefix] = useState<string | null>(null);
   const [adapterEnvResult, setAdapterEnvResult] =
@@ -49,15 +95,41 @@ export function CoachOnboardingPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Reset env test state when the adapter changes — old result no longer applies.
-  const lastAdapterRef = useRef(adapterType);
+  // Reset env test state when the adapter or its config changes — old result
+  // no longer applies.
+  const lastAdapterKeyRef = useRef(`${adapterType}|${model}|${url}`);
   useEffect(() => {
-    if (lastAdapterRef.current !== adapterType) {
-      lastAdapterRef.current = adapterType;
+    const key = `${adapterType}|${model}|${url}`;
+    if (lastAdapterKeyRef.current !== key) {
+      lastAdapterKeyRef.current = key;
       setAdapterEnvResult(null);
       setAdapterEnvError(null);
     }
-  }, [adapterType]);
+  }, [adapterType, model, url]);
+
+  const effectiveAdapterCommand = resolveEffectiveAdapterCommand(adapterType, "");
+
+  function handleAdapterTypeChange(nextType: string) {
+    setAdapterType(nextType);
+    setForceUnsetAnthropicApiKey(false);
+    if (nextType === "codex_local") {
+      if (!model) setModel(DEFAULT_CODEX_LOCAL_MODEL);
+      return;
+    }
+    if (nextType === "opencode_local") {
+      setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
+      return;
+    }
+    if (nextType === "gemini_local" && !model) {
+      setModel(DEFAULT_GEMINI_LOCAL_MODEL);
+      return;
+    }
+    if (nextType === "cursor" && !model) {
+      setModel(DEFAULT_CURSOR_LOCAL_MODEL);
+      return;
+    }
+    setModel("");
+  }
 
   const testPassed =
     adapterEnvResult !== null && adapterEnvResult.status !== "fail";
@@ -78,12 +150,21 @@ export function CoachOnboardingPage() {
     return { id: company.id, issuePrefix: company.issuePrefix };
   }
 
-  async function runTest(): Promise<AdapterEnvironmentTestResult | null> {
+  async function runTest(
+    adapterConfigOverride?: Record<string, unknown>,
+  ): Promise<AdapterEnvironmentTestResult | null> {
     setAdapterEnvLoading(true);
     setAdapterEnvError(null);
     try {
       const { id } = await ensureCompany();
-      const adapterConfig = buildCoachAdapterConfig(adapterType);
+      const adapterConfig =
+        adapterConfigOverride
+        ?? buildCoachAdapterConfig({
+          adapterType,
+          model,
+          url,
+          forceUnsetAnthropicApiKey,
+        });
       const result = await agentsApi.testEnvironment(id, adapterType, {
         adapterConfig,
       });
@@ -96,6 +177,36 @@ export function CoachOnboardingPage() {
       return null;
     } finally {
       setAdapterEnvLoading(false);
+    }
+  }
+
+  async function handleUnsetAnthropicApiKey() {
+    if (unsetAnthropicLoading) return;
+    setUnsetAnthropicLoading(true);
+    setError(null);
+    setAdapterEnvError(null);
+    setForceUnsetAnthropicApiKey(true);
+    try {
+      const configWithUnset = buildCoachAdapterConfig({
+        adapterType,
+        model,
+        url,
+        forceUnsetAnthropicApiKey: true,
+      });
+      const result = await runTest(configWithUnset);
+      if (result?.status === "fail") {
+        setError(
+          "Retried with ANTHROPIC_API_KEY unset, but the environment test is still failing.",
+        );
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to unset ANTHROPIC_API_KEY and retry.",
+      );
+    } finally {
+      setUnsetAnthropicLoading(false);
     }
   }
 
@@ -123,7 +234,12 @@ export function CoachOnboardingPage() {
         return;
       }
 
-      const adapterConfig = buildCoachAdapterConfig(adapterType);
+      const adapterConfig = buildCoachAdapterConfig({
+        adapterType,
+        model,
+        url,
+        forceUnsetAnthropicApiKey,
+      });
       const hire = await agentsApi.hire(id, {
         name: "Coach",
         role: "coach",
@@ -184,54 +300,32 @@ export function CoachOnboardingPage() {
           </p>
 
           <div className="mt-5">
-            <label className="text-xs text-muted-foreground mb-2 block">
-              Adapter
-            </label>
-            <AdapterTypePicker
-              value={adapterType}
-              onChange={setAdapterType}
-              disabled={submitting || adapterEnvLoading}
+            <AdapterStepFields
+              companyId={companyId}
+              adapterType={adapterType}
+              onAdapterTypeChange={handleAdapterTypeChange}
+              model={model}
+              onModelChange={setModel}
+              url={url}
+              onUrlChange={setUrl}
+              envResult={adapterEnvResult}
+              envError={adapterEnvError}
+              envLoading={adapterEnvLoading}
+              onRunProbe={() => {
+                void runTest();
+              }}
+              forceUnsetAnthropicApiKey={forceUnsetAnthropicApiKey}
+              unsetAnthropicLoading={unsetAnthropicLoading}
+              onUnsetAnthropicApiKey={handleUnsetAnthropicApiKey}
+              effectiveAdapterCommand={effectiveAdapterCommand}
+              enabled={!submitting}
             />
-            <p className="mt-2 text-[11px] text-muted-foreground">
-              We'll use the adapter's defaults. You can edit the agent's config later
-              once the conversation starts.
-            </p>
-          </div>
-
-          <div className="mt-5 space-y-2">
-            <div className="flex items-center justify-between gap-2">
-              <span className="text-xs text-muted-foreground">
-                Adapter environment
-              </span>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={runTest}
-                disabled={adapterEnvLoading || submitting}
-              >
-                {adapterEnvLoading ? (
-                  <>
-                    <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
-                    Testing…
-                  </>
-                ) : adapterEnvResult ? (
-                  "Re-test"
-                ) : (
-                  "Test now"
-                )}
-              </Button>
-            </div>
-            {adapterEnvError ? (
-              <p className="text-xs text-red-600">{adapterEnvError}</p>
-            ) : null}
-            {adapterEnvResult ? (
-              <AdapterEnvironmentResult result={adapterEnvResult} />
-            ) : (
-              <p className="text-[11px] text-muted-foreground">
+            {!adapterEnvResult ? (
+              <p className="mt-3 text-[11px] text-muted-foreground">
                 We'll verify your adapter can reach a model before starting. Test
                 runs automatically when you click Start, or trigger it now.
               </p>
-            )}
+            ) : null}
           </div>
 
           <div className="mt-5">

--- a/ui/src/components/CoachOnboardingPage.tsx
+++ b/ui/src/components/CoachOnboardingPage.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
+import { Link, useNavigate } from "@/lib/router";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+import { useCompany } from "../context/CompanyContext";
+import { companiesApi } from "../api/companies";
+import { agentsApi } from "../api/agents";
+import { issuesApi } from "../api/issues";
+import { projectsApi } from "../api/projects";
+import { queryKeys } from "../lib/queryKeys";
+import { buildNewAgentRuntimeConfig } from "../lib/new-agent-runtime-config";
+import {
+  ONBOARDING_PROJECT_NAME,
+  buildOnboardingIssuePayload,
+} from "../lib/onboarding-launch";
+import { getUIAdapter } from "../adapters";
+import { defaultCreateValues } from "./agent-config-defaults";
+import { AdapterTypePicker } from "./AdapterTypePicker";
+import { AdapterEnvironmentResult } from "./AdapterEnvironmentResult";
+import { OnboardingChrome } from "./OnboardingChrome";
+
+const COACH_ISSUE_TITLE = "Welcome — let's figure out what your company should do";
+const COACH_ISSUE_DESCRIPTION =
+  "Your Coach will start the conversation here. Reply when you're ready.";
+
+function buildCoachAdapterConfig(adapterType: string): Record<string, unknown> {
+  const adapter = getUIAdapter(adapterType);
+  return adapter.buildAdapterConfig({
+    ...defaultCreateValues,
+    adapterType,
+    dangerouslySkipPermissions:
+      adapterType === "claude_local" || adapterType === "opencode_local",
+  });
+}
+
+export function CoachOnboardingPage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { setSelectedCompanyId } = useCompany();
+  const [adapterType, setAdapterType] = useState<string>("claude_local");
+  const [companyId, setCompanyId] = useState<string | null>(null);
+  const [companyPrefix, setCompanyPrefix] = useState<string | null>(null);
+  const [adapterEnvResult, setAdapterEnvResult] =
+    useState<AdapterEnvironmentTestResult | null>(null);
+  const [adapterEnvError, setAdapterEnvError] = useState<string | null>(null);
+  const [adapterEnvLoading, setAdapterEnvLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset env test state when the adapter changes — old result no longer applies.
+  const lastAdapterRef = useRef(adapterType);
+  useEffect(() => {
+    if (lastAdapterRef.current !== adapterType) {
+      lastAdapterRef.current = adapterType;
+      setAdapterEnvResult(null);
+      setAdapterEnvError(null);
+    }
+  }, [adapterType]);
+
+  const testPassed =
+    adapterEnvResult !== null && adapterEnvResult.status !== "fail";
+
+  async function ensureCompany(): Promise<{ id: string; issuePrefix: string }> {
+    if (companyId && companyPrefix) {
+      return { id: companyId, issuePrefix: companyPrefix };
+    }
+    const company = await companiesApi.create({
+      name: "Untitled",
+      description: "Onboarding draft — your Coach is helping you shape this.",
+    });
+    setSelectedCompanyId(company.id);
+    queryClient.invalidateQueries({ queryKey: queryKeys.companies.all });
+    await companiesApi.update(company.id, { status: "draft" });
+    setCompanyId(company.id);
+    setCompanyPrefix(company.issuePrefix);
+    return { id: company.id, issuePrefix: company.issuePrefix };
+  }
+
+  async function runTest(): Promise<AdapterEnvironmentTestResult | null> {
+    setAdapterEnvLoading(true);
+    setAdapterEnvError(null);
+    try {
+      const { id } = await ensureCompany();
+      const adapterConfig = buildCoachAdapterConfig(adapterType);
+      const result = await agentsApi.testEnvironment(id, adapterType, {
+        adapterConfig,
+      });
+      setAdapterEnvResult(result);
+      return result;
+    } catch (err) {
+      setAdapterEnvError(
+        err instanceof Error ? err.message : "Adapter environment test failed",
+      );
+      return null;
+    } finally {
+      setAdapterEnvLoading(false);
+    }
+  }
+
+  async function handleStart() {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const { id, issuePrefix } = await ensureCompany();
+
+      // Test must pass (or warn) before we commit to hiring. If the user
+      // didn't run it explicitly, run it now.
+      const result = adapterEnvResult ?? (await runTest());
+      if (!result) {
+        // runTest sets adapterEnvError; surface it on the Start button row too.
+        if (!adapterEnvError) {
+          setError("Couldn't reach the adapter to test it. Try again.");
+        }
+        return;
+      }
+      if (result.status === "fail") {
+        setError(
+          "Adapter environment test failed. Fix the issues above before continuing.",
+        );
+        return;
+      }
+
+      const adapterConfig = buildCoachAdapterConfig(adapterType);
+      const hire = await agentsApi.hire(id, {
+        name: "Coach",
+        role: "coach",
+        adapterType,
+        adapterConfig,
+        runtimeConfig: buildNewAgentRuntimeConfig(),
+      });
+      const agentId = hire.agent.id;
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(id) });
+
+      const project = await projectsApi.create(id, {
+        name: ONBOARDING_PROJECT_NAME,
+        status: "in_progress",
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.projects.list(id) });
+
+      const issue = await issuesApi.create(
+        id,
+        buildOnboardingIssuePayload({
+          title: COACH_ISSUE_TITLE,
+          description: COACH_ISSUE_DESCRIPTION,
+          assigneeAgentId: agentId,
+          projectId: project.id,
+          goalId: null,
+        }),
+      );
+      queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(id) });
+
+      const issueRef =
+        (issue as { identifier?: string; id: string }).identifier ?? issue.id;
+      navigate(`/${issuePrefix}/onboarding/chat/${issueRef}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to start onboarding");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const startDisabled = submitting || adapterEnvLoading;
+  const startLabel = submitting
+    ? "Starting…"
+    : testPassed
+      ? "Start with a Coach"
+      : adapterEnvResult?.status === "fail"
+        ? "Fix issues above"
+        : "Test & start with a Coach";
+
+  return (
+    <OnboardingChrome showAnimation={true}>
+      <div className="w-full max-w-md mx-auto my-auto px-8 py-12 space-y-4">
+        <div className="rounded-lg border border-border bg-card p-6">
+          <h1 className="text-xl font-semibold">Talk to a Coach</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            We'll spin up a Coach agent and start a conversation. The Coach helps you
+            figure out what your company should focus on by asking a handful of questions,
+            then proposes a name and mission you can accept or refine. When you're ready,
+            the Coach becomes your CEO.
+          </p>
+
+          <div className="mt-5">
+            <label className="text-xs text-muted-foreground mb-2 block">
+              Adapter
+            </label>
+            <AdapterTypePicker
+              value={adapterType}
+              onChange={setAdapterType}
+              disabled={submitting || adapterEnvLoading}
+            />
+            <p className="mt-2 text-[11px] text-muted-foreground">
+              We'll use the adapter's defaults. You can edit the agent's config later
+              once the conversation starts.
+            </p>
+          </div>
+
+          <div className="mt-5 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-xs text-muted-foreground">
+                Adapter environment
+              </span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={runTest}
+                disabled={adapterEnvLoading || submitting}
+              >
+                {adapterEnvLoading ? (
+                  <>
+                    <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                    Testing…
+                  </>
+                ) : adapterEnvResult ? (
+                  "Re-test"
+                ) : (
+                  "Test now"
+                )}
+              </Button>
+            </div>
+            {adapterEnvError ? (
+              <p className="text-xs text-red-600">{adapterEnvError}</p>
+            ) : null}
+            {adapterEnvResult ? (
+              <AdapterEnvironmentResult result={adapterEnvResult} />
+            ) : (
+              <p className="text-[11px] text-muted-foreground">
+                We'll verify your adapter can reach a model before starting. Test
+                runs automatically when you click Start, or trigger it now.
+              </p>
+            )}
+          </div>
+
+          <div className="mt-5">
+            <Button onClick={handleStart} disabled={startDisabled}>
+              {submitting ? (
+                <>
+                  <Loader2 className="h-3.5 w-3.5 mr-1 animate-spin" />
+                  {startLabel}
+                </>
+              ) : (
+                startLabel
+              )}
+            </Button>
+          </div>
+          {error ? <p className="mt-3 text-sm text-red-600">{error}</p> : null}
+        </div>
+        <p className="text-xs text-muted-foreground text-center">
+          Want a form-based setup instead?{" "}
+          <Link to="/onboarding/classic" className="underline">
+            Switch to classic onboarding
+          </Link>
+          .
+        </p>
+      </div>
+    </OnboardingChrome>
+  );
+}

--- a/ui/src/components/OnboardingChat.tsx
+++ b/ui/src/components/OnboardingChat.tsx
@@ -284,6 +284,13 @@ export function OnboardingChat() {
         <p className="text-[11px] text-muted-foreground">
           Your Coach asks questions to help shape your company. Answer freely; the conversation is just between you and the Coach.
         </p>
+        <p className="text-[11px] text-muted-foreground mt-1">
+          Prefer to fill out a form?{" "}
+          <a href="/onboarding/classic" className="underline">
+            Switch to classic onboarding
+          </a>
+          {" "}— this Coach conversation will stay here as a draft.
+        </p>
       </div>
 
       <div

--- a/ui/src/components/OnboardingChat.tsx
+++ b/ui/src/components/OnboardingChat.tsx
@@ -1,0 +1,378 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  CompanyPortabilityFileEntry,
+  IssueComment,
+  IssueThreadInteraction,
+  RequestConfirmationInteraction,
+  RequestConfirmationIssueDocumentTarget,
+} from "@paperclipai/shared";
+import { useNavigate, useParams } from "@/lib/router";
+import { Button } from "@/components/ui/button";
+import { cn } from "../lib/utils";
+import { useCompany } from "../context/CompanyContext";
+import { issuesApi } from "../api/issues";
+import { agentsApi } from "../api/agents";
+import { companiesApi } from "../api/companies";
+import { queryKeys } from "../lib/queryKeys";
+import { Loader2 } from "lucide-react";
+import { OnboardingChrome } from "./OnboardingChrome";
+
+const POLL_INTERVAL_MS = 4000;
+const COACH_RESPONSE_GRACE_MS = 1500;
+const COACH_PACKAGE_DOCUMENT_KEY = "coach-package";
+
+type ChatBubble = {
+  id: string;
+  side: "coach" | "you";
+  body: string;
+  createdAt: Date;
+};
+
+function classifyComment(
+  comment: IssueComment,
+  coachAgentId: string | null,
+): ChatBubble | null {
+  const side: ChatBubble["side"] | null = (() => {
+    if (coachAgentId && comment.authorAgentId === coachAgentId) return "coach";
+    if (comment.authorUserId) return "you";
+    if (comment.authorAgentId) return "coach";
+    return null;
+  })();
+  if (!side) return null;
+  return {
+    id: comment.id,
+    side,
+    body: comment.body,
+    createdAt: comment.createdAt instanceof Date ? comment.createdAt : new Date(comment.createdAt),
+  };
+}
+
+function findPendingLaunchConfirmation(
+  interactions: IssueThreadInteraction[] | undefined,
+): RequestConfirmationInteraction | null {
+  if (!interactions) return null;
+  for (const interaction of interactions) {
+    if (interaction.kind !== "request_confirmation") continue;
+    if (interaction.status !== "pending") continue;
+    const target = interaction.payload.target;
+    if (!target || target.type !== "issue_document") continue;
+    const docTarget = target as RequestConfirmationIssueDocumentTarget;
+    if (docTarget.key !== COACH_PACKAGE_DOCUMENT_KEY) continue;
+    return interaction as RequestConfirmationInteraction;
+  }
+  return null;
+}
+
+function parsePackageDocument(body: string): Record<string, CompanyPortabilityFileEntry> | null {
+  try {
+    const parsed = JSON.parse(body);
+    if (!parsed || typeof parsed !== "object") return null;
+    const files = (parsed as { files?: unknown }).files;
+    if (!files || typeof files !== "object" || Array.isArray(files)) return null;
+    return files as Record<string, CompanyPortabilityFileEntry>;
+  } catch {
+    return null;
+  }
+}
+
+export function OnboardingChat() {
+  const params = useParams<{ companyPrefix?: string; issueRef?: string }>();
+  const issueRef = params.issueRef;
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { setSelectedCompanyId, companies } = useCompany();
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [launching, setLaunching] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+  const lastSendAtRef = useRef<number>(0);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const issueQuery = useQuery({
+    queryKey: queryKeys.issues.detail(issueRef ?? ""),
+    queryFn: () => issuesApi.get(issueRef!),
+    enabled: Boolean(issueRef),
+  });
+  const issue = issueQuery.data ?? null;
+  const issueId = issue?.id ?? null;
+  const coachAgentId = issue?.assigneeAgentId ?? null;
+
+  useEffect(() => {
+    if (issue?.companyId) setSelectedCompanyId(issue.companyId);
+  }, [issue?.companyId, setSelectedCompanyId]);
+
+  const commentsQuery = useQuery({
+    queryKey: ["onboarding-chat", "comments", issueId],
+    queryFn: () => issuesApi.listComments(issueId!, { order: "asc", limit: 200 }),
+    enabled: Boolean(issueId),
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+
+  const interactionsQuery = useQuery({
+    queryKey: ["onboarding-chat", "interactions", issueId],
+    queryFn: () => issuesApi.listInteractions(issueId!),
+    enabled: Boolean(issueId),
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+
+  const coachQuery = useQuery({
+    queryKey: queryKeys.agents.detail(coachAgentId ?? ""),
+    queryFn: () => agentsApi.get(coachAgentId!),
+    enabled: Boolean(coachAgentId),
+    refetchInterval: POLL_INTERVAL_MS,
+  });
+  const coach = coachQuery.data ?? null;
+
+  const company = useMemo(
+    () => (issue ? companies.find((c) => c.id === issue.companyId) ?? null : null),
+    [issue, companies],
+  );
+
+  const bubbles = useMemo(() => {
+    const raw = commentsQuery.data ?? [];
+    return raw
+      .map((c) => classifyComment(c, coachAgentId))
+      .filter((b): b is ChatBubble => b !== null);
+  }, [commentsQuery.data, coachAgentId]);
+
+  const launchConfirmation = useMemo(
+    () => findPendingLaunchConfirmation(interactionsQuery.data),
+    [interactionsQuery.data],
+  );
+
+  const coachThinking = useMemo(() => {
+    if (launchConfirmation) return false;
+    const lastBubble = bubbles[bubbles.length - 1];
+    const userJustSent = lastBubble?.side === "you";
+    const agentRunning = coach?.status === "running";
+    const sinceSendOk = Date.now() - lastSendAtRef.current >= COACH_RESPONSE_GRACE_MS;
+    return (userJustSent || agentRunning) && sinceSendOk && !sending;
+  }, [launchConfirmation, bubbles, coach?.status, sending]);
+
+  useEffect(() => {
+    const node = scrollRef.current;
+    if (!node) return;
+    node.scrollTop = node.scrollHeight;
+  }, [bubbles.length, coachThinking, launchConfirmation?.id]);
+
+  async function handleSend() {
+    if (!issueId || !draft.trim() || sending) return;
+    setSending(true);
+    setSendError(null);
+    try {
+      await issuesApi.addComment(issueId, draft.trim());
+      lastSendAtRef.current = Date.now();
+      setDraft("");
+      await queryClient.invalidateQueries({
+        queryKey: ["onboarding-chat", "comments", issueId],
+      });
+    } catch (err) {
+      setSendError(err instanceof Error ? err.message : "Failed to send");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  async function handleLaunch() {
+    if (!issueId || !issue || !launchConfirmation || launching) return;
+    setLaunching(true);
+    setLaunchError(null);
+    try {
+      const doc = await issuesApi.getDocument(issueId, COACH_PACKAGE_DOCUMENT_KEY);
+      const files = parsePackageDocument(doc.body);
+      if (!files || Object.keys(files).length === 0) {
+        throw new Error(
+          "The Coach's package document is empty or malformed. Ask the Coach to rewrite it.",
+        );
+      }
+
+      await companiesApi.applyImportToCompany(issue.companyId, {
+        source: { type: "inline", files },
+        target: { mode: "existing_company", companyId: issue.companyId },
+        collisionStrategy: "skip",
+      });
+
+      await companiesApi.update(issue.companyId, { status: "active" });
+
+      await issuesApi.acceptInteraction(issueId, launchConfirmation.id);
+
+      const targetCompany =
+        companies.find((c) => c.id === issue.companyId) ?? company;
+      const prefix = targetCompany?.issuePrefix ?? params.companyPrefix ?? "";
+      navigate(`/${prefix}/dashboard`);
+    } catch (err) {
+      setLaunchError(err instanceof Error ? err.message : "Failed to launch");
+    } finally {
+      setLaunching(false);
+    }
+  }
+
+  async function handleHoldOn() {
+    if (!issueId || !launchConfirmation || launching) return;
+    setLaunching(true);
+    setLaunchError(null);
+    try {
+      await issuesApi.rejectInteraction(issueId, launchConfirmation.id);
+      await queryClient.invalidateQueries({
+        queryKey: ["onboarding-chat", "interactions", issueId],
+      });
+    } catch (err) {
+      setLaunchError(err instanceof Error ? err.message : "Failed to send rejection");
+    } finally {
+      setLaunching(false);
+    }
+  }
+
+  if (!issueRef) {
+    return (
+      <OnboardingChrome showAnimation={false}>
+        <div className="mx-auto max-w-2xl py-10 text-sm text-muted-foreground">
+          No onboarding chat selected.
+        </div>
+      </OnboardingChrome>
+    );
+  }
+
+  if (issueQuery.isLoading) {
+    return (
+      <OnboardingChrome showAnimation={false}>
+        <div className="mx-auto max-w-2xl py-10 text-sm text-muted-foreground flex items-center gap-2 px-4">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading your Coach…
+        </div>
+      </OnboardingChrome>
+    );
+  }
+
+  if (issueQuery.isError || !issue) {
+    return (
+      <OnboardingChrome showAnimation={false}>
+        <div className="mx-auto max-w-2xl py-10 px-4">
+          <div className="rounded-lg border border-border bg-card p-6">
+            <h1 className="text-lg font-semibold">Couldn't open the onboarding chat</h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {issueQuery.error instanceof Error ? issueQuery.error.message : "Unknown error"}
+            </p>
+            <div className="mt-4">
+              <Button variant="outline" onClick={() => navigate("/onboarding")}>
+                Restart onboarding
+              </Button>
+            </div>
+          </div>
+        </div>
+      </OnboardingChrome>
+    );
+  }
+
+  const heading = company?.name && company.name !== "Untitled"
+    ? `Onboarding — ${company.name}`
+    : "Talking with your Coach";
+
+  return (
+    <OnboardingChrome showAnimation={false}>
+    <div className="mx-auto flex h-full max-w-2xl flex-col px-4 py-6">
+      <div className="mb-4">
+        <h1 className="text-base font-medium">{heading}</h1>
+        <p className="text-[11px] text-muted-foreground">
+          Your Coach asks questions to help shape your company. Answer freely; the conversation is just between you and the Coach.
+        </p>
+      </div>
+
+      <div
+        ref={scrollRef}
+        className="flex-1 overflow-y-auto rounded-lg border border-border bg-card p-4 space-y-3"
+      >
+        {bubbles.length === 0 && !coachThinking && !launchConfirmation ? (
+          <p className="text-sm text-muted-foreground">
+            Your Coach is getting set up. The first question will appear in a moment…
+          </p>
+        ) : null}
+        {bubbles.map((bubble) => (
+          <div
+            key={bubble.id}
+            className={cn(
+              "flex",
+              bubble.side === "you" ? "justify-end" : "justify-start",
+            )}
+          >
+            <div
+              className={cn(
+                "max-w-[85%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap",
+                bubble.side === "you"
+                  ? "bg-foreground text-background"
+                  : "bg-muted text-foreground",
+              )}
+            >
+              {bubble.body}
+            </div>
+          </div>
+        ))}
+        {coachThinking ? (
+          <div className="flex justify-start">
+            <div className="max-w-[85%] rounded-lg bg-muted px-3 py-2 text-sm text-muted-foreground italic">
+              Coach is thinking…
+            </div>
+          </div>
+        ) : null}
+        {launchConfirmation ? (
+          <div className="flex justify-start">
+            <div className="w-full rounded-lg border border-border bg-muted/30 p-4 space-y-3">
+              <div className="text-sm font-medium">{launchConfirmation.payload.prompt}</div>
+              {launchConfirmation.payload.detailsMarkdown ? (
+                <div className="text-sm text-muted-foreground whitespace-pre-wrap">
+                  {launchConfirmation.payload.detailsMarkdown}
+                </div>
+              ) : null}
+              <div className="flex items-center gap-2">
+                <Button onClick={handleLaunch} disabled={launching}>
+                  {launching ? "Launching…" : (launchConfirmation.payload.acceptLabel ?? "Launch")}
+                </Button>
+                <Button variant="outline" onClick={handleHoldOn} disabled={launching}>
+                  {launchConfirmation.payload.rejectLabel ?? "Hold on"}
+                </Button>
+              </div>
+              {launchError ? (
+                <p className="text-sm text-red-600">{launchError}</p>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-3">
+        <textarea
+          className="w-full resize-none rounded-md border border-border bg-transparent px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50 min-h-[60px]"
+          placeholder={
+            bubbles.length === 0
+              ? "Wait for your Coach to ask the first question…"
+              : "Reply to your Coach…"
+          }
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={sending || launching}
+        />
+        <div className="mt-2 flex items-center justify-between gap-3">
+          <p className="text-[11px] text-muted-foreground">
+            Enter to send. Shift-Enter for a new line.
+          </p>
+          <Button onClick={handleSend} disabled={!draft.trim() || sending || launching}>
+            {sending ? "Sending…" : "Send"}
+          </Button>
+        </div>
+        {sendError ? (
+          <p className="mt-2 text-sm text-red-600">{sendError}</p>
+        ) : null}
+      </div>
+    </div>
+    </OnboardingChrome>
+  );
+}

--- a/ui/src/components/OnboardingChat.tsx
+++ b/ui/src/components/OnboardingChat.tsx
@@ -17,6 +17,8 @@ import { companiesApi } from "../api/companies";
 import { queryKeys } from "../lib/queryKeys";
 import { Loader2 } from "lucide-react";
 import { OnboardingChrome } from "./OnboardingChrome";
+import { OnboardingStepTabs } from "./OnboardingStepTabs";
+import { COACH_STEP_TABS } from "./onboarding-coach-steps";
 
 const POLL_INTERVAL_MS = 4000;
 const COACH_RESPONSE_GRACE_MS = 1500;
@@ -279,6 +281,13 @@ export function OnboardingChat() {
   return (
     <OnboardingChrome showAnimation={false}>
     <div className="mx-auto flex h-full max-w-2xl flex-col px-4 py-6">
+      <OnboardingStepTabs
+        items={COACH_STEP_TABS}
+        activeId="chat"
+        onSelect={(id) => {
+          if (id === "configure") navigate("/onboarding");
+        }}
+      />
       <div className="mb-4">
         <h1 className="text-base font-medium">{heading}</h1>
         <p className="text-[11px] text-muted-foreground">

--- a/ui/src/components/OnboardingChrome.tsx
+++ b/ui/src/components/OnboardingChrome.tsx
@@ -1,0 +1,61 @@
+import { X } from "lucide-react";
+import { cn } from "../lib/utils";
+import { AsciiArtAnimation } from "./AsciiArtAnimation";
+
+interface OnboardingChromeProps {
+  children: React.ReactNode;
+  /** Show the animated right-side panel. Defaults to true (the entry-point look). */
+  showAnimation?: boolean;
+  /** If provided, renders a close button in the top-left that calls this. */
+  onClose?: () => void;
+  /** Optional className override for the outer container (rare). */
+  className?: string;
+}
+
+/**
+ * Shared chrome for the onboarding flow. Mirrors the classic wizard's split
+ * layout — full-viewport background, left content pane, animated ASCII pane on
+ * the right (md+). Used by both the Coach entry page and the Coach chat so the
+ * onboarding experience feels continuous.
+ */
+export function OnboardingChrome({
+  children,
+  showAnimation = true,
+  onClose,
+  className,
+}: OnboardingChromeProps) {
+  return (
+    <div className={cn("fixed inset-0 z-40 bg-background", className)}>
+      <div className="absolute inset-0 flex">
+        {onClose ? (
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute top-4 left-4 z-10 rounded-sm p-1.5 text-muted-foreground/60 hover:text-foreground transition-colors"
+          >
+            <X className="h-5 w-5" />
+            <span className="sr-only">Close</span>
+          </button>
+        ) : null}
+
+        <div
+          className={cn(
+            "w-full flex flex-col overflow-y-auto transition-[width] duration-500 ease-in-out",
+            showAnimation ? "md:w-1/2" : "md:w-full",
+          )}
+        >
+          {children}
+        </div>
+
+        <div
+          className={cn(
+            "hidden md:block overflow-hidden bg-[#1d1d1d] transition-[width,opacity] duration-500 ease-in-out",
+            showAnimation ? "w-1/2 opacity-100" : "w-0 opacity-0",
+          )}
+        >
+          <AsciiArtAnimation />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/OnboardingStepTabs.tsx
+++ b/ui/src/components/OnboardingStepTabs.tsx
@@ -1,0 +1,58 @@
+import type { ComponentType, SVGProps } from "react";
+import { cn } from "../lib/utils";
+
+export interface OnboardingStepTabItem {
+  id: string;
+  label: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  disabled?: boolean;
+}
+
+interface OnboardingStepTabsProps {
+  items: ReadonlyArray<OnboardingStepTabItem>;
+  activeId: string;
+  onSelect?: (id: string) => void;
+  className?: string;
+}
+
+export function OnboardingStepTabs({
+  items,
+  activeId,
+  onSelect,
+  className,
+}: OnboardingStepTabsProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-0 mb-8 border-b border-border",
+        className,
+      )}
+    >
+      {items.map(({ id, label, icon: Icon, disabled }) => {
+        const isActive = id === activeId;
+        return (
+          <button
+            key={id}
+            type="button"
+            disabled={disabled}
+            onClick={() => {
+              if (disabled || isActive) return;
+              onSelect?.(id);
+            }}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-2 text-xs font-medium border-b-2 -mb-px transition-colors",
+              disabled
+                ? "border-transparent text-muted-foreground/40 cursor-not-allowed"
+                : isActive
+                  ? "border-foreground text-foreground cursor-default"
+                  : "border-transparent text-muted-foreground hover:text-foreground/70 hover:border-border cursor-pointer",
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
-import { useLocation, useNavigate, useParams } from "@/lib/router";
+import { Link, useLocation, useNavigate, useParams } from "@/lib/router";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { companiesApi } from "../api/companies";
@@ -700,6 +700,20 @@ export function OnboardingWizard() {
                       onChange={(e) => setCompanyGoal(e.target.value)}
                     />
                   </div>
+                  <p className="text-xs text-muted-foreground text-center pt-2">
+                    Want a conversation instead?{" "}
+                    <Link
+                      to="/onboarding"
+                      onClick={() => {
+                        setRouteDismissed(true);
+                        closeOnboarding();
+                      }}
+                      className="underline"
+                    >
+                      Switch to Coach onboarding
+                    </Link>
+                    .
+                  </p>
                 </div>
               )}
 

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -225,6 +225,17 @@ export function OnboardingWizard() {
     adapterType === "claude_local" &&
     adapterEnvResult?.status === "fail" &&
     hasAnthropicApiKeyOverrideCheck;
+  // Step 2 Next button — derived from probe state.
+  const stepTwoTestFailed =
+    isLocalAdapter && adapterEnvResult?.status === "fail";
+  const stepTwoTestNotRun = isLocalAdapter && adapterEnvResult === null;
+  const stepTwoLabel = loading
+    ? "Creating..."
+    : stepTwoTestFailed
+      ? "Fix issues above"
+      : stepTwoTestNotRun
+        ? "Test & next"
+        : "Next";
   const filteredModels = useMemo(() => {
     const query = modelSearch.trim().toLowerCase();
     return (adapterModels ?? []).filter((entry) => {
@@ -415,6 +426,12 @@ export function OnboardingWizard() {
       if (isLocalAdapter) {
         const result = adapterEnvResult ?? (await runAdapterEnvironmentTest());
         if (!result) return;
+        // The probe is advisory: a `fail` result does NOT block hire here.
+        // Visible gating happens via the disabled state on the Step 2 Next
+        // button when the user has explicitly run the probe and seen the
+        // failure. Clicking "Test & next" before the probe has run still
+        // proceeds through a failing probe by design — tightening that to
+        // block in the handler is a separate decision.
       }
 
       const hire = await agentsApi.hire(createdCompanyId, {
@@ -1120,7 +1137,10 @@ export function OnboardingWizard() {
                     <Button
                       size="sm"
                       disabled={
-                        !agentName.trim() || loading || adapterEnvLoading
+                        !agentName.trim()
+                        || loading
+                        || adapterEnvLoading
+                        || stepTwoTestFailed
                       }
                       onClick={handleStep2Next}
                     >
@@ -1129,7 +1149,7 @@ export function OnboardingWizard() {
                       ) : (
                         <ArrowRight className="h-3.5 w-3.5 mr-1" />
                       )}
-                      {loading ? "Creating..." : "Next"}
+                      {stepTwoLabel}
                     </Button>
                   )}
                   {step === 3 && (

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -24,11 +24,7 @@ import {
   extractProviderIdWithFallback
 } from "../lib/model-utils";
 import { getUIAdapter } from "../adapters";
-import { listUIAdapters } from "../adapters";
-import { isVisualAdapterChoice } from "../adapters/metadata";
-import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
-import { getAdapterDisplay } from "../adapters/adapter-display-registry";
 import { defaultCreateValues } from "./agent-config-defaults";
 import { parseOnboardingGoalInput } from "../lib/onboarding-goal";
 import {
@@ -46,6 +42,8 @@ import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
+import { AdapterEnvironmentResult } from "./AdapterEnvironmentResult";
+import { AdapterTypePicker } from "./AdapterTypePicker";
 import {
   Building2,
   Bot,
@@ -54,8 +52,8 @@ import {
   ArrowLeft,
   ArrowRight,
   Check,
-  Loader2,
   ChevronDown,
+  Loader2,
   X
 } from "lucide-react";
 
@@ -77,9 +75,6 @@ export function OnboardingWizard() {
   const location = useLocation();
   const { companyPrefix } = useParams<{ companyPrefix?: string }>();
   const [routeDismissed, setRouteDismissed] = useState(false);
-
-  // Sync disabled adapter types from server so adapter grid filters them out
-  const disabledTypes = useDisabledAdaptersSync();
 
   const routeOnboardingOptions =
     companyPrefix && companiesLoading
@@ -122,7 +117,6 @@ export function OnboardingWizard() {
   const [forceUnsetAnthropicApiKey, setForceUnsetAnthropicApiKey] =
     useState(false);
   const [unsetAnthropicLoading, setUnsetAnthropicLoading] = useState(false);
-  const [showMoreAdapters, setShowMoreAdapters] = useState(false);
 
   // Step 3
   const [taskTitle, setTaskTitle] = useState(
@@ -203,23 +197,6 @@ export function OnboardingWizard() {
   const adapterCaps = getCapabilities(adapterType);
   const isLocalAdapter = adapterCaps.supportsInstructionsBundle || adapterCaps.supportsSkills || adapterCaps.supportsLocalAgentJwt;
 
-  // Build adapter grids dynamically from the UI registry + display metadata.
-  // External/plugin adapters automatically appear with generic defaults.
-  const { recommendedAdapters, moreAdapters } = useMemo(() => {
-    const SYSTEM_ADAPTER_TYPES = new Set(["process", "http"]);
-    const all = listUIAdapters()
-      .filter((a) =>
-        !SYSTEM_ADAPTER_TYPES.has(a.type) &&
-        !disabledTypes.has(a.type) &&
-        isVisualAdapterChoice(a.type)
-      )
-      .map((a) => ({ ...getAdapterDisplay(a.type), type: a.type }));
-
-    return {
-      recommendedAdapters: all.filter((a) => a.recommended),
-      moreAdapters: all.filter((a) => !a.recommended),
-    };
-  }, [disabledTypes]);
   const COMMAND_PLACEHOLDERS: Record<string, string> = {
     claude_local: "claude",
     codex_local: "codex",
@@ -740,103 +717,30 @@ export function OnboardingWizard() {
                     <label className="text-xs text-muted-foreground mb-2 block">
                       Adapter type
                     </label>
-                    <div className="grid grid-cols-2 gap-2">
-                      {recommendedAdapters.map((opt) => (
-                        <button
-                          key={opt.type}
-                          className={cn(
-                            "flex flex-col items-center gap-1.5 rounded-md border p-3 text-xs transition-colors relative",
-                            adapterType === opt.type
-                              ? "border-foreground bg-accent"
-                              : "border-border hover:bg-accent/50"
-                          )}
-                          onClick={() => {
-                            const nextType = opt.type;
-                            setAdapterType(nextType);
-                            if (nextType === "codex_local") {
-                              if (!model) {
-                                setModel(DEFAULT_CODEX_LOCAL_MODEL);
-                              }
-                              return;
-                            }
-                            if (nextType === "opencode_local") {
-                              setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
-                              return;
-                            }
-                            setModel("");
-                          }}
-                        >
-                          {opt.recommended && (
-                            <span className="absolute -top-1.5 right-1.5 bg-green-500 text-white text-[9px] font-semibold px-1.5 py-0.5 rounded-full leading-none">
-                              Recommended
-                            </span>
-                          )}
-                          <opt.icon className="h-4 w-4" />
-                          <span className="font-medium">{opt.label}</span>
-                          <span className="text-muted-foreground text-[10px]">
-                            {opt.description}
-                          </span>
-                        </button>
-                      ))}
-                    </div>
-
-                    <button
-                      className="flex items-center gap-1.5 mt-3 text-xs text-muted-foreground hover:text-foreground transition-colors"
-                      onClick={() => setShowMoreAdapters((v) => !v)}
-                    >
-                      <ChevronDown
-                        className={cn(
-                          "h-3 w-3 transition-transform",
-                          showMoreAdapters ? "rotate-0" : "-rotate-90"
-                        )}
-                      />
-                      More Agent Adapter Types
-                    </button>
-
-                    {showMoreAdapters && (
-                      <div className="grid grid-cols-2 gap-2 mt-2">
-                        {moreAdapters.map((opt) => (
-                           <button
-                             key={opt.type}
-                             disabled={!!opt.comingSoon}
-                             className={cn(
-                               "flex flex-col items-center gap-1.5 rounded-md border p-3 text-xs transition-colors relative",
-                               opt.comingSoon
-                                 ? "border-border opacity-40 cursor-not-allowed"
-                                 : adapterType === opt.type
-                                 ? "border-foreground bg-accent"
-                                 : "border-border hover:bg-accent/50"
-                             )}
-                             onClick={() => {
-                               if (opt.comingSoon) return;
-                               const nextType = opt.type;
-                              setAdapterType(nextType);
-                              if (nextType === "gemini_local" && !model) {
-                                setModel(DEFAULT_GEMINI_LOCAL_MODEL);
-                                return;
-                              }
-                              if (nextType === "cursor" && !model) {
-                                setModel(DEFAULT_CURSOR_LOCAL_MODEL);
-                                return;
-                              }
-                              if (nextType === "opencode_local") {
-                                setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
-                                return;
-                              }
-                              setModel("");
-                            }}
-                          >
-                            <opt.icon className="h-4 w-4" />
-                            <span className="font-medium">{opt.label}</span>
-                            <span className="text-muted-foreground text-[10px]">
-                              {opt.comingSoon
-                                ? opt.disabledLabel ?? "Coming soon"
-                                : opt.description}
-                            </span>
-                          </button>
-                        ))}
-                      </div>
-                    )}
+                    <AdapterTypePicker
+                      value={adapterType}
+                      onChange={(nextType) => {
+                        setAdapterType(nextType);
+                        // Auto-default model when switching adapters that need one.
+                        if (nextType === "codex_local") {
+                          if (!model) setModel(DEFAULT_CODEX_LOCAL_MODEL);
+                          return;
+                        }
+                        if (nextType === "opencode_local") {
+                          setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
+                          return;
+                        }
+                        if (nextType === "gemini_local" && !model) {
+                          setModel(DEFAULT_GEMINI_LOCAL_MODEL);
+                          return;
+                        }
+                        if (nextType === "cursor" && !model) {
+                          setModel(DEFAULT_CURSOR_LOCAL_MODEL);
+                          return;
+                        }
+                        setModel("");
+                      }}
+                    />
                   </div>
 
                   {/* Conditional adapter fields */}
@@ -1272,56 +1176,3 @@ export function OnboardingWizard() {
   );
 }
 
-function AdapterEnvironmentResult({
-  result
-}: {
-  result: AdapterEnvironmentTestResult;
-}) {
-  const statusLabel =
-    result.status === "pass"
-      ? "Passed"
-      : result.status === "warn"
-      ? "Warnings"
-      : "Failed";
-  const statusClass =
-    result.status === "pass"
-      ? "text-green-700 dark:text-green-300 border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10"
-      : result.status === "warn"
-      ? "text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-500/40 bg-amber-50 dark:bg-amber-500/10"
-      : "text-red-700 dark:text-red-300 border-red-300 dark:border-red-500/40 bg-red-50 dark:bg-red-500/10";
-
-  return (
-    <div className={`rounded-md border px-2.5 py-2 text-[11px] ${statusClass}`}>
-      <div className="flex items-center justify-between gap-2">
-        <span className="font-medium">{statusLabel}</span>
-        <span className="opacity-80">
-          {new Date(result.testedAt).toLocaleTimeString()}
-        </span>
-      </div>
-      <div className="mt-1.5 space-y-1">
-        {result.checks.map((check, idx) => (
-          <div
-            key={`${check.code}-${idx}`}
-            className="leading-relaxed break-words"
-          >
-            <span className="font-medium uppercase tracking-wide opacity-80">
-              {check.level}
-            </span>
-            <span className="mx-1 opacity-60">·</span>
-            <span>{check.message}</span>
-            {check.detail && (
-              <span className="block opacity-75 break-all">
-                ({check.detail})
-              </span>
-            )}
-            {check.hint && (
-              <span className="block opacity-90 break-words">
-                Hint: {check.hint}
-              </span>
-            )}
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -37,6 +37,7 @@ import {
   AdapterStepFields,
   resolveEffectiveAdapterCommand,
 } from "./AdapterStepFields";
+import { OnboardingStepTabs, type OnboardingStepTabItem } from "./OnboardingStepTabs";
 import {
   Building2,
   Bot,
@@ -52,6 +53,13 @@ import {
 
 type Step = 1 | 2 | 3 | 4;
 type AdapterType = string;
+
+const WIZARD_STEP_TABS: ReadonlyArray<OnboardingStepTabItem> = [
+  { id: "1", label: "Company", icon: Building2 },
+  { id: "2", label: "Agent", icon: Bot },
+  { id: "3", label: "Task", icon: ListTodo },
+  { id: "4", label: "Launch", icon: Rocket },
+];
 
 const DEFAULT_TASK_DESCRIPTION = `You are the CEO. You set the direction for the company.
 
@@ -569,32 +577,12 @@ export function OnboardingWizard() {
             )}
           >
             <div className="w-full max-w-md mx-auto my-auto px-8 py-12 shrink-0">
-              {/* Progress tabs */}
-              <div className="flex items-center gap-0 mb-8 border-b border-border">
-                {(
-                  [
-                    { step: 1 as Step, label: "Company", icon: Building2 },
-                    { step: 2 as Step, label: "Agent", icon: Bot },
-                    { step: 3 as Step, label: "Task", icon: ListTodo },
-                    { step: 4 as Step, label: "Launch", icon: Rocket }
-                  ] as const
-                ).map(({ step: s, label, icon: Icon }) => (
-                  <button
-                    key={s}
-                    type="button"
-                    onClick={() => setStep(s)}
-                    className={cn(
-                      "flex items-center gap-1.5 px-3 py-2 text-xs font-medium border-b-2 -mb-px transition-colors cursor-pointer",
-                      s === step
-                        ? "border-foreground text-foreground"
-                        : "border-transparent text-muted-foreground hover:text-foreground/70 hover:border-border"
-                    )}
-                  >
-                    <Icon className="h-3.5 w-3.5" />
-                    {label}
-                  </button>
-                ))}
-              </div>
+              <OnboardingStepTabs
+                items={WIZARD_STEP_TABS}
+                activeId={String(step)}
+                onSelect={(id) => setStep(Number(id) as Step)}
+              />
+
 
               {/* Step content */}
               {step === 1 && (

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useRef, useCallback, useMemo } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState, useRef, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
 import { Link, useLocation, useNavigate, useParams } from "@/lib/router";
 import { useDialog } from "../context/DialogContext";
@@ -12,17 +12,8 @@ import { issuesApi } from "../api/issues";
 import { projectsApi } from "../api/projects";
 import { queryKeys } from "../lib/queryKeys";
 import { Dialog, DialogPortal } from "@/components/ui/dialog";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger
-} from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 import { cn } from "../lib/utils";
-import {
-  extractModelName,
-  extractProviderIdWithFallback
-} from "../lib/model-utils";
 import { getUIAdapter } from "../adapters";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
 import { defaultCreateValues } from "./agent-config-defaults";
@@ -42,8 +33,10 @@ import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
 import { resolveRouteOnboardingOptions } from "../lib/onboarding-route";
 import { AsciiArtAnimation } from "./AsciiArtAnimation";
-import { AdapterEnvironmentResult } from "./AdapterEnvironmentResult";
-import { AdapterTypePicker } from "./AdapterTypePicker";
+import {
+  AdapterStepFields,
+  resolveEffectiveAdapterCommand,
+} from "./AdapterStepFields";
 import {
   Building2,
   Bot,
@@ -52,7 +45,6 @@ import {
   ArrowLeft,
   ArrowRight,
   Check,
-  ChevronDown,
   Loader2,
   X
 } from "lucide-react";
@@ -96,8 +88,6 @@ export function OnboardingWizard() {
   const [step, setStep] = useState<Step>(initialStep);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [modelOpen, setModelOpen] = useState(false);
-  const [modelSearch, setModelSearch] = useState("");
 
   // Step 1
   const [companyName, setCompanyName] = useState("");
@@ -184,30 +174,11 @@ export function OnboardingWizard() {
     if (step === 3) autoResizeTextarea();
   }, [step, taskDescription, autoResizeTextarea]);
 
-  const { data: adapterModels } = useQuery({
-    // The wizard doesn't expose an environment selector, so models always
-    // resolve against the local Paperclip host (environmentId = null).
-    queryKey: createdCompanyId
-      ? queryKeys.agents.adapterModels(createdCompanyId, adapterType, null)
-      : ["agents", "none", "adapter-models", adapterType, null],
-    queryFn: () => agentsApi.adapterModels(createdCompanyId!, adapterType, { environmentId: null }),
-    enabled: Boolean(createdCompanyId) && effectiveOnboardingOpen && step === 2
-  });
   const getCapabilities = useAdapterCapabilities();
   const adapterCaps = getCapabilities(adapterType);
   const isLocalAdapter = adapterCaps.supportsInstructionsBundle || adapterCaps.supportsSkills || adapterCaps.supportsLocalAgentJwt;
 
-  const COMMAND_PLACEHOLDERS: Record<string, string> = {
-    claude_local: "claude",
-    codex_local: "codex",
-    gemini_local: "gemini",
-    pi_local: "pi",
-    cursor: "agent",
-    opencode_local: "opencode",
-  };
-  const effectiveAdapterCommand =
-    command.trim() ||
-    (COMMAND_PLACEHOLDERS[adapterType] ?? adapterType.replace(/_local$/, ""));
+  const effectiveAdapterCommand = resolveEffectiveAdapterCommand(adapterType, command);
 
   useEffect(() => {
     if (step !== 2) return;
@@ -215,16 +186,6 @@ export function OnboardingWizard() {
     setAdapterEnvError(null);
   }, [step, adapterType, model, command, args, url]);
 
-  const selectedModel = (adapterModels ?? []).find((m) => m.id === model);
-  const hasAnthropicApiKeyOverrideCheck =
-    adapterEnvResult?.checks.some(
-      (check) =>
-        check.code === "claude_anthropic_api_key_overrides_subscription"
-    ) ?? false;
-  const shouldSuggestUnsetAnthropicApiKey =
-    adapterType === "claude_local" &&
-    adapterEnvResult?.status === "fail" &&
-    hasAnthropicApiKeyOverrideCheck;
   // Step 2 Next button — derived from probe state.
   const stepTwoTestFailed =
     isLocalAdapter && adapterEnvResult?.status === "fail";
@@ -236,41 +197,27 @@ export function OnboardingWizard() {
       : stepTwoTestNotRun
         ? "Test & next"
         : "Next";
-  const filteredModels = useMemo(() => {
-    const query = modelSearch.trim().toLowerCase();
-    return (adapterModels ?? []).filter((entry) => {
-      if (!query) return true;
-      const provider = extractProviderIdWithFallback(entry.id, "");
-      return (
-        entry.id.toLowerCase().includes(query) ||
-        entry.label.toLowerCase().includes(query) ||
-        provider.toLowerCase().includes(query)
-      );
-    });
-  }, [adapterModels, modelSearch]);
-  const groupedModels = useMemo(() => {
-    if (adapterType !== "opencode_local") {
-      return [
-        {
-          provider: "models",
-          entries: [...filteredModels].sort((a, b) => a.id.localeCompare(b.id))
-        }
-      ];
+
+  function handleAdapterTypeChange(nextType: string) {
+    setAdapterType(nextType);
+    if (nextType === "codex_local") {
+      if (!model) setModel(DEFAULT_CODEX_LOCAL_MODEL);
+      return;
     }
-    const groups = new Map<string, Array<{ id: string; label: string }>>();
-    for (const entry of filteredModels) {
-      const provider = extractProviderIdWithFallback(entry.id);
-      const bucket = groups.get(provider) ?? [];
-      bucket.push(entry);
-      groups.set(provider, bucket);
+    if (nextType === "opencode_local") {
+      setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
+      return;
     }
-    return Array.from(groups.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([provider, entries]) => ({
-        provider,
-        entries: [...entries].sort((a, b) => a.id.localeCompare(b.id))
-      }));
-  }, [filteredModels, adapterType]);
+    if (nextType === "gemini_local" && !model) {
+      setModel(DEFAULT_GEMINI_LOCAL_MODEL);
+      return;
+    }
+    if (nextType === "cursor" && !model) {
+      setModel(DEFAULT_CURSOR_LOCAL_MODEL);
+      return;
+    }
+    setModel("");
+  }
 
   function reset() {
     setStep(1);
@@ -700,20 +647,6 @@ export function OnboardingWizard() {
                       onChange={(e) => setCompanyGoal(e.target.value)}
                     />
                   </div>
-                  <p className="text-xs text-muted-foreground text-center pt-2">
-                    Want a conversation instead?{" "}
-                    <Link
-                      to="/onboarding"
-                      onClick={() => {
-                        setRouteDismissed(true);
-                        closeOnboarding();
-                      }}
-                      className="underline"
-                    >
-                      Switch to Coach onboarding
-                    </Link>
-                    .
-                  </p>
                 </div>
               )}
 
@@ -743,278 +676,26 @@ export function OnboardingWizard() {
                     />
                   </div>
 
-                  {/* Adapter type radio cards */}
-                  <div>
-                    <label className="text-xs text-muted-foreground mb-2 block">
-                      Adapter type
-                    </label>
-                    <AdapterTypePicker
-                      value={adapterType}
-                      onChange={(nextType) => {
-                        setAdapterType(nextType);
-                        // Auto-default model when switching adapters that need one.
-                        if (nextType === "codex_local") {
-                          if (!model) setModel(DEFAULT_CODEX_LOCAL_MODEL);
-                          return;
-                        }
-                        if (nextType === "opencode_local") {
-                          setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
-                          return;
-                        }
-                        if (nextType === "gemini_local" && !model) {
-                          setModel(DEFAULT_GEMINI_LOCAL_MODEL);
-                          return;
-                        }
-                        if (nextType === "cursor" && !model) {
-                          setModel(DEFAULT_CURSOR_LOCAL_MODEL);
-                          return;
-                        }
-                        setModel("");
-                      }}
-                    />
-                  </div>
-
-                  {/* Conditional adapter fields */}
-                  {isLocalAdapter && (
-                    <div className="space-y-3">
-                      <div>
-                        <label className="text-xs text-muted-foreground mb-1 block">
-                          Model
-                        </label>
-                        <Popover
-                          open={modelOpen}
-                          onOpenChange={(next) => {
-                            setModelOpen(next);
-                            if (!next) setModelSearch("");
-                          }}
-                        >
-                          <PopoverTrigger asChild>
-                            <button className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-sm hover:bg-accent/50 transition-colors w-full justify-between">
-                              <span
-                                className={cn(
-                                  !model && "text-muted-foreground"
-                                )}
-                              >
-                                {selectedModel
-                                  ? selectedModel.label
-                                  : model ||
-                                    (adapterType === "opencode_local"
-                                      ? "Select model (required)"
-                                      : "Default")}
-                              </span>
-                              <ChevronDown className="h-3 w-3 text-muted-foreground" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent
-                            className="w-[var(--radix-popover-trigger-width)] p-1"
-                            align="start"
-                          >
-                            <input
-                              className="w-full px-2 py-1.5 text-xs bg-transparent outline-none border-b border-border mb-1 placeholder:text-muted-foreground/50"
-                              placeholder="Search models..."
-                              value={modelSearch}
-                              onChange={(e) => setModelSearch(e.target.value)}
-                              autoFocus
-                            />
-                            {adapterType !== "opencode_local" && (
-                              <button
-                                className={cn(
-                                  "flex items-center gap-2 w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50",
-                                  !model && "bg-accent"
-                                )}
-                                onClick={() => {
-                                  setModel("");
-                                  setModelOpen(false);
-                                }}
-                              >
-                                Default
-                              </button>
-                            )}
-                            <div className="max-h-[240px] overflow-y-auto">
-                              {groupedModels.map((group) => (
-                                <div
-                                  key={group.provider}
-                                  className="mb-1 last:mb-0"
-                                >
-                                  {adapterType === "opencode_local" && (
-                                    <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
-                                      {group.provider} ({group.entries.length})
-                                    </div>
-                                  )}
-                                  {group.entries.map((m) => (
-                                    <button
-                                      key={m.id}
-                                      className={cn(
-                                        "flex items-center w-full px-2 py-1.5 text-sm rounded hover:bg-accent/50",
-                                        m.id === model && "bg-accent"
-                                      )}
-                                      onClick={() => {
-                                        setModel(m.id);
-                                        setModelOpen(false);
-                                      }}
-                                    >
-                                      <span
-                                        className="block w-full text-left truncate"
-                                        title={m.id}
-                                      >
-                                        {adapterType === "opencode_local"
-                                          ? extractModelName(m.id)
-                                          : m.label}
-                                      </span>
-                                    </button>
-                                  ))}
-                                </div>
-                              ))}
-                            </div>
-                            {filteredModels.length === 0 && (
-                              <p className="px-2 py-1.5 text-xs text-muted-foreground">
-                                No models discovered.
-                              </p>
-                            )}
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    </div>
-                  )}
-
-                  {isLocalAdapter && (
-                    <div className="space-y-2 rounded-md border border-border p-3">
-                      <div className="flex items-center justify-between gap-2">
-                        <div>
-                          <p className="text-xs font-medium">
-                            Adapter environment check
-                          </p>
-                          <p className="text-[11px] text-muted-foreground">
-                            Runs a live probe that asks the adapter CLI to
-                            respond with hello.
-                          </p>
-                        </div>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="h-7 px-2.5 text-xs"
-                          disabled={adapterEnvLoading}
-                          onClick={() => void runAdapterEnvironmentTest()}
-                        >
-                          {adapterEnvLoading ? "Testing..." : "Test now"}
-                        </Button>
-                      </div>
-
-                      {adapterEnvError && (
-                        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-2 text-[11px] text-destructive">
-                          {adapterEnvError}
-                        </div>
-                      )}
-
-                      {adapterEnvResult &&
-                      adapterEnvResult.status === "pass" ? (
-                        <div className="flex items-center gap-2 rounded-md border border-green-300 dark:border-green-500/40 bg-green-50 dark:bg-green-500/10 px-3 py-2 text-xs text-green-700 dark:text-green-300 animate-in fade-in slide-in-from-bottom-1 duration-300">
-                          <Check className="h-3.5 w-3.5 shrink-0" />
-                          <span className="font-medium">Passed</span>
-                        </div>
-                      ) : adapterEnvResult ? (
-                        <AdapterEnvironmentResult result={adapterEnvResult} />
-                      ) : null}
-
-                      {shouldSuggestUnsetAnthropicApiKey && (
-                        <div className="rounded-md border border-amber-300/60 bg-amber-50/40 px-2.5 py-2 space-y-2">
-                          <p className="text-[11px] text-amber-900/90 leading-relaxed">
-                            Claude failed while{" "}
-                            <span className="font-mono">ANTHROPIC_API_KEY</span>{" "}
-                            is set. You can clear it in this CEO adapter config
-                            and retry the probe.
-                          </p>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            className="h-7 px-2.5 text-xs"
-                            disabled={
-                              adapterEnvLoading || unsetAnthropicLoading
-                            }
-                            onClick={() => void handleUnsetAnthropicApiKey()}
-                          >
-                            {unsetAnthropicLoading
-                              ? "Retrying..."
-                              : "Unset ANTHROPIC_API_KEY"}
-                          </Button>
-                        </div>
-                      )}
-
-                      {adapterEnvResult && adapterEnvResult.status === "fail" && (
-                        <div className="rounded-md border border-border/70 bg-muted/20 px-2.5 py-2 text-[11px] space-y-1.5">
-                          <p className="font-medium">Manual debug</p>
-                          <p className="text-muted-foreground font-mono break-all">
-                            {adapterType === "cursor"
-                              ? `${effectiveAdapterCommand} -p --mode ask --output-format json \"Respond with hello.\"`
-                              : adapterType === "codex_local"
-                              ? `${effectiveAdapterCommand} exec --json -`
-                              : adapterType === "gemini_local"
-                                ? `${effectiveAdapterCommand} --output-format json "Respond with hello."`
-                              : adapterType === "opencode_local"
-                                ? `${effectiveAdapterCommand} run --format json "Respond with hello."`
-                              : `${effectiveAdapterCommand} --print - --output-format stream-json --verbose`}
-                          </p>
-                          <p className="text-muted-foreground">
-                            Prompt:{" "}
-                            <span className="font-mono">Respond with hello.</span>
-                          </p>
-                          {adapterType === "cursor" ||
-                          adapterType === "codex_local" ||
-                          adapterType === "gemini_local" ||
-                          adapterType === "opencode_local" ? (
-                            <p className="text-muted-foreground">
-                              If auth fails, set{" "}
-                              <span className="font-mono">
-                                {adapterType === "cursor"
-                                  ? "CURSOR_API_KEY"
-                                  : adapterType === "gemini_local"
-                                    ? "GEMINI_API_KEY"
-                                    : "OPENAI_API_KEY"}
-                              </span>{" "}
-                              in env or run{" "}
-                              <span className="font-mono">
-                                {adapterType === "cursor"
-                                  ? "agent login"
-                                  : adapterType === "codex_local"
-                                    ? "codex login"
-                                    : adapterType === "gemini_local"
-                                      ? "gemini auth"
-                                      : "opencode auth login"}
-                              </span>
-                              .
-                            </p>
-                          ) : (
-                            <p className="text-muted-foreground">
-                              If login is required, run{" "}
-                              <span className="font-mono">claude login</span>{" "}
-                              and retry.
-                            </p>
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  )}
-
-                  {(adapterType === "http" ||
-                    adapterType === "openclaw_gateway") && (
-                    <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">
-                        {adapterType === "openclaw_gateway"
-                          ? "Gateway URL"
-                          : "Webhook URL"}
-                      </label>
-                      <input
-                        className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
-                        placeholder={
-                          adapterType === "openclaw_gateway"
-                            ? "ws://127.0.0.1:18789"
-                            : "https://..."
-                        }
-                        value={url}
-                        onChange={(e) => setUrl(e.target.value)}
-                      />
-                    </div>
-                  )}
+                  <AdapterStepFields
+                    companyId={createdCompanyId}
+                    adapterType={adapterType}
+                    onAdapterTypeChange={handleAdapterTypeChange}
+                    model={model}
+                    onModelChange={setModel}
+                    url={url}
+                    onUrlChange={setUrl}
+                    envResult={adapterEnvResult}
+                    envError={adapterEnvError}
+                    envLoading={adapterEnvLoading}
+                    onRunProbe={() => {
+                      void runAdapterEnvironmentTest();
+                    }}
+                    forceUnsetAnthropicApiKey={forceUnsetAnthropicApiKey}
+                    unsetAnthropicLoading={unsetAnthropicLoading}
+                    onUnsetAnthropicApiKey={handleUnsetAnthropicApiKey}
+                    effectiveAdapterCommand={effectiveAdapterCommand}
+                    enabled={effectiveOnboardingOpen && step === 2}
+                  />
                 </div>
               )}
 
@@ -1192,6 +873,20 @@ export function OnboardingWizard() {
                   )}
                 </div>
               </div>
+              <p className="text-xs text-muted-foreground text-center pt-3">
+                Want a conversation instead?{" "}
+                <Link
+                  to="/onboarding"
+                  onClick={() => {
+                    setRouteDismissed(true);
+                    closeOnboarding();
+                  }}
+                  className="underline"
+                >
+                  Switch to Coach onboarding
+                </Link>
+                .
+              </p>
             </div>
           </div>
 

--- a/ui/src/components/onboarding-coach-steps.ts
+++ b/ui/src/components/onboarding-coach-steps.ts
@@ -1,0 +1,25 @@
+import { MessageSquare, SlidersHorizontal } from "lucide-react";
+import type { OnboardingStepTabItem } from "./OnboardingStepTabs";
+
+export const COACH_STEP_CONFIGURE = "configure";
+export const COACH_STEP_CHAT = "chat";
+
+export function buildCoachStepTabs(options?: {
+  chatDisabled?: boolean;
+}): ReadonlyArray<OnboardingStepTabItem> {
+  return [
+    {
+      id: COACH_STEP_CONFIGURE,
+      label: "Configure",
+      icon: SlidersHorizontal,
+    },
+    {
+      id: COACH_STEP_CHAT,
+      label: "Chat",
+      icon: MessageSquare,
+      disabled: options?.chatDisabled ?? false,
+    },
+  ];
+}
+
+export const COACH_STEP_TABS = buildCoachStepTabs();

--- a/ui/src/lib/onboarding-route.test.ts
+++ b/ui/src/lib/onboarding-route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isClassicOnboardingPath,
   isOnboardingPath,
   resolveRouteOnboardingOptions,
   shouldRedirectCompanylessRouteToOnboarding,
@@ -14,39 +15,84 @@ describe("isOnboardingPath", () => {
     expect(isOnboardingPath("/pap/onboarding")).toBe(true);
   });
 
+  it("matches the classic onboarding suffix at the global route", () => {
+    expect(isOnboardingPath("/onboarding/classic")).toBe(true);
+  });
+
+  it("matches the classic onboarding suffix at the company-prefixed route", () => {
+    expect(isOnboardingPath("/pap/onboarding/classic")).toBe(true);
+  });
+
   it("ignores non-onboarding routes", () => {
     expect(isOnboardingPath("/pap/dashboard")).toBe(false);
   });
 });
 
+describe("isClassicOnboardingPath", () => {
+  it("matches the global classic onboarding route", () => {
+    expect(isClassicOnboardingPath("/onboarding/classic")).toBe(true);
+  });
+
+  it("matches the company-prefixed classic onboarding route", () => {
+    expect(isClassicOnboardingPath("/pap/onboarding/classic")).toBe(true);
+  });
+
+  it("does not match the bare onboarding route", () => {
+    expect(isClassicOnboardingPath("/onboarding")).toBe(false);
+  });
+
+  it("does not match the company-prefixed bare onboarding route", () => {
+    expect(isClassicOnboardingPath("/pap/onboarding")).toBe(false);
+  });
+});
+
 describe("resolveRouteOnboardingOptions", () => {
-  it("opens company creation for the global onboarding route", () => {
+  it("opens company creation for the global classic onboarding route", () => {
     expect(
       resolveRouteOnboardingOptions({
-        pathname: "/onboarding",
+        pathname: "/onboarding/classic",
         companies: [],
       }),
     ).toEqual({ initialStep: 1 });
   });
 
-  it("opens agent creation when the prefixed company exists", () => {
+  it("opens agent creation when the classic prefixed company exists", () => {
     expect(
       resolveRouteOnboardingOptions({
-        pathname: "/pap/onboarding",
+        pathname: "/pap/onboarding/classic",
         companyPrefix: "pap",
         companies: [{ id: "company-1", issuePrefix: "PAP" }],
       }),
     ).toEqual({ initialStep: 2, companyId: "company-1" });
   });
 
-  it("falls back to company creation when the prefixed company is missing", () => {
+  it("falls back to company creation when the classic prefixed company is missing", () => {
     expect(
       resolveRouteOnboardingOptions({
-        pathname: "/pap/onboarding",
+        pathname: "/pap/onboarding/classic",
         companyPrefix: "pap",
         companies: [],
       }),
     ).toEqual({ initialStep: 1 });
+  });
+
+  it("does not auto-open the wizard for the new Coach onboarding route", () => {
+    expect(
+      resolveRouteOnboardingOptions({
+        pathname: "/onboarding",
+        companies: [],
+      }),
+    ).toBeNull();
+  });
+
+  it("does not auto-open the wizard for the company-prefixed Coach onboarding route", () => {
+    expect(
+      resolveRouteOnboardingOptions({
+        pathname: "/pap/onboarding",
+        companyPrefix: "pap",
+        companies: [{ id: "company-1", issuePrefix: "PAP" }],
+      }),
+    ).toBeNull();
   });
 });
 
@@ -64,6 +110,15 @@ describe("shouldRedirectCompanylessRouteToOnboarding", () => {
     expect(
       shouldRedirectCompanylessRouteToOnboarding({
         pathname: "/onboarding",
+        hasCompanies: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not redirect when already on classic onboarding", () => {
+    expect(
+      shouldRedirectCompanylessRouteToOnboarding({
+        pathname: "/onboarding/classic",
         hasCompanies: false,
       }),
     ).toBe(false);

--- a/ui/src/lib/onboarding-route.ts
+++ b/ui/src/lib/onboarding-route.ts
@@ -4,14 +4,44 @@ type OnboardingRouteCompany = {
 };
 
 export function isOnboardingPath(pathname: string): boolean {
-  const segments = pathname.split("/").filter(Boolean);
+  const segments = pathname.split("/").filter(Boolean).map((s) => s.toLowerCase());
 
-  if (segments.length === 1) {
-    return segments[0]?.toLowerCase() === "onboarding";
+  // Strip a trailing /classic segment so /onboarding and /onboarding/classic
+  // (and the company-prefixed equivalents) are both recognized as onboarding
+  // entry points by the redirect logic.
+  const trimmed =
+    segments.length > 0 && segments[segments.length - 1] === "classic"
+      ? segments.slice(0, -1)
+      : segments;
+
+  if (trimmed.length === 1) {
+    return trimmed[0] === "onboarding";
   }
 
+  if (trimmed.length === 2) {
+    return trimmed[1] === "onboarding";
+  }
+
+  return false;
+}
+
+// The dialog-style onboarding wizard auto-opens only on the classic route. The
+// new Coach-driven flow at `/onboarding` is a regular page.
+export function isClassicOnboardingPath(pathname: string): boolean {
+  const segments = pathname.split("/").filter(Boolean);
+
   if (segments.length === 2) {
-    return segments[1]?.toLowerCase() === "onboarding";
+    return (
+      segments[0]?.toLowerCase() === "onboarding"
+      && segments[1]?.toLowerCase() === "classic"
+    );
+  }
+
+  if (segments.length === 3) {
+    return (
+      segments[1]?.toLowerCase() === "onboarding"
+      && segments[2]?.toLowerCase() === "classic"
+    );
   }
 
   return false;
@@ -24,7 +54,9 @@ export function resolveRouteOnboardingOptions(params: {
 }): { initialStep: 1 | 2; companyId?: string } | null {
   const { pathname, companyPrefix, companies } = params;
 
-  if (!isOnboardingPath(pathname)) return null;
+  // Only auto-open the dialog wizard for the classic onboarding route. The
+  // new Coach-driven flow at `/onboarding` is a regular page (CoachOnboardingPage).
+  if (!isClassicOnboardingPath(pathname)) return null;
 
   if (!companyPrefix) {
     return { initialStep: 1 };


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The current onboarding wizard asks users to articulate their company's mission as a one-line textarea before any agent exists. Most operators don't know their goal in concrete enough terms to type it cold, and a vague mission cascades through the org chart, tasks, and CEO heartbeat
> - This pull request introduces an alternate "Coach" onboarding path: the user picks an adapter, runs the env probe, and is dropped into a focused chat with a Coach agent that runs Five Whys, infers a workflow pattern, proposes a hiring plan, and writes an Agent Companies (`agentcompanies/v1`) package — which the chat imports atomically into a live company via the existing `/companies/{id}/imports/apply` endpoint
> - The classic 4-step wizard remains reachable at `/onboarding/classic` so the existing form-based flow is preserved as an escape hatch
> - The benefit is a more opinionated, hand-hold-y first-run that produces a stronger founding mission and team than a textarea would

## Stack note

Stacked on **#5378** (extracts `AdapterTypePicker` and `AdapterEnvironmentResult` into shared components, both consumed here). Land #5378 first; once it does, this PR's diff collapses to the Coach-specific changes.

## Path 2 acknowledgement

Per `CONTRIBUTING.md`, this is a Path 2 (bigger / impactful) feature. Opened as a **reference implementation** for direction-setting feedback rather than expecting immediate merge. `ROADMAP.md` doesn't mention this surface; happy to redirect to the plugin system or close if it overlaps with planned core work.

## What Changed

**Schema / shared types**
- `'draft'` added to `COMPANY_STATUSES` (next to `active`/`paused`/`archived`). DB column is text — no migration.
- `'coach'` added to `AGENT_ROLES` + `AGENT_ROLE_LABELS`.
- `updateCompanyBrandingSchema` accepts `status: 'active'` (narrow allowance) so the Coach can flip a draft company live via agent auth at launch.

**Server**
- `server/src/routes/companies.ts` PATCH handler allows `role === 'coach'` alongside `'ceo'` for company updates during onboarding.

**Skill**
- `skills/paperclip-coach/SKILL.md` — new Coach playbook. Self-wake guard. Output discipline forbids operational status narration. Phases: opener → Five Whys ladder → synthesis (workflow pattern + hiring plan) → package generation (writes Agent Companies file map as a JSON document on the issue) → launch (posts a `RequestConfirmation` referencing the document via `target.type: 'issue_document'`). Reuses company-creator's interview principles (workflow inference, propose-don't-ask hiring, lean defaults, execution contract).

**UI**
- `CoachOnboardingPage.tsx` — adapter picker + required env probe + start. Uses the shared `AdapterTypePicker` and `AdapterEnvironmentResult` from #5378. Start gated on probe pass/warn.
- `OnboardingChat.tsx` — focused chat surface. Polls comments + interactions. Renders messages as bubbles, "Coach is thinking…" indicator, inline launch confirmation card. On accept: fetches the package document, parses the JSON file map, calls `/companies/{id}/imports/apply` with `target=existing, collisionStrategy=skip`, patches status to `active`, accepts the interaction, redirects to `/{prefix}/dashboard`.
- `OnboardingChrome.tsx` — shared full-viewport split layout (left form / chat pane, right `AsciiArtAnimation`). Used by both Coach pages.
- App routes: `/onboarding` → Coach flow, `/onboarding/classic` → existing wizard. The wizard's URL-based auto-open is now gated on the classic path only.
- **Inverse navigation:** wizard's Step 1 shows a "Switch to Coach onboarding" link mirroring the existing reverse link on `CoachOnboardingPage`.
- `companiesApi.applyImportToCompany` helper added.

**Tests**
- `ui/src/lib/onboarding-route.test.ts` — `resolveRouteOnboardingOptions` no longer auto-opens the wizard at the bare `/onboarding` (that's the Coach page now); it auto-opens at `/onboarding/classic`. Existing assertions moved to the classic path; new assertions cover the bare path returning `null`, the new `isClassicOnboardingPath` predicate, and the extended `isOnboardingPath` (which now also recognizes the classic suffix so the companyless-redirect predicate considers either flow as an onboarding entry).
- `tests/e2e/onboarding.spec.ts` and `tests/e2e/planning-mode-visual-verification.spec.ts` navigate to `/onboarding/classic` since the bare `/onboarding` now serves the Coach flow.

## Verification

- `pnpm typecheck` — green across `@paperclipai/shared`, `@paperclipai/server`, `@paperclipai/ui`.
- `pnpm test` — onboarding-route unit tests pass.
- Manual end-to-end with `pnpm dev`:
  - `/onboarding` → Coach entry page with adapter picker; "Test now" creates a draft company silently and runs the probe; Start gated until pass/warn.
  - On Start → land on `/{prefix}/onboarding/chat/{ref}` with the focused chat.
  - Coach posts opener, drives Five Whys via comments, proposes name + workflow + hiring plan, writes the `coach-package` document, posts the launch confirmation. Launch runs the import and redirects to the new live company's dashboard.
  - `/onboarding/classic` → existing 4-step wizard works unchanged, with the new "Switch to Coach onboarding" link on Step 1.

### Screenshots

**Coach entry — pre-probe:**

![Coach entry pre-probe](https://github.com/jondwillis/paperclip/raw/screenshots/pr-2-coach-onboarding/coach-01-entry-pretest.png)

**Coach entry — after the probe passes (Start enabled):**

![Coach entry post-pass](https://github.com/jondwillis/paperclip/raw/screenshots/pr-2-coach-onboarding/coach-02-entry-postpass.png)

**Classic wizard Step 1 — new "Switch to Coach onboarding" inverse link:**

![Wizard inverse link](https://github.com/jondwillis/paperclip/raw/screenshots/pr-2-coach-onboarding/coach-03-wizard-step1-inverse-link.png)

> **Note:** an earlier capture of the chat surface was removed from this PR description because it was taken against a stale draft from before the SKILL.md output-discipline rules were tightened, and showed both (a) the Coach's opener mis-attributed to the user side and (b) operational/heartbeat reasoning leaking into comment bodies. (a) is not reproducible against the current code (fresh sessions post with `authorAgentId` set via the agent JWT, so `OnboardingChat`'s classifier routes correctly). (b) was a skill-prompting weakness; this PR includes a stronger "what is and isn't a comment" rule plus an explicit anti-pattern list. A fresh chat-surface screenshot will be added once a clean end-to-end run confirms both are resolved.

## Risks

- **New role + status values.** Other code paths may switch on roles or filter on status. The Coach role gets a narrow allowance (PATCH branding + the `status: 'active'` write at launch). The draft status is short-lived — flipped to `active` immediately when the user accepts the launch — but if onboarding is abandoned mid-flow, an `Untitled` draft remains. Sidebar listing was not audited for draft filtering; cosmetic v1.5 follow-up.
- **Coach persistence after launch.** The import uses `collisionStrategy: skip`, so the Coach agent (and the onboarding issue) remain in the new live company. Cosmetic.
- **Self-wake on own comments.** The platform fires `issue_commented` wakes for the Coach's own comments. The skill's self-wake guard reads the latest comment and exits silently if it's the Coach. Each self-wake still costs a heartbeat round-trip.
- **Skill prompting fragility.** The Coach is an LLM running a markdown playbook. Earlier dev iterations showed the LLM occasionally posting operational reasoning (heartbeat plumbing, self-wake guard outcomes) into user-visible comment bodies. The latest SKILL.md tightens "what is and isn't a comment" with explicit anti-patterns; behavior is monitored via fresh sessions, but a future hardening could be a server-side filter that drops Coach comments matching reasoning-prefix patterns rather than relying on prompt discipline alone.
- **Package generation correctness.** The Coach builds an `agentcompanies/v1` package payload via the LLM. If it generates malformed JSON, the launch card surfaces a parse error.
- **Polling cadence.** Chat polls every 4s for new comments + interactions.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`) — 1M context, default Claude Code harness with tool use, no extended-thinking mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
