### PR TITLE
fix: use loopback URL for PAPERCLIP_RUNTIME_API_URL on loopback-bound servers

### DIFF
--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -313,7 +313,10 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
   });
 
   it("rewrites explicit-port auth public URLs when detect-port selects a new port", async () => {
+    // Use a non-loopback bind host so PAPERCLIP_RUNTIME_API_URL reflects the public URL.
+    // For loopback hosts, PAPERCLIP_RUNTIME_API_URL always uses the loopback address (CES-3523).
     loadConfigMock.mockReturnValueOnce(buildTestConfig({
+      host: "0.0.0.0",
       port: 3100,
       authBaseUrlMode: "explicit",
       authPublicBaseUrl: "http://my-host.ts.net:3100",
@@ -328,7 +331,10 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
   });
 
   it("keeps no-port auth public URLs stable when detect-port selects a new port", async () => {
+    // Use a non-loopback bind host so PAPERCLIP_RUNTIME_API_URL reflects the public URL.
+    // For loopback hosts, PAPERCLIP_RUNTIME_API_URL always uses the loopback address (CES-3523).
     loadConfigMock.mockReturnValueOnce(buildTestConfig({
+      host: "0.0.0.0",
       port: 3100,
       authBaseUrlMode: "explicit",
       authPublicBaseUrl: "https://paperclip.example",
@@ -340,5 +346,22 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.listenPort).toBe(3110);
     expect(started.apiUrl).toBe("https://paperclip.example");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("https://paperclip.example");
+  });
+
+  it("uses loopback URL for PAPERCLIP_RUNTIME_API_URL when bound to loopback, even if authPublicBaseUrl is set (CES-3523)", async () => {
+    // Scenario: server binds to 127.0.0.1 and has a public tunnel URL configured.
+    // Agents run on the same machine, so PAPERCLIP_RUNTIME_API_URL must be the
+    // loopback address to stay connected when the tunnel goes down or changes.
+    loadConfigMock.mockReturnValueOnce(buildTestConfig({
+      host: "127.0.0.1",
+      port: 3100,
+      authBaseUrlMode: "explicit",
+      authPublicBaseUrl: "https://tunnel.example.localtunnel.me",
+    }));
+
+    const started = await startServer();
+
+    expect(started.apiUrl).toBe("https://tunnel.example.localtunnel.me");
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3100");
   });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -514,4 +514,15 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.apiUrl).toBe("https://tunnel.example.localtunnel.me");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3100");
   });
+
+  it("brackets IPv6 loopback ::1 in PAPERCLIP_RUNTIME_API_URL to produce a valid URL", async () => {
+    loadConfigMock.mockReturnValueOnce(buildTestConfig({
+      host: "::1",
+      port: 3100,
+    }));
+
+    await startServer();
+
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://[::1]:3100");
+  });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -463,7 +463,10 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
   });
 
   it("rewrites explicit-port auth public URLs when detect-port selects a new port", async () => {
+    // Use a non-loopback bind host so PAPERCLIP_RUNTIME_API_URL reflects the public URL.
+    // For loopback hosts, PAPERCLIP_RUNTIME_API_URL always uses the loopback address (CES-3523).
     loadConfigMock.mockReturnValueOnce(buildTestConfig({
+      host: "0.0.0.0",
       port: 3100,
       authBaseUrlMode: "explicit",
       authPublicBaseUrl: "http://my-host.ts.net:3100",
@@ -478,7 +481,10 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
   });
 
   it("keeps no-port auth public URLs stable when detect-port selects a new port", async () => {
+    // Use a non-loopback bind host so PAPERCLIP_RUNTIME_API_URL reflects the public URL.
+    // For loopback hosts, PAPERCLIP_RUNTIME_API_URL always uses the loopback address (CES-3523).
     loadConfigMock.mockReturnValueOnce(buildTestConfig({
+      host: "0.0.0.0",
       port: 3100,
       authBaseUrlMode: "explicit",
       authPublicBaseUrl: "https://paperclip.example",
@@ -490,5 +496,22 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(started.listenPort).toBe(3110);
     expect(started.apiUrl).toBe("https://paperclip.example");
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("https://paperclip.example");
+  });
+
+  it("uses loopback URL for PAPERCLIP_RUNTIME_API_URL when bound to loopback, even if authPublicBaseUrl is set (CES-3523)", async () => {
+    // Scenario: server binds to 127.0.0.1 and has a public tunnel URL configured.
+    // Agents run on the same machine, so PAPERCLIP_RUNTIME_API_URL must be the
+    // loopback address to stay connected when the tunnel goes down or changes.
+    loadConfigMock.mockReturnValueOnce(buildTestConfig({
+      host: "127.0.0.1",
+      port: 3100,
+      authBaseUrlMode: "explicit",
+      authPublicBaseUrl: "https://tunnel.example.localtunnel.me",
+    }));
+
+    const started = await startServer();
+
+    expect(started.apiUrl).toBe("https://tunnel.example.localtunnel.me");
+    expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("http://127.0.0.1:3100");
   });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -464,7 +464,7 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
 
   it("rewrites explicit-port auth public URLs when detect-port selects a new port", async () => {
     // Use a non-loopback bind host so PAPERCLIP_RUNTIME_API_URL reflects the public URL.
-    // For loopback hosts, PAPERCLIP_RUNTIME_API_URL always uses the loopback address (CES-3523).
+    // For loopback hosts, PAPERCLIP_RUNTIME_API_URL always uses the loopback address.
     loadConfigMock.mockReturnValueOnce(buildTestConfig({
       host: "0.0.0.0",
       port: 3100,
@@ -482,7 +482,7 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
 
   it("keeps no-port auth public URLs stable when detect-port selects a new port", async () => {
     // Use a non-loopback bind host so PAPERCLIP_RUNTIME_API_URL reflects the public URL.
-    // For loopback hosts, PAPERCLIP_RUNTIME_API_URL always uses the loopback address (CES-3523).
+    // For loopback hosts, PAPERCLIP_RUNTIME_API_URL always uses the loopback address.
     loadConfigMock.mockReturnValueOnce(buildTestConfig({
       host: "0.0.0.0",
       port: 3100,
@@ -498,7 +498,7 @@ describe("startServer PAPERCLIP_API_URL handling", () => {
     expect(process.env.PAPERCLIP_RUNTIME_API_URL).toBe("https://paperclip.example");
   });
 
-  it("uses loopback URL for PAPERCLIP_RUNTIME_API_URL when bound to loopback, even if authPublicBaseUrl is set (CES-3523)", async () => {
+  it("uses loopback URL for PAPERCLIP_RUNTIME_API_URL when bound to loopback, even if authPublicBaseUrl is set", async () => {
     // Scenario: server binds to 127.0.0.1 and has a public tunnel URL configured.
     // Agents run on the same machine, so PAPERCLIP_RUNTIME_API_URL must be the
     // loopback address to stay connected when the tunnel goes down or changes.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -647,7 +647,14 @@ export async function startServer(): Promise<StartedServer> {
   });
   process.env.PAPERCLIP_LISTEN_HOST = runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
-  process.env.PAPERCLIP_RUNTIME_API_URL = runtimeApiUrl;
+  // When the server binds to a loopback address, agents always run on the same machine.
+  // Use the loopback URL for PAPERCLIP_RUNTIME_API_URL so agents stay connected even
+  // when the public tunnel URL changes or goes down (CES-3523). authPublicBaseUrl
+  // continues to be used only for OAuth callbacks and external access.
+  const agentRuntimeApiUrl = isLoopbackHost(runtimeListenHost)
+    ? `http://${runtimeListenHost}:${listenPort}`
+    : runtimeApiUrl;
+  process.env.PAPERCLIP_RUNTIME_API_URL = agentRuntimeApiUrl;
   process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify(runtimeApiCandidates);
   process.env.PAPERCLIP_API_URL = configuredApiUrl;
   

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -725,8 +725,10 @@ export async function startServer(): Promise<StartedServer> {
   // Use the loopback URL for PAPERCLIP_RUNTIME_API_URL so agents stay connected even
   // when the public tunnel URL changes or goes down (CES-3523). authPublicBaseUrl
   // continues to be used only for OAuth callbacks and external access.
+  const loopbackHost =
+    runtimeListenHost === "::1" ? `[${runtimeListenHost}]` : runtimeListenHost;
   const agentRuntimeApiUrl = isLoopbackHost(runtimeListenHost)
-    ? `http://${runtimeListenHost}:${listenPort}`
+    ? `http://${loopbackHost}:${listenPort}`
     : runtimeApiUrl;
   process.env.PAPERCLIP_RUNTIME_API_URL = agentRuntimeApiUrl;
   process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify(runtimeApiCandidates);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -723,8 +723,8 @@ export async function startServer(): Promise<StartedServer> {
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
   // When the server binds to a loopback address, agents always run on the same machine.
   // Use the loopback URL for PAPERCLIP_RUNTIME_API_URL so agents stay connected even
-  // when the public tunnel URL changes or goes down (CES-3523). authPublicBaseUrl
-  // continues to be used only for OAuth callbacks and external access.
+  // when the public tunnel URL changes or goes down. authPublicBaseUrl continues to be
+  // used only for OAuth callbacks and external access.
   const loopbackHost =
     runtimeListenHost === "::1" ? `[${runtimeListenHost}]` : runtimeListenHost;
   const agentRuntimeApiUrl = isLoopbackHost(runtimeListenHost)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -721,7 +721,14 @@ export async function startServer(): Promise<StartedServer> {
   });
   process.env.PAPERCLIP_LISTEN_HOST = runtimeListenHost;
   process.env.PAPERCLIP_LISTEN_PORT = String(listenPort);
-  process.env.PAPERCLIP_RUNTIME_API_URL = runtimeApiUrl;
+  // When the server binds to a loopback address, agents always run on the same machine.
+  // Use the loopback URL for PAPERCLIP_RUNTIME_API_URL so agents stay connected even
+  // when the public tunnel URL changes or goes down (CES-3523). authPublicBaseUrl
+  // continues to be used only for OAuth callbacks and external access.
+  const agentRuntimeApiUrl = isLoopbackHost(runtimeListenHost)
+    ? `http://${runtimeListenHost}:${listenPort}`
+    : runtimeApiUrl;
+  process.env.PAPERCLIP_RUNTIME_API_URL = agentRuntimeApiUrl;
   process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify(runtimeApiCandidates);
   process.env.PAPERCLIP_API_URL = configuredApiUrl;
   


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, injecting env vars into each agent run
> - The agent runtime URL chain is: server sets `PAPERCLIP_RUNTIME_API_URL` → `buildPaperclipEnv` reads it → agent receives it as `PAPERCLIP_API_URL`
> - `choosePrimaryRuntimeApiUrl` correctly prioritizes `authPublicBaseUrl` (tunnel URL) for external access
> - But when the server binds to a loopback address (`127.0.0.1`), agents always run on the same machine — using the tunnel URL for internal agent communication means agents lose connectivity whenever the tunnel changes or goes down
> - The existing `buildPaperclipEnv` already prefers `PAPERCLIP_RUNTIME_API_URL` over `PAPERCLIP_API_URL`, so the fix only needs to change how the server sets `PAPERCLIP_RUNTIME_API_URL`
> - This PR adds a loopback check: when `runtimeListenHost` is a loopback address, use the loopback URL for `PAPERCLIP_RUNTIME_API_URL` regardless of `authPublicBaseUrl`
> - The benefit is agents on loopback-bound servers stay connected to the API even when the public tunnel is down or its URL changes

## Linked Issues or Issue Description

Refs #5563

Related: #5027, #6630, #7552

## What Changed

- `server/src/index.ts`: compute `agentRuntimeApiUrl` using `isLoopbackHost(runtimeListenHost)` — loopback hosts get `http://{host}:{port}` (with IPv6 bracket wrapping for `::1` → `http://[::1]:{port}`), all others keep the existing `runtimeApiUrl` (which may be the public tunnel URL)
- `server/src/__tests__/server-startup-feedback-export.test.ts`: updated two existing tests that used the default loopback `host: "127.0.0.1"` to use `host: "0.0.0.0"` instead, preserving their intent (port-rewrite and stable-no-port tunnel URL behavior on non-loopback hosts); added tests verifying `PAPERCLIP_RUNTIME_API_URL` uses loopback when bound to `127.0.0.1` and that IPv6 `::1` is correctly bracketed

## Verification

```bash
# Run the targeted test
cd server && npx vitest run src/__tests__/server-startup-feedback-export.test.ts
# Expected: 12 tests pass
```

Manual verification: start a local server with `host: "127.0.0.1"` and `authPublicBaseUrl` set to a tunnel URL. Confirm that `PAPERCLIP_RUNTIME_API_URL` in the process environment is `http://127.0.0.1:{port}`, not the tunnel URL.

## Risks

- Low risk. The change only affects `PAPERCLIP_RUNTIME_API_URL`, not `PAPERCLIP_API_URL` (which is unchanged for external consumers). `buildPaperclipEnv` already consumes `PAPERCLIP_RUNTIME_API_URL` as the higher-priority source, so this is the minimal intervention point.
- Existing tests updated to explicitly opt into non-loopback host to preserve their original verification intent.
- No database migrations, API contract changes, or UI changes.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6 (Claude Sonnet 4.6)
- Context: 200k token context window
- Capabilities: tool use, code analysis, multi-file editing, test execution
- Mode: Engineering Manager agent heartbeat via Paperclip

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Refs #5563` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge