### PR TITLE
[AGE-13028] PR-bearing done guard — block done transition on open/failing PRs

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2648,6 +2648,47 @@ export function issueRoutes(
       }
     }
 
+    // PR-bearing done guard: block done transition when linked PRs are not merged or have failing CI
+    const effectiveNextStatus = typeof updateFields.status === "string" ? updateFields.status : existing.status;
+    const transitioningToDone = effectiveNextStatus === "done" && existing.status !== "done";
+    if (transitioningToDone && nextExecutionPolicy) {
+      const hasReviewOrApprovalStage = nextExecutionPolicy.stages.some(
+        (stage) => stage.type === "review" || stage.type === "approval",
+      );
+      if (hasReviewOrApprovalStage) {
+        const workProducts = await workProductsSvc.listForIssue(existing.id);
+        const pullRequests = workProducts.filter((wp) => wp.type === "pull_request");
+        const unmergedPRs = pullRequests.filter(
+          (wp) => wp.status !== "merged" && wp.status !== "closed",
+        );
+        if (unmergedPRs.length > 0) {
+          res.status(422).json({
+            error: "Cannot mark issue as done: linked pull request is not merged",
+            blockingWorkProducts: unmergedPRs.map((wp) => ({
+              id: wp.id,
+              title: wp.title,
+              url: wp.url,
+              status: wp.status,
+            })),
+          });
+          return;
+        }
+        const unhealthyPRs = pullRequests.filter((wp) => wp.healthStatus === "unhealthy");
+        if (unhealthyPRs.length > 0) {
+          res.status(422).json({
+            error: "Cannot mark issue as done: linked pull request has failing CI checks",
+            blockingWorkProducts: unhealthyPRs.map((wp) => ({
+              id: wp.id,
+              title: wp.title,
+              url: wp.url,
+              healthStatus: wp.healthStatus,
+            })),
+          });
+          return;
+        }
+      }
+    }
+
     let issue;
     try {
       if (transition.decision && decisionId) {


### PR DESCRIPTION
## Thinking Path

AGE-13028 requires blocking `done` transitions when an issue has linked pull_request work products that are not merged/closed or have failing CI. The parent issue (AGE-13014) established that agents marked issues as done while PRs were still open/failing. This guard enforces the constraint server-side, not in any single agent's logic.

## What Changed

- **`server/src/routes/issues.ts`**: Added PR-bearing done guard in the PATCH `/issues/:id` handler (after `applyIssueExecutionPolicyTransition`, before the DB update). The guard:
  1. Checks if the effective next status is `"done"` (transitioning to done, not already done)
  2. Only applies when the issue has a non-null `nextExecutionPolicy` containing `review` or `approval` stages — issues with `null` executionPolicy bypass the guard entirely (backwards compatibility)
  3. Queries linked work products via `workProductsSvc.listForIssue()`
  4. Filters for `pull_request` type work products
  5. Rejects with `422` if any PR is not `merged` or `closed`, returning `blockingWorkProducts` array with id/title/url/status
  6. Rejects with `422` if any PR has `healthStatus === "unhealthy"`, returning `blockingWorkProducts` array with id/title/url/healthStatus

## Verification

- TypeScript compilation: server typecheck passes (pre-existing errors in `plugin-host-services.ts` and `plugin-local-folders.ts` are unrelated)
- Test suite: all existing tests pass; the 2 failures are pre-existing (SSH fixture timeout, sandbox-callback-bridge)
- The guard is opt-in via executionPolicy: issues with `null` policy are not gated (backwards compatibility requirement from spec)
- Error responses follow existing `422` pattern with `error` and structured detail fields

## Risks

- **Edge case: PRs without CI status** — work products may have `healthStatus: "unknown"` rather than `"healthy"` or `"unhealthy"`. The guard only blocks on `"unhealthy"`, so `"unknown"` passes through. This is intentional: we only block on proven failure, not on missing data.
- **Edge case: no PRs linked** — if an issue has an execution policy with review/approval stages but no linked PRs, the guard passes (no pull_requests to block on). This aligns with the spec's "documentation-only" opt-out for issues without PRs.
- **Performance** — adds one DB query per done transition on gated issues. This is acceptable since done transitions are infrequent and `listForIssue` is a simple indexed query.

## Model Used

Claude Sonnet 4 (anthropic/claude-sonnet-4-20250514), 200K context window, coding and code review capabilities.

## Checklist

- [x] Behavior matches spec (AGE-13028 Scope 3 / AGE-13014 Scope 3)
- [x] Typecheck passes (no new errors introduced)
- [x] Existing tests pass (no regressions)
- [x] Contracts synced — `workProductService.listForIssue()` already returns `IssueWorkProduct` with `type`, `status`, `healthStatus` fields used by this guard
- [x] No doc changes needed — this is an internal guard, not a user-facing API change
- [x] PR description follows template