### PR TITLE
LAM-295: stop firing long_active_duration productivity reviews

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -337,7 +337,11 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(await listProductivityReviews(seeded.companyId)).toHaveLength(4);
   });
 
-  it("creates a long-active review without enabling a continuation hold", async () => {
+  // LAM-295: long_active_duration no longer spawns a productivity review.
+  // Multi-heartbeat work (design docs, customer jobs, campaigns) legitimately
+  // exceeds the 6h threshold; the trigger was over-firing. The longActive
+  // boolean is still computed in collectEvidence as observability evidence.
+  it("does not create a review when only the long-active threshold is crossed", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue({
       status: "in_progress",
@@ -353,10 +357,8 @@ describeEmbeddedPostgres("productivity review service", () => {
       now,
     });
 
-    expect(result.created).toBe(1);
-    const [review] = await listProductivityReviews(seeded.companyId);
-    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
-    expect(review?.priority).toBe("medium");
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
     expect(hold.held).toBe(false);
   });
 

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -186,7 +186,10 @@ function choosePrimaryTrigger(input: {
 }): ProductivityReviewTrigger | null {
   if (input.noComment) return "no_comment_streak";
   if (input.highChurn) return "high_churn";
-  if (input.longActive) return "long_active_duration";
+  // LAM-295: long_active_duration removed per board directive 2026-05-09.
+  // longActive is still computed in collectEvidence as observability evidence
+  // (multi-heartbeat work like design docs / customer jobs / campaigns hit 6h
+  // legitimately and should not spawn a productivity review).
   return null;
 }
 


### PR DESCRIPTION
## Summary

Per board directive 2026-05-09 (LAM-284 / LAM-295 thread), remove `long_active_duration` from `choosePrimaryTrigger` in `productivity-review.ts`. The 6h threshold over-fires for legitimate multi-heartbeat work (design docs, customer jobs, campaigns, partner outreach).

The `longActive` boolean is still computed in `collectEvidence` and surfaced in the evidence section — kept as observability signal even though it no longer spawns a review.

## Diff (logic)

```diff
   if (input.noComment) return "no_comment_streak";
   if (input.highChurn) return "high_churn";
-  if (input.longActive) return "long_active_duration";
+  // LAM-295: long_active_duration removed per board directive 2026-05-09.
   return null;
```

## Test changes

- Updated `productivity-review-service.test.ts`: the previous "creates a long-active review" test now asserts `result.created === 0` and no review row when only the longActive threshold is crossed.

## Context

Hot-patch was applied to the locally installed `@paperclipai/server@2026.428.0` npx cache to stop the bleeding (5 productivity reviews spawned in one day on legitimate long-running work). This PR lands the same change in source so the next install carries it.

Tracking issues: LAM-295 (parent), LAM-298 (this upstream landing).