### PR TITLE
fix(recovery): break silent-run cascade with log mtime + meta-review exemption

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -323,6 +323,10 @@ The recovery service owns this contract:
 - honor active snooze decisions before creating more review work
 - build the `outputSilence` summary shown by live-run and active-run API responses
 
+Liveness signals are layered. The `lastOutputAt` and `lastOutputSeq` columns track structured streaming events the heartbeat pipeline observed. Some adapters (notably `claude_local`) can keep appending the per-run ndjson at `data/run-logs/{companyId}/{agentId}/{runId}.ndjson` while the structured sequence counter pauses, so a candidate flagged by the SQL filter is also re-evaluated against the on-disk log mtime before any review work is created. A run-log mtime within the suspicion window is treated as proof of activity even when `lastOutputAt` is stale.
+
+Meta-review chains are excluded by design. A run whose triggering source issue itself has `originKind=stale_active_run_evaluation` is the watchdog reviewing another silent run; the periodic scan does not spawn another `stale_active_run_evaluation` for that meta-review, so the watchdog cannot recursively review itself.
+
 Suspicious silence creates a medium-priority review issue for the selected recovery owner. Critical silence raises that review issue to high priority and blocks the source issue on the explicit evaluation task without cancelling the active process.
 
 Watchdog decisions are explicit operator/recovery-owner decisions:

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
 import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { resolvePaperclipInstanceRoot } from "../home-paths.ts";
 import {
   agents,
   companies,
@@ -220,7 +223,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const leakedJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
     const leakedGithubToken = "ghp_1234567890abcdefghijklmnopqrstuvwxyz";
-    const { companyId } = await seedRunningRun({
+    const seeded = await seedRunningRun({
       now,
       ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
       logChunk: [
@@ -229,6 +232,12 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
         `GITHUB_TOKEN=${leakedGithubToken}`,
       ].join("\n"),
     });
+    const { companyId } = seeded;
+    const [seededRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, seeded.runId));
+    const basePath = process.env.RUN_LOG_BASE_PATH ?? path.resolve(resolvePaperclipInstanceRoot(), "data", "run-logs");
+    const absLogPath = path.resolve(basePath, seededRun!.logRef!);
+    const staleMtime = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 5 * 60_000);
+    await fs.utimes(absLogPath, staleMtime, staleMtime);
     const heartbeat = heartbeatService(db);
 
     await heartbeat.scanSilentActiveRuns({ now, companyId });
@@ -546,5 +555,82 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       createdByRunId: randomUUID(),
     });
     expect(decision.createdByRunId).toBe(managerRunId);
+  });
+
+  it("treats a recently-written ndjson log file as fresh activity even when lastOutputAt is stale", async () => {
+    const now = new Date();
+    const seeded = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 5 * 60_000,
+      logChunk: "tool_use {}\ntool_result {}\n",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId: seeded.companyId });
+
+    expect(result.scanned).toBe(1);
+    expect(result.freshLog).toBe(1);
+    expect(result.created).toBe(0);
+    expect(result.evaluationIssueIds).toEqual([]);
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, seeded.companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+  });
+
+  it("still flags a run whose ndjson log file mtime is older than the suspicion window", async () => {
+    const now = new Date();
+    const seeded = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 5 * 60_000,
+      logChunk: "tool_use {}\ntool_result {}\n",
+    });
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, seeded.runId));
+    const basePath = process.env.RUN_LOG_BASE_PATH ?? path.resolve(resolvePaperclipInstanceRoot(), "data", "run-logs");
+    const absLogPath = path.resolve(basePath, run!.logRef!);
+    const staleMtime = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS - 5 * 60_000);
+    await fs.utimes(absLogPath, staleMtime, staleMtime);
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId: seeded.companyId });
+
+    expect(result.freshLog).toBe(0);
+    expect(result.created).toBe(1);
+  });
+
+  it("does not spawn a meta-review when the source issue is itself a stale_active_run_evaluation", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const seeded = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 5 * 60_000,
+    });
+    const phantomRunId = randomUUID();
+    await db
+      .update(issues)
+      .set({
+        originKind: "stale_active_run_evaluation",
+        originId: phantomRunId,
+        originFingerprint: `stale_active_run:${seeded.companyId}:${phantomRunId}`,
+      })
+      .where(eq(issues.id, seeded.issueId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId: seeded.companyId });
+
+    expect(result.metaReviewSkipped).toBe(1);
+    expect(result.created).toBe(0);
+    expect(result.evaluationIssueIds).toEqual([]);
+    const otherEvaluations = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, seeded.companyId),
+          eq(issues.originKind, "stale_active_run_evaluation"),
+          eq(issues.originId, seeded.runId),
+        ),
+      );
+    expect(otherEvaluations).toHaveLength(0);
   });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -752,6 +752,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
   }
 
+  async function readRunLogMtimeMs(
+    run: Pick<typeof heartbeatRuns.$inferSelect, "id" | "logStore" | "logRef">,
+  ): Promise<number | null> {
+    if (!run.logStore || !run.logRef) return null;
+    try {
+      const stat = await runLogStore.stat({ store: run.logStore as "local_file", logRef: run.logRef });
+      return stat?.mtimeMs ?? null;
+    } catch (err) {
+      logger.warn({ err, runId: run.id }, "failed to stat run log for liveness check");
+      return null;
+    }
+  }
+
   async function resolveStaleRunSourceIssue(run: typeof heartbeatRuns.$inferSelect) {
     const issueId = issueIdFromRunContext(run.contextSnapshot);
     if (!issueId) return null;
@@ -1139,12 +1152,24 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       escalated: 0,
       snoozed: 0,
       skipped: 0,
+      freshLog: 0,
+      metaReviewSkipped: 0,
       evaluationIssueIds: [] as string[],
     };
 
     for (const run of candidates) {
       if (await latestActiveOutputQuietUntilDecision(run.companyId, run.id, now)) {
         result.snoozed += 1;
+        continue;
+      }
+      const logMtimeMs = await readRunLogMtimeMs(run);
+      if (logMtimeMs !== null && logMtimeMs > suspicionBefore.getTime()) {
+        result.freshLog += 1;
+        continue;
+      }
+      const sourceIssue = await resolveStaleRunSourceIssue(run);
+      if (sourceIssue?.originKind === STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND) {
+        result.metaReviewSkipped += 1;
         continue;
       }
       const outcome = await createOrUpdateStaleRunEvaluation({ run, now });

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -27,6 +27,11 @@ export interface RunLogFinalizeSummary {
   compressed: boolean;
 }
 
+export interface RunLogStat {
+  mtimeMs: number;
+  size: number;
+}
+
 export interface RunLogStore {
   begin(input: { companyId: string; agentId: string; runId: string }): Promise<RunLogHandle>;
   append(
@@ -35,6 +40,7 @@ export interface RunLogStore {
   ): Promise<number>;
   finalize(handle: RunLogHandle): Promise<RunLogFinalizeSummary>;
   read(handle: RunLogHandle, opts?: RunLogReadOptions): Promise<RunLogReadResult>;
+  stat(handle: RunLogHandle): Promise<RunLogStat | null>;
 }
 
 function safeSegments(...segments: string[]) {
@@ -143,6 +149,14 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
       const offset = opts?.offset ?? 0;
       const limitBytes = opts?.limitBytes ?? 256_000;
       return readFileRange(absPath, offset, limitBytes);
+    },
+
+    async stat(handle) {
+      if (handle.store !== "local_file") return null;
+      const absPath = resolveWithin(basePath, handle.logRef);
+      const stat = await fs.stat(absPath).catch(() => null);
+      if (!stat) return null;
+      return { mtimeMs: stat.mtimeMs, size: stat.size };
     },
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The recovery service runs a periodic watchdog that flags long-running agent runs producing no observable output
> - That watchdog relied solely on the `lastOutputAt` / `lastOutputSeq` columns to decide whether a run had gone silent
> - For the `claude_local` adapter, those structured signals can stop advancing while the run-log ndjson keeps growing — so healthy runs were being flagged silent, each evaluation was itself a long run that re-tripped the threshold, and the loop self-perpetuated
> - This pull request adds two independent guardrails: a log-file mtime liveness check that treats recent ndjson writes as proof of activity even when `lastOutputAt` is stale, and a meta-review exemption so the watchdog cannot review another watchdog review
> - The benefit is the silent-run watchdog stays useful for genuinely stuck runs while it stops creating cascades of false-positive review issues that consume the agent budget

## What Changed

- `server/src/services/run-log-store.ts` — added `RunLogStat` interface and `stat(handle)` method to `RunLogStore` (returns `{ mtimeMs, size } | null` for portable file-based liveness)
- `server/src/services/recovery/service.ts`:
  - new `readRunLogMtimeMs(run)` helper that stats the per-run ndjson and tolerates missing/unreadable files
  - `scanSilentActiveRuns` now skips a candidate when its log-file mtime falls inside the suspicion window (reported via new `freshLog` counter)
  - `scanSilentActiveRuns` also resolves the source issue and skips when its `originKind === stale_active_run_evaluation` (reported via new `metaReviewSkipped` counter), so the watchdog cannot recursively review another watchdog review
- `doc/execution-semantics.md` — documents the layered liveness contract (`lastOutputAt` + `lastOutputSeq` vs ndjson mtime) and the meta-review guardrail
- `server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`:
  - new test covers the fresh-mtime skip path (stale `lastOutputAt`, fresh ndjson → `freshLog: 1`, no evaluation)
  - new test backdates the log mtime via `fs.utimes` to confirm genuinely stuck runs still get flagged (`created: 1`)
  - new test covers the meta-review skip path (source issue's `originKind` is `stale_active_run_evaluation` → `metaReviewSkipped: 1`)
  - existing redaction test now backdates its log mtime so it keeps exercising the evaluation path under the new semantics

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts` — **11/11 pass** (8 pre-existing + 3 new), including the redaction test that now relies on the explicit mtime backdate
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/recovery-classifiers.test.ts` — **6/6 pass**

Manual scenario the patch addresses (matches the originating bug report): a `claude_local` run with `lastOutputSeq` stuck at 21 and `lastOutputAt` 1h+ stale, but the ndjson at `data/run-logs/{companyId}/{agentId}/{runId}.ndjson` was last appended <10s ago. Pre-patch: the scanner created a `stale_active_run_evaluation` issue, which became its own slow run and re-tripped the threshold. Post-patch: the file mtime check skips the candidate (`freshLog += 1`) and no evaluation issue is created. Genuinely stuck runs (process alive, file untouched ≥ 1h) still get the suspicious / critical evaluation as before.

## Risks

- Low risk overall. The change is additive (extra skip paths) and the existing SQL filter is unchanged.
- Filesystem stat calls add a small amount of I/O per scan candidate, bounded by the existing `limit(100)` cap on the candidates list. Stat failures are caught and logged via the existing `logger.warn` path; the scanner falls through to the prior behaviour rather than skipping silently.
- Adapters whose `logStore`/`logRef` is null (e.g. runs without a local-file run log) keep the old behaviour because `readRunLogMtimeMs` returns `null` in that case — no regression for non-`claude_local` paths.
- The meta-review exemption matches by `originKind` only on the immediate source issue, not by walking ancestors. This is intentional for V1: the existing cascade was caused by the meta-review's own run, which is exactly the case covered. If we observe a deeper recursion in the wild, expanding the check to ancestors is a follow-up.

## Model Used

- Provider / model: Claude (Anthropic)
- Exact model ID: `claude-opus-4-7`
- Capabilities used: tool use (Read / Edit / Bash / Grep), file-system access to a local Paperclip clone, and direct `vitest` / `tsc` execution against the patched tree

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [x] I have updated relevant documentation to reflect my changes (`doc/execution-semantics.md`)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
