### PR TITLE
[codex] Document Permisoria Obsidian handoff

### DIFF
--- a/doc/PERMISORIA-OBSIDIAN.md
+++ b/doc/PERMISORIA-OBSIDIAN.md
@@ -1,0 +1,47 @@
+# Permisoria Obsidian Integration
+
+This repository remains the implementation source for Paperclip.
+
+For the local `Permisoria Admin` Paperclip company, curated operating knowledge lives in the separate Permisoria Obsidian vault:
+
+`/Users/giovannytorresadrovet/Documents/Permisoria Obsidian Vault`
+
+Start in the vault at:
+
+- `00_Index/Source of Truth Map.md`
+- `00_Index/Paperclip Operations.md`
+- `20_Runbooks/Paperclip Runtime Operations.md`
+- `20_Runbooks/Paperclip Obsidian Integration.md`
+- `40_Reference/Paperclip Obsidian Access Map.md`
+- `40_Reference/Paperclip Skill Cleanup Map.md`
+
+## Ownership Boundary
+
+Paperclip owns live execution state:
+
+- issues, comments, work products, approvals, activity
+- agents, skills, projects, goals, budgets, cost events
+- secrets, runtime env bindings, heartbeat runs, checkout/run state
+
+This repository owns implementation contracts:
+
+- code, migrations, tests, build/deploy commands
+- `doc/SPEC-implementation.md` for the V1 build contract
+- `doc/execution-semantics.md` for runtime/liveness semantics
+- `doc/DEVELOPING.md` for local development commands
+- API and adapter documentation under `docs/`
+
+Obsidian owns curated Permisoria operating memory:
+
+- source-of-truth maps
+- runbooks
+- durable operating decisions
+- reviewed snapshots that point back to Paperclip or Git
+
+Do not copy raw Paperclip run logs, full issue threads, secrets, tokens, or transient execution traces into Obsidian.
+
+## When Updating Docs
+
+- Update repo docs when behavior, commands, schema, APIs, or implementation contracts change.
+- Update Obsidian when the durable operating policy or Permisoria-specific source-of-truth map changes.
+- If repo docs and Obsidian disagree, trust repo docs for implementation behavior and Paperclip for live state, then update the Obsidian note.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies and keeps execution state in the control plane.
> - The repository remains the implementation source for Paperclip code, runtime behavior, and contributor-facing docs.
> - The local `Permisoria Admin` company now uses a separate Permisoria Obsidian vault for curated operating knowledge.
> - Contributors and operators need a repo-local pointer so they do not mistake Obsidian notes for implementation contracts or duplicate Permisoria policy into core docs.
> - This pull request adds a narrow handoff document that links the repo to the external vault while preserving Git, Paperclip, and Obsidian source-of-truth boundaries.
> - The benefit is a safer operational bridge without adding runtime behavior, secrets, or product-specific policy to the Paperclip V1 contract.

## What Changed

- Added `doc/PERMISORIA-OBSIDIAN.md` as a local pointer to the separate Permisoria Obsidian vault.
- Documented which system owns Paperclip execution state, repo implementation contracts, and curated Permisoria operating memory.
- Added guardrails against copying raw Paperclip logs, secrets, tokens, or transient execution traces into Obsidian.

## Verification

- Reviewed `ROADMAP.md`; this is a docs/pointer change and does not implement a roadmap-level core feature.
- Reviewed `.github/PULL_REQUEST_TEMPLATE.md` and used every required section in this PR body.
- Verified the branch diff against `origin/master` is limited to `doc/PERMISORIA-OBSIDIAN.md`.
- No test suite was run because this is documentation-only and does not affect code, schema, runtime behavior, or UI.

## Risks

- Low runtime risk: documentation-only change.
- The path is local-machine specific, so it is useful for this Permisoria operating environment but not a general Paperclip product contract.
- If the vault moves, this pointer will need to be updated.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5.5, tool-enabled coding agent with local shell and GitHub CLI access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
