### PR TITLE
skill: make Co-Authored-By: Paperclip trailer conditional on remote-host privacy

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -240,7 +240,7 @@ For commands, response fields, and MCP tools, read:
 - **Budget**: auto-paused at 100%. Above 80%, focus on critical tasks only.
 - **Escalate** via `chainOfCommand` when stuck. Reassign to manager or create a task for them.
 - **Hiring**: use the `paperclip-create-agent` skill for new agent creation workflows (links to reusable `AGENTS.md` templates like `Coder` and `QA`).
-- **Commit Co-author**: if you make a git commit you MUST add EXACTLY `Co-Authored-By: Paperclip <noreply@paperclip.ing>` to the end of each commit message. Do not put in your agent name, put `Co-Authored-By: Paperclip <noreply@paperclip.ing>`.
+- **Commit Co-author (conditional)**: before each commit, run `git remote -v`. If any remote URL contains a public host (case-insensitive substring match: `github.com`, `gitlab.com`, `bitbucket.org`, `codeberg.org`, `sr.ht` — covers `https://...`, `git@...:...`, and mixed-case forms), DO NOT add the `Co-Authored-By: Paperclip` trailer, and DO NOT include any internal issue key (`{PREFIX}-N`), agent role name, run id, or other orchestration term in the commit subject or body. If there is no remote, or all remotes are local/private (`localhost`, `127.0.0.1`, internal hostnames), append exactly `Co-Authored-By: Paperclip <noreply@paperclip.ing>` to the end of each commit message. When in doubt, treat the remote as public and omit the trailer.
 
 This is rule #1:
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and a lot of those companies use Paperclip-driven agents to maintain real codebases.
> - The generic `paperclip` skill (`skills/paperclip/SKILL.md`) is the agent-facing rule sheet that ships with the runtime, and every agent-driven commit goes through it.
> - One bullet on that sheet today is **unconditional**: every commit MUST end with `Co-Authored-By: Paperclip <noreply@paperclip.ing>`.
> - For any user whose Paperclip company drives a **public** repo (GitHub, GitLab, Bitbucket, Codeberg, sr.ht), that trailer leaks the orchestration vendor into permanent public Git history — a generic agent-commit-hygiene leak that applies to any customer with a public-facing project, not a single-customer quirk.
> - The safe default for an unknown remote should be "treat as public" — the rule should opt **in** to the trailer only when remotes are demonstrably private/local.
> - This pull request makes the trailer conditional on `git remote -v`: append it only when there is no remote, or all remotes are local/private hosts; otherwise omit it (and avoid leaking internal issue keys, agent role names, or run ids into the message).
> - The benefit is that public-repo users no longer need a per-company override or a forked skill to keep orchestration metadata out of their public Git history, and private-repo users keep the existing behavior automatically (no remote ⇒ trailer; private hosts ⇒ trailer).

## What Changed

- `skills/paperclip/SKILL.md`: rewrite the **Commit Co-author** bullet (currently a one-line unconditional rule) into a default-safe **Commit Co-author (conditional)** bullet keyed off `git remote -v`. Public-host substring match (`github.com`, `gitlab.com`, `bitbucket.org`, `codeberg.org`, `sr.ht`, case-insensitive, covering both `https://...` and `git@...:...` forms) ⇒ no trailer, no internal issue keys / role names / run ids in the subject or body. No remote, or all remotes local/private (`localhost`, `127.0.0.1`, internal hostnames) ⇒ append the existing trailer exactly as before. Ambiguous case ⇒ treat as public.
- One-bullet, one-file change. No code, no behavior in the runtime, no schema. Other rules on the page are untouched.

## Verification

- Diff: only the single bullet at the previous line 243 changes; the surrounding "Hiring" and "This is rule #1" lines, and every other bullet/section in `SKILL.md`, are byte-identical.
- Manual check, public-host case: in any local clone with `git remote -v` showing `git@github.com:owner/repo.git`, the rule now directs the agent to omit the trailer. Equivalent for `gitlab.com`, `bitbucket.org`, `codeberg.org`, `sr.ht`, including HTTPS and mixed-case URL forms.
- Manual check, private-host case: with no remote configured, or with only `localhost`/`127.0.0.1`/internal hostnames in `git remote -v`, the rule still requires the existing `Co-Authored-By: Paperclip <noreply@paperclip.ing>` trailer.
- Ambiguous case (unrecognized host, mixed public + private remotes): the rule resolves to "treat as public, omit the trailer" — fail-safe direction for a privacy/leak rule.
- No tests exist for skill text, and CI does not lint `skills/*.md` for content. No tests should need to change.

## Risks

- **Behavior change for existing private-repo users:** none. With no remote, or local/private remotes only, the trailer behavior is unchanged.
- **Behavior change for existing public-repo users:** future commits stop emitting the trailer. Existing public Git history is not rewritten by this PR — that is a per-customer cleanup decision (force-push or `git filter-repo`) and is intentionally out of scope here.
- **False positives from the substring match:** an internal hostname containing the literal substring `github.com` (e.g. an internal mirror) would be classified public and skip the trailer. Acceptable trade-off for a default-safe rule; users with unusual hostnames can adjust per-company.
- **Discoverability of the change:** any company that depended on the unconditional trailer (e.g. for an internal attribution audit) will silently lose it on public repos. The bullet is now self-documenting about why and when, so the migration story is "read the new bullet and decide."
- Low risk overall: docs/skill text only, single bullet, no runtime behavior change.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (`claude-opus-4-7`)
- Mode: Claude Code CLI, standard tool use; no extended thinking
- Context: ~200K
- Role: drafted the conditional rewrite and this PR description against an existing internal plan that specified the public-host substring list and the "treat as public when in doubt" default.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass _(no tests cover `skills/*.md` text; nothing to run)_
- [x] I have added or updated tests where applicable _(N/A — pure docs/skill text)_
- [x] If this change affects the UI, I have included before/after screenshots _(N/A — no UI change)_
- [x] I have updated relevant documentation to reflect my changes _(this PR **is** the documentation change)_
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
