### PR TITLE
[server,adapter-utils] Drain stdio after exit and reconcile dead-PID handles for tracked local adapters

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -352,7 +352,13 @@ describe("runChildProcess", () => {
     expect(result.stdout).toContain('"type":"result"');
   });
 
-  it.skipIf(process.platform === "win32")("does not clean up noisy runs that have no terminal output", async () => {
+  it.skipIf(process.platform === "win32")("resolves the run after parent exit even when a descendant keeps stdio open", async () => {
+    // Regression: previously the orchestrator waited indefinitely for
+    // 'close' to fire, but a grandchild that inherited the parent's
+    // stdout fds could keep them open forever. That left
+    // runningProcesses populated, blocked the orphan reaper, and
+    // surfaced as duplicate "Review silent active run" alerts when
+    // the silence-detector fired (~1h after lastOutputAt).
     const runId = randomUUID();
     let observed = "";
     const resultPromise = runChildProcess(
@@ -375,10 +381,57 @@ describe("runChildProcess", () => {
         onLog: async (_stream, chunk) => {
           observed += chunk;
         },
-        terminalResultCleanup: {
-          graceMs: 50,
-          hasTerminalResult: ({ stdout }) => stdout.includes('"type":"result"'),
+        // Use a tight drain so the test runs quickly. Production
+        // defaults to the full POST_EXIT_STDIO_DRAIN_MS (5s).
+        postExitStdioDrainMs: 200,
+      },
+    );
+
+    const pidMatch = await waitForTextMatch(() => observed, /descendant:(\d+)/);
+    const descendantPid = Number.parseInt(pidMatch?.[1] ?? "", 10);
+    expect(Number.isInteger(descendantPid) && descendantPid > 0).toBe(true);
+
+    try {
+      const result = await resultPromise;
+      expect(result.exitCode).toBe(0);
+      expect(result.postExitDrainTimedOut).toBe(true);
+      expect(runningProcesses.has(runId)).toBe(false);
+    } finally {
+      if (isPidAlive(descendantPid)) {
+        try {
+          process.kill(descendantPid, "SIGKILL");
+        } catch {
+          // Ignore cleanup races.
+        }
+      }
+      runningProcesses.delete(runId);
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("preserves legacy wait-for-close behavior when postExitStdioDrainMs is 0", async () => {
+    const runId = randomUUID();
+    let observed = "";
+    const resultPromise = runChildProcess(
+      runId,
+      process.execPath,
+      [
+        "-e",
+        [
+          "const { spawn } = require('node:child_process');",
+          "const child = spawn(process.execPath, ['-e', \"setInterval(() => process.stdout.write('noise\\\\n'), 50)\"], { stdio: ['ignore', 'inherit', 'ignore'] });",
+          "process.stdout.write(`descendant:${child.pid}\\n`);",
+          "setTimeout(() => process.exit(0), 25);",
+        ].join(" "),
+      ],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 0,
+        graceSec: 1,
+        onLog: async (_stream, chunk) => {
+          observed += chunk;
         },
+        postExitStdioDrainMs: 0,
       },
     );
 
@@ -393,25 +446,13 @@ describe("runChildProcess", () => {
     expect(race).toBe("pending");
     expect(isPidAlive(descendantPid)).toBe(true);
 
-    const running = runningProcesses.get(runId) as
-      | { child: { kill(signal: NodeJS.Signals): boolean }; processGroupId: number | null }
-      | undefined;
     try {
-      if (running?.processGroupId) {
-        process.kill(-running.processGroupId, "SIGKILL");
-      } else {
-        running?.child.kill("SIGKILL");
+      if (isPidAlive(descendantPid)) {
+        process.kill(descendantPid, "SIGKILL");
       }
       await resultPromise;
     } finally {
       runningProcesses.delete(runId);
-      if (isPidAlive(descendantPid)) {
-        try {
-          process.kill(descendantPid, "SIGKILL");
-        } catch {
-          // Ignore cleanup races.
-        }
-      }
     }
   });
 });

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -18,6 +18,11 @@ export interface RunProcessResult {
   stderr: string;
   pid: number | null;
   startedAt: string | null;
+  // Set when the child emitted 'exit' but stdio streams were still open
+  // after POST_EXIT_STDIO_DRAIN_MS, so the orchestrator resolved without
+  // waiting for 'close'. Indicates a grandchild leaked stdio fds; the
+  // recorded exitCode/signal still come from the parent's exit event.
+  postExitDrainTimedOut?: boolean;
 }
 
 export interface TerminalResultCleanupOptions {
@@ -78,6 +83,14 @@ export const runningProcesses = new Map<string, RunningProcess>();
 export const MAX_CAPTURE_BYTES = 4 * 1024 * 1024;
 export const MAX_EXCERPT_BYTES = 32 * 1024;
 const TERMINAL_RESULT_SCAN_OVERLAP_CHARS = 64 * 1024;
+// After the child process emits 'exit', wait at most this long for stdio
+// streams to flush before resolving the run anyway. Without this drain
+// fallback, a grandchild that inherited the child's stdio can keep
+// stdout/stderr open indefinitely, preventing 'close' from firing and
+// leaking the in-memory run handle (see issue: silent active-run alerts
+// when an empty-inbox heartbeat exits cleanly but a tool grandchild
+// outlives the parent).
+const POST_EXIT_STDIO_DRAIN_MS = 5_000;
 const SENSITIVE_ENV_KEY = /(key|token|secret|password|passwd|authorization|cookie)/i;
 const REDACTED_LOG_VALUE = "***REDACTED***";
 const PAPERCLIP_SKILL_ROOT_RELATIVE_CANDIDATES = [
@@ -1888,6 +1901,11 @@ export async function runChildProcess(
     terminalResultCleanup?: TerminalResultCleanupOptions;
     stdin?: string;
     remoteExecution?: RemoteExecutionSpec | null;
+    // Override how long we wait for stdio streams to drain after the
+    // child emits 'exit'. Defaults to POST_EXIT_STDIO_DRAIN_MS (5s).
+    // Set to 0 to disable the drain fallback (legacy behavior: wait
+    // indefinitely for 'close' to fire).
+    postExitStdioDrainMs?: number;
   },
 ): Promise<RunProcessResult> {
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
@@ -2043,9 +2061,20 @@ export async function runChildProcess(
           });
         }
 
+        let finalized = false;
+        let postExitDrainTimer: NodeJS.Timeout | null = null;
+        let postExitDrainFinalized = false;
+        let exitCode: number | null = null;
+        let exitSignal: NodeJS.Signals | null = null;
+
         child.on("error", (err: Error) => {
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          if (postExitDrainTimer) {
+            clearTimeout(postExitDrainTimer);
+            postExitDrainTimer = null;
+          }
+          finalized = true;
           runningProcesses.delete(runId);
           void target.cleanup?.();
           const errno = (err as NodeJS.ErrnoException).code;
@@ -2057,29 +2086,64 @@ export async function runChildProcess(
           reject(new Error(msg));
         });
 
-        child.on("exit", () => {
-          maybeArmTerminalResultCleanup();
-        });
-
-        child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+        const finalizeRun = (source: "close" | "post-exit-drain") => {
+          if (finalized) return;
+          finalized = true;
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
+          if (postExitDrainTimer) {
+            clearTimeout(postExitDrainTimer);
+            postExitDrainTimer = null;
+          }
           runningProcesses.delete(runId);
           void logChain.finally(() => {
             void Promise.resolve()
               .then(() => target.cleanup?.())
               .finally(() => {
               resolve({
-                exitCode: code,
-                signal,
+                exitCode,
+                signal: exitSignal,
                 timedOut,
                 stdout,
                 stderr,
                 pid: child.pid ?? null,
                 startedAt,
+                ...(source === "post-exit-drain" ? { postExitDrainTimedOut: true } : {}),
               });
               });
           });
+        };
+
+        child.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
+          maybeArmTerminalResultCleanup();
+          if (postExitDrainFinalized) return;
+          postExitDrainFinalized = true;
+          // Capture the exit metadata now. If 'close' fires we'll use the
+          // values it reports (which match these), otherwise the drain timer
+          // resolves with what we captured here.
+          exitCode = code;
+          exitSignal = signal;
+          const drainMs = opts.postExitStdioDrainMs ?? POST_EXIT_STDIO_DRAIN_MS;
+          if (drainMs <= 0) return;
+          if (postExitDrainTimer) clearTimeout(postExitDrainTimer);
+          postExitDrainTimer = setTimeout(() => {
+            postExitDrainTimer = null;
+            if (finalized) return;
+            // 'close' never fired within the drain window. A descendant
+            // process is keeping the parent's stdio file descriptors open.
+            // Detach our own stream listeners so they cannot keep the run
+            // hanging on logChain after the next chunk arrives, then
+            // resolve so the orchestrator can clear the in-memory handle.
+            try { child.stdout?.removeAllListeners("data"); } catch { /* noop */ }
+            try { child.stderr?.removeAllListeners("data"); } catch { /* noop */ }
+            finalizeRun("post-exit-drain");
+          }, drainMs);
+        });
+
+        child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+          exitCode = code;
+          exitSignal = signal;
+          finalizeRun("close");
         });
       })
       .catch(reject);

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -939,6 +939,45 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.checkoutRunId).toBe(runId);
   });
 
+  it("reconciles a stale in-memory handle against a dead pid and reaps the run", async () => {
+    // Regression: an upstream stdio leak (grandchild keeps the parent's
+    // stdout/stderr fds open) can cause runChildProcess to never see
+    // 'close' fire, leaving runningProcesses populated even after the
+    // parent has exited. Without reconciliation the reaper's
+    // !runningProcesses.has(runId) gate skips these runs forever; with
+    // reconciliation the dead-pid signal drops the stale handle and we
+    // fall through into the normal reap path.
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: 999_999_999,
+    });
+    runningProcesses.set(runId, {
+      child: { pid: 999_999_999 } as never,
+      graceSec: 1,
+      processGroupId: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+    expect(runningProcesses.has(runId)).toBe(false);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    const failedRun = runs.find((row) => row.id === runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_lost");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.checkoutRunId).toBe(runId);
+  });
+
   it("releases active environment leases when an orphaned run is reaped", async () => {
     const { runId, issueId, companyId } = await seedRunFixture({
       processPid: 999_999_999,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6394,7 +6394,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const reaped: string[] = [];
 
     for (const { run, adapterType, adapterConfig } of activeRuns) {
-      if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
+      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
+      const hasInMemoryHandle = runningProcesses.has(run.id);
+      const hasActiveExecution = activeRunExecutions.has(run.id);
+
+      // Reconcile the in-memory handle against OS PID liveness for tracked
+      // local child-process adapters. A dead PID with a surviving handle is
+      // a leak (e.g. a grandchild kept stdio fds open and 'close' never
+      // fired), so we drop the stale handle and fall through into the reap
+      // path instead of letting the gate below skip the run forever.
+      const recordedPid = typeof run.processPid === "number" ? run.processPid : null;
+      const handleIsStale =
+        hasInMemoryHandle &&
+        tracksLocalChild &&
+        recordedPid !== null &&
+        !isProcessAlive(recordedPid);
+      if (handleIsStale) {
+        runningProcesses.delete(run.id);
+        logger.warn(
+          { runId: run.id, agentId: run.agentId, processPid: recordedPid },
+          "dropping stale in-memory run handle: child pid is no longer alive",
+        );
+      }
+
+      if ((hasInMemoryHandle && !handleIsStale) || hasActiveExecution) continue;
 
       // Apply staleness threshold to avoid false positives
       if (staleThresholdMs > 0) {
@@ -6402,8 +6425,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         if (now.getTime() - refTime < staleThresholdMs) continue;
       }
 
-      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
-      const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
+      const processPidAlive = tracksLocalChild && run.processPid && !handleIsStale && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {


### PR DESCRIPTION
## Summary

Fixes the dead-PID empty-inbox sub-pattern of the EIG-235 silent-active-run issue: codex_local heartbeats that exit cleanly with an empty inbox can leak the in-memory `runningProcesses` handle when a long-lived grandchild keeps the parent's stdio fds open, because Node's `child.on("close")` only fires after stdio fully drains. The handle never clears, no `lifecycle: run finished` event is emitted, the run row stays `running`, and Paperclip's silence detector trips at the 1h threshold and creates a `Review silent active run` triage issue. First reproducer was 50 stuck `MetricsIC` runs in a single instance.

This change addresses the leak at two layers:

1. **Adapter layer (`packages/adapter-utils/src/server-utils.ts`, `runChildProcess`)** — on `'exit'`, capture exit code/signal and arm a bounded stdio drain timer (default 5s, overrideable per-call via `opts.postExitStdioDrainMs`; set to `0` to restore legacy wait-for-close). If `'close'` fires within the window we use it as before. Otherwise we detach the data listeners, mark the result `postExitDrainTimedOut: true`, `runningProcesses.delete(runId)`, finalize the log chain, and resolve so the orchestrator can clear `activeRunExecutions` and emit `lifecycle: run finished`. The `error` handler is hardened to clear the new drain timer + mark the result finalized so we don't double-resolve.

2. **Reaper layer (`server/src/services/heartbeat.ts`, `reapOrphanedRuns`)** — replace the `if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;` early-continue with a reconciliation pass. For tracked local child-process adapters (`isTrackedLocalChildProcessAdapter`), if the in-memory handle is present but the recorded `processPid` is not alive (`!isProcessAlive(run.processPid)`), drop the stale handle and fall through into the existing reap path; otherwise honour the gate as before. Dropped handles are logged with `runId/agentId/processPid` for observability.

Independent of the upstream-stream-reconnect sub-pattern fix in #5457, which covers codex children that stay alive across long upstream/MCP outages without exiting; this drain path is never reached in that case.

## Test plan

- [x] `pnpm --filter @paperclipai/adapter-utils typecheck` — clean
- [x] `pnpm --filter @paperclipai/server typecheck` — clean
- [x] `npx vitest run @paperclipai/adapter-utils packages/adapter-utils/src/server-utils.test.ts` — 33/33 passed including new regression test `runChildProcess > resolves the run after parent exit even when a descendant keeps stdio open` (~2.4 s)
- [ ] `heartbeat-process-recovery.test.ts` — new test `reconciles a stale in-memory handle against a dead pid and reaps the run` is skipped locally (embedded Postgres init failure on this host, not specific to this change). Will run in CI.
