### PR TITLE
feat: add plugin-better-search-example (deep search + author-type filter)

### DIFF
--- a/packages/plugins/examples/plugin-better-search-example/README.md
+++ b/packages/plugins/examples/plugin-better-search-example/README.md
@@ -1,0 +1,50 @@
+# Better Search Plugin (Example)
+
+A Paperclip example plugin that provides deep issue search — across titles, descriptions, and comment bodies — with Human vs. AI author filtering.
+
+## What it does
+
+- **Deep search**: proxies the `GET /api/companies/:id/issues?q=` endpoint which searches title, identifier, description, and comments server-side.
+- **Author-type badges**: each result is badged **Human** or **AI** based on the latest comment author (`authorUserId` vs `authorAgentId`), falling back to the issue creator if there are no comments.
+- **Filter chips**: client-side filter by All / Human / AI Agent over the result set.
+- **Issue navigation**: clicking a result navigates to the issue detail page using the host client-side router.
+
+## Slots used
+
+| Slot | ID | Purpose |
+|------|----|---------|
+| `sidebar` | `better-search-sidebar` | Nav entry in the main sidebar |
+| `sidebarPanel` | `better-search-panel` | Inline search panel with input + results |
+
+## Capabilities declared
+
+- `ui.sidebar.register`
+- `issues.read`
+- `issue.comments.read`
+
+## Build
+
+```bash
+pnpm install
+pnpm run build
+```
+
+Output lands in `dist/`.
+
+## Install in a local Paperclip instance
+
+In the Paperclip admin or plugin settings, load the plugin from the built package:
+
+```
+packages/plugins/examples/plugin-better-search-example
+```
+
+The `paperclipPlugin` field in `package.json` points to the built manifest, worker, and UI.
+
+## Uninstall
+
+Remove the plugin from the Paperclip plugin settings page. No core changes are needed.
+
+## Notes
+
+The `q` parameter is not currently declared in the plugin SDK's `issues.list` TypeScript protocol, but the underlying service accepts it (via the `as any` passthrough in `plugin-host-services.ts`). The cast in `worker.ts` is intentional — see the inline comment.

--- a/packages/plugins/examples/plugin-better-search-example/package.json
+++ b/packages/plugins/examples/plugin-better-search-example/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@paperclipai/plugin-better-search-example",
+  "version": "0.1.0",
+  "description": "Example plugin: deep issue search with Human/AI author-type filter",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps",
+    "build": "tsc && node ./scripts/build-ui.mjs",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*",
+    "@paperclipai/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "esbuild": "^0.27.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/plugin-better-search-example/scripts/build-ui.mjs
+++ b/packages/plugins/examples/plugin-better-search-example/scripts/build-ui.mjs
@@ -1,0 +1,24 @@
+import esbuild from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, "..");
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/ui/index.tsx")],
+  outfile: path.join(packageRoot, "dist/ui/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  sourcemap: true,
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    "@paperclipai/plugin-sdk/ui",
+  ],
+  logLevel: "info",
+});

--- a/packages/plugins/examples/plugin-better-search-example/src/index.ts
+++ b/packages/plugins/examples/plugin-better-search-example/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-better-search-example/src/manifest.ts
+++ b/packages/plugins/examples/plugin-better-search-example/src/manifest.ts
@@ -1,0 +1,43 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+const PLUGIN_ID = "paperclip-better-search-example";
+const SIDEBAR_SLOT_ID = "better-search-sidebar";
+const PANEL_SLOT_ID = "better-search-panel";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: "0.1.0",
+  displayName: "Better Search (Example)",
+  description:
+    "Deep search across issue titles, descriptions, and comments with Human/AI author-type filtering.",
+  author: "Paperclip",
+  categories: ["workspace", "ui"],
+  capabilities: [
+    "ui.sidebar.register",
+    "issues.read",
+    "issue.comments.read",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  ui: {
+    slots: [
+      {
+        type: "sidebar",
+        id: SIDEBAR_SLOT_ID,
+        displayName: "Search",
+        exportName: "BetterSearchSidebar",
+      },
+      {
+        type: "sidebarPanel",
+        id: PANEL_SLOT_ID,
+        displayName: "Better Search",
+        exportName: "BetterSearchPanel",
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-better-search-example/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-better-search-example/src/ui/index.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useState, type CSSProperties } from "react";
+import {
+  useHostContext,
+  usePluginData,
+  type PluginSidebarProps,
+} from "@paperclipai/plugin-sdk/ui";
+import type { SearchResult } from "../worker.js";
+
+type SearchData = {
+  results: SearchResult[];
+  query: string;
+  error?: string;
+};
+
+type AuthorFilter = "all" | "human" | "agent";
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const panelStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+  padding: "8px",
+  fontSize: "13px",
+};
+
+const inputStyle: CSSProperties = {
+  width: "100%",
+  padding: "6px 8px",
+  borderRadius: "6px",
+  border: "1px solid var(--border)",
+  background: "var(--background)",
+  color: "var(--foreground)",
+  fontSize: "13px",
+  boxSizing: "border-box",
+  outline: "none",
+};
+
+const chipRowStyle: CSSProperties = {
+  display: "flex",
+  gap: "4px",
+  flexWrap: "wrap",
+};
+
+function chipStyle(active: boolean): CSSProperties {
+  return {
+    padding: "2px 8px",
+    borderRadius: "12px",
+    border: `1px solid ${active ? "var(--primary, #6366f1)" : "var(--border)"}`,
+    background: active ? "var(--primary, #6366f1)" : "transparent",
+    color: active ? "var(--primary-foreground, #fff)" : "var(--foreground)",
+    cursor: "pointer",
+    fontSize: "11px",
+    fontWeight: active ? 600 : 400,
+  };
+}
+
+const resultListStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
+  maxHeight: "420px",
+  overflowY: "auto",
+};
+
+function resultItemStyle(hovered: boolean): CSSProperties {
+  return {
+    display: "flex",
+    flexDirection: "column",
+    gap: "2px",
+    padding: "6px 8px",
+    borderRadius: "6px",
+    background: hovered
+      ? "color-mix(in srgb, var(--accent, #6366f1) 15%, transparent)"
+      : "transparent",
+    cursor: "pointer",
+    textDecoration: "none",
+    color: "inherit",
+    border: "1px solid transparent",
+    transition: "background 0.1s",
+  };
+}
+
+function authorBadgeStyle(type: SearchResult["latestAuthorType"]): CSSProperties {
+  const colors: Record<SearchResult["latestAuthorType"], { bg: string; color: string }> = {
+    human: { bg: "color-mix(in srgb, #22c55e 20%, transparent)", color: "#15803d" },
+    agent: { bg: "color-mix(in srgb, #6366f1 20%, transparent)", color: "#4338ca" },
+    unknown: { bg: "color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--muted-foreground)" },
+  };
+  const { bg, color } = colors[type];
+  return {
+    display: "inline-block",
+    padding: "1px 5px",
+    borderRadius: "4px",
+    background: bg,
+    color,
+    fontSize: "10px",
+    fontWeight: 600,
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.04em",
+  };
+}
+
+const statusDotColors: Record<string, string> = {
+  done: "#22c55e",
+  cancelled: "#94a3b8",
+  in_progress: "#6366f1",
+  in_review: "#f59e0b",
+  blocked: "#ef4444",
+  todo: "#64748b",
+  backlog: "#94a3b8",
+};
+
+function StatusDot({ status }: { status: string }) {
+  const color = statusDotColors[status] ?? "#94a3b8";
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        width: "7px",
+        height: "7px",
+        borderRadius: "50%",
+        background: color,
+        flexShrink: 0,
+        marginTop: "1px",
+      }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Result row
+// ---------------------------------------------------------------------------
+
+function ResultRow({
+  result,
+  issuesPath,
+}: {
+  result: SearchResult;
+  issuesPath: (id: string) => string;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const authorLabel =
+    result.latestAuthorType === "human"
+      ? "Human"
+      : result.latestAuthorType === "agent"
+      ? "AI"
+      : "?";
+
+  return (
+    <a
+      href={issuesPath(result.identifier ?? result.id)}
+      style={resultItemStyle(hovered)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div style={{ display: "flex", alignItems: "flex-start", gap: "6px" }}>
+        <StatusDot status={result.status} />
+        <span
+          style={{
+            flex: 1,
+            fontWeight: 500,
+            lineHeight: "1.3",
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: "vertical" as const,
+          }}
+        >
+          {result.title}
+        </span>
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: "6px", paddingLeft: "13px" }}>
+        {result.identifier && (
+          <span style={{ color: "var(--muted-foreground)", fontSize: "11px" }}>
+            {result.identifier}
+          </span>
+        )}
+        <span style={authorBadgeStyle(result.latestAuthorType)}>{authorLabel}</span>
+      </div>
+    </a>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
+
+export function BetterSearchPanel() {
+  const context = useHostContext();
+  const [inputValue, setInputValue] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [filter, setFilter] = useState<AuthorFilter>("all");
+
+  // Debounce input → query
+  useEffect(() => {
+    if (!inputValue.trim()) {
+      setDebouncedQuery("");
+      return;
+    }
+    const timer = setTimeout(() => setDebouncedQuery(inputValue.trim()), 350);
+    return () => clearTimeout(timer);
+  }, [inputValue]);
+
+  const searchData = usePluginData<SearchData>(
+    "searchIssues",
+    debouncedQuery && context.companyId
+      ? { companyId: context.companyId, q: debouncedQuery }
+      : undefined
+  );
+
+  const allResults = searchData.data?.results ?? [];
+  const filtered =
+    filter === "all"
+      ? allResults
+      : allResults.filter((r) => r.latestAuthorType === filter);
+
+  function issuesPath(identifier: string): string {
+    return context.companyPrefix
+      ? `/${context.companyPrefix}/issues/${identifier}`
+      : `/issues/${identifier}`;
+  }
+
+  const isSearching = searchData.loading && debouncedQuery.length > 0;
+  const hasError = !!searchData.error;
+  const hasQuery = debouncedQuery.length > 0;
+
+  return (
+    <div style={panelStyle}>
+      <input
+        type="search"
+        placeholder="Search issues…"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        style={inputStyle}
+        autoComplete="off"
+        spellCheck={false}
+      />
+
+      {hasQuery && (
+        <div style={chipRowStyle}>
+          {(["all", "human", "agent"] as AuthorFilter[]).map((f) => (
+            <button
+              key={f}
+              type="button"
+              style={chipStyle(filter === f)}
+              onClick={() => setFilter(f)}
+            >
+              {f === "all" ? "All" : f === "human" ? "Human" : "AI Agent"}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {isSearching && (
+        <div style={{ color: "var(--muted-foreground)", fontSize: "12px", padding: "4px 0" }}>
+          Searching…
+        </div>
+      )}
+
+      {hasError && (
+        <div style={{ color: "#ef4444", fontSize: "12px", padding: "4px 0" }}>
+          Search error. Try again.
+        </div>
+      )}
+
+      {!isSearching && hasQuery && !hasError && (
+        <>
+          {filtered.length === 0 ? (
+            <div style={{ color: "var(--muted-foreground)", fontSize: "12px", padding: "4px 0" }}>
+              No results
+              {filter !== "all" ? ` for ${filter === "human" ? "Human" : "AI Agent"} filter` : ""}
+            </div>
+          ) : (
+            <div style={resultListStyle}>
+              {filtered.map((result) => (
+                <ResultRow key={result.id} result={result} issuesPath={issuesPath} />
+              ))}
+            </div>
+          )}
+          <div
+            style={{
+              color: "var(--muted-foreground)",
+              fontSize: "11px",
+              borderTop: "1px solid var(--border)",
+              paddingTop: "6px",
+            }}
+          >
+            {filtered.length} result{filtered.length !== 1 ? "s" : ""}
+            {allResults.length !== filtered.length
+              ? ` of ${allResults.length} total`
+              : ""}
+          </div>
+        </>
+      )}
+
+      {!hasQuery && (
+        <div style={{ color: "var(--muted-foreground)", fontSize: "12px", padding: "4px 0" }}>
+          Deep search across titles, descriptions, and comments.
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sidebar nav entry
+// ---------------------------------------------------------------------------
+
+export function BetterSearchSidebar({ context }: PluginSidebarProps) {
+  const companyPrefix = context.companyPrefix;
+  const href = companyPrefix ? `/${companyPrefix}` : "/";
+
+  return (
+    <a
+      href={href}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "8px",
+        padding: "6px 8px",
+        borderRadius: "6px",
+        textDecoration: "none",
+        color: "var(--foreground)",
+        fontSize: "13px",
+        fontWeight: 500,
+      }}
+      title="Better Search"
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="6.5" cy="6.5" r="4.5" />
+        <line x1="10.5" y1="10.5" x2="14" y2="14" />
+      </svg>
+      <span>Search</span>
+    </a>
+  );
+}

--- a/packages/plugins/examples/plugin-better-search-example/src/worker.ts
+++ b/packages/plugins/examples/plugin-better-search-example/src/worker.ts
@@ -1,0 +1,103 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import type { Issue, IssueComment } from "@paperclipai/shared";
+
+const PLUGIN_NAME = "better-search-example";
+const SEARCH_LIMIT = 30;
+
+type AuthorType = "human" | "agent" | "unknown";
+
+export type SearchResult = {
+  id: string;
+  identifier: string | null;
+  title: string;
+  status: string;
+  priority: string;
+  assigneeAgentId: string | null;
+  assigneeUserId: string | null;
+  createdAt: string;
+  latestAuthorType: AuthorType;
+};
+
+function deriveAuthorType(issue: Issue, comments: IssueComment[]): AuthorType {
+  if (comments.length > 0) {
+    const latest = comments.reduce((a, b) =>
+      new Date(a.createdAt).getTime() >= new Date(b.createdAt).getTime() ? a : b
+    );
+    if (latest.authorUserId) return "human";
+    if (latest.authorAgentId) return "agent";
+  }
+  if (issue.createdByUserId) return "human";
+  if (issue.createdByAgentId) return "agent";
+  return "unknown";
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info(`${PLUGIN_NAME} plugin setup`);
+
+    ctx.data.register(
+      "searchIssues",
+      async (params: Record<string, unknown>) => {
+        const companyId =
+          typeof params.companyId === "string" ? params.companyId : "";
+        const q = typeof params.q === "string" ? params.q.trim() : "";
+
+        if (!companyId || !q) {
+          return { results: [], query: q };
+        }
+
+        let issues: Issue[];
+        try {
+          // The SDK protocol omits `q`, but the underlying service accepts it.
+          // Casting through unknown passes it through the RPC bridge unchanged.
+          issues = await (
+            ctx.issues.list as (p: unknown) => Promise<Issue[]>
+          )({
+            companyId,
+            q,
+            limit: SEARCH_LIMIT,
+            offset: 0,
+          });
+        } catch (err) {
+          ctx.logger.warn("Issue search failed", { q, error: String(err) });
+          return { results: [], query: q, error: String(err) };
+        }
+
+        // Fetch latest comment for each result in parallel to determine author type.
+        const results = await Promise.all(
+          issues.map(async (issue): Promise<SearchResult> => {
+            let comments: IssueComment[] = [];
+            try {
+              comments = await ctx.issues.listComments(issue.id, companyId);
+            } catch {
+              // Fallback to issue creator if comment fetch fails.
+            }
+            return {
+              id: issue.id,
+              identifier: issue.identifier,
+              title: issue.title,
+              status: issue.status,
+              priority: issue.priority,
+              assigneeAgentId: issue.assigneeAgentId,
+              assigneeUserId: issue.assigneeUserId,
+              createdAt:
+                issue.createdAt instanceof Date
+                  ? issue.createdAt.toISOString()
+                  : String(issue.createdAt),
+              latestAuthorType: deriveAuthorType(issue, comments),
+            };
+          })
+        );
+
+        return { results, query: q };
+      }
+    );
+  },
+
+  async onHealth() {
+    return { status: "ok", message: `${PLUGIN_NAME} ready` };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-better-search-example/tsconfig.json
+++ b/packages/plugins/examples/plugin-better-search-example/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM"],
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,6 +326,37 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
+  packages/plugins/examples/plugin-better-search-example:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@paperclipai/shared':
+        specifier: workspace:*
+        version: link:../../../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.3
+        version: 19.2.3(@types/react@19.2.14)
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
       '@codemirror/lang-javascript':
@@ -396,6 +427,43 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+
+  packages/plugins/examples/plugin-issue-linker-example:
+    dependencies:
+      react:
+        specifier: '>=18'
+        version: 19.2.4
+    devDependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.1
+        version: 16.0.3(rollup@4.60.1)
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.2
+        version: 12.3.0(rollup@4.60.1)(tslib@2.8.1)(typescript@5.9.3)
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
+      rollup:
+        specifier: '>=4.59.0'
+        version: 4.60.1
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/plugins/examples/plugin-kitchen-sink-example:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `packages/plugins/examples/plugin-better-search-example`: a new example plugin for deep issue search
- Proxies the `?q=` issues endpoint to search across titles, descriptions, and comments server-side
- Each result is badged **Human** or **AI** based on the latest comment's `authorUserId` / `authorAgentId`
- Client-side filter chips: **All / Human / AI Agent**
- Clicking a result navigates to the issue detail page via the host router
- Uses `sidebar` + `sidebarPanel` UI slots; declares only `ui.sidebar.register`, `issues.read`, `issue.comments.read`

## Pre-flight verification

Confirmed `?q=` searches description and comment bodies (not just titles): querying `sidebarPanel` returned [BTCAAAAA-704](https://github.com/paperclipai/paperclip) whose title contains no such word.

## Implementation notes

- `worker.ts` calls `ctx.issues.list({ companyId, q, limit: 30, offset: 0 } as unknown)` — the SDK TypeScript protocol omits `q`, but the underlying service passes params through with `as any` (see `plugin-host-services.ts:1023`). The cast is intentional and documented.
- Author type is derived from the latest comment; falls back to `createdByUserId`/`createdByAgentId` on the issue when no comments exist.
- Comment fetches are parallelized per result (up to 30 concurrent calls).

## Test plan

- [ ] Build passes: `pnpm run build` in `packages/plugins/examples/plugin-better-search-example`
- [ ] Typecheck clean: `pnpm run typecheck`
- [ ] Load plugin in local Paperclip instance; sidebar panel appears
- [ ] Typing in search input returns results after debounce (350ms)
- [ ] Results include matches from description/comment bodies, not just titles
- [ ] Human / AI filter chips correctly filter results
- [ ] Clicking a result navigates to the issue detail

## Related

Implements ask **B** from [BTCAAAAA-703] per the CTO feasibility report [BTCAAAAA-704].

🤖 Generated with [Claude Code](https://claude.com/claude-code)