### PR TITLE
fix(dev): respect home .env values when --tailscale-auth is passed

### DIFF
--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -16,9 +16,10 @@ import {
 } from "../server/src/services/local-service-supervisor.ts";
 
 // Minimal .env parser: KEY=VALUE per line, optional surrounding quotes,
-// `#` comments, blank lines ignored. Mirrors the subset of dotenv we need
-// without pulling in the dotenv package (which doesn't resolve from
-// scripts/ — there's no nearest package.json with it as a dependency).
+// `#` comments (whole-line and inline), blank lines ignored. Mirrors the
+// subset of dotenv we need without pulling in the dotenv package (which
+// doesn't resolve from scripts/ — there's no nearest package.json with it
+// as a dependency).
 function parseEnvFile(contents: string): Record<string, string> {
   const result: Record<string, string> = {};
   for (const rawLine of contents.split(/\r?\n/)) {
@@ -29,11 +30,15 @@ function parseEnvFile(contents: string): Record<string, string> {
     const key = line.slice(0, eq).trim();
     if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
     let value = line.slice(eq + 1).trim();
-    if (
-      (value.startsWith("\"") && value.endsWith("\"")) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
+    const quote = value[0] === "\"" || value[0] === "'" ? value[0] : null;
+    if (quote) {
+      const closeIdx = value.indexOf(quote, 1);
+      if (closeIdx !== -1) {
+        value = value.slice(1, closeIdx);
+      }
+    } else {
+      const hashIdx = value.indexOf("#");
+      if (hashIdx !== -1) value = value.slice(0, hashIdx).trimEnd();
     }
     result[key] = value;
   }

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -1,18 +1,60 @@
 #!/usr/bin/env -S node --import tsx
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { createCapturedOutputBuffer, parseJsonResponseWithLimit } from "./dev-runner-output.mjs";
 import { shouldTrackDevServerPath } from "./dev-runner-paths.mjs";
 import { createDevServiceIdentity, repoRoot } from "./dev-service-profile.ts";
+import { resolvePaperclipEnvPath } from "../server/src/paths.ts";
 import {
   findAdoptableLocalService,
   removeLocalServiceRegistryRecord,
   touchLocalServiceRegistryRecord,
   writeLocalServiceRegistryRecord,
 } from "../server/src/services/local-service-supervisor.ts";
+
+// Minimal .env parser: KEY=VALUE per line, optional surrounding quotes,
+// `#` comments, blank lines ignored. Mirrors the subset of dotenv we need
+// without pulling in the dotenv package (which doesn't resolve from
+// scripts/ — there's no nearest package.json with it as a dependency).
+function parseEnvFile(contents: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith("\"") && value.endsWith("\"")) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+// Pre-load the Paperclip home .env (mirrors what server/src/config.ts does on
+// startup) so that any deployment-related values present in .env are visible
+// in process.env BEFORE we construct the child process env below. This lets
+// users override the --tailscale-auth flag's defaults from their .env file
+// (the child uses dotenv with override:false and would otherwise see whatever
+// we forced here first).
+const HOME_ENV_FILE_PATH = resolvePaperclipEnvPath();
+if (existsSync(HOME_ENV_FILE_PATH)) {
+  const parsed = parseEnvFile(readFileSync(HOME_ENV_FILE_PATH, "utf8"));
+  for (const [key, value] of Object.entries(parsed)) {
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
 
 const mode = process.argv[2] === "watch" ? "watch" : "dev";
 const cliArgs = process.argv.slice(3);
@@ -95,11 +137,20 @@ if (mode === "watch") {
 }
 
 if (tailscaleAuth) {
-  env.PAPERCLIP_DEPLOYMENT_MODE = "authenticated";
-  env.PAPERCLIP_DEPLOYMENT_EXPOSURE = "private";
-  env.PAPERCLIP_AUTH_BASE_URL_MODE = "auto";
-  env.HOST = "0.0.0.0";
-  console.log("[paperclip] dev mode: authenticated/private (tailscale-friendly) on 0.0.0.0");
+  // Use ??= so any value already present in process.env (typically from the
+  // Paperclip home .env pre-loaded above) takes precedence over these
+  // convenience defaults. This is what makes setting PAPERCLIP_PUBLIC_URL +
+  // PAPERCLIP_AUTH_BASE_URL_MODE=explicit in .env actually stick.
+  env.PAPERCLIP_DEPLOYMENT_MODE ??= "authenticated";
+  env.PAPERCLIP_DEPLOYMENT_EXPOSURE ??= "private";
+  env.PAPERCLIP_AUTH_BASE_URL_MODE ??= "auto";
+  env.HOST ??= "0.0.0.0";
+  const baseUrlMode = env.PAPERCLIP_AUTH_BASE_URL_MODE;
+  const publicUrl = env.PAPERCLIP_PUBLIC_URL;
+  const detail = baseUrlMode === "explicit" && publicUrl ? ` baseURL=${publicUrl}` : "";
+  console.log(
+    `[paperclip] dev mode: ${env.PAPERCLIP_DEPLOYMENT_MODE}/${env.PAPERCLIP_DEPLOYMENT_EXPOSURE} (tailscale-friendly) on ${env.HOST}${detail}`,
+  );
 } else {
   console.log("[paperclip] dev mode: local_trusted (default)");
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The dev workflow is centered on \`pnpm dev\` (and the \`--tailscale-auth\` variant) driven by \`scripts/dev-runner.ts\`, documented in \`doc/DEVELOPING.md\` under "Tailscale/private-auth dev mode"
> - For authenticated/private deployments, Better Auth needs an explicit base URL or it logs \`[better-auth] Base URL could not be determined…\` at startup; the supported way to set it is \`PAPERCLIP_AUTH_BASE_URL_MODE=explicit\` + \`PAPERCLIP_PUBLIC_URL=...\` in the Paperclip home \`.env\` (resolved by \`server/src/config.ts\` via \`resolvePaperclipEnvPath()\`)
> - When \`--tailscale-auth\` is passed, dev-runner unconditionally sets \`PAPERCLIP_AUTH_BASE_URL_MODE=auto\` (and three other deployment-related vars) on the spawned server child, clobbering anything the user put in their \`.env\`. The server child loads dotenv with \`override: false\`, so once dev-runner has stamped \`auto\` into \`process.env\`, the user's \`.env\` value loses
> - Net effect: there is currently no way to pin Better Auth's base URL on \`pnpm dev --tailscale-auth\` without editing the dev-runner. Users get the warning every restart and end up with auth callbacks/cookies that aren't anchored to the canonical Tailscale hostname
> - This pull request makes \`--tailscale-auth\` a "set defaults if unset" affordance instead of a hard override, and pre-loads the home \`.env\` early enough that those defaults can actually be overridden
> - The benefit is that the documented \`PAPERCLIP_AUTH_BASE_URL_MODE\` / \`PAPERCLIP_PUBLIC_URL\` env knobs work as advertised under \`--tailscale-auth\`, the Better Auth warning disappears, and the existing flag stays useful for fresh setups that don't need the customization

## What Changed

- Added a small inline \`parseEnvFile\` helper in \`scripts/dev-runner.ts\` (no external deps; \`scripts/\` has no nearest \`package.json\`, and \`dotenv\` doesn't resolve from there).
- Pre-load the Paperclip home \`.env\` (resolved with \`resolvePaperclipEnvPath()\` from \`server/src/paths.ts\`, the same helper \`server/src/config.ts\` already uses) into \`process.env\` at the top of dev-runner, only setting keys that are not already present.
- Changed the \`--tailscale-auth\` block from unconditional assignment (\`env.X = "..."\`) to conditional defaults (\`env.X ??= "..."\`) for \`PAPERCLIP_DEPLOYMENT_MODE\`, \`PAPERCLIP_DEPLOYMENT_EXPOSURE\`, \`PAPERCLIP_AUTH_BASE_URL_MODE\`, and \`HOST\`. Default values are unchanged when nothing is set in \`.env\`, so existing fresh-setup behavior is preserved exactly.
- Banner now echoes the resolved baseURL when explicit mode is active, so misconfiguration is easier to spot, e.g.:
  \`\`\`
  [paperclip] dev mode: authenticated/private (tailscale-friendly) on 0.0.0.0 baseURL=http://example.tail-XXXX.ts.net:3100
  \`\`\`

## Verification

- **Unit-level smoke test**: from repo root, with \`PAPERCLIP_AUTH_BASE_URL_MODE=explicit\` and \`PAPERCLIP_PUBLIC_URL=http://<host>:3100\` in \`~/.paperclip/instances/default/.env\`, run:
  \`\`\`sh
  pnpm --filter @paperclipai/server exec tsx ../scripts/dev-runner.ts watch --tailscale-auth
  \`\`\`
  Banner shows: \`dev mode: authenticated/private (tailscale-friendly) on 0.0.0.0 baseURL=http://<host>:3100\`. (If a dev instance is already running, dev-runner correctly detects the existing service via \`findAdoptableLocalService\` and exits without spawning a duplicate — that path also exercises this code.)
- **Cross-cut check**: server's existing auth-config log line confirms the explicit base URL is now respected and the Better Auth \`Base URL could not be determined\` warning is gone:
  \`\`\`
  Authenticated mode auth origin configuration {"authBaseUrlMode":"explicit","authPublicBaseUrl":"http://<host>:3100",…}
  \`\`\`
- **Project-wide typecheck** passes (\`pnpm -r typecheck\` → exit 0 across server, ui, cli, plugin examples).
- **No-config behavior preserved**: if no home \`.env\` exists or it has none of the four keys, the \`??=\` defaults take effect and the dev-runner behaves exactly as before this change.

## Risks

- **Low risk** — changes are confined to \`scripts/dev-runner.ts\`, only run during dev, and only alter dev-runner's behavior in two narrow ways: (1) it now reads a file it already trusted via the spawned child, and (2) it stops overriding env vars the user explicitly set.
- **Behavior parity for users who don't use \`.env\`**: identical defaults preserved (\`authenticated\` / \`private\` / \`auto\` / \`0.0.0.0\`).
- **\`.env\` parser scope**: the inline parser intentionally handles only the format that \`paperclipai onboard\`/CLI commands write (\`KEY=value\` per line, optional surrounding quotes, \`#\` comments, blank lines). It does not implement multi-line values, escape sequences, or variable expansion. Anyone editing \`~/.paperclip/instances/<id>/.env\` by hand with exotic syntax should be aware. Listed here for completeness; the affected file is generated by Paperclip's own CLI and follows this format.
- **No migration impact, no API surface change, no schema/contract change.** No production code path is affected (dev-runner is only used by \`pnpm dev\` / \`pnpm dev:once\` / \`pnpm dev:watch\`, never in built/published artifacts).
- **No new test coverage added**: \`scripts/dev-runner.ts\` is currently outside the project test/typecheck graph (no \`scripts/tsconfig.json\`, no Vitest scope). Adding test infrastructure for the dev-runner is intentionally out of scope here to keep the change reviewable; the verification above is end-to-end smoke + typecheck.

## Model Used

- Provider: Anthropic Claude
- Model: \`claude-opus-4-7\`
- Capabilities used: extended thinking, tool use (shell, file read/edit, grep/glob)
- Surface: Cursor IDE agent

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass — verified \`pnpm -r typecheck\` passes; \`scripts/dev-runner.ts\` has no automated test coverage in the project today (see Risks); end-to-end smoke is documented in Verification
- [x] I have added or updated tests where applicable — N/A: no test infrastructure exists for \`scripts/dev-runner.ts\`; adding it is out of scope for this fix
- [x] If this change affects the UI, I have included before/after screenshots — N/A: no UI changes
- [x] I have updated relevant documentation to reflect my changes — \`doc/DEVELOPING.md\` already documents \`pnpm dev --tailscale-auth\` and \`PAPERCLIP_ALLOWED_HOSTNAMES\`; this change makes the documented \`PAPERCLIP_AUTH_BASE_URL_MODE\` / \`PAPERCLIP_PUBLIC_URL\` env knobs actually work in that mode
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)