### PR TITLE
chore(deps): bump hermes-paperclip-adapter ^0.2.0 -> ^0.3.0

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -66,7 +66,7 @@
     "drizzle-orm": "^0.38.4",
     "embedded-postgres": "^18.1.0-beta.16",
     "express": "^5.1.0",
-    "hermes-paperclip-adapter": "^0.2.0",
+    "hermes-paperclip-adapter": "^0.3.0",
     "jsdom": "^28.1.0",
     "multer": "^2.1.1",
     "open": "^11.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -50,7 +50,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "hermes-paperclip-adapter": "^0.2.0",
+    "hermes-paperclip-adapter": "^0.3.0",
     "lexical": "0.35.0",
     "lucide-react": "^0.574.0",
     "mermaid": "^11.12.0",


### PR DESCRIPTION
## Thinking Path

> Paperclip orchestrates AI agents as Paperclip "employees" via per-CLI adapter
> packages. The Hermes Agent CLI is one such employee, integrated through
> `hermes-paperclip-adapter` published on npm by NousResearch.
>
> Heartbeat wakes call back into the Paperclip API by injecting prompt
> templates that include shell snippets like
> `curl ... | python3 -c "..."`. The Python snippet uses an f-string that
> references issue dictionary keys by name (e.g. `i["identifier"]`).
>
> Until 0.3.0, the adapter's templates emitted the inner double quotes
> unescaped, so bash terminated the `python3 -c "..."` argument prematurely
> and the wake reported `SyntaxError`/`NameError` instead of the issue list.
>
> NousResearch/hermes-paperclip-adapter PR #58 (merged) fixes the quoting
> by escaping the inner double quotes (`f\"{i['identifier']}\"`) so the
> rendered prompt is shell-safe. The fix shipped as `0.3.0`.
>
> Both `server/package.json` and `ui/package.json` here pin the adapter at
> `^0.2.0`. Under semver, `^0.2.0` for a 0-major package only resolves
> patch updates inside the `0.2.x` line. So fresh installs of paperclipai
> still resolve to `0.2.1`, which still has the bug.
>
> This PR bumps the caret to `^0.3.0` in both manifests so consumers pick
> up the published fix on a clean install.

## What Changed

- `server/package.json`: `hermes-paperclip-adapter` pin `^0.2.0` -> `^0.3.0`
- `ui/package.json`:     `hermes-paperclip-adapter` pin `^0.2.0` -> `^0.3.0`

No other code changes. No lockfile change in this PR (see Lockfile note
under Risks).

## Verification

I ran the bumped pins against a live paperclipai instance:

```
paperclipai             2026.4.28.0   (current latest published)
hermes-paperclip-adapter 0.3.0        (installed under the new pin)
```

Heartbeat wakes that previously failed with the unescaped-quote bug now
return clean issue lists, e.g.

```
WIL-74 in_progress medium  Weekly native skill sync + audit
WIL-68 backlog     medium  Browser harness research
...
```

`pnpm -r typecheck` and `pnpm test:run` exit codes match `master` HEAD.
The 9 pre-existing test failures in
`@paperclipai/adapter-utils/src/sandbox-callback-bridge.test.ts`
reproduce on a clean `master` checkout with no other changes, so they
are NOT regressions from this PR.

To verify locally:

```sh
pnpm install --no-frozen-lockfile     # resolves 0.3.0 cleanly
pnpm -r typecheck
pnpm test:run                         # same baseline as master
node -p "require('hermes-paperclip-adapter/package.json').version"
# -> 0.3.0
```

## Risks

**Low behavioral risk.** The 0.3.0 change is a string-escape fix in the
prompt template's Python snippets. The adapter's TypeScript public API is
unchanged. The runtime wire format (REST calls into `/api/...`) is
unchanged. Any consumer that was working on `0.2.1` will keep working on
`0.3.0`; the only observable difference is heartbeat wakes stop failing
on the quoting bug.

**Lockfile / CI tradeoff.** This PR intentionally does NOT touch
`pnpm-lock.yaml`, per the `pr.yml::policy` rule that blocks
manual lockfile commits. Consequence:

- The `policy` job's "Validate dependency resolution when manifests
  change" step uses `pnpm install --lockfile-only --no-frozen-lockfile`,
  which will resolve cleanly. -> policy passes.
- The `verify` job runs `pnpm install --frozen-lockfile`, which will
  fail because the committed lockfile still pins `^0.2.0`. -> verify
  fails.

This is the same catch-22 documented in
`packages/adapter-utils` PR contributors hit when adding deps. The
intended path: maintainers either run the
`refresh-lockfile.yml` workflow against the merge commit on master
(which auto-updates the lockfile post-merge) or merge with a manual
lockfile bump squashed in.

If you'd prefer a different workflow (e.g. include the lockfile in
this PR and waive the policy check, or split into two PRs), happy to
re-submit however you want.

## Model Used

- Provider: OpenRouter
- Model: anthropic/claude-opus-4.7
- Context window: 200K
- Capabilities: tool use, code editing, multi-step reasoning
- Mode: agentic CLI session (Hermes Agent v0.10.0)

## Checklist

- [x] Behavior matches `doc/SPEC-implementation.md` (no behavior change)
- [x] Typecheck, tests, and build pass relative to `master` baseline
      (same pre-existing failures, no new ones)
- [x] Contracts are synced across db/shared/server/ui (no contract change)
- [x] Docs updated when behavior or commands change (none required)
- [x] PR description follows the [PR template](.github/PULL_REQUEST_TEMPLATE.md) with all sections filled in (including Model Used)
