### PR TITLE
feat(plugins): add issue-linker-example plugin

### DIFF
--- a/packages/plugins/examples/plugin-issue-linker-example/.gitignore
+++ b/packages/plugins/examples/plugin-issue-linker-example/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+.paperclip-sdk

--- a/packages/plugins/examples/plugin-issue-linker-example/README.md
+++ b/packages/plugins/examples/plugin-issue-linker-example/README.md
@@ -1,0 +1,51 @@
+# plugin-issue-linker-example
+
+An example Paperclip plugin that adds a toolbar button to the issue detail view. When clicked, it opens an inline search modal that lets you find and link any issue as a blocker of the current issue.
+
+## What it does
+
+- Injects a **"Link related issue"** button into the issue detail toolbar via the `toolbarButton` slot.
+- The button opens a dropdown with a debounced search field that queries all issues in the current company.
+- Selecting an issue calls the `linkIssue` worker action, which adds the selected issue as a blocker of the currently viewed issue using `ctx.issues.relations.addBlockers`.
+- Shows a toast notification on success or failure.
+
+## Manifest slots
+
+| Slot type       | ID                            | Export name                  | Entity types |
+| --------------- | ----------------------------- | ---------------------------- | ------------ |
+| `toolbarButton` | `issue-linker-toolbar-button` | `IssueLinkerToolbarButton`   | `issue`      |
+
+The button only appears on issue detail pages (`entityTypes: ["issue"]`).
+
+## Capabilities declared
+
+```
+"ui.action.register"
+"issues.read"
+"issue.relations.write"
+```
+
+## Build
+
+```bash
+pnpm --filter @paperclipai/plugin-issue-linker-example build
+```
+
+## Install
+
+```bash
+pnpm paperclipai plugin install ./packages/plugins/examples/plugin-issue-linker-example
+```
+
+## Uninstall
+
+Open the Paperclip web UI, navigate to **Settings → Plugins**, find **Issue Linker (Example)**, and click **Uninstall**.
+
+## Development
+
+```bash
+pnpm install
+pnpm --filter @paperclipai/plugin-issue-linker-example dev      # watch builds
+pnpm --filter @paperclipai/plugin-issue-linker-example typecheck
+pnpm --filter @paperclipai/plugin-issue-linker-example build
+```

--- a/packages/plugins/examples/plugin-issue-linker-example/esbuild.config.mjs
+++ b/packages/plugins/examples/plugin-issue-linker-example/esbuild.config.mjs
@@ -1,0 +1,17 @@
+import esbuild from "esbuild";
+import { createPluginBundlerPresets } from "@paperclipai/plugin-sdk/bundlers";
+
+const presets = createPluginBundlerPresets({ uiEntry: "src/ui/index.tsx" });
+const watch = process.argv.includes("--watch");
+
+const workerCtx = await esbuild.context(presets.esbuild.worker);
+const manifestCtx = await esbuild.context(presets.esbuild.manifest);
+const uiCtx = await esbuild.context(presets.esbuild.ui);
+
+if (watch) {
+  await Promise.all([workerCtx.watch(), manifestCtx.watch(), uiCtx.watch()]);
+  console.log("esbuild watch mode enabled for worker, manifest, and ui");
+} else {
+  await Promise.all([workerCtx.rebuild(), manifestCtx.rebuild(), uiCtx.rebuild()]);
+  await Promise.all([workerCtx.dispose(), manifestCtx.dispose(), uiCtx.dispose()]);
+}

--- a/packages/plugins/examples/plugin-issue-linker-example/package.json
+++ b/packages/plugins/examples/plugin-issue-linker-example/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@paperclipai/plugin-issue-linker-example",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Adds a toolbar button to issue detail that lets you search for and link a related issue as a blocker.",
+  "scripts": {
+    "build": "node ./esbuild.config.mjs",
+    "build:rollup": "rollup -c",
+    "dev": "node ./esbuild.config.mjs --watch",
+    "dev:ui": "paperclip-plugin-dev-server --root . --ui-dir dist/ui --port 4177",
+    "test": "vitest run --config ./vitest.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "keywords": [
+    "paperclip",
+    "plugin",
+    "issue-linker"
+  ],
+  "author": "Paperclip",
+  "license": "MIT",
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "esbuild": "^0.27.3",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/plugins/examples/plugin-issue-linker-example/rollup.config.mjs
+++ b/packages/plugins/examples/plugin-issue-linker-example/rollup.config.mjs
@@ -1,0 +1,28 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+import { createPluginBundlerPresets } from "@paperclipai/plugin-sdk/bundlers";
+
+const presets = createPluginBundlerPresets({ uiEntry: "src/ui/index.tsx" });
+
+function withPlugins(config) {
+  if (!config) return null;
+  return {
+    ...config,
+    plugins: [
+      nodeResolve({
+        extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs"],
+      }),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        declaration: false,
+        declarationMap: false,
+      }),
+    ],
+  };
+}
+
+export default [
+  withPlugins(presets.rollup.manifest),
+  withPlugins(presets.rollup.worker),
+  withPlugins(presets.rollup.ui),
+].filter(Boolean);

--- a/packages/plugins/examples/plugin-issue-linker-example/src/manifest.ts
+++ b/packages/plugins/examples/plugin-issue-linker-example/src/manifest.ts
@@ -1,0 +1,36 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+const PLUGIN_ID = "paperclip-issue-linker-example";
+const TOOLBAR_SLOT_ID = "issue-linker-toolbar-button";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: "0.1.0",
+  displayName: "Issue Linker (Example)",
+  description: "Adds a toolbar button to issue detail that lets you search for and link a related issue as a blocker.",
+  author: "Paperclip",
+  categories: ["ui"],
+  capabilities: [
+    "ui.action.register",
+    "issues.read",
+    "issue.relations.write",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  ui: {
+    slots: [
+      {
+        type: "toolbarButton",
+        id: TOOLBAR_SLOT_ID,
+        displayName: "Link related issue",
+        exportName: "IssueLinkerToolbarButton",
+        entityTypes: ["issue"],
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-issue-linker-example/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-issue-linker-example/src/ui/index.tsx
@@ -1,0 +1,156 @@
+import { useState, useEffect, useRef } from "react";
+import { useHostContext, usePluginAction, usePluginData, usePluginToast } from "@paperclipai/plugin-sdk/ui";
+
+interface IssueSummary {
+  id: string;
+  identifier: string;
+  title: string;
+  status: string;
+  priority: string;
+}
+
+interface SearchResult {
+  issues: IssueSummary[];
+}
+
+export function IssueLinkerToolbarButton() {
+  const ctx = useHostContext();
+  const toast = usePluginToast();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Debounce the search query
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), 300);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  // Focus input when modal opens
+  useEffect(() => {
+    if (open) setTimeout(() => inputRef.current?.focus(), 50);
+  }, [open]);
+
+  const searchResult = usePluginData<SearchResult>(
+    "searchIssues",
+    ctx.companyId ? { companyId: ctx.companyId, query: debouncedQuery } : {},
+  );
+
+  const linkIssue = usePluginAction("linkIssue");
+
+  async function handleSelect(targetIssueId: string, targetIdentifier: string) {
+    if (!ctx.companyId || !ctx.entityId) return;
+    try {
+      await linkIssue({ companyId: ctx.companyId, sourceIssueId: ctx.entityId, targetIssueId });
+      toast({ title: "Issue linked", body: `${targetIdentifier} added as blocker.`, tone: "success" });
+      setOpen(false);
+      setQuery("");
+    } catch (err) {
+      toast({ title: "Link failed", body: err instanceof Error ? err.message : String(err), tone: "error" });
+    }
+  }
+
+  return (
+    <div style={{ position: "relative", display: "inline-block" }}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          padding: "4px 10px",
+          fontSize: "12px",
+          borderRadius: "4px",
+          border: "1px solid #ccc",
+          background: "#fff",
+          cursor: "pointer",
+        }}
+      >
+        Link related issue
+      </button>
+
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            top: "calc(100% + 6px)",
+            right: 0,
+            width: "360px",
+            background: "#fff",
+            border: "1px solid #ddd",
+            borderRadius: "6px",
+            boxShadow: "0 4px 16px rgba(0,0,0,0.12)",
+            zIndex: 9999,
+            padding: "12px",
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "8px" }}>
+            <strong style={{ fontSize: "13px" }}>Link a related issue</strong>
+            <button
+              type="button"
+              onClick={() => { setOpen(false); setQuery(""); }}
+              style={{ background: "none", border: "none", cursor: "pointer", fontSize: "14px", color: "#666" }}
+            >
+              ✕
+            </button>
+          </div>
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Search issues…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            style={{
+              width: "100%",
+              boxSizing: "border-box",
+              padding: "6px 8px",
+              fontSize: "13px",
+              border: "1px solid #ccc",
+              borderRadius: "4px",
+              marginBottom: "8px",
+            }}
+          />
+          {searchResult.loading && (
+            <div style={{ fontSize: "12px", color: "#888", padding: "4px 0" }}>Searching…</div>
+          )}
+          {searchResult.error && (
+            <div style={{ fontSize: "12px", color: "#c00", padding: "4px 0" }}>
+              {String(searchResult.error)}
+            </div>
+          )}
+          {searchResult.data && searchResult.data.issues.length === 0 && (
+            <div style={{ fontSize: "12px", color: "#888", padding: "4px 0" }}>No issues found.</div>
+          )}
+          {searchResult.data && searchResult.data.issues.length > 0 && (
+            <ul style={{ listStyle: "none", margin: 0, padding: 0, maxHeight: "240px", overflowY: "auto" }}>
+              {searchResult.data.issues.map((issue) => (
+                <li key={issue.id}>
+                  <button
+                    type="button"
+                    onClick={() => void handleSelect(issue.id, issue.identifier)}
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      width: "100%",
+                      textAlign: "left",
+                      padding: "6px 8px",
+                      border: "none",
+                      borderRadius: "4px",
+                      background: "none",
+                      cursor: "pointer",
+                      fontSize: "12px",
+                    }}
+                    onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "#f5f5f5"; }}
+                    onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "none"; }}
+                  >
+                    <span style={{ fontWeight: 500, color: "#555" }}>{issue.identifier}</span>
+                    <span style={{ color: "#222" }}>{issue.title}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/plugins/examples/plugin-issue-linker-example/src/worker.ts
+++ b/packages/plugins/examples/plugin-issue-linker-example/src/worker.ts
@@ -1,0 +1,51 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info("issue-linker-example plugin setup");
+
+    // getData: search issues by query text
+    ctx.data.register("searchIssues", async (params: Record<string, unknown>) => {
+      const companyId = typeof params.companyId === "string" ? params.companyId : "";
+      const query = typeof params.query === "string" ? params.query.toLowerCase().trim() : "";
+      if (!companyId) return { issues: [] };
+
+      const all = await ctx.issues.list({ companyId, limit: 200 });
+      const filtered = query
+        ? all.filter(
+            (i) =>
+              i.title.toLowerCase().includes(query) ||
+              (i.identifier ?? "").toLowerCase().includes(query),
+          )
+        : all;
+      return {
+        issues: filtered.slice(0, 20).map((i) => ({
+          id: i.id,
+          identifier: i.identifier ?? "",
+          title: i.title,
+          status: i.status,
+          priority: i.priority,
+        })),
+      };
+    });
+
+    // performAction: link selected issue as blocker of the current issue
+    ctx.actions.register("linkIssue", async (params: Record<string, unknown>) => {
+      const companyId = typeof params.companyId === "string" ? params.companyId : "";
+      const sourceIssueId = typeof params.sourceIssueId === "string" ? params.sourceIssueId : "";
+      const targetIssueId = typeof params.targetIssueId === "string" ? params.targetIssueId : "";
+      if (!companyId || !sourceIssueId || !targetIssueId) {
+        throw new Error("Missing required params: companyId, sourceIssueId, targetIssueId");
+      }
+      await ctx.issues.relations.addBlockers(sourceIssueId, [targetIssueId], companyId);
+      return { ok: true };
+    });
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "issue-linker-example ready" };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-issue-linker-example/tests/plugin.spec.ts
+++ b/packages/plugins/examples/plugin-issue-linker-example/tests/plugin.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import manifest from "../src/manifest.js";
+import plugin from "../src/worker.js";
+
+describe("plugin scaffold", () => {
+  it("registers data + actions and handles events", async () => {
+    const harness = createTestHarness({ manifest, capabilities: [...manifest.capabilities, "events.emit"] });
+    await plugin.definition.setup(harness.ctx);
+
+    await harness.emit("issue.created", { issueId: "iss_1" }, { entityId: "iss_1", entityType: "issue" });
+    expect(harness.getState({ scopeKind: "issue", scopeId: "iss_1", stateKey: "seen" })).toBe(true);
+
+    const data = await harness.getData<{ status: string }>("health");
+    expect(data.status).toBe("ok");
+
+    const action = await harness.performAction<{ pong: boolean }>("ping");
+    expect(action.pong).toBe(true);
+  });
+});

--- a/packages/plugins/examples/plugin-issue-linker-example/tsconfig.json
+++ b/packages/plugins/examples/plugin-issue-linker-example/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/plugins/examples/plugin-issue-linker-example/vitest.config.ts
+++ b/packages/plugins/examples/plugin-issue-linker-example/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

- Scaffolds `@paperclipai/plugin-issue-linker-example` under `packages/plugins/examples/`
- Adds a `toolbarButton` slot on issue detail that opens an inline search modal
- Worker registers `searchIssues` (data) and `linkIssue` (action) using `ctx.issues.list` and `ctx.issues.relations.addBlockers`
- Capabilities: `ui.action.register`, `issues.read`, `issue.relations.write`
- Typecheck and build pass with zero errors

## Test plan

- [ ] `pnpm --filter @paperclipai/plugin-issue-linker-example typecheck` passes
- [ ] `pnpm --filter @paperclipai/plugin-issue-linker-example build` passes
- [ ] Plugin installs via `pnpm paperclipai plugin install ./packages/plugins/examples/plugin-issue-linker-example`
- [ ] "Link related issue" button appears in issue detail toolbar
- [ ] Searching issues in the dropdown returns results
- [ ] Selecting an issue adds it as a blocker and shows a success toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)