### PR TITLE
feat(issues): reactive propagation — auto-walk unblocked edges on done (THEA-2810)

### DIFF
--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockWakeup = vi.hoisted(() => vi.fn(async () => undefined));
 const mockIssueService = vi.hoisted(() => ({
   getAncestors: vi.fn(),
+  getAssigneesByIds: vi.fn(async () => []),
   getById: vi.fn(),
   getByIdentifier: vi.fn(async () => null),
   getComment: vi.fn(),
@@ -75,6 +76,40 @@ vi.mock("../services/index.js", () => ({
   }),
 }));
 
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "issue-1",
+    companyId: "company-1",
+    identifier: "PAP-100",
+    title: "Blocker",
+    description: null,
+    status: "in_progress",
+    priority: "medium",
+    parentId: null,
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    executionWorkspaceId: null,
+    labels: [],
+    labelIds: [],
+    ...overrides,
+  };
+}
+
+function makeDependent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "dep-1",
+    assigneeAgentId: "agent-dep",
+    status: "todo",
+    parentId: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    blockerIssueIds: ["issue-1"],
+    ...overrides,
+  };
+}
+
 async function createApp() {
   const [{ issueRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
@@ -105,6 +140,7 @@ describe("issue dependency wakeups in issue routes", () => {
     vi.doUnmock("../middleware/index.js");
     vi.clearAllMocks();
     mockIssueService.getAncestors.mockResolvedValue([]);
+    mockIssueService.getAssigneesByIds.mockResolvedValue([]);
     mockIssueService.getComment.mockResolvedValue(null);
     mockIssueService.getCommentCursor.mockResolvedValue({
       totalComments: 0,
@@ -155,25 +191,32 @@ describe("issue dependency wakeups in issue routes", () => {
       {
         id: "issue-2",
         assigneeAgentId: "agent-2",
+        status: "todo",
+        parentId: null,
+        createdByAgentId: null,
+        createdByUserId: null,
         blockerIssueIds: ["issue-1", "issue-3"],
       },
     ]);
 
     const res = await request(await createApp()).patch("/api/issues/issue-1").send({ status: "done" });
     expect(res.status).toBe(200);
-    await vi.waitFor(() => {
-      expect(mockWakeup).toHaveBeenCalledWith(
-        "agent-2",
-        expect.objectContaining({
-          reason: "issue_blockers_resolved",
-          payload: expect.objectContaining({
-            issueId: "issue-2",
-            resolvedBlockerIssueId: "issue-1",
+    await vi.waitFor(
+      () => {
+        expect(mockWakeup).toHaveBeenCalledWith(
+          "agent-2",
+          expect.objectContaining({
+            reason: "issue_blockers_resolved",
+            payload: expect.objectContaining({
+              issueId: "issue-2",
+              resolvedBlockerIssueId: "issue-1",
+            }),
           }),
-        }),
-      );
-    });
-  });
+        );
+      },
+      { timeout: 10000 },
+    );
+  }, 30000);
 
   it("wakes the parent when all direct children become terminal", async () => {
     mockIssueService.getById.mockResolvedValue({
@@ -243,25 +286,136 @@ describe("issue dependency wakeups in issue routes", () => {
 
     const res = await request(await createApp()).patch("/api/issues/child-1").send({ status: "done" });
     expect(res.status).toBe(200);
-    await vi.waitFor(() => {
-      expect(mockWakeup).toHaveBeenCalledWith(
-        "agent-9",
-        expect.objectContaining({
-          reason: "issue_children_completed",
-          payload: expect.objectContaining({
-            issueId: "parent-1",
-            completedChildIssueId: "child-1",
-            childIssueSummaries: expect.arrayContaining([
-              expect.objectContaining({ identifier: "PAP-101", summary: "Last child finished." }),
-            ]),
+    await vi.waitFor(
+      () => {
+        expect(mockWakeup).toHaveBeenCalledWith(
+          "agent-9",
+          expect.objectContaining({
+            reason: "issue_children_completed",
+            payload: expect.objectContaining({
+              issueId: "parent-1",
+              completedChildIssueId: "child-1",
+              childIssueSummaries: expect.arrayContaining([
+                expect.objectContaining({ identifier: "PAP-101", summary: "Last child finished." }),
+              ]),
+            }),
+            contextSnapshot: expect.objectContaining({
+              childIssueSummaries: expect.arrayContaining([
+                expect.objectContaining({ identifier: "PAP-100", summary: "First child finished." }),
+              ]),
+            }),
           }),
-          contextSnapshot: expect.objectContaining({
-            childIssueSummaries: expect.arrayContaining([
-              expect.objectContaining({ identifier: "PAP-100", summary: "First child finished." }),
-            ]),
+        );
+      },
+      { timeout: 10000 },
+    );
+  }, 30000);
+
+  it("attaches idempotencyKey on blocker-resolved wakes (AC#4)", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    mockIssueService.update.mockResolvedValue(makeIssue({ status: "done" }));
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([
+      makeDependent({ id: "dep-1", assigneeAgentId: "agent-dep", status: "todo" }),
+    ]);
+
+    const res = await request(await createApp()).patch("/api/issues/issue-1").send({ status: "done" });
+    expect(res.status).toBe(200);
+    await vi.waitFor(
+      () => {
+        expect(mockWakeup).toHaveBeenCalledWith(
+          "agent-dep",
+          expect.objectContaining({
+            idempotencyKey: "blockers_resolved:issue-1:dep-1",
           }),
-        }),
-      );
-    });
+        );
+      },
+      { timeout: 10000 },
+    );
+  });
+
+  it("auto-promotes backlog dependents to todo and wakes all siblings (AC#1/AC#2/F4/F8)", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    mockIssueService.update.mockResolvedValue(makeIssue({ status: "done" }));
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([
+      makeDependent({ id: "dep-1", status: "backlog", assigneeAgentId: "agent-s1", blockerIssueIds: ["issue-1"] }),
+      makeDependent({ id: "dep-2", status: "backlog", assigneeAgentId: "agent-s2", blockerIssueIds: ["issue-1"] }),
+      makeDependent({ id: "dep-3", status: "backlog", assigneeAgentId: "agent-s3", blockerIssueIds: ["issue-1"] }),
+    ]);
+
+    const res = await request(await createApp()).patch("/api/issues/issue-1").send({ status: "done" });
+    expect(res.status).toBe(200);
+    await vi.waitFor(
+      () => {
+        expect(mockIssueService.update).toHaveBeenCalledWith("dep-1", { status: "todo" });
+        expect(mockIssueService.update).toHaveBeenCalledWith("dep-2", { status: "todo" });
+        expect(mockIssueService.update).toHaveBeenCalledWith("dep-3", { status: "todo" });
+        expect(mockWakeup).toHaveBeenCalledWith(
+          "agent-s1",
+          expect.objectContaining({ reason: "issue_blockers_resolved" }),
+        );
+        expect(mockWakeup).toHaveBeenCalledWith(
+          "agent-s2",
+          expect.objectContaining({ reason: "issue_blockers_resolved" }),
+        );
+        expect(mockWakeup).toHaveBeenCalledWith(
+          "agent-s3",
+          expect.objectContaining({ reason: "issue_blockers_resolved" }),
+        );
+      },
+      { timeout: 10000 },
+    );
+  });
+
+  it("wakes parent assignee when orphan dependent has no assignee (AC#3/F7)", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    mockIssueService.update.mockResolvedValue(makeIssue({ status: "done" }));
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([
+      makeDependent({ id: "dep-orphan", assigneeAgentId: null, parentId: "parent-1", status: "todo" }),
+    ]);
+    mockIssueService.getAssigneesByIds.mockResolvedValue([{ id: "parent-1", assigneeAgentId: "agent-parent" }]);
+
+    const res = await request(await createApp()).patch("/api/issues/issue-1").send({ status: "done" });
+    expect(res.status).toBe(200);
+    await vi.waitFor(
+      () => {
+        expect(mockWakeup).toHaveBeenCalledWith(
+          "agent-parent",
+          expect.objectContaining({
+            reason: "issue_orphan_blocker_resolved",
+            payload: expect.objectContaining({ issueId: "dep-orphan", needsAssignee: true }),
+          }),
+        );
+      },
+      { timeout: 10000 },
+    );
+  });
+
+  it("falls back to creator when orphan dependent has no assignee and no parent (F7)", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_progress" }));
+    mockIssueService.update.mockResolvedValue(makeIssue({ status: "done" }));
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([
+      makeDependent({
+        id: "dep-orphan",
+        assigneeAgentId: null,
+        parentId: null,
+        createdByAgentId: "agent-creator",
+        status: "todo",
+      }),
+    ]);
+
+    const res = await request(await createApp()).patch("/api/issues/issue-1").send({ status: "done" });
+    expect(res.status).toBe(200);
+    await vi.waitFor(
+      () => {
+        expect(mockWakeup).toHaveBeenCalledWith(
+          "agent-creator",
+          expect.objectContaining({
+            reason: "issue_orphan_blocker_resolved",
+            payload: expect.objectContaining({ issueId: "dep-orphan", needsAssignee: true }),
+          }),
+        );
+      },
+      { timeout: 10000 },
+    );
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2800,22 +2800,57 @@ export function issueRoutes(
       const becameDone = existing.status !== "done" && issue.status === "done";
       if (becameDone) {
         const dependents = await svc.listWakeableBlockedDependents(issue.id);
+
+        // F4/F8: auto-promote backlog dependents whose blockers just cleared
+        const backlogDependents = dependents.filter((d) => d.status === "backlog");
+        await Promise.all(backlogDependents.map((d) => svc.update(d.id, { status: "todo" })));
+
+        // F7: batch-fetch parent assignees for orphan (no-assignee) dependents
+        const orphanParentIds = [
+          ...new Set(
+            dependents
+              .filter((d) => !d.assigneeAgentId && d.parentId)
+              .map((d) => d.parentId!),
+          ),
+        ];
+        const parentRows =
+          orphanParentIds.length > 0
+            ? await svc.getAssigneesByIds(orphanParentIds)
+            : ([] as Array<{ id: string; assigneeAgentId: string | null }>);
+        const parentAssigneeById = new Map(parentRows.map((p) => [p.id, p.assigneeAgentId]));
+
         for (const dependent of dependents) {
-          addWakeup(dependent.assigneeAgentId, {
+          // Resolve the wake target: assignee → parent's assignee → creator
+          let wakeAgentId = dependent.assigneeAgentId ?? null;
+          let wakeReason: string = "issue_blockers_resolved";
+          if (!wakeAgentId) {
+            if (dependent.parentId) {
+              wakeAgentId = parentAssigneeById.get(dependent.parentId) ?? null;
+            }
+            if (!wakeAgentId && dependent.createdByAgentId) {
+              wakeAgentId = dependent.createdByAgentId;
+            }
+            if (wakeAgentId) wakeReason = "issue_orphan_blocker_resolved";
+          }
+          if (!wakeAgentId) continue;
+
+          addWakeup(wakeAgentId, {
             source: "automation",
             triggerDetail: "system",
-            reason: "issue_blockers_resolved",
+            reason: wakeReason,
             payload: {
               issueId: dependent.id,
               resolvedBlockerIssueId: issue.id,
               blockerIssueIds: dependent.blockerIssueIds,
+              ...(wakeReason === "issue_orphan_blocker_resolved" ? { needsAssignee: true } : {}),
             },
+            idempotencyKey: `blockers_resolved:${issue.id}:${dependent.id}`,
             requestedByActorType: actor.actorType,
             requestedByActorId: actor.actorId,
             contextSnapshot: {
               issueId: dependent.id,
               taskId: dependent.id,
-              wakeReason: "issue_blockers_resolved",
+              wakeReason: wakeReason,
               source: "issue.blockers_resolved",
               resolvedBlockerIssueId: issue.id,
               blockerIssueIds: dependent.blockerIssueIds,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2473,6 +2473,14 @@ export function issueService(db: Db) {
       return listIssueProductivityReviewMap(dbOrTx, companyId, sourceIssueIds);
     },
 
+    getAssigneesByIds: async (ids: string[]) => {
+      if (ids.length === 0) return [];
+      return db
+        .select({ id: issues.id, assigneeAgentId: issues.assigneeAgentId })
+        .from(issues)
+        .where(inArray(issues.id, ids));
+    },
+
     listWakeableBlockedDependents: async (blockerIssueId: string) => {
       const blockerIssue = await db
         .select({ id: issues.id, companyId: issues.companyId })
@@ -2486,6 +2494,9 @@ export function issueService(db: Db) {
           id: issues.id,
           assigneeAgentId: issues.assigneeAgentId,
           status: issues.status,
+          parentId: issues.parentId,
+          createdByAgentId: issues.createdByAgentId,
+          createdByUserId: issues.createdByUserId,
         })
         .from(issueRelations)
         .innerJoin(issues, eq(issueRelations.relatedIssueId, issues.id))
@@ -2523,7 +2534,7 @@ export function issueService(db: Db) {
       }
 
       return candidates
-        .filter((candidate) => candidate.assigneeAgentId && !["backlog", "done", "cancelled"].includes(candidate.status))
+        .filter((candidate) => !["done", "cancelled"].includes(candidate.status))
         .map((candidate) => {
           const blockers = blockersByIssueId.get(candidate.id) ?? [];
           return {
@@ -2535,7 +2546,11 @@ export function issueService(db: Db) {
         .filter((candidate) => candidate.allBlockersDone)
         .map((candidate) => ({
           id: candidate.id,
-          assigneeAgentId: candidate.assigneeAgentId!,
+          assigneeAgentId: candidate.assigneeAgentId,
+          status: candidate.status,
+          parentId: candidate.parentId,
+          createdByAgentId: candidate.createdByAgentId,
+          createdByUserId: candidate.createdByUserId,
           blockerIssueIds: candidate.blockerIssueIds,
         }));
     },


### PR DESCRIPTION
## Summary

THEA-2810 Pillar 2 — when a blocker issue flips to `done`, automatically walk its outbound dependency edges and fire wakeups on all newly-unblocked dependents.

- **F4/F8 — backlog auto-promotion**: `backlog` dependents whose all blockers are now `done` are immediately promoted to `todo` before wakeups fire, so agents boot into a ready state.
- **AC#3/F7 — orphan routing**: dependents with no assignee fall back to the parent issue's assignee, then to the creator, with `reason: issue_orphan_blocker_resolved` and `needsAssignee: true` in the payload.
- **AC#4 — idempotency key**: every blocker-resolved wake carries `idempotencyKey: "blockers_resolved:<blockerIssueId>:<dependentId>"` to prevent duplicate wakes on retries.
- **`getAssigneesByIds`**: new batch lookup on `issueService` resolves parent assignees in a single DB round-trip (avoids N+1).
- **`listWakeableBlockedDependents`** expanded to return `status`, `parentId`, `createdByAgentId` and now includes `backlog` dependents (previously filtered out).

## Test plan

- [x] 6 vitest integration tests in `issue-dependency-wakeups-routes.test.ts` — all passing (`Tests 6 passed (6)`)
  - Wakes dependents when final blocker transitions to `done`
  - Wakes parent when all direct children become terminal
  - Attaches `idempotencyKey` on blocker-resolved wakes (AC#4)
  - Auto-promotes `backlog` dependents to `todo` and wakes all siblings (AC#1/AC#2/F4/F8)
  - Wakes parent assignee when orphan dependent has no assignee (AC#3/F7)
  - Falls back to creator when orphan has no assignee and no parent (F7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)