### PR TITLE
fix(claude-local): deny WebSearch/WebFetch on third-party Anthropic gateways

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { isThirdPartyAnthropicGateway } from "./execute.js";
+
+describe("isThirdPartyAnthropicGateway", () => {
+  it("returns false when ANTHROPIC_BASE_URL is unset", () => {
+    expect(isThirdPartyAnthropicGateway({})).toBe(false);
+  });
+
+  it("returns false for the anthropic.com apex host", () => {
+    expect(
+      isThirdPartyAnthropicGateway({ ANTHROPIC_BASE_URL: "https://anthropic.com" }),
+    ).toBe(false);
+  });
+
+  it("returns false for api.anthropic.com (default)", () => {
+    expect(
+      isThirdPartyAnthropicGateway({ ANTHROPIC_BASE_URL: "https://api.anthropic.com" }),
+    ).toBe(false);
+  });
+
+  it("returns true for kimi/moonshot anthropic-shim hosts", () => {
+    expect(
+      isThirdPartyAnthropicGateway({
+        ANTHROPIC_BASE_URL: "https://api.moonshot.cn/anthropic",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for minimax / glm gateway hosts", () => {
+    expect(
+      isThirdPartyAnthropicGateway({
+        ANTHROPIC_BASE_URL: "https://api.minimaxi.com/anthropic",
+      }),
+    ).toBe(true);
+    expect(
+      isThirdPartyAnthropicGateway({
+        ANTHROPIC_BASE_URL: "https://open.bigmodel.cn/api/anthropic",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not treat phishing-style hosts ending with anthropic.com.evil as Anthropic", () => {
+    expect(
+      isThirdPartyAnthropicGateway({
+        ANTHROPIC_BASE_URL: "https://api.anthropic.com.evil.example/anthropic",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when Bedrock auth is enabled (Bedrock is its own path)", () => {
+    expect(
+      isThirdPartyAnthropicGateway({
+        CLAUDE_CODE_USE_BEDROCK: "1",
+        ANTHROPIC_BASE_URL: "https://api.moonshot.cn/anthropic",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for malformed URLs", () => {
+    expect(isThirdPartyAnthropicGateway({ ANTHROPIC_BASE_URL: "not a url" })).toBe(false);
+    expect(isThirdPartyAnthropicGateway({ ANTHROPIC_BASE_URL: "   " })).toBe(false);
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -106,6 +106,29 @@ function isBedrockAuth(env: Record<string, string>): boolean {
   );
 }
 
+// Anthropic-proprietary server-side tools (web_search_*, web_fetch_*) are only
+// honoured by api.anthropic.com. When ANTHROPIC_BASE_URL points at a third-party
+// Anthropic-compatible gateway (e.g. kimi/minimax/glm shims), upstream rejects
+// those tool types with code 20033 "invalid model". Detect non-Anthropic
+// gateways so we can deny those tools at the CLI layer per-run.
+export function isThirdPartyAnthropicGateway(env: Record<string, string>): boolean {
+  if (isBedrockAuth(env)) return false;
+  const raw = env.ANTHROPIC_BASE_URL;
+  if (typeof raw !== "string") return false;
+  const trimmed = raw.trim();
+  if (!trimmed) return false;
+  let host: string;
+  try {
+    host = new URL(trimmed).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  if (!host) return false;
+  return host !== "anthropic.com" && !host.endsWith(".anthropic.com");
+}
+
+const ANTHROPIC_PROPRIETARY_SERVER_TOOLS = ["WebSearch", "WebFetch"] as const;
+
 function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
   if (isBedrockAuth(env)) return "metered_api";
   return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
@@ -593,6 +616,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--append-system-prompt-file", attemptInstructionsFilePath);
     }
     args.push("--add-dir", effectivePromptBundleAddDir);
+    if (isThirdPartyAnthropicGateway(effectiveEnv)) {
+      args.push("--disallowedTools", ANTHROPIC_PROPRIETARY_SERVER_TOOLS.join(","));
+    }
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };


### PR DESCRIPTION
## 摘要

第三方 Anthropic-兼容网关（kimi/minimax/glm 等）不支持 Claude 内置 server-side tool `web_search_20250305` / `web_fetch_*`，调用时返回 code 20033 `invalid model` 把整条 agent run 砍掉。本 PR 在 spawn Claude CLI 前判定网关类型，对第三方网关注入 \`--disallowedTools WebSearch,WebFetch\`，让模型完全不尝试调用这些工具。

## 改动

- \`packages/adapters/claude-local/src/server/execute.ts\`：新增 \`isThirdPartyAnthropicGateway\` helper，基于 \`ANTHROPIC_BASE_URL\` host 后缀白名单判定（\`.anthropic.com\` / apex \`anthropic.com\`），并显式排除 Bedrock。
- 新增 8 个 unit case 覆盖：anthropic.com / 第三方 host / Bedrock 共存 / 畸形 URL。

## 关键决策点

- **白名单判定，非黑名单**：不枚举 kimi/minimax/glm，下次接 deepseek/zhipu 不用再改。
- **WebFetch 一并 deny**：同样是 Anthropic 内置 server-side tool，同样会撞 20033，漏修等于埋雷。
- **per-run + per-agent 隔离**：CLI flag 仅作用于这一次进程，Anthropic 原生 agent（默认 baseURL）不受影响。
- **Bedrock 排除**：Bedrock 走 \`ANTHROPIC_BEDROCK_BASE_URL\` + 不同协议，不应被误伤。

## 验证（已在运维实例跑过）

- \`pnpm vitest run\` — claude-local 全部 22 个 case 通过（含新增 8 个 helper case）
- \`pnpm typecheck\` — 无新错误
- 编译产物 \`execute.js\` 包含注入逻辑
- 运行时验证 \`isThirdPartyAnthropicGateway\`：
  - \`api.lkeap.cloud.tencent.com\` → \`true\`（9 个第三方 agent 全部命中）
  - \`api.anthropic.com\` → \`false\`（Anthropic 原生 agent 不受影响）

## 上下文

- Paperclip issue: ZHUA-274 \"止血：非 Anthropic agent 屏蔽 WebSearch 工具\"（CEO 已 ack 关单，dev server 已加载新代码）
- 诊断来源: ZHUA-273
- 根治路径（独立跟进）: ZHUA-275 — 接 provider-agnostic Web Search MCP（Tavily / Brave）

## Push 上下文

commit 已在运维实例本地 master，且 dev server 已 build + 重启加载。本 PR 是把代码合规化进 \`origin/master\`（运维账号 \`wxpftd\` 在 paperclipai/paperclip 仅 READ 权限，无法直接 push）。

Co-Authored-By: Paperclip <noreply@paperclip.ing>