### PR TITLE
Harden stale-lock recovery for checkout/release ownership conflicts

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFile as execFileCallback, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
 import { and, eq, or, inArray } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
@@ -81,6 +82,7 @@ import {
 } from "../services/recovery/index.ts";
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+const execFile = promisify(execFileCallback);
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -101,6 +103,17 @@ function isPidAlive(pid: number | null | undefined) {
     return true;
   } catch {
     return false;
+  }
+}
+
+async function readProcessGroupId(pid: number) {
+  if (process.platform === "win32") return null;
+  try {
+    const { stdout } = await execFile("ps", ["-o", "pgid=", "-p", String(pid)]);
+    const parsed = Number.parseInt(stdout.trim(), 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
   }
 }
 
@@ -896,6 +909,58 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(agentWakeupRequests.id, wakeupRequestId))
       .then((rows) => rows[0] ?? null);
     expect(wakeup?.status).toBe("claimed");
+  });
+
+  it.skipIf(process.platform === "win32")("reaps a run when pid is alive but no longer belongs to the recorded process group", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const actualProcessGroupId = await readProcessGroupId(child.pid!);
+    expect(actualProcessGroupId).toBeTypeOf("number");
+
+    const { runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      processGroupId: (actualProcessGroupId ?? 0) + 1_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
+
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    expect(events.some((event) => (event.payload as Record<string, unknown> | null)?.stalePidReused === true)).toBe(true);
+  });
+
+  it("reaps detached runs when the recycled pid no longer matches the adapter command", async () => {
+    const { runId, agentId } = await seedRunFixture({
+      adapterType: "claude_local",
+      processPid: process.pid,
+      runErrorCode: "process_detached",
+      includeIssue: false,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const failedRun = runs.find((row) => row.id === runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_lost");
   });
 
   it("queues exactly one retry when the recorded local pid is dead", async () => {

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -213,6 +213,166 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     });
   });
 
+  it("reaps a stale running checkout lock during release when the same assignee presents a newer run", async () => {
+    const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    const issueId = randomUUID();
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "running",
+        processPid: 999_999_999,
+        processGroupId: null,
+        updatedAt: new Date(Date.now() - 2 * 60 * 1000),
+      })
+      .where(eq(heartbeatRuns.id, currentRunId));
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale running release",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, failedRunId)))
+      .post(`/api/issues/${issueId}/release`)
+      .send();
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    const issueRow = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(issueRow).toEqual({
+      status: "todo",
+      assigneeAgentId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+
+    const runRow = await db
+      .select({
+        status: heartbeatRuns.status,
+        errorCode: heartbeatRuns.errorCode,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, currentRunId))
+      .then((rows) => rows[0]);
+    expect(runRow).toEqual({
+      status: "failed",
+      errorCode: "process_lost",
+    });
+  });
+
+  it("reaps a stale running checkout lock during checkout for the same assignee", async () => {
+    const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    const issueId = randomUUID();
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "running",
+        processPid: 999_999_999,
+        processGroupId: null,
+        updatedAt: new Date(Date.now() - 2 * 60 * 1000),
+      })
+      .where(eq(heartbeatRuns.id, currentRunId));
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale running checkout",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, failedRunId)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({
+        agentId,
+        expectedStatuses: ["in_progress"],
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.checkoutRunId).toBe(failedRunId);
+    expect(res.body.executionRunId).toBe(failedRunId);
+
+    const runRow = await db
+      .select({
+        status: heartbeatRuns.status,
+        errorCode: heartbeatRuns.errorCode,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, currentRunId))
+      .then((rows) => rows[0]);
+    expect(runRow).toEqual({
+      status: "failed",
+      errorCode: "process_lost",
+    });
+  });
+
+  it("recovers a stale detached running checkout lock for the same assignee", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const staleRunId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(heartbeatRuns).values({
+      id: staleRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      processPid: 999_999_999,
+      errorCode: "process_detached",
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      startedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Detached stale lock release",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: staleRunId,
+      executionRunId: staleRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/release`)
+      .send();
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    const staleRun = await db
+      .select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, staleRunId))
+      .then((rows) => rows[0] ?? null);
+    expect(staleRun).toEqual({
+      status: "failed",
+      errorCode: "process_lost",
+    });
+  });
+
   it("restricts admin force-release to board users with company access and writes an audit event", async () => {
     const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
     const issueId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -318,6 +318,10 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "opencode_local",
   "pi_local",
 ]);
+const ADAPTER_PROCESS_MATCH_TOKENS: Record<string, string[]> = {
+  claude_local: ["claude"],
+  codex_local: ["codex"],
+};
 const INLINE_BASE64_IMAGE_DATA_RE = /("type":"image","source":\{"type":"base64","data":")([A-Za-z0-9+/=]{1024,})(")/g;
 
 type RuntimeConfigSecretResolver = Pick<
@@ -2132,6 +2136,46 @@ function isProcessAlive(pid: number | null | undefined) {
     if (code === "EPERM") return true;
     if (code === "ESRCH") return false;
     return false;
+  }
+}
+
+async function readProcessCommandLine(pid: number | null | undefined) {
+  if (process.platform === "win32") return null;
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return null;
+  try {
+    const { stdout } = await execFile("ps", ["-o", "command=", "-p", String(pid)]);
+    const commandLine = stdout.trim();
+    return commandLine.length > 0 ? commandLine : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeProcessCommandLine(value: string) {
+  return value.replace(/["']/g, "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+async function isLikelyAdapterChildProcess(input: {
+  adapterType: string;
+  pid: number | null | undefined;
+}) {
+  const tokens = ADAPTER_PROCESS_MATCH_TOKENS[input.adapterType];
+  if (!tokens || tokens.length === 0) return true;
+  const commandLine = await readProcessCommandLine(input.pid);
+  if (!commandLine) return true;
+  const normalized = normalizeProcessCommandLine(commandLine);
+  return tokens.some((token) => normalized.includes(token));
+}
+
+async function readProcessGroupIdForPid(pid: number): Promise<number | null> {
+  if (process.platform === "win32") return null;
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  try {
+    const { stdout } = await execFile("ps", ["-o", "pgid=", "-p", String(pid)]);
+    const parsed = Number.parseInt(stdout.trim(), 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
   }
 }
 
@@ -6403,28 +6447,44 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
-      const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
+      let processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
+      const processGroupMatchesPid = tracksLocalChild && run.processPid && run.processGroupId && processPidAlive
+        ? (await readProcessGroupIdForPid(run.processPid)) === run.processGroupId
+        : true;
+      if (
+        processPidAlive &&
+        run.processPid &&
+        run.errorCode === DETACHED_PROCESS_ERROR_CODE &&
+        !(await isLikelyAdapterChildProcess({ adapterType, pid: run.processPid }))
+      ) {
+        // Detached runs can outlive their original pid; if the pid now belongs to another command, treat it as stale.
+        processPidAlive = false;
+      }
       if (processPidAlive) {
-        if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
-          const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
-          const detachedRun = await setRunStatus(run.id, "running", {
-            error: detachedMessage,
-            errorCode: DETACHED_PROCESS_ERROR_CODE,
-          });
-          if (detachedRun) {
-            await appendRunEvent(detachedRun, await nextRunEventSeq(detachedRun.id), {
-              eventType: "lifecycle",
-              stream: "system",
-              level: "warn",
-              message: detachedMessage,
-              payload: {
-                processPid: run.processPid,
-              },
+        if (!processGroupMatchesPid) {
+          // PID was reused by a different process group; treat this run as orphaned.
+        } else {
+          if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
+            const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
+            const detachedRun = await setRunStatus(run.id, "running", {
+              error: detachedMessage,
+              errorCode: DETACHED_PROCESS_ERROR_CODE,
             });
+            if (detachedRun) {
+              await appendRunEvent(detachedRun, await nextRunEventSeq(detachedRun.id), {
+                eventType: "lifecycle",
+                stream: "system",
+                level: "warn",
+                message: detachedMessage,
+                payload: {
+                  processPid: run.processPid,
+                },
+              });
+            }
           }
+          continue;
         }
-        continue;
       }
 
       let descendantOnlyCleanup = false;
@@ -6489,6 +6549,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           ...(run.processPid ? { processPid: run.processPid } : {}),
           ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
           ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
+          ...(!processGroupMatchesPid ? { stalePidReused: true } : {}),
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
         },
       });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,4 +1,6 @@
 import { Buffer } from "node:buffer";
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
 import { and, asc, desc, eq, gt, inArray, isNull, like, lt, ne, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
@@ -66,6 +68,7 @@ import {
   issueTreeControlService,
   type ActiveIssueTreePauseHoldGate,
 } from "./issue-tree-control.js";
+import { isProcessGroupAlive } from "./local-service-supervisor.js";
 import { parseIssueGraphLivenessIncidentKey } from "./recovery/origins.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
@@ -76,6 +79,41 @@ const ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE = 500;
 export const MAX_CHILD_ISSUES_CREATED_BY_HELPER = 25;
 const MAX_CHILD_COMPLETION_SUMMARIES = 20;
 const CHILD_COMPLETION_SUMMARY_BODY_MAX_CHARS = 500;
+const STALE_HEARTBEAT_RECOVERY_GRACE_MS = 60_000;
+const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+const execFile = promisify(execFileCallback);
+const ADAPTER_PROCESS_MATCH_TOKENS: Record<string, string[]> = {
+  claude_local: ["claude"],
+  codex_local: ["codex"],
+};
+
+function isProcessAlive(pid: number | null | undefined) {
+  if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EPERM") return true;
+    if (code === "ESRCH") return false;
+    return false;
+  }
+}
+
+async function readProcessCommandLine(pid: number) {
+  if (process.platform === "win32") return null;
+  try {
+    const { stdout } = await execFile("ps", ["-o", "command=", "-p", String(pid)]);
+    const commandLine = stdout.trim();
+    return commandLine.length > 0 ? commandLine : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeProcessCommandLine(value: string) {
+  return value.replace(/["']/g, "").replace(/\s+/g, " ").trim().toLowerCase();
+}
 function assertTransition(from: string, to: string) {
   if (from === to) return;
   if (!ALL_ISSUE_STATUSES.includes(to)) {
@@ -2096,14 +2134,91 @@ export function issueService(db: Db) {
     );
   }
 
-  async function isTerminalOrMissingHeartbeatRun(runId: string) {
-    const run = await db
-      .select({ status: heartbeatRuns.status })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, runId))
+  async function isLikelyMatchingAdapterProcess(
+    tx: Db,
+    agentId: string,
+    processPid: number,
+  ) {
+    const agent = await tx
+      .select({ adapterType: agents.adapterType })
+      .from(agents)
+      .where(eq(agents.id, agentId))
       .then((rows) => rows[0] ?? null);
-    if (!run) return true;
-    return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+    if (!agent) return true;
+
+    const tokens = ADAPTER_PROCESS_MATCH_TOKENS[agent.adapterType];
+    if (!tokens || tokens.length === 0 || process.platform === "win32") return true;
+
+    const commandLine = await readProcessCommandLine(processPid);
+    if (!commandLine) return true;
+
+    const normalized = normalizeProcessCommandLine(commandLine);
+    return tokens.some((token) => normalized.includes(token));
+  }
+
+  async function isTerminalOrRecoverablyStaleHeartbeatRun(input: {
+    runId: string;
+    actorAgentId?: string | null;
+    actorRunId?: string | null;
+  }) {
+    return db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${input.runId} for update`,
+      );
+      const run = await tx
+        .select({
+          id: heartbeatRuns.id,
+          status: heartbeatRuns.status,
+          agentId: heartbeatRuns.agentId,
+          processPid: heartbeatRuns.processPid,
+          processGroupId: heartbeatRuns.processGroupId,
+          updatedAt: heartbeatRuns.updatedAt,
+          errorCode: heartbeatRuns.errorCode,
+        })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, input.runId))
+        .then((rows) => rows[0] ?? null);
+      if (!run) return true;
+      if (TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return true;
+
+      if (!input.actorAgentId || run.agentId !== input.actorAgentId) return false;
+      if (input.actorRunId && run.id === input.actorRunId) return false;
+      if (run.status !== "running") return false;
+
+      const now = new Date();
+      const updatedAtMs = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
+      if (now.getTime() - updatedAtMs < STALE_HEARTBEAT_RECOVERY_GRACE_MS) return false;
+
+      const processPidAlive = isProcessAlive(run.processPid);
+      const processGroupAlive = isProcessGroupAlive(run.processGroupId);
+      if (processGroupAlive) return false;
+      if (processPidAlive && run.processPid) {
+        const matchesExpectedAdapter = await isLikelyMatchingAdapterProcess(
+          tx,
+          run.agentId,
+          run.processPid,
+        );
+        if (matchesExpectedAdapter) return false;
+      }
+
+      const updated = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "failed",
+          errorCode: "process_lost",
+          error:
+            run.errorCode === DETACHED_PROCESS_ERROR_CODE
+              ? "Recovered stale detached process lock during issue ownership recovery"
+              : "Recovered stale running lock during issue ownership recovery",
+          finishedAt: now,
+          updatedAt: now,
+        })
+        .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, run.status)))
+        .returning({ id: heartbeatRuns.id })
+        .then((rows) => rows[0] ?? null);
+
+      return Boolean(updated);
+    });
   }
 
   async function adoptStaleCheckoutRun(input: {
@@ -2112,7 +2227,11 @@ export function issueService(db: Db) {
     actorRunId: string;
     expectedCheckoutRunId: string;
   }) {
-    const stale = await isTerminalOrMissingHeartbeatRun(input.expectedCheckoutRunId);
+    const stale = await isTerminalOrRecoverablyStaleHeartbeatRun({
+      runId: input.expectedCheckoutRunId,
+      actorAgentId: input.actorAgentId,
+      actorRunId: input.actorRunId,
+    });
     if (!stale) return null;
 
     const now = new Date();
@@ -3623,7 +3742,11 @@ export function issueService(db: Db) {
         existing.checkoutRunId &&
         !sameRunLock(existing.checkoutRunId, actorRunId ?? null)
       ) {
-        const stale = await isTerminalOrMissingHeartbeatRun(existing.checkoutRunId);
+        const stale = await isTerminalOrRecoverablyStaleHeartbeatRun({
+          runId: existing.checkoutRunId,
+          actorAgentId,
+          actorRunId: actorRunId ?? null,
+        });
         if (!stale) {
           throw conflict("Only checkout run can release issue", {
             issueId: existing.id,


### PR DESCRIPTION
## Summary\n- harden orphaned-run reaping by treating PID/PGID mismatches as stale process reuse\n- add targeted same-agent stale-run reap in issue ownership recovery paths (checkout, assert owner, release)\n- keep stale recovery conservative with a 60s grace window and adapter command checks for detached processes\n\n## Tests\n- pnpm run preflight:workspace-links\n- pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts server/src/__tests__/issue-stale-execution-lock-routes.test.ts