### PR TITLE
Fix Hermes adapter API key check for Minimax and other providers

### DIFF
--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -9,14 +9,23 @@ const hermesExecuteMock = vi.hoisted(() =>
   })),
 );
 
+const hermesTestEnvironmentMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    adapterType: "hermes_local",
+    status: "pass" as const,
+    checks: [] as Array<{
+      code: string;
+      level: "info" | "warn" | "error";
+      message: string;
+      hint?: string | null;
+    }>,
+    testedAt: new Date(0).toISOString(),
+  })),
+);
+
 vi.mock("hermes-paperclip-adapter/server", () => ({
   execute: hermesExecuteMock,
-  testEnvironment: async () => ({
-    adapterType: "hermes_local",
-    status: "pass",
-    checks: [],
-    testedAt: new Date(0).toISOString(),
-  }),
+  testEnvironment: hermesTestEnvironmentMock,
   sessionCodec: null,
   listSkills: async () => [],
   syncSkills: async () => ({ entries: [] }),
@@ -67,6 +76,7 @@ describe("server adapter registry", () => {
     unregisterServerAdapter("claude_local");
     setOverridePaused("claude_local", false);
     hermesExecuteMock.mockClear();
+    hermesTestEnvironmentMock.mockClear();
   });
 
   it("registers external adapters and exposes them through lookup helpers", async () => {
@@ -450,6 +460,96 @@ describe("server adapter registry", () => {
     expect(patchedCtx.agent.adapterConfig.promptTemplate).toBeUndefined();
     // Auth token is still injected.
     expect(patchedCtx.agent.adapterConfig.env.PAPERCLIP_API_KEY).toBe("agent-run-jwt");
+  });
+
+  it("treats a configured Hermes provider key as satisfying the upstream no-API-keys warning", async () => {
+    hermesTestEnvironmentMock.mockResolvedValueOnce({
+      adapterType: "hermes_local",
+      status: "warn",
+      checks: [
+        {
+          level: "warn",
+          message: "No LLM API keys found in environment",
+          hint: "Set ANTHROPIC_API_KEY, OPENROUTER_API_KEY, OPENAI_API_KEY, or ZAI_API_KEY in the agent's env secrets. Hermes may also have keys configured in ~/.hermes/.env",
+          code: "hermes_no_api_keys",
+        },
+      ],
+      testedAt: new Date(0).toISOString(),
+    });
+
+    const adapter = requireServerAdapter("hermes_local");
+    const result = await adapter.testEnvironment({
+      companyId: "company-123",
+      adapterType: "hermes_local",
+      config: {
+        provider: "minimax",
+        env: { MINIMAX_API_KEY: "mm-secret" },
+      },
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.checks).toHaveLength(1);
+    expect(result.checks[0]).toMatchObject({
+      level: "info",
+      code: "hermes_api_keys_found",
+      message: expect.stringContaining("MINIMAX_API_KEY"),
+    });
+  });
+
+  it("infers the expected Hermes key from the model prefix when provider is unset", async () => {
+    hermesTestEnvironmentMock.mockResolvedValueOnce({
+      adapterType: "hermes_local",
+      status: "warn",
+      checks: [
+        {
+          level: "warn",
+          message: "No LLM API keys found in environment",
+          code: "hermes_no_api_keys",
+        },
+      ],
+      testedAt: new Date(0).toISOString(),
+    });
+
+    const adapter = requireServerAdapter("hermes_local");
+    const result = await adapter.testEnvironment({
+      companyId: "company-123",
+      adapterType: "hermes_local",
+      config: {
+        model: "minimax/minimax-m2.5-free",
+        env: { MINIMAX_API_KEY: "mm-secret" },
+      },
+    });
+
+    expect(result.status).toBe("pass");
+    expect(result.checks[0].code).toBe("hermes_api_keys_found");
+  });
+
+  it("preserves the upstream warning when the configured provider key is still missing", async () => {
+    hermesTestEnvironmentMock.mockResolvedValueOnce({
+      adapterType: "hermes_local",
+      status: "warn",
+      checks: [
+        {
+          level: "warn",
+          message: "No LLM API keys found in environment",
+          code: "hermes_no_api_keys",
+        },
+      ],
+      testedAt: new Date(0).toISOString(),
+    });
+
+    const adapter = requireServerAdapter("hermes_local");
+    const result = await adapter.testEnvironment({
+      companyId: "company-123",
+      adapterType: "hermes_local",
+      config: {
+        provider: "minimax",
+        env: {},
+      },
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.checks[0].code).toBe("hermes_no_api_keys");
   });
 });
 

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -190,6 +190,98 @@ function normalizeHermesConfig<T extends { config?: unknown; agent?: unknown }>(
   return ctx;
 }
 
+// ---------------------------------------------------------------------------
+// Hermes provider-aware API key check
+// ---------------------------------------------------------------------------
+// hermes-paperclip-adapter@0.2.0's testEnvironment only checks for ANTHROPIC_API_KEY,
+// OPENROUTER_API_KEY, OPENAI_API_KEY, and ZAI_API_KEY. Hermes itself supports more
+// providers via --provider (minimax, minimax-cn, kimi-coding, nous, ...). When a
+// user wires hermes to one of those providers and sets the matching key (e.g.
+// MINIMAX_API_KEY), the upstream check spuriously warns that no LLM keys are
+// configured and points them at ANTHROPIC_API_KEY. The wrapper below augments
+// the upstream result so a configured-provider key suppresses that false warning.
+
+const HERMES_PROVIDER_KEYS: Record<string, string[]> = {
+  openrouter: ["OPENROUTER_API_KEY"],
+  nous: ["NOUS_API_KEY", "HERMES_API_KEY"],
+  "openai-codex": ["OPENAI_API_KEY"],
+  zai: ["ZAI_API_KEY"],
+  "kimi-coding": ["MOONSHOT_API_KEY", "KIMI_API_KEY"],
+  minimax: ["MINIMAX_API_KEY"],
+  "minimax-cn": ["MINIMAX_API_KEY"],
+};
+
+const HERMES_MODEL_PREFIX_KEYS: Record<string, string[]> = {
+  anthropic: ["ANTHROPIC_API_KEY"],
+  openai: ["OPENAI_API_KEY"],
+  openrouter: ["OPENROUTER_API_KEY"],
+  minimax: ["MINIMAX_API_KEY"],
+  "minimax-cn": ["MINIMAX_API_KEY"],
+  zai: ["ZAI_API_KEY"],
+  moonshot: ["MOONSHOT_API_KEY", "KIMI_API_KEY"],
+  kimi: ["KIMI_API_KEY", "MOONSHOT_API_KEY"],
+  nous: ["NOUS_API_KEY", "HERMES_API_KEY"],
+};
+
+function expectedHermesProviderKeys(config: Record<string, unknown>): string[] {
+  const provider =
+    typeof config.provider === "string" ? config.provider.trim().toLowerCase() : "";
+  const model = typeof config.model === "string" ? config.model.trim().toLowerCase() : "";
+  const keys = new Set<string>();
+  if (provider && provider !== "auto") {
+    for (const k of HERMES_PROVIDER_KEYS[provider] ?? []) keys.add(k);
+  }
+  const slashIdx = model.indexOf("/");
+  if (slashIdx > 0) {
+    const prefix = model.slice(0, slashIdx);
+    for (const k of HERMES_MODEL_PREFIX_KEYS[prefix] ?? []) keys.add(k);
+  }
+  return [...keys];
+}
+
+function hermesEnvHasKey(config: Record<string, unknown>, key: string): boolean {
+  const env =
+    config.env && typeof config.env === "object" && !Array.isArray(config.env)
+      ? (config.env as Record<string, unknown>)
+      : {};
+  const fromConfig = typeof env[key] === "string" && (env[key] as string).length > 0;
+  if (fromConfig) return true;
+  const fromProcess = process.env[key];
+  return typeof fromProcess === "string" && fromProcess.length > 0;
+}
+
+async function hermesTestEnvironmentWithProviderAwareKeys<
+  T extends { config?: unknown },
+>(ctx: T): Promise<Awaited<ReturnType<typeof hermesTestEnvironment>>> {
+  const result = await hermesTestEnvironment(ctx as never);
+  const config =
+    ctx && typeof ctx === "object" && ctx.config && typeof ctx.config === "object"
+      ? (ctx.config as Record<string, unknown>)
+      : {};
+  const expected = expectedHermesProviderKeys(config);
+  if (expected.length === 0) return result;
+
+  const noKeysIdx = result.checks.findIndex((c) => c.code === "hermes_no_api_keys");
+  if (noKeysIdx < 0) return result;
+
+  const found = expected.find((k) => hermesEnvHasKey(config, k));
+  if (!found) return result;
+
+  const checks = result.checks.slice();
+  checks[noKeysIdx] = {
+    level: "info",
+    message: `API key found for configured provider: ${found}`,
+    code: "hermes_api_keys_found",
+  };
+  const hasErrors = checks.some((c) => c.level === "error");
+  const hasWarnings = checks.some((c) => c.level === "warn");
+  return {
+    ...result,
+    status: hasErrors ? "fail" : hasWarnings ? "warn" : "pass",
+    checks,
+  };
+}
+
 function dedupeAdapterModels(models: AdapterModel[]): AdapterModel[] {
   const seen = new Set<string>();
   const result: AdapterModel[] = [];
@@ -427,7 +519,8 @@ const hermesLocalAdapter: ServerAdapterModule = {
 
     return executeHermesLocal(patchedCtx);
   },
-  testEnvironment: (ctx) => hermesTestEnvironment(normalizeHermesConfig(ctx) as never),
+  testEnvironment: (ctx) =>
+    hermesTestEnvironmentWithProviderAwareKeys(normalizeHermesConfig(ctx) as never),
   sessionCodec: hermesSessionCodec,
   listSkills: hermesListSkills,
   syncSkills: hermesSyncSkills,


### PR DESCRIPTION
## Summary
- The Hermes adapter wrapper now inspects the configured `provider`/`model` and recognizes provider-specific keys (`MINIMAX_API_KEY`, `KIMI_API_KEY`/`MOONSHOT_API_KEY`, `NOUS_API_KEY`/`HERMES_API_KEY`, ...) when the upstream `hermes-paperclip-adapter@0.2.0` only checks for `ANTHROPIC_API_KEY`/`OPENROUTER_API_KEY`/`OPENAI_API_KEY`/`ZAI_API_KEY`.
- When the matching key is configured (in `config.env` or `process.env`), the spurious "No LLM API keys found" warning that pointed users at the Anthropic key is replaced with an info-level "API key found for configured provider" check, and overall status is recomputed.
- Falls back to upstream behavior when no provider/model is configured or the expected key is still missing.

Fixes [#5407](https://github.com/paperclipai/paperclip/issues/5407).

## Test plan
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-registry.test.ts` — 20/20 passing, including 3 new cases:
  - configured `provider: minimax` + `MINIMAX_API_KEY` suppresses the upstream warning
  - `model: minimax/...` (no explicit provider) infers the expected key from the model prefix
  - missing key still surfaces the original warning
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-routes.test.ts src/__tests__/agent-adapter-validation-routes.test.ts` — 10/10 passing.
- [ ] Manual verification: configure a Hermes agent with `provider=minimax` and a `MINIMAX_API_KEY` env secret, run "Test environment", confirm the result is `pass` with `hermes_api_keys_found` instead of `hermes_no_api_keys`.