### PR TITLE
KIN-1078: fix issue comment delta pagination

### DIFF
--- a/server/src/__tests__/issue-comments-delta-routes.test.ts
+++ b/server/src/__tests__/issue-comments-delta-routes.test.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  companies,
+  createDb,
+  issueComments,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue comment delta route tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+describeEmbeddedPostgres("issue comment delta routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-comment-delta-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "board",
+        userId: "board-user",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "admin", status: "active" }],
+        isInstanceAdmin: false,
+        source: "session",
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  it("returns an empty ascending delta after a freshly written comment", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Delta comments issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const app = createApp(companyId);
+    const created = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Newest comment" });
+
+    expect(created.status, JSON.stringify(created.body)).toBe(201);
+    expect(created.body.id).toBeTruthy();
+
+    const delta = await request(app)
+      .get(`/api/issues/${issueId}/comments`)
+      .query({ after: created.body.id, order: "asc" });
+
+    expect(delta.status, JSON.stringify(delta.body)).toBe(200);
+    expect(delta.body).toEqual([]);
+
+    const thread = await request(app).get(`/api/issues/${issueId}/comments`);
+    expect(thread.status, JSON.stringify(thread.body)).toBe(200);
+    expect(thread.body).toHaveLength(1);
+    expect(thread.body[0]?.id).toBe(created.body.id);
+    expect(thread.body[0]?.body).toBe("Newest comment");
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -953,6 +953,113 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(comments.map((comment) => comment.id)).toEqual([firstCommentId]);
   });
 
+  it("paginates newer comments in ascending order from an anchor comment", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const firstCommentId = randomUUID();
+    const anchorCommentId = randomUUID();
+    const latestCommentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Paged comments issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        id: firstCommentId,
+        companyId,
+        issueId,
+        body: "First comment",
+        createdAt: new Date("2026-03-26T10:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T10:00:00.000Z"),
+      },
+      {
+        id: anchorCommentId,
+        companyId,
+        issueId,
+        body: "Anchor comment",
+        createdAt: new Date("2026-03-26T11:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T11:00:00.000Z"),
+      },
+      {
+        id: latestCommentId,
+        companyId,
+        issueId,
+        body: "Latest comment",
+        createdAt: new Date("2026-03-26T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T12:00:00.000Z"),
+      },
+    ]);
+
+    const comments = await svc.listComments(issueId, {
+      afterCommentId: anchorCommentId,
+      order: "asc",
+      limit: 50,
+    });
+
+    expect(comments.map((comment) => comment.id)).toEqual([latestCommentId]);
+  });
+
+  it("returns an empty ascending delta after the latest comment anchor", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const firstCommentId = randomUUID();
+    const latestCommentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Delta comments issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values([
+      {
+        id: firstCommentId,
+        companyId,
+        issueId,
+        body: "First comment",
+        createdAt: new Date("2026-03-26T10:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T10:00:00.000Z"),
+      },
+      {
+        id: latestCommentId,
+        companyId,
+        issueId,
+        body: "Latest comment",
+        createdAt: new Date("2026-03-26T11:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T11:00:00.000Z"),
+      },
+    ]);
+
+    const comments = await svc.listComments(issueId, {
+      afterCommentId: latestCommentId,
+      order: "asc",
+      limit: 50,
+    });
+
+    expect(comments).toEqual([]);
+  });
+
   it("includes blockedBy summaries on list rows in one batched pass", async () => {
     const companyId = randomUUID();
     const blockerId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3250,7 +3250,7 @@ export function issueService(db: Db) {
         const anchor = await db
           .select({
             id: issueComments.id,
-            createdAt: issueComments.createdAt,
+            createdAtCursor: sql<string>`to_char(${issueComments.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
           })
           .from(issueComments)
           .where(and(eq(issueComments.issueId, issueId), eq(issueComments.id, afterCommentId)))
@@ -3259,14 +3259,8 @@ export function issueService(db: Db) {
         if (!anchor) return [];
         conditions.push(
           order === "asc"
-            ? or(
-                gt(issueComments.createdAt, anchor.createdAt),
-                and(eq(issueComments.createdAt, anchor.createdAt), gt(issueComments.id, anchor.id)),
-              )!
-            : or(
-                lt(issueComments.createdAt, anchor.createdAt),
-                and(eq(issueComments.createdAt, anchor.createdAt), lt(issueComments.id, anchor.id)),
-              )!,
+            ? sql`(${issueComments.createdAt}, ${issueComments.id}) > (${anchor.createdAtCursor}::timestamptz, ${anchor.id}::uuid)`
+            : sql`(${issueComments.createdAt}, ${issueComments.id}) < (${anchor.createdAtCursor}::timestamptz, ${anchor.id}::uuid)`,
         );
       }
 


### PR DESCRIPTION
## Summary
- fix issue comment delta pagination to compare comment anchors with an exact database-native `(created_at, id)` cursor
- eliminate the `Date` encoding failure on `GET /api/issues/:id/comments?after=<comment-id>&order=asc`
- keep freshly written comments visible in the full thread while returning an empty delta immediately after polling from that new anchor

## Test Plan
- `pnpm exec vitest run --project @paperclipai/server server/src/__tests__/issues-service.test.ts -t "paginates newer comments in ascending order from an anchor comment|returns an empty ascending delta after the latest comment anchor|paginates earlier comments in descending order from an anchor comment"`
- `pnpm exec vitest run --project @paperclipai/server server/src/__tests__/issue-comments-delta-routes.test.ts`

Closes KIN-1078