### PR TITLE
docs: add npx registry workaround for onboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,10 +297,10 @@ npx paperclipai onboard --yes
 > npm config get registry
 > ```
 >
-> Workaround (force the public npm registry for this command):
+> Workaround (cross-platform; force the public npm registry for this command):
 >
 > ```bash
-> npm_config_registry=https://registry.npmjs.org npx paperclipai onboard --yes
+> npx --registry https://registry.npmjs.org paperclipai onboard --yes
 > ```
 
 That quickstart path now defaults to trusted local loopback mode for the fastest first run. To start in authenticated/private mode instead, choose a bind preset explicitly:

--- a/README.md
+++ b/README.md
@@ -287,6 +287,22 @@ Open source. Self-hosted. No Paperclip account required.
 npx paperclipai onboard --yes
 ```
 
+> **Troubleshooting: private npm registry `.npmrc`**
+>
+> If this fails with an `E404` for `paperclipai` (or similar) and you use a private npm registry (for example GitHub Packages) via a global `~/.npmrc`, `npx` may be resolving `paperclipai` against that private registry instead of the public npm registry.
+>
+> Diagnostic:
+>
+> ```bash
+> npm config get registry
+> ```
+>
+> Workaround (force the public npm registry for this command):
+>
+> ```bash
+> npm_config_registry=https://registry.npmjs.org npx paperclipai onboard --yes
+> ```
+
 That quickstart path now defaults to trusted local loopback mode for the fastest first run. To start in authenticated/private mode instead, choose a bind preset explicitly:
 
 ```bash

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -125,6 +125,22 @@ For a first-time local install, you can bootstrap and run in one command:
 pnpm paperclipai run
 ```
 
+> **Note: private npm registry `.npmrc` + first-run onboarding**
+>
+> The first-run experience often starts with `npx paperclipai onboard --yes` (before you have a repo checkout). If your global `~/.npmrc` sets `registry` to a private registry (for example GitHub Packages), `npx` may try to resolve `paperclipai` from that private registry and fail with `E404`.
+>
+> Diagnostic:
+>
+> ```sh
+> npm config get registry
+> ```
+>
+> Workaround (force the public npm registry for this command):
+>
+> ```sh
+> npm_config_registry=https://registry.npmjs.org npx paperclipai onboard --yes
+> ```
+
 `paperclipai run` does:
 
 1. auto-onboard if config is missing

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -135,10 +135,10 @@ pnpm paperclipai run
 > npm config get registry
 > ```
 >
-> Workaround (force the public npm registry for this command):
+> Workaround (cross-platform; force the public npm registry for this command):
 >
 > ```sh
-> npm_config_registry=https://registry.npmjs.org npx paperclipai onboard --yes
+> npx --registry https://registry.npmjs.org paperclipai onboard --yes
 > ```
 
 `paperclipai run` does:


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and the fastest first-run path is `npx paperclipai onboard --yes`.
> - This change touches the first-run onboarding path, specifically how users install and execute Paperclip through `npx`.
> - `npx` resolves packages using the caller’s active npm registry configuration.
> - If a user’s global `~/.npmrc` points `registry` at a private registry, such as GitHub Packages, npm may try to resolve `paperclipai` there instead of the public npm registry.
> - That can fail with `E404` even though `paperclipai` exists on the public npm registry.
> - This pull request documents the failure mode and adds a per-command public-registry override plus a simple diagnostic.
> - The benefit is an immediate recovery path for first-run users without changing runtime code or relying on repo-local config.
> - This is intentionally docs-only because it fixes onboarding friction before users even clone the repo.

## What Changed

- Updated `README.md` Quickstart with a troubleshooting note for private-registry `.npmrc` setups.
- Added the diagnostic command:

```bash
npm config get registry
```

- Documented the workaround command:

```bash
npm_config_registry=https://registry.npmjs.org npx paperclipai onboard --yes
```

- Updated `doc/DEVELOPING.md` near “One-Command Local Run” with the same note because first-run onboarding often starts via `npx` before a repo checkout.
- Fixes #5346.

## Verification

- Reproduced the private-registry failure mode using a temporary npm config pointing to GitHub Packages.

### Private registry failure reproduction

<img width="1297" height="385" alt="Private registry E404 reproduction" src="https://github.com/user-attachments/assets/28632fec-60e0-40b3-bc61-191185d5fe80" />

- Ran the exact reproduction-proof command with a per-command public npm registry override:

```bash
npm_config_userconfig=/tmp/paperclip-npmrc-repro/npmrc \
npm_config_registry=https://registry.npmjs.org \
npm view paperclipai version
```

- Confirmed it returned:

```bash
2026.428.0
```

### Public registry override success

<img width="612" height="137" alt="Public registry override success" src="https://github.com/user-attachments/assets/3c0c15c0-23d1-4c52-addd-56cd6847a146" />

## Risks

- Low risk. Docs-only change.
- No runtime code, package behavior, migrations, or UI behavior are changed.
- I intentionally did not add a repository `.npmrc` because the reported failure occurs during first-run `npx`, before the user necessarily has a repo checkout. A repo-local `.npmrc` would not reliably affect that path.
- I also did not add a `curl`/`wget` installer fallback because there is no documented official install script URL in scope for this fix.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.2 via Cursor IDE, tool-use enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge