### PR TITLE
fix(PLA-323): thread pluginDbId through registerPluginTools so dispatch can find the worker

### DIFF
--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1904,7 +1904,11 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        // Pass the DB UUID (`pluginId`) as the third arg so dispatch can correlate
+        // each tool to the worker manager (keyed by DB UUID, not by plugin key).
+        // Without this, `workerManager.isRunning(tool.pluginDbId)` checks the plugin
+        // KEY against a UUID-keyed map and fails closed — see PLA-323.
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.test.ts
+++ b/server/src/services/plugin-tool-dispatcher.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+
+import { createPluginToolDispatcher } from "./plugin-tool-dispatcher.js";
+
+/**
+ * PLA-323 regression: the dispatcher's `registerPluginTools(...)` must thread
+ * an optional `pluginDbId` (the plugin row's DB UUID) through to the registry
+ * so that each registered tool's `tool.pluginDbId` is the UUID, not the plugin
+ * key.
+ *
+ * Why this matters: `executeTool` in `plugin-tool-registry.ts` checks
+ * `workerManager.isRunning(tool.pluginDbId)` to decide whether to dispatch.
+ * The worker manager is keyed by DB UUID. If `pluginDbId` is left to default
+ * to the plugin key (e.g. `"platform.cad"`), every dispatch fails closed with
+ * `502 "worker for plugin '<key>' is not running"` even when the worker is
+ * running. PLA-308 hit this path for `cad:run_script` / `cad:export`.
+ */
+describe("PluginToolDispatcher.registerPluginTools — pluginDbId threading (PLA-323)", () => {
+  function makeManifest(pluginKey: string): PaperclipPluginManifestV1 {
+    return {
+      id: pluginKey,
+      apiVersion: 1,
+      version: "1.0.0",
+      displayName: "Test plugin",
+      description: "fixture for PLA-323",
+      author: "test",
+      categories: ["automation"],
+      capabilities: ["agent.tools.register"],
+      entrypoints: { worker: "dist/worker.js" },
+      tools: [
+        {
+          name: "run_script",
+          displayName: "Run Script",
+          description: "Run a script",
+          parametersSchema: { type: "object", properties: {} },
+        },
+      ],
+    } as PaperclipPluginManifestV1;
+  }
+
+  it("stamps the DB UUID onto registered tools when pluginDbId is provided", () => {
+    const dispatcher = createPluginToolDispatcher();
+    const pluginKey = "platform.cad";
+    const pluginDbId = "1f8d7b6c-0a2e-4f1c-9b3d-2c4f5e6a7b8d";
+
+    dispatcher.registerPluginTools(pluginKey, makeManifest(pluginKey), pluginDbId);
+
+    const tool = dispatcher.getTool(`${pluginKey}:run_script`);
+    expect(tool, "tool should be registered under namespaced name").not.toBeNull();
+    expect(tool!.pluginId).toBe(pluginKey);
+    // The fix under test: pluginDbId is the UUID, not the plugin key.
+    expect(tool!.pluginDbId).toBe(pluginDbId);
+    expect(tool!.pluginDbId).not.toBe(pluginKey);
+  });
+
+  it("falls back to pluginId when pluginDbId is omitted (backwards-compat)", () => {
+    const dispatcher = createPluginToolDispatcher();
+    const pluginKey = "platform.cad";
+
+    dispatcher.registerPluginTools(pluginKey, makeManifest(pluginKey));
+
+    const tool = dispatcher.getTool(`${pluginKey}:run_script`);
+    expect(tool).not.toBeNull();
+    // Without a UUID, the registry stamps pluginId itself onto pluginDbId so
+    // pre-PLA-323 callers continue to work (used in tests where id === key).
+    expect(tool!.pluginDbId).toBe(pluginKey);
+  });
+});

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,16 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's unique identifier (the plugin key, e.g. `platform.cad`)
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - The plugin row's DB UUID. When provided, it is stamped onto each
+   *   registered tool so dispatch can correlate to the worker manager (which is keyed by
+   *   DB UUID, not plugin key). Optional for backward compatibility / test scenarios.
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +433,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Plugins extend the host with capabilities, including agent-callable tools (e.g. `cad:run_script`, `cad:export`)
> - When a plugin worker is healthy and the agent invokes a tool, the host's `PluginToolDispatcher` routes the call to the right worker via `PluginToolRegistry.executeTool`
> - That dispatch path checks `workerManager.isRunning(tool.pluginDbId)` to decide whether to fire the RPC. The worker manager is keyed by the plugin row's DB UUID, not by the plugin key
> - But `pluginDbId` was never threaded from `plugin-loader.ts` through `plugin-tool-dispatcher.ts.registerPluginTools()` into `plugin-tool-registry.registerPlugin()`, so each tool ended up with `pluginDbId = pluginKey` (e.g. `"platform.cad"`). The UUID-keyed worker manager returned `false` and dispatch failed closed with `502 "worker for plugin '<key>' is not running"`, even when the worker was running
> - This pull request threads the optional `pluginDbId` end-to-end with a 3-line plumbing patch and adds a focused regression test
> - The benefit is that plugin agent tools dispatch correctly to running workers; without it, every agent tool call from any plugin is broken at runtime, regardless of how healthy the worker is

## What Changed

- `server/src/services/plugin-tool-dispatcher.ts` — added an optional `pluginDbId?: string` parameter to the `registerPluginTools` interface declaration and the factory implementation, forwarding it to `registry.registerPlugin(...)`. Backwards-compatible: existing two-arg callers still work.
- `server/src/services/plugin-loader.ts` — at the only host call site (the `manifest.tools` block in plugin activation), pass the DB UUID (`pluginId` in loader scope) as the third argument. `pluginKey` continues to be the namespacing key passed as the first argument.
- `server/src/services/plugin-tool-dispatcher.test.ts` (new) — focused regression test that registers a plugin via the dispatcher with a synthetic UUID and asserts `tool.pluginDbId === uuid` (and not the plugin key). Includes a backwards-compat case that asserts the registry's existing fallback to `pluginId` when the third arg is omitted.

The downstream `PluginToolRegistry.registerPlugin(pluginId, manifest, pluginDbId?)` already accepted and plumbed this argument through `addTool` to `tool.pluginDbId` — this PR just wires it end-to-end.

## Verification

Test commands run from the worktree root, with `corepack`-shimmed `pnpm@9.15.4`:

- Targeted regression test (the new file):
  ```
  pnpm --filter @paperclipai/server exec vitest run src/services/plugin-tool-dispatcher.test.ts
  → Test Files  1 passed (1) | Tests  2 passed (2) | 1.97s
  ```
- Negative control — the new test reproduces the bug on master (patch reverted via `git stash`):
  ```
  Test Files  1 failed (1) | Tests  1 failed | 1 passed (2)
  AssertionError: expected 'platform.cad' to be '1f8d7b6c-…' (the UUID)
  ```
- Adjacent plugin tests — five files, no regressions:
  ```
  pnpm --filter @paperclipai/server exec vitest run \
    src/services/plugin-tool-dispatcher.test.ts \
    src/__tests__/plugin-orchestration-apis.test.ts \
    src/__tests__/plugin-worker-manager.test.ts \
    src/__tests__/plugin-routes-authz.test.ts \
    src/__tests__/plugin-database.test.ts
  → Test Files  5 passed (5) | Tests  47 passed (47) | 15.24s
  ```
- Full server typecheck:
  ```
  pnpm --filter @paperclipai/server typecheck
  → clean (no errors)
  ```
- Full repo test suite (CI runner — `pnpm test` → `node scripts/run-vitest-stable.mjs`): every server, shared, db, adapter, and UI vitest invocation passes. The only failures are 2 pre-existing flakes in the `paperclipai` CLI package (`src/__tests__/network-bind.test.ts` and `src/__tests__/onboard.test.ts`), both rooted in the test environment having a tailnet IP (e.g. `100.71.239.94`) instead of pure loopback (`127.0.0.1`). Reproduced these same 2 failures on `origin/master` with no patch applied (negative control) — they are not caused by this PR.
  ```
  paperclipai partition: Test Files  2 failed | 21 passed (23) | Tests  2 failed | 124 passed (126)
  reason: tailscale-bound test runner; assertion expects 127.0.0.1, gets the host's tailnet IP
  ```

Manual: not required for this PR. The runtime behaviour change (dispatch can now find the worker) is what unblocks PLA-308 / PLA-305 manual smoke testing post-deploy; that gate is owned by the upstream maintainer and tracked separately.

## Risks

- Low risk. The change is a 3-line plumbing patch through one parameter that the registry layer has already accepted as optional since its introduction.
- Backwards compatible: callers that omit the new third argument behave exactly as before — `tool.pluginDbId` falls back to `pluginId`. No existing tests changed; no behaviour change for plugins that don't go through `plugin-loader` (e.g. test fixtures that build the registry directly).
- No new runtime dependencies, no schema changes, no migration. Loader-level edit is in the existing `manifest.tools` activation block; if `manifest.tools` is empty the call site is skipped (unchanged).

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

This is a bug fix (Path 1 / Small focused change per CONTRIBUTING.md), not a feature contribution.

## Model Used

- Provider: Anthropic (via Claude Code CLI)
- Exact model id: `claude-opus-4-7` (Claude Opus 4 / "Opus 4.6")
- Capability details: extended thinking + tool use; ~200k context window; sandboxed shell, file edits, and `gh` CLI access through Claude Code

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work *(this is a bug fix, not a roadmap feature)*
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable *(new `plugin-tool-dispatcher.test.ts` with two cases including a confirmed negative-control reproduction of the bug)*
- [x] If this change affects the UI, I have included before/after screenshots — N/A: server-only fix, no UI surface
- [x] I have updated relevant documentation to reflect my changes — N/A: JSDoc on the interface declaration is updated to document the new parameter; no external/operator docs reference this internal seam
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

Follows `CONTRIBUTING.md` PR template — sections present: **Thinking Path**, **What Changed**, **Verification**, **Risks**, **Model Used**, **Checklist** (every item ticked or marked N/A with reason). Path-1 (small focused bug fix per CONTRIBUTING.md §"Path 1: Small, Focused Changes"); no `#dev` Discord agreement required for this size. One PR = one logical change (the dispatcher manifest-validator P2 finding is filed separately at `claudegoogl-sudo/paperclip-plugin-cad#6` and is out of scope here).
