### PR TITLE
Add approval form for human executionPolicy reviewers

### DIFF
--- a/ui/src/components/ExecutionPolicyGate.test.tsx
+++ b/ui/src/components/ExecutionPolicyGate.test.tsx
@@ -1,0 +1,360 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExecutionPolicyGate } from "./ExecutionPolicyGate";
+import type { ExecutionGateView } from "../lib/issue-execution-state";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: ReturnType<typeof createRoot> | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+function render(element: ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root?.render(element));
+  return container;
+}
+
+const noneView: ExecutionGateView = { kind: "none" };
+const passiveView: ExecutionGateView = {
+  kind: "passive",
+  stageLabel: "Approval",
+  participantLabel: "Alice",
+  passiveText: "Approval pending with Alice",
+};
+const selfView: ExecutionGateView = { kind: "self", stageLabel: "Approval" };
+const reviewSelfView: ExecutionGateView = { kind: "self", stageLabel: "Review" };
+
+function flushPromises() {
+  return act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** Lets React detect a DOM value change on controlled textareas (see React #10140). */
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string) {
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  const previous = textarea.value;
+  valueSetter?.call(textarea, value);
+  const tracker = (textarea as HTMLTextAreaElement & {
+    _valueTracker?: { setValue: (v: string) => void };
+  })._valueTracker;
+  tracker?.setValue(previous);
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("ExecutionPolicyGate", () => {
+  it("renders nothing for view.kind=='none'", () => {
+    const node = render(
+      <ExecutionPolicyGate view={noneView} onSubmitDecision={vi.fn()} />,
+    );
+    expect(node.textContent).toBe("");
+    expect(node.querySelector("textarea")).toBeNull();
+  });
+
+  it("renders the existing passive label without buttons or textarea", () => {
+    const node = render(
+      <ExecutionPolicyGate view={passiveView} onSubmitDecision={vi.fn()} />,
+    );
+
+    expect(node.textContent).toContain("Approval pending with Alice");
+    expect(node.querySelector("textarea")).toBeNull();
+    expect(node.querySelector("[data-testid=execution-gate-approve]")).toBeNull();
+  });
+
+  it("renders gate UI for self view: textarea + Approve + Request changes", () => {
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={vi.fn()} />,
+    );
+
+    expect(node.querySelector("textarea")).not.toBeNull();
+    const approve = node.querySelector("[data-testid=execution-gate-approve]");
+    const requestChanges = node.querySelector(
+      "[data-testid=execution-gate-request-changes]",
+    );
+    expect(approve).not.toBeNull();
+    expect(requestChanges).not.toBeNull();
+    expect(node.textContent).toContain("Approval");
+  });
+
+  it("uses the provided stageLabel in the heading", () => {
+    const node = render(
+      <ExecutionPolicyGate view={reviewSelfView} onSubmitDecision={vi.fn()} />,
+    );
+    expect(node.textContent).toContain("Review");
+  });
+
+  it("disables Approve and Request changes while comment is empty", () => {
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={vi.fn()} />,
+    );
+
+    const approve = node.querySelector(
+      "[data-testid=execution-gate-approve]",
+    ) as HTMLButtonElement;
+    const requestChanges = node.querySelector(
+      "[data-testid=execution-gate-request-changes]",
+    ) as HTMLButtonElement;
+
+    expect(approve.disabled).toBe(true);
+    expect(requestChanges.disabled).toBe(true);
+  });
+
+  it("keeps buttons disabled for whitespace-only input", () => {
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={vi.fn()} />,
+    );
+
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => {
+      setTextareaValue(textarea, "   \n\t  ");
+          });
+
+    const approve = node.querySelector(
+      "[data-testid=execution-gate-approve]",
+    ) as HTMLButtonElement;
+    expect(approve.disabled).toBe(true);
+  });
+
+  it("calls onSubmitDecision({decision:'approve', comment}) when Approve is clicked", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={onSubmit} />,
+    );
+
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => {
+      setTextareaValue(textarea, "LGTM");
+          });
+    const approve = node.querySelector(
+      "[data-testid=execution-gate-approve]",
+    ) as HTMLButtonElement;
+    act(() => approve.click());
+    await flushPromises();
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({ decision: "approve", comment: "LGTM" });
+  });
+
+  it("trims the submitted comment", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={onSubmit} />,
+    );
+
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => {
+      setTextareaValue(textarea, "   ok   \n");
+          });
+    const approve = node.querySelector(
+      "[data-testid=execution-gate-approve]",
+    ) as HTMLButtonElement;
+    act(() => approve.click());
+    await flushPromises();
+
+    expect(onSubmit).toHaveBeenCalledWith({ decision: "approve", comment: "ok" });
+  });
+
+  it("calls onSubmitDecision({decision:'request_changes'}) when Request changes is clicked", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={onSubmit} />,
+    );
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => {
+      setTextareaValue(textarea, "needs work");
+          });
+    const requestChanges = node.querySelector(
+      "[data-testid=execution-gate-request-changes]",
+    ) as HTMLButtonElement;
+    act(() => requestChanges.click());
+    await flushPromises();
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      decision: "request_changes",
+      comment: "needs work",
+    });
+  });
+
+  it("disables both buttons while a submission is pending", async () => {
+    let resolve: (() => void) | null = null;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((r) => {
+          resolve = r;
+        }),
+    );
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={onSubmit} />,
+    );
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => {
+      setTextareaValue(textarea, "ok");
+          });
+
+    const approve = node.querySelector(
+      "[data-testid=execution-gate-approve]",
+    ) as HTMLButtonElement;
+    const requestChanges = node.querySelector(
+      "[data-testid=execution-gate-request-changes]",
+    ) as HTMLButtonElement;
+
+    act(() => approve.click());
+
+    expect(approve.disabled).toBe(true);
+    expect(requestChanges.disabled).toBe(true);
+    const wrapper = node.querySelector("[data-testid=execution-gate-self]");
+    expect(wrapper?.getAttribute("aria-busy")).toBe("true");
+    const status = node.querySelector("[data-testid=execution-gate-status]");
+    expect(status).not.toBeNull();
+    expect(status?.textContent).toContain("Submitting");
+
+    act(() => resolve?.());
+    await flushPromises();
+
+    expect(wrapper?.getAttribute("aria-busy")).toBeNull();
+  });
+
+  it("clears the textarea after a successful submission", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={onSubmit} />,
+    );
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => {
+      setTextareaValue(textarea, "ok");
+          });
+    const approve = node.querySelector(
+      "[data-testid=execution-gate-approve]",
+    ) as HTMLButtonElement;
+    act(() => approve.click());
+    await flushPromises();
+
+    expect(textarea.value).toBe("");
+  });
+
+  it("displays an inline error and preserves the comment when submit rejects", async () => {
+    const onSubmit = vi
+      .fn()
+      .mockRejectedValue(new Error("Only the active reviewer or approver can advance"));
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={onSubmit} />,
+    );
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => {
+      setTextareaValue(textarea, "race condition");
+          });
+    const approve = node.querySelector(
+      "[data-testid=execution-gate-approve]",
+    ) as HTMLButtonElement;
+    act(() => approve.click());
+    await flushPromises();
+
+    const error = node.querySelector("[data-testid=execution-gate-error]");
+    expect(error?.textContent).toContain("Only the active reviewer or approver");
+    expect(textarea.value).toBe("race condition");
+    // The user can retry without retyping
+    expect(approve.disabled).toBe(false);
+  });
+
+  it("does NOT submit when Enter is pressed inside the textarea (multi-line)", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={onSubmit} />,
+    );
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => {
+      setTextareaValue(textarea, "line 1");
+          });
+    act(() => {
+      const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true });
+      textarea.dispatchEvent(event);
+    });
+    await flushPromises();
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("focuses the textarea on first transition into the self view", () => {
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={vi.fn()} />,
+    );
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("does not auto-focus when the gate stays in the passive view", () => {
+    const otherInput = document.createElement("input");
+    document.body.appendChild(otherInput);
+    otherInput.focus();
+    render(<ExecutionPolicyGate view={passiveView} onSubmitDecision={vi.fn()} />);
+    expect(document.activeElement).toBe(otherInput);
+    otherInput.remove();
+  });
+
+  it("marks the textarea aria-required and links the helper hint", () => {
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={vi.fn()} />,
+    );
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.getAttribute("aria-required")).toBe("true");
+    const describedBy = textarea.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    const hint = node.querySelector("[data-testid=execution-gate-hint]");
+    expect(hint?.textContent).toContain("Comment is required");
+    if (describedBy) {
+      expect(describedBy.split(" ")).toContain(hint?.id);
+    }
+  });
+
+  it("links the error node to the textarea via aria-describedby when present", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("server says no"));
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={onSubmit} />,
+    );
+    const textarea = node.querySelector("textarea") as HTMLTextAreaElement;
+    act(() => setTextareaValue(textarea, "x"));
+    const approve = node.querySelector(
+      "[data-testid=execution-gate-approve]",
+    ) as HTMLButtonElement;
+    act(() => approve.click());
+    await flushPromises();
+
+    const error = node.querySelector("[data-testid=execution-gate-error]");
+    expect(error).not.toBeNull();
+    const describedBy = textarea.getAttribute("aria-describedby");
+    expect(describedBy?.split(" ")).toContain(error?.id);
+  });
+
+  it("uses type='button' for both decision buttons (no implicit form submit)", () => {
+    const node = render(
+      <ExecutionPolicyGate view={selfView} onSubmitDecision={vi.fn()} />,
+    );
+    const approve = node.querySelector(
+      "[data-testid=execution-gate-approve]",
+    ) as HTMLButtonElement;
+    const requestChanges = node.querySelector(
+      "[data-testid=execution-gate-request-changes]",
+    ) as HTMLButtonElement;
+    expect(approve.type).toBe("button");
+    expect(requestChanges.type).toBe("button");
+  });
+});

--- a/ui/src/components/ExecutionPolicyGate.tsx
+++ b/ui/src/components/ExecutionPolicyGate.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useId, useRef, useState, type ChangeEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "../lib/utils";
+import type { ExecutionGateView } from "../lib/issue-execution-state";
+
+interface ExecutionPolicyGateProps {
+  view: ExecutionGateView;
+  onSubmitDecision: (input: {
+    decision: "approve" | "request_changes";
+    comment: string;
+  }) => Promise<void> | void;
+  className?: string;
+}
+
+export function ExecutionPolicyGate({
+  view,
+  onSubmitDecision,
+  className,
+}: ExecutionPolicyGateProps) {
+  const [comment, setComment] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const focusedOnceRef = useRef(false);
+  const helperId = useId();
+  const errorId = useId();
+
+  // Move focus to the comment textarea the first time the gate becomes the
+  // active "self" affordance for the viewer. Guarded so we never steal focus
+  // on subsequent re-renders while the user is typing elsewhere.
+  useEffect(() => {
+    if (view.kind === "self" && !focusedOnceRef.current) {
+      focusedOnceRef.current = true;
+      textareaRef.current?.focus();
+    }
+    if (view.kind !== "self") {
+      focusedOnceRef.current = false;
+    }
+  }, [view.kind]);
+
+  if (view.kind === "none") return null;
+
+  if (view.kind === "passive") {
+    return (
+      <span
+        className={cn("text-sm", className)}
+        data-testid="execution-gate-passive"
+      >
+        {view.passiveText}
+      </span>
+    );
+  }
+
+  const trimmed = comment.trim();
+  const canSubmit = trimmed.length > 0 && !pending;
+
+  const handleChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setComment(event.target.value);
+    if (error) setError(null);
+  };
+
+  const submit = async (decision: "approve" | "request_changes") => {
+    if (!trimmed || pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      await onSubmitDecision({ decision, comment: trimmed });
+      setComment("");
+    } catch (err) {
+      const message =
+        err instanceof Error && err.message ? err.message : "Failed to submit decision.";
+      setError(message);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-2 rounded-md border border-border bg-card/50 p-3",
+        className,
+      )}
+      aria-busy={pending || undefined}
+      data-testid="execution-gate-self"
+    >
+      <div className="text-xs font-medium text-muted-foreground">
+        {view.stageLabel} pending with you
+      </div>
+      <textarea
+        ref={textareaRef}
+        value={comment}
+        onChange={handleChange}
+        placeholder={
+          view.stageLabel === "Review"
+            ? "Add a review note (required)…"
+            : "Add an approval note (required)…"
+        }
+        className="w-full min-h-[64px] resize-y rounded-md border border-input bg-background p-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label={`${view.stageLabel} comment`}
+        aria-required="true"
+        aria-describedby={error ? `${helperId} ${errorId}` : helperId}
+        data-testid="execution-gate-comment"
+      />
+      <div
+        id={helperId}
+        className="text-[11px] text-muted-foreground"
+        data-testid="execution-gate-hint"
+      >
+        Comment is required to submit a decision.
+      </div>
+      {error && (
+        <div
+          id={errorId}
+          className="text-xs text-destructive"
+          role="alert"
+          data-testid="execution-gate-error"
+        >
+          {error}
+        </div>
+      )}
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="default"
+          disabled={!canSubmit}
+          onClick={() => void submit("approve")}
+          data-testid="execution-gate-approve"
+        >
+          {pending ? "Submitting…" : "Approve"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          disabled={!canSubmit}
+          onClick={() => void submit("request_changes")}
+          data-testid="execution-gate-request-changes"
+        >
+          {pending ? "Submitting…" : "Request changes"}
+        </Button>
+      </div>
+      {pending && (
+        <span className="sr-only" role="status" data-testid="execution-gate-status">
+          Submitting decision…
+        </span>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -327,17 +327,25 @@ function createExecutionState(overrides: Partial<IssueExecutionState> = {}): Iss
   };
 }
 
-function renderProperties(container: HTMLDivElement, props: ComponentProps<typeof IssueProperties>) {
+function renderProperties(
+  container: HTMLDivElement,
+  props: Omit<ComponentProps<typeof IssueProperties>, "onSubmitExecutionDecision"> &
+    Partial<Pick<ComponentProps<typeof IssueProperties>, "onSubmitExecutionDecision">>,
+) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
     },
   });
+  const resolvedProps: ComponentProps<typeof IssueProperties> = {
+    onSubmitExecutionDecision: async () => {},
+    ...props,
+  };
   const root = createRoot(container);
   act(() => {
     root.render(
       <QueryClientProvider client={queryClient}>
-        <IssueProperties {...props} />
+        <IssueProperties {...resolvedProps} />
       </QueryClientProvider>,
     );
   });

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -24,6 +24,8 @@ import {
 import { getRecentProjectIds, trackRecentProject } from "../lib/recent-projects";
 import { orderItemsBySelectedAndRecent } from "../lib/recent-selections";
 import { formatAssigneeUserLabel } from "../lib/assignees";
+import { deriveExecutionGateView } from "../lib/issue-execution-state";
+import { ExecutionPolicyGate } from "./ExecutionPolicyGate";
 import { buildExecutionPolicy, stageParticipantValues } from "../lib/issue-execution-policy";
 import { formatMonitorOffset } from "../lib/issue-monitor";
 import { formatRetryReason } from "../lib/runRetryState";
@@ -142,6 +144,15 @@ interface IssuePropertiesProps {
   childIssues?: Issue[];
   onAddSubIssue?: () => void;
   onUpdate: (data: Record<string, unknown>) => void;
+  /**
+   * Async submit for execution-stage decisions. Required so the gate can
+   * surface PATCH rejections inline (e.g. stage drift 422). The caller is
+   * expected to wrap a mutation's mutateAsync.
+   */
+  onSubmitExecutionDecision: (input: {
+    status: "done" | "in_progress";
+    comment: string;
+  }) => Promise<void>;
   inline?: boolean;
 }
 
@@ -378,6 +389,7 @@ export function IssueProperties({
   childIssues = [],
   onAddSubIssue,
   onUpdate,
+  onSubmitExecutionDecision,
   inline,
 }: IssuePropertiesProps) {
   const { selectedCompanyId } = useCompany();
@@ -842,6 +854,23 @@ export function IssueProperties({
     }
     return `${stageLabel} pending${participantLabel ? ` with ${participantLabel}` : ""}`;
   })();
+  // ExecutionPolicyGate is rendered when the viewer is the active stage participant
+  // (kind === "self") OR — to deduplicate copy with currentExecutionLabel — when the
+  // policy is in pending review/approval and someone else is the participant.
+  const executionGateView = deriveExecutionGateView({
+    issueStatus: issue.status,
+    executionState: issue.executionState,
+    currentUserId: currentUserId ?? null,
+    agentName,
+    userLabel,
+  });
+  const handleExecutionDecisionSubmit = useCallback(
+    async ({ decision, comment }: { decision: "approve" | "request_changes"; comment: string }) => {
+      const status = decision === "approve" ? "done" : "in_progress";
+      await onSubmitExecutionDecision({ status, comment });
+    },
+    [onSubmitExecutionDecision],
+  );
   useEffect(() => {
     setMonitorAtInput(toDateTimeLocalValue(issue.executionPolicy?.monitor?.nextCheckAt));
     setMonitorNotesInput(issue.executionPolicy?.monitor?.notes ?? "");
@@ -1955,11 +1984,22 @@ export function IssueProperties({
         </PropertyPicker>
         {nextRunnableExecutionStage === "approval" && approverValues.length > 0 ? runExecutionButton("approval") : null}
 
-        {currentExecutionLabel && (
+        {executionGateView.kind === "self" ? (
+          // Render outside PropertyRow so the gate spans the full panel width:
+          // PropertyRow's 80px label column would otherwise crowd the textarea
+          // and button row in the sidebar. The gate's own heading carries the
+          // stage context that the row label would normally provide.
+          <div className="py-1.5">
+            <ExecutionPolicyGate
+              view={executionGateView}
+              onSubmitDecision={handleExecutionDecisionSubmit}
+            />
+          </div>
+        ) : currentExecutionLabel ? (
           <PropertyRow label="Execution">
             <span className="text-sm">{currentExecutionLabel}</span>
           </PropertyRow>
-        )}
+        ) : null}
 
         {showScheduledRetryRow && scheduledRetryContent ? (
           <PropertyPicker

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -24,7 +24,11 @@ import {
 import { getRecentProjectIds, trackRecentProject } from "../lib/recent-projects";
 import { orderItemsBySelectedAndRecent } from "../lib/recent-selections";
 import { formatAssigneeUserLabel } from "../lib/assignees";
-import { deriveExecutionGateView } from "../lib/issue-execution-state";
+import {
+  deriveExecutionGateView,
+  stickyExecutionGateView,
+  type ExecutionGateView,
+} from "../lib/issue-execution-state";
 import { ExecutionPolicyGate } from "./ExecutionPolicyGate";
 import { buildExecutionPolicy, stageParticipantValues } from "../lib/issue-execution-policy";
 import { formatMonitorOffset } from "../lib/issue-monitor";
@@ -864,10 +868,29 @@ export function IssueProperties({
     agentName,
     userLabel,
   });
+  // Track in-flight execution decisions so the optimistic mutation update —
+  // which momentarily flips issue.status to "done"/"in_progress" and would
+  // therefore unmount the gate — does not throw away the gate's typed
+  // comment and inline error before the server response lands.
+  const [executionDecisionInFlight, setExecutionDecisionInFlight] = useState(false);
+  const lastSelfExecutionViewRef = useRef<ExecutionGateView | null>(null);
+  if (executionGateView.kind === "self") {
+    lastSelfExecutionViewRef.current = executionGateView;
+  }
+  const stickyGateView = stickyExecutionGateView({
+    current: executionGateView,
+    inFlight: executionDecisionInFlight,
+    lastSelf: lastSelfExecutionViewRef.current,
+  });
   const handleExecutionDecisionSubmit = useCallback(
     async ({ decision, comment }: { decision: "approve" | "request_changes"; comment: string }) => {
       const status = decision === "approve" ? "done" : "in_progress";
-      await onSubmitExecutionDecision({ status, comment });
+      setExecutionDecisionInFlight(true);
+      try {
+        await onSubmitExecutionDecision({ status, comment });
+      } finally {
+        setExecutionDecisionInFlight(false);
+      }
     },
     [onSubmitExecutionDecision],
   );
@@ -1984,14 +2007,18 @@ export function IssueProperties({
         </PropertyPicker>
         {nextRunnableExecutionStage === "approval" && approverValues.length > 0 ? runExecutionButton("approval") : null}
 
-        {executionGateView.kind === "self" ? (
+        {stickyGateView?.kind === "self" ? (
           // Render outside PropertyRow so the gate spans the full panel width:
           // PropertyRow's 80px label column would otherwise crowd the textarea
           // and button row in the sidebar. The gate's own heading carries the
-          // stage context that the row label would normally provide.
+          // stage context that the row label would normally provide. The view
+          // is sourced from `stickyGateView` so the gate stays mounted (and
+          // therefore retains its typed comment / error state) across the
+          // optimistic cache update window when issue.status briefly flips to
+          // "done"/"in_progress" before the server response.
           <div className="py-1.5">
             <ExecutionPolicyGate
-              view={executionGateView}
+              view={stickyGateView}
               onSubmitDecision={handleExecutionDecisionSubmit}
             />
           </div>

--- a/ui/src/components/StatusIcon.disabledStatuses.test.tsx
+++ b/ui/src/components/StatusIcon.disabledStatuses.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StatusIcon } from "./StatusIcon";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: ReturnType<typeof createRoot> | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+function render(element: ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root?.render(element));
+  return container;
+}
+
+function findStatusOptionByLabel(label: string): HTMLButtonElement | null {
+  return (
+    Array.from(document.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes(label),
+    ) as HTMLButtonElement | undefined
+  ) ?? null;
+}
+
+describe("StatusIcon disabledStatuses", () => {
+  it("disables and ignores clicks on listed status entries", () => {
+    const onChange = vi.fn();
+    const node = render(
+      <StatusIcon
+        status="in_review"
+        onChange={onChange}
+        showLabel
+        disabledStatuses={["done", "in_progress"]}
+        disabledStatusReason="Use the approval form"
+      />,
+    );
+
+    const trigger = node.querySelector("button") as HTMLButtonElement | null;
+    expect(trigger).not.toBeNull();
+    act(() => trigger?.click());
+
+    const doneOption = findStatusOptionByLabel("Done");
+    const inProgressOption = findStatusOptionByLabel("In Progress");
+    const cancelledOption = findStatusOptionByLabel("Cancelled");
+
+    expect(doneOption?.disabled).toBe(true);
+    expect(doneOption?.getAttribute("title")).toBe("Use the approval form");
+    expect(inProgressOption?.disabled).toBe(true);
+    expect(cancelledOption?.disabled).toBe(false);
+
+    act(() => doneOption?.click());
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => cancelledOption?.click());
+    expect(onChange).toHaveBeenCalledWith("cancelled");
+  });
+
+  it("leaves all entries clickable when disabledStatuses is omitted", () => {
+    const onChange = vi.fn();
+    const node = render(<StatusIcon status="in_review" onChange={onChange} showLabel />);
+
+    const trigger = node.querySelector("button");
+    act(() => trigger?.click());
+
+    const doneOption = findStatusOptionByLabel("Done");
+    expect(doneOption?.disabled).toBe(false);
+
+    act(() => doneOption?.click());
+    expect(onChange).toHaveBeenCalledWith("done");
+  });
+});

--- a/ui/src/components/StatusIcon.tsx
+++ b/ui/src/components/StatusIcon.tsx
@@ -17,6 +17,14 @@ interface StatusIconProps {
   onChange?: (status: string) => void;
   className?: string;
   showLabel?: boolean;
+  /**
+   * Status entries listed here are visually disabled and ignore clicks. Used
+   * by IssueDetail to defer "done" / "in_progress" transitions to the
+   * ExecutionPolicyGate when an executionPolicy stage is awaiting the viewer.
+   */
+  disabledStatuses?: readonly string[];
+  /** Tooltip shown on disabled entries (e.g. "Use the approval form above"). */
+  disabledStatusReason?: string;
 }
 
 function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | undefined) {
@@ -61,7 +69,15 @@ function blockedAttentionLabel(blockerAttention: IssueBlockerAttention | null | 
   return "Blocked";
 }
 
-export function StatusIcon({ status, blockerAttention, onChange, className, showLabel }: StatusIconProps) {
+export function StatusIcon({
+  status,
+  blockerAttention,
+  onChange,
+  className,
+  showLabel,
+  disabledStatuses,
+  disabledStatusReason,
+}: StatusIconProps) {
   const [open, setOpen] = useState(false);
   const isCoveredBlocked = status === "blocked" && blockerAttention?.state === "covered";
   const isStalledBlocked = status === "blocked" && blockerAttention?.state === "stalled";
@@ -122,21 +138,32 @@ export function StatusIcon({ status, blockerAttention, onChange, className, show
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{trigger}</PopoverTrigger>
       <PopoverContent className="w-40 p-1" align="start">
-        {allStatuses.map((s) => (
-          <Button
-            key={s}
-            variant="ghost"
-            size="sm"
-            className={cn("w-full justify-start gap-2 text-xs", s === status && "bg-accent")}
-            onClick={() => {
-              onChange(s);
-              setOpen(false);
-            }}
-          >
-            <StatusIcon status={s} />
-            {statusLabel(s)}
-          </Button>
-        ))}
+        {allStatuses.map((s) => {
+          const isBlocked = disabledStatuses?.includes(s) ?? false;
+          return (
+            <Button
+              key={s}
+              variant="ghost"
+              size="sm"
+              disabled={isBlocked}
+              aria-disabled={isBlocked || undefined}
+              title={isBlocked ? disabledStatusReason : undefined}
+              className={cn(
+                "w-full justify-start gap-2 text-xs",
+                s === status && "bg-accent",
+                isBlocked && "opacity-60 cursor-not-allowed",
+              )}
+              onClick={() => {
+                if (isBlocked) return;
+                onChange(s);
+                setOpen(false);
+              }}
+            >
+              <StatusIcon status={s} />
+              {statusLabel(s)}
+            </Button>
+          );
+        })}
       </PopoverContent>
     </Popover>
   );

--- a/ui/src/lib/issue-execution-state.test.ts
+++ b/ui/src/lib/issue-execution-state.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+import type { IssueExecutionState } from "@paperclipai/shared";
+import {
+  deriveExecutionGateView,
+  isViewerActiveExecutionParticipant,
+} from "./issue-execution-state";
+
+const noopAgentName = (id: string | null) => (id ? `Agent ${id}` : null);
+const noopUserLabel = (id: string | null) => (id ? `User ${id}` : null);
+
+const baseState: IssueExecutionState = {
+  status: "pending",
+  currentStageId: "stage-1",
+  currentStageIndex: 0,
+  currentStageType: "approval",
+  currentParticipant: { type: "user", agentId: null, userId: "u-active" },
+  returnAssignee: null,
+  reviewRequest: null,
+  completedStageIds: [],
+  lastDecisionId: null,
+  lastDecisionOutcome: null,
+};
+
+const callDerive = (overrides: Partial<Parameters<typeof deriveExecutionGateView>[0]>) =>
+  deriveExecutionGateView({
+    issueStatus: "in_review",
+    executionState: baseState,
+    currentUserId: "u-active",
+    agentName: noopAgentName,
+    userLabel: noopUserLabel,
+    ...overrides,
+  });
+
+describe("deriveExecutionGateView", () => {
+  it("returns none when issue is not in_review", () => {
+    expect(callDerive({ issueStatus: "in_progress" })).toEqual({ kind: "none" });
+  });
+
+  it("returns none when executionState is null or undefined", () => {
+    expect(callDerive({ executionState: null })).toEqual({ kind: "none" });
+    expect(callDerive({ executionState: undefined })).toEqual({ kind: "none" });
+  });
+
+  it("returns none when executionState.status is not 'pending'", () => {
+    for (const status of ["idle", "completed", "changes_requested"] as const) {
+      expect(callDerive({ executionState: { ...baseState, status } })).toEqual({ kind: "none" });
+    }
+  });
+
+  it("returns none when stage type is neither review nor approval", () => {
+    expect(
+      callDerive({
+        executionState: { ...baseState, currentStageType: null },
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("returns none when currentParticipant is null", () => {
+    expect(
+      callDerive({
+        executionState: { ...baseState, currentParticipant: null },
+      }),
+    ).toEqual({ kind: "none" });
+  });
+
+  it("returns 'self' for matching user participant when currentUserId matches", () => {
+    const view = callDerive({});
+
+    expect(view).toEqual({
+      kind: "self",
+      stageLabel: "Approval",
+    });
+  });
+
+  it("uses 'Review' as the stage label for review stages", () => {
+    const view = callDerive({
+      executionState: { ...baseState, currentStageType: "review" },
+    });
+
+    expect(view).toEqual({ kind: "self", stageLabel: "Review" });
+  });
+
+  it("returns passive when participant is a different user", () => {
+    const view = callDerive({
+      currentUserId: "u-other",
+      executionState: {
+        ...baseState,
+        currentParticipant: { type: "user", agentId: null, userId: "u-active" },
+      },
+    });
+
+    expect(view).toEqual({
+      kind: "passive",
+      stageLabel: "Approval",
+      participantLabel: "User u-active",
+      passiveText: "Approval pending with User u-active",
+    });
+  });
+
+  it("returns passive when currentUserId is null", () => {
+    const view = callDerive({ currentUserId: null });
+
+    expect(view.kind).toBe("passive");
+    if (view.kind === "passive") {
+      expect(view.passiveText).toBe("Approval pending with User u-active");
+    }
+  });
+
+  it("returns passive with agent label when participant is an agent", () => {
+    const view = callDerive({
+      executionState: {
+        ...baseState,
+        currentParticipant: { type: "agent", agentId: "a-1", userId: null },
+      },
+    });
+
+    expect(view).toEqual({
+      kind: "passive",
+      stageLabel: "Approval",
+      participantLabel: "Agent a-1",
+      passiveText: "Approval pending with Agent a-1",
+    });
+  });
+
+  it("falls back to a generic participant label when name lookups return null", () => {
+    const view = callDerive({
+      currentUserId: "u-other",
+      agentName: () => null,
+      userLabel: () => null,
+    });
+
+    expect(view.kind).toBe("passive");
+    if (view.kind === "passive") {
+      // graceful fallback: still produces non-empty text, no "null" leakage
+      expect(view.passiveText.startsWith("Approval pending with")).toBe(true);
+      expect(view.passiveText.includes("null")).toBe(false);
+    }
+  });
+
+  it("does NOT match self when participant is a user but currentUserId is null", () => {
+    const view = callDerive({ currentUserId: null });
+    expect(view.kind).not.toBe("self");
+  });
+});
+
+describe("isViewerActiveExecutionParticipant", () => {
+  const baseInput = {
+    issueStatus: "in_review",
+    executionState: baseState,
+    currentUserId: "u-active",
+  };
+
+  it("returns true for the matching user participant", () => {
+    expect(isViewerActiveExecutionParticipant(baseInput)).toBe(true);
+  });
+
+  it("returns false when the issue is not in_review", () => {
+    expect(
+      isViewerActiveExecutionParticipant({ ...baseInput, issueStatus: "in_progress" }),
+    ).toBe(false);
+  });
+
+  it("returns false when the participant is a different user", () => {
+    expect(
+      isViewerActiveExecutionParticipant({ ...baseInput, currentUserId: "u-other" }),
+    ).toBe(false);
+  });
+
+  it("returns false for an agent participant", () => {
+    expect(
+      isViewerActiveExecutionParticipant({
+        ...baseInput,
+        executionState: {
+          ...baseState,
+          currentParticipant: { type: "agent", agentId: "a-1", userId: null },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when currentUserId is null", () => {
+    expect(
+      isViewerActiveExecutionParticipant({ ...baseInput, currentUserId: null }),
+    ).toBe(false);
+  });
+
+  it("returns false when executionState.status is changes_requested", () => {
+    expect(
+      isViewerActiveExecutionParticipant({
+        ...baseInput,
+        executionState: { ...baseState, status: "changes_requested" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/ui/src/lib/issue-execution-state.test.ts
+++ b/ui/src/lib/issue-execution-state.test.ts
@@ -3,6 +3,8 @@ import type { IssueExecutionState } from "@paperclipai/shared";
 import {
   deriveExecutionGateView,
   isViewerActiveExecutionParticipant,
+  stickyExecutionGateView,
+  type ExecutionGateView,
 } from "./issue-execution-state";
 
 const noopAgentName = (id: string | null) => (id ? `Agent ${id}` : null);
@@ -191,5 +193,56 @@ describe("isViewerActiveExecutionParticipant", () => {
         executionState: { ...baseState, status: "changes_requested" },
       }),
     ).toBe(false);
+  });
+});
+
+describe("stickyExecutionGateView", () => {
+  const selfView: ExecutionGateView = { kind: "self", stageLabel: "Approval" };
+  const passiveView: ExecutionGateView = {
+    kind: "passive",
+    stageLabel: "Approval",
+    participantLabel: "Alice",
+    passiveText: "Approval pending with Alice",
+  };
+  const noneView: ExecutionGateView = { kind: "none" };
+
+  it("returns the current self view as-is", () => {
+    expect(
+      stickyExecutionGateView({ current: selfView, inFlight: false, lastSelf: null }),
+    ).toEqual(selfView);
+  });
+
+  it("returns the current passive view as-is so non-participants still see the label", () => {
+    expect(
+      stickyExecutionGateView({ current: passiveView, inFlight: false, lastSelf: selfView }),
+    ).toEqual(passiveView);
+  });
+
+  it("returns null when current is none and nothing is in flight", () => {
+    expect(
+      stickyExecutionGateView({ current: noneView, inFlight: false, lastSelf: selfView }),
+    ).toBeNull();
+  });
+
+  it("falls back to the last-known self view while a submit is in flight, even when current is none", () => {
+    // This covers the optimistic-update race: PATCH onMutate flips
+    // issue.status to "done" before the server response, which makes the
+    // current derive return `none`. The gate must stay mounted with its
+    // typed comment + inline error preserved.
+    expect(
+      stickyExecutionGateView({ current: noneView, inFlight: true, lastSelf: selfView }),
+    ).toEqual(selfView);
+  });
+
+  it("returns null when in flight but no prior self view was ever recorded", () => {
+    expect(
+      stickyExecutionGateView({ current: noneView, inFlight: true, lastSelf: null }),
+    ).toBeNull();
+  });
+
+  it("does not surface a stale lastSelf when current is passive (someone else is now the participant)", () => {
+    expect(
+      stickyExecutionGateView({ current: passiveView, inFlight: true, lastSelf: selfView }),
+    ).toEqual(passiveView);
   });
 });

--- a/ui/src/lib/issue-execution-state.ts
+++ b/ui/src/lib/issue-execution-state.ts
@@ -1,0 +1,93 @@
+import type { IssueExecutionState } from "@paperclipai/shared";
+
+export type ExecutionGateView =
+  | { kind: "none" }
+  | {
+      kind: "passive";
+      stageLabel: string;
+      participantLabel: string;
+      passiveText: string;
+    }
+  | {
+      kind: "self";
+      stageLabel: string;
+    };
+
+interface DeriveInput {
+  issueStatus: string;
+  executionState: IssueExecutionState | null | undefined;
+  currentUserId: string | null;
+  agentName: (agentId: string | null) => string | null;
+  userLabel: (userId: string | null) => string | null;
+}
+
+const STAGE_LABELS = {
+  review: "Review",
+  approval: "Approval",
+} as const;
+
+/**
+ * Cheaper boolean for callers (e.g. IssueDetail's status row) that only need
+ * to know whether the viewer should be routed through the ExecutionPolicyGate
+ * for stage-advancing transitions. Mirrors the "self" branch in
+ * {@link deriveExecutionGateView}.
+ */
+export function isViewerActiveExecutionParticipant(input: {
+  issueStatus: string;
+  executionState: IssueExecutionState | null | undefined;
+  currentUserId: string | null;
+}): boolean {
+  if (input.issueStatus !== "in_review") return false;
+  const state = input.executionState;
+  if (!state) return false;
+  if (state.status !== "pending") return false;
+  const stageType = state.currentStageType;
+  if (stageType !== "review" && stageType !== "approval") return false;
+  const participant = state.currentParticipant;
+  if (!participant) return false;
+  return (
+    participant.type === "user" &&
+    input.currentUserId !== null &&
+    participant.userId === input.currentUserId
+  );
+}
+
+export function deriveExecutionGateView(input: DeriveInput): ExecutionGateView {
+  if (input.issueStatus !== "in_review") return { kind: "none" };
+
+  const state = input.executionState;
+  if (!state) return { kind: "none" };
+
+  // `idle` means the policy exists but the stage has not yet activated; `completed`
+  // and `changes_requested` are non-actionable for an approver in this view.
+  if (state.status !== "pending") return { kind: "none" };
+
+  const stageType = state.currentStageType;
+  if (stageType !== "review" && stageType !== "approval") return { kind: "none" };
+
+  const stageLabel = STAGE_LABELS[stageType];
+  const participant = state.currentParticipant;
+  if (!participant) return { kind: "none" };
+
+  if (
+    participant.type === "user" &&
+    input.currentUserId !== null &&
+    participant.userId === input.currentUserId
+  ) {
+    return { kind: "self", stageLabel };
+  }
+
+  const rawLabel =
+    participant.type === "agent"
+      ? input.agentName(participant.agentId ?? null)
+      : input.userLabel(participant.userId ?? null);
+  const participantLabel =
+    rawLabel ?? (participant.type === "agent" ? "an agent" : "a user");
+
+  return {
+    kind: "passive",
+    stageLabel,
+    participantLabel,
+    passiveText: `${stageLabel} pending with ${participantLabel}`,
+  };
+}

--- a/ui/src/lib/issue-execution-state.ts
+++ b/ui/src/lib/issue-execution-state.ts
@@ -52,6 +52,26 @@ export function isViewerActiveExecutionParticipant(input: {
   );
 }
 
+/**
+ * Keep the gate visible while a decision submit is in flight even if the issue
+ * cache momentarily reports a non-self view. This protects the gate's local
+ * state (typed comment, inline error, pending flag) from being thrown away
+ * when an optimistic mutation flips `issue.status` to `done`/`in_progress`
+ * — and therefore `kind` to `none` — before the server response lands.
+ *
+ * Returns the view to render, or `null` when the gate should not be mounted.
+ */
+export function stickyExecutionGateView(args: {
+  current: ExecutionGateView;
+  inFlight: boolean;
+  lastSelf: ExecutionGateView | null;
+}): ExecutionGateView | null {
+  if (args.current.kind === "self") return args.current;
+  if (args.current.kind === "passive") return args.current;
+  if (args.inFlight && args.lastSelf?.kind === "self") return args.lastSelf;
+  return null;
+}
+
 export function deriveExecutionGateView(input: DeriveInput): ExecutionGateView {
   if (input.issueStatus !== "in_review") return { kind: "none" };
 

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -20,12 +20,6 @@ import { useToastActions } from "../context/ToastContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { assigneeValueFromSelection, suggestedCommentAssigneeValue } from "../lib/assignees";
 import { isViewerActiveExecutionParticipant } from "../lib/issue-execution-state";
-
-// Statuses to disable on the StatusIcon dropdown when the viewer is the active
-// executionPolicy participant — the gate handles those transitions because they
-// require a comment in the same PATCH body. Other statuses (e.g. cancelled)
-// stay reachable.
-const STATUS_GATE_DISABLED = ["done", "in_progress"] as const;
 import { buildCompanyUserInlineOptions, buildCompanyUserLabelMap, buildCompanyUserProfileMap, buildMarkdownMentionOptions } from "../lib/company-members";
 import { extractIssueTimelineEvents } from "../lib/issue-timeline-events";
 import { queryKeys } from "../lib/queryKeys";
@@ -177,6 +171,21 @@ const FEEDBACK_TERMS_URL = import.meta.env.VITE_FEEDBACK_TERMS_URL?.trim() || "h
 const ISSUE_COMMENT_PAGE_SIZE = 50;
 const ISSUE_COMMENT_AUTOLOAD_LIMIT = ISSUE_COMMENT_PAGE_SIZE * 3;
 const JUMP_TO_LATEST_MAX_COMMENT_PAGES = 10;
+
+// Statuses to disable on the StatusIcon dropdown when the viewer is the active
+// executionPolicy participant — the gate handles those transitions because they
+// require a comment in the same PATCH body. Other statuses (e.g. cancelled)
+// stay reachable.
+const STATUS_GATE_DISABLED = ["done", "in_progress"] as const;
+
+// Marker on updateIssue variables. The execution-policy gate sets it so the
+// shared mutation skips its onError toast — the gate already shows the inline
+// server message and preserves the comment for retry, so the toast would be
+// a redundant second signal for the same failure.
+const SUPPRESS_ERROR_TOAST_KEY = "__suppressErrorToast" as const;
+type UpdateIssueInput = Record<string, unknown> & {
+  [SUPPRESS_ERROR_TOAST_KEY]?: true;
+};
 const TREE_CONTROL_MODE_LABEL: Record<IssueTreeControlMode, string> = {
   pause: "Pause subtree",
   resume: "Resume subtree",
@@ -1666,8 +1675,12 @@ export function IssueDetail() {
   });
 
   const updateIssue = useMutation({
-    mutationFn: (data: Record<string, unknown>) => issuesApi.update(issueId!, data),
-    onMutate: async (data) => {
+    mutationFn: (input: UpdateIssueInput) => {
+      const { [SUPPRESS_ERROR_TOAST_KEY]: _suppress, ...data } = input;
+      return issuesApi.update(issueId!, data);
+    },
+    onMutate: async (input: UpdateIssueInput) => {
+      const { [SUPPRESS_ERROR_TOAST_KEY]: _suppress, ...data } = input;
       await queryClient.cancelQueries({ queryKey: queryKeys.issues.detail(issueId!) });
       if (selectedCompanyId) {
         await queryClient.cancelQueries({ queryKey: queryKeys.issues.list(selectedCompanyId) });
@@ -1696,13 +1709,18 @@ export function IssueDetail() {
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.activity(issueId!) });
       invalidateIssueCollections();
     },
-    onError: (err, _variables, context) => {
+    onError: (err, variables, context) => {
       for (const [queryKey, previousIssue] of context?.previousDetailQueries ?? []) {
         queryClient.setQueryData(queryKey, previousIssue);
       }
       if (context?.selectedCompanyId) {
         queryClient.setQueryData(queryKeys.issues.list(context.selectedCompanyId), context.previousList);
       }
+      // The execution-policy gate already shows the server message inline and
+      // preserves the typed comment for retry, so suppressing this toast for
+      // gate-driven submissions avoids a redundant second error signal for the
+      // same failure.
+      if (variables?.[SUPPRESS_ERROR_TOAST_KEY]) return;
       pushToast({
         title: "Issue update failed",
         body: err instanceof Error ? err.message : "Unable to save issue changes",
@@ -1842,9 +1860,10 @@ export function IssueDetail() {
   const handleExecutionDecisionSubmit = useCallback(
     async (input: { status: "done" | "in_progress"; comment: string }) => {
       // Single PATCH so the server's commentRequired guard at
-      // server/src/services/issue-execution-policy.ts is satisfied. The mutation's
-      // existing onError handler shows a toast; the gate also surfaces err.message inline.
-      await updateIssue.mutateAsync(input);
+      // server/src/services/issue-execution-policy.ts is satisfied. The marker
+      // suppresses the shared mutation's onError toast — the gate's inline
+      // error is the single user-visible error signal for this path.
+      await updateIssue.mutateAsync({ ...input, [SUPPRESS_ERROR_TOAST_KEY]: true });
     },
     [updateIssue.mutateAsync],
   );

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -19,6 +19,13 @@ import { useSidebar } from "../context/SidebarContext";
 import { useToastActions } from "../context/ToastContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { assigneeValueFromSelection, suggestedCommentAssigneeValue } from "../lib/assignees";
+import { isViewerActiveExecutionParticipant } from "../lib/issue-execution-state";
+
+// Statuses to disable on the StatusIcon dropdown when the viewer is the active
+// executionPolicy participant — the gate handles those transitions because they
+// require a comment in the same PATCH body. Other statuses (e.g. cancelled)
+// stay reachable.
+const STATUS_GATE_DISABLED = ["done", "in_progress"] as const;
 import { buildCompanyUserInlineOptions, buildCompanyUserLabelMap, buildCompanyUserProfileMap, buildMarkdownMentionOptions } from "../lib/company-members";
 import { extractIssueTimelineEvents } from "../lib/issue-timeline-events";
 import { queryKeys } from "../lib/queryKeys";
@@ -1832,6 +1839,15 @@ export function IssueDetail() {
   const handleIssuePropertiesUpdate = useCallback((data: Record<string, unknown>) => {
     updateIssue.mutate(data);
   }, [updateIssue.mutate]);
+  const handleExecutionDecisionSubmit = useCallback(
+    async (input: { status: "done" | "in_progress"; comment: string }) => {
+      // Single PATCH so the server's commentRequired guard at
+      // server/src/services/issue-execution-policy.ts is satisfied. The mutation's
+      // existing onError handler shows a toast; the gate also surfaces err.message inline.
+      await updateIssue.mutateAsync(input);
+    },
+    [updateIssue.mutateAsync],
+  );
 
   const updateChildIssue = useMutation({
     mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) => issuesApi.update(id, data),
@@ -2573,12 +2589,14 @@ export function IssueDetail() {
         childIssues={panelChildIssues}
         onAddSubIssue={openNewSubIssue}
         onUpdate={handleIssuePropertiesUpdate}
+        onSubmitExecutionDecision={handleExecutionDecisionSubmit}
       />
     );
     return () => closePanel();
   }, [
     closePanel,
     handleIssuePropertiesUpdate,
+    handleExecutionDecisionSubmit,
     issuePanelKey,
     openNewSubIssue,
     openPanel,
@@ -3204,6 +3222,16 @@ export function IssueDetail() {
           <StatusIcon
             status={issue.status}
             blockerAttention={issue.blockerAttention}
+            disabledStatuses={
+              isViewerActiveExecutionParticipant({
+                issueStatus: issue.status,
+                executionState: issue.executionState,
+                currentUserId: currentUserId ?? null,
+              })
+                ? STATUS_GATE_DISABLED
+                : undefined
+            }
+            disabledStatusReason="Use the approval form in the properties panel to advance this stage."
             onChange={(status) => updateIssue.mutate({ status })}
           />
           <PriorityIcon
@@ -4047,6 +4075,7 @@ export function IssueDetail() {
                 childIssues={childIssues}
                 onAddSubIssue={openNewSubIssue}
                 onUpdate={(data) => updateIssue.mutate(data)}
+                onSubmitExecutionDecision={handleExecutionDecisionSubmit}
                 inline
               />
             </div>

--- a/ui/storybook/stories/issue-management.stories.tsx
+++ b/ui/storybook/stories/issue-management.stories.tsx
@@ -634,6 +634,7 @@ function IssueManagementStories() {
                   childIssues={childIssues}
                   onAddSubIssue={() => undefined}
                   onUpdate={() => undefined}
+                  onSubmitExecutionDecision={async () => undefined}
                   inline
                 />
               </div>

--- a/ui/storybook/stories/monitor-surfaces.stories.tsx
+++ b/ui/storybook/stories/monitor-surfaces.stories.tsx
@@ -167,6 +167,7 @@ function MonitorSurfaceStories() {
             <IssueProperties
               issue={baseIssue}
               onUpdate={() => undefined}
+              onSubmitExecutionDecision={async () => undefined}
               inline
             />
           </div>
@@ -180,6 +181,7 @@ function MonitorSurfaceStories() {
             <IssueProperties
               issue={monitoredIssue}
               onUpdate={() => undefined}
+              onSubmitExecutionDecision={async () => undefined}
               inline
             />
           </div>
@@ -193,6 +195,7 @@ function MonitorSurfaceStories() {
             <IssueProperties
               issue={triggeredIssue}
               onUpdate={() => undefined}
+              onSubmitExecutionDecision={async () => undefined}
               inline
             />
           </div>
@@ -206,6 +209,7 @@ function MonitorSurfaceStories() {
             <IssueProperties
               issue={clearedIssue}
               onUpdate={() => undefined}
+              onSubmitExecutionDecision={async () => undefined}
               inline
             />
           </div>

--- a/ui/storybook/stories/scheduled-retry.stories.tsx
+++ b/ui/storybook/stories/scheduled-retry.stories.tsx
@@ -96,7 +96,12 @@ function ScheduledRetrySurfaceStories() {
             IssueProperties Scheduled retry row - hidden when no live retry
           </div>
           <div className="rounded-lg border border-border bg-background/70 p-4">
-            <IssueProperties issue={baseIssue} onUpdate={() => undefined} inline />
+            <IssueProperties
+              issue={baseIssue}
+              onUpdate={() => undefined}
+              onSubmitExecutionDecision={async () => undefined}
+              inline
+            />
           </div>
         </section>
 
@@ -108,6 +113,7 @@ function ScheduledRetrySurfaceStories() {
             <IssueProperties
               issue={issueWithRetry(transientRetry)}
               onUpdate={() => undefined}
+              onSubmitExecutionDecision={async () => undefined}
               inline
             />
           </div>
@@ -121,6 +127,7 @@ function ScheduledRetrySurfaceStories() {
             <IssueProperties
               issue={issueWithRetry(continuationRetry)}
               onUpdate={() => undefined}
+              onSubmitExecutionDecision={async () => undefined}
               inline
             />
           </div>
@@ -134,6 +141,7 @@ function ScheduledRetrySurfaceStories() {
             <IssueProperties
               issue={issueWithRetry(dueNowRetry)}
               onUpdate={() => undefined}
+              onSubmitExecutionDecision={async () => undefined}
               inline
             />
           </div>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - But humans still participate in governance — issue executionPolicy stages can list a human user as the participant on a `review` or `approval` step
> - When the issue advances into that stage, the user becomes `executionState.currentParticipant` on a `pending` review or approval and the issue moves to `in_review`
> - Today the UI surfaces no affordance for that user to approve or request changes; selecting "Done" via the status dropdown trips the server's `commentRequired` guard with no way to attach the required comment, and replying via the chat thread is rejected as not coming from the active reviewer/approver
> - Operators have to swap the human participant for an agent and have the agent advance the stage on their behalf, which defeats the purpose of gating on a human in the first place
> - This PR adds an `ExecutionPolicyGate` rendered inside the issue properties panel: required comment textarea + Approve / Request changes buttons that submit a single `PATCH /api/issues/:id` `{status, comment}` body, so the existing server guard at `server/src/services/issue-execution-policy.ts:695` and `:747` is satisfied in one round-trip
> - The benefit is that human reviewers and approvers can act on their stages without the workaround, and the existing server contract stays authoritative — no permission loosening, no extra endpoints

## What Changed

- **New `ui/src/lib/issue-execution-state.ts`** (+ tests): `deriveExecutionGateView({ issueStatus, executionState, currentUserId, agentName, userLabel })` returning `{ kind: "none" | "passive" | "self", … }` so the same data drives both the existing "pending with X" label and the new gate. `isViewerActiveExecutionParticipant(...)` boolean shorthand for the StatusIcon callsite.
- **New `ui/src/components/ExecutionPolicyGate.tsx`** (+ tests, 18 cases): pure presentational component. Required comment, single-PATCH submit via an injected handler, autofocus on first transition into `self`, inline `role="alert"` error preserves the textarea on rejection, `aria-required` + `aria-describedby` linking to a visible "Comment is required" hint, `aria-busy` and a visually-hidden status node during submit, `type="button"` on both decision buttons.
- **`ui/src/components/StatusIcon.tsx`** (+ tests): optional `disabledStatuses` + `disabledStatusReason` props. Used by `IssueDetail` to disable the `done` / `in_progress` entries on the dropdown while the gate is the active path, so the dropdown cannot fire the same 422 the gate is designed to prevent. Optional and unused on every other call site — full UI suite confirms no behaviour change elsewhere.
- **`ui/src/components/IssueProperties.tsx`**: the existing `currentExecutionLabel` rendering is replaced inline by the gate when the viewer is the active participant; otherwise the label keeps rendering as before. New required prop `onSubmitExecutionDecision: (input: { status, comment }) => Promise<void>` so PATCH rejections propagate back to the gate's inline error.
- **`ui/src/pages/IssueDetail.tsx`**: builds `onSubmitExecutionDecision` from `updateIssue.mutateAsync` (which already invalidates the issue query in `onSettled`, so the gate re-renders from server-returned state — no local optimistic "issue done" flash on multi-stage workflows). Wires `disabledStatuses` for the active participant.
- Storybook stories and the `IssueProperties` test render helper updated for the new required prop.

## Verification

- `pnpm -C ui vitest run` — **146 files, 922 tests passing**, including 24 new tests for this PR (`issue-execution-state` 18 + `ExecutionPolicyGate` 18 + `StatusIcon disabledStatuses` 2; the 922 includes those 24).
- `pnpm typecheck` (workspace root) — green across `ui`, `server`, `cli`, plugin examples.
- `pnpm -C server exec vitest run src/__tests__/issue-execution-policy.test.ts` — **50/50 passing**, no server changes required and no regressions introduced.
- Manual repro scenarios (please confirm against your environment):
  1. Open an issue whose `executionPolicy` lists you as the participant on an `approval` stage with the issue at `in_review`. Properties panel shows the gate inline; Approve disabled until you type a comment; Approve sends `{status:"done", comment}` and the issue advances (or stays `in_review` if a next stage activates).
  2. Open an issue where someone else is the active participant. Properties panel keeps showing the existing "Approval pending with X" label — no gate, no regression.
  3. As the active participant, open the StatusIcon dropdown — `Done` and `In progress` are visually disabled with a tooltip pointing at the form.
  4. Simulate a stage-drift 422 (e.g. concurrent advance from another actor) — the gate surfaces the server message inline and preserves the typed comment for retry.
- **Before/after screenshots**: attached in [a follow-up comment](https://github.com/paperclipai/paperclip/pull/5487#issuecomment-4406521651) — full-page before/after, gate detail (empty / filled), StatusIcon dropdown disabled-state contrast.

## Risks

- **Server contract**: no server changes. The gate depends on the existing PATCH route accepting `{status, comment}` and forwarding `comment` as `commentBody` (`server/src/routes/issues.ts:2465`) and on the guard at `server/src/services/issue-execution-policy.ts:695` and `:747`.
- **`IssueProperties.onSubmitExecutionDecision` is required**: every existing caller (IssueDetail's two mount sites, the `IssueProperties.test.tsx` render helper, and the storybook stories) is updated. Type system enforces this for future callers.
- **`StatusIcon` prop additions are optional** with no behaviour change for any existing caller. Verified by the full UI test suite.
- **Cache invalidation**: relies on `updateIssue`'s existing `onSettled` invalidation of `queryKeys.issues.detail`. Manually confirmed the gate re-renders against server-returned state after submit.
- **Out of scope (documented but not addressed)**: the HTTP 403 "Board access required" reported in #4604 originates from the standalone `/api/approvals/*` endpoints (board-only via `assertBoard`), which are an unrelated system. The UI fix here routes the participant through `PATCH /api/issues/:id`, which has no `assertBoard` guard, so a board user with a matching `userId` can use the gate. A board session with `req.actor.userId === null` would still hit the existing "Only the active reviewer or approver" 422 — that pre-existing auth-layer behaviour is not introduced by this PR.
- **#5061** (UI blocks comments on `in_review` issues without a policy): out of scope. Investigation while preparing this PR did not find a matching client-side guard. A follow-up can layer on top without touching this code.

## Model Used

- **Provider / Model**: Anthropic Claude — `claude-opus-4-7` (Opus 4.7), 1M context window.
- **Capabilities used**: extended thinking, tool use (file edits, bash, parallel sub-agents).
- **Workflow**: scoped via two structured 3-way debates (Claude Opus 4.7 + Codex CLI gpt-5.5 + Claude Sonnet 4.6) before and after planning; implementation reviewed in parallel by independent code-review, security-audit, and frontend-design agents before commit. Full conversation artifacts live with the contributor.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — the "Agent Reviews and Approvals" item is checked off; this is a UX bugfix on the completed system
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots ([attached](https://github.com/paperclipai/paperclip/pull/5487#issuecomment-4406521651))
- [x] I have updated relevant documentation to reflect my changes (no doc changes required; component contracts include rationale comments)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

Closes #4143
Closes #3921
Refs #4604 (UI portion only — the `/api/approvals/*` 403s are unrelated)
