### PR TITLE
feat: surface Hermes work products in issue detail

### DIFF
--- a/ui/src/components/IssueWorkProductsSection.test.tsx
+++ b/ui/src/components/IssueWorkProductsSection.test.tsx
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { IssueWorkProduct } from "@paperclipai/shared";
+import {
+  IssueWorkProductsSection,
+  getHermesExecutionDetails,
+  sortIssueWorkProductsForDisplay,
+} from "./IssueWorkProductsSection";
+
+function workProduct(overrides: Partial<IssueWorkProduct>): IssueWorkProduct {
+  return {
+    id: overrides.id ?? "wp-1",
+    companyId: "company-1",
+    projectId: null,
+    issueId: "issue-1",
+    executionWorkspaceId: null,
+    runtimeServiceId: null,
+    type: "artifact",
+    provider: "custom",
+    externalId: null,
+    title: "Work product",
+    url: null,
+    status: "active",
+    reviewState: "none",
+    isPrimary: false,
+    healthStatus: "unknown",
+    summary: null,
+    metadata: null,
+    createdByRunId: null,
+    createdAt: new Date("2026-04-30T00:00:00Z"),
+    updatedAt: new Date("2026-04-30T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("IssueWorkProductsSection", () => {
+  it("prioritizes Hermes Kanban execution products and extracts task metadata", () => {
+    const generic = workProduct({
+      id: "generic",
+      provider: "github",
+      title: "Pull request",
+      updatedAt: new Date("2026-05-01T01:00:00Z"),
+    });
+    const hermes = workProduct({
+      id: "hermes",
+      provider: "hermes-kanban",
+      type: "preview_url",
+      title: "Hermes Kanban board",
+      url: "https://hermes-workspace.tail54e18.ts.net/kanban/tasks/root-1",
+      summary: "Launch complete",
+      metadata: {
+        rootTaskId: "root-1",
+        childTaskIds: ["child-1", "child-2"],
+        statusSummary: "2 tasks running",
+      },
+      updatedAt: new Date("2026-04-30T01:00:00Z"),
+    });
+
+    expect(sortIssueWorkProductsForDisplay([generic, hermes]).map((product) => product.id)).toEqual([
+      "hermes",
+      "generic",
+    ]);
+    expect(getHermesExecutionDetails(hermes)).toEqual({
+      rootTaskId: "root-1",
+      childTaskCount: 2,
+      statusSummary: "2 tasks running",
+    });
+  });
+
+  it("renders Hermes execution links, rollup details, generic products, and an empty state", () => {
+    const html = renderToStaticMarkup(
+      <IssueWorkProductsSection
+        products={[
+          workProduct({
+            id: "hermes-board",
+            provider: "hermes-kanban",
+            type: "preview_url",
+            title: "Hermes Kanban board",
+            url: "https://hermes-workspace.tail54e18.ts.net/kanban/tasks/root-1",
+            metadata: {
+              rootTaskId: "root-1",
+              childTaskIds: ["child-1", "child-2"],
+              statusSummary: "Blocked waiting on API token scope",
+            },
+          }),
+          workProduct({
+            id: "doc",
+            provider: "paperclip",
+            type: "document",
+            title: "MVP notes",
+            summary: "Operator handoff",
+          }),
+        ]}
+      />,
+    );
+
+    expect(html).toContain('data-hermes-execution-panel="true"');
+    expect(html).toContain('data-hermes-execution-readout="1 Hermes"');
+    expect(html).toContain("Hermes execution");
+    expect(html).toContain("Hermes Kanban board");
+    expect(html).toContain("https://hermes-workspace.tail54e18.ts.net/kanban/tasks/root-1");
+    expect(html).toContain("Root task");
+    expect(html).toContain("root-1");
+    expect(html).toContain("Child tasks");
+    expect(html).toContain("2");
+    expect(html).toContain("Blocked waiting on API token scope");
+    expect(html).toContain("MVP notes");
+    expect(html).toContain("bg-[color-mix(in_srgb,var(--accent)_20%,var(--card))]");
+    expect(html).toContain("bg-[color-mix(in_srgb,var(--accent)_18%,var(--card))]");
+    expect(html).toContain("bg-[color-mix(in_srgb,var(--foreground)_5%,var(--card))]");
+    expect(html).toContain("font-mono text-[11px] font-medium uppercase tracking-[0.22em] text-[var(--text-display)]");
+    expect(html).toContain("border-l-[3px] border-[var(--event-accent)]");
+    expect(html).toContain("font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-display)]");
+    expect(html).not.toContain("status-live-bg");
+    expect(html).not.toContain("status-live-fg");
+    expect(html).not.toContain("linear-gradient");
+    expect(html).not.toContain("rounded-full");
+
+    const emptyHtml = renderToStaticMarkup(<IssueWorkProductsSection products={[]} />);
+    expect(emptyHtml).toContain('data-hermes-execution-panel="true"');
+    expect(emptyHtml).toContain("No Hermes execution links yet");
+  });
+});

--- a/ui/src/components/IssueWorkProductsSection.tsx
+++ b/ui/src/components/IssueWorkProductsSection.tsx
@@ -1,0 +1,190 @@
+import type { IssueWorkProduct } from "@paperclipai/shared";
+
+function metadataRecord(product: IssueWorkProduct): Record<string, unknown> {
+  return product.metadata && typeof product.metadata === "object" && !Array.isArray(product.metadata)
+    ? product.metadata
+    : {};
+}
+
+function metadataString(metadata: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = metadata[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return null;
+}
+
+function metadataArrayCount(metadata: Record<string, unknown>, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const value = metadata[key];
+    if (Array.isArray(value)) return value.length;
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+function productTimestamp(product: IssueWorkProduct): number {
+  const value = product.updatedAt instanceof Date
+    ? product.updatedAt.getTime()
+    : new Date(product.updatedAt).getTime();
+  return Number.isFinite(value) ? value : 0;
+}
+
+function isHermesKanbanProduct(product: IssueWorkProduct): boolean {
+  return product.provider === "hermes-kanban";
+}
+
+export function sortIssueWorkProductsForDisplay(products: IssueWorkProduct[]): IssueWorkProduct[] {
+  return [...products].sort((a, b) => {
+    const aHermes = isHermesKanbanProduct(a) ? 0 : 1;
+    const bHermes = isHermesKanbanProduct(b) ? 0 : 1;
+    if (aHermes !== bHermes) return aHermes - bHermes;
+    if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
+    return productTimestamp(b) - productTimestamp(a);
+  });
+}
+
+export function getHermesExecutionDetails(product: IssueWorkProduct): {
+  rootTaskId: string | null;
+  childTaskCount: number | null;
+  statusSummary: string | null;
+} {
+  const metadata = metadataRecord(product);
+  return {
+    rootTaskId: metadataString(metadata, "rootTaskId", "root_task_id", "hermesRootTaskId"),
+    childTaskCount: metadataArrayCount(metadata, "childTaskIds", "child_task_ids", "hermesChildTaskIds", "childTaskCount"),
+    statusSummary: metadataString(metadata, "statusSummary", "status_summary", "lastStatusSummary"),
+  };
+}
+
+function providerLabel(provider: string): string {
+  if (provider === "hermes-kanban") return "Hermes Kanban";
+  return provider.replace(/[-_]/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function statusLabel(status: string): string {
+  return status.replace(/_/g, " ");
+}
+
+function WorkProductCard({ product }: { product: IssueWorkProduct }) {
+  const details = getHermesExecutionDetails(product);
+  const isHermes = isHermesKanbanProduct(product);
+  const summary = details.statusSummary ?? product.summary;
+
+  return (
+    <article
+      className={
+        isHermes
+          ? "border border-[var(--border-visible)] bg-[color-mix(in_srgb,var(--foreground)_5%,var(--card))] p-3"
+          : "border border-[color-mix(in_srgb,var(--border-visible)_32%,transparent)] bg-[color-mix(in_srgb,var(--accent)_18%,var(--card))] p-3"
+      }
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={
+                isHermes
+                  ? "border-l-[3px] border-[var(--event-accent)] bg-[color-mix(in_srgb,var(--foreground)_7%,var(--background))] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-display)]"
+                  : "border border-[color-mix(in_srgb,var(--border-visible)_38%,transparent)] bg-background px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-display)]"
+              }
+            >
+              {providerLabel(product.provider)}
+            </span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+              {product.type.replace(/_/g, " ")}
+            </span>
+            {product.isPrimary && (
+              <span className="border-l-[3px] border-[var(--status-live-border)] bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-display)]">
+                Primary
+              </span>
+            )}
+          </div>
+          {product.url ? (
+            <a
+              href={product.url}
+              target="_blank"
+              rel="noreferrer"
+              className="block truncate font-mono text-[11px] font-medium uppercase tracking-[0.22em] text-[var(--text-display)] hover:underline"
+              title={product.url}
+            >
+              {product.title}
+            </a>
+          ) : (
+            <p className="truncate font-mono text-[11px] font-medium uppercase tracking-[0.22em] text-[var(--text-display)]">{product.title}</p>
+          )}
+          {summary && <p className="text-xs leading-5 text-muted-foreground">{summary}</p>}
+        </div>
+        <span className="shrink-0 border-l-[3px] border-[var(--border-visible)] bg-[color-mix(in_srgb,var(--foreground)_5%,var(--card))] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-display)]">
+          {statusLabel(product.status)}
+        </span>
+      </div>
+
+      {(details.rootTaskId || details.childTaskCount !== null || product.externalId) && (
+        <dl className="mt-3 grid grid-cols-1 gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+          {details.rootTaskId && (
+            <div>
+              <dt className="font-mono uppercase tracking-[0.18em] text-[10px]">Root task</dt>
+              <dd className="font-mono text-foreground">{details.rootTaskId}</dd>
+            </div>
+          )}
+          {details.childTaskCount !== null && (
+            <div>
+              <dt className="font-mono uppercase tracking-[0.18em] text-[10px]">Child tasks</dt>
+              <dd className="font-mono text-foreground">{details.childTaskCount}</dd>
+            </div>
+          )}
+          {product.externalId && (
+            <div>
+              <dt className="font-mono uppercase tracking-[0.18em] text-[10px]">External ID</dt>
+              <dd className="font-mono text-foreground">{product.externalId}</dd>
+            </div>
+          )}
+        </dl>
+      )}
+    </article>
+  );
+}
+
+export function IssueWorkProductsSection({ products }: { products: IssueWorkProduct[] }) {
+  const sortedProducts = sortIssueWorkProductsForDisplay(products);
+  const hermesCount = sortedProducts.filter(isHermesKanbanProduct).length;
+  const hermesReadout = `${hermesCount} Hermes`;
+
+  return (
+    <section
+      data-hermes-execution-panel="true"
+      className="space-y-3 border border-[var(--border-visible)] bg-[color-mix(in_srgb,var(--accent)_20%,var(--card))] p-3"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="space-y-1">
+          <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground">Execution surface</span>
+          <h3 className="font-mono text-[11px] font-medium uppercase tracking-[0.22em] text-[var(--text-display)]">Hermes execution</h3>
+          <p className="text-xs text-muted-foreground">
+            Kanban, Conductor, and artifact links attached to this issue.
+          </p>
+        </div>
+        {hermesCount > 0 && (
+          <span
+            data-hermes-execution-readout={hermesReadout}
+            className="border-l-[3px] border-[var(--event-accent)] bg-[color-mix(in_srgb,var(--foreground)_5%,var(--card))] px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-[var(--text-display)]"
+          >
+            {hermesReadout}
+          </span>
+        )}
+      </div>
+
+      {sortedProducts.length === 0 ? (
+        <p className="border border-dashed border-[color-mix(in_srgb,var(--border-visible)_38%,transparent)] p-3 text-xs text-muted-foreground">
+          No Hermes execution links yet. Launch Hermes Kanban for this issue to attach board, root task, and status roll-up links here.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {sortedProducts.map((product) => (
+            <WorkProductCard key={product.id} product={product} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -194,6 +194,10 @@ vi.mock("../components/IssueDocumentsSection", () => ({
   IssueDocumentsSection: () => <div>Documents</div>,
 }));
 
+vi.mock("../components/IssueWorkProductsSection", () => ({
+  IssueWorkProductsSection: () => <div>Work Products</div>,
+}));
+
 vi.mock("../components/IssuesList", () => ({
   IssuesList: (props: { issueBadgeById?: Map<string, string> }) => {
     mockIssuesListRender(props);

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -65,6 +65,7 @@ import { InlineEditor } from "../components/InlineEditor";
 import { IssueChatThread, type IssueChatComposerHandle } from "../components/IssueChatThread";
 import { IssueContinuationHandoff } from "../components/IssueContinuationHandoff";
 import { IssueDocumentsSection } from "../components/IssueDocumentsSection";
+import { IssueWorkProductsSection } from "../components/IssueWorkProductsSection";
 import { IssuesList } from "../components/IssuesList";
 import { AgentIcon } from "../components/AgentIconPicker";
 import { IssueReferenceActivitySummary } from "../components/IssueReferenceActivitySummary";
@@ -3217,6 +3218,8 @@ export function IssueDetail() {
         }}
         extraActions={!hasAttachments ? attachmentUploadButton : null}
       />
+
+      <IssueWorkProductsSection products={issue.workProducts ?? []} />
 
       {attachmentsInitialLoading ? (
         <IssueSectionSkeleton titleWidth="w-24" rows={2} />


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies and needs clear operator visibility into execution.
> - The issue detail page is the narrowest place to expose execution artifacts without inventing a larger dashboard surface.
> - EMT-20's Hermes Kanban MVP already writes Hermes work-products/comments, but the issue detail UX did not surface those artifacts clearly enough.
> - That made it harder to trace a Paperclip issue to its Hermes execution board, root task, and roll-up status from the existing issue workflow.
> - This pull request adds a focused issue-detail visibility slice that prioritizes Hermes execution artifacts while preserving generic work-products.
> - The benefit is a smaller, grounded execution surface in the existing issue detail page that makes Hermes-backed work legible without expanding scope beyond the MVP slice.

## What Changed

- added `ui/src/components/IssueWorkProductsSection.tsx` to sort Hermes work-products first and render provider, status, board/task link, root task ID, child task count, and status summary metadata
- added `ui/src/components/IssueWorkProductsSection.test.tsx` to cover Hermes-first sorting, metadata extraction, mixed generic/Hermes rendering, and the empty state
- wired `IssueWorkProductsSection` into `ui/src/pages/IssueDetail.tsx`
- updated `ui/src/pages/IssueDetail.test.tsx` to mock the new section in page-level coverage

## Verification

- `pnpm vitest run ui/src/components/IssueWorkProductsSection.test.tsx ui/src/pages/IssueDetail.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm --filter @paperclipai/ui build`
- `pnpm -r typecheck`
- `pnpm build`
- `pnpm test:run` (fails on pre-existing unrelated CLI tailnet tests: `src/__tests__/network-bind.test.ts` and `src/__tests__/onboard.test.ts` expecting loopback host but detecting a tailscale address on Raven)

## Risks

- Low risk UI-only change, but the new panel depends on existing work-product metadata keys being present for the richer Hermes readouts.
- If future Hermes work-product metadata names drift, the panel still renders generic cards but may lose some root-task/child-count/status-summary detail until mappings are updated.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.4 via Hermes Agent with terminal, file reading, and git/GitHub tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
