### PR TITLE
fix: refuse to start in dev when UI dist is missing (BRA-513)

### DIFF
--- a/server/src/__tests__/app-static-ui.test.ts
+++ b/server/src/__tests__/app-static-ui.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { assertStaticUiDist, resolveStaticUiDist } from "../app.js";
+
+// Helpers
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-ui-test-"));
+}
+
+function withIndexHtml(dir: string): string {
+  fs.writeFileSync(path.join(dir, "index.html"), "<html></html>");
+  return dir;
+}
+
+const tmpDirs: string[] = [];
+
+function tmpDir(): string {
+  const d = makeTmpDir();
+  tmpDirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  for (const d of tmpDirs.splice(0)) {
+    fs.rmSync(d, { recursive: true, force: true });
+  }
+});
+
+// resolveStaticUiDist
+
+describe("resolveStaticUiDist", () => {
+  it("returns undefined when no candidate contains index.html", () => {
+    const empty = tmpDir();
+    expect(resolveStaticUiDist([empty, "/does/not/exist"])).toBeUndefined();
+  });
+
+  it("returns the first candidate that contains index.html", () => {
+    const first = withIndexHtml(tmpDir());
+    const second = withIndexHtml(tmpDir());
+    expect(resolveStaticUiDist([first, second])).toBe(first);
+  });
+
+  it("skips candidates missing index.html and returns the next match", () => {
+    const empty = tmpDir();
+    const withHtml = withIndexHtml(tmpDir());
+    expect(resolveStaticUiDist([empty, withHtml])).toBe(withHtml);
+  });
+
+  it("returns undefined for an empty candidates list", () => {
+    expect(resolveStaticUiDist([])).toBeUndefined();
+  });
+});
+
+// assertStaticUiDist — regression for BRA-513
+// Verifies that the server refuses to start in dev when ui/dist is missing,
+// instead of silently falling back to API-only mode.
+
+describe("assertStaticUiDist", () => {
+  it("returns the dist path when index.html is present", () => {
+    const dist = withIndexHtml(tmpDir());
+    expect(assertStaticUiDist([dist], "development")).toBe(dist);
+    expect(assertStaticUiDist([dist], "production")).toBe(dist);
+  });
+
+  it("throws in development when no candidate has index.html", () => {
+    const empty = tmpDir();
+    expect(() => assertStaticUiDist([empty], "development")).toThrow(
+      /UI dist not found|pnpm --filter @paperclipai\/ui build/,
+    );
+  });
+
+  it("includes the searched paths in the dev error message", () => {
+    const empty = tmpDir();
+    expect(() => assertStaticUiDist([empty], "development")).toThrow(empty);
+  });
+
+  it("returns undefined in production when no candidate has index.html", () => {
+    const empty = tmpDir();
+    expect(assertStaticUiDist([empty], "production")).toBeUndefined();
+  });
+
+  it("returns undefined for an unrecognised nodeEnv value", () => {
+    const empty = tmpDir();
+    expect(assertStaticUiDist([empty], "staging")).toBeUndefined();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -105,6 +105,33 @@ export function shouldEnablePrivateHostnameGuard(opts: {
   );
 }
 
+export function resolveStaticUiDist(candidates: string[]): string | undefined {
+  return candidates.find((p) => fs.existsSync(path.join(p, "index.html")));
+}
+
+export function assertStaticUiDist(
+  candidates: string[],
+  nodeEnv: string | undefined = process.env.NODE_ENV,
+): string | undefined {
+  const distPath = resolveStaticUiDist(candidates);
+  if (distPath) return distPath;
+  if (nodeEnv === "development") {
+    const bold = "\x1b[1m";
+    const reset = "\x1b[0m";
+    const red = "\x1b[41m\x1b[97m";
+    throw new Error(
+      `\n${red}${bold}  Paperclip: UI dist not found  ${reset}\n\n` +
+      `Searched:\n${candidates.map((c) => `  • ${c}`).join("\n")}\n\n` +
+      `Fix: ${bold}pnpm --filter @paperclipai/ui build${reset}\n` +
+      `Then restart the server.\n`,
+    );
+  }
+  return undefined;
+}
+
+const API_ONLY_BODY =
+  "Paperclip API — UI not served from this process. See https://paperclip.ing/docs/deployment.";
+
 export async function createApp(
   db: Db,
   opts: {
@@ -302,20 +329,21 @@ export async function createApp(
   }));
 
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  let uiDistPath: string | undefined;
   if (opts.uiMode === "static") {
     // Try published location first (server/ui-dist/), then monorepo dev location (../../ui/dist)
     const candidates = [
       path.resolve(__dirname, "../ui-dist"),
       path.resolve(__dirname, "../../ui/dist"),
     ];
-    const uiDist = candidates.find((p) => fs.existsSync(path.join(p, "index.html")));
-    if (uiDist) {
-      const indexHtml = applyUiBranding(fs.readFileSync(path.join(uiDist, "index.html"), "utf-8"));
+    uiDistPath = assertStaticUiDist(candidates);
+    if (uiDistPath) {
+      const indexHtml = applyUiBranding(fs.readFileSync(path.join(uiDistPath, "index.html"), "utf-8"));
       // Hashed asset files (Vite emits them under /assets/<name>.<hash>.<ext>)
       // never change once built, so they can be cached aggressively.
       app.use(
         "/assets",
-        express.static(path.join(uiDist, "assets"), {
+        express.static(path.join(uiDistPath, "assets"), {
           maxAge: "1y",
           immutable: true,
         }),
@@ -326,7 +354,7 @@ export async function createApp(
       // served by this middleware for `/` and `/index.html`, and it must
       // never outlive the asset hashes it points at.
       app.use(
-        express.static(uiDist, {
+        express.static(uiDistPath, {
           maxAge: "1h",
           setHeaders(res, filePath) {
             if (path.basename(filePath) === "index.html") {
@@ -353,8 +381,20 @@ export async function createApp(
           .end(indexHtml);
       });
     } else {
+      // Non-dev fallback: dist is missing but server is not in dev mode; run API-only
+      // and serve a helpful plain-text response at / so operators see something actionable
+      // instead of Express's default "Cannot GET /".
       console.warn("[paperclip] UI dist not found; running in API-only mode");
+      app.get("/", (_req, res) => {
+        res.status(200).type("text/plain").send(API_ONLY_BODY);
+      });
     }
+  }
+
+  if (opts.uiMode === "none") {
+    app.get("/", (_req, res) => {
+      res.status(200).type("text/plain").send(API_ONLY_BODY);
+    });
   }
 
   if (opts.uiMode === "vite-dev") {
@@ -447,5 +487,5 @@ export async function createApp(
     void flushPluginLogBuffer();
   });
 
-  return app;
+  return { app, uiDistPath };
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -593,7 +593,7 @@ export async function startServer(): Promise<StartedServer> {
     }
   };
   const pluginWorkerManager = createPluginWorkerManager();
-  const app = await createApp(db as any, {
+  const { app, uiDistPath } = await createApp(db as any, {
     uiMode,
     serverPort: listenPort,
     storageService,
@@ -840,6 +840,7 @@ export async function startServer(): Promise<StartedServer> {
         requestedPort: requestedListenPort,
         listenPort,
         uiMode,
+        uiDistPath,
         db: startupDbInfo,
         migrationSummary,
         heartbeatSchedulerEnabled: config.heartbeatSchedulerEnabled,

--- a/server/src/startup-banner.ts
+++ b/server/src/startup-banner.ts
@@ -26,6 +26,7 @@ type StartupBannerOptions = {
   requestedPort: number;
   listenPort: number;
   uiMode: UiMode;
+  uiDistPath?: string;
   db: ExternalPostgresInfo | EmbeddedPostgresInfo;
   migrationSummary: string;
   heartbeatSchedulerEnabled: boolean;
@@ -43,6 +44,7 @@ const ansi = {
   cyan: "\x1b[36m",
   green: "\x1b[32m",
   yellow: "\x1b[33m",
+  red: "\x1b[31m",
   magenta: "\x1b[35m",
   blue: "\x1b[34m",
 };
@@ -143,6 +145,15 @@ export function printStartupBanner(opts: StartupBannerOptions): void {
     color("╚═╝     ╚═╝  ╚═╝╚═╝     ╚══════╝╚═╝  ╚═╝ ╚═════╝╚══════╝╚═╝╚═╝     ", "cyan"),
   ];
 
+  const uiDistRow: string | null = opts.uiMode === "static"
+    ? row(
+        "UI Dist",
+        opts.uiDistPath
+          ? color(opts.uiDistPath, "dim")
+          : color("MISSING — run: pnpm --filter @paperclipai/ui build", "red"),
+      )
+    : null;
+
   const lines = [
     "",
     ...art,
@@ -154,6 +165,7 @@ export function printStartupBanner(opts: StartupBannerOptions): void {
     row("Server", portValue),
     row("API", `${apiUrl} ${color(`(health: ${apiUrl}/health)`, "dim")}`),
     row("UI", uiUrl),
+    uiDistRow,
     row("Database", dbDetails),
     row("Migrations", opts.migrationSummary),
     row(


### PR DESCRIPTION
## Thinking Path

> - Paperclip's server package boots with one of three UI modes: `vite-dev`, `static`, or `none`. In `static` mode it resolves the bundled SPA from `server/ui-dist/` or `../../ui/dist`.
> - When neither candidate directory contains an `index.html`, the server silently degrades to API-only mode — the SPA fallback route is never registered, and any non-`/api` GET returns Express's default `Cannot GET /` 404.
> - This degradation was invisible: a single `console.warn` at `server/src/app.ts:353` was the only signal, but `GET /api/health` still returns 200, so port-readiness checks pass and the operator has no obvious indication that the UI is missing.
> - This caused real pain on [BRA-497]: the board was unreachable, the only clue was a buried console warning, and the fix was non-obvious.
> - This PR makes the failure loud in dev (throw with a red banner and the exact fix command), routes the intentional API-only case (`uiMode === "none"`) and the non-dev fallback to a `200 text/plain` response at `/` instead of Express's cryptic `Cannot GET /`, surfaces the resolved dist path in the startup banner, and adds a regression test.

## What Changed

- **`server/src/app.ts`**: extracted two new exported helpers:
  - `resolveStaticUiDist(candidates)` — pure, testable; finds the first candidate directory containing `index.html`
  - `assertStaticUiDist(candidates, nodeEnv?)` — throws a red-banner `Error` in `NODE_ENV=development` when no dist is found; in non-dev it returns `undefined` and falls through to the API-only path
- **`server/src/app.ts`** (static-UI block): replaced the silent `console.warn` + bare fallback with a call to `assertStaticUiDist`; added a `GET /` handler that returns `200 text/plain` with an actionable message when the dist is missing in non-dev environments
- **`server/src/app.ts`** (`uiMode === "none"`): added the same `200 text/plain` handler so the intentional API-only mode no longer returns Express's default `Cannot GET /`
- **`server/src/app.ts`**: `createApp` now returns `{ app, uiDistPath }` (was `app`) so callers can forward the resolved path
- **`server/src/index.ts`**: destructures `{ app, uiDistPath }` from `createApp` and passes `uiDistPath` to `printStartupBanner`
- **`server/src/startup-banner.ts`**: added `uiDistPath?: string` to `StartupBannerOptions`, added `"red"` to the ANSI color map, added a dedicated `"UI Dist"` row that shows the resolved path (dimmed) or `"MISSING — run: pnpm --filter @paperclipai/ui build"` in red
- **`server/src/__tests__/app-static-ui.test.ts`** (new): 9 tests covering `resolveStaticUiDist` (returns undefined when missing, returns first matching candidate, skips non-matching candidates, handles empty list) and `assertStaticUiDist` (returns path when present, throws in dev when missing, error includes searched paths, returns undefined in non-dev, returns undefined for unrecognised env)

## Verification

```bash
# Run the new regression tests
node_modules/.bin/vitest run server/src/__tests__/app-static-ui.test.ts
# → 9 tests pass

# Run adjacent app unit tests to confirm no regressions
node_modules/.bin/vitest run server/src/__tests__/app-hmr-port.test.ts \
  server/src/__tests__/app-private-hostname-gate.test.ts \
  server/src/__tests__/app-vite-dev-routing.test.ts
# → 10 tests pass

# Typecheck
cd server && tsc --noEmit
# → clean
```

Manual: boot the server in `NODE_ENV=development` with no `ui/dist/` present → process exits with a clear red banner. Boot with `serveUi: false` (uiMode=none) → `GET /` returns `200 text/plain` with the API-only message.

## Risks

- **Return-type change on `createApp`**: the function now returns `{ app, uiDistPath }` instead of `app`. Only one caller (`server/src/index.ts`) is affected; tests that import `createApp` from `app.ts` directly were not found (they use local wrapper functions). Risk: low.
- **Non-dev behavior change**: previously the non-dev missing-dist fallback silently served no route at `/`; now it serves `200 text/plain`. This is strictly more correct and more useful. Risk: low.
- **`assertStaticUiDist` throws in dev**: replaces a `console.warn` with a thrown `Error`. This is the intended behavior; any process that was relying on the server starting in API-only mode silently in dev will now fail fast. Risk: intentional and desired.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Tool use and code execution enabled (Claude Code agent)
- Extended context

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge