### PR TITLE
fix(recovery): make stranded-issue sweep descendant-aware (PLA-315)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2827,4 +2827,192 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
   });
+
+  it("skips a parent issue when a direct descendant has a live heartbeat run (PLA-321)", async () => {
+    const { companyId, agentId, issueId: parentIssueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+    });
+
+    const childAgentId = randomUUID();
+    const childIssueId = randomUUID();
+    const childRunId = randomUUID();
+    const childWakeupRequestId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db.insert(agents).values({
+      id: childAgentId,
+      companyId,
+      name: "ChildCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: childWakeupRequestId,
+      companyId,
+      agentId: childAgentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: childIssueId },
+      status: "claimed",
+      runId: childRunId,
+      claimedAt: now,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: childRunId,
+      companyId,
+      agentId: childAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId: childWakeupRequestId,
+      contextSnapshot: { issueId: childIssueId, taskId: childIssueId },
+      startedAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: childIssueId,
+      companyId,
+      parentId: parentIssueId,
+      title: "Live child of stranded parent",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: childAgentId,
+      checkoutRunId: childRunId,
+      executionRunId: childRunId,
+      issueNumber: 9001,
+      identifier: `T-CHILD-9001`,
+      startedAt: now,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.escalated).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.issueIds).not.toContain(parentIssueId);
+
+    const parent = await db.select().from(issues).where(eq(issues.id, parentIssueId)).then((rows) => rows[0] ?? null);
+    expect(parent?.status).toBe("in_progress");
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+
+    // The active descendant has its own assignee; the parent's agent must not have been re-woken either.
+    const parentAgentWakes = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, agentId)));
+    expect(parentAgentWakes.every((row) => row.reason !== "issue_assignment_recovery")).toBe(true);
+  });
+
+  it("skips a grandparent issue when only a 2-deep descendant has a live heartbeat run (PLA-321 recursion)", async () => {
+    const { companyId, agentId, issueId: grandparentIssueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+    });
+
+    const middleIssueId = randomUUID();
+    const grandchildIssueId = randomUUID();
+    const grandchildAgentId = randomUUID();
+    const grandchildRunId = randomUUID();
+    const grandchildWakeupRequestId = randomUUID();
+    const now = new Date("2026-03-19T02:00:00.000Z");
+
+    // Middle issue exists in the chain but has no live run/wake of its own.
+    await db.insert(issues).values({
+      id: middleIssueId,
+      companyId,
+      parentId: grandparentIssueId,
+      title: "Inert middle of chain",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 9100,
+      identifier: `T-MID-9100`,
+    });
+
+    await db.insert(agents).values({
+      id: grandchildAgentId,
+      companyId,
+      name: "GrandchildCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: grandchildWakeupRequestId,
+      companyId,
+      agentId: grandchildAgentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId: grandchildIssueId },
+      status: "claimed",
+      runId: grandchildRunId,
+      claimedAt: now,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: grandchildRunId,
+      companyId,
+      agentId: grandchildAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "running",
+      wakeupRequestId: grandchildWakeupRequestId,
+      contextSnapshot: { issueId: grandchildIssueId, taskId: grandchildIssueId },
+      startedAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: grandchildIssueId,
+      companyId,
+      parentId: middleIssueId,
+      title: "Live grandchild driving the chain",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: grandchildAgentId,
+      checkoutRunId: grandchildRunId,
+      executionRunId: grandchildRunId,
+      issueNumber: 9101,
+      identifier: `T-GC-9101`,
+      startedAt: now,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.escalated).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.issueIds).not.toContain(grandparentIssueId);
+
+    const grandparent = await db.select().from(issues).where(eq(issues.id, grandparentIssueId)).then((rows) => rows[0] ?? null);
+    expect(grandparent?.status).toBe("in_progress");
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+  });
+
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -392,7 +392,37 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows[0] ?? null);
   }
 
+  async function collectIssueAndDescendantIds(
+    companyId: string,
+    rootIssueId: string,
+    maxDepth = 50,
+  ): Promise<string[]> {
+    const visited = new Set<string>([rootIssueId]);
+    let frontier: string[] = [rootIssueId];
+    for (let depth = 0; depth < maxDepth && frontier.length > 0; depth += 1) {
+      const children = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            inArray(issues.parentId, frontier),
+          ),
+        );
+      const next: string[] = [];
+      for (const child of children) {
+        if (!visited.has(child.id)) {
+          visited.add(child.id);
+          next.push(child.id);
+        }
+      }
+      frontier = next;
+    }
+    return Array.from(visited);
+  }
+
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
+    const issueIds = await collectIssueAndDescendantIds(companyId, issueId);
     const [run, deferredWake] = await Promise.all([
       db
         .select({ id: heartbeatRuns.id })
@@ -401,7 +431,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           and(
             eq(heartbeatRuns.companyId, companyId),
             inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
-            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+            inArray(sql<string>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`, issueIds),
           ),
         )
         .limit(1)
@@ -413,7 +443,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           and(
             eq(agentWakeupRequests.companyId, companyId),
             eq(agentWakeupRequests.status, "deferred_issue_execution"),
-            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+            inArray(sql<string>`${agentWakeupRequests.payload} ->> 'issueId'`, issueIds),
           ),
         )
         .limit(1)


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, so its harness must reliably distinguish stranded work from work that is making progress somewhere in the issue graph.
> - The recovery subsystem (`server/src/services/recovery/service.ts`) sweeps assigned `todo`/`in_progress` issues and files `Recover stalled issue …` recovery tickets when no live execution path exists.
> - The current `hasActiveExecutionPath(companyId, issueId)` predicate only considers `heartbeatRuns` and `agentWakeupRequests` rows whose `contextSnapshot.issueId` / `payload.issueId` matches the issue itself.
> - That misses the common tracker/parent shape where the parent's own `executionRunId` is null but a descendant is actively running — three false-positive recoveries fired today against PLA-305 (PLA-310, PLA-314, PLA-320), and CEO escalated.
> - This pull request widens the predicate so that an assigned issue is treated as live if **any descendant** (via `parentId`, BFS-bounded, cycle-safe) has a live run or deferred wake.
> - The benefit is that tracker/parent issues stop being escalated to `blocked` while their child work is still alive, eliminating the recurring noise without weakening leaf-stranded detection.

## What Changed

- `server/src/services/recovery/service.ts`: added `collectIssueAndDescendantIds(companyId, rootIssueId, maxDepth = 50)` — BFS over `issues.parentId`, deduped via a `visited` set, depth-bounded to defuse pathological cycles. `hasActiveExecutionPath` now unions descendant ids with the issue itself and feeds the union into the existing two queries via `inArray(sql<string>\`… ->> 'issueId'\`, issueIds)`. Sibling / related-work links are intentionally not consulted; only `parentId` descendants.
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: added two integration tests covering the parent-with-live-child scenario and a 2-deep grandparent → parent → grandchild chain where only the grandchild has the live run. Both assert that `reconcileStrandedAssignedIssues()` does not enqueue recovery, does not escalate, and does not create a stranded recovery issue when a descendant is alive.

## Verification

```
$ pnpm --filter @paperclipai/server exec vitest run heartbeat-process-recovery
…
 Test Files  1 passed (1)
      Tests  45 passed (45)
   Duration  30.45s
```

Failing-then-passing demonstration of the new tests against current `master`:

```
$ git stash push -- server/src/services/recovery/service.ts   # revert only the fix
$ pnpm --filter @paperclipai/server exec vitest run heartbeat-process-recovery -t "PLA-321"
…
 FAIL  … > skips a parent issue when a direct descendant has a live heartbeat run (PLA-321)
 FAIL  … > skips a grandparent issue when only a 2-deep descendant has a live heartbeat run (PLA-321 recursion)
      Tests  2 failed | 43 skipped (45)

$ git stash pop                                                # restore the fix
$ pnpm --filter @paperclipai/server exec vitest run heartbeat-process-recovery -t "PLA-321"
…
 ✓ … > skips a parent issue when a direct descendant has a live heartbeat run (PLA-321)
 ✓ … > skips a grandparent issue when only a 2-deep descendant has a live heartbeat run (PLA-321 recursion)
      Tests  2 passed | 43 skipped (45)
```

No production sweep was needed to repro — the new tests reproduce the symptom deterministically.

## Risks

- **False negatives if descendant query mis-detects activity from unrelated runs.** Mitigated by scoping with `eq(heartbeatRuns.companyId, companyId)` and `inArray(heartbeatRuns.status, EXECUTION_PATH_HEARTBEAT_RUN_STATUSES)`, and by collecting descendants via the strictly hierarchical `parentId` link only — siblings / `issueRelations.blocks` etc. are deliberately ignored.
- **Recursion depth / cycles.** BFS is bounded at `maxDepth = 50` and uses a `visited` set, so pathological data (e.g. a cycle introduced by a bad migration) cannot infinitely loop the sweep.
- **Per-sweep DB load.** One additional `select id from issues where companyId = ? and parentId IN (frontier)` round-trip per BFS layer per candidate. In the common shallow-tree case this is one extra query per issue. The existing recovery sweep already issues several queries per candidate, so the marginal cost is small.
- **No behavior change for genuine leaf strandedness.** The 43 existing recovery tests (covering leaf todo/in_progress strandedness, productive-continuation recovery, successful-run handoff, paused-tree holds, etc.) continue to pass unchanged.

## Model Used

- Claude Opus 4.6 (`claude-opus-4-7`), via Claude Code, with extended thinking + tool use (file edits, vitest invocation, git/gh CLI). No other models contributed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — this is a Path-1 bug fix in the recovery sweep, not a roadmap item
- [x] I have run tests locally and they pass (`pnpm --filter @paperclipai/server exec vitest run heartbeat-process-recovery` → 45/45)
- [x] I have added or updated tests where applicable (two new integration tests, both fail on `master` and pass with the fix)
- [x] If this change affects the UI, I have included before/after screenshots — N/A, server-only change
- [x] I have updated relevant documentation to reflect my changes — N/A, internal predicate change with no public API surface; behavior is documented in code via the new helper and in the failing/passing test cases
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Follows `CONTRIBUTING.md` PR template — sections present: Thinking Path, What Changed, Verification, Risks, Model Used, Checklist.
