### PR TITLE
fix(codex-local): classify chatgpt transport failures as transient

### DIFF
--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -137,4 +137,22 @@ describe("isCodexTransientUpstreamError", () => {
       }),
     ).toBe(false);
   });
+
+  it("classifies stream disconnects to the Codex chatgpt.com transport as transient", () => {
+    expect(
+      isCodexTransientUpstreamError({
+        errorMessage:
+          "stream disconnected before completion: error sending request for url (https://chatgpt.com/backend-api/codex/responses)",
+      }),
+    ).toBe(true);
+  });
+
+  it("classifies websocket DNS lookup failures to the Codex chatgpt.com transport as transient", () => {
+    expect(
+      isCodexTransientUpstreamError({
+        errorMessage:
+          "websocket DNS lookup failed for wss://chatgpt.com/backend-api/codex/responses: getaddrinfo ENOTFOUND chatgpt.com",
+      }),
+    ).toBe(true);
+  });
 });

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -8,6 +8,10 @@ import {
 const CODEX_TRANSIENT_UPSTREAM_RE =
   /(?:we(?:'|’)re\s+currently\s+experiencing\s+high\s+demand|temporary\s+errors|rate[-\s]?limit(?:ed)?|too\s+many\s+requests|\b429\b|server\s+overloaded|service\s+unavailable|try\s+again\s+later)/i;
 const CODEX_REMOTE_COMPACTION_RE = /remote\s+compact\s+task/i;
+const CODEX_CHATGPT_TRANSPORT_RE =
+  /(?:https|wss):\/\/chatgpt\.com\/backend-api\/codex\/(?:responses|models)\b/i;
+const CODEX_TRANSPORT_FAILURE_RE =
+  /(?:stream\s+disconnected\s+before\s+completion|error\s+sending\s+request|getaddrinfo\s+(?:enotfound|eai_again)|dns\s+lookup\s+failed|websocket\s+dns\s+lookup\s+failed)/i;
 const CODEX_USAGE_LIMIT_RE =
   /you(?:'|’)ve hit your usage limit for .+\.\s+switch to another model now,\s+or try again at\s+([^.!\n]+)(?:[.!]|\n|$)/i;
 
@@ -253,6 +257,9 @@ export function isCodexTransientUpstreamError(input: {
   const haystack = buildCodexErrorHaystack(input);
 
   if (extractCodexRetryNotBefore(input) != null) return true;
+  if (CODEX_CHATGPT_TRANSPORT_RE.test(haystack) && CODEX_TRANSPORT_FAILURE_RE.test(haystack)) {
+    return true;
+  }
   if (!CODEX_TRANSIENT_UPSTREAM_RE.test(haystack)) return false;
   // Keep automatic retries scoped to the observed remote-compaction/high-demand
   // failure shape, plus explicit usage-limit windows that tell us when retrying


### PR DESCRIPTION
## Summary

- Classifies `chatgpt.com` transport errors (stream disconnects, DNS lookup failures) as transient so they trigger automatic retries instead of permanent failure
- Adds regex patterns to detect `chatgpt.com/backend-api/codex/` URLs combined with transport failure messages
- Includes 2 new test cases covering stream disconnect and websocket DNS lookup failure scenarios

## Context

Recurring `codex_local` DNS/WebSocket failures to `chatgpt.com` were causing permanent task failures in Paperclip-managed runs. These are transient network issues that should be retried automatically.

## Test plan

- [x] `parse.test.ts`: 11 tests pass (2 new)
- [x] `codex-local-execute.test.ts`: 13 tests pass