### PR TITLE
fix(routines): dedup routine execution issues with blocked/orphan predecessor

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -11,6 +11,7 @@ import {
   executionWorkspaces,
   heartbeatRuns,
   instanceSettings,
+  issueComments,
   issueInboxArchives,
   issueReadStates,
   issues,
@@ -50,6 +51,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     await db.delete(activityLog);
     await db.delete(issueInboxArchives);
     await db.delete(issueReadStates);
+    await db.delete(issueComments);
     await db.delete(routineRuns);
     await db.delete(routineTriggers);
     await db.delete(routines);
@@ -258,13 +260,18 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues.map((issue) => issue.id)).toContain(run.linkedIssueId);
   });
 
-  it("dispatches without 23505 when a previous open routine issue still references a terminal heartbeat run", async () => {
-    // Reproduces TER-1323: a stale routine_execution issue stuck open (e.g. 'blocked')
-    // with executionRunId pointing at a heartbeat run that is no longer queued/running
-    // would collide on issues_open_routine_execution_uq when the next dispatch tried
-    // to set executionRunId on a freshly created issue. The auto-heal on dispatch
-    // entry should null the orphan executionRunId and allow the new run to proceed.
-    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+  // Helper for TER-1492 / TER-1323 tests: seed a previous routine_execution
+  // issue stuck in `blocked` with a terminal heartbeat run (the production
+  // shape that TER-1488 / TER-1405 exhibited). Returns the predecessor row.
+  async function seedBlockedPredecessor(opts: {
+    companyId: string;
+    agentId: string;
+    issueSvc: ReturnType<typeof issueService>;
+    routine: { id: string; projectId: string | null; title: string; description: string | null; priority: string; assigneeAgentId: string | null };
+    triggeredAt: Date;
+    heartbeatStatus?: "completed" | "failed";
+  }) {
+    const { companyId, agentId, issueSvc, routine, triggeredAt } = opts;
     const previousRunId = randomUUID();
     const terminalHeartbeatRunId = randomUUID();
     const previousIssue = await issueSvc.create(companyId, {
@@ -286,7 +293,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       triggerId: null,
       source: "schedule",
       status: "issue_created",
-      triggeredAt: new Date("2026-04-29T15:00:00.000Z"),
+      triggeredAt,
       linkedIssueId: previousIssue.id,
     });
 
@@ -296,21 +303,165 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       agentId,
       invocationSource: "assignment",
       triggerDetail: "system",
-      status: "completed",
+      status: opts.heartbeatStatus ?? "completed",
       contextSnapshot: { issueId: previousIssue.id },
-      startedAt: new Date("2026-04-29T15:01:00.000Z"),
-      finishedAt: new Date("2026-04-29T15:05:00.000Z"),
+      startedAt: new Date(triggeredAt.getTime() + 60_000),
+      finishedAt: new Date(triggeredAt.getTime() + 5 * 60_000),
     });
 
     await db
       .update(issues)
       .set({
         executionRunId: terminalHeartbeatRunId,
-        executionLockedAt: new Date("2026-04-29T15:01:00.000Z"),
+        executionLockedAt: new Date(triggeredAt.getTime() + 60_000),
       })
       .where(eq(issues.id, previousIssue.id));
 
+    return previousIssue;
+  }
+
+  it("dedups a new dispatch into a blocked predecessor, posts a comment, and heals orphan executionRunId", async () => {
+    // TER-1492: when a previous routine_execution issue is still `blocked`,
+    // the engine must coalesce the new tick into it instead of spawning a
+    // fresh issue (which produced the TER-1405/TER-1488 duplicates). Also
+    // verifies the TER-1323 orphan-heal regression: the predecessor's
+    // executionRunId must be nulled out so it leaves the unique index.
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousIssue = await seedBlockedPredecessor({
+      companyId,
+      agentId,
+      issueSvc,
+      routine,
+      triggeredAt: new Date("2026-04-29T15:00:00.000Z"),
+      heartbeatStatus: "completed",
+    });
+
     const run = await svc.runRoutine(routine.id, { source: "schedule" });
+
+    expect(run.status).toBe("coalesced");
+    expect(run.failureReason).toBeNull();
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+
+    const routineIssues = await db
+      .select({ id: issues.id, status: issues.status, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+
+    // No fresh issue was spawned: the predecessor remains the only routine_execution issue.
+    expect(routineIssues).toHaveLength(1);
+    expect(routineIssues[0]!.id).toBe(previousIssue.id);
+    expect(routineIssues[0]!.status).toBe("blocked");
+    // TER-1323 regression: orphan executionRunId healed to null.
+    expect(routineIssues[0]!.executionRunId).toBeNull();
+
+    // The dedup branch posts a comment on the surviving issue with the tick context.
+    const comments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, previousIssue.id));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]!.body).toContain("Routine tick at");
+    expect(comments[0]!.body).toContain("schedule");
+    expect(comments[0]!.body).toContain("blocked");
+  });
+
+  it("collapses consecutive scheduler ticks into the same blocked predecessor without 23505", async () => {
+    // TER-1492 + TER-1323 smoke gate: two consecutive ticks against the same
+    // blocked predecessor must both succeed (no unique-index collision) and
+    // both must coalesce into the same surviving issue.
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousIssue = await seedBlockedPredecessor({
+      companyId,
+      agentId,
+      issueSvc,
+      routine,
+      triggeredAt: new Date("2026-04-29T15:00:00.000Z"),
+      heartbeatStatus: "failed",
+    });
+
+    const firstRun = await svc.runRoutine(routine.id, { source: "schedule" });
+    const secondRun = await svc.runRoutine(routine.id, { source: "schedule" });
+
+    expect(firstRun.status).toBe("coalesced");
+    expect(firstRun.failureReason).toBeNull();
+    expect(firstRun.linkedIssueId).toBe(previousIssue.id);
+
+    expect(secondRun.status).toBe("coalesced");
+    expect(secondRun.failureReason).toBeNull();
+    expect(secondRun.linkedIssueId).toBe(previousIssue.id);
+
+    const routineIssues = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+    expect(routineIssues).toHaveLength(1);
+
+    const comments = await db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, previousIssue.id));
+    expect(comments.length).toBe(2);
+  });
+
+  it("creates a fresh execution issue once the blocked predecessor transitions out of blocked", async () => {
+    // TER-1492 acceptance criterion (c): the dedup is conditional on
+    // status=blocked. Once the predecessor is resolved (done/cancelled/etc.),
+    // the next tick must produce a fresh issue rather than coalescing.
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousIssue = await seedBlockedPredecessor({
+      companyId,
+      agentId,
+      issueSvc,
+      routine,
+      triggeredAt: new Date("2026-04-29T15:00:00.000Z"),
+    });
+
+    const dedupRun = await svc.runRoutine(routine.id, { source: "schedule" });
+    expect(dedupRun.status).toBe("coalesced");
+    expect(dedupRun.linkedIssueId).toBe(previousIssue.id);
+
+    // Predecessor is unblocked and resolved.
+    await db
+      .update(issues)
+      .set({ status: "done", updatedAt: new Date() })
+      .where(eq(issues.id, previousIssue.id));
+
+    const freshRun = await svc.runRoutine(routine.id, { source: "schedule" });
+    expect(freshRun.status).toBe("issue_created");
+    expect(freshRun.failureReason).toBeNull();
+    expect(freshRun.linkedIssueId).toBeTruthy();
+    expect(freshRun.linkedIssueId).not.toBe(previousIssue.id);
+
+    const routineIssues = await db
+      .select({ id: issues.id, status: issues.status })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+    expect(routineIssues).toHaveLength(2);
+    expect(routineIssues.find((i) => i.id === previousIssue.id)!.status).toBe("done");
+    expect(routineIssues.find((i) => i.id === freshRun.linkedIssueId)!.status).not.toBe("blocked");
+  });
+
+  it("bypasses dedup when concurrencyPolicy is always_enqueue", async () => {
+    // TER-1492 acceptance criterion (d): an explicit `always_enqueue` policy
+    // is the user opting into parallel routine execution. We must respect
+    // that even when a blocked predecessor exists, log a warning, and let
+    // the orphan-heal keep the unique index from colliding.
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    await db
+      .update(routines)
+      .set({ concurrencyPolicy: "always_enqueue" })
+      .where(eq(routines.id, routine.id));
+    const refreshedRoutine = { ...routine, concurrencyPolicy: "always_enqueue" };
+    const previousIssue = await seedBlockedPredecessor({
+      companyId,
+      agentId,
+      issueSvc,
+      routine: refreshedRoutine,
+      triggeredAt: new Date("2026-04-29T15:00:00.000Z"),
+    });
+
+    const run = await svc.runRoutine(routine.id, { source: "schedule" });
+
     expect(run.status).toBe("issue_created");
     expect(run.failureReason).toBeNull();
     expect(run.linkedIssueId).toBeTruthy();
@@ -320,80 +471,17 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       .select({ id: issues.id, status: issues.status, executionRunId: issues.executionRunId })
       .from(issues)
       .where(eq(issues.originId, routine.id));
-
     expect(routineIssues).toHaveLength(2);
-
-    const healedPrevious = routineIssues.find((issue) => issue.id === previousIssue.id);
-    expect(healedPrevious).toBeDefined();
-    expect(healedPrevious!.executionRunId).toBeNull();
-    expect(healedPrevious!.status).toBe("blocked");
-
-    const fresh = routineIssues.find((issue) => issue.id === run.linkedIssueId);
-    expect(fresh).toBeDefined();
-    expect(fresh!.executionRunId).toBeTruthy();
-  });
-
-  it("dispatches without 23505 across two consecutive scheduler ticks when an orphan persists", async () => {
-    // Mirrors the production smoke gate from TER-1323: two clean consecutive runs
-    // for the same routine after the fix lands. Without auto-heal the second tick
-    // would 23505 again because the first tick re-creates a fresh issue while the
-    // orphan still holds the unique-index entry.
-    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
-    const previousRunId = randomUUID();
-    const terminalHeartbeatRunId = randomUUID();
-    const previousIssue = await issueSvc.create(companyId, {
-      projectId: routine.projectId,
-      title: routine.title,
-      description: routine.description,
-      status: "blocked",
-      priority: routine.priority,
-      assigneeAgentId: routine.assigneeAgentId,
-      originKind: "routine_execution",
-      originId: routine.id,
-      originRunId: previousRunId,
-    });
-
-    await db.insert(routineRuns).values({
-      id: previousRunId,
-      companyId,
-      routineId: routine.id,
-      triggerId: null,
-      source: "schedule",
-      status: "issue_created",
-      triggeredAt: new Date("2026-04-29T15:00:00.000Z"),
-      linkedIssueId: previousIssue.id,
-    });
-
-    await db.insert(heartbeatRuns).values({
-      id: terminalHeartbeatRunId,
-      companyId,
-      agentId,
-      invocationSource: "assignment",
-      triggerDetail: "system",
-      status: "failed",
-      contextSnapshot: { issueId: previousIssue.id },
-      startedAt: new Date("2026-04-29T15:01:00.000Z"),
-      finishedAt: new Date("2026-04-29T15:05:00.000Z"),
-    });
-
-    await db
-      .update(issues)
-      .set({
-        executionRunId: terminalHeartbeatRunId,
-        executionLockedAt: new Date("2026-04-29T15:01:00.000Z"),
-      })
-      .where(eq(issues.id, previousIssue.id));
-
-    const firstRun = await svc.runRoutine(routine.id, { source: "schedule" });
-    expect(firstRun.status).toBe("issue_created");
-    expect(firstRun.failureReason).toBeNull();
-
-    const secondRun = await svc.runRoutine(routine.id, { source: "schedule" });
-    // The first tick already created a fresh issue with a live queued heartbeat run,
-    // so the second tick should coalesce into it instead of trying to insert another.
-    expect(secondRun.status).toBe("coalesced");
-    expect(secondRun.failureReason).toBeNull();
-    expect(secondRun.linkedIssueId).toBe(firstRun.linkedIssueId);
+    // Predecessor still blocked, orphan healed.
+    const healedPrevious = routineIssues.find((i) => i.id === previousIssue.id)!;
+    expect(healedPrevious.status).toBe("blocked");
+    expect(healedPrevious.executionRunId).toBeNull();
+    // No dedup comment was posted on the predecessor.
+    const comments = await db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, previousIssue.id));
+    expect(comments).toHaveLength(0);
   });
 
   it("creates draft routines without a project or default assignee", async () => {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -258,6 +258,144 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues.map((issue) => issue.id)).toContain(run.linkedIssueId);
   });
 
+  it("dispatches without 23505 when a previous open routine issue still references a terminal heartbeat run", async () => {
+    // Reproduces TER-1323: a stale routine_execution issue stuck open (e.g. 'blocked')
+    // with executionRunId pointing at a heartbeat run that is no longer queued/running
+    // would collide on issues_open_routine_execution_uq when the next dispatch tried
+    // to set executionRunId on a freshly created issue. The auto-heal on dispatch
+    // entry should null the orphan executionRunId and allow the new run to proceed.
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const terminalHeartbeatRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "blocked",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "schedule",
+      status: "issue_created",
+      triggeredAt: new Date("2026-04-29T15:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: terminalHeartbeatRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "completed",
+      contextSnapshot: { issueId: previousIssue.id },
+      startedAt: new Date("2026-04-29T15:01:00.000Z"),
+      finishedAt: new Date("2026-04-29T15:05:00.000Z"),
+    });
+
+    await db
+      .update(issues)
+      .set({
+        executionRunId: terminalHeartbeatRunId,
+        executionLockedAt: new Date("2026-04-29T15:01:00.000Z"),
+      })
+      .where(eq(issues.id, previousIssue.id));
+
+    const run = await svc.runRoutine(routine.id, { source: "schedule" });
+    expect(run.status).toBe("issue_created");
+    expect(run.failureReason).toBeNull();
+    expect(run.linkedIssueId).toBeTruthy();
+    expect(run.linkedIssueId).not.toBe(previousIssue.id);
+
+    const routineIssues = await db
+      .select({ id: issues.id, status: issues.status, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+
+    expect(routineIssues).toHaveLength(2);
+
+    const healedPrevious = routineIssues.find((issue) => issue.id === previousIssue.id);
+    expect(healedPrevious).toBeDefined();
+    expect(healedPrevious!.executionRunId).toBeNull();
+    expect(healedPrevious!.status).toBe("blocked");
+
+    const fresh = routineIssues.find((issue) => issue.id === run.linkedIssueId);
+    expect(fresh).toBeDefined();
+    expect(fresh!.executionRunId).toBeTruthy();
+  });
+
+  it("dispatches without 23505 across two consecutive scheduler ticks when an orphan persists", async () => {
+    // Mirrors the production smoke gate from TER-1323: two clean consecutive runs
+    // for the same routine after the fix lands. Without auto-heal the second tick
+    // would 23505 again because the first tick re-creates a fresh issue while the
+    // orphan still holds the unique-index entry.
+    const { agentId, companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const terminalHeartbeatRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "blocked",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "schedule",
+      status: "issue_created",
+      triggeredAt: new Date("2026-04-29T15:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: terminalHeartbeatRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      contextSnapshot: { issueId: previousIssue.id },
+      startedAt: new Date("2026-04-29T15:01:00.000Z"),
+      finishedAt: new Date("2026-04-29T15:05:00.000Z"),
+    });
+
+    await db
+      .update(issues)
+      .set({
+        executionRunId: terminalHeartbeatRunId,
+        executionLockedAt: new Date("2026-04-29T15:01:00.000Z"),
+      })
+      .where(eq(issues.id, previousIssue.id));
+
+    const firstRun = await svc.runRoutine(routine.id, { source: "schedule" });
+    expect(firstRun.status).toBe("issue_created");
+    expect(firstRun.failureReason).toBeNull();
+
+    const secondRun = await svc.runRoutine(routine.id, { source: "schedule" });
+    // The first tick already created a fresh issue with a live queued heartbeat run,
+    // so the second tick should coalesce into it instead of trying to insert another.
+    expect(secondRun.status).toBe("coalesced");
+    expect(secondRun.failureReason).toBeNull();
+    expect(secondRun.linkedIssueId).toBe(firstRun.linkedIssueId);
+  });
+
   it("creates draft routines without a project or default assignee", async () => {
     const { companyId, svc } = await seedFixture();
 

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -943,6 +943,58 @@ export function routineService(
       .then((rows) => rows[0] ?? null);
   }
 
+  // Null `executionRunId` on open routine_execution issues whose heartbeat run is
+  // no longer live. The unique index `issues_open_routine_execution_uq` includes
+  // any open issue with `executionRunId IS NOT NULL`, but `findLiveExecutionIssue`
+  // only matches when the heartbeat run is still queued/running/scheduled_retry.
+  // Without this auto-heal, a stale issue (heartbeat already terminal but the
+  // issue still in `blocked`/`in_progress`) is invisible to coalescence yet
+  // collides with the index when a fresh dispatch tries to set `executionRunId`,
+  // surfacing as 23505 `issues_open_routine_execution_uq` and failing the run.
+  async function healOrphanRoutineExecutionRunIds(
+    routine: typeof routines.$inferSelect,
+    executor: Db = db,
+  ) {
+    const orphanRows = await executor
+      .select({ id: issues.id, executionRunId: issues.executionRunId })
+      .from(issues)
+      .leftJoin(heartbeatRuns, eq(heartbeatRuns.id, issues.executionRunId))
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.originId, routine.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+          isNotNull(issues.executionRunId),
+          or(
+            isNull(heartbeatRuns.id),
+            sql`${heartbeatRuns.status} not in ('queued', 'running', 'scheduled_retry')`,
+          ),
+        ),
+      );
+
+    if (orphanRows.length === 0) return [];
+
+    for (const orphan of orphanRows) {
+      if (!orphan.executionRunId) continue;
+      await executor
+        .update(issues)
+        .set({ executionRunId: null, updatedAt: new Date() })
+        .where(and(eq(issues.id, orphan.id), eq(issues.executionRunId, orphan.executionRunId)));
+    }
+
+    logger.warn(
+      {
+        routineId: routine.id,
+        companyId: routine.companyId,
+        healedIssueIds: orphanRows.map((row) => row.id),
+      },
+      "Cleared stale executionRunId on routine_execution issues to avoid issues_open_routine_execution_uq collisions",
+    );
+    return orphanRows;
+  }
+
   async function createWebhookSecret(
     companyId: string,
     routineId: string,
@@ -1156,36 +1208,48 @@ export function routineService(
         : undefined;
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
+
+      const coalesceIntoExistingIssue = async (
+        existingIssue: typeof issues.$inferSelect,
+      ) => {
+        const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+        if (manualRunnerUserId) {
+          await touchIssueForUserInbox(txDb, {
+            companyId: input.routine.companyId,
+            issueId: existingIssue.id,
+            userId: manualRunnerUserId,
+            touchedAt: triggeredAt,
+          });
+        }
+        const updated = await finalizeRun(createdRun.id, {
+          status,
+          linkedIssueId: existingIssue.id,
+          coalescedIntoRunId: existingIssue.originRunId,
+          completedAt: triggeredAt,
+        }, txDb);
+        await updateRoutineTouchedState({
+          routineId: input.routine.id,
+          triggerId: input.trigger?.id ?? null,
+          triggeredAt,
+          status,
+          issueId: existingIssue.id,
+          nextRunAt,
+        }, txDb);
+        return updated ?? createdRun;
+      };
+
       try {
+        // Heal stale orphan executionRunIds before checking for live issues, so
+        // a previously-failed dispatch's open issue cannot keep colliding with
+        // the unique index forever.
+        await healOrphanRoutineExecutionRunIds(input.routine, txDb);
+
         const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
           kind: issueOriginKind,
           id: issueOriginId,
         });
         if (activeIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
-          const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
-          if (manualRunnerUserId) {
-            await touchIssueForUserInbox(txDb, {
-              companyId: input.routine.companyId,
-              issueId: activeIssue.id,
-              userId: manualRunnerUserId,
-              touchedAt: triggeredAt,
-            });
-          }
-          const updated = await finalizeRun(createdRun.id, {
-            status,
-            linkedIssueId: activeIssue.id,
-            coalescedIntoRunId: activeIssue.originRunId,
-            completedAt: triggeredAt,
-          }, txDb);
-          await updateRoutineTouchedState({
-            routineId: input.routine.id,
-            triggerId: input.trigger?.id ?? null,
-            triggeredAt,
-            status,
-            issueId: activeIssue.id,
-            nextRunAt,
-          }, txDb);
-          return updated ?? createdRun;
+          return await coalesceIntoExistingIssue(activeIssue);
         }
 
         try {
@@ -1221,6 +1285,7 @@ export function routineService(
             throw error;
           }
 
+          await healOrphanRoutineExecutionRunIds(input.routine, txDb);
           const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
             kind: issueOriginKind,
             id: issueOriginId,
@@ -1276,6 +1341,36 @@ export function routineService(
         }, txDb);
         return updated ?? createdRun;
       } catch (error) {
+        const isOpenExecutionConflict =
+          !!error &&
+          typeof error === "object" &&
+          "code" in error &&
+          (error as { code?: string }).code === "23505" &&
+          "constraint" in error &&
+          (error as { constraint?: string }).constraint === "issues_open_routine_execution_uq";
+
+        if (isOpenExecutionConflict && input.routine.concurrencyPolicy !== "always_enqueue") {
+          // The collision can fire either at issueSvc.create (concurrent insert
+          // of a fresh routine_execution issue) or at the downstream UPDATE that
+          // assigns executionRunId to a newly created issue when an orphan still
+          // holds the unique index entry. Drop the half-created issue, heal any
+          // remaining orphans, and try to coalesce into the surviving live issue.
+          if (createdIssue) {
+            await txDb.delete(issues).where(eq(issues.id, createdIssue.id));
+            createdIssue = null;
+          }
+          await healOrphanRoutineExecutionRunIds(input.routine, txDb);
+          const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
+            kind: issueOriginKind,
+            id: issueOriginId,
+          });
+          if (existingIssue) {
+            return await coalesceIntoExistingIssue(existingIssue);
+          }
+          // No live issue found even after healing — fall through and surface the
+          // original constraint error so the run is marked failed for visibility.
+        }
+
         if (createdIssue) {
           await txDb.delete(issues).where(eq(issues.id, createdIssue.id));
         }

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -931,6 +931,36 @@ export function routineService(
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  // TER-1492: dedup target for the case where a previous routine_execution
+  // issue is still `blocked`. The blocker's heartbeat run has already
+  // terminated, so `findLiveExecutionIssue` (which requires a live heartbeat)
+  // does not see this issue. Without this lookup the dispatch loop spawns a
+  // new execution issue every tick while the predecessor sits blocked on the
+  // same unblock owner/action, inflating the board and burning budget.
+  async function findOpenBlockedExecutionIssue(
+    routine: typeof routines.$inferSelect,
+    executor: Db = db,
+    dispatchFingerprint?: string | null,
+  ) {
+    const fingerprintCondition = routineExecutionFingerprintCondition(dispatchFingerprint);
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.originId, routine.id),
+          eq(issues.status, "blocked"),
+          isNull(issues.hiddenAt),
+          ...(fingerprintCondition ? [fingerprintCondition] : []),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -1161,6 +1191,14 @@ export function routineService(
       title,
       description,
     });
+    // TER-1492: when the dispatch coalesces into a `blocked` predecessor, we
+    // need to post a comment on that predecessor surfacing the tick context.
+    // The comment must run on a connection that does not contend with the
+    // dispatch tx (the tx still holds row locks on the predecessor from the
+    // orphan-heal UPDATE), so we capture the intent inside the tx and post
+    // the comment only after the tx commits.
+    let pendingBlockedDedupComment: { issueId: string; body: string } | null = null;
+
     const run = await db.transaction(async (tx) => {
       const txDb = tx as unknown as Db;
       await tx.execute(
@@ -1252,6 +1290,65 @@ export function routineService(
           return await coalesceIntoExistingIssue(activeIssue);
         }
 
+        // TER-1492: before creating a new execution issue, check whether a
+        // previous one is still `blocked`. The orphan-heal nulled out its
+        // executionRunId and findLiveExecutionIssue cannot see it, but
+        // spawning a parallel issue under the same blocker just produces a
+        // duplicate (see TER-1405/TER-1488 consolidation). Default behavior
+        // is to dedup; users that explicitly opt into `always_enqueue`
+        // bypass it and we log a warning so the fan-out is traceable.
+        const blockedPredecessor = await findOpenBlockedExecutionIssue(
+          input.routine,
+          txDb,
+          dispatchFingerprint,
+        );
+        if (blockedPredecessor) {
+          if (input.routine.concurrencyPolicy === "always_enqueue") {
+            logger.warn(
+              {
+                event: "routine_execution_blocked_predecessor_bypassed",
+                routineId: input.routine.id,
+                companyId: input.routine.companyId,
+                blockedIssueId: blockedPredecessor.id,
+                concurrencyPolicy: input.routine.concurrencyPolicy,
+                runSource: input.source,
+              },
+              "Routine has a blocked predecessor but concurrencyPolicy=always_enqueue; bypassing dedup",
+            );
+          } else {
+            logger.warn(
+              {
+                event: "routine_execution_skipped_due_to_blocked_predecessor",
+                routineId: input.routine.id,
+                companyId: input.routine.companyId,
+                blockedIssueId: blockedPredecessor.id,
+                runSource: input.source,
+                triggerId: input.trigger?.id ?? null,
+              },
+              "Skipping routine execution: predecessor issue is still blocked",
+            );
+
+            const triggerLabel = input.trigger?.id
+              ? `${input.source} (trigger ${input.trigger.id})`
+              : input.source;
+            // Capture the intended comment; we post it post-commit so the
+            // outer-connection write does not contend with the dispatch tx
+            // for row locks on the predecessor (which the tx still holds).
+            const dedupBody = [
+              `🔁 Routine tick at ${triggeredAt.toISOString()} via \`${triggerLabel}\`.`,
+              "",
+              "Skipping new execution issue — this predecessor is still `blocked`.",
+              "Subsequent ticks will collapse here until status changes.",
+            ].join("\n");
+            const coalescedRun = await coalesceIntoExistingIssue(blockedPredecessor);
+            pendingBlockedDedupComment = {
+              issueId: blockedPredecessor.id,
+              body: dedupBody,
+            };
+            return coalescedRun;
+          }
+        }
+
         try {
           createdIssue = await issueSvc.create(input.routine.companyId, {
             projectId,
@@ -1291,30 +1388,7 @@ export function routineService(
             id: issueOriginId,
           });
           if (!existingIssue) throw error;
-          const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
-          if (manualRunnerUserId) {
-            await touchIssueForUserInbox(txDb, {
-              companyId: input.routine.companyId,
-              issueId: existingIssue.id,
-              userId: manualRunnerUserId,
-              touchedAt: triggeredAt,
-            });
-          }
-          const updated = await finalizeRun(createdRun.id, {
-            status,
-            linkedIssueId: existingIssue.id,
-            coalescedIntoRunId: existingIssue.originRunId,
-            completedAt: triggeredAt,
-          }, txDb);
-          await updateRoutineTouchedState({
-            routineId: input.routine.id,
-            triggerId: input.trigger?.id ?? null,
-            triggeredAt,
-            status,
-            issueId: existingIssue.id,
-            nextRunAt,
-          }, txDb);
-          return updated ?? createdRun;
+          return await coalesceIntoExistingIssue(existingIssue);
         }
 
         // Keep the dispatch lock until the issue is linked to a queued heartbeat run.
@@ -1390,6 +1464,29 @@ export function routineService(
         return failed ?? createdRun;
       }
     });
+
+    // Post-commit: post the blocked-predecessor dedup comment now that the
+    // dispatch tx has released its row locks. This is best-effort — if the
+    // comment write fails the dedup decision still stands.
+    if (pendingBlockedDedupComment) {
+      try {
+        await issueSvc.addComment(
+          pendingBlockedDedupComment.issueId,
+          pendingBlockedDedupComment.body,
+          {},
+        );
+      } catch (commentErr) {
+        logger.warn(
+          {
+            event: "routine_execution_blocked_dedup_comment_failed",
+            routineId: input.routine.id,
+            blockedIssueId: pendingBlockedDedupComment.issueId,
+            error: commentErr instanceof Error ? commentErr.message : String(commentErr),
+          },
+          "Failed to post blocked-predecessor dedup comment; coalesce decision still applied",
+        );
+      }
+    }
 
     if (input.source === "schedule" || input.source === "webhook") {
       const actorId = input.source === "schedule" ? "routine-scheduler" : "routine-webhook";


### PR DESCRIPTION
## Summary

Fixes routine execution duplication/churn around `issues_open_routine_execution_uq` when a previous routine execution issue remains open/blocked while its heartbeat run is already terminal.

Includes:
- `d51a3de` — heal orphan `executionRunId` values so stale open routine issues no longer collide with the unique index.
- `4c86511` — coalesce/dedup new routine executions into an existing blocked predecessor instead of creating duplicate routine execution issues.

## Terratek refs

- TER-1396: publish credential/branch handoff
- TER-1394: merge/deploy patch `d51a3de`
- TER-1462: operationalize same patch
- TER-1492: dedup routine execution when predecessor is blocked

## Why

Without this, Paperclip can keep creating duplicate routine execution issues, leaving blockers noisy and forcing manual board hygiene.

## Validation

Patch includes regression coverage in `server/src/__tests__/routines-service.test.ts` for:
- orphan terminal heartbeat run collision recovery
- consecutive scheduler tick dedup/coalescing
- blocked predecessor dedup behavior

Branch was published from the Paperclip VPS handoff workspace for TER-1396.