### PR TITLE
Honor comma-separated and repeated priority filter on issue list (GLA-190)

### DIFF
--- a/server/src/__tests__/issues-list-query-coercion.test.ts
+++ b/server/src/__tests__/issues-list-query-coercion.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { coerceListQueryParam } from "../routes/issues.ts";
+
+describe("coerceListQueryParam", () => {
+  it("returns undefined for missing values", () => {
+    expect(coerceListQueryParam(undefined)).toBeUndefined();
+    expect(coerceListQueryParam(null)).toBeUndefined();
+  });
+
+  it("passes through a single comma-separated string", () => {
+    expect(coerceListQueryParam("critical,high")).toBe("critical,high");
+  });
+
+  it("trims whitespace around the value", () => {
+    expect(coerceListQueryParam("  high  ")).toBe("high");
+  });
+
+  it("treats the empty / whitespace-only string as undefined", () => {
+    expect(coerceListQueryParam("")).toBeUndefined();
+    expect(coerceListQueryParam("   ")).toBeUndefined();
+  });
+
+  it("flattens the repeated-key array form into a comma-separated string", () => {
+    expect(coerceListQueryParam(["critical", "high"])).toBe("critical,high");
+  });
+
+  it("flattens mixed array entries that themselves contain commas", () => {
+    expect(coerceListQueryParam(["critical,high", "medium"])).toBe("critical,high,medium");
+  });
+
+  it("drops empty array entries", () => {
+    expect(coerceListQueryParam(["critical", "", "  ", "high"])).toBe("critical,high");
+    expect(coerceListQueryParam([])).toBeUndefined();
+    expect(coerceListQueryParam(["", "   "])).toBeUndefined();
+  });
+
+  it("rejects non-string array entries (qs nested form) by returning undefined", () => {
+    // qs's nested-object form would return an object here; failing closed
+    // is preferable to silently widening the result set.
+    expect(coerceListQueryParam([{ foo: "bar" } as unknown as string])).toBeUndefined();
+  });
+
+  it("rejects non-string, non-array values by returning undefined", () => {
+    expect(coerceListQueryParam({ foo: "bar" })).toBeUndefined();
+    expect(coerceListQueryParam(42 as unknown)).toBeUndefined();
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -460,6 +460,87 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(result.map((issue) => issue.id)).toEqual([grandchildId]);
   });
 
+  it("scopes issue lists by single priority value", async () => {
+    const companyId = randomUUID();
+    const criticalId = randomUUID();
+    const highId = randomUUID();
+    const mediumId = randomUUID();
+    const lowId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      { id: criticalId, companyId, title: "Critical", status: "todo", priority: "critical" },
+      { id: highId, companyId, title: "High", status: "todo", priority: "high" },
+      { id: mediumId, companyId, title: "Medium", status: "todo", priority: "medium" },
+      { id: lowId, companyId, title: "Low", status: "todo", priority: "low" },
+    ]);
+
+    const result = await svc.list(companyId, { priority: "high" });
+
+    expect(new Set(result.map((issue) => issue.id))).toEqual(new Set([highId]));
+  });
+
+  it("scopes issue lists by comma-separated priority values", async () => {
+    const companyId = randomUUID();
+    const criticalId = randomUUID();
+    const highId = randomUUID();
+    const mediumId = randomUUID();
+    const lowId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      { id: criticalId, companyId, title: "Critical", status: "todo", priority: "critical" },
+      { id: highId, companyId, title: "High", status: "todo", priority: "high" },
+      { id: mediumId, companyId, title: "Medium", status: "todo", priority: "medium" },
+      { id: lowId, companyId, title: "Low", status: "todo", priority: "low" },
+    ]);
+
+    const result = await svc.list(companyId, { priority: "critical,high" });
+
+    expect(new Set(result.map((issue) => issue.id))).toEqual(new Set([criticalId, highId]));
+  });
+
+  it("combines comma-separated priority and status filters", async () => {
+    const companyId = randomUUID();
+    const criticalTodo = randomUUID();
+    const highInProgress = randomUUID();
+    const highDone = randomUUID();
+    const mediumTodo = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values([
+      { id: criticalTodo, companyId, title: "Critical todo", status: "todo", priority: "critical" },
+      { id: highInProgress, companyId, title: "High in progress", status: "in_progress", priority: "high" },
+      { id: highDone, companyId, title: "High done", status: "done", priority: "high" },
+      { id: mediumTodo, companyId, title: "Medium todo", status: "todo", priority: "medium" },
+    ]);
+
+    const result = await svc.list(companyId, {
+      priority: "critical,high",
+      status: "todo,in_progress",
+    });
+
+    expect(new Set(result.map((issue) => issue.id))).toEqual(new Set([criticalTodo, highInProgress]));
+  });
+
   it("accepts issue identifiers with alphanumeric prefixes through getById", async () => {
     const companyId = randomUUID();
     const issueId = randomUUID();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -375,6 +375,32 @@ const INVALID_AGENT_IN_REVIEW_DISPOSITION_MESSAGE =
   "link or request a pending approval, assign a human reviewer with assigneeUserId, set a typed executionState.currentParticipant through an execution policy, " +
   "or schedule an issue monitor for an external review/check. After creating one of those review paths, retry the status update.";
 
+// Accepts the comma-separated form (`?priority=critical,high`) and the
+// repeated-key form (`?priority=critical&priority=high`, parsed by Express
+// as a string array) and normalizes both to a single comma-separated string
+// the service layer already understands. Anything else (objects from `qs`'s
+// nested-form parser, etc.) is rejected as undefined so a malformed query
+// fails closed instead of silently widening the result set.
+export function coerceListQueryParam(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (Array.isArray(value)) {
+    const parts: string[] = [];
+    for (const entry of value) {
+      if (typeof entry !== "string") return undefined;
+      for (const piece of entry.split(",")) {
+        const trimmed = piece.trim();
+        if (trimmed.length > 0) parts.push(trimmed);
+      }
+    }
+    return parts.length > 0 ? parts.join(",") : undefined;
+  }
+  return undefined;
+}
+
 function executionPrincipalsEqual(
   left: ParsedExecutionState["currentParticipant"] | null,
   right: ParsedExecutionState["currentParticipant"] | null,
@@ -1381,7 +1407,8 @@ export function issueRoutes(
     const offset = parsedOffset ?? 0;
 
     const result = await svc.list(companyId, {
-      status: req.query.status as string | undefined,
+      status: coerceListQueryParam(req.query.status),
+      priority: coerceListQueryParam(req.query.priority),
       assigneeAgentId: req.query.assigneeAgentId as string | undefined,
       participantAgentId: req.query.participantAgentId as string | undefined,
       assigneeUserId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -120,6 +120,7 @@ function buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(
 
 export interface IssueFilters {
   status?: string;
+  priority?: string;
   assigneeAgentId?: string;
   participantAgentId?: string;
   assigneeUserId?: string;
@@ -2227,8 +2228,20 @@ export function issueService(db: Db) {
         `);
       }
       if (filters?.status) {
-        const statuses = filters.status.split(",").map((s) => s.trim());
-        conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
+        const statuses = filters.status.split(",").map((s) => s.trim()).filter(Boolean);
+        if (statuses.length === 1) {
+          conditions.push(eq(issues.status, statuses[0]));
+        } else if (statuses.length > 1) {
+          conditions.push(inArray(issues.status, statuses));
+        }
+      }
+      if (filters?.priority) {
+        const priorities = filters.priority.split(",").map((s) => s.trim()).filter(Boolean);
+        if (priorities.length === 1) {
+          conditions.push(eq(issues.priority, priorities[0]));
+        } else if (priorities.length > 1) {
+          conditions.push(inArray(issues.priority, priorities));
+        }
       }
       if (filters?.assigneeAgentId) {
         conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));


### PR DESCRIPTION
## Summary

`GET /api/companies/:companyId/issues?priority=critical,high` silently ignored the filter and returned every priority. The repeated-key form `?priority=critical&priority=high` 500'd. The same path already accepted comma-separated `status=`, so the asymmetry was the bug.

- Add `priority?: string` to `IssueFilters` and mirror the existing `status` parser in `issueService.list` (server/src/services/issues.ts)
- In the route, introduce `coerceListQueryParam` and run both `status` and `priority` through it so the comma-separated form and Express's repeated-key array form fold into the single comma-separated string the service understands. Fails closed (returns `undefined`) on shapes the service cannot interpret instead of silently widening the result set (server/src/routes/issues.ts)
- Tighten the `status` filter parser to drop empty parts so a stray comma can no longer fall through to the `inArray([])` path

## Acceptance criteria

- [x] `GET …?priority=critical,high&status=todo,in_progress` returns only critical and high rows
- [x] `GET …?priority=high` (single value) keeps working
- [x] Repeated-key form `priority=critical&priority=high` works (no longer 500s)

## Tests

- New embedded-postgres tests in `issues-service.test.ts` cover single-value, comma-separated, and combined `priority`+`status` filters
- New unit test file `issues-list-query-coercion.test.ts` covers `coerceListQueryParam` across the comma-separated, repeated-key, mixed, and malformed-input paths

```
$ cd server && npx vitest run src/__tests__/issues-service.test.ts src/__tests__/issues-list-query-coercion.test.ts
 Test Files  2 passed (2)
      Tests  56 passed (56)
```

## Follow-up

- Once landed, `.planning/security/safeguard/run.py:fetch_in_scope` can drop the client-side priority filter and reinstate the server-side `priority=` query (tracked in [GLA-187](/GLA/issues/GLA-187)).

Refs: GLA-190, GLA-187