### PR TITLE
fix(server): PATCH assignee wake via queueIssueAssignmentWakeup

### DIFF
--- a/server/src/__tests__/environment-selection-route-guards.test.ts
+++ b/server/src/__tests__/environment-selection-route-guards.test.ts
@@ -66,6 +66,10 @@ vi.mock("../services/index.js", () => ({
   }),
   agentService: () => ({
     getById: vi.fn(),
+    resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({
+      agent: { id: raw.trim(), companyId: "company-1" },
+      ambiguous: false,
+    })),
   }),
   executionWorkspaceService: () => ({}),
   goalService: () => ({
@@ -75,13 +79,17 @@ vi.mock("../services/index.js", () => ({
   heartbeatService: () => ({
     getRun: vi.fn(),
     getActiveRunForAgent: vi.fn(),
+    reportRunActivity: vi.fn(async () => undefined),
+    cancelRun: vi.fn(async () => null),
   }),
   issueApprovalService: () => ({
     listApprovalsForIssue: vi.fn(),
     unlink: vi.fn(),
   }),
   documentService: () => ({}),
-  routineService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
   workProductService: () => ({}),
 }));
 
@@ -93,8 +101,10 @@ vi.mock("../services/secrets.js", () => ({
   secretService: () => mockSecretService,
 }));
 
+const mockQueueIssueAssignmentWakeup = vi.hoisted(() => vi.fn());
+
 vi.mock("../services/issue-assignment-wakeup.js", () => ({
-  queueIssueAssignmentWakeup: vi.fn(),
+  queueIssueAssignmentWakeup: mockQueueIssueAssignmentWakeup,
 }));
 
 function buildApp(routerFactory: (app: express.Express) => void) {
@@ -382,5 +392,88 @@ describe.sequential("execution environment route guards", () => {
 
     expect(res.status).not.toBe(422);
     expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  describe("PATCH assignment wakeup (MON-485)", () => {
+    const agentA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const agentB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+    const patchWakeIssue = {
+      id: "issue-patch-wakeup",
+      companyId: "company-1",
+      status: "todo" as const,
+      assigneeAgentId: agentA,
+      assigneeUserId: null,
+      createdByUserId: null,
+      identifier: "PAP-WAKE",
+      title: "Wakeup PATCH",
+      description: "desc",
+      workMode: "planning" as const,
+      priority: "medium" as const,
+      executionPolicy: null,
+      executionState: null,
+      parentId: null,
+      goalId: null,
+      projectId: null,
+      labels: [] as unknown[],
+      labelIds: [] as unknown[],
+      executionWorkspaceId: null,
+      updatedAt: new Date(),
+    };
+
+    async function settleAfterPatch() {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    beforeEach(() => {
+      mockQueueIssueAssignmentWakeup.mockClear();
+      mockIssueService.getById.mockResolvedValue({ ...patchWakeIssue });
+      mockIssueService.update.mockImplementation(async (_id: string, fields: Record<string, unknown>) =>
+        ({
+          ...patchWakeIssue,
+          ...fields,
+          assigneeAgentId:
+            fields.assigneeAgentId === undefined ? patchWakeIssue.assigneeAgentId : fields.assigneeAgentId,
+          assigneeUserId:
+            fields.assigneeUserId === undefined ? patchWakeIssue.assigneeUserId : fields.assigneeUserId,
+        }));
+    });
+
+    it("queues exactly one assignment wakeup when assigneeAgentId changes to another agent", async () => {
+      const app = createIssueApp();
+      const res = await request(app).patch(`/api/issues/${patchWakeIssue.id}`).send({ assigneeAgentId: agentB });
+      await settleAfterPatch();
+
+      expect(res.status).toBe(200);
+      expect(mockQueueIssueAssignmentWakeup).toHaveBeenCalledTimes(1);
+      expect(mockQueueIssueAssignmentWakeup).toHaveBeenCalledWith(
+        expect.objectContaining({
+          issue: expect.objectContaining({ id: patchWakeIssue.id, assigneeAgentId: agentB }),
+          mutation: "patch",
+          contextSource: "issue.patch",
+          reason: "issue_assigned",
+        }),
+      );
+    });
+
+    it("queues no assignment wakeup when only description changes", async () => {
+      const app = createIssueApp();
+      const res = await request(app).patch(`/api/issues/${patchWakeIssue.id}`).send({
+        description: "updated body",
+      });
+      await settleAfterPatch();
+
+      expect(res.status).toBe(200);
+      expect(mockQueueIssueAssignmentWakeup).not.toHaveBeenCalled();
+    });
+
+    it("routes unassign PATCH through wakeup helper without heartbeat (null assignee short-circuit)", async () => {
+      const app = createIssueApp();
+      const res = await request(app).patch(`/api/issues/${patchWakeIssue.id}`).send({ assigneeAgentId: null });
+      await settleAfterPatch();
+
+      expect(res.status).toBe(200);
+      expect(mockQueueIssueAssignmentWakeup).not.toHaveBeenCalled();
+    });
   });
 });

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+
+describe("queueIssueAssignmentWakeup", () => {
+  it("does not invoke heartbeat wakeup when assigneeAgentId is null", async () => {
+    const wakeup = vi.fn(async () => undefined);
+    await Promise.resolve(
+      queueIssueAssignmentWakeup({
+        heartbeat: { wakeup },
+        issue: { id: "issue-1", assigneeAgentId: null, status: "todo" },
+        reason: "issue_assigned",
+        mutation: "patch",
+        contextSource: "issue.patch.test",
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      }),
+    );
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke heartbeat wakeup when issue status is backlog", async () => {
+    const wakeup = vi.fn(async () => undefined);
+    await Promise.resolve(
+      queueIssueAssignmentWakeup({
+        heartbeat: { wakeup },
+        issue: {
+          id: "issue-1",
+          assigneeAgentId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          status: "backlog",
+        },
+        reason: "issue_assigned",
+        mutation: "patch",
+        contextSource: "issue.patch.test",
+      }),
+    );
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
+  it("invokes wakeup for agent assignee on active status", async () => {
+    const agentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const wakeup = vi.fn(async () => undefined);
+    await Promise.resolve(
+      queueIssueAssignmentWakeup({
+        heartbeat: { wakeup },
+        issue: { id: "issue-1", assigneeAgentId: agentId, status: "todo" },
+        reason: "issue_assigned",
+        mutation: "patch",
+        contextSource: "issue.patch.test",
+      }),
+    );
+    expect(wakeup).toHaveBeenCalledTimes(1);
+    expect(wakeup).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({
+        source: "assignment",
+        payload: { issueId: "issue-1", mutation: "patch" },
+      }),
+    );
+  });
+
+  it("merges payloadExtras and contextSnapshotExtras into wakeup options", async () => {
+    const agentId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const wakeup = vi.fn(async () => undefined);
+    await Promise.resolve(
+      queueIssueAssignmentWakeup({
+        heartbeat: { wakeup },
+        issue: { id: "issue-1", assigneeAgentId: agentId, status: "todo" },
+        reason: "issue_assigned",
+        mutation: "update",
+        contextSource: "issue.update",
+        payloadExtras: { commentId: "c1" },
+        contextSnapshotExtras: { taskId: "issue-1", commentId: "c1" },
+      }),
+    );
+    expect(wakeup).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({
+        payload: { issueId: "issue-1", mutation: "update", commentId: "c1" },
+        contextSnapshot: { issueId: "issue-1", source: "issue.update", taskId: "issue-1", commentId: "c1" },
+      }),
+    );
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3117,33 +3117,36 @@ export function issueRoutes(
 
       if (executionStageWakeup) {
         addWakeup(executionStageWakeup.agentId, executionStageWakeup.wakeup);
-      } else if (assigneeChanged && issue.assigneeAgentId && issue.status !== "backlog") {
-        addWakeup(issue.assigneeAgentId, {
-          source: "assignment",
-          triggerDetail: "system",
+      }
+      if (assigneeChanged && issue.assigneeAgentId && issue.status !== "backlog") {
+        const assigneeWakePayloadExtras: Record<string, unknown> = {
+          ...(comment ? { commentId: comment.id } : {}),
+          ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+          ...(interruptedRunId ? { interruptedRunId } : {}),
+        };
+        const assigneeWakeContextExtras: Record<string, unknown> = {
+          ...(comment
+            ? {
+                taskId: issue.id,
+                commentId: comment.id,
+                wakeCommentId: comment.id,
+              }
+            : {}),
+          ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+          ...(interruptedRunId ? { interruptedRunId } : {}),
+        };
+        void queueIssueAssignmentWakeup({
+          heartbeat,
+          issue,
           reason: "issue_assigned",
-          payload: {
-            issueId: issue.id,
-            ...(comment ? { commentId: comment.id } : {}),
-            mutation: "update",
-            ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
-            ...(interruptedRunId ? { interruptedRunId } : {}),
-          },
+          mutation: comment ? "update" : "patch",
+          contextSource: comment ? "issue.update" : "issue.patch",
           requestedByActorType: actor.actorType,
           requestedByActorId: actor.actorId,
-          contextSnapshot: {
-            issueId: issue.id,
-            ...(comment
-              ? {
-                  taskId: issue.id,
-                  commentId: comment.id,
-                  wakeCommentId: comment.id,
-                }
-              : {}),
-            source: "issue.update",
-            ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
-            ...(interruptedRunId ? { interruptedRunId } : {}),
-          },
+          payloadExtras:
+            Object.keys(assigneeWakePayloadExtras).length > 0 ? assigneeWakePayloadExtras : undefined,
+          contextSnapshotExtras:
+            Object.keys(assigneeWakeContextExtras).length > 0 ? assigneeWakeContextExtras : undefined,
         });
       }
 

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -26,6 +26,10 @@ export function queueIssueAssignmentWakeup(input: {
   contextSource: string;
   requestedByActorType?: "user" | "agent" | "system";
   requestedByActorId?: string | null;
+  /** Merged shallowly onto the default `{ issueId, mutation }` wakeup payload */
+  payloadExtras?: Record<string, unknown>;
+  /** Merged shallowly onto the default `{ issueId, source }` context snapshot */
+  contextSnapshotExtras?: Record<string, unknown>;
   rethrowOnError?: boolean;
 }) {
   if (!input.issue.assigneeAgentId || input.issue.status === "backlog") return;
@@ -35,10 +39,10 @@ export function queueIssueAssignmentWakeup(input: {
       source: "assignment",
       triggerDetail: "system",
       reason: input.reason,
-      payload: { issueId: input.issue.id, mutation: input.mutation },
+      payload: { issueId: input.issue.id, mutation: input.mutation, ...(input.payloadExtras ?? {}) },
       requestedByActorType: input.requestedByActorType,
       requestedByActorId: input.requestedByActorId ?? null,
-      contextSnapshot: { issueId: input.issue.id, source: input.contextSource },
+      contextSnapshot: { issueId: input.issue.id, source: input.contextSource, ...(input.contextSnapshotExtras ?? {}) },
     })
     .catch((err) => {
       logger.warn({ err, issueId: input.issue.id }, "failed to wake assignee on issue assignment");


### PR DESCRIPTION
## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies.
> - `PATCH /api/issues/:id` already merged several wakeups inside a trailing `void (async () => { ... })()` block, including execution-stage wakeups and assignee-change wakeups.
> - That block chained **execution-stage** wakeups and **assignee-change** wakeups with `if (executionStageWakeup) { ... } else if (assigneeChanged && ...)`, so any time an execution-stage wakeup was present, assignee-change wakeups were skipped, even when the PATCH reassigned the issue to another agent.
> - Boards that batch “stage transition + reassign + comment” then saw new assignees stall until the next scheduled tick, which dominated end-to-end unblock latency in operated companies.
> - Create, child, and interaction paths already use `queueIssueAssignmentWakeup`; PATCH assignee changes should use the same pathway and stay consistent for logging, payload shape, and heartbeat behavior.
> - This pull request splits those branches so both can run, routes assignee-change PATCH wakeups through `queueIssueAssignmentWakeup`, and adds optional shallow `payloadExtras` / `contextSnapshotExtras` so comment, resume, and interrupt fields stay aligned with the previous inline wakeup shape.
> - **Benefit:** immediate, event-driven wakeups for PATCH-driven reassignment, even when an execution-stage wakeup is also queued, without waiting on cron-style sweeps.

## What Changed

- Replaced the execution-stage / assignee `else if` with two independent `if` blocks in the `PATCH /api/issues/:id` deferred wakeup section, so assignee-change wakeups are not dropped when `buildExecutionStageWakeup` returns a wakeup.
- When `assigneeChanged` and the updated issue has an **agent** assignee and `status !== "backlog"`, enqueue via `queueIssueAssignmentWakeup`.
- Used `mutation` / `contextSource` values of `"patch"` / `"issue.patch"` when there is no merged comment on that response path.
- Used `mutation` / `contextSource` values of `"update"` / `"issue.update"` when a `comment` exists.
- Passed optional extras, including comment IDs, resume metadata, and interrupt metadata, through the new optional fields.
- Extended `queueIssueAssignmentWakeup` with optional `payloadExtras` and `contextSnapshotExtras`, shallow-merged onto the default payload and context snapshot.
- Added `server/src/__tests__/issue-assignment-wakeup.test.ts` for guard behavior and extras merging.
- Extended `environment-selection-route-guards.test.ts` with PATCH assignment-wakeup cases.
- Strengthened route-test mocks for `resolveByReference`, `syncRunStatusForIssue`, and heartbeat stubs.
- Fixes #5313.

## Verification

```bash
pnpm -r typecheck
pnpm test
pnpm exec vitest run server/src/__tests__/issue-assignment-wakeup.test.ts server/src/__tests__/environment-selection-route-guards.test.ts
```

All of the above were run locally and passed. No manual UI verification was performed because this is server-only behavior.

## Risks

- More wakeups may be queued per PATCH when both an execution-stage wakeup and an assignee-change wakeup apply. This is the intended fix for the boarded-unblock bottleneck.
- Heartbeat `addWakeup` merging still dedupes by map key inside the batch where it applies, but `queueIssueAssignmentWakeup` invokes `heartbeat.wakeup` directly. Callers should assume potential duplicate edges unless coalescing covers the pair. Wakeup volume/noise should be monitored after shipping.
- Assignee wakeups moved from inline `addWakeup` semantics using `mutation: "update"` / `source: "issue.update"` to `mutation: "patch"` / `source: "issue.patch"` when there is no comment on that path. Downstream parsers that only key on `"update"` should be verified.
- No DB migrations or API schema changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected. See `CONTRIBUTING.md`.

## Model Used

Cursor IDE — GPT-5.3.

Tooling: codebase read/search, patches, Vitest/pnpm in terminal.

Human input: branch layout, commit message, verification runs, and PR text assembly.

## Checklist

- [x] I have included a thinking path that traces from project context to this change.
- [x] I have specified the model used.
- [x] I have checked `ROADMAP.md` and confirmed this PR does not duplicate planned core work.
- [x] I have run tests locally and they pass.
- [x] I have added or updated tests where applicable.
- [x] If this change affects the UI, I have included before/after screenshots. N/A — no UI changes.
- [x] I have updated relevant documentation to reflect my changes. N/A — no behavioral doc delta required beyond code/tests.
- [x] I have considered and documented risks above.
- [x] I will address all Greptile and reviewer comments before requesting merge.