### PR TITLE
[ui] Enter-to-send and Shift+Enter newline in MarkdownEditor (ALL-416)

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -1052,7 +1052,7 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
           }}
           onBlur={() => onBlur?.()}
           onKeyDown={(event) => {
-            if (onSubmit && event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+            if (onSubmit && event.key === "Enter" && !event.shiftKey) {
               event.preventDefault();
               onSubmit();
             }
@@ -1131,6 +1131,14 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
               return;
             }
           }
+        }
+
+        // Plain Enter (no Shift) submits — placed after autocomplete so mention-Enter still works
+        if (onSubmit && e.key === "Enter" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+          e.preventDefault();
+          e.stopPropagation();
+          onSubmit();
+          return;
         }
       }}
       onDragEnter={(evt) => {


### PR DESCRIPTION
## Summary

- **Enter** in the chat composer now submits the message (plain Enter, no modifier keys)
- **Shift+Enter** inserts a newline (passes through to MDXEditor/Lexical as a soft line break)
- **Cmd/Ctrl+Enter** still submits (backward compat)
- Autocomplete (@ mentions, /skills) still selects on Enter — the new submit handler is placed **after** the `mentionActive` block so mention-Enter fires first

## Changes

`ui/src/components/MarkdownEditor.tsx`

1. **Rich editor `onKeyDownCapture`** — added a plain-Enter submit block after the autocomplete `mentionActive` block:
   ```js
   // Plain Enter (no Shift) submits — placed after autocomplete so mention-Enter still works
   if (onSubmit && e.key === "Enter" && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
     e.preventDefault();
     e.stopPropagation();
     onSubmit();
     return;
   }
   ```

2. **Fallback `<textarea>` `onKeyDown`** — changed from Cmd/Ctrl+Enter to any Enter without Shift:
   ```js
   if (onSubmit && event.key === "Enter" && !event.shiftKey) {
   ```

## Acceptance criteria

- [x] Pressing Enter submits
- [x] Pressing Shift+Enter inserts newline (not intercepted)
- [x] Autocomplete still works on Enter
- [x] Send button still works
- [x] Cmd/Ctrl+Enter still submits (backward compat)

## Test plan

- Open a chat composer, type a message, press Enter → should submit
- Open a chat composer, type a message, press Shift+Enter → should insert newline
- Trigger an @ mention, navigate with arrows, press Enter → should complete the mention, not submit
- Trigger a /skill, navigate with arrows, press Enter → should complete the skill, not submit
- Press Cmd/Ctrl+Enter → should submit (backward compat)

Resolves ALL-416

🤖 Generated with [Claude Code](https://claude.com/claude-code)