### PR TITLE
Add agent brain and project memory read-only endpoints

### DIFF
--- a/server/src/__tests__/adapter-model-refresh-routes.test.ts
+++ b/server/src/__tests__/adapter-model-refresh-routes.test.ts
@@ -78,6 +78,7 @@ function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     agentService: () => ({}),
     agentInstructionsService: () => mockAgentInstructionsService,
+  agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
     accessService: () => mockAccessService,
     approvalService: () => mockApprovalService,
     companySkillService: () => mockCompanySkillService,

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -62,6 +62,7 @@ const mockLogActivity = vi.hoisted(() => vi.fn());
 vi.mock("../services/index.js", () => ({
   agentService: () => mockAgentService,
   agentInstructionsService: () => mockAgentInstructionsService,
+  agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
   accessService: () => mockAccessService,
   approvalService: () => mockApprovalService,
   companySkillService: () => mockCompanySkillService,
@@ -83,6 +84,7 @@ function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     agentService: () => mockAgentService,
     agentInstructionsService: () => mockAgentInstructionsService,
+    agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
     accessService: () => mockAccessService,
     approvalService: () => mockApprovalService,
     companySkillService: () => mockCompanySkillService,

--- a/server/src/__tests__/agent-brain-routes.test.ts
+++ b/server/src/__tests__/agent-brain-routes.test.ts
@@ -1,0 +1,205 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../errors.js";
+
+vi.unmock("http");
+vi.unmock("node:http");
+
+const agentId = "11111111-1111-4111-8111-111111111111";
+const companyId = "22222222-2222-4222-8222-222222222222";
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockAgentBrainService = vi.hoisted(() => ({
+  getManifest: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => mockAgentService,
+  agentBrainService: () => mockAgentBrainService,
+  agentInstructionsService: () => ({}),
+  accessService: () => mockAccessService,
+  approvalService: () => ({}),
+  companySkillService: () => ({ listRuntimeSkillEntries: vi.fn() }),
+  budgetService: () => ({}),
+  environmentService: () => ({ getById: vi.fn() }),
+  heartbeatService: () => ({}),
+  issueApprovalService: () => ({}),
+  issueService: () => ({}),
+  logActivity: vi.fn(),
+  secretService: () => ({
+    normalizeAdapterConfigForPersistence: vi.fn(async (_c: string, cfg: Record<string, unknown>) => cfg),
+  }),
+  syncInstructionsBundleConfigFromFilePath: vi.fn((_a, c) => c),
+  workspaceOperationService: () => ({}),
+}));
+
+vi.mock("../adapters/index.js", () => ({
+  findServerAdapter: vi.fn((type: string) => ({ type })),
+  findActiveServerAdapter: vi.fn(() => null),
+  listAdapterModels: vi.fn(),
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => ({
+    getGeneral: vi.fn(async () => ({ censorUsernameInLogs: false })),
+  }),
+}));
+
+function makeAgent() {
+  return {
+    id: agentId,
+    companyId,
+    name: "Brainy",
+    role: "engineer",
+    title: "Brainy",
+    status: "idle",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "claude_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    permissions: { canCreateAgents: false },
+    updatedAt: new Date(),
+  };
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ agentRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+async function withApp(
+  actor: Record<string, unknown>,
+  buildRequest: (baseUrl: string) => request.Test,
+) {
+  const app = await createApp(actor);
+  const { createServer } = await vi.importActual<typeof import("node:http")>("node:http");
+  const server = createServer(app);
+  try {
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("expected TCP address");
+    return await buildRequest(`http://127.0.0.1:${address.port}`);
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  }
+}
+
+const boardActor = {
+  type: "board",
+  userId: "local-board",
+  companyIds: [companyId],
+  source: "local_implicit",
+  isInstanceAdmin: false,
+};
+
+const otherCompanyAgentActor = {
+  type: "agent",
+  agentId: "99999999-9999-4999-8999-999999999999",
+  companyId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+};
+
+describe("agent brain routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgentService.getById.mockResolvedValue(makeAgent());
+    mockAgentBrainService.getManifest.mockResolvedValue({
+      agentId,
+      companyId,
+      agentHome: "/tmp/agent-home",
+      sections: [
+        { key: "life", root: "/tmp/agent-home/life", exists: false, isFile: false, files: [] },
+        { key: "memory", root: "/tmp/agent-home/memory", exists: true, isFile: false, files: [{ path: "a.md", size: 5, mtime: "2026-05-07T00:00:00.000Z" }] },
+        { key: "MEMORY.md", root: "/tmp/agent-home/MEMORY.md", exists: false, isFile: true, files: [] },
+      ],
+    });
+    mockAgentBrainService.readFile.mockResolvedValue({
+      section: "memory",
+      path: "a.md",
+      size: 5,
+      mtime: "2026-05-07T00:00:00.000Z",
+      content: "alpha",
+    });
+  });
+
+  it("GET /agents/:id/brain returns the manifest for board callers", async () => {
+    const res = await withApp(boardActor, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}/brain`),
+    );
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.sections.map((s: { key: string }) => s.key)).toEqual(["life", "memory", "MEMORY.md"]);
+    expect(mockAgentBrainService.getManifest).toHaveBeenCalledWith(expect.objectContaining({ id: agentId }));
+  });
+
+  it("GET /agents/:id/brain returns 404 when the agent does not exist", async () => {
+    mockAgentService.getById.mockResolvedValueOnce(null);
+    const res = await withApp(boardActor, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}/brain`),
+    );
+    expect(res.status).toBe(404);
+    expect(mockAgentBrainService.getManifest).not.toHaveBeenCalled();
+  });
+
+  it("GET /agents/:id/brain returns 403 when called by an agent from another company", async () => {
+    const res = await withApp(otherCompanyAgentActor, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}/brain`),
+    );
+    expect(res.status).toBe(403);
+    expect(mockAgentBrainService.getManifest).not.toHaveBeenCalled();
+  });
+
+  it("GET /agents/:id/brain/file returns 422 when path is missing", async () => {
+    mockAgentBrainService.readFile.mockImplementationOnce(async () => {
+      throw new HttpError(422, "Query parameter 'path' is required");
+    });
+    const res = await withApp(boardActor, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}/brain/file`),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it("GET /agents/:id/brain/file forwards path query and returns the file detail", async () => {
+    const res = await withApp(boardActor, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}/brain/file?path=memory/a.md`),
+    );
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.content).toBe("alpha");
+    expect(mockAgentBrainService.readFile).toHaveBeenCalledWith(
+      expect.objectContaining({ id: agentId }),
+      "memory/a.md",
+    );
+  });
+
+  it("GET /agents/:id/brain/file returns 403 when called by an agent from another company", async () => {
+    const res = await withApp(otherCompanyAgentActor, (baseUrl) =>
+      request(baseUrl).get(`/api/agents/${agentId}/brain/file?path=memory/a.md`),
+    );
+    expect(res.status).toBe(403);
+    expect(mockAgentBrainService.readFile).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/agent-brain-service.test.ts
+++ b/server/src/__tests__/agent-brain-service.test.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { agentBrainService, AGENT_BRAIN_SECTIONS } from "../services/agent-brain.js";
+
+const ORIGINAL_PAPERCLIP_HOME = process.env.PAPERCLIP_HOME;
+const ORIGINAL_INSTANCE_ID = process.env.PAPERCLIP_INSTANCE_ID;
+
+let tmpDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+async function setupAgentHome(): Promise<{ home: string; agent: { id: string; companyId: string }; agentHome: string }> {
+  const home = await makeTempDir("paperclip-agent-brain-home-");
+  process.env.PAPERCLIP_HOME = home;
+  process.env.PAPERCLIP_INSTANCE_ID = "test-instance";
+  const agent = { id: "agent-1", companyId: "company-1" };
+  const agentHome = path.join(
+    home,
+    "instances",
+    "test-instance",
+    "companies",
+    agent.companyId,
+    "agents",
+    agent.id,
+  );
+  await fs.mkdir(agentHome, { recursive: true });
+  return { home, agent, agentHome };
+}
+
+beforeEach(() => {
+  tmpDirs = [];
+});
+
+afterEach(async () => {
+  if (ORIGINAL_PAPERCLIP_HOME === undefined) delete process.env.PAPERCLIP_HOME;
+  else process.env.PAPERCLIP_HOME = ORIGINAL_PAPERCLIP_HOME;
+  if (ORIGINAL_INSTANCE_ID === undefined) delete process.env.PAPERCLIP_INSTANCE_ID;
+  else process.env.PAPERCLIP_INSTANCE_ID = ORIGINAL_INSTANCE_ID;
+  await Promise.all(tmpDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("agentBrainService.getManifest", () => {
+  it("returns three sections in stable order with `exists: false` when nothing is on disk", async () => {
+    const { agent } = await setupAgentHome();
+    const svc = agentBrainService();
+    const manifest = await svc.getManifest(agent);
+    expect(manifest.sections.map((s) => s.key)).toEqual(AGENT_BRAIN_SECTIONS.map((s) => s.key));
+    for (const section of manifest.sections) {
+      expect(section.exists).toBe(false);
+      expect(section.files).toEqual([]);
+    }
+  });
+
+  it("lists files under life/ and memory/ and surfaces MEMORY.md as a single-file section", async () => {
+    const { agent, agentHome } = await setupAgentHome();
+    await fs.mkdir(path.join(agentHome, "life", "areas"), { recursive: true });
+    await fs.writeFile(path.join(agentHome, "life", "areas", "team.yml"), "name: team");
+    await fs.mkdir(path.join(agentHome, "memory"), { recursive: true });
+    await fs.writeFile(path.join(agentHome, "memory", "today.md"), "today");
+    await fs.writeFile(path.join(agentHome, "MEMORY.md"), "- index entry");
+
+    const svc = agentBrainService();
+    const manifest = await svc.getManifest(agent);
+
+    const lifeSection = manifest.sections.find((s) => s.key === "life");
+    const memorySection = manifest.sections.find((s) => s.key === "memory");
+    const indexSection = manifest.sections.find((s) => s.key === "MEMORY.md");
+    expect(lifeSection?.exists).toBe(true);
+    expect(lifeSection?.files.map((f) => f.path)).toEqual(["areas/team.yml"]);
+    expect(memorySection?.exists).toBe(true);
+    expect(memorySection?.files.map((f) => f.path)).toEqual(["today.md"]);
+    expect(indexSection?.exists).toBe(true);
+    expect(indexSection?.isFile).toBe(true);
+    expect(indexSection?.files).toEqual([
+      expect.objectContaining({ path: "MEMORY.md", size: "- index entry".length }),
+    ]);
+  });
+});
+
+describe("agentBrainService.readFile", () => {
+  it("requires a non-empty path", async () => {
+    const { agent } = await setupAgentHome();
+    const svc = agentBrainService();
+    await expect(svc.readFile(agent, "")).rejects.toThrow();
+    await expect(svc.readFile(agent, "   ")).rejects.toThrow();
+  });
+
+  it("rejects paths that are not anchored to a known section", async () => {
+    const { agent } = await setupAgentHome();
+    const svc = agentBrainService();
+    await expect(svc.readFile(agent, "secrets/master.key")).rejects.toThrow();
+  });
+
+  it("rejects parent-directory traversal even after the section prefix", async () => {
+    const { agent, agentHome } = await setupAgentHome();
+    await fs.writeFile(path.join(path.dirname(agentHome), "OUTSIDE.md"), "leak");
+    const svc = agentBrainService();
+    await expect(svc.readFile(agent, "memory/../../OUTSIDE.md")).rejects.toThrow();
+  });
+
+  it("rejects symlinks that escape the section root", async () => {
+    const { agent, agentHome } = await setupAgentHome();
+    const memoryRoot = path.join(agentHome, "memory");
+    await fs.mkdir(memoryRoot, { recursive: true });
+    const outside = await makeTempDir("paperclip-agent-brain-outside-");
+    const secret = path.join(outside, "secret.md");
+    await fs.writeFile(secret, "PWNED");
+    await fs.symlink(secret, path.join(memoryRoot, "leak.md"));
+
+    const svc = agentBrainService();
+    await expect(svc.readFile(agent, "memory/leak.md")).rejects.toThrow();
+  });
+
+  it("reads files happily when they live inside the section", async () => {
+    const { agent, agentHome } = await setupAgentHome();
+    await fs.mkdir(path.join(agentHome, "memory"), { recursive: true });
+    await fs.writeFile(path.join(agentHome, "memory", "a.md"), "alpha");
+    await fs.writeFile(path.join(agentHome, "MEMORY.md"), "index");
+
+    const svc = agentBrainService();
+    const file = await svc.readFile(agent, "memory/a.md");
+    expect(file.section).toBe("memory");
+    expect(file.path).toBe("a.md");
+    expect(file.content).toBe("alpha");
+
+    const indexFile = await svc.readFile(agent, "MEMORY.md");
+    expect(indexFile.section).toBe("MEMORY.md");
+    expect(indexFile.content).toBe("index");
+  });
+
+  it("rejects nested paths under the single-file MEMORY.md section", async () => {
+    const { agent, agentHome } = await setupAgentHome();
+    await fs.writeFile(path.join(agentHome, "MEMORY.md"), "index");
+    const svc = agentBrainService();
+    await expect(svc.readFile(agent, "MEMORY.md/sub")).rejects.toThrow();
+  });
+});

--- a/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
+++ b/server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
@@ -178,6 +178,7 @@ vi.mock("../routes/authz.js", async () => {
 vi.mock("../services/index.js", () => ({
   agentService: () => mockAgentService,
   agentInstructionsService: () => mockAgentInstructionsService,
+  agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
   accessService: () => mockAccessService,
   approvalService: () => mockApprovalService,
   companySkillService: () => mockCompanySkillService,

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -39,6 +39,7 @@ const mockFindServerAdapter = vi.hoisted(() => vi.fn());
 vi.mock("../services/index.js", () => ({
   agentService: () => mockAgentService,
   agentInstructionsService: () => mockAgentInstructionsService,
+  agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
   accessService: () => mockAccessService,
   approvalService: () => ({}),
   companySkillService: () => ({ listRuntimeSkillEntries: vi.fn() }),
@@ -62,6 +63,7 @@ function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     agentService: () => mockAgentService,
     agentInstructionsService: () => mockAgentInstructionsService,
+  agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
     accessService: () => mockAccessService,
     approvalService: () => ({}),
     companySkillService: () => ({ listRuntimeSkillEntries: vi.fn() }),

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -51,6 +51,7 @@ function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     agentService: () => mockAgentService,
     agentInstructionsService: () => ({}),
+  agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
     accessService: () => ({}),
     approvalService: () => ({}),
     companySkillService: () => ({ listRuntimeSkillEntries: vi.fn() }),

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -186,6 +186,7 @@ function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     agentService: () => mockAgentService,
     agentInstructionsService: () => mockAgentInstructionsService,
+    agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
     accessService: () => mockAccessService,
     approvalService: () => mockApprovalService,
     companySkillService: () => mockCompanySkillService,

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -73,6 +73,7 @@ vi.mock("../telemetry.js", () => ({
 vi.mock("../services/index.js", () => ({
   agentService: () => mockAgentService,
   agentInstructionsService: () => mockAgentInstructionsService,
+  agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
   accessService: () => mockAccessService,
   approvalService: () => mockApprovalService,
   companySkillService: () => mockCompanySkillService,
@@ -107,6 +108,7 @@ function registerModuleMocks() {
   vi.doMock("../services/index.js", () => ({
     agentService: () => mockAgentService,
     agentInstructionsService: () => mockAgentInstructionsService,
+    agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
     accessService: () => mockAccessService,
     approvalService: () => mockApprovalService,
     companySkillService: () => mockCompanySkillService,

--- a/server/src/__tests__/agent-test-environment-routes.test.ts
+++ b/server/src/__tests__/agent-test-environment-routes.test.ts
@@ -42,6 +42,7 @@ const mockInstanceSettingsService = vi.hoisted(() => ({
 vi.mock("../services/index.js", () => ({
   agentService: () => mockAgentService,
   agentInstructionsService: () => ({}),
+  agentBrainService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
   accessService: () => mockAccessService,
   approvalService: () => ({}),
   companySkillService: () => ({

--- a/server/src/__tests__/claude-code-project-slug.test.ts
+++ b/server/src/__tests__/claude-code-project-slug.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { slugifyClaudeCodeProjectCwd } from "../lib/claude-code-project-slug.js";
+
+describe("slugifyClaudeCodeProjectCwd", () => {
+  it("matches the observed Claude-Code convention for nested project paths", () => {
+    const cwd = "/Users/jane/.paperclip/instances/default/projects/foo/_default";
+    expect(slugifyClaudeCodeProjectCwd(cwd)).toBe(
+      "-Users-jane--paperclip-instances-default-projects-foo--default",
+    );
+  });
+
+  it("preserves hyphens already present in identifiers (UUIDs etc.)", () => {
+    const cwd = "/Users/me/projects/58cafe4e-122f-4c5a-aba4-5b9b4f31f2bc/workspace";
+    expect(slugifyClaudeCodeProjectCwd(cwd)).toBe(
+      "-Users-me-projects-58cafe4e-122f-4c5a-aba4-5b9b4f31f2bc-workspace",
+    );
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(slugifyClaudeCodeProjectCwd("")).toBe("");
+  });
+
+  it("does not collapse consecutive non-alphanumeric runs", () => {
+    expect(slugifyClaudeCodeProjectCwd("/a//b")).toBe("-a--b");
+    expect(slugifyClaudeCodeProjectCwd("/a/_b")).toBe("-a--b");
+  });
+
+  it("treats unicode and whitespace as non-alphanumeric (replaced with hyphen)", () => {
+    expect(slugifyClaudeCodeProjectCwd("/a b/cafe")).toBe("-a-b-cafe");
+  });
+});

--- a/server/src/__tests__/environment-selection-route-guards.test.ts
+++ b/server/src/__tests__/environment-selection-route-guards.test.ts
@@ -54,6 +54,7 @@ const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
   projectService: () => mockProjectService,
+  projectMemoryService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
   issueService: () => mockIssueService,
   companyService: () => mockCompanyService,
   environmentService: () => mockEnvironmentService,

--- a/server/src/__tests__/project-goal-telemetry-routes.test.ts
+++ b/server/src/__tests__/project-goal-telemetry-routes.test.ts
@@ -38,6 +38,7 @@ vi.mock("../services/index.js", () => ({
   goalService: () => mockGoalService,
   logActivity: mockLogActivity,
   projectService: () => mockProjectService,
+  projectMemoryService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
   secretService: () => mockSecretService,
   workspaceOperationService: () => mockWorkspaceOperationService,
 }));
@@ -57,6 +58,7 @@ function registerModuleMocks() {
     goalService: () => mockGoalService,
     logActivity: mockLogActivity,
     projectService: () => mockProjectService,
+    projectMemoryService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
     secretService: () => mockSecretService,
     workspaceOperationService: () => mockWorkspaceOperationService,
   }));

--- a/server/src/__tests__/project-memory-routes.test.ts
+++ b/server/src/__tests__/project-memory-routes.test.ts
@@ -1,0 +1,184 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HttpError } from "../errors.js";
+
+vi.unmock("http");
+vi.unmock("node:http");
+
+const projectId = "44444444-4444-4444-8444-444444444444";
+const companyId = "22222222-2222-4222-8222-222222222222";
+
+const mockProjectService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockProjectMemoryService = vi.hoisted(() => ({
+  getManifest: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  projectService: () => mockProjectService,
+  projectMemoryService: () => mockProjectMemoryService,
+  logActivity: vi.fn(),
+  workspaceOperationService: () => ({}),
+}));
+
+vi.mock("../services/workspace-runtime.js", () => ({
+  buildWorkspaceRuntimeDesiredStatePatch: vi.fn(),
+  listConfiguredRuntimeServiceEntries: vi.fn(),
+  runWorkspaceJobForControl: vi.fn(),
+  startRuntimeServicesForWorkspaceControl: vi.fn(),
+  stopRuntimeServicesForProjectWorkspace: vi.fn(),
+}));
+
+vi.mock("../services/environments.js", () => ({
+  environmentService: () => ({ getById: vi.fn() }),
+}));
+
+vi.mock("../services/secrets.js", () => ({
+  secretService: () => ({
+    normalizeAdapterConfigForPersistence: vi.fn(async (_c: string, cfg: Record<string, unknown>) => cfg),
+    normalizeEnvBindingsForPersistence: vi.fn(async (_c: string, env: unknown) => env),
+  }),
+}));
+
+function makeProject() {
+  return {
+    id: projectId,
+    companyId,
+    name: "Onboarding",
+    status: "in_progress",
+    codebase: { effectiveLocalFolder: "/Users/me/projects/foo" },
+  };
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ projectRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/projects.js")>("../routes/projects.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", projectRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+async function withApp(
+  actor: Record<string, unknown>,
+  buildRequest: (baseUrl: string) => request.Test,
+) {
+  const app = await createApp(actor);
+  const { createServer } = await vi.importActual<typeof import("node:http")>("node:http");
+  const server = createServer(app);
+  try {
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("expected TCP address");
+    return await buildRequest(`http://127.0.0.1:${address.port}`);
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  }
+}
+
+const boardActor = {
+  type: "board",
+  userId: "local-board",
+  companyIds: [companyId],
+  source: "local_implicit",
+  isInstanceAdmin: false,
+};
+
+const otherCompanyAgentActor = {
+  type: "agent",
+  agentId: "99999999-9999-4999-8999-999999999999",
+  companyId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+};
+
+describe("project memory routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProjectService.getById.mockResolvedValue(makeProject());
+    mockProjectMemoryService.getManifest.mockResolvedValue({
+      projectId,
+      companyId,
+      resolvedCwd: "/Users/me/projects/foo",
+      slug: "-Users-me-projects-foo",
+      root: "/home/.claude/projects/-Users-me-projects-foo/memory",
+      exists: true,
+      files: [{ path: "MEMORY.md", size: 12, mtime: "2026-05-07T00:00:00.000Z" }],
+    });
+    mockProjectMemoryService.readFile.mockResolvedValue({
+      path: "MEMORY.md",
+      size: 12,
+      mtime: "2026-05-07T00:00:00.000Z",
+      content: "- index entry",
+    });
+  });
+
+  it("GET /projects/:id/memory returns the manifest for board callers", async () => {
+    const res = await withApp(boardActor, (baseUrl) =>
+      request(baseUrl).get(`/api/projects/${projectId}/memory`),
+    );
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.files).toHaveLength(1);
+    expect(mockProjectMemoryService.getManifest).toHaveBeenCalledWith(expect.objectContaining({ id: projectId }));
+  });
+
+  it("GET /projects/:id/memory returns 404 when the project does not exist", async () => {
+    mockProjectService.getById.mockResolvedValueOnce(null);
+    const res = await withApp(boardActor, (baseUrl) =>
+      request(baseUrl).get(`/api/projects/${projectId}/memory`),
+    );
+    expect(res.status).toBe(404);
+    expect(mockProjectMemoryService.getManifest).not.toHaveBeenCalled();
+  });
+
+  it("GET /projects/:id/memory returns 403 when called by an agent from another company", async () => {
+    const res = await withApp(otherCompanyAgentActor, (baseUrl) =>
+      request(baseUrl).get(`/api/projects/${projectId}/memory`),
+    );
+    expect(res.status).toBe(403);
+    expect(mockProjectMemoryService.getManifest).not.toHaveBeenCalled();
+  });
+
+  it("GET /projects/:id/memory/file returns 422 when path is missing", async () => {
+    mockProjectMemoryService.readFile.mockImplementationOnce(async () => {
+      throw new HttpError(422, "Query parameter 'path' is required");
+    });
+    const res = await withApp(boardActor, (baseUrl) =>
+      request(baseUrl).get(`/api/projects/${projectId}/memory/file`),
+    );
+    expect(res.status).toBe(422);
+  });
+
+  it("GET /projects/:id/memory/file forwards the path query", async () => {
+    const res = await withApp(boardActor, (baseUrl) =>
+      request(baseUrl).get(`/api/projects/${projectId}/memory/file?path=MEMORY.md`),
+    );
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.content).toBe("- index entry");
+    expect(mockProjectMemoryService.readFile).toHaveBeenCalledWith(
+      expect.objectContaining({ id: projectId }),
+      "MEMORY.md",
+    );
+  });
+
+  it("GET /projects/:id/memory/file returns 403 when called by an agent from another company", async () => {
+    const res = await withApp(otherCompanyAgentActor, (baseUrl) =>
+      request(baseUrl).get(`/api/projects/${projectId}/memory/file?path=MEMORY.md`),
+    );
+    expect(res.status).toBe(403);
+    expect(mockProjectMemoryService.readFile).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/project-memory-service.test.ts
+++ b/server/src/__tests__/project-memory-service.test.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { projectMemoryService } from "../services/project-memory.js";
+import { slugifyClaudeCodeProjectCwd } from "../lib/claude-code-project-slug.js";
+
+const ORIGINAL_HOME = process.env.HOME;
+
+let tmpDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  tmpDirs = [];
+});
+
+afterEach(async () => {
+  if (ORIGINAL_HOME === undefined) delete process.env.HOME;
+  else process.env.HOME = ORIGINAL_HOME;
+  await Promise.all(tmpDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function setupHome(): Promise<{ home: string; claudeProjectsRoot: string }> {
+  const home = await makeTempDir("paperclip-project-memory-home-");
+  process.env.HOME = home;
+  const claudeProjectsRoot = path.join(home, ".claude", "projects");
+  await fs.mkdir(claudeProjectsRoot, { recursive: true });
+  return { home, claudeProjectsRoot };
+}
+
+function projectWithCwd(cwd: string | null) {
+  return {
+    id: "project-1",
+    companyId: "company-1",
+    codebase: cwd ? { effectiveLocalFolder: cwd } : null,
+  };
+}
+
+describe("projectMemoryService.getManifest", () => {
+  it("returns a clean manifest when the project has no resolvable cwd", async () => {
+    await setupHome();
+    const svc = projectMemoryService();
+    const manifest = await svc.getManifest(projectWithCwd(null));
+    expect(manifest.root).toBeNull();
+    expect(manifest.exists).toBe(false);
+    expect(manifest.files).toEqual([]);
+  });
+
+  it("returns exists=false with an empty file list when the directory is missing", async () => {
+    await setupHome();
+    const svc = projectMemoryService();
+    // The slugified directory does not exist on disk yet.
+    const manifest = await svc.getManifest(projectWithCwd("/Users/me/nope"));
+    expect(manifest.exists).toBe(false);
+    expect(manifest.files).toEqual([]);
+    expect(manifest.slug).toBe(slugifyClaudeCodeProjectCwd("/Users/me/nope"));
+    expect(manifest.root).toContain(manifest.slug!);
+  });
+
+  it("lists files when the project memory directory exists", async () => {
+    const { claudeProjectsRoot } = await setupHome();
+    const cwd = "/Users/me/projects/foo";
+    const slug = slugifyClaudeCodeProjectCwd(cwd);
+    const memoryRoot = path.join(claudeProjectsRoot, slug, "memory");
+    await fs.mkdir(memoryRoot, { recursive: true });
+    await fs.writeFile(path.join(memoryRoot, "a.md"), "alpha");
+    await fs.writeFile(path.join(memoryRoot, "MEMORY.md"), "index");
+
+    const svc = projectMemoryService();
+    const manifest = await svc.getManifest(projectWithCwd(cwd));
+    expect(manifest.exists).toBe(true);
+    expect(manifest.files.map((f) => f.path).sort()).toEqual(["MEMORY.md", "a.md"]);
+  });
+});
+
+describe("projectMemoryService.readFile", () => {
+  it("requires a non-empty path", async () => {
+    const { claudeProjectsRoot } = await setupHome();
+    const cwd = "/Users/me/projects/foo";
+    const slug = slugifyClaudeCodeProjectCwd(cwd);
+    await fs.mkdir(path.join(claudeProjectsRoot, slug, "memory"), { recursive: true });
+
+    const svc = projectMemoryService();
+    await expect(svc.readFile(projectWithCwd(cwd), "")).rejects.toThrow();
+  });
+
+  it("rejects path traversal", async () => {
+    const { claudeProjectsRoot } = await setupHome();
+    const cwd = "/Users/me/projects/foo";
+    const slug = slugifyClaudeCodeProjectCwd(cwd);
+    const memoryRoot = path.join(claudeProjectsRoot, slug, "memory");
+    await fs.mkdir(memoryRoot, { recursive: true });
+    await fs.writeFile(path.join(claudeProjectsRoot, slug, "OUTSIDE.md"), "leak");
+
+    const svc = projectMemoryService();
+    await expect(svc.readFile(projectWithCwd(cwd), "../OUTSIDE.md")).rejects.toThrow();
+  });
+
+  it("rejects symlinks that escape the memory root", async () => {
+    const { claudeProjectsRoot } = await setupHome();
+    const cwd = "/Users/me/projects/foo";
+    const slug = slugifyClaudeCodeProjectCwd(cwd);
+    const memoryRoot = path.join(claudeProjectsRoot, slug, "memory");
+    await fs.mkdir(memoryRoot, { recursive: true });
+    const outside = await makeTempDir("paperclip-project-memory-outside-");
+    const secret = path.join(outside, "secret.md");
+    await fs.writeFile(secret, "PWNED");
+    await fs.symlink(secret, path.join(memoryRoot, "leak.md"));
+
+    const svc = projectMemoryService();
+    await expect(svc.readFile(projectWithCwd(cwd), "leak.md")).rejects.toThrow();
+  });
+
+  it("reads files happily when they live inside the memory root", async () => {
+    const { claudeProjectsRoot } = await setupHome();
+    const cwd = "/Users/me/projects/foo";
+    const slug = slugifyClaudeCodeProjectCwd(cwd);
+    const memoryRoot = path.join(claudeProjectsRoot, slug, "memory");
+    await fs.mkdir(memoryRoot, { recursive: true });
+    await fs.writeFile(path.join(memoryRoot, "a.md"), "alpha");
+
+    const svc = projectMemoryService();
+    const file = await svc.readFile(projectWithCwd(cwd), "a.md");
+    expect(file.path).toBe("a.md");
+    expect(file.content).toBe("alpha");
+    expect(file.size).toBe(5);
+  });
+});

--- a/server/src/__tests__/project-routes-env.test.ts
+++ b/server/src/__tests__/project-routes-env.test.ts
@@ -32,6 +32,7 @@ vi.mock("../services/index.js", () => ({
   environmentService: () => mockEnvironmentService,
   logActivity: mockLogActivity,
   projectService: () => mockProjectService,
+  projectMemoryService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
   secretService: () => mockSecretService,
   workspaceOperationService: () => mockWorkspaceOperationService,
 }));
@@ -58,6 +59,7 @@ function registerModuleMocks() {
     environmentService: () => mockEnvironmentService,
     logActivity: mockLogActivity,
     projectService: () => mockProjectService,
+  projectMemoryService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
     secretService: () => mockSecretService,
     workspaceOperationService: () => mockWorkspaceOperationService,
   }));

--- a/server/src/__tests__/sandboxed-fs.test.ts
+++ b/server/src/__tests__/sandboxed-fs.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  listSandboxedFilesRecursive,
+  normalizeSandboxRelativePath,
+  readSandboxedFile,
+  resolvePathInSandbox,
+} from "../lib/sandboxed-fs.js";
+
+let tmpRoots: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-sandboxed-fs-"));
+  tmpRoots.push(dir);
+  return dir;
+}
+
+beforeEach(() => {
+  tmpRoots = [];
+});
+
+afterEach(async () => {
+  await Promise.all(tmpRoots.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("normalizeSandboxRelativePath", () => {
+  it("rejects empty paths", () => {
+    expect(() => normalizeSandboxRelativePath("")).toThrow();
+    expect(() => normalizeSandboxRelativePath("   ")).toThrow();
+  });
+
+  it("rejects parent-directory traversal", () => {
+    expect(() => normalizeSandboxRelativePath("..")).toThrow();
+    expect(() => normalizeSandboxRelativePath("../etc/passwd")).toThrow();
+    expect(() => normalizeSandboxRelativePath("foo/../../bar")).toThrow();
+  });
+
+  it("strips leading slashes (matches existing codebase convention) and rejects NUL bytes", () => {
+    expect(normalizeSandboxRelativePath("/foo/bar.md")).toBe("foo/bar.md");
+    const raw = `foo${String.fromCharCode(0)}bar`;
+    expect(() => normalizeSandboxRelativePath(raw)).toThrow();
+  });
+
+  it("normalizes backslashes and leading slashes", () => {
+    expect(normalizeSandboxRelativePath("foo/bar.md")).toBe("foo/bar.md");
+    expect(normalizeSandboxRelativePath("/foo/bar.md")).toBe("foo/bar.md");
+    expect(normalizeSandboxRelativePath("foo\\bar.md")).toBe("foo/bar.md");
+  });
+});
+
+describe("resolvePathInSandbox", () => {
+  it("resolves valid relative paths under the root", async () => {
+    const root = await makeTempDir();
+    const resolved = resolvePathInSandbox(root, "foo/bar.md");
+    expect(resolved.startsWith(path.resolve(root))).toBe(true);
+    expect(resolved.endsWith(path.join("foo", "bar.md"))).toBe(true);
+  });
+
+  it("rejects traversal even when lexically valid components are present", async () => {
+    const root = await makeTempDir();
+    expect(() => resolvePathInSandbox(root, "../escape")).toThrow();
+    expect(() => resolvePathInSandbox(root, "ok/../../escape")).toThrow();
+  });
+});
+
+describe("listSandboxedFilesRecursive", () => {
+  it("returns null when the root does not exist", async () => {
+    const tmp = await makeTempDir();
+    const missing = path.join(tmp, "does-not-exist");
+    expect(await listSandboxedFilesRecursive(missing)).toBeNull();
+  });
+
+  it("returns [] for empty directories and ignores junk + symlinks", async () => {
+    const root = await makeTempDir();
+    const empty = await listSandboxedFilesRecursive(root);
+    expect(empty).toEqual([]);
+
+    await fs.writeFile(path.join(root, ".DS_Store"), "junk");
+    await fs.mkdir(path.join(root, "node_modules"));
+    await fs.writeFile(path.join(root, "node_modules", "lib.js"), "// ignored");
+    await fs.symlink("/etc/passwd", path.join(root, "danger.lnk")).catch(() => undefined);
+    const after = await listSandboxedFilesRecursive(root);
+    expect(after).toEqual([]);
+  });
+
+  it("walks nested directories and sorts the result", async () => {
+    const root = await makeTempDir();
+    await fs.mkdir(path.join(root, "memory"), { recursive: true });
+    await fs.writeFile(path.join(root, "memory", "z.md"), "z");
+    await fs.writeFile(path.join(root, "memory", "a.md"), "a");
+    await fs.writeFile(path.join(root, "MEMORY.md"), "top");
+
+    const files = await listSandboxedFilesRecursive(root);
+    expect(files?.map((f) => f.path)).toEqual(["MEMORY.md", "memory/a.md", "memory/z.md"]);
+    expect(files?.find((f) => f.path === "MEMORY.md")?.size).toBe(3);
+  });
+});
+
+describe("readSandboxedFile", () => {
+  it("returns null for missing files", async () => {
+    const root = await makeTempDir();
+    expect(await readSandboxedFile(root, "nope.md")).toBeNull();
+  });
+
+  it("rejects symlink escapes via real-path checking", async () => {
+    const root = await makeTempDir();
+    const outside = await makeTempDir();
+    const secretAbs = path.join(outside, "secret.md");
+    await fs.writeFile(secretAbs, "TOP SECRET");
+
+    // Create a symlink inside the sandbox that points outside.
+    const linkPath = path.join(root, "leak.md");
+    await fs.symlink(secretAbs, linkPath);
+
+    await expect(readSandboxedFile(root, "leak.md")).rejects.toThrow();
+  });
+
+  it("reads files happily when they live inside the sandbox", async () => {
+    const root = await makeTempDir();
+    await fs.writeFile(path.join(root, "hello.md"), "hi");
+    const detail = await readSandboxedFile(root, "hello.md");
+    expect(detail?.content).toBe("hi");
+    expect(detail?.size).toBe(2);
+    expect(detail?.path).toBe("hello.md");
+  });
+});

--- a/server/src/__tests__/workspace-runtime-routes-authz.test.ts
+++ b/server/src/__tests__/workspace-runtime-routes-authz.test.ts
@@ -40,6 +40,7 @@ vi.mock("../services/index.js", () => ({
   executionWorkspaceService: () => mockExecutionWorkspaceService,
   logActivity: mockLogActivity,
   projectService: () => mockProjectService,
+  projectMemoryService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
   secretService: () => mockSecretService,
   workspaceOperationService: () => mockWorkspaceOperationService,
 }));
@@ -66,6 +67,7 @@ function registerWorkspaceRouteMocks() {
     executionWorkspaceService: () => mockExecutionWorkspaceService,
     logActivity: mockLogActivity,
     projectService: () => mockProjectService,
+    projectMemoryService: () => ({ getManifest: vi.fn(), readFile: vi.fn() }),
     secretService: () => mockSecretService,
     workspaceOperationService: () => mockWorkspaceOperationService,
   }));

--- a/server/src/lib/claude-code-project-slug.ts
+++ b/server/src/lib/claude-code-project-slug.ts
@@ -1,0 +1,21 @@
+/**
+ * Map a working directory to the slug Claude Code uses for its project memory
+ * folder under `~/.claude/projects/<slug>/`.
+ *
+ * Observed convention (Claude Code as of 2026-05): every character that is not
+ * an alphanumeric or `-` is replaced with `-`. Hyphens already present in the
+ * cwd are preserved. The leading slash on POSIX paths therefore becomes a
+ * leading `-`, and consecutive non-alphanumerics produce consecutive `-`s
+ * (they are not collapsed).
+ *
+ * Example:
+ *   `/Users/jane/.paperclip/instances/default/projects/foo/_default`
+ *     -> `-Users-jane--paperclip-instances-default-projects-foo--default`
+ *
+ * Keep this helper as the single source of truth so we can swap conventions if
+ * Claude Code ever changes them.
+ */
+export function slugifyClaudeCodeProjectCwd(cwd: string): string {
+  if (typeof cwd !== "string" || cwd.length === 0) return "";
+  return cwd.replace(/[^a-zA-Z0-9-]/g, "-");
+}

--- a/server/src/lib/sandboxed-fs.ts
+++ b/server/src/lib/sandboxed-fs.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { unprocessable } from "../errors.js";
+
+const IGNORED_FILE_NAMES = new Set([".DS_Store", "Thumbs.db", "Desktop.ini"]);
+const IGNORED_DIRECTORY_NAMES = new Set([
+  ".git",
+  ".nox",
+  ".pytest_cache",
+  ".ruff_cache",
+  ".tox",
+  ".venv",
+  "__pycache__",
+  "node_modules",
+  "venv",
+]);
+
+export type SandboxedFile = {
+  /** Forward-slash path relative to the sandbox root. */
+  path: string;
+  /** Size in bytes. */
+  size: number;
+  /** Modification time as ISO-8601 UTC. */
+  mtime: string;
+};
+
+export type SandboxedFileDetail = SandboxedFile & {
+  /** UTF-8 file contents. */
+  content: string;
+};
+
+/**
+ * Normalize a caller-supplied relative path. Rejects empty inputs, absolute paths,
+ * and `..` segments before any filesystem access happens. Embedded NUL bytes are
+ * also rejected — Node would throw on the FS call anyway, but failing early gives
+ * a stable error code.
+ */
+export function normalizeSandboxRelativePath(candidate: string): string {
+  const raw = typeof candidate === "string" ? candidate : "";
+  for (let i = 0; i < raw.length; i += 1) {
+    if (raw.charCodeAt(i) === 0) {
+      throw unprocessable("Path contains an invalid character");
+    }
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    throw unprocessable("Path must not be empty");
+  }
+  const normalized = path.posix.normalize(trimmed.replaceAll("\\", "/")).replace(/^\/+/, "");
+  if (!normalized || normalized === "." || normalized === ".." || normalized.startsWith("../")) {
+    throw unprocessable("Path must stay within the sandbox root");
+  }
+  if (path.isAbsolute(normalized)) {
+    throw unprocessable("Path must be relative");
+  }
+  return normalized;
+}
+
+/**
+ * Lexically resolve `relativePath` under `rootPath`. Rejects anything that escapes
+ * the root via `..`. Symlink crossings are caught later by `assertRealPathInside`.
+ */
+export function resolvePathInSandbox(rootPath: string, relativePath: string): string {
+  const normalizedRelativePath = normalizeSandboxRelativePath(relativePath);
+  const absoluteRoot = path.resolve(rootPath);
+  const absolutePath = path.resolve(absoluteRoot, normalizedRelativePath);
+  const relativeToRoot = path.relative(absoluteRoot, absolutePath);
+  if (
+    relativeToRoot === ".."
+    || relativeToRoot.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relativeToRoot)
+  ) {
+    throw unprocessable("Path must stay within the sandbox root");
+  }
+  return absolutePath;
+}
+
+/**
+ * Resolve `targetPath` and `rootPath` to their real paths and require the result
+ * to live inside the (real) root. Defeats symlink-escape attacks where the
+ * lexical resolver would have accepted the path.
+ */
+export async function assertRealPathInside(
+  rootPath: string,
+  targetPath: string,
+): Promise<string> {
+  const realRoot = await fs.realpath(rootPath).catch(() => path.resolve(rootPath));
+  const realTarget = await fs.realpath(targetPath);
+  const relativeToRoot = path.relative(realRoot, realTarget);
+  if (
+    relativeToRoot === ".."
+    || relativeToRoot.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relativeToRoot)
+  ) {
+    throw unprocessable("Path must stay within the sandbox root");
+  }
+  return realTarget;
+}
+
+function shouldIgnore(entry: { name: string; isDirectory(): boolean; isFile(): boolean; isSymbolicLink?: () => boolean }): boolean {
+  if (entry.name === "." || entry.name === "..") return true;
+  if (entry.isSymbolicLink && entry.isSymbolicLink()) return true;
+  if (entry.isDirectory()) return IGNORED_DIRECTORY_NAMES.has(entry.name);
+  if (!entry.isFile()) return true;
+  return (
+    IGNORED_FILE_NAMES.has(entry.name)
+    || entry.name.startsWith("._")
+    || entry.name.endsWith(".pyc")
+    || entry.name.endsWith(".pyo")
+  );
+}
+
+/**
+ * Recursively list files under `rootPath`. Returns `null` if the root does not
+ * exist or is not a directory. Returns `[]` if the root is empty or contains
+ * only ignored entries. Symlinks are skipped to keep the sandbox honest.
+ */
+export async function listSandboxedFilesRecursive(rootPath: string): Promise<SandboxedFile[] | null> {
+  const stat = await fs.stat(rootPath).catch(() => null);
+  if (!stat?.isDirectory()) return null;
+  const out: SandboxedFile[] = [];
+  await walk(rootPath, "");
+  out.sort((a, b) => a.path.localeCompare(b.path));
+  return out;
+
+  async function walk(currentPath: string, relativeDir: string) {
+    const entries = await fs.readdir(currentPath, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      if (shouldIgnore(entry)) continue;
+      const childAbsolute = path.join(currentPath, entry.name);
+      const childRelative = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(childAbsolute, childRelative);
+        continue;
+      }
+      const fileStat = await fs.stat(childAbsolute).catch(() => null);
+      if (!fileStat || !fileStat.isFile()) continue;
+      out.push({
+        path: childRelative,
+        size: fileStat.size,
+        mtime: fileStat.mtime.toISOString(),
+      });
+    }
+  }
+}
+
+/**
+ * Read a single file under `rootPath`, applying the lexical and real-path
+ * sandbox checks. Returns `null` if the file does not exist (so callers can
+ * map that to a 404 cleanly).
+ */
+export async function readSandboxedFile(
+  rootPath: string,
+  relativePath: string,
+): Promise<SandboxedFileDetail | null> {
+  const lexical = resolvePathInSandbox(rootPath, relativePath);
+  const stat = await fs.stat(lexical).catch(() => null);
+  if (!stat || !stat.isFile()) return null;
+  await assertRealPathInside(rootPath, lexical);
+  const content = await fs.readFile(lexical, "utf8");
+  return {
+    path: normalizeSandboxRelativePath(relativePath),
+    size: stat.size,
+    mtime: stat.mtime.toISOString(),
+    content,
+  };
+}

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -34,6 +34,7 @@ import { trackAgentCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
 import {
   agentService,
+  agentBrainService,
   agentInstructionsService,
   accessService,
   approvalService,
@@ -174,6 +175,7 @@ export function agentRoutes(
   const issueApprovalsSvc = issueApprovalService(db);
   const secretsSvc = secretService(db);
   const instructions = agentInstructionsService();
+  const brain = agentBrainService();
   const companySkills = companySkillService(db);
   const workspaceOperations = workspaceOperationService(db);
   const instanceSettings = instanceSettingsService(db);
@@ -2384,6 +2386,29 @@ export function agentRoutes(
     }
     await assertCanReadAgent(req, existing);
     res.json(await instructions.getBundle(existing));
+  });
+
+  router.get("/agents/:id/brain", async (req, res) => {
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    await assertCanReadAgent(req, existing);
+    res.json(await brain.getManifest(existing));
+  });
+
+  router.get("/agents/:id/brain/file", async (req, res) => {
+    const id = req.params.id as string;
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    await assertCanReadAgent(req, existing);
+    const requestedPath = typeof req.query.path === "string" ? req.query.path : "";
+    res.json(await brain.readFile(existing, requestedPath));
   });
 
   router.patch("/agents/:id/instructions-bundle", validate(updateAgentInstructionsBundleSchema), async (req, res) => {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -13,7 +13,12 @@ import {
 import type { WorkspaceRuntimeDesiredState, WorkspaceRuntimeServiceStateMap } from "@paperclipai/shared";
 import { trackProjectCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
-import { projectService, logActivity, workspaceOperationService } from "../services/index.js";
+import {
+  projectService,
+  projectMemoryService,
+  logActivity,
+  workspaceOperationService,
+} from "../services/index.js";
 import { conflict, forbidden } from "../errors.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import {
@@ -41,6 +46,7 @@ const SHARED_WORKSPACE_STOP_AND_RESTART_ACTIONS = new Set(["stop", "restart"]);
 export function projectRoutes(db: Db) {
   const router = Router();
   const svc = projectService(db);
+  const memory = projectMemoryService();
   const secretsSvc = secretService(db);
   const workspaceOperations = workspaceOperationService(db);
   const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
@@ -113,6 +119,29 @@ export function projectRoutes(db: Db) {
     }
     assertCompanyAccess(req, project.companyId);
     res.json(project);
+  });
+
+  router.get("/projects/:id/memory", async (req, res) => {
+    const id = req.params.id as string;
+    const project = await svc.getById(id);
+    if (!project) {
+      res.status(404).json({ error: "Project not found" });
+      return;
+    }
+    assertCompanyAccess(req, project.companyId);
+    res.json(await memory.getManifest(project));
+  });
+
+  router.get("/projects/:id/memory/file", async (req, res) => {
+    const id = req.params.id as string;
+    const project = await svc.getById(id);
+    if (!project) {
+      res.status(404).json({ error: "Project not found" });
+      return;
+    }
+    assertCompanyAccess(req, project.companyId);
+    const requestedPath = typeof req.query.path === "string" ? req.query.path : "";
+    res.json(await memory.readFile(project, requestedPath));
   });
 
   router.post("/companies/:companyId/projects", validate(createProjectSchema), async (req, res) => {

--- a/server/src/services/agent-brain.ts
+++ b/server/src/services/agent-brain.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { notFound, unprocessable } from "../errors.js";
+import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+import {
+  listSandboxedFilesRecursive,
+  normalizeSandboxRelativePath,
+  readSandboxedFile,
+  type SandboxedFile,
+  type SandboxedFileDetail,
+} from "../lib/sandboxed-fs.js";
+
+type AgentLike = {
+  id: string;
+  companyId: string;
+};
+
+export type AgentBrainSection = {
+  /** Stable key the UI uses to group entries: `life`, `memory`, or `MEMORY.md`. */
+  key: string;
+  /** Absolute filesystem root for this section. */
+  root: string;
+  /** True if `root` exists on disk and is the expected file/directory type. */
+  exists: boolean;
+  /** True for the single-file `MEMORY.md` section, false for the directory sections. */
+  isFile: boolean;
+  /** Files discovered under `root`. For the single-file section this is at most one entry. */
+  files: SandboxedFile[];
+};
+
+export type AgentBrainManifest = {
+  agentId: string;
+  companyId: string;
+  /** AGENT_HOME (the parent of the section roots), useful for the UI to render breadcrumbs. */
+  agentHome: string;
+  sections: AgentBrainSection[];
+};
+
+export type AgentBrainFileDetail = SandboxedFileDetail & {
+  /** Which allow-listed section the file lives in (`life`, `memory`, or `MEMORY.md`). */
+  section: string;
+};
+
+/** The three roots that make up Layer B. Order is preserved in the manifest. */
+export const AGENT_BRAIN_SECTIONS = [
+  { key: "life", isFile: false },
+  { key: "memory", isFile: false },
+  { key: "MEMORY.md", isFile: true },
+] as const;
+
+type Section = typeof AGENT_BRAIN_SECTIONS[number];
+
+function resolveAgentHome(agent: AgentLike): string {
+  return path.resolve(
+    resolvePaperclipInstanceRoot(),
+    "companies",
+    agent.companyId,
+    "agents",
+    agent.id,
+  );
+}
+
+function resolveSectionRoot(agent: AgentLike, section: Section): string {
+  return path.resolve(resolveAgentHome(agent), section.key);
+}
+
+function findSectionByKey(key: string): Section | null {
+  return AGENT_BRAIN_SECTIONS.find((section) => section.key === key) ?? null;
+}
+
+export function agentBrainService() {
+  async function describeSection(agent: AgentLike, section: Section): Promise<AgentBrainSection> {
+    const root = resolveSectionRoot(agent, section);
+    if (section.isFile) {
+      const stat = await fs.stat(root).catch(() => null);
+      if (!stat?.isFile()) {
+        return { key: section.key, root, exists: false, isFile: true, files: [] };
+      }
+      return {
+        key: section.key,
+        root,
+        exists: true,
+        isFile: true,
+        files: [
+          { path: section.key, size: stat.size, mtime: stat.mtime.toISOString() },
+        ],
+      };
+    }
+    const files = await listSandboxedFilesRecursive(root);
+    return {
+      key: section.key,
+      root,
+      exists: files !== null,
+      isFile: false,
+      files: files ?? [],
+    };
+  }
+
+  async function getManifest(agent: AgentLike): Promise<AgentBrainManifest> {
+    const sections = await Promise.all(
+      AGENT_BRAIN_SECTIONS.map((section) => describeSection(agent, section)),
+    );
+    return {
+      agentId: agent.id,
+      companyId: agent.companyId,
+      agentHome: resolveAgentHome(agent),
+      sections,
+    };
+  }
+
+  async function readFile(agent: AgentLike, requestedPath: string): Promise<AgentBrainFileDetail> {
+    const trimmed = typeof requestedPath === "string" ? requestedPath.trim() : "";
+    if (!trimmed) {
+      throw unprocessable("Query parameter 'path' is required");
+    }
+    const normalized = normalizeSandboxRelativePath(trimmed);
+    const slashIndex = normalized.indexOf("/");
+    const sectionKey = slashIndex === -1 ? normalized : normalized.slice(0, slashIndex);
+    const remainder = slashIndex === -1 ? "" : normalized.slice(slashIndex + 1);
+    const section = findSectionByKey(sectionKey);
+    if (!section) {
+      throw unprocessable(
+        "Brain file paths must begin with one of: life, memory, MEMORY.md",
+      );
+    }
+    if (section.isFile) {
+      if (remainder) {
+        throw unprocessable(`Section '${section.key}' is a single file; nested paths are not allowed`);
+      }
+      const detail = await readSandboxedFile(resolveAgentHome(agent), section.key);
+      if (!detail) throw notFound("Brain file not found");
+      return { ...detail, section: section.key };
+    }
+    if (!remainder) {
+      throw unprocessable(`Section '${section.key}' requires a sub-path (e.g. '${section.key}/foo.md')`);
+    }
+    const detail = await readSandboxedFile(resolveSectionRoot(agent, section), remainder);
+    if (!detail) throw notFound("Brain file not found");
+    return { ...detail, section: section.key };
+  }
+
+  return {
+    getManifest,
+    readFile,
+    /** Test/inspection helper: expose the section roots so callers can stage fixtures. */
+    resolveSectionRoot: (agent: AgentLike, key: string) => {
+      const section = findSectionByKey(key);
+      if (!section) throw unprocessable(`Unknown brain section '${key}'`);
+      return resolveSectionRoot(agent, section);
+    },
+    resolveAgentHome,
+  };
+}
+
+export type AgentBrainService = ReturnType<typeof agentBrainService>;

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -4,6 +4,8 @@ export { feedbackService } from "./feedback.js";
 export { companySkillService } from "./company-skills.js";
 export { agentService, deduplicateAgentName } from "./agents.js";
 export { agentInstructionsService, syncInstructionsBundleConfigFromFilePath } from "./agent-instructions.js";
+export { agentBrainService, AGENT_BRAIN_SECTIONS } from "./agent-brain.js";
+export { projectMemoryService } from "./project-memory.js";
 export { assetService } from "./assets.js";
 export { documentService, extractLegacyPlanBody } from "./documents.js";
 export {

--- a/server/src/services/project-memory.ts
+++ b/server/src/services/project-memory.ts
@@ -1,0 +1,99 @@
+import os from "node:os";
+import path from "node:path";
+import { notFound, unprocessable } from "../errors.js";
+import { slugifyClaudeCodeProjectCwd } from "../lib/claude-code-project-slug.js";
+import {
+  listSandboxedFilesRecursive,
+  readSandboxedFile,
+  type SandboxedFile,
+  type SandboxedFileDetail,
+} from "../lib/sandboxed-fs.js";
+
+type ProjectLike = {
+  id: string;
+  companyId: string;
+  codebase?: { effectiveLocalFolder?: string | null } | null;
+};
+
+export type ProjectMemoryManifest = {
+  projectId: string;
+  companyId: string;
+  /** The cwd we slugified to derive `root`. Useful for debugging / UI tooltips. */
+  resolvedCwd: string | null;
+  /** The slug Claude Code uses for `~/.claude/projects/<slug>/`. */
+  slug: string | null;
+  /** The absolute memory directory, or null if no cwd was available. */
+  root: string | null;
+  /** True if `root` exists on disk. */
+  exists: boolean;
+  files: SandboxedFile[];
+};
+
+function resolveClaudeProjectsRoot(): string {
+  return path.resolve(os.homedir(), ".claude", "projects");
+}
+
+function resolveProjectMemoryRoot(project: ProjectLike): {
+  cwd: string | null;
+  slug: string | null;
+  root: string | null;
+} {
+  const cwd = project.codebase?.effectiveLocalFolder?.trim() || null;
+  if (!cwd) return { cwd: null, slug: null, root: null };
+  const slug = slugifyClaudeCodeProjectCwd(cwd);
+  if (!slug) return { cwd, slug: null, root: null };
+  const root = path.resolve(resolveClaudeProjectsRoot(), slug, "memory");
+  return { cwd, slug, root };
+}
+
+export function projectMemoryService() {
+  async function getManifest(project: ProjectLike): Promise<ProjectMemoryManifest> {
+    const { cwd, slug, root } = resolveProjectMemoryRoot(project);
+    if (!root) {
+      return {
+        projectId: project.id,
+        companyId: project.companyId,
+        resolvedCwd: cwd,
+        slug,
+        root: null,
+        exists: false,
+        files: [],
+      };
+    }
+    const files = await listSandboxedFilesRecursive(root);
+    return {
+      projectId: project.id,
+      companyId: project.companyId,
+      resolvedCwd: cwd,
+      slug,
+      root,
+      exists: files !== null,
+      files: files ?? [],
+    };
+  }
+
+  async function readFile(project: ProjectLike, requestedPath: string): Promise<SandboxedFileDetail> {
+    const trimmed = typeof requestedPath === "string" ? requestedPath.trim() : "";
+    if (!trimmed) {
+      throw unprocessable("Query parameter 'path' is required");
+    }
+    const { root } = resolveProjectMemoryRoot(project);
+    if (!root) {
+      throw unprocessable("Project has no resolvable local folder; cannot read memory files");
+    }
+    const detail = await readSandboxedFile(root, trimmed);
+    if (!detail) throw notFound("Memory file not found");
+    return detail;
+  }
+
+  return {
+    getManifest,
+    readFile,
+    /** Inspection helper for tests / future debug endpoints. */
+    resolveRoot: (project: ProjectLike) => resolveProjectMemoryRoot(project),
+    /** Stable client constant: the `~/.claude/projects/` parent root. */
+    claudeProjectsRoot: resolveClaudeProjectsRoot(),
+  };
+}
+
+export type ProjectMemoryService = ReturnType<typeof projectMemoryService>;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents with two on-disk memory layers per agent/project, neither of which the UI can browse today.
> - Layer A is Claude Code's auto-memory (`~/.claude/projects/<slug>/memory/`); Layer B is the agent's PARA memory under `AGENT_HOME/{life,memory,MEMORY.md}`.
> - The only existing endpoint for any of this is `GET /agents/:id/instructions-bundle`, which surfaces the agent prompt — not memory.
> - To unblock the upcoming "Brain tab" / "Memory tab" UI work (COR-7), the server needs read-only manifests + sandboxed file reads for both layers, gated by the existing auth helpers.
> - This pull request adds four routes (`/agents/:id/brain`, `/agents/:id/brain/file`, `/projects/:id/memory`, `/projects/:id/memory/file`), the underlying services, a small sandbox library, and a Claude-Code slug helper.
> - The benefit is that the UI can render an agent's "brain" and a project's memory without separate per-call auth wiring, while the path-sandbox layer prevents `..` escapes and symlinks from leaking files outside the allow-listed roots.

## What Changed

- New `server/src/lib/sandboxed-fs.ts` shared helpers: `normalizeSandboxRelativePath`, `resolvePathInSandbox`, `assertRealPathInside` (real-path check defeats symlink escapes), `listSandboxedFilesRecursive` (skips symlinks + the usual ignore list), `readSandboxedFile`.
- New `server/src/lib/claude-code-project-slug.ts` — single source of truth for cwd → `~/.claude/projects/<slug>/` (every non-`[a-zA-Z0-9-]` char becomes `-`). Centralised so we can swap if Claude Code ever changes the convention.
- New `server/src/services/agent-brain.ts` — manifest + sandboxed read for Layer B. Manifest returns three sections (`life`, `memory`, `MEMORY.md`) so the UI can render them as separate panes; the file reader requires the path to start with one of those keys.
- New `server/src/services/project-memory.ts` — manifest + sandboxed read for Layer A; resolves `project.codebase.effectiveLocalFolder` and surfaces a clean empty manifest when the project has no resolvable cwd.
- Wired the new services into `server/src/services/index.ts`.
- New routes in `server/src/routes/agents.ts` and `server/src/routes/projects.ts`, gated by the existing `assertCanReadAgent` and `assertCompanyAccess` helpers.
- 6 new vitest files cover happy paths, empty state, path traversal, symlink escape, single-file vs directory section semantics, and cross-company auth (403). 12 existing route test files updated to declare `agentBrainService` / `projectMemoryService` in their `services/index.js` mocks (drop-by side effect of adding two new top-level exports).

## Verification

```bash
cd server
pnpm typecheck                                                              # clean
pnpm vitest run src/__tests__/{sandboxed-fs,claude-code-project-slug,agent-brain-service,project-memory-service,agent-brain-routes,project-memory-routes}.test.ts
# 6 files, 44 tests, all green

pnpm vitest run src/__tests__/{agent,project,workspace,environment-selection,authz,error-handler,adapter-model-refresh}*.test.ts
# 23 files, 180 tests, all green (route + service surface affected by the new top-level service exports)
```

Manual smoke against a live instance is deferred until this PR lands and is deployed; the running paperclipai server is the published npm package, not this branch.

## Risks

- Low risk overall: routes are GET-only and gated by existing auth helpers. The path-sandbox combines a lexical resolve with `fs.realpath` to defeat symlink escapes; symlinks are also skipped during recursive listing.
- The slug rule (`[^a-zA-Z0-9-]` → `-`) was inferred from observed Claude Code behaviour. The single helper means we can swap the rule in one place if Claude Code ever changes it.
- Two new top-level exports were added to `server/src/services/index.ts`; existing route tests that mock the entire module had to declare the new exports. All affected tests have been updated; if other downstream consumers mock the same surface they may need the same treatment.

> Checked `ROADMAP.md`: this is part of the agent-knowledge surface for the upcoming UI work (COR-7) and does not duplicate planned core work.

## Model Used

- Provider/model: Anthropic Claude (Opus 4.7 — `claude-opus-4-7`).
- Capabilities: code generation, multi-file edits, tool use (filesystem, shell, vitest, gh CLI).
- Mode: standard (no extended thinking explicitly enabled).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only
- [x] I have updated relevant documentation to reflect my changes — JSDoc on every exported helper / service function
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
