### PR TITLE
fix(plugin-sdk): resolve symlinks in runWorker main-module guard

### DIFF
--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -34,6 +34,7 @@
  * @see PLUGIN_SPEC.md §14 — SDK Surface
  */
 
+import { realpathSync } from "node:fs";
 import path from "node:path";
 import { createInterface, type Interface as ReadlineInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
@@ -223,10 +224,25 @@ export function runWorker(
   }
   const entry = process.argv[1];
   if (typeof entry !== "string") return;
-  const thisFile = path.resolve(fileURLToPath(moduleUrl));
-  const entryPath = path.resolve(entry);
+  // Resolve symlinks on both sides before comparing. On macOS, /tmp is a
+  // symlink to /private/tmp; the host's spawn passes the kernel-resolved
+  // real path as argv[1], while fileURLToPath(import.meta.url) preserves
+  // the un-resolved path the module was loaded with. Without realpath the
+  // comparison fails for any plugin built under /tmp and the worker exits
+  // silently (code=0) before the RPC host starts. realpathSync is a no-op
+  // when no symlinks are involved.
+  const thisFile = realPathOrSelf(path.resolve(fileURLToPath(moduleUrl)));
+  const entryPath = realPathOrSelf(path.resolve(entry));
   if (thisFile === entryPath) {
     startWorkerRpcHost({ plugin });
+  }
+}
+
+function realPathOrSelf(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
   }
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through plugins; \`@paperclipai/plugin-sdk\` provides the worker bootstrap that every plugin uses to start its RPC host
> - \`runWorker(plugin, import.meta.url)\` in \`worker-rpc-host.ts\` guards on \`path.resolve(fileURLToPath(moduleUrl)) === path.resolve(process.argv[1])\` so the RPC host only starts when the file is run as a main module (not when imported from a test)
> - On macOS \`/tmp\` is a symlink to \`/private/tmp\`; the kernel resolves it for argv[1] but \`fileURLToPath\` doesn't, so the comparison fails and the worker exits silently with code 0 before the host can initialize — surfaced to the plugin developer only as \`Activation failed: Worker process exited (code=0, signal=null)\` with no further diagnostic
> - This bites every plugin developer who clones into \`/tmp\` (a common workflow for ephemeral experiments), and is non-obvious because the same plugin works fine when relocated
> - This pull request resolves symlinks on both sides via \`fs.realpathSync\` before comparing, with a try/catch fallback that preserves the previous behavior for missing paths
> - The benefit is plugins built under symlinked paths (\`/tmp\`, FUSE/overlayfs, sandboxed filesystems) initialize correctly with no developer-visible behavior change on non-symlinked paths

## What Changed

- \`packages/plugins/sdk/src/worker-rpc-host.ts\`: import \`realpathSync\` from \`node:fs\`, wrap both sides of the main-module comparison through a \`realPathOrSelf\` helper that swallows ENOENT/EACCES so the previous fallback semantics hold.

## Verification

Reproduced on macOS 25.4 (Darwin), Node 22, with a plugin checkout under \`/tmp\`:

- **Pre-fix**: plugin install succeeds, manifest is parsed, lifecycle reports \`status: ready\`. First tool dispatch returns \`Activation failed: Worker initialize failed for "<plugin-uuid>": Worker process exited (code=0, signal=null)\`. The worker's argv[1] is the kernel real path \`/private/tmp/.../dist/worker.js\` while the module URL resolves to \`/tmp/.../dist/worker.js\`; the guard returns false silently.
- **Post-fix**: \`realpathSync\` collapses both sides to \`/private/tmp/.../dist/worker.js\`; guard passes, RPC host starts, plugin activates and dispatches tools normally.

\`realpathSync\` is a no-op when no symlinks are involved, so this change is behavior-equivalent on Linux/CI and on macOS plugins not located under \`/tmp\`. Built locally (\`pnpm --filter @paperclipai/plugin-sdk build\`) — no type errors. The package has no test script today; happy to add a unit test for \`runWorker\` if you'd like one in this PR.

## Risks

**Low.** \`realpathSync\` is the wrong call for plugins that intentionally rely on symlink-preserving path identity, but no such case exists in the worker bootstrap — the guard's whole purpose is "is this file the entrypoint of the current Node process?", which is a real-path question. The try/catch fallback means a missing file degrades to the un-realpath'd comparison, which is the pre-fix behavior.

Behaviour-equivalent for the path the SDK has historically taken; only changes the symlinked-path case that was previously a silent failure.

## Model Used

- Provider: Anthropic Claude Code
- Capability details: tool use (file edit, bash, gh CLI), used end-to-end for repro analysis, fix authoring, and PR drafting

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass — \`pnpm --filter @paperclipai/plugin-sdk build\` is green; the SDK package has no \`test\` script so no test run to report. Happy to add one.
- [ ] I have added or updated tests where applicable — see note above
- [x] If this change affects the UI, I have included before/after screenshots — N/A, SDK-only fix
- [x] I have updated relevant documentation to reflect my changes — JSDoc-adjacent inline comment explains the symlink rationale
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge