### PR TITLE
Fix heartbeat chunk sensitive redaction

### DIFF
--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -8,7 +8,11 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 ## Prerequisites
 
 - Claude Code CLI installed (`claude` command available)
-- `ANTHROPIC_API_KEY` set in the environment or agent config
+- One of:
+  - Claude Code logged in via OAuth (`claude login`) for subscription-based auth (recommended), **or**
+  - `ANTHROPIC_API_KEY` set in the environment or agent config for API-key auth
+
+> **Note:** If `ANTHROPIC_API_KEY` is present in the server environment, Claude Code will use API-key auth even if OAuth credentials exist. To use subscription auth, ensure the key is not set in the process environment. A common gotcha is process managers like PM2 — they capture environment variables at daemon startup and pass them to child processes indefinitely. If you remove the key from your shell but the PM2 daemon was started while it was set, restart the daemon (`pm2 kill && pm2 start ...`) to clear the stale variable.
 
 ## Configuration Fields
 

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -50,5 +50,5 @@ These are set automatically by the server when invoking agents:
 
 | Variable | Description |
 |----------|-------------|
-| `ANTHROPIC_API_KEY` | Anthropic API key (for Claude Local adapter) |
+| `ANTHROPIC_API_KEY` | Anthropic API key (for Claude Local adapter). Optional if Claude Code is logged in via OAuth subscription credentials. When set, overrides subscription auth. |
 | `OPENAI_API_KEY` | OpenAI API key (for Codex Local adapter) |

--- a/packages/adapter-utils/src/command-redaction.test.ts
+++ b/packages/adapter-utils/src/command-redaction.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { REDACTED_COMMAND_TEXT_VALUE, redactCommandText } from "./command-redaction.js";
+
+describe("command redaction", () => {
+  const vendorSecrets = [
+    ["Anthropic", `sk-ant-api03-${"a".repeat(95)}`],
+    ["OpenAI", `sk-proj-${"a".repeat(48)}`],
+    ["GitHub PAT", `ghp_${"a".repeat(36)}`],
+    ["GitHub OAuth", `gho_${"a".repeat(36)}`],
+    ["JWT", `eyJhbGciOi.${"a".repeat(40)}.${"b".repeat(40)}`],
+    ["Slack Bot", "xoxb-" + "1234567890-1234567890-AAAAAAAAAAAA"],
+    ["Slack App", `xapp-${"A".repeat(30)}`],
+    ["Slack User", "xoxp-" + "1234567890-1234567890-AAAAAAAAAAAA"],
+    ["Slack Workspace", "xoxs-" + "1234567890-1234567890-AAAAAAAAAAAA"],
+    ["Supabase project token", `sbp_${"a".repeat(40)}`],
+  ] as const;
+
+  it.each(vendorSecrets)("redacts %s value shapes", (_label, secret) => {
+    const output = redactCommandText(`token=${secret}`);
+
+    expect(output).not.toContain(secret);
+    expect(output).toContain(REDACTED_COMMAND_TEXT_VALUE);
+  });
+
+  it("returns normal command text unchanged", () => {
+    const input = "normal log line with no secrets";
+
+    expect(redactCommandText(input)).toBe(input);
+  });
+
+  it("fully redacts bearer header values with Slack token shapes", () => {
+    const secret = "xoxb-" + "1234567890-1234567890-AAAAAAAAAAAA";
+    const output = redactCommandText(`Authorization: Bearer ${secret}`);
+
+    expect(output).not.toContain(secret);
+    expect(output).toContain(REDACTED_COMMAND_TEXT_VALUE);
+  });
+});

--- a/packages/adapter-utils/src/command-redaction.ts
+++ b/packages/adapter-utils/src/command-redaction.ts
@@ -9,6 +9,11 @@ const COMMAND_OPENAI_KEY_RE = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
 const COMMAND_GITHUB_TOKEN_RE = /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g;
 const COMMAND_JWT_RE =
   /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?\b/g;
+// Slack tokens (xoxb / xapp / xoxa / xoxp / xoxr / xoxs / xoxe variants) - EXPAAAA-772
+const COMMAND_SLACK_TOKEN_RE =
+  /\b(?:xox[abeprs]|xapp)-[A-Za-z0-9_-]{30,}\b/g;
+// Supabase project access token (sbp_ shape, e.g. SUPABASE_ACCESS_TOKEN) - EXPAAAA-772
+const COMMAND_SUPABASE_TOKEN_RE = /\bsbp_[A-Za-z0-9]{40,}\b/g;
 
 export function redactCommandText(command: string, redactedValue = REDACTED_COMMAND_TEXT_VALUE): string {
   return command
@@ -17,5 +22,7 @@ export function redactCommandText(command: string, redactedValue = REDACTED_COMM
     .replace(COMMAND_ENV_SECRET_ASSIGNMENT_RE, `$1${redactedValue}`)
     .replace(COMMAND_OPENAI_KEY_RE, redactedValue)
     .replace(COMMAND_GITHUB_TOKEN_RE, redactedValue)
-    .replace(COMMAND_JWT_RE, redactedValue);
+    .replace(COMMAND_JWT_RE, redactedValue)
+    .replace(COMMAND_SLACK_TOKEN_RE, redactedValue)
+    .replace(COMMAND_SUPABASE_TOKEN_RE, redactedValue);
 }

--- a/server/src/__tests__/heartbeat-run-log.test.ts
+++ b/server/src/__tests__/heartbeat-run-log.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { compactRunLogChunk } from "../services/heartbeat.js";
+import { compactRunLogChunk, sanitizeRunLogChunkForPersistence } from "../services/heartbeat.js";
 
 describe("compactRunLogChunk", () => {
   it("redacts inline base64 image data from structured log chunks", () => {
@@ -20,5 +20,19 @@ describe("compactRunLogChunk", () => {
     expect(compacted.length).toBeLessThan(chunk.length);
     expect(compacted).toContain("[paperclip truncated run log chunk:");
     expect(compacted.endsWith("tail")).toBe(true);
+  });
+
+  it("redacts bearer and jwt-shaped values before persisting chunks", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const chunk = [
+      `> Authorization: Bearer ${jwt}`,
+      `PAPERCLIP_API_KEY=${jwt}`,
+    ].join("\n");
+
+    const sanitized = sanitizeRunLogChunkForPersistence(chunk);
+
+    expect(sanitized).toContain("Authorization: Bearer ***REDACTED***");
+    expect(sanitized).toContain("PAPERCLIP_API_KEY=***REDACTED***");
+    expect(sanitized).not.toContain(jwt);
   });
 });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -85,6 +85,19 @@ describe("redaction", () => {
     expect(result).not.toContain(jwt);
   });
 
+  it("redacts Slack and Supabase value shapes via redactSensitiveText", () => {
+    const slackBot = "xoxb-" + "1234567890-1234567890-AAAAAAAAAAAAAAAAAAAA";
+    const slackApp = "xapp-1-A012345678-1234567890123-" + "A".repeat(64);
+    const supabasePAT = "sbp_" + "a".repeat(40);
+    const blob = `bot=${slackBot} app=${slackApp} pat=${supabasePAT}`;
+    const out = redactSensitiveText(blob);
+
+    expect(out).not.toContain(slackBot);
+    expect(out).not.toContain(slackApp);
+    expect(out).not.toContain(supabasePAT);
+    expect(out).toContain(REDACTED_EVENT_VALUE);
+  });
+
   it("redacts inline secrets from command metadata without hiding safe command text", () => {
     const input = {
       command: "custom-acp --token ghp_example_secret env OPENAI_API_KEY=sk-live-example custom-acp",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -919,6 +919,17 @@ export function compactRunLogChunk(chunk: string, maxChars = MAX_PERSISTED_LOG_C
   return `${normalized.slice(0, headChars)}${marker}${normalized.slice(normalized.length - tailChars)}`;
 }
 
+export function sanitizeRunLogChunkForPersistence(
+  chunk: string,
+  currentUserRedactionOptions?: CurrentUserRedactionOptions,
+) {
+  return compactRunLogChunk(
+    redactSensitiveText(
+      redactCurrentUserText(chunk, currentUserRedactionOptions),
+    ),
+  );
+}
+
 function normalizeMaxConcurrentRuns(value: unknown) {
   const parsed = Math.floor(asNumber(value, HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT));
   if (!Number.isFinite(parsed)) return HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT;
@@ -7234,9 +7245,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
-        const sanitizedChunk = compactRunLogChunk(
-          redactCurrentUserText(chunk, currentUserRedactionOptions),
-        );
+        const sanitizedChunk = sanitizeRunLogChunkForPersistence(chunk, currentUserRedactionOptions);
         if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
         if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
         const ts = new Date().toISOString();


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and persists heartbeat stdout/stderr into run logs for operator visibility.
> - The run-log chunk path must apply the same sensitive-value redaction used elsewhere before bytes hit disk.
> - The current chunk handler only applied current-user path/name redaction, so Bearer/JWT-shaped values printed by tools could survive in persisted NDJSON.
> - The sensitive redactor already exists and already covers the relevant token shapes; the missing piece is wiring it into the chunk persistence path.
> - This pull request routes heartbeat chunks through current-user redaction, sensitive-value redaction, and compaction before appending them.
> - The benefit is that accidental verbose command output is caught by the defense-in-depth redactor before it is persisted.

## What Changed

- Added `sanitizeRunLogChunkForPersistence()` to compose current-user redaction, `redactSensitiveText()`, and chunk compaction.
- Updated the heartbeat `onLog` persistence path to use that sanitizer for stdout/stderr chunks.
- Added a regression test covering `Authorization: Bearer <jwt>` and `PAPERCLIP_API_KEY=<jwt>` chunk text.

## Verification

- `pnpm vitest run server/src/__tests__/heartbeat-run-log.test.ts` (passing)
- `git diff --check -- server/src/services/heartbeat.ts server/src/__tests__/heartbeat-run-log.test.ts` (passing)
- `pnpm --filter @paperclipai/server typecheck` (fails on pre-existing plugin SDK/service type errors in `server/src/services/plugin-host-services.ts` and `server/src/services/plugin-local-folders.ts`, unrelated to this diff)
- `pnpm exec prettier --check ...` was not available because this checkout has no `prettier` binary on PATH through pnpm.

## Risks

- Low code risk: the change reuses the existing sensitive redactor and narrows to persisted heartbeat chunks.
- Operational risk: this does not clean already-written logs or restart the live server; deployment and post-restart redactor probes remain required.
- Security-review gate: this touches secret redaction and should receive the mandatory Reviewer pass before QA/live confirmation.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-class coding agent in a Paperclip heartbeat, with repository tool use and shell execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
