### PR TITLE
docs(pr-template): add Layout and Smoke gate for FE/UI PRs (STO-722)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,26 @@
 
 -
 
+## Layout & Smoke
+
+<!--
+  Required for UI / FE PRs. Backend-only PRs can write "N/A — backend only".
+
+  Layout-sensitive changes are ones that touch CSS, component structure,
+  flex/grid, spacing tokens, breakpoints, navigation chrome, or anything
+  that visibly moves pixels for an existing user. If unsure, mark yes.
+
+  Smoke test gate: large FE changes must run at least one smoke check
+  (`pnpm test:e2e` subset, `scripts/smoke/*`, or a manual
+  before/after screenshot pass) before this PR is merge-eligible.
+  State exactly what was run and the result.
+-->
+
+- Layout-sensitive change? **(yes / no — explain below)**
+-
+- Smoke check run: **(command / manual steps + result)**
+-
+
 > For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.
 
 ## Model Used
@@ -62,6 +82,8 @@
 - [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
 - [ ] I have run tests locally and they pass
 - [ ] I have added or updated tests where applicable
+- [ ] I have answered the Layout & Smoke section (or marked it N/A — backend only)
+- [ ] If this is a layout-sensitive FE change, I have run a smoke check and stated the result
 - [ ] If this change affects the UI, I have included before/after screenshots
 - [ ] I have updated relevant documentation to reflect my changes
 - [ ] I have considered and documented any risks above


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Contributors (human and agent) submit code through pull requests, and the PR template is the only checkpoint that runs on every change before review
> - 2026-04-29 retro SC3 captured a recurring failure mode: large FE changes shipping without an explicit "did you look at the actual rendered result?" gate, so layout regressions slipped past review
> - The current template asks for screenshots only inside Verification/Checklist, with no dedicated self-attest about layout sensitivity, so reviewers can't quickly tell whether a smoke pass was actually performed
> - This pull request adds a single `Layout & Smoke` section + two checklist items so layout-sensitive FE PRs must explicitly state (a) yes/no on layout sensitivity and (b) which smoke check was run with the result
> - The benefit is a cheap, in-template gate that surfaces the FE-regression risk class before merge, with an explicit `N/A — backend only` escape hatch so backend PRs aren't taxed

## What Changed

- Added `## Layout & Smoke` section to `.github/PULL_REQUEST_TEMPLATE.md`, placed between `Risks` and `Model Used`
- Section asks two questions: (1) is this layout-sensitive? (2) which smoke check was run + result?
- Backend-only PRs can satisfy the section with `N/A — backend only`
- Added two checklist items:
  - `I have answered the Layout & Smoke section (or marked it N/A — backend only)`
  - `If this is a layout-sensitive FE change, I have run a smoke check and stated the result`
- No code or workflow changes — pure template / documentation update

## Verification

- Render `/.github/PULL_REQUEST_TEMPLATE.md` on GitHub and confirm the new section + two checklist items appear
- Open a draft PR after this is merged and confirm the new template auto-fills with the `Layout & Smoke` section
- Existing sections (Thinking Path, What Changed, Verification, Risks, Model Used, Checklist) are unchanged in heading/order — diff is additive only

```sh
git diff master --stat .github/PULL_REQUEST_TEMPLATE.md
# .github/PULL_REQUEST_TEMPLATE.md | 22 ++++++++++++++++++++++
```

## Risks

- Low risk. Documentation-only change to the PR template.
- Existing open PRs are not retroactively required to fill the new section — the template only affects PRs opened after merge.
- The section's `N/A — backend only` escape hatch keeps backend-only PRs from getting blocked by an FE-shaped gate.

## Layout & Smoke

- Layout-sensitive change? **no — template/docs only, no UI surface touched**
- Smoke check run: **N/A — markdown template change, no runtime behavior**

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Claude Opus 4-7 (Anthropic, ~1M context, extended-thinking off). Used for template wording, section placement, and PR composition. Diff reviewed by author before commit.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass <!-- N/A — markdown only, no test surface -->
- [x] I have added or updated tests where applicable <!-- N/A — markdown only -->
- [x] I have answered the Layout & Smoke section (or marked it N/A — backend only)
- [x] If this is a layout-sensitive FE change, I have run a smoke check and stated the result <!-- N/A — not layout-sensitive -->
- [x] If this change affects the UI, I have included before/after screenshots <!-- N/A — no UI surface -->
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
