### PR TITLE
fix: normalize escaped newlines in routine descriptions

### DIFF
--- a/packages/db/src/migrations/0082_fix_routine_description_newlines.sql
+++ b/packages/db/src/migrations/0082_fix_routine_description_newlines.sql
@@ -1,0 +1,27 @@
+-- Fix literal \n sequences in routine descriptions (should be real newlines).
+-- The create/update validator was missing the multilineTextSchema transform.
+
+UPDATE "routines"
+SET "description" = REPLACE(REPLACE(REPLACE("description", E'\\r' || E'\\n', E'\n'), E'\\n', E'\n'), E'\\r', E'\n'),
+    "updated_at" = NOW()
+WHERE "description" IS NOT NULL
+  AND (position(E'\\n' in "description") > 0 OR position(E'\\r' in "description") > 0);
+
+-- Also fix routine revision snapshots that captured the corrupted data.
+UPDATE "routine_revisions"
+SET "snapshot" = jsonb_set(
+  "snapshot"::jsonb,
+  '{routine,description}',
+  to_jsonb(
+    REPLACE(REPLACE(REPLACE(
+      "snapshot"::jsonb->'routine'->>'description',
+      E'\\r' || E'\\n', E'\n'),
+      E'\\n', E'\n'),
+      E'\\r', E'\n')
+  )
+)
+WHERE "snapshot"::jsonb->'routine'->>'description' IS NOT NULL
+  AND (
+    position(E'\\n' in "snapshot"::jsonb->'routine'->>'description') > 0
+    OR position(E'\\r' in "snapshot"::jsonb->'routine'->>'description') > 0
+  );

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1778067785040,
       "tag": "0081_optimal_dormammu",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1778352000000,
+      "tag": "0082_fix_routine_description_newlines",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -12,6 +12,7 @@ import {
   ISSUE_EXECUTION_WORKSPACE_PREFERENCES,
   issueExecutionWorkspaceSettingsSchema,
 } from "./issue.js";
+import { multilineTextSchema } from "./text.js";
 
 const routineVariableValueSchema = z.union([z.string(), z.number().finite(), z.boolean()]);
 
@@ -53,7 +54,7 @@ export const createRoutineSchema = z.object({
   goalId: z.string().uuid().optional().nullable(),
   parentIssueId: z.string().uuid().optional().nullable(),
   title: z.string().trim().min(1).max(200),
-  description: z.string().optional().nullable(),
+  description: multilineTextSchema.optional().nullable(),
   assigneeAgentId: z.string().uuid().optional().nullable(),
   priority: z.enum(ISSUE_PRIORITIES).optional().default("medium"),
   status: z.enum(ROUTINE_STATUSES).optional().default("active"),


### PR DESCRIPTION
## Summary

- Routine descriptions displayed literal `\n` instead of real line breaks because the create/update validator used `z.string()` instead of `multilineTextSchema`
- Switched `description` field in `createRoutineSchema` (and by extension `updateRoutineSchema`) to use `multilineTextSchema`, matching the pattern already used by issues and approvals
- Added migration 0082 to fix existing corrupted data in both `routines` and `routine_revisions` tables

## Test plan

- [ ] Verify existing routines with corrupted descriptions display correctly after migration
- [ ] Create a new routine via API with `\n` in description — confirm it renders as real line breaks
- [ ] Edit a routine description in the UI — confirm newlines are preserved on save

Fixes SEO-147

🤖 Generated with [Claude Code](https://claude.com/claude-code)