### PR TITLE
fix(docker): update GitHub CLI keyring SHA256 pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates gosu curl git wget ripgrep python3 \
   && mkdir -p -m 755 /etc/apt/keyrings \
   && wget -nv -O/etc/apt/keyrings/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-  && echo "20e0125d6f6e077a9ad46f03371bc26d90b04939fb95170f5a1905099cc6bcc0  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
+  && echo "6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b  /etc/apt/keyrings/githubcli-archive-keyring.gpg" | sha256sum -c - \
   && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
   && mkdir -p -m 755 /etc/apt/sources.list.d \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The Docker images (root \`Dockerfile\` consumed by \`docker/docker-compose.quickstart.yml\`, \`docker/docker-compose.yml\`, and \`docker/docker-compose.untrusted-review.yml\`) are the no-Node-install path documented in \`doc/DOCKER.md\` and the entire untrusted-PR-review workflow in \`doc/UNTRUSTED-PR-REVIEW.md\`
> - The base layer pins the SHA256 of GitHub CLI's apt keyring (\`githubcli-archive-keyring.gpg\`) before installing \`gh\` from \`cli.github.com\`
> - GitHub rotated that signing key upstream, so the file served at \`https://cli.github.com/packages/githubcli-archive-keyring.gpg\` no longer matches the pinned hash and every fresh \`docker build .\` fails at the base apt step with \`sha256sum: WARNING: 1 computed checksum did NOT match\`
> - Without this fix, none of the Docker workflows (quickstart compose, full-stack compose, untrusted PR review, the local image build instructions in \`doc/DOCKER.md\`) work for any contributor on a clean cache
> - This pull request bumps the pinned SHA256 to the current upstream value
> - The benefit is that all Docker-based workflows succeed again on first build with no other changes required

## What Changed

- Updated the pinned SHA256 in \`Dockerfile\` for \`/etc/apt/keyrings/githubcli-archive-keyring.gpg\` from the stale \`20e0125d6f6e077a9ad46f03371bc26d90b04939fb95170f5a1905099cc6bcc0\` to the current upstream value \`6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b\`. The new hash matches the value documented at https://github.com/cli/cli/blob/trunk/docs/install_linux.md and was independently verified against the live download.

## Verification

- Verify the pin matches what GitHub currently serves:
  \`\`\`sh
  curl -sSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sha256sum
  # → 6084d5d7bd8e288441e0e94fc6275570895da18e6751f70f057485dc2d1a811b
  \`\`\`
- Cross-reference the official source of truth: the same hash is documented in \`docs/install_linux.md\` of cli/cli (https://github.com/cli/cli/blob/trunk/docs/install_linux.md).
- A clean rebuild now succeeds. From repo root:
  \`\`\`sh
  docker build --no-cache -t paperclip-local .
  \`\`\`
  Previously failed at the base apt step on the keyring \`sha256sum -c\`. Now completes through to the production stage.
- End-to-end: the full-stack compose path also succeeds:
  \`\`\`sh
  BETTER_AUTH_SECRET=\$(openssl rand -hex 32) \\\\
    docker compose -f docker/docker-compose.yml up --build
  \`\`\`
  Server reaches \`Server listening on 0.0.0.0:3100\` and \`/api/health\` returns \`{\"status\":\"ok\"}\`.

## Risks

- Low risk. Single-line change to a SHA256 pin in a Dockerfile RUN step.
- The only failure mode would be if GitHub were to rotate the key again between this PR landing and a future build — at which point the same fix pattern applies. This is a recurring class of issue that could be solved more durably by removing the hash check (the keyring itself is fetched over HTTPS to a GitHub-controlled domain) or by switching to GPG fingerprint verification, but that is intentionally out of scope here to keep the change minimal and reviewable.
- No runtime behavior change, no migration impact, no API surface change, no schema or contract change. Only affects \`docker build\` cache invalidation (the base layer must be rebuilt once).

## Model Used

- Provider: Anthropic Claude
- Model: \`claude-opus-4-7\`
- Capabilities used: extended thinking, tool use (shell, file read/write, web fetch for cross-referencing https://github.com/cli/cli/blob/trunk/docs/install_linux.md, and live SHA256 verification via \`curl ... | sha256sum\`)
- Surface: Cursor IDE agent

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass — N/A: Dockerfile-only change with no unit-test coverage; verified by clean rebuild + full-stack compose smoke (see Verification)
- [x] I have added or updated tests where applicable — N/A: no test infrastructure exists for Dockerfile keyring pins
- [x] If this change affects the UI, I have included before/after screenshots — N/A: no UI changes
- [x] I have updated relevant documentation to reflect my changes — no docs reference this hash; \`doc/DOCKER.md\` workflows are unblocked by this change
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)