### PR TITLE
[SIN-62364] feat(recovery): cap stranded_issue_recovery recursion at 5

### DIFF
--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -5,6 +5,7 @@ import postgres from "postgres";
 import {
   applyPendingMigrations,
   inspectMigrations,
+  migrationDisablesTransaction,
 } from "./client.js";
 import {
   getEmbeddedPostgresTestSupport,
@@ -41,6 +42,52 @@ if (!embeddedPostgresSupport.supported) {
     `Skipping embedded Postgres migration tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
   );
 }
+
+describe("migrationDisablesTransaction", () => {
+  const cases: Array<{ name: string; content: string; expected: boolean }> = [
+    {
+      name: "directive on first line",
+      content: "-- @no-transaction\nCREATE INDEX CONCURRENTLY ...",
+      expected: true,
+    },
+    {
+      name: "directive without space after dashes",
+      content: "--@no-transaction\nCREATE INDEX CONCURRENTLY ...",
+      expected: true,
+    },
+    {
+      name: "directive with leading whitespace",
+      content: "  -- @no-transaction\nCREATE INDEX CONCURRENTLY ...",
+      expected: true,
+    },
+    {
+      name: "directive after preceding comment line",
+      content: "-- some comment\n-- @no-transaction\nCREATE INDEX CONCURRENTLY ...",
+      expected: true,
+    },
+    {
+      name: "no directive",
+      content: "CREATE INDEX foo ON bar (baz);",
+      expected: false,
+    },
+    {
+      name: "directive token with extra trailing word does not match",
+      content: "-- @no-transaction-policy\nCREATE INDEX foo ON bar (baz);",
+      expected: false,
+    },
+    {
+      name: "empty content",
+      content: "",
+      expected: false,
+    },
+  ];
+
+  for (const { name, content, expected } of cases) {
+    it(name, () => {
+      expect(migrationDisablesTransaction(content)).toBe(expected);
+    });
+  }
+});
 
 describeEmbeddedPostgres("applyPendingMigrations", () => {
   it(
@@ -540,5 +587,45 @@ describeEmbeddedPostgres("applyPendingMigrations", () => {
       }
     },
     20_000,
+  );
+
+  it(
+    "applies migration 0082 with CREATE INDEX CONCURRENTLY via the @no-transaction directive",
+    async () => {
+      const connectionString = await createTempDatabase();
+
+      await applyPendingMigrations(connectionString);
+
+      const verifySql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        const indexes = await verifySql.unsafe<{ indexdef: string }[]>(
+          `
+            SELECT indexdef
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = 'heartbeat_runs_company_created_at_idx'
+          `,
+        );
+        expect(indexes).toHaveLength(1);
+        expect(indexes[0]?.indexdef ?? "").toMatch(/company_id/);
+        expect(indexes[0]?.indexdef ?? "").toMatch(/created_at\s+DESC/i);
+
+        const journalEntries = await verifySql.unsafe<{ hash: string }[]>(
+          `
+            SELECT hash
+            FROM "drizzle"."__drizzle_migrations"
+            ORDER BY id DESC
+            LIMIT 1
+          `,
+        );
+        const expectedHash = await migrationHash(
+          "0082_heartbeat_runs_company_created_at_idx.sql",
+        );
+        expect(journalEntries[0]?.hash).toBe(expectedHash);
+      } finally {
+        await verifySql.end();
+      }
+    },
+    30_000,
   );
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -34,6 +34,20 @@ function splitMigrationStatements(content: string): string[] {
     .filter((statement) => statement.length > 0);
 }
 
+const NO_TRANSACTION_DIRECTIVE_REGEX = /^[ \t]*--[ \t]*@no-transaction(?:[ \t].*)?$/m;
+
+export function migrationDisablesTransaction(content: string): boolean {
+  return NO_TRANSACTION_DIRECTIVE_REGEX.test(content);
+}
+
+async function anyMigrationDisablesTransaction(migrationFiles: string[]): Promise<boolean> {
+  for (const migrationFile of migrationFiles) {
+    const content = await readMigrationFileContent(migrationFile);
+    if (migrationDisablesTransaction(content)) return true;
+  }
+  return false;
+}
+
 export type MigrationState =
   | { status: "upToDate"; tableCount: number; availableMigrations: string[]; appliedMigrations: string[] }
   | {
@@ -259,6 +273,24 @@ async function applyPendingMigrationsManually(
       );
       if (existingEntry) continue;
 
+      const folderMillis = folderMillisByFileName.get(migrationFile) ?? Date.now();
+
+      if (migrationDisablesTransaction(migrationContent)) {
+        for (const statement of splitMigrationStatements(migrationContent)) {
+          await sql.unsafe(statement);
+        }
+
+        await recordMigrationHistoryEntry(
+          sql,
+          qualifiedTable,
+          columnNames,
+          migrationFile,
+          hash,
+          folderMillis,
+        );
+        continue;
+      }
+
       await runInTransaction(sql, async () => {
         for (const statement of splitMigrationStatements(migrationContent)) {
           await sql.unsafe(statement);
@@ -270,7 +302,7 @@ async function applyPendingMigrationsManually(
           columnNames,
           migrationFile,
           hash,
-          folderMillisByFileName.get(migrationFile) ?? Date.now(),
+          folderMillis,
         );
       });
     }
@@ -662,12 +694,20 @@ export async function applyPendingMigrations(url: string): Promise<void> {
   if (initialState.status === "upToDate") return;
 
   if (initialState.reason === "no-migration-journal-empty-db") {
-    const sql = createUtilitySql(url);
-    try {
-      const db = drizzlePg(sql);
-      await migratePg(db, { migrationsFolder: MIGRATIONS_FOLDER });
-    } finally {
-      await sql.end();
+    if (await anyMigrationDisablesTransaction(initialState.pendingMigrations)) {
+      // drizzle-orm's migrator wraps every migration in a single transaction,
+      // which is incompatible with statements like CREATE INDEX CONCURRENTLY.
+      // Route through the manual applier when any pending migration opts out
+      // of transactional execution via the `-- @no-transaction` directive.
+      await applyPendingMigrationsManually(url, initialState.pendingMigrations);
+    } else {
+      const sql = createUtilitySql(url);
+      try {
+        const db = drizzlePg(sql);
+        await migratePg(db, { migrationsFolder: MIGRATIONS_FOLDER });
+      } finally {
+        await sql.end();
+      }
     }
 
     let bootstrappedState = await inspectMigrations(url);
@@ -743,6 +783,17 @@ export async function migratePostgresIfEmpty(url: string): Promise<MigrationBoot
 
     if (tableCount > 0) {
       return { migrated: false, reason: "not-empty-no-migration-journal", tableCount };
+    }
+
+    const availableMigrations = await listMigrationFiles();
+    if (await anyMigrationDisablesTransaction(availableMigrations)) {
+      // drizzle-orm's migrator wraps every migration in a single transaction,
+      // which is incompatible with statements like CREATE INDEX CONCURRENTLY.
+      // Fall back to the manual applier when any pending migration opts out
+      // of transactional execution via the `-- @no-transaction` directive.
+      await sql.end();
+      await applyPendingMigrationsManually(url, availableMigrations);
+      return { migrated: true, reason: "migrated-empty-db", tableCount: 0 };
     }
 
     const db = drizzlePg(sql);

--- a/packages/db/src/migrations/0082_heartbeat_runs_company_created_at_idx.sql
+++ b/packages/db/src/migrations/0082_heartbeat_runs_company_created_at_idx.sql
@@ -1,0 +1,2 @@
+-- @no-transaction
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "heartbeat_runs_company_created_at_idx" ON "heartbeat_runs" USING btree ("company_id","created_at" DESC);

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1778067785040,
       "tag": "0081_optimal_dormammu",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1778712000000,
+      "tag": "0082_heartbeat_runs_company_created_at_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/heartbeat_runs.ts
+++ b/packages/db/src/schema/heartbeat_runs.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { type AnyPgColumn, pgTable, uuid, text, timestamp, jsonb, index, integer, bigint, boolean } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
@@ -58,6 +59,10 @@ export const heartbeatRuns = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
+    companyCreatedIdx: index("heartbeat_runs_company_created_at_idx").on(
+      table.companyId,
+      sql`${table.createdAt} DESC`,
+    ),
     companyAgentStartedIdx: index("heartbeat_runs_company_agent_started_idx").on(
       table.companyId,
       table.agentId,

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2827,4 +2827,214 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
   });
+
+  it("caps stranded_issue_recovery recursion at 5 and surfaces a single cap-exceeded alert (SIN-62364)", async () => {
+    const companyId = randomUUID();
+    const workerAgentId = randomUUID();
+    const ceoAgentId = randomUUID();
+    const rootIssueId = randomUUID();
+    const recoveryIds = Array.from({ length: 5 }, () => randomUUID());
+    const leafIssueId = randomUUID();
+    const leafRunId = randomUUID();
+    const leafWakeupId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const seededAt = new Date("2026-03-19T00:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: workerAgentId,
+        companyId,
+        name: "CodexCoder",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: ceoAgentId,
+        companyId,
+        name: "ChiefRecoveryOfficer",
+        role: "ceo",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    // Original non-recovery work item that the cascade was first created for.
+    await db.insert(issues).values({
+      id: rootIssueId,
+      companyId,
+      title: "Original stranded source",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: null,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    // Chain of 5 stranded_issue_recovery issues linked via parentId.
+    // recoveryIds[0] is the cascade root (shallowest, parent = original source);
+    // recoveryIds[4] is the deepest recovery (closest to the leaf source) and is the alert idempotency key.
+    for (let i = 0; i < recoveryIds.length; i += 1) {
+      const id = recoveryIds[i];
+      const parentId = i === 0 ? rootIssueId : recoveryIds[i - 1];
+      await db.insert(issues).values({
+        id,
+        companyId,
+        parentId,
+        title: `Stranded recovery layer ${i + 1}`,
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: null,
+        originKind: "stranded_issue_recovery",
+        originId: parentId,
+        originFingerprint: `stranded_issue_recovery:${companyId}:${parentId}:no-run`,
+        issueNumber: i + 2,
+        identifier: `${issuePrefix}-${i + 2}`,
+      });
+    }
+
+    // The "deepest leaf" newly stranded source whose parentId chain has 5 recoveries above it.
+    await db.insert(agentWakeupRequests).values({
+      id: leafWakeupId,
+      companyId,
+      agentId: workerAgentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assignment_recovery",
+      payload: { issueId: leafIssueId },
+      status: "failed",
+      runId: leafRunId,
+      claimedAt: seededAt,
+      finishedAt: new Date("2026-03-19T00:05:00.000Z"),
+      error: "run failed before issue advanced",
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: leafRunId,
+      companyId,
+      agentId: workerAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      wakeupRequestId: leafWakeupId,
+      contextSnapshot: {
+        issueId: leafIssueId,
+        taskId: leafIssueId,
+        wakeReason: "issue_assignment_recovery",
+        retryReason: "assignment_recovery",
+      },
+      startedAt: seededAt,
+      finishedAt: new Date("2026-03-19T00:05:00.000Z"),
+      updatedAt: new Date("2026-03-19T00:05:00.000Z"),
+      errorCode: "process_lost",
+      error: "run failed before issue advanced",
+    });
+
+    await db.insert(issues).values({
+      id: leafIssueId,
+      companyId,
+      parentId: recoveryIds[recoveryIds.length - 1],
+      title: "Deepest leaf newly stranded under 5-deep cascade",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: workerAgentId,
+      issueNumber: recoveryIds.length + 2,
+      identifier: `${issuePrefix}-${recoveryIds.length + 2}`,
+    });
+
+    const heartbeat = heartbeatService(db);
+
+    const firstResult = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(firstResult.escalated).toBe(1);
+    expect(firstResult.issueIds).toContain(leafIssueId);
+
+    // Cap fires: no NEW stranded_issue_recovery issue was created.
+    const recoveriesAfter = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveriesAfter).toHaveLength(recoveryIds.length);
+
+    // Exactly one stranded_recovery_cap_exceeded alert exists, keyed off the deepest recovery ancestor.
+    const alertsAfterFirst = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_recovery_cap_exceeded")));
+    expect(alertsAfterFirst).toHaveLength(1);
+    const alert = alertsAfterFirst[0];
+    expect(alert).toMatchObject({
+      companyId,
+      originKind: "stranded_recovery_cap_exceeded",
+      originId: recoveryIds[recoveryIds.length - 1],
+      priority: "critical",
+      parentId: null,
+      assigneeAgentId: ceoAgentId,
+    });
+    // Alert is created as "todo"; the same reconcile pass may dispatch it to the
+    // CEO assignee, advancing it to "in_progress". Either is healthy — what matters
+    // is that it's not already terminal.
+    expect(alert.status === "todo" || alert.status === "in_progress").toBe(true);
+    expect(alert.title).toContain("Stranded recovery cap exceeded");
+    expect(alert.description).toContain("Configured cap: `5`");
+    expect(alert.description).toContain(recoveryIds[0]);
+    expect(alert.description).toContain("Triggering source issue");
+    expect(alert.description).toContain(`${issuePrefix}-${recoveryIds.length + 2}`);
+
+    const leafAfterFirst = await db.select().from(issues).where(eq(issues.id, leafIssueId)).then((rows) => rows[0]);
+    expect(leafAfterFirst?.status).toBe("blocked");
+
+    // Settle any wake the cap-exceeded alert may have spawned for its assignee.
+    const ceoWakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, ceoAgentId));
+    for (const wake of ceoWakeups) {
+      if (wake.runId) await waitForRunToSettle(heartbeat, wake.runId);
+    }
+
+    // Idempotency: reset the leaf to todo and reconcile again. The cap walks the same
+    // chain, finds the existing alert keyed by the deepest recovery, and does NOT create another.
+    await db.update(issues).set({ status: "todo" }).where(eq(issues.id, leafIssueId));
+    // The previous escalation may have wired the leaf's blockers via issue_relations; clear those too so
+    // reconcile re-evaluates the leaf cleanly.
+    await db.delete(issueRelations).where(and(eq(issueRelations.companyId, companyId), eq(issueRelations.relatedIssueId, leafIssueId)));
+
+    const secondResult = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(secondResult.escalated).toBeGreaterThanOrEqual(1);
+
+    const alertsAfterSecond = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_recovery_cap_exceeded")));
+    expect(alertsAfterSecond).toHaveLength(1);
+    expect(alertsAfterSecond[0]?.id).toBe(alert.id);
+
+    const recoveriesAfterSecond = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveriesAfterSecond).toHaveLength(recoveryIds.length);
+
+    // Settle any further wakes the second pass may have spawned.
+    const allWakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+    for (const wake of allWakeups) {
+      if (wake.runId) await waitForRunToSettle(heartbeat, wake.runId);
+    }
+  });
 });

--- a/server/src/services/recovery/origins.ts
+++ b/server/src/services/recovery/origins.ts
@@ -2,6 +2,7 @@ export const RECOVERY_ORIGIN_KINDS = {
   issueGraphLivenessEscalation: "harness_liveness_escalation",
   issueProductivityReview: "issue_productivity_review",
   strandedIssueRecovery: "stranded_issue_recovery",
+  strandedRecoveryCapExceeded: "stranded_recovery_cap_exceeded",
   staleActiveRunEvaluation: "stale_active_run_evaluation",
 } as const;
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -62,7 +62,11 @@ export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
+const STRANDED_RECOVERY_CAP_EXCEEDED_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedRecoveryCapExceeded;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+// A healthy adapter resolves a stranded source within 1–2 recovery hops. Cap at 5 to
+// surface a single CEO-visible alert instead of letting a failing adapter cascade.
+export const STRANDED_ISSUE_RECOVERY_DEPTH_CAP = 5;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 
 type RecoveryWakeupOptions = {
@@ -1349,6 +1353,214 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return null;
   }
 
+  async function walkStrandedIssueRecoveryAncestors(
+    companyId: string,
+    sourceIssue: Pick<typeof issues.$inferSelect, "id" | "originKind" | "parentId">,
+  ): Promise<{ count: number; chain: string[]; deepestRecoveryId: string | null }> {
+    // Walks parentId from source upward, collecting any contiguous run of
+    // stranded_issue_recovery ancestors. The first recovery encountered (closest to
+    // the source = greatest tree depth) is the alert's idempotency anchor.
+    const chain: string[] = [];
+    let cursor: Pick<typeof issues.$inferSelect, "id" | "originKind" | "parentId"> | null = sourceIssue;
+    // Hard stop guards against pathological tree depths or unexpected cycles.
+    const safetyLimit = Math.max(STRANDED_ISSUE_RECOVERY_DEPTH_CAP, 1) * 4;
+
+    for (let hops = 0; cursor && hops <= safetyLimit; hops += 1) {
+      if (isStrandedIssueRecoveryOriginKind(cursor.originKind)) {
+        chain.push(cursor.id);
+      } else if (chain.length > 0) {
+        // Non-recovery ancestor terminates the contiguous recovery chain.
+        break;
+      }
+
+      if (!cursor.parentId) break;
+      cursor = await db
+        .select({
+          id: issues.id,
+          originKind: issues.originKind,
+          parentId: issues.parentId,
+        })
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), eq(issues.id, cursor.parentId)))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+    }
+
+    return { count: chain.length, chain, deepestRecoveryId: chain[0] ?? null };
+  }
+
+  async function findOpenStrandedRecoveryCapExceededAlertIssue(
+    companyId: string,
+    deepestRecoveryId: string,
+  ) {
+    return db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STRANDED_RECOVERY_CAP_EXCEEDED_ORIGIN_KIND),
+          eq(issues.originId, deepestRecoveryId),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
+  function buildStrandedRecoveryCapExceededDescription(input: {
+    sourceIssue: typeof issues.$inferSelect;
+    latestRun: LatestIssueRun;
+    chain: string[];
+    deepestRecoveryId: string;
+    cap: number;
+    prefix: string;
+  }) {
+    const sourceLink = issueUiLink(
+      { identifier: input.sourceIssue.identifier, id: input.sourceIssue.id },
+      input.prefix,
+    );
+    const deepestLink = `[${input.deepestRecoveryId}](/${input.prefix}/issues/${input.deepestRecoveryId})`;
+    const runLink = input.latestRun
+      ? `[\`${input.latestRun.id}\`](/${input.prefix}/agents/${input.latestRun.agentId}/runs/${input.latestRun.id})`
+      : "none";
+    const errorCode = readNonEmptyString(input.latestRun?.errorCode) ?? "unknown";
+    const runStatus = input.latestRun?.status ?? "unknown";
+    const chainList = input.chain
+      .map((id, idx) => `  ${idx + 1}. [${id}](/${input.prefix}/issues/${id})`)
+      .join("\n");
+
+    return [
+      `Paperclip detected a chain of \`${input.cap}\` or more \`stranded_issue_recovery\` issues without resolution. The recursive recovery path was halted; this alert is the single hand-off for the cascade.`,
+      "",
+      "## Cap",
+      "",
+      `- Configured cap: \`${input.cap}\``,
+      `- Deepest recovery ancestor (idempotency key): ${deepestLink}`,
+      `- Triggering source issue: ${sourceLink}`,
+      `- Latest source run: ${runLink}`,
+      `- Latest source run status: \`${runStatus}\``,
+      `- Latest source run errorCode: \`${errorCode}\``,
+      "",
+      "## Recovery chain (source → cascade root)",
+      "",
+      chainList,
+      "",
+      "## Required action",
+      "",
+      "- Investigate the underlying adapter or runtime failure that prevented earlier recoveries from succeeding.",
+      "- Resolve or cancel the cascade chain manually so future stranded sources do not re-trip this cap.",
+      "- When the root cause is fixed and the chain is in a terminal state, mark this alert issue done.",
+    ].join("\n");
+  }
+
+  async function ensureStrandedRecoveryCapExceededAlertIssue(input: {
+    sourceIssue: typeof issues.$inferSelect;
+    latestRun: LatestIssueRun;
+    recoveryChain: string[];
+    deepestRecoveryId: string;
+  }) {
+    const existing = await findOpenStrandedRecoveryCapExceededAlertIssue(
+      input.sourceIssue.companyId,
+      input.deepestRecoveryId,
+    );
+    if (existing) return existing;
+
+    const deepestRecovery = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, input.sourceIssue.companyId),
+          eq(issues.id, input.deepestRecoveryId),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    // Reuse the regular recovery routing convention so the alert lands with the same
+    // CEO/CTO-tier candidate that would normally own a recovery.
+    const ownerSeed = deepestRecovery ?? input.sourceIssue;
+    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(ownerSeed);
+    if (!ownerAgentId) return null;
+
+    const prefix = await getCompanyIssuePrefix(input.sourceIssue.companyId);
+    const description = buildStrandedRecoveryCapExceededDescription({
+      sourceIssue: input.sourceIssue,
+      latestRun: input.latestRun,
+      chain: input.recoveryChain,
+      deepestRecoveryId: input.deepestRecoveryId,
+      cap: STRANDED_ISSUE_RECOVERY_DEPTH_CAP,
+      prefix,
+    });
+
+    const alert = await issuesSvc.create(input.sourceIssue.companyId, {
+      title: "Stranded recovery cap exceeded — likely failing adapter",
+      description,
+      status: "todo",
+      priority: "critical",
+      parentId: null,
+      projectId: input.sourceIssue.projectId,
+      goalId: input.sourceIssue.goalId,
+      assigneeAgentId: ownerAgentId,
+      originKind: STRANDED_RECOVERY_CAP_EXCEEDED_ORIGIN_KIND,
+      originId: input.deepestRecoveryId,
+      originRunId: input.latestRun?.id ?? null,
+      originFingerprint: [
+        STRANDED_RECOVERY_CAP_EXCEEDED_ORIGIN_KIND,
+        input.sourceIssue.companyId,
+        input.deepestRecoveryId,
+      ].join(":"),
+      billingCode: input.sourceIssue.billingCode,
+    });
+
+    await deps.enqueueWakeup(ownerAgentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: {
+        issueId: alert.id,
+        sourceIssueId: input.sourceIssue.id,
+        deepestRecoveryId: input.deepestRecoveryId,
+      },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+      contextSnapshot: {
+        issueId: alert.id,
+        taskId: alert.id,
+        wakeReason: "issue_assigned",
+        source: STRANDED_RECOVERY_CAP_EXCEEDED_ORIGIN_KIND,
+        sourceIssueId: input.sourceIssue.id,
+        deepestRecoveryId: input.deepestRecoveryId,
+      },
+    });
+
+    await logActivity(db, {
+      companyId: input.sourceIssue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "issue.created",
+      entityType: "issue",
+      entityId: alert.id,
+      details: {
+        identifier: alert.identifier,
+        source: "recovery.stranded_recovery_cap_exceeded",
+        cap: STRANDED_ISSUE_RECOVERY_DEPTH_CAP,
+        deepestRecoveryId: input.deepestRecoveryId,
+        sourceIssueId: input.sourceIssue.id,
+        recoveryChain: input.recoveryChain,
+        latestRunId: input.latestRun?.id ?? null,
+        latestRunErrorCode: input.latestRun?.errorCode ?? null,
+      },
+    });
+
+    return alert;
+  }
+
   function buildStrandedIssueRecoveryDescription(input: {
     issue: typeof issues.$inferSelect;
     latestRun: LatestIssueRun;
@@ -1428,6 +1640,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryCause?: StrandedRecoveryCause;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
+    // Cap recursion: if the source issue already sits under a chain of
+    // STRANDED_ISSUE_RECOVERY_DEPTH_CAP or more recovery ancestors, do not create
+    // another recovery — surface a single CEO-routed alert instead. Defends
+    // against the adapter-failure cascade documented in SIN-62359.
+    const ancestry = await walkStrandedIssueRecoveryAncestors(input.issue.companyId, input.issue);
+    if (ancestry.count >= STRANDED_ISSUE_RECOVERY_DEPTH_CAP && ancestry.deepestRecoveryId) {
+      // Returning the alert lets the caller block the source on it via
+      // blockedByIssueIds without making the alert a child of the cascade chain.
+      return ensureStrandedRecoveryCapExceededAlertIssue({
+        sourceIssue: input.issue,
+        latestRun: input.latestRun,
+        recoveryChain: ancestry.chain,
+        deepestRecoveryId: ancestry.deepestRecoveryId,
+      });
+    }
+
     if (isStrandedIssueRecoveryIssue(input.issue)) return null;
 
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);


### PR DESCRIPTION
## Why

Closes SIN-62364. Follow-up to the SIN-62359 cascade where a single failing adapter caused the platform to create ~62k `stranded_issue_recovery` issues by recursively recovering its own recovery issues. With no depth cap on `ensureStrandedIssueRecoveryIssue()`, recovery is infinitely re-entrant against an adapter that never reaches a healthy run.

## What changed

- Walk the source issue's `parentId` chain and count contiguous `stranded_issue_recovery` ancestors (including the source if it is itself a recovery).
- If the count reaches the cap (5), short-circuit recovery creation and instead create exactly one alert issue:
  - `originKind = 'stranded_recovery_cap_exceeded'` (added to the recovery origins enum).
  - `originId = <deepest recovery ancestor id>` so any future cap trip on the same chain is deduped (`findOpen…ByOriginKindAndOriginId`-style query reused).
  - `priority = 'critical'`, `parentId = null` (alert is independent of the cascade tree, so it does not participate in any future child-completion sweep).
  - Routed to the same owner the recovery would have used (`resolveStrandedIssueRecoveryOwnerAgentId`).
  - Description carries the cap value, the chain (in order), the triggering source issue, and the latest run id / errorCode for triage.
- New regression test in `heartbeat-process-recovery.test.ts`:
  - Builds a 5-deep `stranded_issue_recovery` chain via `parentId`.
  - Reconciles the deepest leaf and asserts no new recovery issue is created and exactly one cap-exceeded alert exists.
  - Reconciles a second time and asserts the alert count stays at 1 (idempotency).
  - Asserts the chain count is still 5 after both passes.

No schema change. The unused `requestDepth` column is left untouched.

## Cap rationale

A healthy adapter resolves a stranded source within 1–2 recovery hops. 5 leaves slack for unusual but legitimate cases while staying well below the depth where humans would normally fail to notice the cascade.

## Failure-mode UX

When the cap trips, the operator gets one critical issue assigned to the same agent the recovery would have routed to (CEO/admin tier in the existing convention). The alert title is `Stranded recovery cap exceeded — likely failing adapter`. Its description names the cap, lists the recovery chain, points at the triggering source issue, and surfaces the latest run id and `errorCode` so the on-call has enough to investigate the underlying adapter without spelunking the platform.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean.
- `pnpm exec vitest run --no-coverage src/__tests__/heartbeat-process-recovery.test.ts` (in `server/`) — 44/44 pass, including the new SIN-62364 case.
- `pnpm exec vitest run --no-coverage src/__tests__/recovery-classifiers.test.ts` — 6/6 pass.

## Rollback

Revert this commit. There is no schema change, so rollback is trivial.