### PR TITLE
feat: add Paperclip inbox Telegram notifier

### DIFF
--- a/docs/runbooks/paperclip-inbox-telegram-notifier.md
+++ b/docs/runbooks/paperclip-inbox-telegram-notifier.md
@@ -1,0 +1,70 @@
+# Paperclip inbox Telegram notifier
+
+This bridge polls Paperclip's inbox badge signal and sends Telegram notifications only when the inbox becomes actionable.
+
+## What it uses
+
+- Source signal: `GET /api/companies/:companyId/sidebar-badges`
+- Script entrypoint: `scripts/paperclip-inbox-telegram-notifier.ts`
+- Decision logic: `server/src/services/inbox-telegram-notifier.ts`
+- Root package command: `pnpm run notify:paperclip-inbox-telegram`
+
+## Behavior
+
+The notifier reads the current sidebar badge snapshot and persists local state so it does not spam on every poll.
+
+Notification rules:
+
+- do not notify when inbox count is `0`
+- notify on the first observed positive inbox count
+- notify when a positive inbox count changes
+- do not re-notify when the positive inbox count is unchanged
+
+The message includes:
+
+- company label
+- current inbox count
+- confirmation that the source is `sidebar-badges`
+- breakdown of failed runs / alerts / join requests / approvals
+- optional inbox URL
+- observation timestamp
+
+## Required environment variables
+
+- `PAPERCLIP_COMPANY_ID`
+- `PAPERCLIP_TELEGRAM_BOT_TOKEN`
+- `PAPERCLIP_TELEGRAM_CHAT_ID`
+
+## Optional environment variables
+
+- `PAPERCLIP_API_BASE` — defaults to `http://127.0.0.1:3100/api`
+- `PAPERCLIP_COMPANY_LABEL` — display label in the Telegram message
+- `PAPERCLIP_INBOX_URL` — link included in the message
+- `PAPERCLIP_INBOX_STATE_FILE` — path to persisted anti-spam state
+
+Default state path:
+
+- `.runtime/paperclip-inbox-telegram-state.json`
+
+## Example
+
+```bash
+PAPERCLIP_COMPANY_ID="cbc62b74-e2c6-43c5-ab0e-1310102cadb8" \
+PAPERCLIP_TELEGRAM_BOT_TOKEN="<bot-token>" \
+PAPERCLIP_TELEGRAM_CHAT_ID="8287422597" \
+PAPERCLIP_COMPANY_LABEL="Emtesseract" \
+PAPERCLIP_INBOX_URL="https://paperclip.example/inbox/recent" \
+pnpm run notify:paperclip-inbox-telegram
+```
+
+## Verification
+
+Targeted tests:
+
+```bash
+pnpm vitest run \
+  server/src/__tests__/inbox-telegram-notifier.test.ts \
+  server/src/__tests__/paperclip-inbox-telegram-notifier-script.test.ts
+```
+
+The package-script smoke test verifies that the root command works end-to-end against a stubbed `sidebar-badges` response and does not attempt Telegram delivery when the inbox count is unchanged.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "evals:smoke": "cd evals/promptfoo && npx promptfoo@0.103.3 eval",
     "test:release-smoke": "npx playwright test --config tests/release-smoke/playwright.config.ts",
     "test:release-smoke:headed": "npx playwright test --config tests/release-smoke/playwright.config.ts --headed",
-    "metrics:paperclip-commits": "tsx scripts/paperclip-commit-metrics.ts"
+    "metrics:paperclip-commits": "tsx scripts/paperclip-commit-metrics.ts",
+    "notify:paperclip-inbox-telegram": "pnpm --filter @paperclipai/server exec tsx ../scripts/paperclip-inbox-telegram-notifier.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/scripts/paperclip-inbox-telegram-notifier.ts
+++ b/scripts/paperclip-inbox-telegram-notifier.ts
@@ -1,0 +1,144 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createDefaultInboxTelegramNotifierState,
+  decideInboxTelegramNotification,
+  formatInboxTelegramMessage,
+  normalizeInboxBadgeSnapshot,
+  type InboxBadgeSnapshot,
+  type InboxTelegramNotifierState,
+} from "../server/src/services/inbox-telegram-notifier.ts";
+
+const API_BASE = process.env.PAPERCLIP_API_BASE ?? "http://127.0.0.1:3100/api";
+const COMPANY_ID = requireEnv("PAPERCLIP_COMPANY_ID");
+const TELEGRAM_BOT_TOKEN = requireEnv("PAPERCLIP_TELEGRAM_BOT_TOKEN");
+const TELEGRAM_CHAT_ID = requireEnv("PAPERCLIP_TELEGRAM_CHAT_ID");
+const COMPANY_LABEL = process.env.PAPERCLIP_COMPANY_LABEL ?? COMPANY_ID;
+const INBOX_URL = process.env.PAPERCLIP_INBOX_URL ?? null;
+const DEFAULT_STATE_FILE = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../.runtime/paperclip-inbox-telegram-state.json",
+);
+const STATE_FILE = process.env.PAPERCLIP_INBOX_STATE_FILE ?? DEFAULT_STATE_FILE;
+const observedAt = new Date().toISOString();
+
+const response = await fetchJson<InboxBadgeSnapshot>(`${API_BASE}/companies/${COMPANY_ID}/sidebar-badges`);
+const snapshot = normalizeInboxBadgeSnapshot(response);
+const previousState = await readState(STATE_FILE);
+const decision = decideInboxTelegramNotification({
+  previousState,
+  snapshot,
+  observedAt,
+});
+
+let telegramMessageId: number | null = null;
+let message: string | null = null;
+if (decision.shouldNotify) {
+  message = formatInboxTelegramMessage(snapshot, {
+    companyLabel: COMPANY_LABEL,
+    inboxUrl: INBOX_URL,
+    observedAt,
+  });
+  telegramMessageId = await sendTelegramMessage({
+    botToken: TELEGRAM_BOT_TOKEN,
+    chatId: TELEGRAM_CHAT_ID,
+    text: message,
+  });
+}
+
+await writeState(STATE_FILE, decision.nextState);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      apiBase: API_BASE,
+      companyId: COMPANY_ID,
+      stateFile: STATE_FILE,
+      observedAt,
+      snapshot,
+      shouldNotify: decision.shouldNotify,
+      reason: decision.reason,
+      telegramMessageId,
+      message,
+    },
+    null,
+    2,
+  ),
+);
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: {
+      accept: "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed: ${response.status} ${response.statusText} ${await response.text()}`);
+  }
+  return (await response.json()) as T;
+}
+
+async function sendTelegramMessage(params: {
+  botToken: string;
+  chatId: string;
+  text: string;
+}): Promise<number | null> {
+  const response = await fetch(`https://api.telegram.org/bot${params.botToken}/sendMessage`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+    },
+    body: JSON.stringify({
+      chat_id: params.chatId,
+      text: params.text,
+      disable_web_page_preview: true,
+    }),
+  });
+
+  const data = (await response.json()) as {
+    ok?: boolean;
+    description?: string;
+    result?: { message_id?: number };
+  };
+
+  if (!response.ok || !data.ok) {
+    throw new Error(`Telegram sendMessage failed: ${response.status} ${response.statusText} ${data.description ?? "unknown error"}`);
+  }
+
+  return data.result?.message_id ?? null;
+}
+
+async function readState(stateFile: string): Promise<InboxTelegramNotifierState> {
+  try {
+    const raw = await readFile(stateFile, "utf8");
+    return {
+      ...createDefaultInboxTelegramNotifierState(),
+      ...(JSON.parse(raw) as Partial<InboxTelegramNotifierState>),
+    };
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return createDefaultInboxTelegramNotifierState();
+    }
+    throw error;
+  }
+}
+
+async function writeState(stateFile: string, state: InboxTelegramNotifierState): Promise<void> {
+  await mkdir(path.dirname(stateFile), { recursive: true });
+  await writeFile(stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
+  return Boolean(error) && typeof error === "object" && "code" in error && error.code === "ENOENT";
+}

--- a/server/src/__tests__/inbox-telegram-notifier.test.ts
+++ b/server/src/__tests__/inbox-telegram-notifier.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDefaultInboxTelegramNotifierState,
+  decideInboxTelegramNotification,
+  deriveInboxAlertCount,
+  formatInboxTelegramMessage,
+} from "../services/inbox-telegram-notifier.js";
+
+describe("inbox telegram notifier", () => {
+  it("does not notify when the first observed inbox count is zero", () => {
+    const decision = decideInboxTelegramNotification({
+      previousState: createDefaultInboxTelegramNotifierState(),
+      snapshot: { inbox: 0, approvals: 0, failedRuns: 0, joinRequests: 0 },
+      observedAt: "2026-05-02T03:00:00.000Z",
+    });
+
+    expect(decision.shouldNotify).toBe(false);
+    expect(decision.reason).toBe("no_action_needed");
+    expect(decision.nextState.lastObservedInboxCount).toBe(0);
+    expect(decision.nextState.lastNotifiedInboxCount).toBeNull();
+  });
+
+  it("notifies on the first positive inbox count", () => {
+    const decision = decideInboxTelegramNotification({
+      previousState: createDefaultInboxTelegramNotifierState(),
+      snapshot: { inbox: 3, approvals: 1, failedRuns: 1, joinRequests: 0 },
+      observedAt: "2026-05-02T03:01:00.000Z",
+    });
+
+    expect(decision.shouldNotify).toBe(true);
+    expect(decision.reason).toBe("initial_positive");
+    expect(decision.nextState.lastObservedInboxCount).toBe(3);
+    expect(decision.nextState.lastNotifiedInboxCount).toBe(3);
+  });
+
+  it("does not re-notify when the positive inbox count is unchanged", () => {
+    const decision = decideInboxTelegramNotification({
+      previousState: {
+        lastObservedInboxCount: 3,
+        lastObservedAt: "2026-05-02T03:01:00.000Z",
+        lastNotifiedInboxCount: 3,
+        lastNotifiedAt: "2026-05-02T03:01:00.000Z",
+      },
+      snapshot: { inbox: 3, approvals: 1, failedRuns: 1, joinRequests: 0 },
+      observedAt: "2026-05-02T03:02:00.000Z",
+    });
+
+    expect(decision.shouldNotify).toBe(false);
+    expect(decision.reason).toBe("no_action_needed");
+    expect(decision.nextState.lastObservedInboxCount).toBe(3);
+    expect(decision.nextState.lastNotifiedInboxCount).toBe(3);
+  });
+
+  it("notifies when the inbox count changes while still positive", () => {
+    const decision = decideInboxTelegramNotification({
+      previousState: {
+        lastObservedInboxCount: 3,
+        lastObservedAt: "2026-05-02T03:01:00.000Z",
+        lastNotifiedInboxCount: 3,
+        lastNotifiedAt: "2026-05-02T03:01:00.000Z",
+      },
+      snapshot: { inbox: 5, approvals: 1, failedRuns: 2, joinRequests: 1 },
+      observedAt: "2026-05-02T03:03:00.000Z",
+    });
+
+    expect(decision.shouldNotify).toBe(true);
+    expect(decision.reason).toBe("count_changed");
+    expect(decision.nextState.lastObservedInboxCount).toBe(5);
+    expect(decision.nextState.lastNotifiedInboxCount).toBe(5);
+  });
+
+  it("updates observed state without notifying when the inbox clears", () => {
+    const decision = decideInboxTelegramNotification({
+      previousState: {
+        lastObservedInboxCount: 5,
+        lastObservedAt: "2026-05-02T03:03:00.000Z",
+        lastNotifiedInboxCount: 5,
+        lastNotifiedAt: "2026-05-02T03:03:00.000Z",
+      },
+      snapshot: { inbox: 0, approvals: 0, failedRuns: 0, joinRequests: 0 },
+      observedAt: "2026-05-02T03:04:00.000Z",
+    });
+
+    expect(decision.shouldNotify).toBe(false);
+    expect(decision.nextState.lastObservedInboxCount).toBe(0);
+    expect(decision.nextState.lastNotifiedInboxCount).toBe(5);
+  });
+
+  it("derives alert count from the inbox total", () => {
+    expect(
+      deriveInboxAlertCount({
+        inbox: 5,
+        approvals: 1,
+        failedRuns: 2,
+        joinRequests: 1,
+      }),
+    ).toBe(1);
+  });
+
+  it("formats a human-readable Telegram message", () => {
+    const message = formatInboxTelegramMessage(
+      {
+        inbox: 5,
+        approvals: 1,
+        failedRuns: 2,
+        joinRequests: 1,
+      },
+      {
+        companyLabel: "Emtesseract",
+        inboxUrl: "https://paperclip.example/inbox/recent",
+        observedAt: "2026-05-02T03:05:00.000Z",
+      },
+    );
+
+    expect(message).toContain("Paperclip inbox update for Emtesseract");
+    expect(message).toContain("Inbox count: 5");
+    expect(message).toContain("2 failed runs, 1 alert, 1 join request, 1 approval");
+    expect(message).toContain("Open inbox: https://paperclip.example/inbox/recent");
+  });
+});

--- a/server/src/__tests__/paperclip-inbox-telegram-notifier-script.test.ts
+++ b/server/src/__tests__/paperclip-inbox-telegram-notifier-script.test.ts
@@ -1,0 +1,126 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { createServer, type AddressInfo } from "node:net";
+import { spawn } from "node:child_process";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+describe("notify:paperclip-inbox-telegram package script", () => {
+  const cleanup: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) {
+      await cleanup.pop()?.();
+    }
+  });
+
+  it("runs successfully from the repo root when the inbox count is unchanged", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-inbox-telegram-"));
+    const stateFile = path.join(tempDir, "state.json");
+    await writeFile(
+      stateFile,
+      JSON.stringify(
+        {
+          lastObservedInboxCount: 1,
+          lastObservedAt: "2026-05-02T10:20:00.000Z",
+          lastNotifiedInboxCount: 1,
+          lastNotifiedAt: "2026-05-02T10:20:00.000Z",
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const server = await listenJsonServer({ inbox: 1, approvals: 0, failedRuns: 1, joinRequests: 0 });
+    cleanup.push(() => server.close());
+
+    const result = await runCommand("pnpm", ["run", "notify:paperclip-inbox-telegram"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PAPERCLIP_API_BASE: `${server.baseUrl}/api`,
+        PAPERCLIP_COMPANY_ID: "test-company",
+        PAPERCLIP_TELEGRAM_BOT_TOKEN: "unused-token",
+        PAPERCLIP_TELEGRAM_CHAT_ID: "unused-chat",
+        PAPERCLIP_INBOX_STATE_FILE: stateFile,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout.slice(result.stdout.indexOf("{")));
+    expect(payload.shouldNotify).toBe(false);
+    expect(payload.reason).toBe("no_action_needed");
+
+    const state = JSON.parse(await readFile(stateFile, "utf8"));
+    expect(state.lastObservedInboxCount).toBe(1);
+    expect(state.lastNotifiedInboxCount).toBe(1);
+  }, 30_000);
+});
+
+async function listenJsonServer(payload: unknown): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const server = createServer((socket) => {
+    socket.once("data", () => {
+      const body = JSON.stringify(payload);
+      socket.end(
+        [
+          "HTTP/1.1 200 OK",
+          "Content-Type: application/json",
+          `Content-Length: ${Buffer.byteLength(body)}`,
+          "Connection: close",
+          "",
+          body,
+        ].join("\r\n"),
+      );
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (exitCode) => {
+      if (exitCode !== 0) {
+        reject(new Error(`command failed with exit ${exitCode}\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+        return;
+      }
+      resolve({ exitCode, stdout, stderr });
+    });
+  });
+}

--- a/server/src/services/inbox-telegram-notifier.ts
+++ b/server/src/services/inbox-telegram-notifier.ts
@@ -1,0 +1,164 @@
+export interface InboxBadgeSnapshot {
+  inbox: number;
+  approvals: number;
+  failedRuns: number;
+  joinRequests: number;
+}
+
+export interface InboxTelegramNotifierState {
+  lastObservedInboxCount: number | null;
+  lastObservedAt: string | null;
+  lastNotifiedInboxCount: number | null;
+  lastNotifiedAt: string | null;
+}
+
+export interface NotificationDecision {
+  shouldNotify: boolean;
+  reason: "initial_positive" | "count_changed" | "no_action_needed";
+  nextState: InboxTelegramNotifierState;
+}
+
+export interface NotificationMessageOptions {
+  companyLabel: string;
+  inboxUrl?: string | null;
+  observedAt: string;
+}
+
+export function createDefaultInboxTelegramNotifierState(): InboxTelegramNotifierState {
+  return {
+    lastObservedInboxCount: null,
+    lastObservedAt: null,
+    lastNotifiedInboxCount: null,
+    lastNotifiedAt: null,
+  };
+}
+
+export function normalizeInboxBadgeSnapshot(input: Partial<InboxBadgeSnapshot>): InboxBadgeSnapshot {
+  return {
+    inbox: normalizeCount(input.inbox),
+    approvals: normalizeCount(input.approvals),
+    failedRuns: normalizeCount(input.failedRuns),
+    joinRequests: normalizeCount(input.joinRequests),
+  };
+}
+
+export function deriveInboxAlertCount(snapshot: InboxBadgeSnapshot): number {
+  return Math.max(0, snapshot.inbox - snapshot.failedRuns - snapshot.joinRequests - snapshot.approvals);
+}
+
+export function decideInboxTelegramNotification(params: {
+  previousState?: Partial<InboxTelegramNotifierState> | null;
+  snapshot: Partial<InboxBadgeSnapshot>;
+  observedAt: string;
+}): NotificationDecision {
+  const snapshot = normalizeInboxBadgeSnapshot(params.snapshot);
+  const previousState = normalizeState(params.previousState);
+  const previousCount = previousState.lastObservedInboxCount;
+  const currentCount = snapshot.inbox;
+
+  const nextState: InboxTelegramNotifierState = {
+    ...previousState,
+    lastObservedInboxCount: currentCount,
+    lastObservedAt: params.observedAt,
+  };
+
+  if (currentCount <= 0) {
+    return {
+      shouldNotify: false,
+      reason: "no_action_needed",
+      nextState,
+    };
+  }
+
+  if (previousCount === null) {
+    return {
+      shouldNotify: true,
+      reason: "initial_positive",
+      nextState: {
+        ...nextState,
+        lastNotifiedInboxCount: currentCount,
+        lastNotifiedAt: params.observedAt,
+      },
+    };
+  }
+
+  if (previousCount !== currentCount) {
+    return {
+      shouldNotify: true,
+      reason: "count_changed",
+      nextState: {
+        ...nextState,
+        lastNotifiedInboxCount: currentCount,
+        lastNotifiedAt: params.observedAt,
+      },
+    };
+  }
+
+  return {
+    shouldNotify: false,
+    reason: "no_action_needed",
+    nextState,
+  };
+}
+
+export function formatInboxTelegramMessage(
+  snapshotInput: Partial<InboxBadgeSnapshot>,
+  options: NotificationMessageOptions,
+): string {
+  const snapshot = normalizeInboxBadgeSnapshot(snapshotInput);
+  const alerts = deriveInboxAlertCount(snapshot);
+  const breakdown: string[] = [];
+
+  if (snapshot.failedRuns > 0) {
+    breakdown.push(`${snapshot.failedRuns} failed run${snapshot.failedRuns === 1 ? "" : "s"}`);
+  }
+  if (alerts > 0) {
+    breakdown.push(`${alerts} alert${alerts === 1 ? "" : "s"}`);
+  }
+  if (snapshot.joinRequests > 0) {
+    breakdown.push(`${snapshot.joinRequests} join request${snapshot.joinRequests === 1 ? "" : "s"}`);
+  }
+  if (snapshot.approvals > 0) {
+    breakdown.push(`${snapshot.approvals} approval${snapshot.approvals === 1 ? "" : "s"}`);
+  }
+
+  const lines = [
+    `Paperclip inbox update for ${options.companyLabel}`,
+    `Inbox count: ${snapshot.inbox}`,
+    `Source: /api/companies/:companyId/sidebar-badges`,
+    `Breakdown: ${breakdown.length > 0 ? breakdown.join(", ") : "no actionable badge categories reported"}`,
+    `Observed at: ${options.observedAt}`,
+  ];
+
+  if (options.inboxUrl) {
+    lines.push(`Open inbox: ${options.inboxUrl}`);
+  }
+
+  return lines.join("\n");
+}
+
+function normalizeState(
+  input?: Partial<InboxTelegramNotifierState> | null,
+): InboxTelegramNotifierState {
+  const base = createDefaultInboxTelegramNotifierState();
+  if (!input) return base;
+  return {
+    lastObservedInboxCount:
+      typeof input.lastObservedInboxCount === "number" && Number.isFinite(input.lastObservedInboxCount)
+        ? input.lastObservedInboxCount
+        : base.lastObservedInboxCount,
+    lastObservedAt: typeof input.lastObservedAt === "string" ? input.lastObservedAt : base.lastObservedAt,
+    lastNotifiedInboxCount:
+      typeof input.lastNotifiedInboxCount === "number" && Number.isFinite(input.lastNotifiedInboxCount)
+        ? input.lastNotifiedInboxCount
+        : base.lastNotifiedInboxCount,
+    lastNotifiedAt: typeof input.lastNotifiedAt === "string" ? input.lastNotifiedAt : base.lastNotifiedAt,
+  };
+}
+
+function normalizeCount(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return 0;
+  }
+  return Math.max(0, Math.trunc(value));
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for AI-agent companies, so operator-visible alerts need to be routable outside the web UI when the board needs attention.
> - The relevant subsystem here is Paperclip inbox state, specifically the company-scoped `sidebar-badges` signal that already aggregates failed runs, alerts, join requests, and approvals.
> - EMT-15 asked for the smallest reliable Paperclip inbox -> Telegram bridge owned in the mamerbot Paperclip repo rather than ad hoc manual checking.
> - The main product risk was notification spam, so the implementation needed persisted anti-spam state and deterministic rules around first-positive and count-change transitions.
> - Paperclip already has a server package and a root package command surface, so the cleanest implementation was shared notification decision logic in `server/src/services`, a script entrypoint in `scripts/`, and a root package command for operations.
> - This pull request adds that notifier slice, the package command, docs, and targeted tests including a repo-root smoke test for the command wiring.
> - The benefit is a reproducible, repo-owned path for delivering Paperclip inbox events to Mark on Telegram with grounded verification and no repeat-notify spam on unchanged counts.

## What Changed

- Added `server/src/services/inbox-telegram-notifier.ts` with badge normalization, anti-spam state handling, notification decision logic, and Telegram message formatting.
- Added `scripts/paperclip-inbox-telegram-notifier.ts` to fetch `sidebar-badges`, persist state, and send Telegram messages only when the decision logic says to notify.
- Added a root package command `notify:paperclip-inbox-telegram` so the notifier can be run from the repo root.
- Added targeted tests for decision logic and a repo-root package-script smoke test.
- Added `docs/runbooks/paperclip-inbox-telegram-notifier.md` documenting configuration, behavior, and verification.

## Verification

- `pnpm vitest run server/src/__tests__/inbox-telegram-notifier.test.ts server/src/__tests__/paperclip-inbox-telegram-notifier-script.test.ts`
- Controlled positive smoke previously executed on Raven against a stubbed `sidebar-badges` response and live Telegram bot credentials, producing one notifying run and one unchanged-count no-op run.

## Risks

- Low to moderate: the notifier depends on the current `sidebar-badges` response shape remaining stable.
- Misconfigured env vars or state-file paths will prevent delivery; the runbook documents the required settings.
- This adds an outbound Telegram side effect, so operators should use a dedicated state file per deployment context to avoid duplicate notifications across multiple schedulers.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.4 via Hermes Agent / Codex tool-use environment, with terminal, file editing, and verification tool support.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge