### PR TITLE
[SIN-62368] heartbeat_runs(company_id, created_at DESC) index for dashboard read path

### DIFF
--- a/packages/db/src/client.test.ts
+++ b/packages/db/src/client.test.ts
@@ -5,6 +5,7 @@ import postgres from "postgres";
 import {
   applyPendingMigrations,
   inspectMigrations,
+  migrationDisablesTransaction,
 } from "./client.js";
 import {
   getEmbeddedPostgresTestSupport,
@@ -41,6 +42,52 @@ if (!embeddedPostgresSupport.supported) {
     `Skipping embedded Postgres migration tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
   );
 }
+
+describe("migrationDisablesTransaction", () => {
+  const cases: Array<{ name: string; content: string; expected: boolean }> = [
+    {
+      name: "directive on first line",
+      content: "-- @no-transaction\nCREATE INDEX CONCURRENTLY ...",
+      expected: true,
+    },
+    {
+      name: "directive without space after dashes",
+      content: "--@no-transaction\nCREATE INDEX CONCURRENTLY ...",
+      expected: true,
+    },
+    {
+      name: "directive with leading whitespace",
+      content: "  -- @no-transaction\nCREATE INDEX CONCURRENTLY ...",
+      expected: true,
+    },
+    {
+      name: "directive after preceding comment line",
+      content: "-- some comment\n-- @no-transaction\nCREATE INDEX CONCURRENTLY ...",
+      expected: true,
+    },
+    {
+      name: "no directive",
+      content: "CREATE INDEX foo ON bar (baz);",
+      expected: false,
+    },
+    {
+      name: "directive token with extra trailing word does not match",
+      content: "-- @no-transaction-policy\nCREATE INDEX foo ON bar (baz);",
+      expected: false,
+    },
+    {
+      name: "empty content",
+      content: "",
+      expected: false,
+    },
+  ];
+
+  for (const { name, content, expected } of cases) {
+    it(name, () => {
+      expect(migrationDisablesTransaction(content)).toBe(expected);
+    });
+  }
+});
 
 describeEmbeddedPostgres("applyPendingMigrations", () => {
   it(
@@ -540,5 +587,45 @@ describeEmbeddedPostgres("applyPendingMigrations", () => {
       }
     },
     20_000,
+  );
+
+  it(
+    "applies migration 0082 with CREATE INDEX CONCURRENTLY via the @no-transaction directive",
+    async () => {
+      const connectionString = await createTempDatabase();
+
+      await applyPendingMigrations(connectionString);
+
+      const verifySql = postgres(connectionString, { max: 1, onnotice: () => {} });
+      try {
+        const indexes = await verifySql.unsafe<{ indexdef: string }[]>(
+          `
+            SELECT indexdef
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND indexname = 'heartbeat_runs_company_created_at_idx'
+          `,
+        );
+        expect(indexes).toHaveLength(1);
+        expect(indexes[0]?.indexdef ?? "").toMatch(/company_id/);
+        expect(indexes[0]?.indexdef ?? "").toMatch(/created_at\s+DESC/i);
+
+        const journalEntries = await verifySql.unsafe<{ hash: string }[]>(
+          `
+            SELECT hash
+            FROM "drizzle"."__drizzle_migrations"
+            ORDER BY id DESC
+            LIMIT 1
+          `,
+        );
+        const expectedHash = await migrationHash(
+          "0082_heartbeat_runs_company_created_at_idx.sql",
+        );
+        expect(journalEntries[0]?.hash).toBe(expectedHash);
+      } finally {
+        await verifySql.end();
+      }
+    },
+    30_000,
   );
 });

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -34,6 +34,20 @@ function splitMigrationStatements(content: string): string[] {
     .filter((statement) => statement.length > 0);
 }
 
+const NO_TRANSACTION_DIRECTIVE_REGEX = /^[ \t]*--[ \t]*@no-transaction(?:[ \t].*)?$/m;
+
+export function migrationDisablesTransaction(content: string): boolean {
+  return NO_TRANSACTION_DIRECTIVE_REGEX.test(content);
+}
+
+async function anyMigrationDisablesTransaction(migrationFiles: string[]): Promise<boolean> {
+  for (const migrationFile of migrationFiles) {
+    const content = await readMigrationFileContent(migrationFile);
+    if (migrationDisablesTransaction(content)) return true;
+  }
+  return false;
+}
+
 export type MigrationState =
   | { status: "upToDate"; tableCount: number; availableMigrations: string[]; appliedMigrations: string[] }
   | {
@@ -259,6 +273,24 @@ async function applyPendingMigrationsManually(
       );
       if (existingEntry) continue;
 
+      const folderMillis = folderMillisByFileName.get(migrationFile) ?? Date.now();
+
+      if (migrationDisablesTransaction(migrationContent)) {
+        for (const statement of splitMigrationStatements(migrationContent)) {
+          await sql.unsafe(statement);
+        }
+
+        await recordMigrationHistoryEntry(
+          sql,
+          qualifiedTable,
+          columnNames,
+          migrationFile,
+          hash,
+          folderMillis,
+        );
+        continue;
+      }
+
       await runInTransaction(sql, async () => {
         for (const statement of splitMigrationStatements(migrationContent)) {
           await sql.unsafe(statement);
@@ -270,7 +302,7 @@ async function applyPendingMigrationsManually(
           columnNames,
           migrationFile,
           hash,
-          folderMillisByFileName.get(migrationFile) ?? Date.now(),
+          folderMillis,
         );
       });
     }
@@ -662,12 +694,20 @@ export async function applyPendingMigrations(url: string): Promise<void> {
   if (initialState.status === "upToDate") return;
 
   if (initialState.reason === "no-migration-journal-empty-db") {
-    const sql = createUtilitySql(url);
-    try {
-      const db = drizzlePg(sql);
-      await migratePg(db, { migrationsFolder: MIGRATIONS_FOLDER });
-    } finally {
-      await sql.end();
+    if (await anyMigrationDisablesTransaction(initialState.pendingMigrations)) {
+      // drizzle-orm's migrator wraps every migration in a single transaction,
+      // which is incompatible with statements like CREATE INDEX CONCURRENTLY.
+      // Route through the manual applier when any pending migration opts out
+      // of transactional execution via the `-- @no-transaction` directive.
+      await applyPendingMigrationsManually(url, initialState.pendingMigrations);
+    } else {
+      const sql = createUtilitySql(url);
+      try {
+        const db = drizzlePg(sql);
+        await migratePg(db, { migrationsFolder: MIGRATIONS_FOLDER });
+      } finally {
+        await sql.end();
+      }
     }
 
     let bootstrappedState = await inspectMigrations(url);
@@ -743,6 +783,17 @@ export async function migratePostgresIfEmpty(url: string): Promise<MigrationBoot
 
     if (tableCount > 0) {
       return { migrated: false, reason: "not-empty-no-migration-journal", tableCount };
+    }
+
+    const availableMigrations = await listMigrationFiles();
+    if (await anyMigrationDisablesTransaction(availableMigrations)) {
+      // drizzle-orm's migrator wraps every migration in a single transaction,
+      // which is incompatible with statements like CREATE INDEX CONCURRENTLY.
+      // Fall back to the manual applier when any pending migration opts out
+      // of transactional execution via the `-- @no-transaction` directive.
+      await sql.end();
+      await applyPendingMigrationsManually(url, availableMigrations);
+      return { migrated: true, reason: "migrated-empty-db", tableCount: 0 };
     }
 
     const db = drizzlePg(sql);

--- a/packages/db/src/migrations/0082_heartbeat_runs_company_created_at_idx.sql
+++ b/packages/db/src/migrations/0082_heartbeat_runs_company_created_at_idx.sql
@@ -1,0 +1,2 @@
+-- @no-transaction
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "heartbeat_runs_company_created_at_idx" ON "heartbeat_runs" USING btree ("company_id","created_at" DESC);

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1778067785040,
       "tag": "0081_optimal_dormammu",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1778712000000,
+      "tag": "0082_heartbeat_runs_company_created_at_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/heartbeat_runs.ts
+++ b/packages/db/src/schema/heartbeat_runs.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { type AnyPgColumn, pgTable, uuid, text, timestamp, jsonb, index, integer, bigint, boolean } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
@@ -58,6 +59,10 @@ export const heartbeatRuns = pgTable(
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
+    companyCreatedIdx: index("heartbeat_runs_company_created_at_idx").on(
+      table.companyId,
+      sql`${table.createdAt} DESC`,
+    ),
     companyAgentStartedIdx: index("heartbeat_runs_company_agent_started_idx").on(
       table.companyId,
       table.agentId,


### PR DESCRIPTION
## Why

The dashboard hot path `heartbeat.list()` runs

```sql
SELECT ... FROM heartbeat_runs WHERE company_id = $1 ORDER BY created_at DESC LIMIT 200;
```

on every page load. None of the four existing `heartbeat_runs` indexes cover that shape, so on a populated DB the planner falls back to a parallel sequential scan + top-N heapsort. On the live `/opt/paperclip` instance (188,237 rows in one company) this hit the 50s server hard timeout on `dashboard`, `sidebar-badges`, `live-runs`, and per-issue `runs` — operators saw it as system-wide "lentidão".

This PR adds a btree index covering exactly that shape, plus the migration-runner plumbing to ship it without taking a write lock on a live DB.

## What changed (single commit)

- **`packages/db/src/schema/heartbeat_runs.ts`** — adds `companyCreatedIdx` on `(company_id, created_at DESC)`.
- **`packages/db/src/migrations/0082_heartbeat_runs_company_created_at_idx.sql`** — `-- @no-transaction` directive + `CREATE INDEX CONCURRENTLY IF NOT EXISTS`. Idempotent (safe to re-run; safe if the index was created out-of-band).
- **`packages/db/src/migrations/meta/_journal.json`** — registers idx 82.
- **`packages/db/src/client.ts`** — adds `migrationDisablesTransaction(...)` helper and routes empty-DB bootstrap through `applyPendingMigrationsManually` whenever any pending migration disables transactions, since drizzle-orm's bundled migrator wraps every file in a single `BEGIN ... COMMIT`. Required because Postgres rejects `CREATE INDEX CONCURRENTLY` inside a transaction.
- **`packages/db/src/client.test.ts`** — 7 directive parser cases + integration test asserting migration 0082 creates the index and is recorded in the journal.

## Acceptance evidence

Run on the live `/opt/paperclip` Postgres (SIN company, 188,237 `heartbeat_runs` rows):

| Query | Plan (before) | Plan (after) | Duration |
| --- | --- | --- | --- |
| `WHERE company_id = $1 ORDER BY created_at DESC LIMIT 200` | Limit -> Gather Merge -> Parallel Seq Scan -> top-N heapsort | Limit -> Index Scan using `heartbeat_runs_company_created_at_idx` | 521 ms (warm) / ~50 s (cold) -> **0.795 ms** |

The four existing indexes still get picked for their original query shapes (agent-scoped `started_at`, liveness-scoped `created_at`, status + `last_output_at`, status + `process_started_at`) — verified via `EXPLAIN`.

Tests green:
- `pnpm --filter @paperclipai/db test` — 26/26
- `pnpm exec vitest run server/src/__tests__/heartbeat-list.test.ts` — 4/4
- `db` + `server` typecheck clean

## Reversibility / rollback

Migration is `IF NOT EXISTS`, so dropping the index without rolling back the migration row is safe (the next start would simply recreate it, fast and concurrent):

```bash
PGPASSWORD=paperclip psql -h 127.0.0.1 -p 54329 -U paperclip -d paperclip \
  -c "DROP INDEX CONCURRENTLY IF EXISTS heartbeat_runs_company_created_at_idx;"
```

To also roll back the migration row:

```sql
DELETE FROM "drizzle"."__drizzle_migrations" WHERE name = '0082_heartbeat_runs_company_created_at_idx.sql';
```

No write locks are taken at any point — `CREATE INDEX CONCURRENTLY` is online.

## Independence from the recovery cap

This branch is cherry-picked clean onto `origin/master`, independent of the SIN-62366 recursion-cap work (#5514). The two changes can land in either order.

## Lenses applied

- **Observability before optimization** — measured the real hot path on the live DB, fixed exactly that shape.
- **Reversibility / blast radius** — `CREATE INDEX CONCURRENTLY`, idempotent migration, simple `DROP INDEX CONCURRENTLY` rollback.
- **Boring technology budget** — plain btree index + a small directive in the existing migration runner.

## Trail

- Sindireceita issue: SIN-62368
- Fork dev PR: https://github.com/ia-dev-sindireceita/paperclip/pull/1 (LGTM'd by CTO)
- Companion (independent): #5514 (SIN-62366 recursion cap)