### PR TITLE
fix(codex-local): serialize OAuth refresh to prevent token-reuse failures

### DIFF
--- a/packages/adapters/codex-local/src/server/auth-lock.test.ts
+++ b/packages/adapters/codex-local/src/server/auth-lock.test.ts
@@ -1,0 +1,139 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetCodexAuthLockQueueForTests,
+  acquireCodexAuthLock,
+  resolveDefaultCodexAuthLockPath,
+} from "./auth-lock.js";
+
+let tmpDir: string;
+let lockPath: string;
+
+beforeEach(async () => {
+  await __resetCodexAuthLockQueueForTests();
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-auth-lock-"));
+  lockPath = path.join(tmpDir, ".paperclip-auth-refresh.lock");
+});
+
+afterEach(async () => {
+  await __resetCodexAuthLockQueueForTests();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("resolveDefaultCodexAuthLockPath", () => {
+  it("uses CODEX_HOME when set", () => {
+    expect(resolveDefaultCodexAuthLockPath({ CODEX_HOME: "/tmp/codex" })).toBe(
+      "/tmp/codex/.paperclip-auth-refresh.lock",
+    );
+  });
+
+  it("falls back to ~/.codex when CODEX_HOME is unset", () => {
+    expect(resolveDefaultCodexAuthLockPath({})).toBe(
+      path.join(os.homedir(), ".codex", ".paperclip-auth-refresh.lock"),
+    );
+  });
+});
+
+describe("acquireCodexAuthLock", () => {
+  it("creates a lock file while held and removes it on release", async () => {
+    const handle = await acquireCodexAuthLock({ lockPath, holdTimeoutMs: 0 });
+    const stat = await fs.stat(lockPath);
+    expect(stat.isFile()).toBe(true);
+
+    await handle.release();
+    expect(handle.released()).toBe(true);
+
+    await expect(fs.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("serializes concurrent in-process acquisitions", async () => {
+    const order: string[] = [];
+
+    const first = acquireCodexAuthLock({ lockPath, holdTimeoutMs: 0 }).then(async (handle) => {
+      order.push("first:acquired");
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      order.push("first:releasing");
+      await handle.release();
+    });
+
+    const second = acquireCodexAuthLock({ lockPath, holdTimeoutMs: 0 }).then(async (handle) => {
+      order.push("second:acquired");
+      await handle.release();
+    });
+
+    await Promise.all([first, second]);
+
+    expect(order).toEqual([
+      "first:acquired",
+      "first:releasing",
+      "second:acquired",
+    ]);
+  });
+
+  it("waits for an existing on-disk lock to release before claiming", async () => {
+    // Write a fresh, "owned" lock file from a fake pid that we keep alive
+    // (use process.pid so pidIsAlive returns true).
+    const payload = {
+      pid: process.pid,
+      hostname: os.hostname(),
+      startedAt: Date.now(),
+      acquirer: "external-test-holder",
+    };
+    await fs.mkdir(path.dirname(lockPath), { recursive: true });
+    await fs.writeFile(lockPath, JSON.stringify(payload));
+
+    const sleeps: number[] = [];
+    let cleared = false;
+    const sleep = async (ms: number) => {
+      sleeps.push(ms);
+      // After two polls, simulate the external holder releasing the lock.
+      if (!cleared && sleeps.length >= 2) {
+        cleared = true;
+        await fs.rm(lockPath, { force: true });
+      }
+    };
+
+    const handle = await acquireCodexAuthLock({ lockPath, holdTimeoutMs: 0, sleep });
+    expect(sleeps.length).toBeGreaterThan(0);
+    await handle.release();
+  });
+
+  it("reclaims a lock older than staleMs", async () => {
+    const stalePayload = {
+      pid: 999_999, // unlikely-to-exist pid
+      hostname: os.hostname(),
+      startedAt: Date.now() - 10_000,
+      acquirer: "external-stale",
+    };
+    await fs.mkdir(path.dirname(lockPath), { recursive: true });
+    await fs.writeFile(lockPath, JSON.stringify(stalePayload));
+
+    const reclaimedLogs: string[] = [];
+    const handle = await acquireCodexAuthLock({
+      lockPath,
+      holdTimeoutMs: 0,
+      staleMs: 1_000,
+      onLog: (m) => {
+        reclaimedLogs.push(m);
+      },
+    });
+    expect(reclaimedLogs.some((m) => m.includes("Reclaiming stale"))).toBe(true);
+    await handle.release();
+  });
+
+  it("auto-releases after holdTimeoutMs even if release() is never called", async () => {
+    const handle = await acquireCodexAuthLock({ lockPath, holdTimeoutMs: 25 });
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    expect(handle.released()).toBe(true);
+    await expect(fs.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("is idempotent on repeated release()", async () => {
+    const handle = await acquireCodexAuthLock({ lockPath, holdTimeoutMs: 0 });
+    await handle.release();
+    await handle.release();
+    expect(handle.released()).toBe(true);
+  });
+});

--- a/packages/adapters/codex-local/src/server/auth-lock.ts
+++ b/packages/adapters/codex-local/src/server/auth-lock.ts
@@ -1,0 +1,255 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Serializes Codex CLI auth-refresh windows so concurrent codex_local runs on
+ * the same machine do not race on the single OAuth refresh token stored in
+ * `~/.codex/auth.json`.
+ *
+ * The refresh-token grant rotates each access token: when two codex processes
+ * race, one writes a fresh token pair and the other gets back
+ * "Your access token could not be refreshed because your refresh token was
+ * already used." That bubbles up as `adapter_failed` and strands the agent.
+ *
+ * We hold an exclusive file lock from just before spawn until the codex process
+ * either emits its first stdout chunk (the JSONL stream starts only after auth
+ * is past) or exits. The lock is paired with an in-process mutex so multiple
+ * codex_local runs inside the same Node process serialize without filesystem
+ * polling.
+ */
+
+const LOCK_FILENAME = ".paperclip-auth-refresh.lock";
+const DEFAULT_STALE_MS = 60_000;
+const DEFAULT_HOLD_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MIN_MS = 50;
+const POLL_INTERVAL_MAX_MS = 500;
+
+export type CodexAuthLockReleaseReason =
+  | "first_output"
+  | "completed"
+  | "timeout"
+  | "manual";
+
+export type CodexAuthLockHandle = {
+  release: (reason?: CodexAuthLockReleaseReason) => Promise<void>;
+  released: () => boolean;
+};
+
+export type AcquireCodexAuthLockOptions = {
+  /** Absolute path to the lock file. Defaults to a sibling of `auth.json`. */
+  lockPath?: string;
+  /** Lock files older than this are considered abandoned and reclaimed. */
+  staleMs?: number;
+  /** Auto-release after this many ms even if no one calls release(). */
+  holdTimeoutMs?: number;
+  /** Time source override for tests. */
+  now?: () => number;
+  /** Sleep override for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Optional log sink invoked when the lock is reclaimed or auto-released. */
+  onLog?: (message: string) => void | Promise<void>;
+  /** AbortSignal that cancels the acquire wait loop. */
+  signal?: AbortSignal;
+};
+
+type LockFilePayload = {
+  pid: number;
+  hostname: string;
+  startedAt: number;
+  acquirer: string;
+};
+
+function defaultLockPath(): string {
+  const codexHome = process.env.CODEX_HOME?.trim();
+  const dir = codexHome && codexHome.length > 0 ? codexHome : path.join(os.homedir(), ".codex");
+  return path.join(dir, LOCK_FILENAME);
+}
+
+export function resolveDefaultCodexAuthLockPath(env: NodeJS.ProcessEnv = process.env): string {
+  const codexHome = env.CODEX_HOME?.trim();
+  const dir = codexHome && codexHome.length > 0 ? codexHome : path.join(os.homedir(), ".codex");
+  return path.join(dir, LOCK_FILENAME);
+}
+
+let inProcessQueue: Promise<void> = Promise.resolve();
+
+function enqueueInProcess(): {
+  wait: Promise<void>;
+  release: () => void;
+} {
+  let release!: () => void;
+  const next = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const previous = inProcessQueue;
+  inProcessQueue = previous.then(() => next);
+  return {
+    wait: previous,
+    release,
+  };
+}
+
+async function readLockPayload(lockPath: string): Promise<LockFilePayload | null> {
+  try {
+    const raw = await fs.readFile(lockPath, "utf8");
+    const parsed = JSON.parse(raw) as Partial<LockFilePayload>;
+    if (
+      typeof parsed.pid !== "number" ||
+      typeof parsed.startedAt !== "number" ||
+      typeof parsed.hostname !== "string" ||
+      typeof parsed.acquirer !== "string"
+    ) {
+      return null;
+    }
+    return parsed as LockFilePayload;
+  } catch {
+    return null;
+  }
+}
+
+function pidIsAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    // EPERM means the pid exists but we can't signal it — still alive.
+    return code === "EPERM";
+  }
+}
+
+function nextBackoff(current: number): number {
+  return Math.min(POLL_INTERVAL_MAX_MS, Math.max(POLL_INTERVAL_MIN_MS, current * 2));
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function tryClaimLockFile(
+  lockPath: string,
+  payload: LockFilePayload,
+): Promise<boolean> {
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  try {
+    const handle = await fs.open(lockPath, "wx");
+    try {
+      await handle.writeFile(JSON.stringify(payload));
+    } finally {
+      await handle.close();
+    }
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") return false;
+    throw err;
+  }
+}
+
+export async function acquireCodexAuthLock(
+  options: AcquireCodexAuthLockOptions = {},
+): Promise<CodexAuthLockHandle> {
+  const lockPath = options.lockPath ?? defaultLockPath();
+  const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
+  const holdTimeoutMs = options.holdTimeoutMs ?? DEFAULT_HOLD_TIMEOUT_MS;
+  const now = options.now ?? (() => Date.now());
+  const sleep = options.sleep ?? defaultSleep;
+  const onLog = options.onLog ?? (() => undefined);
+  const signal = options.signal;
+  const acquirer = `codex_local:${process.pid}:${now()}`;
+  const hostname = os.hostname();
+
+  const inProcess = enqueueInProcess();
+  await inProcess.wait;
+
+  let backoff = POLL_INTERVAL_MIN_MS;
+
+  const claim = async (): Promise<boolean> => {
+    const payload: LockFilePayload = {
+      pid: process.pid,
+      hostname,
+      startedAt: now(),
+      acquirer,
+    };
+    return tryClaimLockFile(lockPath, payload);
+  };
+
+  while (true) {
+    if (signal?.aborted) {
+      inProcess.release();
+      throw new Error("acquireCodexAuthLock aborted");
+    }
+
+    if (await claim()) break;
+
+    const existing = await readLockPayload(lockPath);
+    const age = existing ? now() - existing.startedAt : Number.POSITIVE_INFINITY;
+    const ownerAlive = existing
+      ? existing.hostname === hostname && pidIsAlive(existing.pid)
+      : false;
+
+    if (existing && (age > staleMs || (!ownerAlive && age > POLL_INTERVAL_MAX_MS))) {
+      await onLog(
+        `[paperclip] Reclaiming stale Codex auth lock (pid=${existing.pid}, age=${Math.round(age)}ms)`,
+      );
+      await fs.rm(lockPath, { force: true });
+      backoff = POLL_INTERVAL_MIN_MS;
+      continue;
+    }
+
+    await sleep(backoff);
+    backoff = nextBackoff(backoff);
+  }
+
+  let released = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+  const releaseFile = async () => {
+    try {
+      await fs.rm(lockPath, { force: true });
+    } catch {
+      // best-effort
+    }
+  };
+
+  const release = async (reason: CodexAuthLockReleaseReason = "manual"): Promise<void> => {
+    if (released) return;
+    released = true;
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = null;
+    }
+    try {
+      await releaseFile();
+    } finally {
+      inProcess.release();
+    }
+    if (reason === "timeout") {
+      await onLog(
+        `[paperclip] Codex auth lock auto-released after ${holdTimeoutMs}ms hold timeout`,
+      );
+    }
+  };
+
+  if (holdTimeoutMs > 0) {
+    timeoutHandle = setTimeout(() => {
+      void release("timeout");
+    }, holdTimeoutMs);
+    if (typeof timeoutHandle.unref === "function") timeoutHandle.unref();
+  }
+
+  return {
+    release,
+    released: () => released,
+  };
+}
+
+/**
+ * Test helper: drains the in-process serialization queue so unit tests do not
+ * leak ordering across cases.
+ */
+export async function __resetCodexAuthLockQueueForTests(): Promise<void> {
+  await inProcessQueue;
+  inProcessQueue = Promise.resolve();
+}

--- a/packages/adapters/codex-local/src/server/execute.refresh-retry.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.refresh-retry.test.ts
@@ -1,0 +1,246 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetCodexAuthLockQueueForTests } from "./auth-lock.js";
+
+const REUSE_ERROR_LINE =
+  "stream error: Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.";
+
+const SUCCESS_STDOUT = [
+  JSON.stringify({ type: "thread.started", thread_id: "thread_after_retry" }),
+  JSON.stringify({
+    type: "item.completed",
+    item: { type: "agent_message", text: "Recovered after refresh retry" },
+  }),
+  JSON.stringify({
+    type: "turn.completed",
+    usage: { input_tokens: 5, cached_input_tokens: 1, output_tokens: 2 },
+  }),
+].join("\n");
+
+const { runChildProcess, ensureCommandResolvable, resolveCommandForLogs } = vi.hoisted(() => ({
+  runChildProcess: vi.fn(),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async () => "/usr/bin/codex"),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+type AttemptShape = {
+  exitCode: number;
+  stderr: string;
+  stdout: string;
+};
+
+function reuseFailureAttempt(): AttemptShape {
+  return {
+    exitCode: 1,
+    stderr: REUSE_ERROR_LINE,
+    stdout: "",
+  };
+}
+
+function successfulAttempt(): AttemptShape {
+  return {
+    exitCode: 0,
+    stderr: "",
+    stdout: SUCCESS_STDOUT,
+  };
+}
+
+describe("execute refresh-token-reuse retry", () => {
+  const cleanupDirs: string[] = [];
+  let codexHomeDir: string;
+  let workspaceDir: string;
+  let lockPath: string;
+
+  beforeEach(async () => {
+    await __resetCodexAuthLockQueueForTests();
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-refresh-retry-"));
+    cleanupDirs.push(rootDir);
+    codexHomeDir = path.join(rootDir, "codex-home");
+    workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(codexHomeDir, { recursive: true });
+    await mkdir(workspaceDir, { recursive: true });
+    await writeFile(path.join(codexHomeDir, "auth.json"), "{}", "utf8");
+    lockPath = path.join(codexHomeDir, ".paperclip-auth-refresh.lock");
+    // Point CODEX_HOME at our fixture so prepareManagedCodexHome short-circuits
+    // and we don't touch the real shared ~/.codex directory.
+    process.env.CODEX_HOME = codexHomeDir;
+    process.env.PAPERCLIP_HOME = path.join(rootDir, "paperclip-home");
+    // Force a fresh shared-home root so the refresh lock lives under our tmpdir.
+  });
+
+  afterEach(async () => {
+    delete process.env.CODEX_HOME;
+    delete process.env.PAPERCLIP_HOME;
+    delete process.env.PAPERCLIP_CODEX_AUTH_LOCK;
+    vi.clearAllMocks();
+    await __resetCodexAuthLockQueueForTests();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("re-runs codex once when stderr matches the refresh-token-reuse error", async () => {
+    runChildProcess
+      .mockResolvedValueOnce({
+        ...reuseFailureAttempt(),
+        signal: null,
+        timedOut: false,
+        pid: 100,
+        startedAt: new Date().toISOString(),
+      })
+      .mockResolvedValueOnce({
+        ...successfulAttempt(),
+        signal: null,
+        timedOut: false,
+        pid: 101,
+        startedAt: new Date().toISOString(),
+      });
+
+    const logs: string[] = [];
+    const result = await execute({
+      runId: "run-refresh-retry",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        cwd: workspaceDir,
+        // Intentionally do NOT set OPENAI_API_KEY so billingType resolves to
+        // "subscription" and the auth lock + retry path is exercised.
+        env: {},
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async (_stream, chunk) => {
+        logs.push(chunk);
+      },
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(2);
+    expect(result.exitCode).toBe(0);
+    expect(result.errorMessage).toBeNull();
+    expect(result.sessionId).toBe("thread_after_retry");
+    expect(logs.join("\n")).toContain("refresh-token reuse detected");
+  });
+
+  it("does not retry when OPENAI_API_KEY is configured (api-key billing has no refresh window)", async () => {
+    runChildProcess.mockResolvedValueOnce({
+      ...reuseFailureAttempt(),
+      signal: null,
+      timedOut: false,
+      pid: 200,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await execute({
+      runId: "run-no-retry-apikey",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        cwd: workspaceDir,
+        env: {
+          OPENAI_API_KEY: "sk-test",
+        },
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("respects PAPERCLIP_CODEX_AUTH_LOCK=0 by skipping the lock and retry", async () => {
+    process.env.PAPERCLIP_CODEX_AUTH_LOCK = "0";
+    runChildProcess.mockResolvedValueOnce({
+      ...reuseFailureAttempt(),
+      signal: null,
+      timedOut: false,
+      pid: 300,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await execute({
+      runId: "run-lock-disabled",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+        cwd: workspaceDir,
+        env: {},
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(1);
+    // Lock file should never have been created.
+    await expect(rm(lockPath, { force: false })).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -40,6 +40,7 @@ import {
 import {
   parseCodexJsonl,
   extractCodexRetryNotBefore,
+  isCodexRefreshTokenReuseError,
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
 } from "./parse.js";
@@ -47,6 +48,7 @@ import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolv
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 import { buildCodexExecArgs } from "./codex-args.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
+import { acquireCodexAuthLock, type CodexAuthLockHandle } from "./auth-lock.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const CODEX_ROLLOUT_NOISE_RE =
@@ -668,6 +670,22 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     heartbeatPromptChars: renderedPrompt.length,
   };
 
+  // Paperclip-managed codex homes share a single ~/.codex/auth.json via
+  // symlink. The codex CLI's ChatGPT auth rotates the refresh token on every
+  // refresh, so concurrent runs racing on that file get back "refresh token
+  // already used" and bubble adapter_failed. Serialize the refresh window
+  // machine-wide. Skip when there is nothing shared to protect: api-key
+  // billing, remote execution targets, an operator-supplied CODEX_HOME, or an
+  // explicit PAPERCLIP_CODEX_AUTH_LOCK=0 opt-out.
+  const authLockDisabled = (process.env.PAPERCLIP_CODEX_AUTH_LOCK ?? "").trim() === "0";
+  const sharedCodexHome = resolveSharedCodexHomeDir(process.env);
+  const shouldUseAuthLock =
+    !authLockDisabled &&
+    !executionTargetIsRemote &&
+    billingType === "subscription" &&
+    configuredCodexHome === null;
+  const authLockPath = path.join(sharedCodexHome, ".paperclip-auth-refresh.lock");
+
   const runAttempt = async (resumeSessionId: string | null) => {
     const execArgs = buildCodexExecArgs(
       forceSaferInvocation ? { ...config, fastMode: false } : config,
@@ -695,32 +713,55 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
 
-    const proc = await runAdapterExecutionTargetProcess(runId, executionTarget, command, args, {
-      cwd,
-      env,
-      stdin: prompt,
-      timeoutSec,
-      graceSec,
-      onSpawn,
-      onLog: async (stream, chunk) => {
-        if (stream !== "stderr") {
-          await onLog(stream, chunk);
-          return;
-        }
-        const cleaned = stripCodexRolloutNoise(chunk);
-        if (!cleaned.trim()) return;
-        await onLog(stream, cleaned);
-      },
-    });
-    const cleanedStderr = stripCodexRolloutNoise(proc.stderr);
-    return {
-      proc: {
-        ...proc,
-        stderr: cleanedStderr,
-      },
-      rawStderr: proc.stderr,
-      parsed: parseCodexJsonl(proc.stdout),
+    let authLock: CodexAuthLockHandle | null = null;
+    if (shouldUseAuthLock) {
+      authLock = await acquireCodexAuthLock({
+        lockPath: authLockPath,
+        onLog: (message) => onLog("stdout", `${message}\n`),
+      });
+    }
+
+    const releaseAuthLock = (reason: "first_output" | "completed" | "manual") => {
+      if (!authLock || authLock.released()) return;
+      void authLock.release(reason);
     };
+
+    let firstStdoutChunkSeen = false;
+
+    try {
+      const proc = await runAdapterExecutionTargetProcess(runId, executionTarget, command, args, {
+        cwd,
+        env,
+        stdin: prompt,
+        timeoutSec,
+        graceSec,
+        onSpawn,
+        onLog: async (stream, chunk) => {
+          if (stream !== "stderr") {
+            if (!firstStdoutChunkSeen && chunk.length > 0) {
+              firstStdoutChunkSeen = true;
+              releaseAuthLock("first_output");
+            }
+            await onLog(stream, chunk);
+            return;
+          }
+          const cleaned = stripCodexRolloutNoise(chunk);
+          if (!cleaned.trim()) return;
+          await onLog(stream, cleaned);
+        },
+      });
+      const cleanedStderr = stripCodexRolloutNoise(proc.stderr);
+      return {
+        proc: {
+          ...proc,
+          stderr: cleanedStderr,
+        },
+        rawStderr: proc.stderr,
+        parsed: parseCodexJsonl(proc.stdout),
+      };
+    } finally {
+      releaseAuthLock("completed");
+    }
   };
 
   const toResult = (
@@ -813,8 +854,44 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   };
 
+  const initialAttemptStderrSummary = (
+    proc: { stderr: string; stdout: string; exitCode: number | null },
+    parsedErrorMessage: string | null,
+  ): string => {
+    const fromParsed = parsedErrorMessage?.trim();
+    if (fromParsed) return fromParsed;
+    return firstNonEmptyLine(proc.stderr) || `Codex exited with code ${proc.exitCode ?? -1}`;
+  };
+
   try {
-    const initial = await runAttempt(sessionId);
+    let initial = await runAttempt(sessionId);
+    // One-shot retry when a concurrent codex run rotated the OAuth refresh
+    // token while we were trying to refresh ours. The lock above prevents the
+    // race in the common case, but a stale/missing lock (e.g. across worktree
+    // instances or after a crash) can still let two processes meet at the
+    // refresh window. By the time we observe the error the other process has
+    // already written fresh tokens to auth.json, so re-spawning codex picks
+    // them up cleanly.
+    if (
+      shouldUseAuthLock &&
+      !initial.proc.timedOut &&
+      (initial.proc.exitCode ?? 0) !== 0 &&
+      isCodexRefreshTokenReuseError({
+        stdout: initial.proc.stdout,
+        stderr: initial.rawStderr,
+        errorMessage: initial.parsed.errorMessage,
+      })
+    ) {
+      const summary = initialAttemptStderrSummary(initial.proc, initial.parsed.errorMessage);
+      await onLog(
+        "stdout",
+        `[paperclip] Codex refresh-token reuse detected (${summary}); retrying once after re-reading auth.json.\n`,
+      );
+      // Brief pause so the rotating process can finish persisting the new
+      // tokens to disk before we re-spawn.
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      initial = await runAttempt(sessionId);
+    }
     if (
       sessionId &&
       !initial.proc.timedOut &&

--- a/packages/adapters/codex-local/src/server/parse.test.ts
+++ b/packages/adapters/codex-local/src/server/parse.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   extractCodexRetryNotBefore,
+  isCodexRefreshTokenReuseError,
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
   parseCodexJsonl,
@@ -134,6 +135,47 @@ describe("isCodexTransientUpstreamError", () => {
           "  }",
           "}",
         ].join("\n"),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isCodexRefreshTokenReuseError", () => {
+  it("matches the canonical Codex CLI refresh-reuse error", () => {
+    expect(
+      isCodexRefreshTokenReuseError({
+        errorMessage:
+          "Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches when the error appears in stderr", () => {
+    expect(
+      isCodexRefreshTokenReuseError({
+        stderr:
+          "stream error: Your access token could not be refreshed because your refresh token was already used.",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches looser wordings that still indicate reuse", () => {
+    expect(
+      isCodexRefreshTokenReuseError({
+        errorMessage: "refresh token already used",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not classify unrelated auth errors as reuse", () => {
+    expect(
+      isCodexRefreshTokenReuseError({
+        errorMessage: "401 Unauthorized: invalid signature",
+      }),
+    ).toBe(false);
+    expect(
+      isCodexRefreshTokenReuseError({
+        errorMessage: "Please log out and sign in again",
       }),
     ).toBe(false);
   });

--- a/packages/adapters/codex-local/src/server/parse.ts
+++ b/packages/adapters/codex-local/src/server/parse.ts
@@ -10,6 +10,8 @@ const CODEX_TRANSIENT_UPSTREAM_RE =
 const CODEX_REMOTE_COMPACTION_RE = /remote\s+compact\s+task/i;
 const CODEX_USAGE_LIMIT_RE =
   /you(?:'|’)ve hit your usage limit for .+\.\s+switch to another model now,\s+or try again at\s+([^.!\n]+)(?:[.!]|\n|$)/i;
+const CODEX_REFRESH_TOKEN_REUSE_RE =
+  /(?:access\s+token\s+could\s+not\s+be\s+refreshed[^.\n]*refresh\s+token[^.\n]*already\s+used|refresh\s+token\s+(?:was|has\s+been)?\s*already\s+used)/i;
 
 export function parseCodexJsonl(stdout: string) {
   let sessionId: string | null = null;
@@ -258,4 +260,13 @@ export function isCodexTransientUpstreamError(input: {
   // failure shape, plus explicit usage-limit windows that tell us when retrying
   // becomes safe again.
   return CODEX_REMOTE_COMPACTION_RE.test(haystack) || /high\s+demand|temporary\s+errors/i.test(haystack);
+}
+
+export function isCodexRefreshTokenReuseError(input: {
+  stdout?: string | null;
+  stderr?: string | null;
+  errorMessage?: string | null;
+}): boolean {
+  const haystack = buildCodexErrorHaystack(input);
+  return CODEX_REFRESH_TOKEN_REUSE_RE.test(haystack);
 }


### PR DESCRIPTION
> Draft PR — happy to coordinate further in `#dev` before review if maintainers prefer that path. This is a focused bug fix (race condition in OAuth refresh), not a roadmap-scoped feature, so we opted for a draft over waiting on out-of-band Discord access. Redirect us to `#dev` and we'll move the discussion there.

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The `codex-local` adapter spawns a `codex` CLI per agent run and shares `~/.codex/auth.json` across runs via symlink so every agent uses the same OAuth tokens
> - When two agents enter the OAuth refresh window concurrently, both processes try to redeem the single rotating refresh token; one wins, the other gets `refresh token already used` and the run is stranded as `adapter_failed`
> - Refresh contention is rare in single-agent setups but is the dominant cause of stranded runs once you have several agents heartbeating in parallel against the same `CODEX_HOME`
> - This pull request serializes the refresh window with a machine-wide file lock plus an in-process mutex, and adds a one-shot retry that re-spawns `codex` (so it re-reads the rotated `auth.json`) when reuse is still detected
> - The benefit is that concurrent codex_local runs no longer strand each other on transient OAuth races, without changing the auth model for api-key, remote, or operator-supplied `CODEX_HOME` setups (those skip the lock)

## What Changed

- Add `auth-lock.ts`: machine-wide file lock at `~/.codex/.paperclip-auth-refresh.lock` acquired before each codex spawn and released on first stdout chunk, paired with an in-process async mutex so same-Node concurrent runs serialize without filesystem polling.
- Wire the lock into `execute.ts` for the spawn path; skip the lock for api-key billing, remote execution targets, an operator-supplied `CODEX_HOME`, or the explicit `PAPERCLIP_CODEX_AUTH_LOCK=0` opt-out.
- Add `isCodexRefreshTokenReuseError` in `parse.ts` to detect the upstream "refresh token already used" failure mode from codex stderr.
- Add a one-shot retry in `execute.ts` that re-spawns codex on detected reuse failures (covers stale lock files and pre-existing concurrent processes from a separate Node instance).
- Cover the lock primitive, the parse predicate, and the retry path with vitest unit tests (`auth-lock.test.ts`, `parse.test.ts`, `execute.refresh-retry.test.ts`).

## Verification

- `pnpm --filter @paperclip/adapter-codex-local test` — the new vitest suites cover the lock acquisition/release lifecycle, the parse predicate against representative codex stderr fragments, and the retry flow that re-spawns codex after a reuse error.
- Manual: ran two concurrent codex_local agents in a shared `CODEX_HOME` with the refresh window forced; pre-fix one run reliably failed with `refresh token already used`, post-fix both runs complete and the second observes the rotated token from the first.
- Existing adapter tests still green; no behavioral change for api-key / remote / operator `CODEX_HOME` paths (covered by the skip predicate in `execute.ts`).

## Risks

- **Low–medium.** The lock is scoped to the spawn-and-first-stdout window, so it cannot deadlock a long-running codex process; the retry is one-shot to avoid loops. Worst case if the lock primitive misbehaves, `PAPERCLIP_CODEX_AUTH_LOCK=0` disables it without code changes.
- The lock file lives under `~/.codex/`, which is shared with the codex CLI itself. The path uses a `.paperclip-` prefix to avoid colliding with codex's own state, but operators with custom `CODEX_HOME` layouts should confirm they're comfortable with that location (or use the env-var opt-out).
- No migration. No public API changes. No effect on api-key billing, remote execution, or non-codex_local adapters.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`), extended thinking enabled, tool use (file edits, bash, vitest, gh CLI). Implementation, tests, and PR body authored by the model under human (CEO) authorization.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots <!-- N/A: backend adapter only -->
- [ ] I have updated relevant documentation to reflect my changes <!-- happy to add an `auth-lock` note to the codex-local README if maintainers want it -->
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
