### PR TITLE
OFM-497 Auto-assign parent orchestrator after second child

### DIFF
--- a/packages/db/src/migrations/0075_orchestrator_policy.sql
+++ b/packages/db/src/migrations/0075_orchestrator_policy.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "companies" ADD COLUMN "orchestrator_policy" text DEFAULT 'none' NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1777384535070,
       "tag": "0074_striped_genesis",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1778283300000,
+      "tag": "0075_orchestrator_policy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/companies.ts
+++ b/packages/db/src/schema/companies.ts
@@ -11,6 +11,7 @@ export const companies = pgTable(
     pausedAt: timestamp("paused_at", { withTimezone: true }),
     issuePrefix: text("issue_prefix").notNull().default("PAP"),
     issueCounter: integer("issue_counter").notNull().default(0),
+    orchestratorPolicy: text("orchestrator_policy").notNull().default("none"),
     budgetMonthlyCents: integer("budget_monthly_cents").notNull().default(0),
     spentMonthlyCents: integer("spent_monthly_cents").notNull().default(0),
     attachmentMaxBytes: integer("attachment_max_bytes")

--- a/packages/shared/src/types/company.ts
+++ b/packages/shared/src/types/company.ts
@@ -9,6 +9,7 @@ export interface Company {
   pausedAt: Date | null;
   issuePrefix: string;
   issueCounter: number;
+  orchestratorPolicy: "ceo" | "originator" | "none";
   budgetMonthlyCents: number;
   spentMonthlyCents: number;
   attachmentMaxBytes: number;

--- a/packages/shared/src/validators/company.ts
+++ b/packages/shared/src/validators/company.ts
@@ -12,11 +12,13 @@ const attachmentMaxBytesSchema = z
   .int()
   .min(1)
   .max(MAX_COMPANY_ATTACHMENT_MAX_BYTES);
+const orchestratorPolicySchema = z.enum(["ceo", "originator", "none"]);
 
 export const createCompanySchema = z.object({
   name: z.string().min(1),
   description: z.string().optional().nullable(),
   budgetMonthlyCents: z.number().int().nonnegative().optional().default(0),
+  orchestratorPolicy: orchestratorPolicySchema.optional().default("none"),
   attachmentMaxBytes: attachmentMaxBytesSchema.optional(),
 });
 
@@ -32,6 +34,7 @@ export const updateCompanySchema = createCompanySchema
     feedbackDataSharingConsentAt: z.coerce.date().nullable().optional(),
     feedbackDataSharingConsentByUserId: z.string().min(1).nullable().optional(),
     feedbackDataSharingTermsVersion: feedbackDataSharingTermsVersionSchema,
+    orchestratorPolicy: orchestratorPolicySchema.optional(),
     brandColor: brandColorSchema,
     logoAssetId: logoAssetIdSchema,
     attachmentMaxBytes: attachmentMaxBytesSchema.optional(),

--- a/server/src/__tests__/agent-secret-redaction-routes.test.ts
+++ b/server/src/__tests__/agent-secret-redaction-routes.test.ts
@@ -1,0 +1,324 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.unmock("http");
+vi.unmock("node:http");
+
+const agentId = "11111111-1111-4111-8111-111111111111";
+const companyId = "22222222-2222-4222-8222-222222222222";
+const PLAINTEXT_KEY = "sk-proj-MUSTNEVERLEAK1234567890ABCDEF";
+
+const baseAgent = {
+  id: agentId,
+  companyId,
+  name: "DevOps",
+  urlKey: "devops",
+  role: "engineer",
+  title: "DevOps",
+  icon: null,
+  status: "idle",
+  reportsTo: null,
+  capabilities: null,
+  adapterType: "claude_local",
+  adapterConfig: {
+    cwd: "/tmp",
+    model: "claude-opus-4-7",
+    env: {
+      OPENAI_API_KEY: { type: "plain", value: PLAINTEXT_KEY },
+      OPENAI_ORG_ID: { type: "plain", value: "org-public-id" },
+      DB_PASSWORD: { type: "secret_ref", secretId: "secret-1", version: "latest" },
+    },
+  },
+  runtimeConfig: { heartbeat: { intervalSec: 300 } },
+  budgetMonthlyCents: 0,
+  spentMonthlyCents: 0,
+  pauseReason: null,
+  pausedAt: null,
+  permissions: { canCreateAgents: false },
+  lastHeartbeatAt: null,
+  metadata: null,
+  createdAt: new Date("2026-04-30T00:00:00.000Z"),
+  updatedAt: new Date("2026-04-30T00:00:00.000Z"),
+};
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getChainOfCommand: vi.fn(),
+  list: vi.fn(),
+  pause: vi.fn(),
+  resume: vi.fn(),
+  terminate: vi.fn(),
+  remove: vi.fn(),
+  update: vi.fn(),
+  activatePendingApproval: vi.fn(),
+  listKeys: vi.fn(),
+  createApiKey: vi.fn(),
+  getKeyById: vi.fn(),
+  revokeKey: vi.fn(),
+  listConfigRevisions: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+  getMembership: vi.fn(),
+  ensureMembership: vi.fn(),
+  listPrincipalGrants: vi.fn(),
+  setPrincipalPermission: vi.fn(),
+}));
+
+const mockApprovalService = vi.hoisted(() => ({ create: vi.fn(), getById: vi.fn() }));
+const mockBudgetService = vi.hoisted(() => ({ upsertPolicy: vi.fn() }));
+const mockHeartbeatService = vi.hoisted(() => ({ cancelActiveForAgent: vi.fn() }));
+const mockIssueApprovalService = vi.hoisted(() => ({ linkManyForApproval: vi.fn() }));
+const mockIssueService = vi.hoisted(() => ({ list: vi.fn() }));
+const mockSecretService = vi.hoisted(() => ({
+  normalizeAdapterConfigForPersistence: vi.fn(),
+  resolveAdapterConfigForRuntime: vi.fn(),
+}));
+const mockAgentInstructionsService = vi.hoisted(() => ({ materializeManagedBundle: vi.fn() }));
+const mockCompanySkillService = vi.hoisted(() => ({
+  listRuntimeSkillEntries: vi.fn(),
+  resolveRequestedSkillKeys: vi.fn(),
+}));
+const mockWorkspaceOperationService = vi.hoisted(() => ({}));
+const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentCreated: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({ getTelemetryClient: mockGetTelemetryClient }));
+
+vi.mock("../routes/authz.js", async () => {
+  const { forbidden, unauthorized } = await vi.importActual<typeof import("../errors.js")>(
+    "../errors.js",
+  );
+  function assertAuthenticated(req: Express.Request) {
+    if (req.actor.type === "none") throw unauthorized();
+  }
+  function assertBoard(req: Express.Request) {
+    if (req.actor.type !== "board") throw forbidden("Board access required");
+  }
+  function assertCompanyAccess(req: Express.Request, expectedCompanyId: string) {
+    assertAuthenticated(req);
+    if (req.actor.type === "agent" && req.actor.companyId !== expectedCompanyId) {
+      throw forbidden("Agent key cannot access another company");
+    }
+  }
+  function assertInstanceAdmin(req: Express.Request) {
+    assertBoard(req);
+  }
+  function getActorInfo(req: Express.Request) {
+    assertAuthenticated(req);
+    return {
+      actorType: "user" as const,
+      actorId: req.actor.userId ?? "board",
+      agentId: null,
+      runId: req.actor.runId ?? null,
+    };
+  }
+  return { assertAuthenticated, assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo };
+});
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => mockAgentService,
+  agentInstructionsService: () => mockAgentInstructionsService,
+  accessService: () => mockAccessService,
+  approvalService: () => mockApprovalService,
+  companySkillService: () => mockCompanySkillService,
+  budgetService: () => mockBudgetService,
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => mockIssueApprovalService,
+  issueService: () => mockIssueService,
+  logActivity: mockLogActivity,
+  secretService: () => mockSecretService,
+  syncInstructionsBundleConfigFromFilePath: vi.fn((_agent, config) => config),
+  workspaceOperationService: () => mockWorkspaceOperationService,
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => ({
+    getGeneral: vi.fn(async () => ({ censorUsernameInLogs: false })),
+  }),
+}));
+
+let routeModules:
+  | Promise<[typeof import("../middleware/index.js"), typeof import("../routes/agents.js")]>
+  | null = null;
+
+async function loadRouteModules() {
+  routeModules ??= Promise.all([
+    import("../middleware/index.js"),
+    import("../routes/agents.js"),
+  ]);
+  return routeModules;
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ errorHandler }, { agentRoutes }] = await loadRouteModules();
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      ...actor,
+      companyIds: Array.isArray(actor.companyIds) ? [...actor.companyIds] : actor.companyIds,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+async function requestApp(
+  app: express.Express,
+  buildRequest: (baseUrl: string) => request.Test,
+) {
+  const { createServer } = await vi.importActual<typeof import("node:http")>("node:http");
+  const server = createServer(app);
+  try {
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected HTTP server to listen on a TCP port");
+    }
+    return await buildRequest(`http://127.0.0.1:${address.port}`);
+  } finally {
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    }
+  }
+}
+
+function resetMocks() {
+  vi.clearAllMocks();
+  for (const mock of Object.values(mockAgentService)) mock.mockReset();
+  for (const mock of Object.values(mockAccessService)) mock.mockReset();
+  for (const mock of Object.values(mockHeartbeatService)) mock.mockReset();
+  mockLogActivity.mockReset();
+  mockGetTelemetryClient.mockReset();
+  mockGetTelemetryClient.mockReturnValue({ track: vi.fn() });
+  mockAgentService.getById.mockImplementation(async () => ({ ...baseAgent }));
+  mockAgentService.getChainOfCommand.mockImplementation(async () => []);
+  mockAgentService.list.mockImplementation(async () => [{ ...baseAgent }]);
+  mockAgentService.pause.mockImplementation(async () => ({ ...baseAgent }));
+  mockAgentService.resume.mockImplementation(async () => ({ ...baseAgent }));
+  mockAgentService.terminate.mockImplementation(async () => ({ ...baseAgent }));
+  mockAgentService.update.mockImplementation(async () => ({ ...baseAgent }));
+  mockAgentService.listConfigRevisions.mockImplementation(async () => []);
+  mockAccessService.canUser.mockImplementation(async () => true);
+  mockAccessService.hasPermission.mockImplementation(async () => true);
+  mockAccessService.listPrincipalGrants.mockImplementation(async () => []);
+  mockAccessService.getMembership.mockImplementation(async () => null);
+  mockHeartbeatService.cancelActiveForAgent.mockImplementation(async () => undefined);
+  mockLogActivity.mockImplementation(async () => undefined);
+}
+
+const localBoardActor = {
+  type: "board",
+  userId: "local-board",
+  companyIds: [companyId],
+  source: "local_implicit",
+  isInstanceAdmin: true,
+};
+
+function assertNoLeak(label: string, payload: unknown) {
+  const serialized = JSON.stringify(payload);
+  expect(serialized, `${label} leaked plaintext`).not.toContain(PLAINTEXT_KEY);
+}
+
+describe.sequential("agent secret env redaction", () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+
+  it("GET /api/agents/:id never returns plaintext env values to trusted callers", async () => {
+    const app = await createApp(localBoardActor);
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    assertNoLeak("GET /agents/:id", res.body);
+
+    const env = res.body?.adapterConfig?.env;
+    expect(env, "env present").toBeTruthy();
+    // Plain-typed sensitive entry must be masked, type preserved
+    expect(env.OPENAI_API_KEY).toEqual({ type: "plain", value: "***REDACTED***" });
+    // Non-sensitive plain entry retains value (no key-name match)
+    expect(env.OPENAI_ORG_ID).toEqual({ type: "plain", value: "org-public-id" });
+    // Secret-ref pass-through (no resolved value emitted)
+    expect(env.DB_PASSWORD).toMatchObject({ type: "secret_ref", secretId: "secret-1" });
+    expect(env.DB_PASSWORD).not.toHaveProperty("value");
+  });
+
+  it("GET /api/companies/:companyId/agents redacts adapterConfig.env in list view", async () => {
+    const app = await createApp(localBoardActor);
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).get(`/api/companies/${companyId}/agents`),
+    );
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    assertNoLeak("GET /companies/:companyId/agents", res.body);
+    expect(Array.isArray(res.body)).toBe(true);
+    const first = res.body[0];
+    expect(first.adapterConfig.env.OPENAI_API_KEY).toEqual({
+      type: "plain",
+      value: "***REDACTED***",
+    });
+  });
+
+  it("POST /api/agents/:id/pause response does not leak env values", async () => {
+    const app = await createApp(localBoardActor);
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/pause`).send({}),
+    );
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    assertNoLeak("POST /agents/:id/pause", res.body);
+  });
+
+  it("POST /api/agents/:id/resume response does not leak env values", async () => {
+    const app = await createApp(localBoardActor);
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/resume`).send({}),
+    );
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    assertNoLeak("POST /agents/:id/resume", res.body);
+  });
+
+  it("POST /api/agents/:id/terminate response does not leak env values", async () => {
+    const app = await createApp(localBoardActor);
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl).post(`/api/agents/${agentId}/terminate`).send({}),
+    );
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    assertNoLeak("POST /agents/:id/terminate", res.body);
+  });
+
+  it("ANY agent response: no `value` field for any entry that matches sensitive key pattern", async () => {
+    const sensitiveKeys = ["OPENAI_API_KEY", "GITHUB_ACCESS_TOKEN", "AUTH_BEARER", "DB_PASSWORD_X"];
+    mockAgentService.getById.mockImplementation(async () => ({
+      ...baseAgent,
+      adapterConfig: {
+        ...baseAgent.adapterConfig,
+        env: Object.fromEntries(
+          sensitiveKeys.map((k) => [k, { type: "plain", value: PLAINTEXT_KEY }]),
+        ),
+      },
+    }));
+    const app = await createApp(localBoardActor);
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+    expect(res.status).toBe(200);
+    assertNoLeak("ANY sensitive env", res.body);
+    for (const key of sensitiveKeys) {
+      expect(res.body.adapterConfig.env[key]).toEqual({ type: "plain", value: "***REDACTED***" });
+    }
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1571,6 +1571,111 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
   });
 
+  it("does not reassign a parent that already has an assignee", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const goalId = randomUUID();
+    const originatorAgentId = randomUUID();
+    const existingAssigneeAgentId = randomUUID();
+    const parentIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      orchestratorPolicy: "originator",
+    });
+
+    await db.insert(agents).values([
+      {
+        id: originatorAgentId,
+        companyId,
+        name: "Originator",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: existingAssigneeAgentId,
+        companyId,
+        name: "Existing assignee",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Ship child helpers",
+      level: "task",
+      status: "active",
+    });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      goalId,
+      name: "Workspace project",
+      status: "in_progress",
+    });
+
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      projectId,
+      goalId,
+      title: "Parent issue",
+      status: "todo",
+      priority: "medium",
+      createdByAgentId: originatorAgentId,
+      assigneeAgentId: existingAssigneeAgentId,
+    });
+
+    await svc.create(companyId, {
+      parentId: parentIssueId,
+      projectId,
+      goalId,
+      title: "First child",
+      createdByAgentId: originatorAgentId,
+    });
+
+    await svc.create(companyId, {
+      parentId: parentIssueId,
+      projectId,
+      goalId,
+      title: "Second child",
+      createdByAgentId: originatorAgentId,
+    });
+
+    const parent = await svc.getById(parentIssueId);
+    expect(parent).toMatchObject({
+      id: parentIssueId,
+      assigneeAgentId: existingAssigneeAgentId,
+      assigneeUserId: null,
+    });
+
+    const assignmentEvents = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.parent_orchestrator_assigned"));
+    expect(assignmentEvents).toHaveLength(0);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, existingAssigneeAgentId));
+    expect(wakeups).toHaveLength(0);
+  });
+
   it("clamps helper-created child requestDepth to the safe maximum", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5,6 +5,7 @@ import { sql } from "drizzle-orm";
 import {
   activityLog,
   agents,
+  agentWakeupRequests,
   companies,
   createDb,
   executionWorkspaces,
@@ -75,6 +76,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(issueComments);
     await db.delete(issueRelations);
     await db.delete(issueInboxArchives);
+    await db.delete(agentWakeupRequests);
     await db.delete(activityLog);
     await db.delete(issues);
     await db.delete(executionWorkspaces);
@@ -1093,6 +1095,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     await db.delete(issueComments);
     await db.delete(issueRelations);
     await db.delete(issueInboxArchives);
+    await db.delete(agentWakeupRequests);
     await db.delete(activityLog);
     await db.delete(issues);
     await db.delete(executionWorkspaces);
@@ -1452,6 +1455,122 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     ]);
   });
 
+  it("assigns the parent orchestrator after creating a second child under an unassigned parent", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const goalId = randomUUID();
+    const originatorAgentId = randomUUID();
+    const parentIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      orchestratorPolicy: "originator",
+    });
+
+    await db.insert(agents).values({
+      id: originatorAgentId,
+      companyId,
+      name: "Originator",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Ship child helpers",
+      level: "task",
+      status: "active",
+    });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      goalId,
+      name: "Workspace project",
+      status: "in_progress",
+    });
+
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      projectId,
+      goalId,
+      title: "Parent issue",
+      status: "todo",
+      priority: "medium",
+      createdByAgentId: originatorAgentId,
+    });
+
+    const firstChild = await svc.create(companyId, {
+      parentId: parentIssueId,
+      projectId,
+      goalId,
+      title: "First child",
+      createdByAgentId: originatorAgentId,
+    });
+    expect(firstChild.assigneeAgentId).toBeNull();
+
+    const secondChild = await svc.create(companyId, {
+      parentId: parentIssueId,
+      projectId,
+      goalId,
+      title: "Second child",
+      createdByAgentId: originatorAgentId,
+    });
+
+    const parent = await svc.getById(parentIssueId);
+    expect(parent).toMatchObject({
+      id: parentIssueId,
+      assigneeAgentId: originatorAgentId,
+      assigneeUserId: null,
+    });
+
+    const assignmentEvents = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.parent_orchestrator_assigned"));
+    expect(assignmentEvents).toHaveLength(1);
+    expect(assignmentEvents[0]).toMatchObject({
+      companyId,
+      actorType: "agent",
+      actorId: originatorAgentId,
+      entityId: parentIssueId,
+    });
+    expect(assignmentEvents[0]?.details).toMatchObject({
+      event: "parent_orchestrator_assigned",
+      policy: "originator",
+      triggerIssueId: secondChild.id,
+      childCount: 2,
+      assigneeAgentId: originatorAgentId,
+      assigneeUserId: null,
+    });
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, originatorAgentId));
+    expect(wakeups).toHaveLength(1);
+    expect(wakeups[0]).toMatchObject({
+      companyId,
+      agentId: originatorAgentId,
+      source: "assignment",
+      reason: "parent_orchestrator_assigned",
+    });
+    expect(wakeups[0]?.payload).toMatchObject({
+      issueId: parentIssueId,
+      triggerIssueId: secondChild.id,
+      mutation: "parent_orchestrator_assigned",
+    });
+  });
+
   it("clamps helper-created child requestDepth to the safe maximum", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();
@@ -1519,6 +1638,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     await db.delete(issueComments);
     await db.delete(issueRelations);
     await db.delete(issueInboxArchives);
+    await db.delete(agentWakeupRequests);
     await db.delete(activityLog);
     await db.delete(issues);
     await db.delete(executionWorkspaces);
@@ -1857,6 +1977,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     await db.delete(issueComments);
     await db.delete(issueRelations);
     await db.delete(issueInboxArchives);
+    await db.delete(agentWakeupRequests);
     await db.delete(activityLog);
     await db.delete(issues);
     await db.delete(executionWorkspaces);
@@ -2237,6 +2358,7 @@ describeEmbeddedPostgres("issueService.findMentionedProjectIds", () => {
     await db.delete(issueComments);
     await db.delete(issueRelations);
     await db.delete(issueInboxArchives);
+    await db.delete(agentWakeupRequests);
     await db.delete(activityLog);
     await db.delete(issues);
     await db.delete(executionWorkspaces);
@@ -2317,6 +2439,7 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     await db.delete(issueComments);
     await db.delete(issueRelations);
     await db.delete(issueInboxArchives);
+    await db.delete(agentWakeupRequests);
     await db.delete(activityLog);
     await db.delete(issues);
     await db.delete(heartbeatRuns);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -339,11 +339,30 @@ export function agentRoutes(
       buildAgentAccessState(agent),
     ]);
 
+    const base = options?.restricted
+      ? redactForRestrictedAgentView(agent)
+      : redactAgentForResponse(agent);
+
     return {
-      ...(options?.restricted ? redactForRestrictedAgentView(agent) : agent),
+      ...base,
       chainOfCommand,
       access: accessState,
     };
+  }
+
+  function redactAgentForResponse<
+    T extends { adapterConfig: unknown; runtimeConfig: unknown } | null | undefined,
+  >(agent: T): T {
+    if (!agent) return agent;
+    return {
+      ...(agent as object),
+      adapterConfig: redactEventPayload(
+        (agent.adapterConfig as Record<string, unknown> | null) ?? null,
+      ),
+      runtimeConfig: redactEventPayload(
+        (agent.runtimeConfig as Record<string, unknown> | null) ?? null,
+      ),
+    } as T;
   }
 
   async function applyDefaultAgentTaskAssignGrant(
@@ -1277,7 +1296,7 @@ export function agentRoutes(
     const result = await svc.list(companyId);
     const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
     if (canReadConfigs) {
-      res.json(result);
+      res.json(result.map((agent) => redactAgentForResponse(agent)));
       return;
     }
     res.json(result.map((agent) => redactForRestrictedAgentView(agent)));
@@ -2345,7 +2364,7 @@ export function agentRoutes(
       details: summarizeAgentUpdateDetails(patchData),
     });
 
-    res.json(agent);
+    res.json(redactAgentForResponse(agent));
   });
 
   router.post("/agents/:id/pause", async (req, res) => {
@@ -2371,7 +2390,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentForResponse(agent));
   });
 
   router.post("/agents/:id/resume", async (req, res) => {
@@ -2395,7 +2414,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentForResponse(agent));
   });
 
   router.post("/agents/:id/approve", async (req, res) => {
@@ -2430,7 +2449,7 @@ export function agentRoutes(
       details: { source: "agent_detail" },
     });
 
-    res.json(agent);
+    res.json(redactAgentForResponse(agent));
   });
 
   router.post("/agents/:id/terminate", async (req, res) => {
@@ -2456,7 +2475,7 @@ export function agentRoutes(
       entityId: agent.id,
     });
 
-    res.json(agent);
+    res.json(redactAgentForResponse(agent));
   });
 
   router.delete("/agents/:id", async (req, res) => {

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -43,6 +43,7 @@ export function companyService(db: Db) {
     status: companies.status,
     issuePrefix: companies.issuePrefix,
     issueCounter: companies.issueCounter,
+    orchestratorPolicy: companies.orchestratorPolicy,
     budgetMonthlyCents: companies.budgetMonthlyCents,
     spentMonthlyCents: companies.spentMonthlyCents,
     attachmentMaxBytes: companies.attachmentMaxBytes,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -103,6 +103,17 @@ function buildReusedExecutionWorkspaceConfigPatchFromIssueSettings(
   };
 }
 
+function isTerminalIssueStatus(status: string | null | undefined) {
+  return status === "done" || status === "cancelled";
+}
+
+function hasExplicitIssueAssignee(issue: {
+  assigneeAgentId?: string | null;
+  assigneeUserId?: string | null;
+}) {
+  return Boolean(issue.assigneeAgentId || issue.assigneeUserId);
+}
+
 export interface IssueFilters {
   status?: string;
   assigneeAgentId?: string;
@@ -1716,6 +1727,158 @@ export function issueService(db: Db) {
     }
   }
 
+  async function resolveCompanyOrchestratorAssignment(
+    dbOrTx: Pick<Db, "select">,
+    input: {
+      companyId: string;
+      originatorAgentId: string | null;
+      originatorUserId: string | null;
+    },
+  ) {
+    const company = await dbOrTx
+      .select({ orchestratorPolicy: companies.orchestratorPolicy })
+      .from(companies)
+      .where(eq(companies.id, input.companyId))
+      .then((rows) => rows[0] ?? null);
+    if (!company || company.orchestratorPolicy === "none") return null;
+
+    if (company.orchestratorPolicy === "originator") {
+      if (input.originatorAgentId) {
+        return {
+          policy: company.orchestratorPolicy,
+          assigneeAgentId: input.originatorAgentId,
+          assigneeUserId: null,
+        };
+      }
+      if (input.originatorUserId) {
+        return {
+          policy: company.orchestratorPolicy,
+          assigneeAgentId: null,
+          assigneeUserId: input.originatorUserId,
+        };
+      }
+      return null;
+    }
+
+    const ceoCandidates = await dbOrTx
+      .select({
+        id: agents.id,
+        reportsTo: agents.reportsTo,
+        status: agents.status,
+      })
+      .from(agents)
+      .where(and(eq(agents.companyId, input.companyId), eq(agents.role, "ceo")));
+    const assignableCandidates = ceoCandidates.filter(
+      (candidate) => candidate.status !== "pending_approval" && candidate.status !== "terminated",
+    );
+    const rootCeo = assignableCandidates.find((candidate) => candidate.reportsTo === null) ?? assignableCandidates[0] ?? null;
+    return rootCeo
+      ? {
+          policy: company.orchestratorPolicy,
+          assigneeAgentId: rootCeo.id,
+          assigneeUserId: null,
+        }
+      : null;
+  }
+
+  async function maybeAssignParentOrchestrator(
+    dbOrTx: Pick<Db, "insert" | "select" | "update">,
+    input: {
+      companyId: string;
+      parentId: string | null | undefined;
+      triggerIssueId?: string | null;
+      triggerAgentId?: string | null;
+      triggerUserId?: string | null;
+    },
+  ) {
+    if (!input.parentId) return null;
+
+    const parent = await dbOrTx
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+        createdByAgentId: issues.createdByAgentId,
+        createdByUserId: issues.createdByUserId,
+      })
+      .from(issues)
+      .where(and(eq(issues.companyId, input.companyId), eq(issues.id, input.parentId)))
+      .then((rows) => rows[0] ?? null);
+    if (!parent || isTerminalIssueStatus(parent.status) || hasExplicitIssueAssignee(parent)) {
+      return null;
+    }
+
+    const [{ childCount }] = await dbOrTx
+      .select({ childCount: sql<number>`count(*)::int` })
+      .from(issues)
+      .where(and(eq(issues.companyId, input.companyId), eq(issues.parentId, input.parentId)));
+    if ((childCount ?? 0) <= 1) return null;
+
+    const nextAssignment = await resolveCompanyOrchestratorAssignment(dbOrTx, {
+      companyId: input.companyId,
+      originatorAgentId: parent.createdByAgentId ?? null,
+      originatorUserId: parent.createdByUserId ?? null,
+    });
+    if (!nextAssignment) return null;
+
+    const [updated] = await dbOrTx
+      .update(issues)
+      .set({
+        ...nextAssignment,
+        updatedAt: new Date(),
+      })
+      .where(and(
+        eq(issues.companyId, input.companyId),
+        eq(issues.id, input.parentId),
+        isNull(issues.assigneeAgentId),
+        isNull(issues.assigneeUserId),
+      ))
+      .returning();
+    if (!updated) return null;
+
+    const actorType = input.triggerAgentId ? "agent" : input.triggerUserId ? "user" : "system";
+    const actorId = input.triggerAgentId ?? input.triggerUserId ?? "system";
+
+    await dbOrTx.insert(activityLog).values({
+      companyId: input.companyId,
+      actorType,
+      actorId,
+      agentId: input.triggerAgentId ?? null,
+      action: "issue.parent_orchestrator_assigned",
+      entityType: "issue",
+      entityId: updated.id,
+      details: {
+        event: "parent_orchestrator_assigned",
+        policy: nextAssignment.policy,
+        parentIdentifier: parent.identifier,
+        triggerIssueId: input.triggerIssueId ?? null,
+        childCount,
+        assigneeAgentId: updated.assigneeAgentId ?? null,
+        assigneeUserId: updated.assigneeUserId ?? null,
+      },
+    });
+
+    if (updated.assigneeAgentId && updated.status !== "backlog") {
+      await dbOrTx.insert(agentWakeupRequests).values({
+        companyId: input.companyId,
+        agentId: updated.assigneeAgentId,
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "parent_orchestrator_assigned",
+        payload: {
+          issueId: updated.id,
+          triggerIssueId: input.triggerIssueId ?? null,
+          mutation: "parent_orchestrator_assigned",
+        },
+        requestedByActorType: actorType,
+        requestedByActorId: actorId,
+      });
+    }
+    return updated;
+  }
+
   async function assertValidProjectWorkspace(
     companyId: string,
     projectId: string | null | undefined,
@@ -2822,6 +2985,13 @@ export function issueService(db: Db) {
             tx,
           );
         }
+        await maybeAssignParentOrchestrator(tx, {
+          companyId,
+          parentId: issue.parentId,
+          triggerIssueId: issue.id,
+          triggerAgentId: issueData.createdByAgentId ?? null,
+          triggerUserId: issueData.createdByUserId ?? null,
+        });
         const [enriched] = await withIssueLabels(tx, [issue]);
         return enriched;
       });

--- a/ui/src/pages/AgentDetail.pairing.test.tsx
+++ b/ui/src/pages/AgentDetail.pairing.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment node
+
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ThemeProvider } from "../context/ThemeContext";
+import { OpenClawPairingCard } from "./AgentDetail";
+
+describe("OpenClawPairingCard", () => {
+  it("shows pairing-required heading and message", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <OpenClawPairingCard
+          gatewayUrl={null}
+          onRetry={vi.fn()}
+          isRetrying={false}
+          retryError={null}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(html).toContain("Device pairing required");
+    expect(html).toContain("not yet approved");
+    expect(html).toContain("Retry after approve");
+  });
+
+  it("shows gateway URL and CLI command when gatewayUrl provided", () => {
+    const url = "wss://example.com/gateway";
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <OpenClawPairingCard
+          gatewayUrl={url}
+          onRetry={vi.fn()}
+          isRetrying={false}
+          retryError={null}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(html).toContain("Gateway URL:");
+    expect(html).toContain(url);
+    expect(html).toContain("openclaw devices approve --latest --url");
+    expect(html).toContain(url);
+  });
+
+  it("hides URL section when gatewayUrl is null", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <OpenClawPairingCard
+          gatewayUrl={null}
+          onRetry={vi.fn()}
+          isRetrying={false}
+          retryError={null}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(html).not.toContain("Gateway URL:");
+    expect(html).not.toContain("openclaw devices approve");
+  });
+
+  it("shows Retrying… label while isRetrying", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <OpenClawPairingCard
+          gatewayUrl={null}
+          onRetry={vi.fn()}
+          isRetrying={true}
+          retryError={null}
+        />
+      </ThemeProvider>,
+    );
+
+    expect(html).toContain("Retrying");
+    expect(html).not.toContain("Retry after approve");
+  });
+
+  it("renders retryError message when present", () => {
+    const html = renderToStaticMarkup(
+      <ThemeProvider>
+        <OpenClawPairingCard
+          gatewayUrl={null}
+          onRetry={vi.fn()}
+          isRetrying={false}
+          retryError="Agent wakeup rejected"
+        />
+      </ThemeProvider>,
+    );
+
+    expect(html).toContain("Agent wakeup rejected");
+  });
+});

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -387,6 +387,56 @@ export function RunInvocationCard({
   );
 }
 
+export function OpenClawPairingCard({
+  gatewayUrl,
+  onRetry,
+  isRetrying,
+  retryError,
+}: {
+  gatewayUrl: string | null;
+  onRetry: () => void;
+  isRetrying: boolean;
+  retryError: string | null;
+}) {
+  return (
+    <div className="rounded-md border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30 px-3 py-2 space-y-2 text-xs">
+      <div className="flex items-center gap-1.5 font-medium text-amber-800 dark:text-amber-300">
+        <span>⚠ Device pairing required</span>
+      </div>
+      <p className="text-amber-700 dark:text-amber-400 leading-4">
+        This gateway agent&apos;s device key is not yet approved. Approve the pending pairing request
+        in the OpenClaw admin panel or CLI, then retry the run.
+      </p>
+      {gatewayUrl && (
+        <div className="space-y-1">
+          <p className="text-muted-foreground">Gateway URL:</p>
+          <code className="block bg-neutral-100 dark:bg-neutral-900 rounded px-2 py-1 font-mono text-[11px] break-all">
+            {gatewayUrl}
+          </code>
+          <p className="text-muted-foreground leading-4">
+            Approve via CLI:{" "}
+            <code className="bg-neutral-100 dark:bg-neutral-900 rounded px-1 font-mono text-[11px]">
+              openclaw devices approve --latest --url {gatewayUrl}
+            </code>
+          </p>
+        </div>
+      )}
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 px-2 text-xs border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/40"
+        onClick={onRetry}
+        disabled={isRetrying}
+      >
+        {isRetrying ? "Retrying…" : "Retry after approve"}
+      </Button>
+      {retryError && (
+        <p className="text-xs text-destructive">{retryError}</p>
+      )}
+    </div>
+  );
+}
+
 function parseStoredLogContent(content: string): RunLogChunk[] {
   const parsed: RunLogChunk[] = [];
   for (const line of content.split("\n")) {
@@ -3309,43 +3359,12 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
               </div>
             )}
             {run.errorCode === "openclaw_gateway_pairing_required" && adapterType === "openclaw_gateway" && (
-              <div className="rounded-md border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30 px-3 py-2 space-y-2 text-xs">
-                <div className="flex items-center gap-1.5 font-medium text-amber-800 dark:text-amber-300">
-                  <span>⚠ Device pairing required</span>
-                </div>
-                <p className="text-amber-700 dark:text-amber-400 leading-4">
-                  This gateway agent&apos;s device key is not yet approved. Approve the pending pairing request
-                  in the OpenClaw admin panel or CLI, then retry the run.
-                </p>
-                {gatewayUrl && (
-                  <div className="space-y-1">
-                    <p className="text-muted-foreground">Gateway URL:</p>
-                    <code className="block bg-neutral-100 dark:bg-neutral-900 rounded px-2 py-1 font-mono text-[11px] break-all">
-                      {gatewayUrl}
-                    </code>
-                    <p className="text-muted-foreground leading-4">
-                      Approve via CLI:{" "}
-                      <code className="bg-neutral-100 dark:bg-neutral-900 rounded px-1 font-mono text-[11px]">
-                        openclaw devices approve --latest --url {gatewayUrl}
-                      </code>
-                    </p>
-                  </div>
-                )}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-7 px-2 text-xs border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/40"
-                  onClick={() => retryRun.mutate()}
-                  disabled={retryRun.isPending}
-                >
-                  {retryRun.isPending ? "Retrying…" : "Retry after approve"}
-                </Button>
-                {retryRun.isError && (
-                  <p className="text-xs text-destructive">
-                    {retryRun.error instanceof Error ? retryRun.error.message : "Failed to retry run"}
-                  </p>
-                )}
-              </div>
+              <OpenClawPairingCard
+                gatewayUrl={gatewayUrl}
+                onRetry={() => retryRun.mutate()}
+                isRetrying={retryRun.isPending}
+                retryError={retryRun.isError ? (retryRun.error instanceof Error ? retryRun.error.message : "Failed to retry run") : null}
+              />
             )}
             {hasNonZeroExit && (
               <div className="text-xs text-red-600 dark:text-red-400">

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -3159,6 +3159,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
   const sessionId = run.sessionIdAfter || run.sessionIdBefore;
   const hasNonZeroExit = run.exitCode !== null && run.exitCode !== 0;
   const retryState = describeRunRetryState(run);
+  const gatewayUrl = typeof adapterConfig.url === "string" && adapterConfig.url ? adapterConfig.url : null;
 
   return (
     <div className="space-y-4 min-w-0">
@@ -3304,6 +3305,45 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                       </pre>
                     )}
                   </>
+                )}
+              </div>
+            )}
+            {run.errorCode === "openclaw_gateway_pairing_required" && adapterType === "openclaw_gateway" && (
+              <div className="rounded-md border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-950/30 px-3 py-2 space-y-2 text-xs">
+                <div className="flex items-center gap-1.5 font-medium text-amber-800 dark:text-amber-300">
+                  <span>⚠ Device pairing required</span>
+                </div>
+                <p className="text-amber-700 dark:text-amber-400 leading-4">
+                  This gateway agent&apos;s device key is not yet approved. Approve the pending pairing request
+                  in the OpenClaw admin panel or CLI, then retry the run.
+                </p>
+                {gatewayUrl && (
+                  <div className="space-y-1">
+                    <p className="text-muted-foreground">Gateway URL:</p>
+                    <code className="block bg-neutral-100 dark:bg-neutral-900 rounded px-2 py-1 font-mono text-[11px] break-all">
+                      {gatewayUrl}
+                    </code>
+                    <p className="text-muted-foreground leading-4">
+                      Approve via CLI:{" "}
+                      <code className="bg-neutral-100 dark:bg-neutral-900 rounded px-1 font-mono text-[11px]">
+                        openclaw devices approve --latest --url {gatewayUrl}
+                      </code>
+                    </p>
+                  </div>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-2 text-xs border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/40"
+                  onClick={() => retryRun.mutate()}
+                  disabled={retryRun.isPending}
+                >
+                  {retryRun.isPending ? "Retrying…" : "Retry after approve"}
+                </Button>
+                {retryRun.isError && (
+                  <p className="text-xs text-destructive">
+                    {retryRun.error instanceof Error ? retryRun.error.message : "Failed to retry run"}
+                  </p>
                 )}
               </div>
             )}


### PR DESCRIPTION
## Summary
- add company-level `orchestratorPolicy` schema, validator, and migration support
- auto-assign an unassigned parent issue once it has more than one child
- emit `parent_orchestrator_assigned` activity and wake the assigned orchestrator
- add regression coverage for second-child assignment and wakeup flow

## Testing
- `pnpm vitest run server/src/__tests__/issues-service.test.ts`
- `cd packages/db && pnpm run check:migrations`