### PR TITLE
feat: add triageOnly checkout mode for comment-woken blocked issues

### DIFF
--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -235,6 +235,7 @@ export type IssueExecutionWorkspaceSettings = z.infer<typeof issueExecutionWorks
 export const checkoutIssueSchema = z.object({
   agentId: z.string().uuid(),
   expectedStatuses: z.array(z.enum(ISSUE_STATUSES)).nonempty(),
+  triageOnly: z.boolean().optional(),
 });
 
 export type CheckoutIssue = z.infer<typeof checkoutIssueSchema>;

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2256,6 +2256,50 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     ).rejects.toMatchObject({ status: 422 });
   });
 
+  it("triageOnly checkout succeeds on blocked issue and preserves blocked status", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const blockerId = randomUUID();
+    const blockedId = randomUUID();
+    await db.insert(issues).values([
+      { id: blockerId, companyId, title: "Blocker", status: "todo", priority: "medium" },
+      {
+        id: blockedId,
+        companyId,
+        title: "Blocked",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId,
+      },
+    ]);
+    await svc.update(blockedId, { blockedByIssueIds: [blockerId] });
+
+    const result = await svc.checkout(blockedId, assigneeAgentId, ["blocked"], null, true);
+
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("blocked");
+    expect(result?.checkoutRunId).toBeNull();
+    expect(result?.executionRunId).toBeNull();
+  });
+
   it("wakes parents only when all direct children are terminal", async () => {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3380,7 +3380,7 @@ export function issueRoutes(
 
     const checkoutRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !checkoutRunId) return;
-    const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId);
+    const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId, req.body.triageOnly);
     const actor = getActorInfo(req);
 
     await logActivity(db, {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3315,7 +3315,13 @@ export function issueService(db: Db) {
         return enriched;
       }),
 
-    checkout: async (id: string, agentId: string, expectedStatuses: string[], checkoutRunId: string | null) => {
+    checkout: async (
+      id: string,
+      agentId: string,
+      expectedStatuses: string[],
+      checkoutRunId: string | null,
+      triageOnly?: boolean,
+    ) => {
       const issueCompany = await db
         .select({ companyId: issues.companyId })
         .from(issues)
@@ -3341,10 +3347,12 @@ export function issueService(db: Db) {
 
       await clearExecutionRunIfTerminal(id);
 
-      const dependencyReadiness = await listIssueDependencyReadinessMap(db, issueCompany.companyId, [id]);
-      const unresolvedBlockerIssueIds = dependencyReadiness.get(id)?.unresolvedBlockerIssueIds ?? [];
-      if (unresolvedBlockerIssueIds.length > 0) {
-        throw unprocessable("Issue is blocked by unresolved blockers", { unresolvedBlockerIssueIds });
+      if (!triageOnly) {
+        const dependencyReadiness = await listIssueDependencyReadinessMap(db, issueCompany.companyId, [id]);
+        const unresolvedBlockerIssueIds = dependencyReadiness.get(id)?.unresolvedBlockerIssueIds ?? [];
+        if (unresolvedBlockerIssueIds.length > 0) {
+          throw unprocessable("Issue is blocked by unresolved blockers", { unresolvedBlockerIssueIds });
+        }
       }
 
       const sameRunAssigneeCondition = checkoutRunId
@@ -3356,17 +3364,28 @@ export function issueService(db: Db) {
       const executionLockCondition = checkoutRunId
         ? or(isNull(issues.executionRunId), eq(issues.executionRunId, checkoutRunId))
         : isNull(issues.executionRunId);
-      const updated = await db
-        .update(issues)
-        .set({
+
+      const setFields = triageOnly
+        ? {
           assigneeAgentId: agentId,
           assigneeUserId: null,
           checkoutRunId,
           executionRunId: checkoutRunId,
-          status: "in_progress",
+          updatedAt: now,
+        }
+        : {
+          assigneeAgentId: agentId,
+          assigneeUserId: null,
+          checkoutRunId,
+          executionRunId: checkoutRunId,
+          status: "in_progress" as const,
           startedAt: now,
           updatedAt: now,
-        })
+        };
+
+      const updated = await db
+        .update(issues)
+        .set(setFields)
         .where(
           and(
             eq(issues.id, id),

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -49,7 +49,7 @@ Overrides and special cases:
 - `PAPERCLIP_TASK_ID` set and assigned to you → prioritize that task first.
 - `PAPERCLIP_WAKE_REASON=issue_commented` with `PAPERCLIP_WAKE_COMMENT_ID` → read the comment, then checkout and address the feedback (applies to `in_review` too).
 - `PAPERCLIP_WAKE_REASON=issue_comment_mentioned` → read the comment thread first even if you're not the assignee. Self-assign (via checkout) only if the comment explicitly directs you to take the task. Otherwise respond in comments if useful and continue with your own assigned work; do not self-assign.
-- Wake payload says `dependency-blocked interaction: yes` → the issue is still blocked for deliverable work. Do not try to unblock it. Read the comment, name the unresolved blocker(s), and respond/triage via comments or documents. Use the scoped wake context rather than treating a checkout failure as a blocker.
+- Wake payload says `dependency-blocked interaction: yes` → the issue is still blocked for deliverable work. Do not try to unblock it. Use a `triageOnly: true` checkout (see Step 5), then read the comment, name the unresolved blocker(s), and respond via comments. Do not do deliverable work.
 - **Blocked-task dedup:** before touching a `blocked` task, check the thread. If your most recent comment was a blocked-status update and no one has replied since, skip entirely — do not checkout, do not re-comment. Only re-engage on new context (comment, status change, event wake).
 - Nothing assigned and no valid mention handoff → exit the heartbeat.
 
@@ -62,6 +62,19 @@ Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLI
 ```
 
 If already checked out by you, returns normally. If owned by another agent: `409 Conflict` — stop, pick a different task. **Never retry a 409.**
+
+**Triage checkout for comment-woken blocked issues.** When you are woken by a comment on a `blocked` issue with unresolved `blockedByIssueIds`, a normal checkout returns `422` because the blocker gate is not cleared. To post a triage response without unblocking the issue, use `triageOnly: true`:
+
+```
+POST /api/issues/{issueId}/checkout
+{ "agentId": "{your-agent-id}", "expectedStatuses": ["blocked"], "triageOnly": true }
+```
+
+With `triageOnly: true`:
+- The blocker dependency gate is bypassed — no `422` for unresolved blockers
+- The issue status stays `blocked` (no transition to `in_progress`)
+- The run association is recorded for traceability
+- Use this only to post a comment or triage response; do not do deliverable work under a triage checkout
 
 **Step 6 — Understand context.** Prefer `GET /api/issues/{issueId}/heartbeat-context` first. It gives you compact issue state, ancestor summaries, goal/project info, and comment cursor metadata without forcing a full thread replay.
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies via heartbeats
> - Agents use `POST /api/issues/{id}/checkout` before doing any work — this is enforced by the skill and the "MUST checkout before work" rule
> - Issues with unresolved `blockedByIssueIds` always fail checkout with 422, because the dependency gate rejects any execution attempt on a blocked issue
> - When an agent is woken by a comment on a blocked issue, it should triage the comment — read it, name the unresolved blockers, respond — without transitioning the issue out of `blocked`
> - Without `triageOnly`, agents face a dilemma: either skip checkout (violating the rule) or get a 422 and treat it as an error
> - Refs [FOR-1405](https://github.com/paperclipai/paperclip/issues) (docs workaround) and [FOR-1365](https://github.com/paperclipai/paperclip/issues) (investigation). This PR provides the clean server-side fix.
> - This PR adds `triageOnly: true` as an optional field on checkout: bypasses the blocker gate, preserves `blocked` status, records the run association

## What Changed

- **`packages/shared/src/validators/issue.ts`**: `checkoutIssueSchema` gains `triageOnly: z.boolean().optional()`
- **`server/src/services/issues.ts`**: `checkout()` accepts `triageOnly?: boolean`; when true, skips the `unresolvedBlockerIssueIds` check; DB update omits `status` and `startedAt` fields so status stays `blocked`
- **`server/src/routes/issues.ts`**: passes `req.body.triageOnly` to `svc.checkout()`
- **`skills/paperclip/SKILL.md`**: documents the new triage checkout in Step 5 and updates the Step 4 dependency-blocked interaction override to reference it

## Verification

```bash
# Run targeted test
DATABASE_URL="postgresql://localhost:54329/paperclip_test" \
  npx vitest run server/src/__tests__/issues-service.test.ts

# Type-check
pnpm --filter @paperclipai/shared typecheck
pnpm --filter @paperclipai/server typecheck
```

All 45 service tests pass, all 4 checkout-wakeup tests pass. New test: `triageOnly checkout succeeds on blocked issue and preserves blocked status` — inserts a blocked issue with an unresolved blocker, calls checkout with `triageOnly: true`, asserts the issue comes back with `status: "blocked"`.

Manual: send `POST /api/issues/{id}/checkout` with `{ "agentId": "...", "expectedStatuses": ["blocked"], "triageOnly": true }` on an issue with unresolved blockers — should return 200 with issue, status stays `blocked`, no 422.

## Risks

- Existing checkout behavior is unchanged when `triageOnly` is absent or false — the new flag is purely additive and opt-in
- A `triageOnly` checkout does not grant permission to do deliverable work; the skill documentation explicitly warns against it — agents who ignore this would post work on a blocked issue, which is an agent logic error, not a server constraint to enforce here
- The run association is recorded when `checkoutRunId` is non-null (production), but null in service-level tests (FK constraint prevents test-injected fake run IDs)

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6 (Claude Sonnet 4.6)
- Context: full repo, compiled dist for reference, vitest test runner
- Tool use enabled

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge