### PR TITLE
feat(ite-171): Tosca Cloud TypeScript client

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,6 +649,18 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
+  tools/tosca-cloud-agent/client:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
   ui:
     dependencies:
       '@assistant-ui/react':
@@ -3844,6 +3856,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -6499,46 +6512,6 @@ packages:
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -10405,21 +10378,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -13521,41 +13494,11 @@ snapshots:
       lightningcss: 1.30.2
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      tsx: 4.21.0
-
-  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.60.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.2.3
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      tsx: 4.21.0
-
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13573,7 +13516,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -13598,7 +13541,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13616,7 +13559,7 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vite-node: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - packages/*
   - packages/adapters/*
+  - tools/**
   - packages/plugins/*
   # Keep sandbox-provider plugins installable as standalone packages without
   # forcing root pnpm-lock.yaml churn for their third-party deps.

--- a/tools/tosca-cloud-agent/client/fixtures/agents.json
+++ b/tools/tosca-cloud-agent/client/fixtures/agents.json
@@ -1,0 +1,56 @@
+{
+  "list": {
+    "items": [
+      {
+        "id": "agent-001",
+        "name": "Windows Runner 01",
+        "status": "online",
+        "version": "15.2.1",
+        "capabilities": ["web", "sap", "windows"],
+        "workspaceIds": ["ws-001", "ws-002"],
+        "registeredAt": "2025-01-10T09:00:00.000Z",
+        "lastSeenAt": "2025-05-07T11:55:00.000Z"
+      },
+      {
+        "id": "agent-002",
+        "name": "Windows Runner 02",
+        "status": "busy",
+        "version": "15.2.1",
+        "capabilities": ["web", "windows"],
+        "workspaceIds": ["ws-001"],
+        "registeredAt": "2025-02-01T10:00:00.000Z",
+        "lastSeenAt": "2025-05-07T11:58:00.000Z"
+      }
+    ],
+    "total": 2,
+    "page": 1,
+    "pageSize": 20
+  },
+  "get": {
+    "id": "agent-001",
+    "name": "Windows Runner 01",
+    "status": "online",
+    "version": "15.2.1",
+    "capabilities": ["web", "sap", "windows"],
+    "workspaceIds": ["ws-001", "ws-002"],
+    "registeredAt": "2025-01-10T09:00:00.000Z",
+    "lastSeenAt": "2025-05-07T11:55:00.000Z"
+  },
+  "listForWorkspace": {
+    "items": [
+      {
+        "id": "agent-001",
+        "name": "Windows Runner 01",
+        "status": "online",
+        "version": "15.2.1",
+        "capabilities": ["web", "sap", "windows"],
+        "workspaceIds": ["ws-001", "ws-002"],
+        "registeredAt": "2025-01-10T09:00:00.000Z",
+        "lastSeenAt": "2025-05-07T11:55:00.000Z"
+      }
+    ],
+    "total": 1,
+    "page": 1,
+    "pageSize": 20
+  }
+}

--- a/tools/tosca-cloud-agent/client/fixtures/executions.json
+++ b/tools/tosca-cloud-agent/client/fixtures/executions.json
@@ -1,0 +1,77 @@
+{
+  "list": {
+    "items": [
+      {
+        "id": "exec-001",
+        "workspaceId": "ws-001",
+        "projectId": "proj-001",
+        "status": "passed",
+        "agentId": "agent-001",
+        "testCaseIds": ["tc-001", "tc-002"],
+        "results": [
+          { "testCaseId": "tc-001", "status": "passed", "durationMs": 12500, "error": null },
+          { "testCaseId": "tc-002", "status": "passed", "durationMs": 34200, "error": null }
+        ],
+        "startedAt": "2025-05-01T08:00:00.000Z",
+        "completedAt": "2025-05-01T08:01:30.000Z",
+        "createdAt": "2025-05-01T07:59:00.000Z"
+      },
+      {
+        "id": "exec-002",
+        "workspaceId": "ws-001",
+        "projectId": "proj-001",
+        "status": "failed",
+        "agentId": "agent-001",
+        "testCaseIds": ["tc-001"],
+        "results": [
+          { "testCaseId": "tc-001", "status": "failed", "durationMs": 8300, "error": "Element not found: #submit-btn" }
+        ],
+        "startedAt": "2025-05-06T14:00:00.000Z",
+        "completedAt": "2025-05-06T14:00:15.000Z",
+        "createdAt": "2025-05-06T13:59:00.000Z"
+      }
+    ],
+    "total": 2,
+    "page": 1,
+    "pageSize": 20
+  },
+  "get": {
+    "id": "exec-001",
+    "workspaceId": "ws-001",
+    "projectId": "proj-001",
+    "status": "passed",
+    "agentId": "agent-001",
+    "testCaseIds": ["tc-001", "tc-002"],
+    "results": [
+      { "testCaseId": "tc-001", "status": "passed", "durationMs": 12500, "error": null },
+      { "testCaseId": "tc-002", "status": "passed", "durationMs": 34200, "error": null }
+    ],
+    "startedAt": "2025-05-01T08:00:00.000Z",
+    "completedAt": "2025-05-01T08:01:30.000Z",
+    "createdAt": "2025-05-01T07:59:00.000Z"
+  },
+  "create": {
+    "id": "exec-003",
+    "workspaceId": "ws-001",
+    "projectId": "proj-001",
+    "status": "pending",
+    "agentId": null,
+    "testCaseIds": ["tc-001"],
+    "results": [],
+    "startedAt": null,
+    "completedAt": null,
+    "createdAt": "2025-05-07T12:00:00.000Z"
+  },
+  "cancel": {
+    "id": "exec-003",
+    "workspaceId": "ws-001",
+    "projectId": "proj-001",
+    "status": "cancelled",
+    "agentId": null,
+    "testCaseIds": ["tc-001"],
+    "results": [],
+    "startedAt": null,
+    "completedAt": "2025-05-07T12:00:30.000Z",
+    "createdAt": "2025-05-07T12:00:00.000Z"
+  }
+}

--- a/tools/tosca-cloud-agent/client/fixtures/projects.json
+++ b/tools/tosca-cloud-agent/client/fixtures/projects.json
@@ -1,0 +1,41 @@
+{
+  "list": {
+    "items": [
+      {
+        "id": "proj-001",
+        "workspaceId": "ws-001",
+        "name": "KYC Automation",
+        "description": "KYC process automation test suite",
+        "createdAt": "2025-01-20T09:00:00.000Z",
+        "updatedAt": "2025-03-25T11:00:00.000Z"
+      },
+      {
+        "id": "proj-002",
+        "workspaceId": "ws-001",
+        "name": "Onboarding Flows",
+        "description": "End-to-end onboarding test suite",
+        "createdAt": "2025-02-10T10:00:00.000Z",
+        "updatedAt": "2025-04-10T09:30:00.000Z"
+      }
+    ],
+    "total": 2,
+    "page": 1,
+    "pageSize": 20
+  },
+  "get": {
+    "id": "proj-001",
+    "workspaceId": "ws-001",
+    "name": "KYC Automation",
+    "description": "KYC process automation test suite",
+    "createdAt": "2025-01-20T09:00:00.000Z",
+    "updatedAt": "2025-03-25T11:00:00.000Z"
+  },
+  "create": {
+    "id": "proj-003",
+    "workspaceId": "ws-001",
+    "name": "New Project",
+    "description": "",
+    "createdAt": "2025-05-01T12:00:00.000Z",
+    "updatedAt": "2025-05-01T12:00:00.000Z"
+  }
+}

--- a/tools/tosca-cloud-agent/client/fixtures/sso-token.json
+++ b/tools/tosca-cloud-agent/client/fixtures/sso-token.json
@@ -1,0 +1,5 @@
+{
+  "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.fixture",
+  "token_type": "bearer",
+  "expires_in": 3600
+}

--- a/tools/tosca-cloud-agent/client/fixtures/test-cases.json
+++ b/tools/tosca-cloud-agent/client/fixtures/test-cases.json
@@ -1,0 +1,64 @@
+{
+  "list": {
+    "items": [
+      {
+        "id": "tc-001",
+        "projectId": "proj-001",
+        "workspaceId": "ws-001",
+        "name": "Login Happy Path",
+        "description": "Validates successful user login",
+        "status": "active",
+        "tags": ["smoke", "login"],
+        "createdAt": "2025-01-25T09:00:00.000Z",
+        "updatedAt": "2025-03-01T10:00:00.000Z"
+      },
+      {
+        "id": "tc-002",
+        "projectId": "proj-001",
+        "workspaceId": "ws-001",
+        "name": "Document Upload",
+        "description": "Validates KYC document upload flow",
+        "status": "active",
+        "tags": ["kyc", "upload"],
+        "createdAt": "2025-01-26T09:00:00.000Z",
+        "updatedAt": "2025-03-05T10:00:00.000Z"
+      },
+      {
+        "id": "tc-003",
+        "projectId": "proj-001",
+        "workspaceId": "ws-001",
+        "name": "Legacy Flow",
+        "description": "Old onboarding flow, no longer used",
+        "status": "deprecated",
+        "tags": ["legacy"],
+        "createdAt": "2025-01-10T09:00:00.000Z",
+        "updatedAt": "2025-02-28T10:00:00.000Z"
+      }
+    ],
+    "total": 3,
+    "page": 1,
+    "pageSize": 20
+  },
+  "get": {
+    "id": "tc-001",
+    "projectId": "proj-001",
+    "workspaceId": "ws-001",
+    "name": "Login Happy Path",
+    "description": "Validates successful user login",
+    "status": "active",
+    "tags": ["smoke", "login"],
+    "createdAt": "2025-01-25T09:00:00.000Z",
+    "updatedAt": "2025-03-01T10:00:00.000Z"
+  },
+  "create": {
+    "id": "tc-004",
+    "projectId": "proj-001",
+    "workspaceId": "ws-001",
+    "name": "Password Reset",
+    "description": "Validates password reset flow",
+    "status": "active",
+    "tags": ["auth"],
+    "createdAt": "2025-05-07T12:00:00.000Z",
+    "updatedAt": "2025-05-07T12:00:00.000Z"
+  }
+}

--- a/tools/tosca-cloud-agent/client/fixtures/workspaces.json
+++ b/tools/tosca-cloud-agent/client/fixtures/workspaces.json
@@ -1,0 +1,44 @@
+{
+  "list": {
+    "items": [
+      {
+        "id": "ws-001",
+        "name": "Itecor Workspace",
+        "description": "Main workspace for Itecor projects",
+        "createdAt": "2025-01-15T09:00:00.000Z",
+        "updatedAt": "2025-03-20T14:30:00.000Z"
+      },
+      {
+        "id": "ws-002",
+        "name": "Dev Workspace",
+        "description": "Development and staging workspace",
+        "createdAt": "2025-02-01T10:00:00.000Z",
+        "updatedAt": "2025-04-05T08:15:00.000Z"
+      }
+    ],
+    "total": 2,
+    "page": 1,
+    "pageSize": 20
+  },
+  "get": {
+    "id": "ws-001",
+    "name": "Itecor Workspace",
+    "description": "Main workspace for Itecor projects",
+    "createdAt": "2025-01-15T09:00:00.000Z",
+    "updatedAt": "2025-03-20T14:30:00.000Z"
+  },
+  "create": {
+    "id": "ws-003",
+    "name": "New Workspace",
+    "description": "A freshly created workspace",
+    "createdAt": "2025-05-01T12:00:00.000Z",
+    "updatedAt": "2025-05-01T12:00:00.000Z"
+  },
+  "update": {
+    "id": "ws-001",
+    "name": "Updated Workspace",
+    "description": "Main workspace for Itecor projects",
+    "createdAt": "2025-01-15T09:00:00.000Z",
+    "updatedAt": "2025-05-07T10:00:00.000Z"
+  }
+}

--- a/tools/tosca-cloud-agent/client/package.json
+++ b/tools/tosca-cloud-agent/client/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@paperclipai/tosca-cloud-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/tools/tosca-cloud-agent/client/src/__tests__/auth.test.ts
+++ b/tools/tosca-cloud-agent/client/src/__tests__/auth.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { clearSSOTokenCache, resolveAuth, resolvePatAuth } from "../auth.js";
+import { ToscaAuthError } from "../types.js";
+import {
+  mockJsonResponse,
+  mockSequentialJsonResponses,
+} from "./helpers.js";
+import ssoTokenFixture from "../../fixtures/sso-token.json" with { type: "json" };
+
+describe("resolvePatAuth", () => {
+  it("returns Bearer header from PAT token", () => {
+    const auth = resolvePatAuth({ type: "pat", token: "my-secret-pat" });
+    expect(auth.authorizationHeader).toBe("Bearer my-secret-pat");
+  });
+});
+
+describe("resolveAuth — PAT", () => {
+  it("resolves PAT credentials without calling fetch", async () => {
+    const fetch = mockJsonResponse({});
+    const auth = await resolveAuth({ type: "pat", token: "tok-123" }, fetch);
+    expect(auth.authorizationHeader).toBe("Bearer tok-123");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveAuth — SSO", () => {
+  afterEach(() => {
+    clearSSOTokenCache();
+  });
+
+  it("fetches an OAuth2 client_credentials token", async () => {
+    const fetch = mockJsonResponse(ssoTokenFixture);
+    const auth = await resolveAuth(
+      {
+        type: "sso",
+        tenantUrl: "https://myorg.tricentis.com",
+        clientId: "client-abc",
+        clientSecret: "secret-xyz",
+      },
+      fetch,
+    );
+
+    expect(fetch).toHaveBeenCalledOnce();
+    const [url, init] = fetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://myorg.tricentis.com/oauth/token");
+    expect(init.method).toBe("POST");
+    expect(auth.authorizationHeader).toBe(
+      `Bearer ${ssoTokenFixture.access_token}`,
+    );
+  });
+
+  it("caches the SSO token for subsequent calls", async () => {
+    const fetch = mockSequentialJsonResponses([
+      { body: ssoTokenFixture },
+      { body: ssoTokenFixture },
+    ]);
+    const creds = {
+      type: "sso" as const,
+      tenantUrl: "https://myorg.tricentis.com",
+      clientId: "client-abc",
+      clientSecret: "secret-xyz",
+    };
+    await resolveAuth(creds, fetch);
+    await resolveAuth(creds, fetch);
+
+    expect(fetch).toHaveBeenCalledOnce();
+  });
+
+  it("throws ToscaAuthError when the token endpoint returns non-OK", async () => {
+    const fetch = mockJsonResponse({ error: "invalid_client" }, 401);
+    await expect(
+      resolveAuth(
+        {
+          type: "sso",
+          tenantUrl: "https://myorg.tricentis.com",
+          clientId: "bad-client",
+          clientSecret: "bad-secret",
+        },
+        fetch,
+      ),
+    ).rejects.toThrow(ToscaAuthError);
+  });
+});

--- a/tools/tosca-cloud-agent/client/src/__tests__/helpers.ts
+++ b/tools/tosca-cloud-agent/client/src/__tests__/helpers.ts
@@ -1,0 +1,62 @@
+import { vi } from "vitest";
+
+/** Intersection that satisfies both fetch's call signature and vi mock introspection */
+export type MockFetch = typeof globalThis.fetch & {
+  readonly mock: { readonly calls: ReadonlyArray<readonly [string | URL | Request, RequestInit?]> };
+};
+
+/** Build a mock fetch that responds with a JSON body */
+export function mockJsonResponse(body: unknown, status = 200): MockFetch {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : String(status),
+    json: () => Promise.resolve(body),
+  } as Response) as unknown as MockFetch;
+}
+
+/** Build a mock fetch that returns different responses per call */
+export function mockSequentialJsonResponses(
+  responses: ReadonlyArray<{ readonly body: unknown; readonly status?: number }>,
+): MockFetch {
+  const mock = vi.fn();
+  for (const { body, status = 200 } of responses) {
+    mock.mockResolvedValueOnce({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? "OK" : String(status),
+      json: () => Promise.resolve(body),
+    } as Response);
+  }
+  return mock as unknown as MockFetch;
+}
+
+/** Return the URL string from the first call of a fetch mock */
+export function firstCallUrl(mock: MockFetch): string {
+  const [url] = mock.mock.calls[0] as [string, RequestInit?];
+  return url;
+}
+
+/** Return the parsed request body from the first call of a fetch mock */
+export function firstCallBody(mock: MockFetch): unknown {
+  const [, init] = mock.mock.calls[0] as [string, RequestInit?];
+  if (!init?.body) return undefined;
+  return JSON.parse(init.body as string);
+}
+
+/** Return the Authorization header from the first call of a fetch mock */
+export function firstCallAuthHeader(mock: MockFetch): string | undefined {
+  const [, init] = mock.mock.calls[0] as [string, RequestInit?];
+  const headers = init?.headers as Record<string, string> | undefined;
+  return headers?.["Authorization"];
+}
+
+/** A raw vi.fn() that satisfies typeof globalThis.fetch — for 204 scenarios */
+export function mockNoContentResponse(): MockFetch {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 204,
+    statusText: "No Content",
+    json: () => Promise.reject(new Error("no body for 204")),
+  } as Response) as unknown as MockFetch;
+}

--- a/tools/tosca-cloud-agent/client/src/__tests__/http.test.ts
+++ b/tools/tosca-cloud-agent/client/src/__tests__/http.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { HttpClient } from "../http.js";
+import { ToscaApiError } from "../types.js";
+import {
+  firstCallAuthHeader,
+  firstCallBody,
+  firstCallUrl,
+  mockJsonResponse,
+  mockNoContentResponse,
+} from "./helpers.js";
+
+const BASE_URL = "https://myorg.tricentis.com";
+const PAT_CREDS = { type: "pat" as const, token: "test-token" };
+
+function makeClient(fetchFn: typeof globalThis.fetch): HttpClient {
+  return new HttpClient({ baseUrl: BASE_URL, credentials: PAT_CREDS, fetchFn });
+}
+
+describe("HttpClient", () => {
+  it("sends Authorization header with PAT credentials", async () => {
+    const fetch = mockJsonResponse({ id: "1" });
+    const client = makeClient(fetch);
+    await client.get("/api/v1/test");
+    expect(firstCallAuthHeader(fetch)).toBe("Bearer test-token");
+  });
+
+  it("appends query params to the URL", async () => {
+    const fetch = mockJsonResponse({});
+    const client = makeClient(fetch);
+    await client.get("/api/v1/items", { page: 2, pageSize: 10 });
+    expect(firstCallUrl(fetch)).toContain("page=2");
+    expect(firstCallUrl(fetch)).toContain("pageSize=10");
+  });
+
+  it("omits undefined query params", async () => {
+    const fetch = mockJsonResponse({});
+    const client = makeClient(fetch);
+    await client.get("/api/v1/items", { page: undefined, pageSize: 10 });
+    expect(firstCallUrl(fetch)).not.toContain("page=");
+    expect(firstCallUrl(fetch)).toContain("pageSize=10");
+  });
+
+  it("sends JSON body on POST", async () => {
+    const fetch = mockJsonResponse({ id: "new" }, 201);
+    const client = makeClient(fetch);
+    await client.post("/api/v1/items", { name: "foo" });
+    expect(firstCallBody(fetch)).toEqual({ name: "foo" });
+  });
+
+  it("throws ToscaApiError on non-OK response", async () => {
+    const errorBody = { code: "NOT_FOUND", message: "Resource not found" };
+    const fetch = mockJsonResponse(errorBody, 404);
+    const client = makeClient(fetch);
+    await expect(client.get("/api/v1/missing")).rejects.toThrow(ToscaApiError);
+    await expect(client.get("/api/v1/missing")).rejects.toMatchObject({
+      status: 404,
+      body: errorBody,
+    });
+  });
+
+  it("returns undefined for 204 No Content", async () => {
+    const fetch = mockNoContentResponse();
+    const client = makeClient(fetch);
+    const result = await client.delete("/api/v1/items/1");
+    expect(result).toBeUndefined();
+  });
+});

--- a/tools/tosca-cloud-agent/client/src/__tests__/resources/agents.test.ts
+++ b/tools/tosca-cloud-agent/client/src/__tests__/resources/agents.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { ToscaCloudClient } from "../../client.js";
+import { firstCallUrl, mockJsonResponse } from "../helpers.js";
+import agentsFixture from "../../../fixtures/agents.json" with { type: "json" };
+
+const BASE_URL = "https://myorg.tricentis.com";
+const CREDS = { type: "pat" as const, token: "test-token" };
+
+function makeClient(fetchFn: typeof globalThis.fetch): ToscaCloudClient {
+  return new ToscaCloudClient({ baseUrl: BASE_URL, credentials: CREDS, fetchFn });
+}
+
+describe("AgentsResource", () => {
+  it("lists all agents", async () => {
+    const fetch = mockJsonResponse(agentsFixture.list);
+    const client = makeClient(fetch);
+    const page = await client.agents.list();
+    expect(page.items).toHaveLength(2);
+    expect(firstCallUrl(fetch)).toContain("/api/v1/agents");
+  });
+
+  it("gets a single agent", async () => {
+    const fetch = mockJsonResponse(agentsFixture.get);
+    const client = makeClient(fetch);
+    const agent = await client.agents.get("agent-001");
+    expect(agent.id).toBe("agent-001");
+    expect(agent.status).toBe("online");
+    expect(agent.capabilities).toContain("sap");
+  });
+
+  it("lists agents scoped to a workspace", async () => {
+    const fetch = mockJsonResponse(agentsFixture.listForWorkspace);
+    const client = makeClient(fetch);
+    const page = await client.agents.listForWorkspace("ws-001");
+    expect(page.items).toHaveLength(1);
+    expect(firstCallUrl(fetch)).toContain("/api/v1/workspaces/ws-001/agents");
+  });
+
+  it("identifies busy agents in the list", async () => {
+    const fetch = mockJsonResponse(agentsFixture.list);
+    const client = makeClient(fetch);
+    const page = await client.agents.list();
+    const busyAgents = page.items.filter((a) => a.status === "busy");
+    expect(busyAgents).toHaveLength(1);
+    expect(busyAgents[0]!.id).toBe("agent-002");
+  });
+});

--- a/tools/tosca-cloud-agent/client/src/__tests__/resources/executions.test.ts
+++ b/tools/tosca-cloud-agent/client/src/__tests__/resources/executions.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { ToscaCloudClient } from "../../client.js";
+import {
+  firstCallUrl,
+  mockJsonResponse,
+  mockNoContentResponse,
+} from "../helpers.js";
+import executionsFixture from "../../../fixtures/executions.json" with { type: "json" };
+
+const BASE_URL = "https://myorg.tricentis.com";
+const CREDS = { type: "pat" as const, token: "test-token" };
+
+function makeClient(fetchFn: typeof globalThis.fetch): ToscaCloudClient {
+  return new ToscaCloudClient({ baseUrl: BASE_URL, credentials: CREDS, fetchFn });
+}
+
+describe("ExecutionsResource", () => {
+  it("lists executions for a workspace", async () => {
+    const fetch = mockJsonResponse(executionsFixture.list);
+    const client = makeClient(fetch);
+    const page = await client.executions.list("ws-001");
+    expect(page.items).toHaveLength(2);
+    expect(firstCallUrl(fetch)).toContain("/api/v1/workspaces/ws-001/executions");
+  });
+
+  it("gets a single execution with results", async () => {
+    const fetch = mockJsonResponse(executionsFixture.get);
+    const client = makeClient(fetch);
+    const exec = await client.executions.get("ws-001", "exec-001");
+    expect(exec.id).toBe("exec-001");
+    expect(exec.status).toBe("passed");
+    expect(exec.results).toHaveLength(2);
+    expect(exec.results[0]!.error).toBeNull();
+  });
+
+  it("creates an execution with specified test cases", async () => {
+    const fetch = mockJsonResponse(executionsFixture.create, 201);
+    const client = makeClient(fetch);
+    const exec = await client.executions.create("ws-001", {
+      projectId: "proj-001",
+      testCaseIds: ["tc-001"],
+    });
+    expect(exec.id).toBe("exec-003");
+    expect(exec.status).toBe("pending");
+    expect(exec.results).toHaveLength(0);
+  });
+
+  it("cancels a running execution", async () => {
+    const fetch = mockJsonResponse(executionsFixture.cancel);
+    const client = makeClient(fetch);
+    const exec = await client.executions.cancel("ws-001", "exec-003", {
+      reason: "Test cancelled by engineer",
+    });
+    expect(exec.status).toBe("cancelled");
+    expect(firstCallUrl(fetch)).toContain(
+      "/api/v1/workspaces/ws-001/executions/exec-003/cancel",
+    );
+  });
+
+  it("reflects failed execution results including error message", async () => {
+    const fetch = mockJsonResponse(executionsFixture.list);
+    const client = makeClient(fetch);
+    const page = await client.executions.list("ws-001");
+    const failed = page.items.find((e) => e.status === "failed");
+    expect(failed).toBeDefined();
+    expect(failed!.results[0]!.error).toBe("Element not found: #submit-btn");
+  });
+
+  it("deletes an execution (204)", async () => {
+    const fetch = mockNoContentResponse();
+    const client = makeClient(fetch);
+    await expect(
+      client.executions.delete("ws-001", "exec-001"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tools/tosca-cloud-agent/client/src/__tests__/resources/projects.test.ts
+++ b/tools/tosca-cloud-agent/client/src/__tests__/resources/projects.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { ToscaCloudClient } from "../../client.js";
+import {
+  firstCallUrl,
+  mockJsonResponse,
+  mockNoContentResponse,
+} from "../helpers.js";
+import projectsFixture from "../../../fixtures/projects.json" with { type: "json" };
+
+const BASE_URL = "https://myorg.tricentis.com";
+const CREDS = { type: "pat" as const, token: "test-token" };
+
+function makeClient(fetchFn: typeof globalThis.fetch): ToscaCloudClient {
+  return new ToscaCloudClient({ baseUrl: BASE_URL, credentials: CREDS, fetchFn });
+}
+
+describe("ProjectsResource", () => {
+  it("lists projects for a workspace", async () => {
+    const fetch = mockJsonResponse(projectsFixture.list);
+    const client = makeClient(fetch);
+    const page = await client.projects.list("ws-001");
+    expect(page.items).toHaveLength(2);
+    expect(page.items[0]!.workspaceId).toBe("ws-001");
+    expect(firstCallUrl(fetch)).toContain("/api/v1/workspaces/ws-001/projects");
+  });
+
+  it("gets a single project", async () => {
+    const fetch = mockJsonResponse(projectsFixture.get);
+    const client = makeClient(fetch);
+    const proj = await client.projects.get("ws-001", "proj-001");
+    expect(proj.id).toBe("proj-001");
+    expect(proj.workspaceId).toBe("ws-001");
+  });
+
+  it("creates a project", async () => {
+    const fetch = mockJsonResponse(projectsFixture.create, 201);
+    const client = makeClient(fetch);
+    const proj = await client.projects.create("ws-001", { name: "New Project" });
+    expect(proj.id).toBe("proj-003");
+  });
+
+  it("updates a project", async () => {
+    const updated = { ...projectsFixture.get, name: "Renamed" };
+    const fetch = mockJsonResponse(updated);
+    const client = makeClient(fetch);
+    const proj = await client.projects.update("ws-001", "proj-001", { name: "Renamed" });
+    expect(proj.name).toBe("Renamed");
+  });
+
+  it("deletes a project (204)", async () => {
+    const fetch = mockNoContentResponse();
+    const client = makeClient(fetch);
+    await expect(client.projects.delete("ws-001", "proj-001")).resolves.toBeUndefined();
+  });
+});

--- a/tools/tosca-cloud-agent/client/src/__tests__/resources/test-cases.test.ts
+++ b/tools/tosca-cloud-agent/client/src/__tests__/resources/test-cases.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { ToscaCloudClient } from "../../client.js";
+import {
+  firstCallUrl,
+  mockJsonResponse,
+  mockNoContentResponse,
+} from "../helpers.js";
+import testCasesFixture from "../../../fixtures/test-cases.json" with { type: "json" };
+
+const BASE_URL = "https://myorg.tricentis.com";
+const CREDS = { type: "pat" as const, token: "test-token" };
+
+function makeClient(fetchFn: typeof globalThis.fetch): ToscaCloudClient {
+  return new ToscaCloudClient({ baseUrl: BASE_URL, credentials: CREDS, fetchFn });
+}
+
+describe("TestCasesResource", () => {
+  it("lists test cases for a project", async () => {
+    const fetch = mockJsonResponse(testCasesFixture.list);
+    const client = makeClient(fetch);
+    const page = await client.testCases.list("ws-001", "proj-001");
+    expect(page.items).toHaveLength(3);
+    expect(firstCallUrl(fetch)).toContain(
+      "/api/v1/workspaces/ws-001/projects/proj-001/testcases",
+    );
+  });
+
+  it("identifies deprecated test cases in the list", async () => {
+    const fetch = mockJsonResponse(testCasesFixture.list);
+    const client = makeClient(fetch);
+    const page = await client.testCases.list("ws-001", "proj-001");
+    const deprecated = page.items.filter((tc) => tc.status === "deprecated");
+    expect(deprecated).toHaveLength(1);
+    expect(deprecated[0]!.id).toBe("tc-003");
+  });
+
+  it("gets a single test case", async () => {
+    const fetch = mockJsonResponse(testCasesFixture.get);
+    const client = makeClient(fetch);
+    const tc = await client.testCases.get("ws-001", "proj-001", "tc-001");
+    expect(tc.id).toBe("tc-001");
+    expect(tc.status).toBe("active");
+    expect(tc.tags).toContain("smoke");
+  });
+
+  it("creates a test case", async () => {
+    const fetch = mockJsonResponse(testCasesFixture.create, 201);
+    const client = makeClient(fetch);
+    const tc = await client.testCases.create("ws-001", "proj-001", {
+      name: "Password Reset",
+      tags: ["auth"],
+    });
+    expect(tc.id).toBe("tc-004");
+    expect(tc.status).toBe("active");
+  });
+
+  it("updates a test case status to deprecated", async () => {
+    const updated = { ...testCasesFixture.get, status: "deprecated" as const };
+    const fetch = mockJsonResponse(updated);
+    const client = makeClient(fetch);
+    const tc = await client.testCases.update("ws-001", "proj-001", "tc-001", {
+      status: "deprecated",
+    });
+    expect(tc.status).toBe("deprecated");
+  });
+
+  it("deletes a test case (204)", async () => {
+    const fetch = mockNoContentResponse();
+    const client = makeClient(fetch);
+    await expect(
+      client.testCases.delete("ws-001", "proj-001", "tc-001"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tools/tosca-cloud-agent/client/src/__tests__/resources/workspaces.test.ts
+++ b/tools/tosca-cloud-agent/client/src/__tests__/resources/workspaces.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { ToscaCloudClient } from "../../client.js";
+import {
+  firstCallUrl,
+  mockJsonResponse,
+  mockNoContentResponse,
+} from "../helpers.js";
+import workspacesFixture from "../../../fixtures/workspaces.json" with { type: "json" };
+
+const BASE_URL = "https://myorg.tricentis.com";
+const CREDS = { type: "pat" as const, token: "test-token" };
+
+function makeClient(fetchFn: typeof globalThis.fetch): ToscaCloudClient {
+  return new ToscaCloudClient({ baseUrl: BASE_URL, credentials: CREDS, fetchFn });
+}
+
+describe("WorkspacesResource", () => {
+  it("lists workspaces", async () => {
+    const fetch = mockJsonResponse(workspacesFixture.list);
+    const client = makeClient(fetch);
+    const page = await client.workspaces.list();
+    expect(page.items).toHaveLength(2);
+    expect(page.items[0]!.id).toBe("ws-001");
+    expect(firstCallUrl(fetch)).toContain("/api/v1/workspaces");
+  });
+
+  it("passes pagination params", async () => {
+    const fetch = mockJsonResponse(workspacesFixture.list);
+    const client = makeClient(fetch);
+    await client.workspaces.list({ page: 2, pageSize: 5 });
+    expect(firstCallUrl(fetch)).toContain("page=2");
+    expect(firstCallUrl(fetch)).toContain("pageSize=5");
+  });
+
+  it("gets a single workspace", async () => {
+    const fetch = mockJsonResponse(workspacesFixture.get);
+    const client = makeClient(fetch);
+    const ws = await client.workspaces.get("ws-001");
+    expect(ws.id).toBe("ws-001");
+    expect(ws.name).toBe("Itecor Workspace");
+    expect(firstCallUrl(fetch)).toContain("/api/v1/workspaces/ws-001");
+  });
+
+  it("creates a workspace", async () => {
+    const fetch = mockJsonResponse(workspacesFixture.create, 201);
+    const client = makeClient(fetch);
+    const ws = await client.workspaces.create({
+      name: "New Workspace",
+      description: "A freshly created workspace",
+    });
+    expect(ws.id).toBe("ws-003");
+    expect(ws.name).toBe("New Workspace");
+  });
+
+  it("updates a workspace", async () => {
+    const fetch = mockJsonResponse(workspacesFixture.update);
+    const client = makeClient(fetch);
+    const ws = await client.workspaces.update("ws-001", { name: "Updated Workspace" });
+    expect(ws.name).toBe("Updated Workspace");
+  });
+
+  it("deletes a workspace (204)", async () => {
+    const fetch = mockNoContentResponse();
+    const client = makeClient(fetch);
+    await expect(client.workspaces.delete("ws-001")).resolves.toBeUndefined();
+  });
+});

--- a/tools/tosca-cloud-agent/client/src/auth.ts
+++ b/tools/tosca-cloud-agent/client/src/auth.ts
@@ -1,0 +1,84 @@
+import type { PATCredentials, SSOCredentials, ToscaCredentials } from "./types.js";
+import { ToscaAuthError } from "./types.js";
+
+export interface ResolvedAuth {
+  readonly authorizationHeader: string;
+}
+
+interface SSOTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+}
+
+interface TokenCache {
+  token: string;
+  expiresAt: number;
+}
+
+const ssoTokenCache = new Map<string, TokenCache>();
+
+function cacheKey(creds: SSOCredentials): string {
+  return `${creds.tenantUrl}::${creds.clientId}`;
+}
+
+async function fetchSSOToken(
+  creds: SSOCredentials,
+  fetchFn: typeof globalThis.fetch,
+): Promise<string> {
+  const key = cacheKey(creds);
+  const cached = ssoTokenCache.get(key);
+  if (cached && cached.expiresAt > Date.now() + 30_000) {
+    return cached.token;
+  }
+
+  const tokenUrl = new URL("/oauth/token", creds.tenantUrl).toString();
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: creds.clientId,
+    client_secret: creds.clientSecret,
+  });
+
+  const response = await fetchFn(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new ToscaAuthError(
+      `SSO token request failed with status ${response.status}`,
+    );
+  }
+
+  const data = (await response.json()) as SSOTokenResponse;
+  if (!data.access_token) {
+    throw new ToscaAuthError("SSO token response missing access_token");
+  }
+
+  ssoTokenCache.set(key, {
+    token: data.access_token,
+    expiresAt: Date.now() + data.expires_in * 1000,
+  });
+
+  return data.access_token;
+}
+
+export function resolvePatAuth(creds: PATCredentials): ResolvedAuth {
+  return { authorizationHeader: `Bearer ${creds.token}` };
+}
+
+export async function resolveAuth(
+  creds: ToscaCredentials,
+  fetchFn: typeof globalThis.fetch,
+): Promise<ResolvedAuth> {
+  if (creds.type === "pat") {
+    return resolvePatAuth(creds);
+  }
+  const token = await fetchSSOToken(creds, fetchFn);
+  return { authorizationHeader: `Bearer ${token}` };
+}
+
+export function clearSSOTokenCache(): void {
+  ssoTokenCache.clear();
+}

--- a/tools/tosca-cloud-agent/client/src/client.ts
+++ b/tools/tosca-cloud-agent/client/src/client.ts
@@ -1,0 +1,37 @@
+import type { ToscaCredentials } from "./types.js";
+import { HttpClient } from "./http.js";
+import { AgentsResource } from "./resources/agents.js";
+import { ExecutionsResource } from "./resources/executions.js";
+import { ProjectsResource } from "./resources/projects.js";
+import { TestCasesResource } from "./resources/test-cases.js";
+import { WorkspacesResource } from "./resources/workspaces.js";
+
+export interface ToscaCloudClientOptions {
+  /** Base URL of the Tosca Cloud tenant, e.g. https://myorg.tricentis.com */
+  baseUrl: string;
+  credentials: ToscaCredentials;
+  /** Override fetch implementation for testing */
+  fetchFn?: typeof globalThis.fetch;
+}
+
+export class ToscaCloudClient {
+  readonly workspaces: WorkspacesResource;
+  readonly projects: ProjectsResource;
+  readonly testCases: TestCasesResource;
+  readonly executions: ExecutionsResource;
+  readonly agents: AgentsResource;
+
+  constructor(options: ToscaCloudClientOptions) {
+    const http = new HttpClient({
+      baseUrl: options.baseUrl,
+      credentials: options.credentials,
+      fetchFn: options.fetchFn,
+    });
+
+    this.workspaces = new WorkspacesResource(http);
+    this.projects = new ProjectsResource(http);
+    this.testCases = new TestCasesResource(http);
+    this.executions = new ExecutionsResource(http);
+    this.agents = new AgentsResource(http);
+  }
+}

--- a/tools/tosca-cloud-agent/client/src/http.ts
+++ b/tools/tosca-cloud-agent/client/src/http.ts
@@ -1,0 +1,91 @@
+import type { ToscaCredentials } from "./types.js";
+import { ToscaApiError } from "./types.js";
+import { resolveAuth } from "./auth.js";
+
+export interface HttpClientOptions {
+  baseUrl: string;
+  credentials: ToscaCredentials;
+  fetchFn?: typeof globalThis.fetch;
+}
+
+export class HttpClient {
+  private readonly baseUrl: string;
+  private readonly credentials: ToscaCredentials;
+  private readonly fetchFn: typeof globalThis.fetch;
+
+  constructor(options: HttpClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.credentials = options.credentials;
+    this.fetchFn = options.fetchFn ?? globalThis.fetch;
+  }
+
+  async request<T>(
+    method: string,
+    path: string,
+    options?: {
+      params?: Record<string, string | number | boolean | undefined>;
+      body?: unknown;
+    },
+  ): Promise<T> {
+    const auth = await resolveAuth(this.credentials, this.fetchFn);
+
+    const url = new URL(this.baseUrl + path);
+    if (options?.params) {
+      for (const [key, value] of Object.entries(options.params)) {
+        if (value !== undefined) {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: auth.authorizationHeader,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+
+    const response = await this.fetchFn(url.toString(), {
+      method,
+      headers,
+      body: options?.body !== undefined ? JSON.stringify(options.body) : undefined,
+    });
+
+    if (!response.ok) {
+      let errorBody: { code: string; message: string; details?: Record<string, unknown> };
+      try {
+        errorBody = (await response.json()) as typeof errorBody;
+      } catch {
+        errorBody = {
+          code: "UNKNOWN",
+          message: `HTTP ${response.status} ${response.statusText}`,
+        };
+      }
+      throw new ToscaApiError(response.status, errorBody);
+    }
+
+    if (response.status === 204) {
+      return undefined as unknown as T;
+    }
+
+    return (await response.json()) as T;
+  }
+
+  get<T>(
+    path: string,
+    params?: Record<string, string | number | boolean | undefined>,
+  ): Promise<T> {
+    return this.request<T>("GET", path, { params });
+  }
+
+  post<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("POST", path, { body });
+  }
+
+  patch<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("PATCH", path, { body });
+  }
+
+  delete<T = void>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>("DELETE", path, { body });
+  }
+}

--- a/tools/tosca-cloud-agent/client/src/index.ts
+++ b/tools/tosca-cloud-agent/client/src/index.ts
@@ -1,0 +1,31 @@
+export { ToscaCloudClient } from "./client.js";
+export type { ToscaCloudClientOptions } from "./client.js";
+export {
+  ToscaApiError,
+  ToscaAuthError,
+} from "./types.js";
+export type {
+  Agent,
+  AgentStatus,
+  CancelExecutionParams,
+  CreateExecutionParams,
+  CreateProjectParams,
+  CreateTestCaseParams,
+  CreateWorkspaceParams,
+  Execution,
+  ExecutionResult,
+  ExecutionStatus,
+  Page,
+  PageParams,
+  PATCredentials,
+  Project,
+  SSOCredentials,
+  TestCase,
+  TestCaseStatus,
+  ToscaApiErrorBody,
+  ToscaCredentials,
+  UpdateProjectParams,
+  UpdateTestCaseParams,
+  UpdateWorkspaceParams,
+  Workspace,
+} from "./types.js";

--- a/tools/tosca-cloud-agent/client/src/resources/agents.ts
+++ b/tools/tosca-cloud-agent/client/src/resources/agents.ts
@@ -1,0 +1,27 @@
+import type { HttpClient } from "../http.js";
+import type { Agent, Page, PageParams } from "../types.js";
+
+export class AgentsResource {
+  constructor(private readonly http: HttpClient) {}
+
+  list(params?: PageParams): Promise<Page<Agent>> {
+    return this.http.get<Page<Agent>>("/api/v1/agents", {
+      page: params?.page,
+      pageSize: params?.pageSize,
+    });
+  }
+
+  get(agentId: string): Promise<Agent> {
+    return this.http.get<Agent>(`/api/v1/agents/${agentId}`);
+  }
+
+  listForWorkspace(
+    workspaceId: string,
+    params?: PageParams,
+  ): Promise<Page<Agent>> {
+    return this.http.get<Page<Agent>>(
+      `/api/v1/workspaces/${workspaceId}/agents`,
+      { page: params?.page, pageSize: params?.pageSize },
+    );
+  }
+}

--- a/tools/tosca-cloud-agent/client/src/resources/executions.ts
+++ b/tools/tosca-cloud-agent/client/src/resources/executions.ts
@@ -1,0 +1,52 @@
+import type { HttpClient } from "../http.js";
+import type {
+  CancelExecutionParams,
+  CreateExecutionParams,
+  Execution,
+  Page,
+  PageParams,
+} from "../types.js";
+
+export class ExecutionsResource {
+  constructor(private readonly http: HttpClient) {}
+
+  list(workspaceId: string, params?: PageParams): Promise<Page<Execution>> {
+    return this.http.get<Page<Execution>>(
+      `/api/v1/workspaces/${workspaceId}/executions`,
+      { page: params?.page, pageSize: params?.pageSize },
+    );
+  }
+
+  get(workspaceId: string, executionId: string): Promise<Execution> {
+    return this.http.get<Execution>(
+      `/api/v1/workspaces/${workspaceId}/executions/${executionId}`,
+    );
+  }
+
+  create(
+    workspaceId: string,
+    params: CreateExecutionParams,
+  ): Promise<Execution> {
+    return this.http.post<Execution>(
+      `/api/v1/workspaces/${workspaceId}/executions`,
+      params,
+    );
+  }
+
+  cancel(
+    workspaceId: string,
+    executionId: string,
+    params?: CancelExecutionParams,
+  ): Promise<Execution> {
+    return this.http.post<Execution>(
+      `/api/v1/workspaces/${workspaceId}/executions/${executionId}/cancel`,
+      params,
+    );
+  }
+
+  delete(workspaceId: string, executionId: string): Promise<void> {
+    return this.http.delete<void>(
+      `/api/v1/workspaces/${workspaceId}/executions/${executionId}`,
+    );
+  }
+}

--- a/tools/tosca-cloud-agent/client/src/resources/projects.ts
+++ b/tools/tosca-cloud-agent/client/src/resources/projects.ts
@@ -1,0 +1,49 @@
+import type { HttpClient } from "../http.js";
+import type {
+  CreateProjectParams,
+  Page,
+  PageParams,
+  Project,
+  UpdateProjectParams,
+} from "../types.js";
+
+export class ProjectsResource {
+  constructor(private readonly http: HttpClient) {}
+
+  list(workspaceId: string, params?: PageParams): Promise<Page<Project>> {
+    return this.http.get<Page<Project>>(
+      `/api/v1/workspaces/${workspaceId}/projects`,
+      { page: params?.page, pageSize: params?.pageSize },
+    );
+  }
+
+  get(workspaceId: string, projectId: string): Promise<Project> {
+    return this.http.get<Project>(
+      `/api/v1/workspaces/${workspaceId}/projects/${projectId}`,
+    );
+  }
+
+  create(workspaceId: string, params: CreateProjectParams): Promise<Project> {
+    return this.http.post<Project>(
+      `/api/v1/workspaces/${workspaceId}/projects`,
+      params,
+    );
+  }
+
+  update(
+    workspaceId: string,
+    projectId: string,
+    params: UpdateProjectParams,
+  ): Promise<Project> {
+    return this.http.patch<Project>(
+      `/api/v1/workspaces/${workspaceId}/projects/${projectId}`,
+      params,
+    );
+  }
+
+  delete(workspaceId: string, projectId: string): Promise<void> {
+    return this.http.delete<void>(
+      `/api/v1/workspaces/${workspaceId}/projects/${projectId}`,
+    );
+  }
+}

--- a/tools/tosca-cloud-agent/client/src/resources/test-cases.ts
+++ b/tools/tosca-cloud-agent/client/src/resources/test-cases.ts
@@ -1,0 +1,66 @@
+import type { HttpClient } from "../http.js";
+import type {
+  CreateTestCaseParams,
+  Page,
+  PageParams,
+  TestCase,
+  UpdateTestCaseParams,
+} from "../types.js";
+
+export class TestCasesResource {
+  constructor(private readonly http: HttpClient) {}
+
+  list(
+    workspaceId: string,
+    projectId: string,
+    params?: PageParams,
+  ): Promise<Page<TestCase>> {
+    return this.http.get<Page<TestCase>>(
+      `/api/v1/workspaces/${workspaceId}/projects/${projectId}/testcases`,
+      { page: params?.page, pageSize: params?.pageSize },
+    );
+  }
+
+  get(
+    workspaceId: string,
+    projectId: string,
+    testCaseId: string,
+  ): Promise<TestCase> {
+    return this.http.get<TestCase>(
+      `/api/v1/workspaces/${workspaceId}/projects/${projectId}/testcases/${testCaseId}`,
+    );
+  }
+
+  create(
+    workspaceId: string,
+    projectId: string,
+    params: CreateTestCaseParams,
+  ): Promise<TestCase> {
+    return this.http.post<TestCase>(
+      `/api/v1/workspaces/${workspaceId}/projects/${projectId}/testcases`,
+      params,
+    );
+  }
+
+  update(
+    workspaceId: string,
+    projectId: string,
+    testCaseId: string,
+    params: UpdateTestCaseParams,
+  ): Promise<TestCase> {
+    return this.http.patch<TestCase>(
+      `/api/v1/workspaces/${workspaceId}/projects/${projectId}/testcases/${testCaseId}`,
+      params,
+    );
+  }
+
+  delete(
+    workspaceId: string,
+    projectId: string,
+    testCaseId: string,
+  ): Promise<void> {
+    return this.http.delete<void>(
+      `/api/v1/workspaces/${workspaceId}/projects/${projectId}/testcases/${testCaseId}`,
+    );
+  }
+}

--- a/tools/tosca-cloud-agent/client/src/resources/workspaces.ts
+++ b/tools/tosca-cloud-agent/client/src/resources/workspaces.ts
@@ -1,0 +1,35 @@
+import type { HttpClient } from "../http.js";
+import type {
+  CreateWorkspaceParams,
+  Page,
+  PageParams,
+  UpdateWorkspaceParams,
+  Workspace,
+} from "../types.js";
+
+export class WorkspacesResource {
+  constructor(private readonly http: HttpClient) {}
+
+  list(params?: PageParams): Promise<Page<Workspace>> {
+    return this.http.get<Page<Workspace>>("/api/v1/workspaces", {
+      page: params?.page,
+      pageSize: params?.pageSize,
+    });
+  }
+
+  get(id: string): Promise<Workspace> {
+    return this.http.get<Workspace>(`/api/v1/workspaces/${id}`);
+  }
+
+  create(params: CreateWorkspaceParams): Promise<Workspace> {
+    return this.http.post<Workspace>("/api/v1/workspaces", params);
+  }
+
+  update(id: string, params: UpdateWorkspaceParams): Promise<Workspace> {
+    return this.http.patch<Workspace>(`/api/v1/workspaces/${id}`, params);
+  }
+
+  delete(id: string): Promise<void> {
+    return this.http.delete<void>(`/api/v1/workspaces/${id}`);
+  }
+}

--- a/tools/tosca-cloud-agent/client/src/types.ts
+++ b/tools/tosca-cloud-agent/client/src/types.ts
@@ -1,0 +1,179 @@
+// ─── Credentials ─────────────────────────────────────────────────────────────
+
+export interface PATCredentials {
+  readonly type: "pat";
+  readonly token: string;
+}
+
+export interface SSOCredentials {
+  readonly type: "sso";
+  readonly tenantUrl: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+}
+
+export type ToscaCredentials = PATCredentials | SSOCredentials;
+
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+export interface PageParams {
+  page?: number;
+  pageSize?: number;
+}
+
+export interface Page<T> {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+// ─── Workspace ────────────────────────────────────────────────────────────────
+
+export interface Workspace {
+  id: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateWorkspaceParams {
+  name: string;
+  description?: string;
+}
+
+export interface UpdateWorkspaceParams {
+  name?: string;
+  description?: string;
+}
+
+// ─── Project ─────────────────────────────────────────────────────────────────
+
+export interface Project {
+  id: string;
+  workspaceId: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateProjectParams {
+  name: string;
+  description?: string;
+}
+
+export interface UpdateProjectParams {
+  name?: string;
+  description?: string;
+}
+
+// ─── TestCase ─────────────────────────────────────────────────────────────────
+
+export type TestCaseStatus = "active" | "inactive" | "deprecated";
+
+export interface TestCase {
+  id: string;
+  projectId: string;
+  workspaceId: string;
+  name: string;
+  description: string;
+  status: TestCaseStatus;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateTestCaseParams {
+  name: string;
+  description?: string;
+  tags?: string[];
+}
+
+export interface UpdateTestCaseParams {
+  name?: string;
+  description?: string;
+  status?: TestCaseStatus;
+  tags?: string[];
+}
+
+// ─── Execution ────────────────────────────────────────────────────────────────
+
+export type ExecutionStatus =
+  | "pending"
+  | "running"
+  | "passed"
+  | "failed"
+  | "error"
+  | "cancelled";
+
+export interface ExecutionResult {
+  testCaseId: string;
+  status: ExecutionStatus;
+  durationMs: number;
+  error: string | null;
+}
+
+export interface Execution {
+  id: string;
+  workspaceId: string;
+  projectId: string;
+  status: ExecutionStatus;
+  agentId: string | null;
+  testCaseIds: string[];
+  results: ExecutionResult[];
+  startedAt: string | null;
+  completedAt: string | null;
+  createdAt: string;
+}
+
+export interface CreateExecutionParams {
+  projectId: string;
+  testCaseIds: string[];
+  agentId?: string;
+}
+
+export interface CancelExecutionParams {
+  reason?: string;
+}
+
+// ─── Agent / Runner ───────────────────────────────────────────────────────────
+
+export type AgentStatus = "online" | "offline" | "busy";
+
+export interface Agent {
+  id: string;
+  name: string;
+  status: AgentStatus;
+  version: string;
+  capabilities: string[];
+  workspaceIds: string[];
+  registeredAt: string;
+  lastSeenAt: string;
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+export interface ToscaApiErrorBody {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export class ToscaApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: ToscaApiErrorBody,
+  ) {
+    super(`Tosca API ${status}: ${body.message}`);
+    this.name = "ToscaApiError";
+  }
+}
+
+export class ToscaAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ToscaAuthError";
+  }
+}

--- a/tools/tosca-cloud-agent/client/tsconfig.json
+++ b/tools/tosca-cloud-agent/client/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/tools/tosca-cloud-agent/client/vitest.config.ts
+++ b/tools/tosca-cloud-agent/client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       "server",
       "ui",
       "cli",
+      "tools/tosca-cloud-agent/client",
     ],
   },
 });


### PR DESCRIPTION
## Summary

- Add `tools/tosca-cloud-agent/client/` — typed TypeScript client for the Tricentis Tosca Cloud REST API (ITE-171)
- Auth: PAT bearer + SSO OAuth2 client_credentials with in-memory token cache
- CRUD resources: Workspaces, Projects, TestCases, Executions, Agents/Runners
- Zero `any`, strict TypeScript throughout
- 38 tests across 7 files using JSON fixture cassettes (no network in CI)
- `pnpm-workspace.yaml` extended with `tools/**`; root `vitest.config.ts` extended

## Test plan

- [x] `vitest run` — 38/38 passing
- [x] `tsc --noEmit` — exit 0, zero type errors
- [ ] CTO review: confirm endpoint URL conventions match real Tosca Cloud API when credentials available

Parent: ITE-36 (W3 Agent-ready) | Issue: ITE-171

Generated with Claude Code