### PR TITLE
docs(skills/paperclip): document reading and resolving issue-thread interactions

### DIFF
--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -679,12 +679,173 @@ POST /api/issues/{issueId}/interactions
 
 Rules:
 
-- `continuationPolicy: "wake_assignee"` wakes the assignee only after a `request_confirmation` is accepted.
-- Rejection does not wake the assignee by default. The board/user can add a normal comment when revisions are needed.
+- `continuationPolicy: "wake_assignee"` wakes the assignee on any non-expired resolution (accept or reject).
+- `continuationPolicy: "wake_assignee_on_accept"` wakes the assignee only when the confirmation is accepted; rejection is silent.
+- `continuationPolicy: "none"` (default for `request_confirmation`) never wakes the assignee. Use it when you intend to poll status from another flow.
 - Use idempotency keys that include the target and version, for example `confirmation:${issueId}:plan:${latestRevisionId}`.
 - Set `supersedeOnUserComment: true` when a later board/user comment should expire the pending request. On that wake, revise the artifact/proposal and create a fresh confirmation if approval is still needed.
 - A pending interaction is an explicit waiting path. Before ending the heartbeat, update the source issue into a visible waiting posture, normally `in_review`, and leave a comment that names what the board/user must decide.
 - For plan approval, update the `plan` issue document first, create the confirmation against the latest plan revision, set the source issue to `in_review`, and wait for acceptance before creating implementation subtasks.
+
+### Issue-thread structured questions
+
+Use `ask_user_questions` interactions when you need a structured choice from the board/user (single- or multi-select). Prefer this over a free-text comment when the answer should map cleanly onto follow-up work.
+
+Create a question set:
+
+```json
+POST /api/issues/{issueId}/interactions
+{
+  "kind": "ask_user_questions",
+  "idempotencyKey": "questions:{issueId}:{topic}",
+  "title": "Source needed",
+  "continuationPolicy": "wake_assignee",
+  "payload": {
+    "version": 1,
+    "title": "Pick a source",
+    "submitLabel": "Submit",
+    "questions": [
+      {
+        "id": "source",
+        "prompt": "Which source should we use?",
+        "helpText": "Pick one. We'll cite this in the deliverable.",
+        "selectionMode": "single",
+        "required": true,
+        "options": [
+          { "id": "a", "label": "Option A", "description": "Primary dataset" },
+          { "id": "b", "label": "Option B", "description": "Backup dataset" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- Each question needs a stable `id` unique within the interaction, and each option needs an `id` unique within its question.
+- `selectionMode: "single"` means at most one `optionId` in the response; `"multi"` allows multiple.
+- `required: true` means the user must select at least one option for that question to submit.
+- Default `continuationPolicy` for `ask_user_questions` is `wake_assignee`.
+- Up to 10 questions per interaction, up to 10 options per question.
+
+### Issue-thread task suggestions
+
+Use `suggest_tasks` interactions to propose a set of subtasks that the board/user accepts (in whole or in part). Accepted entries are created as real issues atomically; the response lists the created issue IDs and identifiers.
+
+Create a suggestion:
+
+```json
+POST /api/issues/{issueId}/interactions
+{
+  "kind": "suggest_tasks",
+  "idempotencyKey": "suggest:{issueId}:{planRevisionId}",
+  "title": "Proposed breakdown",
+  "continuationPolicy": "wake_assignee_on_accept",
+  "payload": {
+    "version": 1,
+    "defaultParentId": "{issueId}",
+    "tasks": [
+      {
+        "clientKey": "t1",
+        "title": "Draft listing copy",
+        "description": "Write initial listing copy for plot 1.",
+        "priority": "high",
+        "assigneeAgentId": "{marketerAgentId}"
+      },
+      {
+        "clientKey": "t2",
+        "parentClientKey": "t1",
+        "title": "Review listing copy",
+        "priority": "medium",
+        "assigneeAgentId": "{ceoAgentId}"
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- Each task needs a stable `clientKey` unique within the interaction. Use `parentClientKey` to nest a suggested task under another suggested task in the same interaction; use `parentId` to nest under an existing issue.
+- `assigneeAgentId` and `assigneeUserId` are mutually exclusive.
+- Up to 50 tasks per interaction.
+- On acceptance the board/user can pass `selectedClientKeys` to accept a subset; omitting it accepts everything in the payload.
+- Default `continuationPolicy` is `wake_assignee`. Use `wake_assignee_on_accept` when a rejection should be silent.
+
+### Reading interactions and responses
+
+```
+GET /api/issues/{issueId}/interactions
+```
+
+Returns interactions ordered by `createdAt asc`. Each item shares this base shape:
+
+```jsonc
+{
+  "id": "uuid",
+  "issueId": "uuid",
+  "kind": "suggest_tasks" | "ask_user_questions" | "request_confirmation",
+  "status": "pending" | "accepted" | "rejected" | "answered" | "expired" | "failed",
+  "continuationPolicy": "none" | "wake_assignee" | "wake_assignee_on_accept",
+  "title": "string | null",
+  "summary": "string | null",
+  "idempotencyKey": "string | null",
+  "createdByAgentId": "uuid | null",
+  "createdByUserId": "string | null",
+  "resolvedByAgentId": "uuid | null",
+  "resolvedByUserId": "string | null",
+  "createdAt": "ISO timestamp",
+  "updatedAt": "ISO timestamp",
+  "resolvedAt": "ISO timestamp | null",
+  "payload": { /* the original request payload */ },
+  "result":  { /* null while pending; populated on resolution, see below */ }
+}
+```
+
+`result` shape per kind (populated when `status` leaves `pending`):
+
+- `ask_user_questions` → `{ "version": 1, "answers": [{ "questionId": "...", "optionIds": ["..."] }], "summaryMarkdown": "string | null" }`
+- `suggest_tasks` → `{ "version": 1, "createdTasks": [{ "clientKey": "...", "issueId": "...", "identifier": "...", "parentIssueId": "..." }], "skippedClientKeys": ["..."], "rejectionReason": "string | null" }`
+- `request_confirmation` → `{ "version": 1, "outcome": "accepted" | "rejected" | "superseded_by_comment" | "stale_target" | "duplicate_target", "reason": "string | null", "commentId": "uuid | null" }`
+
+Polling pattern: when you have created an interaction and want to read the response, fetch `GET /api/issues/{issueId}/interactions`, find the item by `id`, and check `status`. While `pending`, `result` is `null`. Once the user resolves it, `result` carries the answer in the shape above. Prefer this over reading the database directly; the API has everything you need.
+
+### Resolving an interaction
+
+The board/user normally drives resolution. Agents with the `issue.interactions:resolve` permission may resolve `suggest_tasks` and `request_confirmation` on behalf of the assignee.
+
+```
+POST /api/issues/{issueId}/interactions/{interactionId}/accept
+{ "selectedClientKeys": ["t1", "t2"] }   // suggest_tasks only; omit to accept all
+
+POST /api/issues/{issueId}/interactions/{interactionId}/reject
+{ "reason": "explanation up to 4000 chars" }   // suggest_tasks and request_confirmation only
+
+POST /api/issues/{issueId}/interactions/{interactionId}/respond
+{ "answers": [{ "questionId": "source", "optionIds": ["a"] }], "summaryMarkdown": "optional" }
+// ask_user_questions only; board auth, not delegated to agents
+```
+
+All three endpoints return the updated interaction with its new `status` and populated `result`.
+
+### Interaction follow-up (assignee wakeup)
+
+When an interaction resolves and `continuationPolicy` triggers a wake, the assignee receives a heartbeat with `PAPERCLIP_WAKE_REASON=issue_commented`. The wake context (`heartbeat-context`) carries:
+
+- `interactionId`
+- `interactionKind` — `suggest_tasks` | `ask_user_questions` | `request_confirmation`
+- `interactionStatus` — `accepted` | `rejected` | `answered` | `expired`
+- `sourceCommentId` — the comment that anchored this interaction (if any)
+- `mutation: "interaction"`
+
+Unlike approvals, no dedicated `PAPERCLIP_INTERACTION_*` env vars are injected — read the wake context and then call `GET /api/issues/{issueId}/interactions` (or filter by id) to retrieve the populated `result`.
+
+Wake firing rules:
+
+- `continuationPolicy: "wake_assignee"` → wake on any non-expired resolution.
+- `continuationPolicy: "wake_assignee_on_accept"` → wake only when `status === "accepted"`.
+- `continuationPolicy: "none"` → never wake (default for `request_confirmation`; the creator must poll).
 
 ### Checking approval status
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents communicate with Paperclip via the API documented in `skills/paperclip/references/api-reference.md`
> - That doc covered `request_confirmation` end-to-end but only listed `ask_user_questions` and `suggest_tasks` in the route table — no payload examples, no response shape, no description of how the creator reads the user's answer
> - When an agent then needed to read a structured user answer, it had no example in the skill and instead inspected the schema source (`packages/db/src/schema/issue_thread_interactions.ts`) and tried `postgres` directly
> - This pull request adds the missing pieces to the skill reference: payload examples for the two undocumented kinds, the `GET /interactions` response shape, the per-kind `result` shape, the resolve endpoints, and a wake-context section symmetric to the existing `Approval follow-up`
> - The benefit is agents stop reaching for source/DB inspection when they need to read or resolve issue-thread interactions, because the skill they already load actually answers the question

## What Changed

Single file: `skills/paperclip/references/api-reference.md`.

- Added section **Issue-thread structured questions** with full `ask_user_questions` payload example, field rules, and default `continuationPolicy`.
- Added section **Issue-thread task suggestions** with full `suggest_tasks` payload example (including `clientKey`/`parentClientKey`), 50-task cap, and `selectedClientKeys` partial-accept note.
- Added section **Reading interactions and responses** with the `GET /api/issues/{issueId}/interactions` base shape and per-kind `result` shapes (`answers` / `createdTasks` / `outcome`). Includes a polling pattern note.
- Added section **Resolving an interaction** documenting `/accept`, `/reject`, `/respond` request bodies and which kinds each endpoint applies to, with a permission note (agents with `issue.interactions:resolve` for accept/reject; board-only for respond).
- Added section **Interaction follow-up (assignee wakeup)** symmetric to the existing **Approval follow-up**: explains the `heartbeat-context` fields the assignee receives (`interactionId`, `interactionKind`, `interactionStatus`, `sourceCommentId`, `mutation: "interaction"`), notes the absence of `PAPERCLIP_INTERACTION_*` env vars, and lists wake-firing rules per `continuationPolicy`.
- Corrected the existing **Issue-thread confirmations** rule list: `wake_assignee` wakes on any non-expired resolution (the previous wording said "only after acceptance"); split out `wake_assignee_on_accept` and noted `none` is the `request_confirmation` default.

## Verification

- All shapes cross-checked against the source on `master` @ `7b44932e`:
  - DB schema: `packages/db/src/schema/issue_thread_interactions.ts` (columns, status enum, `result` jsonb).
  - Validators: `packages/shared/src/validators/issue.ts:392-453` (per-kind discriminated union, accept/reject/respond bodies).
  - Routes: `server/src/routes/issues.ts:208-265` (continuation-wakeup logic), `:556-579` (`assertCanResolveIssueThreadInteraction`), `:3145-3350` (route handlers).
- Per-kind `continuationPolicy` defaults match constants in `packages/shared/src/constants.ts:151-174`.
- Docs-only change. No behavioral risk; not gated by tests. Markdown renders cleanly via local preview.

## Risks

Low risk. Documentation-only edit to a single skill reference file. No source code, schema, route, or build artifact is modified. The one corrected rule (`wake_assignee` semantics) brings the doc in line with the existing source and could only affect agent reasoning that was previously based on the wrong wording.

## Model Used

Claude Opus 4.6 (1M context window) via Claude Code CLI. Used in extended-reasoning mode with Read, Grep, Edit, and Bash tool access. Source verification done by reading the cited files directly during drafting; no inference from prior knowledge.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass — *N/A: documentation-only change, no test-relevant code touched*
- [ ] I have added or updated tests where applicable — *N/A: documentation-only change*
- [ ] If this change affects the UI, I have included before/after screenshots — *N/A: not a UI change*
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
