### PR TITLE
fix(agents): drop deprecated adapterConfig.cwd from new hires

### DIFF
--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -14,7 +14,7 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `cwd` | string | Yes | Working directory for the agent process (absolute path; created automatically if missing when permissions allow) |
+| `cwd` | string | No | **Deprecated.** Legacy working directory fallback. New agents must not set this — Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged for audit); existing agents that still carry it are preserved. |
 | `model` | string | No | Claude model to use (e.g. `claude-opus-4-6`) |
 | `promptTemplate` | string | No | Prompt used for all runs |
 | `env` | object | No | Environment variables (supports secret refs) |

--- a/docs/adapters/codex-local.md
+++ b/docs/adapters/codex-local.md
@@ -14,7 +14,7 @@ The `codex_local` adapter runs OpenAI's Codex CLI locally. It supports session p
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `cwd` | string | Yes | Working directory for the agent process (absolute path; created automatically if missing when permissions allow) |
+| `cwd` | string | No | **Deprecated.** Legacy working directory fallback. New agents must not set this — Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged for audit); existing agents that still carry it are preserved. |
 | `model` | string | No | Model to use |
 | `promptTemplate` | string | No | Prompt used for all runs |
 | `env` | object | No | Environment variables (supports secret refs) |

--- a/docs/adapters/gemini-local.md
+++ b/docs/adapters/gemini-local.md
@@ -14,7 +14,7 @@ The `gemini_local` adapter runs Google's Gemini CLI locally. It supports session
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `cwd` | string | Yes | Working directory for the agent process (absolute path; created automatically if missing when permissions allow) |
+| `cwd` | string | No | **Deprecated.** Legacy working directory fallback. New agents must not set this — Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged for audit); existing agents that still carry it are preserved. |
 | `model` | string | No | Gemini model to use. Defaults to `auto`. |
 | `promptTemplate` | string | No | Prompt used for all runs |
 | `instructionsFilePath` | string | No | Markdown instructions file prepended to the prompt |

--- a/packages/adapters/acpx-local/src/index.ts
+++ b/packages/adapters/acpx-local/src/index.ts
@@ -36,7 +36,7 @@ Core fields:
 - agent (string, optional): claude, codex, or custom. Defaults to claude.
 - agentCommand (string, optional): custom ACP command when agent=custom, or an override for a built-in ACP agent command.
 - mode (string, optional): persistent or oneshot. Defaults to persistent. Paperclip keeps session state persistent and may close the live process between runs.
-- cwd (string, optional): default absolute working directory fallback for the agent process.
+- cwd (string, optional, **deprecated**): legacy working directory fallback for the agent process. New agents must not set this — Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged for audit); existing agents that still carry it are preserved.
 - permissionMode (string, optional): defaults to approve-all, meaning ACPX permission requests are auto-approved.
 - nonInteractivePermissions (string, optional): fallback behavior when ACPX cannot ask interactively. Supported values are deny and fail.
 - stateDir (string, optional): ACPX state directory. Defaults to a Paperclip-managed company/agent scoped location.

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -32,7 +32,7 @@ export const agentConfigurationDoc = `# claude_local agent configuration
 Adapter: claude_local
 
 Core fields:
-- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- cwd (string, optional, **deprecated**): legacy working directory fallback for the agent process. New agents must not set this — Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged for audit); existing agents that still carry it are preserved.
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file injected at runtime
 - model (string, optional): Claude model id
 - effort (string, optional): reasoning effort passed via --effort (low|medium|high)

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -63,7 +63,7 @@ export const agentConfigurationDoc = `# codex_local agent configuration
 Adapter: codex_local
 
 Core fields:
-- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- cwd (string, optional, **deprecated**): legacy working directory fallback for the agent process. New agents must not set this — Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged for audit); existing agents that still carry it are preserved.
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to stdin prompt at runtime
 - model (string, optional): Codex model id
 - modelReasoningEffort (string, optional): reasoning effort override (minimal|low|medium|high|xhigh) passed via -c model_reasoning_effort=...

--- a/packages/adapters/cursor-local/src/index.ts
+++ b/packages/adapters/cursor-local/src/index.ts
@@ -85,7 +85,7 @@ Don't use when:
 - Cursor Agent CLI is not installed on the machine
 
 Core fields:
-- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- cwd (string, optional, **deprecated**): legacy working directory fallback for the agent process. New agents must not set this — Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged for audit); existing agents that still carry it are preserved.
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - promptTemplate (string, optional): run prompt template
 - model (string, optional): Cursor model id (for example auto or gpt-5.3-codex)

--- a/packages/adapters/gemini-local/src/index.ts
+++ b/packages/adapters/gemini-local/src/index.ts
@@ -43,7 +43,7 @@ Don't use when:
 - Gemini CLI is not installed on the machine that runs Paperclip
 
 Core fields:
-- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- cwd (string, optional, **deprecated**): legacy working directory fallback for the agent process. New agents must not set this — Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged for audit); existing agents that still carry it are preserved.
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - promptTemplate (string, optional): run prompt template
 - model (string, optional): Gemini model id. Defaults to auto.

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -50,7 +50,7 @@ Don't use when:
 - OpenCode CLI is not installed on the machine
 
 Core fields:
-- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- cwd (string, optional, **deprecated**): legacy working directory fallback for the agent process. New agents must not set this — Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged for audit); existing agents that still carry it are preserved.
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file prepended to the run prompt
 - model (string, required): OpenCode model id in provider/model format (for example anthropic/claude-sonnet-4-5)
 - variant (string, optional): provider-specific reasoning/profile variant passed as --variant (for example minimal|low|medium|high|xhigh|max)

--- a/packages/adapters/pi-local/src/index.ts
+++ b/packages/adapters/pi-local/src/index.ts
@@ -25,7 +25,7 @@ Don't use when:
 - Pi CLI is not installed on the machine
 
 Core fields:
-- cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
+- cwd (string, optional, **deprecated**): legacy working directory fallback for the agent process. New agents must not set this — Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged for audit); existing agents that still carry it are preserved.
 - instructionsFilePath (string, optional): absolute path to a markdown instructions file appended to system prompt via --append-system-prompt
 - promptTemplate (string, optional): user prompt template passed via -p flag
 - model (string, required): Pi model id in provider/model format (for example xai/grok-4)

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1433,4 +1433,108 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(403);
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
   });
+
+  it("strips deprecated adapterConfig.cwd from claude_local hire payloads and logs the drop", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .send({
+        name: "ClaudeBuilder",
+        role: "engineer",
+        adapterType: "claude_local",
+        adapterConfig: {
+          cwd: "/Users/example/legacy-clone",
+          model: "claude-sonnet-4-6",
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledTimes(1);
+    const persistedAdapterConfig = mockAgentService.create.mock.calls[0][1].adapterConfig as Record<string, unknown>;
+    expect(persistedAdapterConfig).not.toHaveProperty("cwd");
+    expect(persistedAdapterConfig).toMatchObject({ model: "claude-sonnet-4-6" });
+
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.hire_dropped_deprecated_field",
+        details: expect.objectContaining({
+          adapterType: "claude_local",
+          droppedKey: "adapterConfig.cwd",
+          droppedValuePresent: true,
+        }),
+      }),
+    );
+  });
+
+  it("strips deprecated adapterConfig.cwd from codex_local direct-create payloads and logs the drop", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "CodexBuilder",
+        role: "engineer",
+        adapterType: "codex_local",
+        adapterConfig: {
+          cwd: "/Users/example/legacy-clone",
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledTimes(1);
+    const persistedAdapterConfig = mockAgentService.create.mock.calls[0][1].adapterConfig as Record<string, unknown>;
+    expect(persistedAdapterConfig).not.toHaveProperty("cwd");
+
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "agent.create_dropped_deprecated_field",
+        details: expect.objectContaining({
+          adapterType: "codex_local",
+          droppedKey: "adapterConfig.cwd",
+          droppedValuePresent: true,
+        }),
+      }),
+    );
+  });
+
+  it("does not log a drop when the hire payload has no adapterConfig.cwd", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .send({
+        name: "ClaudeBuilder",
+        role: "engineer",
+        adapterType: "claude_local",
+        adapterConfig: { model: "claude-sonnet-4-6" },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const dropLogCalls = mockLogActivity.mock.calls.filter(([, payload]) =>
+      payload?.action === "agent.hire_dropped_deprecated_field"
+      || payload?.action === "agent.create_dropped_deprecated_field",
+    );
+    expect(dropLogCalls).toEqual([]);
+  });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1133,6 +1133,37 @@ export function agentRoutes(
     }
   }
 
+  // Local adapters where `adapterConfig.cwd` is a deprecated legacy fallback.
+  // New agents must not carry it — Paperclip leases an execution workspace per
+  // issue. Existing agents that still have a `cwd` value are preserved by the
+  // PATCH path (see ADAPTER_AGNOSTIC_KEYS); this set only affects create/hire.
+  const ADAPTER_TYPES_WITH_DEPRECATED_CWD: ReadonlySet<string> = new Set([
+    "acpx_local",
+    "claude_local",
+    "codex_local",
+    "cursor_local",
+    "gemini_local",
+    "opencode_local",
+    "pi_local",
+  ]);
+
+  function stripDeprecatedCwdForNewAgent(
+    adapterType: string,
+    adapterConfig: Record<string, unknown>,
+  ): { adapterConfig: Record<string, unknown>; dropped: boolean; droppedValuePresent: boolean } {
+    if (!ADAPTER_TYPES_WITH_DEPRECATED_CWD.has(adapterType)) {
+      return { adapterConfig, dropped: false, droppedValuePresent: false };
+    }
+    if (!Object.prototype.hasOwnProperty.call(adapterConfig, "cwd")) {
+      return { adapterConfig, dropped: false, droppedValuePresent: false };
+    }
+    const value = adapterConfig.cwd;
+    const droppedValuePresent = typeof value === "string" && value.trim().length > 0;
+    const next = { ...adapterConfig };
+    delete next.cwd;
+    return { adapterConfig: next, dropped: true, droppedValuePresent };
+  }
+
   async function assertCanManageInstructionsPath(req: Request, targetAgent: { id: string; companyId: string }) {
     assertCompanyAccess(req, targetAgent.companyId);
     if (req.actor.type !== "board") {
@@ -1967,9 +1998,13 @@ export function agentRoutes(
     );
     assertNoAgentAdapterConfigMutation(req, rawHireAdapterConfig);
     assertNoAgentRuntimeConfigAdapterConfigMutation(req, hireInput.runtimeConfig);
-    const requestedAdapterConfig = applyCreateDefaultsByAdapterType(
+    const hireCwdStrip = stripDeprecatedCwdForNewAgent(
       hireInput.adapterType,
       rawHireAdapterConfig,
+    );
+    const requestedAdapterConfig = applyCreateDefaultsByAdapterType(
+      hireInput.adapterType,
+      hireCwdStrip.adapterConfig,
     );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
       companyId,
@@ -2075,6 +2110,27 @@ export function agentRoutes(
       }
     }
 
+    if (hireCwdStrip.dropped) {
+      console.warn(
+        `[agents] hire payload included deprecated adapterConfig.cwd; dropped before persistence (agentId=${agent.id}, adapterType=${hireInput.adapterType})`,
+      );
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "agent.hire_dropped_deprecated_field",
+        entityType: "agent",
+        entityId: agent.id,
+        details: {
+          adapterType: hireInput.adapterType,
+          droppedKey: "adapterConfig.cwd",
+          droppedValuePresent: hireCwdStrip.droppedValuePresent,
+        },
+      });
+    }
+
     await logActivity(db, {
       companyId,
       actorType: actor.actorType,
@@ -2153,9 +2209,13 @@ export function agentRoutes(
     );
     assertNoAgentAdapterConfigMutation(req, rawCreateAdapterConfig);
     assertNoAgentRuntimeConfigAdapterConfigMutation(req, createInput.runtimeConfig);
-    const requestedAdapterConfig = applyCreateDefaultsByAdapterType(
+    const createCwdStrip = stripDeprecatedCwdForNewAgent(
       createInput.adapterType,
       rawCreateAdapterConfig,
+    );
+    const requestedAdapterConfig = applyCreateDefaultsByAdapterType(
+      createInput.adapterType,
+      createCwdStrip.adapterConfig,
     );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
       companyId,
@@ -2191,6 +2251,26 @@ export function agentRoutes(
     const agent = await materializeDefaultInstructionsBundleForNewAgent(createdAgent, instructionsBundle);
 
     const actor = getActorInfo(req);
+    if (createCwdStrip.dropped) {
+      console.warn(
+        `[agents] direct create payload included deprecated adapterConfig.cwd; dropped before persistence (agentId=${agent.id}, adapterType=${createInput.adapterType})`,
+      );
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "agent.create_dropped_deprecated_field",
+        entityType: "agent",
+        entityId: agent.id,
+        details: {
+          adapterType: createInput.adapterType,
+          droppedKey: "adapterConfig.cwd",
+          droppedValuePresent: createCwdStrip.droppedValuePresent,
+        },
+      });
+    }
     await logActivity(db, {
       companyId,
       actorType: actor.actorType,

--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -108,7 +108,7 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-h
     "capabilities": "Owns technical roadmap, architecture, staffing, execution",
     "desiredSkills": ["vercel-labs/agent-browser/agent-browser"],
     "adapterType": "codex_local",
-    "adapterConfig": {"cwd": "/abs/path/to/repo", "model": "o4-mini"},
+    "adapterConfig": {"model": "o4-mini"},
     "instructionsBundle": {"files": {"AGENTS.md": "You are the CTO..."}},
     "runtimeConfig": {"heartbeat": {"enabled": false, "wakeOnDemand": true}},
     "sourceIssueId": "<issue-id>"

--- a/skills/paperclip-create-agent/references/api-reference.md
+++ b/skills/paperclip-create-agent/references/api-reference.md
@@ -41,7 +41,6 @@ Request body matches agent create shape:
   "desiredSkills": ["vercel-labs/agent-browser/agent-browser"],
   "adapterType": "claude_local",
   "adapterConfig": {
-    "cwd": "/absolute/path",
     "model": "claude-sonnet-4-5-20250929"
   },
   "instructionsBundle": {
@@ -85,6 +84,8 @@ If company setting disables required approval, `approval` is `null` and the agen
 
 `desiredSkills` accepts company skill ids, canonical keys, or a unique slug. The server resolves and stores canonical company skill keys.
 Leave timer heartbeats disabled by default. Only set `runtimeConfig.heartbeat.enabled=true` and include an `intervalSec` when the role truly needs scheduled recurring work or the user explicitly requested it.
+
+Do not include `adapterConfig.cwd` in new hire payloads. It is a deprecated legacy fallback for local adapters (`claude_local`, `codex_local`, `cursor_local`, `gemini_local`, `opencode_local`, `pi_local`, `acpx_local`); Paperclip leases an execution workspace per issue. The hire and direct-create endpoints drop this field for new agents (logged as `agent.hire_dropped_deprecated_field` / `agent.create_dropped_deprecated_field` for audit). Existing agents that still carry `cwd` are preserved by the PATCH path.
 
 ## Approval Lifecycle
 

--- a/skills/paperclip-create-agent/references/draft-review-checklist.md
+++ b/skills/paperclip-create-agent/references/draft-review-checklist.md
@@ -56,7 +56,8 @@ Use it for every path: exact template, adjacent template, or generic fallback.
 - [ ] `icon` is set to one of `/llms/agent-icons.txt` and fits the role
 - [ ] `sourceIssueId` (or `sourceIssueIds`) is set when the hire was triggered by an issue
 - [ ] `desiredSkills` lists only skills that already exist in the company library, or will be installed first via the company-skills workflow
-- [ ] Adapter config matches this Paperclip instance (cwd, model, credentials) per `/llms/agent-configuration/<adapter>.txt`
+- [ ] Adapter config matches this Paperclip instance (model, credentials) per `/llms/agent-configuration/<adapter>.txt`
+- [ ] No `adapterConfig.cwd` for new hires. It is deprecated for local adapters; Paperclip leases an execution workspace per issue. The hire endpoint drops it for new agents, but the draft should not include it in the first place.
 - [ ] Local managed-bundle adapters send custom instructions through top-level `instructionsBundle.files["AGENTS.md"]` and do not set `adapterConfig.promptTemplate` or `bootstrapPromptTemplate`
 - [ ] Placeholders like `{{companyName}}`, `{{managerTitle}}`, `{{issuePrefix}}`, and any URL stubs are replaced with real values
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Local adapters (`claude_local`, `codex_local`, etc.) historically had an `adapterConfig.cwd` field that pointed to a working directory on the host machine
> - Paperclip now leases execution workspaces per issue, making `cwd` semantically obsolete for new agents
> - But the hire endpoint, adapter docs, and the `paperclip-create-agent` skill still accepted or referenced `cwd`, so newly hired agents could still carry the deprecated field
> - A prior hire shipped with a stale `cwd` pointing at a user-local clone instead of the project workspace — semantically misleading and a future failure mode
> - This pull request strips `cwd` from new-agent payloads at the API boundary, marks it deprecated in all adapter config schemas and docs, and removes it from the hire skill templates
> - The benefit is that no future hire can accidentally carry this legacy field, while existing agents that already have `cwd` are left untouched for backward compatibility

## What Changed

- **API boundary defense** (`server/src/routes/agents.ts`): Added `ADAPTER_TYPES_WITH_DEPRECATED_CWD` set and `stripDeprecatedCwdForNewAgent()` helper. Wired into `POST /api/companies/:companyId/agent-hires` and `POST /api/companies/:companyId/agents` to silently drop `cwd` before persistence, emitting a `console.warn` + `logActivity` event (`agent.hire_dropped_deprecated_field` / `agent.create_dropped_deprecated_field`). PATCH route intentionally untouched for backward compat.
- **Adapter config schemas** (`packages/adapters/*/src/index.ts`): Marked `cwd` as `**deprecated**` in `agentConfigurationDoc` for all 7 local adapters: `acpx-local`, `claude-local`, `codex-local`, `cursor-local`, `gemini-local`, `opencode-local`, `pi-local`.
- **Adapter docs** (`docs/adapters/claude-local.md`, `codex-local.md`, `gemini-local.md`): Flipped `cwd` from `Required: Yes` to `No` and labeled it deprecated.
- **`paperclip-create-agent` skill** (`skills/paperclip-create-agent/`): Removed `cwd` from example hire payloads in `SKILL.md` and `references/api-reference.md`. Added explicit "do not include `adapterConfig.cwd`" note. Updated `references/draft-review-checklist.md` to flag `cwd` presence as a review failure.
- **Tests** (`server/src/__tests__/agent-permissions-routes.test.ts`): Three new test cases — hire with `cwd` → stripped + logged; direct-create with `cwd` → stripped + logged; hire without `cwd` → no drop log.

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-permissions-routes.test.ts` — 46 tests pass (3 new + 43 existing)
- `pnpm exec vitest run server/src/__tests__/agent-skills-routes.test.ts server/src/__tests__/hire-hook.test.ts` — 22 tests pass (no regressions on hire-adjacent flows)
- `pnpm --filter @paperclipai/server typecheck` — clean
- Typecheck on all 7 touched adapter packages — clean
- Post-merge staging dry-run hire: confirm new agent created without `cwd`; confirm `agent.hire_dropped_deprecated_field` activity entry when payload contains `cwd`
- UI hire form already gates `cwd` via `shouldShowLegacyWorkingDirectoryField()` which returns `false` for create mode — no UI change needed

## Risks

- **Low risk.** The strip logic only fires on `POST` (create/hire), not `PATCH`, so existing agents with `cwd` are unaffected.
- If any external automation relies on `cwd` being set for newly created agents, it will silently lose the value. Mitigated by the `logActivity` audit trail that records when a drop occurs.
- No migration or schema change — purely runtime defense + doc updates.

## Model Used

- **Provider:** Anthropic (Claude)
- **Model ID:** `claude-opus-4-6` (Opus 4.6)
- **Context:** 200K token context window
- **Capabilities:** Extended thinking, tool use, code execution via Claude Code CLI
- **Agent framework:** Paperclip agent orchestration with `claude_local` adapter

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge