### PR TITLE
fix(server): prefer specific bindHost over allowedHostnames[0] in choosePrimaryRuntimeApiUrl

### DIFF
--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -17,6 +17,83 @@ describe("runtime API discovery", () => {
     ).toBe("https://paperclip.example.com");
   });
 
+  it("prefers a specific bind host over allowedHostnames[0] when it is non-loopback and non-wildcard", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["localhost", "100.117.33.83"],
+        bindHost: "100.117.33.83",
+        port: 3100,
+      }),
+    ).toBe("http://100.117.33.83:3100");
+  });
+
+  it("falls back to allowedHostnames[0] when bindHost is the wildcard address", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["host1.example.test"],
+        bindHost: "0.0.0.0",
+        port: 3102,
+      }),
+    ).toBe("http://host1.example.test:3102");
+  });
+
+  it("falls back to allowedHostnames[0] when bindHost is loopback", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["host1.example.test"],
+        bindHost: "127.0.0.1",
+        port: 3102,
+      }),
+    ).toBe("http://host1.example.test:3102");
+  });
+
+  it("falls back to allowedHostnames[0] when bindHost is empty", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["host1.example.test"],
+        bindHost: "",
+        port: 3102,
+      }),
+    ).toBe("http://host1.example.test:3102");
+  });
+
+  it("authPublicBaseUrl always overrides bindHost and allowedHostnames", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: "https://x.example.com",
+        allowedHostnames: ["host1.example.test"],
+        bindHost: "100.117.33.83",
+        port: 3102,
+      }),
+    ).toBe("https://x.example.com");
+  });
+
+  it("falls back to bindHost loopback when there are no allowedHostnames", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: [],
+        bindHost: "127.0.0.1",
+        port: 3102,
+      }),
+    ).toBe("http://127.0.0.1:3102");
+  });
+
+  it("falls back to localhost when bindHost is wildcard and there are no allowedHostnames", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: [],
+        bindHost: "0.0.0.0",
+        port: 3102,
+      }),
+    ).toBe("http://localhost:3102");
+  });
+
   it("builds ordered callback candidates from explicit, allowed, bind, and interface hosts", () => {
     expect(
       buildRuntimeApiCandidateUrls({

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -61,6 +61,16 @@ export function choosePrimaryRuntimeApiUrl(input: {
     }
   }
 
+  // When the server actually listens on a specific (non-loopback, non-wildcard)
+  // address, that address is the only canonical URL that will reach this process.
+  // Returning allowedHostnames[0] in that case is order-sensitive and breaks
+  // setups where the bind address (e.g. a tailnet IP) is not the first allowed
+  // hostname.
+  const bindHost = normalizeHost(input.bindHost);
+  if (bindHost && !isLoopbackHost(bindHost) && !isWildcardHost(bindHost)) {
+    return formatOrigin("http:", bindHost, input.port);
+  }
+
   const allowedHostname = input.allowedHostnames
     .map((value) => value.trim())
     .find(Boolean);
@@ -68,7 +78,6 @@ export function choosePrimaryRuntimeApiUrl(input: {
     return formatOrigin("http:", allowedHostname, input.port);
   }
 
-  const bindHost = normalizeHost(input.bindHost);
   if (bindHost && !isWildcardHost(bindHost)) {
     return formatOrigin("http:", bindHost, input.port);
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The \`@paperclipai/server\` runtime API discovery layer chooses a single canonical URL (\`PAPERCLIP_RUNTIME_API_URL\` / \`PAPERCLIP_API_URL\`) that the server injects into every spawned child agent so the agent can call back to the control plane
> - Today \`choosePrimaryRuntimeApiUrl\` uses \`allowedHostnames[0]\` whenever no explicit \`authPublicBaseUrl\` is set, ignoring the actual \`bindHost\` of the listener
> - That ordering is fine when \`bindHost\` is wildcard (\`0.0.0.0\`) but is wrong whenever the server is intentionally bound to a single specific address (e.g. \`bind=tailnet\` mode listening on a tailscale IP). If \`allowedHostnames\` happens to list \`localhost\` first — which is the default in a fresh install — child agents are told to call back to a host the server does not listen on, fail with \`ECONNREFUSED\`, and only succeed after retrying through documented fallbacks
> - This pull request makes \`choosePrimaryRuntimeApiUrl\` prefer \`bindHost\` over \`allowedHostnames[0]\` when \`bindHost\` is a specific (non-loopback, non-wildcard) address, while preserving every other priority (\`authPublicBaseUrl\` > specific \`bindHost\` > \`allowedHostnames[0]\` > loopback \`bindHost\` > \`localhost\`)
> - The benefit is that \`bind=tailnet\`-style deployments stop emitting an unreachable canonical URL regardless of \`allowedHostnames\` ordering, eliminating a per-agent failure-and-retry round-trip with no behavior change for default loopback or wildcard binds

## What Changed

- \`server/src/runtime-api.ts\`: in \`choosePrimaryRuntimeApiUrl\`, when \`bindHost\` is a specific (non-loopback, non-wildcard) address, return \`http://<bindHost>:<port>\` before falling through to \`allowedHostnames[0]\`. The original loopback \`bindHost\` and \`localhost\` fallbacks are preserved.
- \`server/src/__tests__/runtime-api.test.ts\`: add 7 unit tests covering the new branch and the preserved fallbacks.
  - specific \`bindHost\` beats \`allowedHostnames[0]\`
  - wildcard \`bindHost\` falls through to \`allowedHostnames[0]\`
  - loopback \`bindHost\` falls through to \`allowedHostnames[0]\`
  - empty \`bindHost\` falls through
  - \`authPublicBaseUrl\` always wins over \`bindHost\`
  - loopback \`bindHost\` is used when no \`allowedHostnames\` are set
  - \`localhost\` is used when \`bindHost\` is wildcard and no \`allowedHostnames\` are set
- \`buildRuntimeApiCandidateUrls\` ordering is intentionally untouched, so the existing fallback list (and its tests) keep their current order.

## Verification

\`\`\`bash
cd server
pnpm install --ignore-scripts
./node_modules/.bin/vitest run src/__tests__/runtime-api.test.ts
\`\`\`

Result: \`12 tests passed\` (5 pre-existing + 7 new).

Type-check on the touched file:

\`\`\`bash
cd server
./node_modules/.bin/tsc --noEmit --target ES2022 --module ESNext \\
  --moduleResolution bundler --strict --skipLibCheck --types node \\
  src/runtime-api.ts src/__tests__/runtime-api.test.ts
\`\`\`

Result: clean (no errors).

Reproduction in the field (before this fix):

\`\`\`text
config.allowedHostnames = ["localhost", "100.117.33.83"]
config.bindHost          = "100.117.33.83"

server starts → injects PAPERCLIP_RUNTIME_API_URL=http://localhost:3100 into child agent
child agent: curl http://localhost:3100/api/agents/me  →  ECONNREFUSED (server only listens on 100.117.33.83)
child agent: curl http://100.117.33.83:3100/api/agents/me  →  200 OK
\`\`\`

After this fix the server injects \`http://100.117.33.83:3100\` directly and the first call succeeds.

## Risks

- Low risk. Behavior changes only when \`bindHost\` is a specific (non-loopback, non-wildcard) address. The default \`bindHost\` (\`0.0.0.0\`) and any explicitly loopback bind (\`127.0.0.1\`, \`localhost\`, \`::1\`) take exactly the same path as before, so the common dev/single-host install is unaffected.
- \`authPublicBaseUrl\` remains the highest-priority override — operators with an explicit public base URL see no change.
- No public types or function signatures change. \`buildRuntimeApiCandidateUrls\` and its ordering are unchanged.

## Model Used

- Claude Opus 4.7 (\`claude-opus-4-7\`), via Claude Code CLI / Anthropic SDK. No extended-thinking mode used; standard tool-use loop with file edits and shell commands. Patch authored with codepath context from the downstream Daimonia repro (issue \`DAI-87\`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, no UI changes
- [x] I have updated relevant documentation to reflect my changes — none needed; behavior is internal
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge