### PR TITLE
[codex_local] Synthetic keepalive while upstream/MCP stream is stalled

### DIFF
--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -46,6 +46,7 @@ import {
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 import { buildCodexExecArgs } from "./codex-args.js";
+import { createCodexUpstreamKeepalive } from "./upstream-keepalive.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
@@ -521,6 +522,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const timeoutSec = asNumber(config.timeoutSec, 0);
   const graceSec = asNumber(config.graceSec, 20);
+  // EIG-235 / EIG-281: keep Paperclip's silence clock alive while codex is
+  // silently retrying an upstream/MCP transport stall (rmcp fatal,
+  // Reconnecting…, Connection reset by peer). 0 disables the keepalive.
+  const upstreamKeepaliveIntervalSec = asNumber(config.upstreamKeepaliveIntervalSec, 30);
+  const upstreamKeepaliveMaxEmits = asNumber(config.upstreamKeepaliveMaxEmits, 0);
 
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
@@ -692,32 +698,43 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       });
     }
 
-    const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
-      cwd,
-      env,
-      stdin: prompt,
-      timeoutSec,
-      graceSec,
-      onSpawn,
-      onLog: async (stream, chunk) => {
-        if (stream !== "stderr") {
-          await onLog(stream, chunk);
-          return;
-        }
-        const cleaned = stripCodexRolloutNoise(chunk);
-        if (!cleaned.trim()) return;
-        await onLog(stream, cleaned);
-      },
+    const keepalive = createCodexUpstreamKeepalive({
+      emit: (stream, chunk) => onLog(stream, chunk),
+      intervalMs: Math.max(0, Math.floor(upstreamKeepaliveIntervalSec * 1000)),
+      maxEmits: upstreamKeepaliveMaxEmits,
     });
-    const cleanedStderr = stripCodexRolloutNoise(proc.stderr);
-    return {
-      proc: {
-        ...proc,
-        stderr: cleanedStderr,
-      },
-      rawStderr: proc.stderr,
-      parsed: parseCodexJsonl(proc.stdout),
-    };
+    try {
+      const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
+        cwd,
+        env,
+        stdin: prompt,
+        timeoutSec,
+        graceSec,
+        onSpawn,
+        onLog: async (stream, chunk) => {
+          if (stream !== "stderr") {
+            keepalive.observe(stream, chunk);
+            await onLog(stream, chunk);
+            return;
+          }
+          const cleaned = stripCodexRolloutNoise(chunk);
+          if (!cleaned.trim()) return;
+          keepalive.observe(stream, cleaned);
+          await onLog(stream, cleaned);
+        },
+      });
+      const cleanedStderr = stripCodexRolloutNoise(proc.stderr);
+      return {
+        proc: {
+          ...proc,
+          stderr: cleanedStderr,
+        },
+        rawStderr: proc.stderr,
+        parsed: parseCodexJsonl(proc.stdout),
+      };
+    } finally {
+      keepalive.stop();
+    }
   };
 
   const toResult = (

--- a/packages/adapters/codex-local/src/server/upstream-keepalive.test.ts
+++ b/packages/adapters/codex-local/src/server/upstream-keepalive.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+import {
+  chunkHasNonStallOutput,
+  codexUpstreamKeepaliveLinePrefix,
+  createCodexUpstreamKeepalive,
+  findCodexUpstreamStreamSignal,
+  isCodexUpstreamStreamSignal,
+} from "./upstream-keepalive.js";
+
+// Fixture lines extracted from the EIG-281 run-log (b988ba64) — they shape the
+// real upstream-stream-stall behaviour the keepalive must defend against.
+const EIG_281_STALL_LINES = [
+  // seq 5 — the rmcp fatal that started the silence window
+  "worker quit with fatal: Client error: HTTP request failed: HTTP error: status code: 401 (Unauthorized) for url: https://chatgpt.com/backend-api/wham/apps, when send initialized notification",
+  // seq 7 / seq 9 — codex SSE reconnect lines (when they finally surface)
+  "error: Reconnecting... 2/5 (stream disconnected before completion: Connection reset by peer (os error 54))",
+  "Reconnecting... 3/5",
+  // seq 13 — rollout-thread-not-found stderr right at the recovery boundary
+  "failed to record rollout items: thread 019dfec9-3e5d-7f90-8d38-1c71dbca858a not found",
+  // models-manager refresh timeout (seq 2 / seq 6)
+  "codex_models_manager: failed to refresh available models: timeout",
+];
+
+const EIG_281_NORMAL_LINES = [
+  JSON.stringify({ type: "thread.started", thread_id: "019dfec9-3e5d-7f90-8d38-1c71dbca858a" }),
+  JSON.stringify({ type: "turn.started" }),
+  JSON.stringify({
+    type: "item.completed",
+    item: { type: "agent_message", text: "no work — empty inbox" },
+  }),
+  JSON.stringify({
+    type: "turn.completed",
+    usage: { input_tokens: 671000, output_tokens: 2000 },
+  }),
+];
+
+type Captured = { stream: "stdout" | "stderr"; chunk: string };
+
+function makeFakeTimer() {
+  type Entry = { handler: () => void; intervalMs: number; nextDueAt: number };
+  let current = 0;
+  const entries = new Map<symbol, Entry>();
+  return {
+    now: () => current,
+    setIntervalImpl: (handler: () => void, intervalMs: number) => {
+      const handle = Symbol("interval");
+      entries.set(handle, {
+        handler,
+        intervalMs,
+        nextDueAt: current + intervalMs,
+      });
+      return handle;
+    },
+    clearIntervalImpl: (handle: unknown) => {
+      if (typeof handle === "symbol") entries.delete(handle);
+    },
+    advance: (ms: number) => {
+      const target = current + ms;
+      // Fire any intervals whose next-due timestamp falls inside the window.
+      // Loop because handlers can advance/clear other entries.
+      while (true) {
+        let nextHandle: symbol | null = null;
+        let nextDueAt = Number.POSITIVE_INFINITY;
+        for (const [handle, entry] of entries) {
+          if (entry.nextDueAt <= target && entry.nextDueAt < nextDueAt) {
+            nextHandle = handle;
+            nextDueAt = entry.nextDueAt;
+          }
+        }
+        if (nextHandle == null) break;
+        const entry = entries.get(nextHandle);
+        if (!entry) break;
+        current = entry.nextDueAt;
+        entry.nextDueAt = current + entry.intervalMs;
+        entry.handler();
+      }
+      current = target;
+    },
+    activeCount: () => entries.size,
+  };
+}
+
+function makeController(opts: {
+  intervalMs: number;
+  maxEmits?: number;
+  captured: Captured[];
+  fake: ReturnType<typeof makeFakeTimer>;
+}) {
+  return createCodexUpstreamKeepalive({
+    intervalMs: opts.intervalMs,
+    maxEmits: opts.maxEmits,
+    emit: (stream, chunk) => {
+      opts.captured.push({ stream, chunk });
+    },
+    setIntervalImpl: opts.fake.setIntervalImpl,
+    clearIntervalImpl: opts.fake.clearIntervalImpl,
+    now: opts.fake.now,
+  });
+}
+
+describe("isCodexUpstreamStreamSignal / findCodexUpstreamStreamSignal", () => {
+  it.each(EIG_281_STALL_LINES)("matches EIG-281 stall fixture: %s", (line) => {
+    expect(isCodexUpstreamStreamSignal(line)).toBe(true);
+    expect(findCodexUpstreamStreamSignal(line)).not.toBeNull();
+  });
+
+  it.each(EIG_281_NORMAL_LINES)("does not match normal codex JSONL line: %s", (line) => {
+    expect(isCodexUpstreamStreamSignal(line)).toBe(false);
+    expect(findCodexUpstreamStreamSignal(line)).toBeNull();
+  });
+
+  it("never re-detects its own keepalive output as a signal", () => {
+    const sample =
+      `${codexUpstreamKeepaliveLinePrefix()} (last signal: "Reconnecting... 3/5"; keepalive #4 at 2026-05-07T22:24:00.000Z)`;
+    expect(isCodexUpstreamStreamSignal(sample)).toBe(false);
+    expect(findCodexUpstreamStreamSignal(sample)).toBeNull();
+  });
+
+  it("scans multi-line chunks for the first signal", () => {
+    const chunk = `prelude line\n${EIG_281_STALL_LINES[1]}\nfollow-up`;
+    expect(findCodexUpstreamStreamSignal(chunk)).toMatch(/Reconnecting\.\.\. 2\/5/);
+  });
+
+  it("truncates very long signal lines", () => {
+    const long = `Reconnecting... 4/5 ${"x".repeat(500)}`;
+    const found = findCodexUpstreamStreamSignal(long);
+    expect(found).not.toBeNull();
+    expect(found!.length).toBeLessThanOrEqual(241);
+    expect(found!.endsWith("…")).toBe(true);
+  });
+});
+
+describe("chunkHasNonStallOutput", () => {
+  it("treats normal codex JSONL output as non-stall", () => {
+    expect(chunkHasNonStallOutput(EIG_281_NORMAL_LINES.join("\n"))).toBe(true);
+  });
+
+  it("treats a chunk that is purely stall-signal lines as not-non-stall", () => {
+    expect(chunkHasNonStallOutput(EIG_281_STALL_LINES.join("\n"))).toBe(false);
+  });
+
+  it("ignores keepalive lines when checking for non-stall output", () => {
+    expect(
+      chunkHasNonStallOutput(
+        `${codexUpstreamKeepaliveLinePrefix()} (last signal: "x"; keepalive #1 at 2026-01-01T00:00:00.000Z)`,
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for empty / whitespace chunks", () => {
+    expect(chunkHasNonStallOutput("")).toBe(false);
+    expect(chunkHasNonStallOutput("   \n\n  ")).toBe(false);
+  });
+});
+
+describe("createCodexUpstreamKeepalive", () => {
+  it("emits a periodic keepalive after a stall signal and stops on real output", () => {
+    const captured: Captured[] = [];
+    const fake = makeFakeTimer();
+    const ctrl = makeController({ intervalMs: 30_000, captured, fake });
+
+    expect(ctrl.active).toBe(false);
+
+    // Observe the EIG-281 rmcp fatal — should activate the keepalive.
+    ctrl.observe("stderr", `${EIG_281_STALL_LINES[0]}\n`);
+    expect(ctrl.active).toBe(true);
+    expect(ctrl.lastSignal).toContain("worker quit with fatal");
+    expect(captured.length).toBe(0);
+
+    // Simulate ~2h of upstream silence — the keepalive should emit roughly once
+    // per intervalMs and keep emitting throughout the stall.
+    fake.advance(2 * 60 * 60 * 1000);
+    expect(captured.length).toBe(240);
+    for (const entry of captured) {
+      expect(entry.stream).toBe("stdout");
+      expect(entry.chunk.startsWith(codexUpstreamKeepaliveLinePrefix())).toBe(true);
+      expect(entry.chunk).toContain("worker quit with fatal");
+    }
+
+    // Codex finally produces a real agent_message — the keepalive should stop.
+    ctrl.observe("stdout", `${EIG_281_NORMAL_LINES[2]}\n`);
+    expect(ctrl.active).toBe(false);
+    expect(ctrl.lastSignal).toBeNull();
+
+    const tally = captured.length;
+    fake.advance(60_000);
+    expect(captured.length).toBe(tally);
+  });
+
+  it("re-activates if a new stall signal arrives after recovery", () => {
+    const captured: Captured[] = [];
+    const fake = makeFakeTimer();
+    const ctrl = makeController({ intervalMs: 1_000, captured, fake });
+
+    ctrl.observe("stderr", `${EIG_281_STALL_LINES[0]}\n`);
+    fake.advance(2_000);
+    expect(captured.length).toBe(2);
+
+    ctrl.observe("stdout", `${EIG_281_NORMAL_LINES[0]}\n`);
+    expect(ctrl.active).toBe(false);
+
+    ctrl.observe("stderr", `${EIG_281_STALL_LINES[2]}\n`);
+    expect(ctrl.active).toBe(true);
+    fake.advance(2_000);
+    expect(captured.length).toBe(4);
+  });
+
+  it("ignores its own emitted keepalive lines (no self-loop)", () => {
+    const captured: Captured[] = [];
+    const fake = makeFakeTimer();
+    const ctrl = makeController({ intervalMs: 1_000, captured, fake });
+
+    ctrl.observe("stderr", `${EIG_281_STALL_LINES[1]}\n`);
+    fake.advance(1_500);
+    expect(captured.length).toBeGreaterThanOrEqual(1);
+
+    // Re-observing the keepalive's own output must not deactivate or re-arm.
+    const ownLine = captured[0]!.chunk;
+    ctrl.observe("stdout", ownLine);
+    expect(ctrl.active).toBe(true);
+    expect(ctrl.lastSignal).toMatch(/Reconnecting/);
+  });
+
+  it("respects maxEmits ceiling", () => {
+    const captured: Captured[] = [];
+    const fake = makeFakeTimer();
+    const ctrl = makeController({ intervalMs: 100, maxEmits: 3, captured, fake });
+
+    ctrl.observe("stderr", `${EIG_281_STALL_LINES[3]}\n`);
+    fake.advance(10_000);
+    expect(captured.length).toBe(3);
+    expect(ctrl.emitCount).toBe(3);
+    expect(ctrl.active).toBe(false);
+  });
+
+  it("intervalMs <= 0 disables emission entirely", () => {
+    const captured: Captured[] = [];
+    const fake = makeFakeTimer();
+    const ctrl = makeController({ intervalMs: 0, captured, fake });
+
+    ctrl.observe("stderr", `${EIG_281_STALL_LINES[0]}\n`);
+    expect(ctrl.active).toBe(false);
+    fake.advance(60_000);
+    expect(captured.length).toBe(0);
+  });
+
+  it("stop() clears the timer and ignores subsequent observations", () => {
+    const captured: Captured[] = [];
+    const fake = makeFakeTimer();
+    const ctrl = makeController({ intervalMs: 1_000, captured, fake });
+
+    ctrl.observe("stderr", `${EIG_281_STALL_LINES[0]}\n`);
+    fake.advance(1_000);
+    expect(captured.length).toBe(1);
+
+    ctrl.stop();
+    expect(fake.activeCount()).toBe(0);
+
+    ctrl.observe("stderr", `${EIG_281_STALL_LINES[1]}\n`);
+    fake.advance(60_000);
+    expect(captured.length).toBe(1);
+    expect(ctrl.active).toBe(false);
+  });
+
+  it("does not deactivate on empty / whitespace chunks", () => {
+    const captured: Captured[] = [];
+    const fake = makeFakeTimer();
+    const ctrl = makeController({ intervalMs: 1_000, captured, fake });
+
+    ctrl.observe("stderr", `${EIG_281_STALL_LINES[0]}\n`);
+    expect(ctrl.active).toBe(true);
+
+    ctrl.observe("stdout", "");
+    ctrl.observe("stdout", "   \n");
+    expect(ctrl.active).toBe(true);
+  });
+});

--- a/packages/adapters/codex-local/src/server/upstream-keepalive.ts
+++ b/packages/adapters/codex-local/src/server/upstream-keepalive.ts
@@ -1,0 +1,168 @@
+// Detects codex_local upstream/MCP transport stalls and emits a periodic
+// synthetic keepalive on the adapter side. The keepalive bumps Paperclip's
+// `lastOutputAt` while codex is silently retrying an upstream stream so the
+// silent-run detector doesn't fire on a transient outage.
+//
+// Background: EIG-235 (umbrella) → EIG-238 / EIG-281 sub-pattern. Codex's MCP
+// client can stall for hours with backoff between the rmcp `worker quit with
+// fatal` event and the next `Reconnecting...` line, emitting nothing on
+// stdout/stderr in between, which freezes Paperclip's silence clock.
+
+const STREAM_STALL_PATTERNS: RegExp[] = [
+  /worker quit with fatal:\s*Client error:\s*HTTP request failed/i,
+  /Reconnecting\.\.\.\s*\d+\s*\/\s*\d+/i,
+  /stream disconnected\b/i,
+  /Connection reset by peer/i,
+  /rmcp[^\n]*?\bfatal\b/i,
+  /codex_models_manager:\s*failed to refresh available models/i,
+  /failed to record rollout items:\s*\w+\s*[a-f0-9-]+\s*not found/i,
+];
+
+const KEEPALIVE_LINE_PREFIX = "[paperclip] codex_local: upstream stream stalled";
+
+export function codexUpstreamKeepaliveLinePrefix(): string {
+  return KEEPALIVE_LINE_PREFIX;
+}
+
+export function isCodexUpstreamStreamSignal(line: string): boolean {
+  if (!line) return false;
+  // Never re-detect our own keepalive output.
+  if (line.startsWith(KEEPALIVE_LINE_PREFIX)) return false;
+  return STREAM_STALL_PATTERNS.some((re) => re.test(line));
+}
+
+export function findCodexUpstreamStreamSignal(chunk: string): string | null {
+  if (!chunk) return null;
+  for (const rawLine of chunk.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (isCodexUpstreamStreamSignal(line)) {
+      return line.length > 240 ? `${line.slice(0, 240)}…` : line;
+    }
+  }
+  return null;
+}
+
+export function chunkHasNonStallOutput(chunk: string): boolean {
+  if (!chunk) return false;
+  for (const rawLine of chunk.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (line.startsWith(KEEPALIVE_LINE_PREFIX)) continue;
+    if (!isCodexUpstreamStreamSignal(line)) return true;
+  }
+  return false;
+}
+
+type EmitFn = (stream: "stdout" | "stderr", chunk: string) => unknown;
+
+export type CodexUpstreamKeepaliveOptions = {
+  emit: EmitFn;
+  intervalMs: number;
+  // Optional ceiling on synthetic emits so a runaway codex hang doesn't fill
+  // the run-log indefinitely. 0 (default) means unlimited.
+  maxEmits?: number;
+  setIntervalImpl?: (handler: () => void, ms: number) => unknown;
+  clearIntervalImpl?: (handle: unknown) => void;
+  now?: () => number;
+};
+
+export type CodexUpstreamKeepaliveController = {
+  observe(stream: "stdout" | "stderr", chunk: string): void;
+  stop(): void;
+  readonly emitCount: number;
+  readonly active: boolean;
+  readonly lastSignal: string | null;
+};
+
+export function createCodexUpstreamKeepalive(
+  options: CodexUpstreamKeepaliveOptions,
+): CodexUpstreamKeepaliveController {
+  const intervalMs = Math.max(0, Math.floor(options.intervalMs ?? 0));
+  const maxEmits = Math.max(0, Math.floor(options.maxEmits ?? 0));
+  const setIntervalImpl =
+    options.setIntervalImpl ??
+    ((handler: () => void, ms: number) => setInterval(handler, ms) as unknown);
+  const clearIntervalImpl =
+    options.clearIntervalImpl ??
+    ((handle: unknown) => clearInterval(handle as ReturnType<typeof setInterval>));
+  const now = options.now ?? Date.now;
+
+  let timer: unknown = null;
+  let lastSignal: string | null = null;
+  let emitCount = 0;
+  let stopped = false;
+
+  const emitOne = () => {
+    if (stopped) return;
+    if (maxEmits > 0 && emitCount >= maxEmits) {
+      clearTimer();
+      return;
+    }
+    emitCount += 1;
+    const isoNow = new Date(now()).toISOString();
+    const message =
+      `${KEEPALIVE_LINE_PREFIX} ` +
+      `(last signal: ${JSON.stringify(lastSignal ?? "")}; keepalive #${emitCount} at ${isoNow})\n`;
+    try {
+      const out = options.emit("stdout", message);
+      if (out && typeof (out as Promise<unknown>).then === "function") {
+        (out as Promise<unknown>).catch(() => {});
+      }
+    } catch {
+      // Swallow emit errors; the keepalive must never crash the run.
+    }
+  };
+
+  const clearTimer = () => {
+    if (timer != null) {
+      clearIntervalImpl(timer);
+      timer = null;
+    }
+  };
+
+  const startTimer = () => {
+    if (intervalMs <= 0 || timer != null || stopped) return;
+    timer = setIntervalImpl(emitOne, intervalMs);
+    const maybeUnref = (timer as { unref?: () => unknown } | null)?.unref;
+    if (typeof maybeUnref === "function") {
+      try {
+        maybeUnref.call(timer);
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  return {
+    observe(_stream, chunk) {
+      if (stopped || !chunk) return;
+      const stallSignal = findCodexUpstreamStreamSignal(chunk);
+      if (stallSignal) {
+        lastSignal = stallSignal;
+        startTimer();
+        return;
+      }
+      // Real output ends the stall window. Pure rollout-noise / empty chunks
+      // are filtered out by the caller before reaching `observe`, so any chunk
+      // we see here that doesn't match the stall patterns is genuine progress.
+      if (chunkHasNonStallOutput(chunk)) {
+        lastSignal = null;
+        clearTimer();
+      }
+    },
+    stop() {
+      stopped = true;
+      clearTimer();
+    },
+    get emitCount() {
+      return emitCount;
+    },
+    get active() {
+      return timer != null;
+    },
+    get lastSignal() {
+      return lastSignal;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

When codex's MCP/SSE transport drops mid-run (e.g. `worker quit with fatal: Client error: HTTP request failed`, `Reconnecting... N/5`, `Connection reset by peer (os error 54)`, `failed to record rollout items: thread X not found`), the codex CLI can sit silently for hours retrying upstream with backoff and emit nothing on stdout/stderr in between. Paperclip's silent-run detector then fires on `lastOutputAt` even though the codex process is alive and progressing through reconnect — generating duplicate `Review silent active run for X` triage issues for the run's assignee.

This change adds an adapter-side **synthetic keepalive** to `packages/adapters/codex-local`. When the wrapper sees any stall-signal line, it installs a periodic stdout emit (`[paperclip] codex_local: upstream stream stalled (last signal: …; keepalive #N at <iso>)`) so the run-log keeps ticking through the gap. The keepalive auto-stops as soon as a non-stall codex line arrives, and stops on process exit.

- New module: `packages/adapters/codex-local/src/server/upstream-keepalive.ts`
- Wired into `runAttempt` in `packages/adapters/codex-local/src/server/execute.ts` (single keepalive controller per attempt, observed inside the existing `onLog` wrapper, stopped in `finally`)
- New config knobs (codex_local adapter config):
  - `upstreamKeepaliveIntervalSec` — default `30`, set to `0` to disable
  - `upstreamKeepaliveMaxEmits` — default `0` (unlimited)

Detection patterns and regression fixtures come straight from the EIG-281 run-log (the second confirmed occurrence of the upstream-stream-reconnect sub-pattern in the EIG-235 umbrella tracker).

This is **independent of and complementary to** the dead-PID empty-inbox fix on `eigs/EIG-235-stdio-drain-fix` (close-vs-exit drain + reaper PID reconciliation). That path covered children that exited without emitting `lifecycle: run finished`. This change covers children that **stay alive** across a long upstream outage and never exit at all.

## Two sub-patterns

| Sub-pattern | Symptom | Coverage |
| --- | --- | --- |
| Dead-PID empty-inbox | Child exits without `lifecycle: run finished`, in-memory handle stays `running` | `eigs/EIG-235-stdio-drain-fix` (separate PR) |
| Upstream-stream reconnect | Child stays alive through long upstream/MCP outage, `lastOutputAt` freezes on a stderr error during the gap | **this PR** |

## Test plan

- [x] 23 new unit tests in `upstream-keepalive.test.ts` covering signal detection (each EIG-281 fixture line), no-self-loop guarantee, activate-on-stall, deactivate-on-recovery, no-deactivate-on-empty-chunk, `maxEmits` cap, disabled mode (`intervalMs <= 0`), `stop()` semantics, and re-activation after a recovery
- [x] Full `pnpm --filter codex-local-adapter test`: 8 files, 45 tests, 0 failures
- [x] `pnpm --filter codex-local-adapter exec tsc --noEmit`: clean
- [ ] Reviewer: replay the `b988ba64-…` EIG-281 run-log against the new adapter and confirm the keepalive line cadence shows up in the run-log during the 2h36m upstream stall