### PR TITLE
fix: agent stays idle after transient errors and stream timeouts

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,7 +10,7 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|stream\s+idle\s+timeout)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
   /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6124,7 +6124,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const nextStatus =
       runningCount > 0
         ? "running"
-        : outcome === "succeeded" || outcome === "cancelled"
+        : outcome === "succeeded" || outcome === "cancelled" || outcome === "timed_out"
           ? "idle"
           : "error";
 
@@ -7876,7 +7876,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
       }
-      await finalizeAgentStatus(agent.id, outcome);
+      // A terminal Claude SDK result (type=result, any is_error) means Claude itself
+      // completed — the adapter infrastructure did not crash. Only "adapter_failed"
+      // (unrecognised process crash, manifest mismatch, etc.) should pin the agent in
+      // error so new wakeups are blocked. All other failed outcomes return to idle.
+      const agentFinalizeOutcome =
+        outcome === "failed" && adapterResult.errorCode !== "adapter_failed"
+          ? "succeeded"
+          : outcome;
+      await finalizeAgentStatus(agent.id, agentFinalizeOutcome);
     } catch (err) {
       const message = redactCurrentUserText(
         err instanceof Error ? err.message : "Unknown adapter failure",


### PR DESCRIPTION
## Summary

Three related fixes to prevent agents getting stuck in `error` state after recoverable Claude SDK errors (tracked internally as TUR-258):

- **`finalizeAgentStatus` — `timed_out` → `idle`**: A timeout outcome no longer pins the agent in error; it returns to idle so future wakeups are not blocked.
- **Completion call site — non-`adapter_failed` → `idle`**: When Claude SDK emits a terminal `type=result` (including `is_error: true`), the run completed at the application level. Only a raw adapter crash (`adapter_failed` error code) should block the agent. All other failed outcomes now resolve to `succeeded` for the purposes of agent-status finalisation.
- **`CLAUDE_TRANSIENT_UPSTREAM_RE` — add `stream idle timeout`**: The Claude SDK emits "stream idle timeout" on connection stalls. Adding this phrase triggers the transient-retry path instead of treating the run as a hard failure.

## Root cause

Previously `finalizeAgentStatus` treated `timed_out` as `"error"` (same as `failed`), and any `failed` outcome — including normal SDK errors — would set the agent to `error` status, preventing the next scheduled wakeup from checking out the issue.

## Test plan

- [ ] Agent that times out returns to `idle`, picks up next heartbeat normally
- [ ] Agent whose Claude run ends with a non-zero exit but a valid `type=result` SDK payload returns to `idle`
- [ ] Error message matching "stream idle timeout" triggers transient retry, not hard failure
- [ ] Agent with a genuine adapter crash (`adapter_failed`) still goes to `error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)