### PR TITLE
Add PAPERCLIP_AUTO_RECOVERY_ISSUES flag (default off)

### DIFF
--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -32,6 +32,7 @@ export interface InstanceExperimentalSettings {
   autoRestartDevServerWhenIdle: boolean;
   enableIssueGraphLivenessAutoRecovery: boolean;
   issueGraphLivenessAutoRecoveryLookbackHours: number;
+  autoRecoveryIssues: boolean;
 }
 
 export interface InstanceSettings {

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -46,6 +46,7 @@ export const instanceExperimentalSettingsSchema = z.object({
     .min(MIN_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS)
     .max(MAX_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS)
     .default(DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS),
+  autoRecoveryIssues: z.boolean().default(false),
 }).strict();
 
 export const patchInstanceExperimentalSettingsSchema = instanceExperimentalSettingsSchema.partial();

--- a/server/src/__tests__/auto-recovery-flag.test.ts
+++ b/server/src/__tests__/auto-recovery-flag.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: vi.fn(),
+}));
+
+import { isAutoRecoveryIssuesEnabled } from "../services/auto-recovery-flag.ts";
+import { instanceSettingsService } from "../services/instance-settings.js";
+
+const mockedInstanceSettingsService = vi.mocked(instanceSettingsService);
+
+function stubExperimental(autoRecoveryIssues: boolean) {
+  mockedInstanceSettingsService.mockReturnValue({
+    getExperimental: vi.fn(async () => ({
+      enableEnvironments: false,
+      enableIsolatedWorkspaces: false,
+      autoRestartDevServerWhenIdle: false,
+      enableIssueGraphLivenessAutoRecovery: false,
+      issueGraphLivenessAutoRecoveryLookbackHours: 24,
+      autoRecoveryIssues,
+    })),
+  } as unknown as ReturnType<typeof instanceSettingsService>);
+}
+
+describe("isAutoRecoveryIssuesEnabled", () => {
+  let priorEnv: string | undefined;
+  beforeEach(() => {
+    priorEnv = process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES;
+    delete process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES;
+    mockedInstanceSettingsService.mockReset();
+  });
+  afterEach(() => {
+    if (priorEnv === undefined) delete process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES;
+    else process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = priorEnv;
+  });
+
+  it("returns false by default when no env override and no instance setting opt-in", async () => {
+    stubExperimental(false);
+    expect(await isAutoRecoveryIssuesEnabled({} as never)).toBe(false);
+  });
+
+  it("env override 'on' beats a disabled instance setting", async () => {
+    process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = "on";
+    stubExperimental(false);
+    expect(await isAutoRecoveryIssuesEnabled({} as never)).toBe(true);
+  });
+
+  it("env override 'off' beats an enabled instance setting", async () => {
+    process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = "off";
+    stubExperimental(true);
+    expect(await isAutoRecoveryIssuesEnabled({} as never)).toBe(false);
+  });
+
+  it("falls through to instance setting when env override is unrecognized", async () => {
+    process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = "maybe";
+    stubExperimental(true);
+    expect(await isAutoRecoveryIssuesEnabled({} as never)).toBe(true);
+  });
+
+  it.each(["true", "1", "yes", "ON"])("treats env value %s as enabled", async (raw) => {
+    process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = raw;
+    stubExperimental(false);
+    expect(await isAutoRecoveryIssuesEnabled({} as never)).toBe(true);
+  });
+
+  it.each(["false", "0", "no", "OFF"])("treats env value %s as disabled", async (raw) => {
+    process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = raw;
+    stubExperimental(true);
+    expect(await isAutoRecoveryIssuesEnabled({} as never)).toBe(false);
+  });
+});

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -257,10 +257,13 @@ async function spawnOrphanedProcessGroup() {
 describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let priorAutoRecoveryFlag: string | undefined;
   const childProcesses = new Set<ChildProcess>();
   const cleanupPids = new Set<number>();
 
   beforeAll(async () => {
+    priorAutoRecoveryFlag = process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES;
+    process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = "on";
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-recovery-");
     db = createDb(tempDb.connectionString);
   }, 20_000);
@@ -390,6 +393,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
     cleanupPids.clear();
     runningProcesses.clear();
+    if (priorAutoRecoveryFlag === undefined) {
+      delete process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES;
+    } else {
+      process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = priorAutoRecoveryFlag;
+    }
     await tempDb?.cleanup();
   });
 

--- a/server/src/__tests__/instance-settings-routes.test.ts
+++ b/server/src/__tests__/instance-settings-routes.test.ts
@@ -67,6 +67,7 @@ describe("instance settings routes", () => {
       autoRestartDevServerWhenIdle: false,
       enableIssueGraphLivenessAutoRecovery: true,
       issueGraphLivenessAutoRecoveryLookbackHours: 24,
+      autoRecoveryIssues: false,
     });
     mockInstanceSettingsService.updateGeneral.mockResolvedValue({
       id: "instance-settings-1",
@@ -84,6 +85,7 @@ describe("instance settings routes", () => {
         autoRestartDevServerWhenIdle: false,
         enableIssueGraphLivenessAutoRecovery: true,
         issueGraphLivenessAutoRecoveryLookbackHours: 24,
+        autoRecoveryIssues: false,
       },
     });
     mockInstanceSettingsService.listCompanyIds.mockResolvedValue(["company-1", "company-2"]);
@@ -126,6 +128,7 @@ describe("instance settings routes", () => {
       autoRestartDevServerWhenIdle: false,
       enableIssueGraphLivenessAutoRecovery: true,
       issueGraphLivenessAutoRecoveryLookbackHours: 24,
+      autoRecoveryIssues: false,
     });
 
     const patchRes = await request(app)

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -36,8 +36,11 @@ if (!embeddedPostgresSupport.supported) {
 describeEmbeddedPostgres("productivity review service", () => {
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
   let db: ReturnType<typeof createDb>;
+  let priorAutoRecoveryFlag: string | undefined;
 
   beforeAll(async () => {
+    priorAutoRecoveryFlag = process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES;
+    process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = "on";
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-productivity-review-");
     db = createDb(tempDb.connectionString);
   }, 30_000);
@@ -47,6 +50,11 @@ describeEmbeddedPostgres("productivity review service", () => {
   });
 
   afterAll(async () => {
+    if (priorAutoRecoveryFlag === undefined) {
+      delete process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES;
+    } else {
+      process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = priorAutoRecoveryFlag;
+    }
     await tempDb?.cleanup();
   });
 
@@ -562,5 +570,40 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(result.failed).toBe(0);
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.requestDepth).toBe(MAX_ISSUE_REQUEST_DEPTH);
+  });
+
+  it("suppresses productivity review creation and emits an activity entry when PAPERCLIP_AUTO_RECOVERY_ISSUES=off", async () => {
+    const previous = process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES;
+    process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = "off";
+    try {
+      const now = new Date("2026-04-28T12:00:00.000Z");
+      const seeded = await seedAssignedIssue();
+      await insertRuns({
+        companyId: seeded.companyId,
+        agentId: seeded.coderId,
+        issueId: seeded.issueId,
+        count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+        now,
+      });
+
+      const result = await productivityReviewService(db).reconcileProductivityReviews({
+        now,
+        companyId: seeded.companyId,
+      });
+
+      expect(result.created).toBe(0);
+      expect(result.suppressed).toBe(1);
+      expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+
+      const suppressed = await db
+        .select()
+        .from(activityLog)
+        .where(eq(activityLog.action, "issue.productivity_review_suppressed"));
+      expect(suppressed).toHaveLength(1);
+      expect(suppressed[0]?.entityId).toBe(seeded.issueId);
+    } finally {
+      if (previous === undefined) delete process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES;
+      else process.env.PAPERCLIP_AUTO_RECOVERY_ISSUES = previous;
+    }
   });
 });

--- a/server/src/services/auto-recovery-flag.ts
+++ b/server/src/services/auto-recovery-flag.ts
@@ -1,0 +1,26 @@
+import type { Db } from "@paperclipai/db";
+import { instanceSettingsService } from "./instance-settings.js";
+
+export const AUTO_RECOVERY_ISSUES_ENV_VAR = "PAPERCLIP_AUTO_RECOVERY_ISSUES";
+
+function readEnvOverride(): boolean | null {
+  const raw = (process.env[AUTO_RECOVERY_ISSUES_ENV_VAR] ?? "").trim().toLowerCase();
+  if (raw === "on" || raw === "true" || raw === "1" || raw === "yes") return true;
+  if (raw === "off" || raw === "false" || raw === "0" || raw === "no") return false;
+  return null;
+}
+
+/**
+ * Resolves whether automatic recovery-style issue creation (productivity reviews
+ * and stranded-issue recovery issues) is enabled. Resolution order:
+ *
+ *   1. `PAPERCLIP_AUTO_RECOVERY_ISSUES` env var (`on` | `off` | unset).
+ *   2. Instance experimental setting `autoRecoveryIssues`.
+ *   3. Default `false` (suppressed) — see THE-303 / THE-408.
+ */
+export async function isAutoRecoveryIssuesEnabled(db: Db): Promise<boolean> {
+  const envOverride = readEnvOverride();
+  if (envOverride !== null) return envOverride;
+  const experimental = await instanceSettingsService(db).getExperimental();
+  return experimental.autoRecoveryIssues;
+}

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -46,6 +46,7 @@ function normalizeExperimentalSettings(raw: unknown): InstanceExperimentalSettin
       issueGraphLivenessAutoRecoveryLookbackHours:
         parsed.data.issueGraphLivenessAutoRecoveryLookbackHours ??
         DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
+      autoRecoveryIssues: parsed.data.autoRecoveryIssues ?? false,
     };
   }
   return {
@@ -55,6 +56,7 @@ function normalizeExperimentalSettings(raw: unknown): InstanceExperimentalSettin
     enableIssueGraphLivenessAutoRecovery: false,
     issueGraphLivenessAutoRecoveryLookbackHours:
       DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
+    autoRecoveryIssues: false,
   };
 }
 

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -12,6 +12,7 @@ import {
 } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
 import { logActivity } from "./activity-log.js";
+import { isAutoRecoveryIssuesEnabled } from "./auto-recovery-flag.js";
 import { budgetService } from "./budgets.js";
 import { issueService } from "./issues.js";
 import {
@@ -637,6 +638,28 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     evidence: ProductivityReviewEvidence,
     opts: { prefix: string; thresholds: ProductivityReviewThresholds },
   ) {
+    if (!(await isAutoRecoveryIssuesEnabled(db))) {
+      await logActivity(db, {
+        companyId: evidence.sourceIssue.companyId,
+        actorType: "system",
+        actorId: "system",
+        action: "issue.productivity_review_suppressed",
+        entityType: "issue",
+        entityId: evidence.sourceIssue.id,
+        agentId: evidence.sourceIssue.assigneeAgentId,
+        details: {
+          source: "productivity_review.reconcile",
+          sourceIssueId: evidence.sourceIssue.id,
+          trigger: evidence.trigger,
+          triggerReasons: evidence.triggerReasons,
+          noCommentStreak: evidence.noCommentStreak,
+          runCountLastHour: evidence.runCountLastHour,
+          commentCountLastHour: evidence.commentCountLastHour,
+        },
+      });
+      return { kind: "suppressed" as const, reviewIssueId: null };
+    }
+
     const existing = await findOpenProductivityReview(evidence.sourceIssue.companyId, evidence.sourceIssue.id);
     if (existing) {
       const refreshState = await getRefreshCommentState(evidence.sourceIssue.companyId, existing.id);
@@ -788,6 +811,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       existing: 0,
       snoozed: 0,
       creationCapped: 0,
+      suppressed: 0,
       skipped: 0,
       failed: 0,
       reviewIssueIds: [] as string[],
@@ -828,6 +852,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         if (outcome.kind === "created") result.created += 1;
         else if (outcome.kind === "updated") result.updated += 1;
         else if (outcome.kind === "creation_capped") result.creationCapped += 1;
+        else if (outcome.kind === "suppressed") result.suppressed += 1;
         else result.existing += 1;
         if (outcome.reviewIssueId) result.reviewIssueIds.push(outcome.reviewIssueId);
       } catch (err) {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -636,9 +636,14 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
 
   async function createOrUpdateReview(
     evidence: ProductivityReviewEvidence,
-    opts: { prefix: string; thresholds: ProductivityReviewThresholds },
+    opts: {
+      prefix: string;
+      thresholds: ProductivityReviewThresholds;
+      autoRecoveryEnabled?: boolean;
+    },
   ) {
-    if (!(await isAutoRecoveryIssuesEnabled(db))) {
+    const autoRecoveryEnabled = opts.autoRecoveryEnabled ?? (await isAutoRecoveryIssuesEnabled(db));
+    if (!autoRecoveryEnabled) {
       await logActivity(db, {
         companyId: evidence.sourceIssue.companyId,
         actorType: "system",
@@ -788,6 +793,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   }) {
     const now = opts?.now ?? new Date();
     const thresholds = buildThresholds(opts?.thresholds);
+    const autoRecoveryEnabled = await isAutoRecoveryIssuesEnabled(db);
     const candidates = await db
       .select()
       .from(issues)
@@ -848,7 +854,11 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         prefixCache.set(candidate.companyId, prefix);
       }
       try {
-        const outcome = await createOrUpdateReview(evidence, { prefix, thresholds });
+        const outcome = await createOrUpdateReview(evidence, {
+          prefix,
+          thresholds,
+          autoRecoveryEnabled,
+        });
         if (outcome.kind === "created") result.created += 1;
         else if (outcome.kind === "updated") result.updated += 1;
         else if (outcome.kind === "creation_capped") result.creationCapped += 1;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1428,10 +1428,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     previousStatus: "todo" | "in_progress";
     recoveryCause?: StrandedRecoveryCause;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
+    autoRecoveryEnabled?: boolean;
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) return null;
 
-    if (!(await isAutoRecoveryIssuesEnabled(db))) {
+    const autoRecoveryEnabled = input.autoRecoveryEnabled ?? (await isAutoRecoveryIssuesEnabled(db));
+    if (!autoRecoveryEnabled) {
       await logActivity(db, {
         companyId: input.issue.companyId,
         actorType: "system",
@@ -1646,6 +1648,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     comment?: string;
     recoveryCause?: StrandedRecoveryCause;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
+    autoRecoveryEnabled?: boolean;
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) {
       return escalateStrandedRecoveryIssueInPlace({
@@ -1661,6 +1664,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       latestRun: input.latestRun,
       recoveryCause: input.recoveryCause,
       successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
+      autoRecoveryEnabled: input.autoRecoveryEnabled,
     });
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const nextBlockerIds = recoveryIssue
@@ -1745,6 +1749,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   async function reconcileStrandedAssignedIssues() {
+    const autoRecoveryEnabled = await isAutoRecoveryIssuesEnabled(db);
     const candidates = await db
       .select()
       .from(issues)
@@ -1845,6 +1850,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
               "Paperclip automatically retried dispatch for this assigned `todo` issue after a lost wake/run, " +
               `but it still has no live execution path.${failureSummary ?? ""} ` +
               "Moving it to `blocked` so it is visible for intervention.",
+            autoRecoveryEnabled,
           });
           if (updated) {
             result.escalated += 1;
@@ -1894,6 +1900,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           latestRun,
           recoveryCause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
           successfulRunHandoffEvidence: handoffEvidence,
+          autoRecoveryEnabled,
         });
         if (updated) {
           result.successfulRunHandoffEscalated += 1;
@@ -1920,6 +1927,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             comment:
               "Paperclip automatically retried continuation for this assigned `in_progress` issue and the retry " +
               "made progress, but it still has no live execution path. Moving it to `blocked` so it is visible for intervention.",
+            autoRecoveryEnabled,
           });
           if (updated) {
             result.escalated += 1;
@@ -1961,6 +1969,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             "Paperclip automatically retried continuation for this assigned `in_progress` issue after its live " +
             `execution disappeared, but it still has no live execution path.${failureSummary ?? ""} ` +
             "Moving it to `blocked` so it is visible for intervention.",
+          autoRecoveryEnabled,
         });
         if (updated) {
           result.escalated += 1;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -27,6 +27,7 @@ import { logger } from "../../middleware/logger.js";
 import { redactCurrentUserText } from "../../log-redaction.js";
 import { redactSensitiveText } from "../../redaction.js";
 import { logActivity } from "../activity-log.js";
+import { isAutoRecoveryIssuesEnabled } from "../auto-recovery-flag.js";
 import { budgetService } from "../budgets.js";
 import { instanceSettingsService } from "../instance-settings.js";
 import { issueTreeControlService } from "../issue-tree-control.js";
@@ -1429,6 +1430,29 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) return null;
+
+    if (!(await isAutoRecoveryIssuesEnabled(db))) {
+      await logActivity(db, {
+        companyId: input.issue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: input.issue.assigneeAgentId,
+        runId: input.latestRun?.id ?? null,
+        action: "issue.stranded_recovery_suppressed",
+        entityType: "issue",
+        entityId: input.issue.id,
+        details: {
+          source: "recovery.ensure_stranded_issue_recovery_issue",
+          identifier: input.issue.identifier,
+          previousStatus: input.previousStatus,
+          recoveryCause: input.recoveryCause ?? "stranded_assigned_issue",
+          latestRunId: input.latestRun?.id ?? null,
+          latestRunStatus: input.latestRun?.status ?? null,
+          latestRunErrorCode: input.latestRun?.errorCode ?? null,
+        },
+      });
+      return null;
+    }
 
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;


### PR DESCRIPTION
## Summary

- New `PAPERCLIP_AUTO_RECOVERY_ISSUES` env var (`on` | `off` | unset) plus matching `experimental.autoRecoveryIssues` instance setting; env override wins, otherwise the instance setting is consulted; default **off**.
- `productivity-review.ts · createOrUpdateReview` short-circuits when disabled and logs `issue.productivity_review_suppressed` instead of creating a "Review productivity for X" issue. The reconcile caller treats the new `suppressed` outcome distinctly so operators can see how often the suppression path fires.
- `recovery/service.ts · ensureStrandedIssueRecoveryIssue` short-circuits when disabled and logs `issue.stranded_recovery_suppressed` instead of creating a "Recover stalled X" issue; the existing caller (`escalateStrandedAssignedIssue`) already handles a null return by leaving the source issue blocked with a comment.

## Why

The stalled-issue detector creates a "Review productivity" issue when an assigned issue looks stuck. When that issue itself stalls, the recovery service creates a "Recover stalled" issue. Recursive creation drowns boards in noise that's not actionable for operators (see e.g. cancelled THE-296→THE-297, THE-298→THE-299 chains). We still want the underlying signal — just not as new board issues by default. Both suppression paths emit activity-log entries so operators retain visibility through the existing activity surface.

## Behavior

| Source | When `PAPERCLIP_AUTO_RECOVERY_ISSUES=on` (or instance setting on) | Default (off) |
|---|---|---|
| `createOrUpdateReview` | Creates / updates the review issue as before | Logs `issue.productivity_review_suppressed`; returns `{ kind: "suppressed" }` |
| `ensureStrandedIssueRecoveryIssue` | Creates the recovery issue as before | Logs `issue.stranded_recovery_suppressed`; returns `null` (caller leaves the source `blocked` with a "no recovery issue created" comment) |

Resolution order in `isAutoRecoveryIssuesEnabled`:
1. `PAPERCLIP_AUTO_RECOVERY_ISSUES` env var (`on`/`true`/`1`/`yes` → enabled; `off`/`false`/`0`/`no` → disabled).
2. Instance experimental setting `autoRecoveryIssues`.
3. Default `false`.

## Files

- `packages/shared/src/types/instance.ts`, `packages/shared/src/validators/instance.ts` — add `autoRecoveryIssues: boolean` to `InstanceExperimentalSettings` (default `false`).
- `server/src/services/instance-settings.ts` — normalize the new field.
- `server/src/services/auto-recovery-flag.ts` — new helper that resolves env + setting.
- `server/src/services/productivity-review.ts` — short-circuit + new `suppressed` outcome bucket in `reconcileProductivityReviews`.
- `server/src/services/recovery/service.ts` — short-circuit at the top of `ensureStrandedIssueRecoveryIssue`.
- Tests:
  - New `server/src/__tests__/auto-recovery-flag.test.ts` covers env/setting resolution.
  - `productivity-review-service.test.ts` adds a suppression test; existing tests pin the env flag to `on` for their describe block so creation behavior is still asserted.
  - `heartbeat-process-recovery.test.ts` pins the env flag to `on` for its describe block.
  - `instance-settings-routes.test.ts` updated for the new field shape.

## Out of scope

- Per-company override via `companies.settings.autoRecoveryIssues` — left as a follow-up; the `companies` table doesn't have a `settings` JSONB column yet, and the instance-level flag is enough to durably solve the immediate noise problem on single-company installs.
- A UI toggle on the experimental settings page; the field is already plumbed through, so this is a small follow-up if desired.

## Test plan

- [x] `pnpm --filter @paperclipai/shared typecheck`
- [x] `pnpm --filter @paperclipai/server typecheck` and `pnpm --filter @paperclipai/ui typecheck`
- [x] `pnpm typecheck` (full repo)
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/productivity-review-service.test.ts` — 12/12 passing (incl. new suppression test)
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts -t "stranded|stalled|recovery"` — 43/43 passing
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/instance-settings-routes.test.ts` — 11/11 passing
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/auto-recovery-flag.test.ts` — 12/12 passing
- [ ] Reviewer to run `pnpm test` end-to-end and confirm no other suite asserts the now-suppressed creation path.