### PR TITLE
DEX-486: surface orphan-candidate issues on dashboard

### DIFF
--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -33,4 +33,9 @@ export interface DashboardSummary {
     pausedProjects: number;
   };
   runActivity: DashboardRunActivityDay[];
+  orphanCandidates: {
+    projectOrphans: number;
+    goalOrphans: number;
+    total: number;
+  };
 }

--- a/server/src/__tests__/dashboard-orphan-candidates.test.ts
+++ b/server/src/__tests__/dashboard-orphan-candidates.test.ts
@@ -162,6 +162,65 @@ describeEmbeddedPostgres("dashboard orphanCandidates", () => {
     });
   });
 
+  it("does not count children whose parentId resolves to a different company", async () => {
+    const companyId = randomUUID();
+    const otherCompanyId = randomUUID();
+    const otherProjectId = randomUUID();
+
+    await db.insert(companies).values([
+      {
+        id: companyId,
+        name: "Tenant A",
+        issuePrefix: `A${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+      {
+        id: otherCompanyId,
+        name: "Tenant B",
+        issuePrefix: `B${otherCompanyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+        requireBoardApprovalForNewAgents: false,
+      },
+    ]);
+
+    await db.insert(projects).values({
+      id: otherProjectId,
+      companyId: otherCompanyId,
+      name: "Other Project",
+      shortName: "other",
+    });
+
+    const otherParentId = randomUUID();
+    const crossTenantChildId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: otherParentId,
+        companyId: otherCompanyId,
+        projectId: otherProjectId,
+        title: "Parent in other tenant",
+        status: "in_progress",
+      },
+      {
+        id: crossTenantChildId,
+        companyId,
+        // Data corruption case: parentId references an issue from a different company.
+        parentId: otherParentId,
+        projectId: null,
+        goalId: null,
+        title: "Cross-tenant orphan (must be excluded)",
+        status: "todo",
+      },
+    ]);
+
+    const summary = await dashboardService(db).summary(companyId);
+
+    expect(summary.orphanCandidates).toEqual({
+      projectOrphans: 0,
+      goalOrphans: 0,
+      total: 0,
+    });
+  });
+
   it("returns zeroes when no orphans exist", async () => {
     const companyId = randomUUID();
 

--- a/server/src/__tests__/dashboard-orphan-candidates.test.ts
+++ b/server/src/__tests__/dashboard-orphan-candidates.test.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  goals,
+  issues,
+  projects,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { dashboardService } from "../services/dashboard.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres dashboard orphan tests: ${embeddedPostgresSupport.reason ?? "unsupported"}`,
+  );
+}
+
+describeEmbeddedPostgres("dashboard orphanCandidates", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-dashboard-orphan-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(goals);
+    await db.delete(projects);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("counts open issues whose parent has projectId/goalId but child does not", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const goalId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Orphan Inc",
+      issuePrefix: `O${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Orphan Project",
+      shortName: "orphan",
+    });
+
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      projectId,
+      title: "Orphan Goal",
+    });
+
+    const parentId = randomUUID();
+    const projectOrphanId = randomUUID();
+    const goalOrphanId = randomUUID();
+    const bothOrphanId = randomUUID();
+    const properChildId = randomUUID();
+    const closedOrphanId = randomUUID();
+    const hiddenOrphanId = randomUUID();
+    const nullParentId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        projectId,
+        goalId,
+        title: "Parent",
+        status: "in_progress",
+      },
+      {
+        id: projectOrphanId,
+        companyId,
+        parentId,
+        projectId: null,
+        goalId,
+        title: "Project orphan",
+        status: "todo",
+      },
+      {
+        id: goalOrphanId,
+        companyId,
+        parentId,
+        projectId,
+        goalId: null,
+        title: "Goal orphan",
+        status: "in_progress",
+      },
+      {
+        id: bothOrphanId,
+        companyId,
+        parentId,
+        projectId: null,
+        goalId: null,
+        title: "Both orphan",
+        status: "blocked",
+      },
+      {
+        id: properChildId,
+        companyId,
+        parentId,
+        projectId,
+        goalId,
+        title: "Proper child",
+        status: "in_progress",
+      },
+      {
+        id: closedOrphanId,
+        companyId,
+        parentId,
+        projectId: null,
+        goalId: null,
+        title: "Closed orphan (excluded)",
+        status: "done",
+      },
+      {
+        id: hiddenOrphanId,
+        companyId,
+        parentId,
+        projectId: null,
+        goalId: null,
+        title: "Hidden orphan (excluded)",
+        status: "todo",
+        hiddenAt: new Date(),
+      },
+      {
+        id: nullParentId,
+        companyId,
+        projectId: null,
+        goalId: null,
+        title: "Top-level no-project (excluded — null parent)",
+        status: "todo",
+      },
+    ]);
+
+    const summary = await dashboardService(db).summary(companyId);
+
+    expect(summary.orphanCandidates).toEqual({
+      projectOrphans: 2, // projectOrphan + bothOrphan
+      goalOrphans: 2, // goalOrphan + bothOrphan
+      total: 3, // projectOrphan + goalOrphan + bothOrphan (deduped)
+    });
+  });
+
+  it("returns zeroes when no orphans exist", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Clean Inc",
+      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const summary = await dashboardService(db).summary(companyId);
+    expect(summary.orphanCandidates).toEqual({
+      projectOrphans: 0,
+      goalOrphans: 0,
+      total: 0,
+    });
+  });
+});

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, sql } from "drizzle-orm";
+import { aliasedTable, and, eq, gte, isNotNull, isNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, approvals, companies, costEvents, heartbeatRuns, issues } from "@paperclipai/db";
 import { notFound } from "../errors.js";
@@ -51,6 +51,34 @@ export function dashboardService(db: Db) {
         .from(approvals)
         .where(and(eq(approvals.companyId, companyId), eq(approvals.status, "pending")))
         .then((rows) => Number(rows[0]?.count ?? 0));
+
+      const parentIssues = aliasedTable(issues, "parent_issues");
+      const orphanRows = await db
+        .select({
+          projectOrphan: sql<number>`count(*) filter (where ${issues.projectId} is null and ${parentIssues.projectId} is not null)`,
+          goalOrphan: sql<number>`count(*) filter (where ${issues.goalId} is null and ${parentIssues.goalId} is not null)`,
+          eitherOrphan: sql<number>`count(*) filter (where (${issues.projectId} is null and ${parentIssues.projectId} is not null) or (${issues.goalId} is null and ${parentIssues.goalId} is not null))`,
+        })
+        .from(issues)
+        .innerJoin(parentIssues, eq(parentIssues.id, issues.parentId))
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            isNotNull(issues.parentId),
+            isNull(issues.hiddenAt),
+            sql`${issues.status} not in ('done', 'cancelled')`,
+            sql`(
+              (${issues.projectId} is null and ${parentIssues.projectId} is not null)
+              or (${issues.goalId} is null and ${parentIssues.goalId} is not null)
+            )`,
+          ),
+        );
+
+      const orphanCandidates = {
+        projectOrphans: Number(orphanRows[0]?.projectOrphan ?? 0),
+        goalOrphans: Number(orphanRows[0]?.goalOrphan ?? 0),
+        total: Number(orphanRows[0]?.eitherOrphan ?? 0),
+      };
 
       const agentCounts: Record<string, number> = {
         active: 0,
@@ -156,6 +184,7 @@ export function dashboardService(db: Db) {
           pausedProjects: budgetOverview.pausedProjectCount,
         },
         runActivity: Array.from(runActivity.values()),
+        orphanCandidates,
       };
     },
   };

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -1,4 +1,4 @@
-import { aliasedTable, and, eq, gte, isNotNull, isNull, sql } from "drizzle-orm";
+import { aliasedTable, and, eq, gte, isNull, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, approvals, companies, costEvents, heartbeatRuns, issues } from "@paperclipai/db";
 import { notFound } from "../errors.js";
@@ -57,14 +57,19 @@ export function dashboardService(db: Db) {
         .select({
           projectOrphan: sql<number>`count(*) filter (where ${issues.projectId} is null and ${parentIssues.projectId} is not null)`,
           goalOrphan: sql<number>`count(*) filter (where ${issues.goalId} is null and ${parentIssues.goalId} is not null)`,
-          eitherOrphan: sql<number>`count(*) filter (where (${issues.projectId} is null and ${parentIssues.projectId} is not null) or (${issues.goalId} is null and ${parentIssues.goalId} is not null))`,
+          total: sql<number>`count(*)`,
         })
         .from(issues)
-        .innerJoin(parentIssues, eq(parentIssues.id, issues.parentId))
+        .innerJoin(
+          parentIssues,
+          and(
+            eq(parentIssues.id, issues.parentId),
+            eq(parentIssues.companyId, issues.companyId),
+          ),
+        )
         .where(
           and(
             eq(issues.companyId, companyId),
-            isNotNull(issues.parentId),
             isNull(issues.hiddenAt),
             sql`${issues.status} not in ('done', 'cancelled')`,
             sql`(
@@ -77,7 +82,7 @@ export function dashboardService(db: Db) {
       const orphanCandidates = {
         projectOrphans: Number(orphanRows[0]?.projectOrphan ?? 0),
         goalOrphans: Number(orphanRows[0]?.goalOrphan ?? 0),
-        total: Number(orphanRows[0]?.eitherOrphan ?? 0),
+        total: Number(orphanRows[0]?.total ?? 0),
       };
 
       const agentCounts: Record<string, number> = {

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -302,6 +302,7 @@ const dashboard: DashboardSummary = {
     pausedProjects: 0,
   },
   runActivity: [],
+  orphanCandidates: { projectOrphans: 0, goalOrphans: 0, total: 0 },
 };
 
 describe("inbox helpers", () => {

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -20,7 +20,7 @@ import { ActivityRow } from "../components/ActivityRow";
 import { Identity } from "../components/Identity";
 import { timeAgo } from "../lib/timeAgo";
 import { cn, formatCents } from "../lib/utils";
-import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard, PauseCircle } from "lucide-react";
+import { Bot, CircleDot, DollarSign, ShieldCheck, LayoutDashboard, PauseCircle, AlertTriangle } from "lucide-react";
 import { ActiveAgentsPanel } from "../components/ActiveAgentsPanel";
 import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRateChart } from "../components/ActivityCharts";
 import { PageSkeleton } from "../components/PageSkeleton";
@@ -233,6 +233,25 @@ export function Dashboard() {
               </div>
               <Link to="/costs" className="text-sm underline underline-offset-2 text-red-100">
                 Open budgets
+              </Link>
+            </div>
+          ) : null}
+
+          {data.orphanCandidates.total > 0 ? (
+            <div className="flex items-start justify-between gap-3 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-500/25 dark:bg-amber-950/60">
+              <div className="flex items-start gap-2.5">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                <div>
+                  <p className="text-sm font-medium text-amber-900 dark:text-amber-100">
+                    {data.orphanCandidates.total} orphan candidate issue{data.orphanCandidates.total === 1 ? "" : "s"}
+                  </p>
+                  <p className="text-xs text-amber-800/80 dark:text-amber-100/70">
+                    {data.orphanCandidates.projectOrphans} missing project · {data.orphanCandidates.goalOrphans} missing goal (parent has it set)
+                  </p>
+                </div>
+              </div>
+              <Link to="/issues" className="text-sm underline underline-offset-2 text-amber-800 dark:text-amber-100 shrink-0">
+                Review
               </Link>
             </div>
           ) : null}

--- a/ui/storybook/fixtures/paperclipData.ts
+++ b/ui/storybook/fixtures/paperclipData.ts
@@ -1281,6 +1281,7 @@ export const storybookDashboardSummary: DashboardSummary = {
     { date: "2026-04-19", succeeded: 5, failed: 0, other: 1, total: 6 },
     { date: "2026-04-20", succeeded: 4, failed: 0, other: 2, total: 6 },
   ],
+  orphanCandidates: { projectOrphans: 0, goalOrphans: 0, total: 0 },
 };
 
 export const storybookLiveRuns: LiveRunForIssue[] = [


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, where every issue belongs to a project/goal so the board can see ownership and progress.
> - The recovery subsystem (server/src/services/recovery/service.ts) creates child issues automatically when liveness invariants like `in_review_without_action_path` fire.
> - When the recovery service or any caller creates a child without copying parent.projectId/goalId, the child becomes an "orphan" — invisible on project boards and outside continuous workflow paths.
> - The DEX-456 incident exposed exactly this: an agent-created decision child of DEX-455 (a recovery issue) had projectId=null while its parent had it set, requiring a manual PATCH to fix.
> - This pull request adds a dashboard surface that counts open issues whose parent has projectId/goalId set but their own field is null, so future regressions show up immediately instead of via manual triage.
> - The benefit is a single-glance signal that catches the orphan-creation regression class for any caller path, not just the recovery service.

## What Changed

- `server/src/services/dashboard.ts`: self-join `issues` to itself on `parentId`; aggregate three counts (`projectOrphans`, `goalOrphans`, `total` deduped) for open issues whose parent has the field set while child does not. Filters: open status, `hiddenAt is null`, parent exists, child's field null and parent's field not null.
- `packages/shared/src/types/dashboard.ts`: extend `DashboardSummary` with `orphanCandidates: { projectOrphans, goalOrphans, total }`.
- `ui/src/pages/Dashboard.tsx`: render amber banner above the metric grid when `orphanCandidates.total > 0`, with a breakdown link to `/issues`.
- `server/src/__tests__/dashboard-orphan-candidates.test.ts`: new embedded-Postgres test suite covering project-only, goal-only, both-orphan, proper-child, closed, hidden, null-parent, and dedup cases (2 tests).
- Existing fixtures (`ui/src/lib/inbox.test.ts`, `ui/storybook/fixtures/paperclipData.ts`) extended with the new field to keep typecheck green.

Acceptance #1 + #2 of DEX-486 (recovery service inheritance) already in place at `server/src/services/recovery/service.ts:2330` since commit `5bd0f578`. This PR covers acceptance #3 (dashboard warning). Sibling DEX-488 covers acceptance #4 (integration test).

## Verification

- `pnpm --filter @paperclipai/server exec vitest run dashboard-orphan-candidates` — 2/2 passed
- `pnpm --filter @paperclipai/server typecheck` — clean
- `pnpm --filter @paperclipai/ui typecheck` — clean
- Manual UI check pending: load dashboard with seeded orphan; banner renders, counts match, link to `/issues` works.

## Risks

Low. The new query is one self-join on `issues` constrained by `companyId` (covered by `issues_company_status_idx`) and the existing `issues_company_parent_idx`, so it should be cheap on populated companies. Worst case it adds a few ms to dashboard summary load. Read-only — no migration, no schema change. Behavioural change is additive (new field, new banner). Existing dashboard consumers that don't read `orphanCandidates` are unaffected; the field is required on the type so any TS consumer is forced to acknowledge it (fixtures updated accordingly).

## Model Used

Claude Opus 4.7 (`claude-opus-4-7`), via the Paperclip Claude Code adapter. Used Edit/Read/Bash tools and embedded-Postgres test runs; no extended thinking.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (type definition + fixtures)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
