### PR TITLE
feat(APE-2982): allow agent JWTs to call plugin tools via execute endpoint

### DIFF
--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -599,4 +599,177 @@ describe.sequential("plugin tool and bridge authz", () => {
     expect(res.body).toEqual({ runId: "run-1", jobId: "job-1" });
     expect(scheduler.triggerJob).toHaveBeenCalledWith("job-1", "manual");
   });
+
+  // ─── Agent JWT tool execution ────────────────────────────────────────────────
+
+  it("allows agent JWT to execute a tool from an enabled plugin (no settings row)", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ content: "ok" });
+    const { app } = await createApp(
+      {
+        type: "agent",
+        agentId: agentA,
+        companyId: companyA,
+        runId: runA,
+      },
+      {},
+      {
+        // Queue: agent-company, run, project, plugin_company_settings (no row = enabled)
+        db: createSelectQueueDb([
+          [{ companyId: companyA }],
+          [{ companyId: companyA, agentId: agentA }],
+          [{ companyId: companyA }],
+          [],
+        ]),
+        toolDeps: {
+          toolDispatcher: {
+            listToolsForAgent: vi.fn(),
+            getTool: vi.fn(() => ({ name: "paperclip.example:search", pluginDbId: pluginId })),
+            executeTool,
+          },
+        },
+      },
+    );
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: { q: "test" },
+        runContext: { agentId: agentA, runId: runA, companyId: companyA, projectId: projectA },
+      });
+
+    expect(res.status).toBe(200);
+    expect(executeTool).toHaveBeenCalledWith(
+      "paperclip.example:search",
+      { q: "test" },
+      { agentId: agentA, runId: runA, companyId: companyA, projectId: projectA },
+    );
+  });
+
+  it("allows agent JWT to execute a tool when plugin_company_settings row has enabled=true", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ content: "ok" });
+    const { app } = await createApp(
+      { type: "agent", agentId: agentA, companyId: companyA, runId: runA },
+      {},
+      {
+        db: createSelectQueueDb([
+          [{ companyId: companyA }],
+          [{ companyId: companyA, agentId: agentA }],
+          [{ companyId: companyA }],
+          [{ enabled: true }],
+        ]),
+        toolDeps: {
+          toolDispatcher: {
+            listToolsForAgent: vi.fn(),
+            getTool: vi.fn(() => ({ name: "paperclip.example:search", pluginDbId: pluginId })),
+            executeTool,
+          },
+        },
+      },
+    );
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: {},
+        runContext: { agentId: agentA, runId: runA, companyId: companyA, projectId: projectA },
+      });
+
+    expect(res.status).toBe(200);
+    expect(executeTool).toHaveBeenCalled();
+  });
+
+  it("rejects agent JWT when the plugin is disabled for the company", async () => {
+    const executeTool = vi.fn();
+    const { app } = await createApp(
+      { type: "agent", agentId: agentA, companyId: companyA, runId: runA },
+      {},
+      {
+        db: createSelectQueueDb([
+          [{ companyId: companyA }],
+          [{ companyId: companyA, agentId: agentA }],
+          [{ companyId: companyA }],
+          [{ enabled: false }],
+        ]),
+        toolDeps: {
+          toolDispatcher: {
+            listToolsForAgent: vi.fn(),
+            getTool: vi.fn(() => ({ name: "paperclip.example:search", pluginDbId: pluginId })),
+            executeTool,
+          },
+        },
+      },
+    );
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: {},
+        runContext: { agentId: agentA, runId: runA, companyId: companyA, projectId: projectA },
+      });
+
+    expect(res.status).toBe(403);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent JWT when runContext.agentId does not match the JWT subject", async () => {
+    const otherAgent = "77777777-7777-4777-8777-777777777777";
+    const executeTool = vi.fn();
+    const { app } = await createApp(
+      { type: "agent", agentId: agentA, companyId: companyA, runId: runA },
+      {},
+      {
+        toolDeps: {
+          toolDispatcher: {
+            listToolsForAgent: vi.fn(),
+            getTool: vi.fn(() => ({ name: "paperclip.example:search", pluginDbId: pluginId })),
+            executeTool,
+          },
+        },
+      },
+    );
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: {},
+        runContext: { agentId: otherAgent, runId: runA, companyId: companyA, projectId: projectA },
+      });
+
+    expect(res.status).toBe(403);
+    expect(executeTool).not.toHaveBeenCalled();
+  });
+
+  it("allows board user to call tools regardless of plugin_company_settings (no settings query for board)", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ content: "ok" });
+    const { app } = await createApp(boardActor(), {}, {
+      // Board user: only 3 rows needed for validateToolRunContextScope
+      db: createSelectQueueDb([
+        [{ companyId: companyA }],
+        [{ companyId: companyA, agentId: agentA }],
+        [{ companyId: companyA }],
+      ]),
+      toolDeps: {
+        toolDispatcher: {
+          listToolsForAgent: vi.fn(),
+          getTool: vi.fn(() => ({ name: "paperclip.example:search", pluginDbId: pluginId })),
+          executeTool,
+        },
+      },
+    });
+
+    const res = await request(app)
+      .post("/api/plugins/tools/execute")
+      .send({
+        tool: "paperclip.example:search",
+        parameters: {},
+        runContext: { agentId: agentA, runId: runA, companyId: companyA, projectId: projectA },
+      });
+
+    expect(res.status).toBe(200);
+    expect(executeTool).toHaveBeenCalled();
+  });
 });

--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -31,6 +31,18 @@ export function assertBoardOrgAccess(req: Request) {
   throw forbidden("Company membership or instance admin access required");
 }
 
+/**
+ * Allows board members (with org access) OR authenticated agents.
+ * Use only on endpoints that perform additional per-agent scope validation
+ * (e.g. validateToolRunContextScope) after this check passes.
+ */
+export function assertBoardOrAgentAccess(req: Request) {
+  if (req.actor.type === "agent") {
+    return;
+  }
+  assertBoardOrgAccess(req);
+}
+
 export function assertInstanceAdmin(req: Request) {
   assertBoard(req);
   if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) {

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -30,6 +30,7 @@ import {
   agents,
   companies,
   heartbeatRuns,
+  pluginCompanySettings,
   pluginLogs,
   pluginWebhookDeliveries,
   projects,
@@ -61,6 +62,7 @@ import {
   assertAuthenticated,
   assertBoard,
   assertBoardOrgAccess,
+  assertBoardOrAgentAccess,
   assertCompanyAccess,
   assertInstanceAdmin,
   getActorInfo,
@@ -574,6 +576,32 @@ export function pluginRoutes(
     return companyId;
   }
 
+  /**
+   * For agent JWT requests, verify the plugin is not explicitly disabled for
+   * the agent's company. Returns true when access is permitted.
+   *
+   * Plugins are enabled by default (no row in plugin_company_settings). A row
+   * with enabled=false means the company has explicitly turned off this plugin.
+   * Board-level callers bypass this check — they already passed assertBoardOrgAccess.
+   */
+  async function assertAgentPluginAccess(pluginDbId: string, companyId: string): Promise<void> {
+    const [setting] = await db
+      .select({ enabled: pluginCompanySettings.enabled })
+      .from(pluginCompanySettings)
+      .where(
+        and(
+          eq(pluginCompanySettings.pluginId, pluginDbId),
+          eq(pluginCompanySettings.companyId, companyId),
+        ),
+      )
+      .limit(1);
+    // A row exists only when the company has overridden defaults. If enabled is
+    // explicitly false, the plugin is off for this company — reject the call.
+    if (setting && !setting.enabled) {
+      throw forbidden("Plugin is not enabled for this company");
+    }
+  }
+
   async function validateToolRunContextScope(runContext: ToolRunContext): Promise<string | null> {
     const [agent] = await db
       .select({ companyId: agents.companyId })
@@ -768,7 +796,7 @@ export function pluginRoutes(
    * - 502 if the plugin worker is unavailable or the RPC call fails
    */
   router.post("/plugins/tools/execute", async (req, res) => {
-    assertBoardOrgAccess(req);
+    assertBoardOrAgentAccess(req);
 
     if (!toolDeps) {
       res.status(501).json({ error: "Plugin tool dispatch is not enabled" });
@@ -801,6 +829,12 @@ export function pluginRoutes(
       return;
     }
 
+    // Agent JWTs may only execute tools on behalf of themselves
+    if (req.actor.type === "agent" && req.actor.agentId !== runContext.agentId) {
+      res.status(403).json({ error: "Agent JWT sub does not match runContext.agentId" });
+      return;
+    }
+
     assertCompanyAccess(req, runContext.companyId);
     const scopeError = await validateToolRunContextScope(runContext);
     if (scopeError) {
@@ -813,6 +847,12 @@ export function pluginRoutes(
     if (!registeredTool) {
       res.status(404).json({ error: `Tool "${tool}" not found` });
       return;
+    }
+
+    // Agent JWTs may only call tools from plugins enabled for their company.
+    // Board callers bypass this — they passed assertBoardOrgAccess above.
+    if (req.actor.type === "agent") {
+      await assertAgentPluginAccess(registeredTool.pluginDbId, runContext.companyId);
     }
 
     try {


### PR DESCRIPTION
## Summary

Agent JWTs are currently blocked from calling `POST /api/plugins/tools/execute` because the route uses `assertBoard` which rejects agent-type tokens. This PR changes the authz check to `assertBoardOrAgentAccess` with proper safeguards:

- **Route authz**: `POST /api/plugins/tools/execute` now uses `assertBoardOrAgentAccess` so agent JWTs can reach the endpoint
- **Agent self-check**: Agent JWT `sub` must match `runContext.agentId` — no cross-agent impersonation
- **Plugin access control**: `assertAgentPluginAccess` rejects agent requests if the plugin is explicitly disabled for the agent's company via `plugin_company_settings`
- **Board bypass preserved**: Board callers still bypass plugin settings checks (they pass `assertBoardOrgAccess`)

## Test Plan

- Five new authz tests added in `plugin-routes-authz.test.ts`:
  - ✅ Agent access when plugin enabled (no settings row)
  - ✅ Agent access when plugin explicitly enabled (row=true)
  - ✅ Agent blocked when plugin disabled (row=false)
  - ✅ Agent blocked with wrong agentId (impersonation check)
  - ✅ Board user bypasses plugin settings check

## Files Changed

- `server/src/routes/plugins.ts` — route authz + agent self-check + plugin access check
- `server/src/routes/authz.ts` — new `assertBoardOrAgentAccess` helper
- `server/src/__tests__/plugin-routes-authz.test.ts` — new test file