### PR TITLE
fix: scope OpenClaw claimed key paths

### DIFF
--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -36,7 +36,7 @@ Request behavior fields:
 - waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000)
 - autoPairOnFirstConnect (boolean, optional): on first "pairing required", attempt device.pair.list/device.pair.approve via shared auth, then retry once (default true)
 - paperclipApiUrl (string, optional): absolute Paperclip base URL advertised in wake text
-- claimedApiKeyPath (string, optional): path to the claimed API key JSON file read by the agent at wake time (default ~/.openclaw/workspace/paperclip-claimed-api-key.json)
+- claimedApiKeyPath (string, optional): path to the claimed API key JSON file read by the agent at wake time (default ~/.openclaw/workspace/paperclip/<companyId>/<agentId>/claimed-api-key.json)
 
 Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run

--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { resolveSessionKey } from "./execute.js";
+import {
+  buildScopedClaimedApiKeyPath,
+  buildWakeText,
+  resolveClaimedApiKeyPath,
+  resolveSessionKey,
+} from "./execute.js";
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {
@@ -48,5 +53,52 @@ describe("resolveSessionKey", () => {
         issueId: null,
       }),
     ).toBe("agent:meridian:paperclip");
+  });
+});
+
+describe("claimed API key path", () => {
+  it("defaults to a company and agent scoped path", () => {
+    expect(resolveClaimedApiKeyPath(undefined, "company-1", "agent-1")).toBe(
+      "~/.openclaw/workspace/paperclip/company-1/agent-1/claimed-api-key.json",
+    );
+  });
+
+  it("falls back to the legacy flat path when ids are missing", () => {
+    expect(buildScopedClaimedApiKeyPath(null, "agent-1")).toBe(
+      "~/.openclaw/workspace/paperclip-claimed-api-key.json",
+    );
+  });
+});
+
+describe("buildWakeText", () => {
+  it("includes scoped path guidance and claimed-key preflight", () => {
+    const text = buildWakeText(
+      {
+        runId: "run-123",
+        agentId: "agent-1",
+        companyId: "company-1",
+        taskId: "issue-1",
+        issueId: "issue-1",
+        wakeReason: "issue_assigned",
+        wakeCommentId: null,
+        approvalId: null,
+        approvalStatus: null,
+        issueIds: [],
+      },
+      {
+        PAPERCLIP_RUN_ID: "run-123",
+        PAPERCLIP_AGENT_ID: "agent-1",
+        PAPERCLIP_COMPANY_ID: "company-1",
+        PAPERCLIP_API_URL: "http://127.0.0.1:3100",
+        PAPERCLIP_CLAIMED_API_KEY_PATH:
+          "~/.openclaw/workspace/paperclip/company-1/agent-1/claimed-api-key.json",
+      },
+      "",
+    );
+
+    expect(text).toContain("PAPERCLIP_CLAIMED_API_KEY_PATH=");
+    expect(text).toContain("Legacy flat path for migration only");
+    expect(text).toContain("Claimed-key preflight before any API call");
+    expect(text).toContain("Verify file.companyId == company-1");
   });
 });

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -331,17 +331,28 @@ function resolvePaperclipApiUrlOverride(value: unknown): string | null {
   }
 }
 
-const DEFAULT_CLAIMED_API_KEY_PATH = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+const LEGACY_CLAIMED_API_KEY_PATH = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
 
-function resolveClaimedApiKeyPath(value: unknown): string {
-  return nonEmpty(value) ?? DEFAULT_CLAIMED_API_KEY_PATH;
+export function buildScopedClaimedApiKeyPath(companyId: string | null, agentId: string | null): string {
+  if (!companyId || !agentId) return LEGACY_CLAIMED_API_KEY_PATH;
+  return `~/.openclaw/workspace/paperclip/${companyId}/${agentId}/claimed-api-key.json`;
+}
+
+export function resolveClaimedApiKeyPath(
+  value: unknown,
+  companyId: string | null,
+  agentId: string | null,
+): string {
+  return nonEmpty(value) ?? buildScopedClaimedApiKeyPath(companyId, agentId);
 }
 
 function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: WakePayload): Record<string, string> {
   const paperclipApiUrlOverride = resolvePaperclipApiUrlOverride(ctx.config.paperclipApiUrl);
+  const claimedApiKeyPath = resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath, ctx.agent.companyId, ctx.agent.id);
   const paperclipEnv: Record<string, string> = {
     ...buildPaperclipEnv(ctx.agent),
     PAPERCLIP_RUN_ID: ctx.runId,
+    PAPERCLIP_CLAIMED_API_KEY_PATH: claimedApiKeyPath,
   };
 
   if (paperclipApiUrlOverride) {
@@ -361,17 +372,20 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
   return paperclipEnv;
 }
 
-function buildWakeText(
+export function buildWakeText(
   payload: WakePayload,
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
 ): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+  const claimedApiKeyPath =
+    nonEmpty(paperclipEnv.PAPERCLIP_CLAIMED_API_KEY_PATH) ??
+    buildScopedClaimedApiKeyPath(nonEmpty(paperclipEnv.PAPERCLIP_COMPANY_ID), nonEmpty(paperclipEnv.PAPERCLIP_AGENT_ID));
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
     "PAPERCLIP_COMPANY_ID",
     "PAPERCLIP_API_URL",
+    "PAPERCLIP_CLAIMED_API_KEY_PATH",
     "PAPERCLIP_TASK_ID",
     "PAPERCLIP_WAKE_REASON",
     "PAPERCLIP_WAKE_COMMENT_ID",
@@ -400,6 +414,7 @@ function buildWakeText(
     `PAPERCLIP_API_KEY=<token from ${claimedApiKeyPath}>`,
     "",
     `Load PAPERCLIP_API_KEY from ${claimedApiKeyPath} (the token you saved after claim-api-key).`,
+    `Legacy flat path for migration only: ${LEGACY_CLAIMED_API_KEY_PATH}`,
     "",
     `api_base=${apiBaseHint}`,
     `task_id=${payload.taskId ?? ""}`,
@@ -409,6 +424,12 @@ function buildWakeText(
     `approval_id=${payload.approvalId ?? ""}`,
     `approval_status=${payload.approvalStatus ?? ""}`,
     `linked_issue_ids=${payload.issueIds.join(",")}`,
+    "",
+    "Claimed-key preflight before any API call:",
+    `- Read ${claimedApiKeyPath} and verify file.agentId == ${paperclipEnv.PAPERCLIP_AGENT_ID}.`,
+    `- Verify file.companyId == ${paperclipEnv.PAPERCLIP_COMPANY_ID}.`,
+    `- If the scoped file is missing and ${LEGACY_CLAIMED_API_KEY_PATH} exists, only migrate it when both ids match.`,
+    "- If either id mismatches, do not attempt Paperclip API calls with that token. Claim a fresh key for this agent/company and save it to the scoped path first.",
     "",
     "HTTP rules:",
     "- Use Authorization: Bearer $PAPERCLIP_API_KEY on every API call.",

--- a/packages/adapters/openclaw-gateway/vitest.config.ts
+++ b/packages/adapters/openclaw-gateway/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/scripts/smoke/openclaw-gateway-e2e.sh
+++ b/scripts/smoke/openclaw-gateway-e2e.sh
@@ -461,10 +461,26 @@ persist_claimed_key_artifacts() {
   local claim_json="$1"
   local workspace_dir="${OPENCLAW_CONFIG_DIR%/}/workspace"
   local skill_dir="${OPENCLAW_CONFIG_DIR%/}/skills/paperclip"
-  local claimed_file="${workspace_dir}/paperclip-claimed-api-key.json"
-  local claimed_raw_file="${workspace_dir}/paperclip-claimed-api-key.raw.json"
+  local suggested_file_path
+  local company_id
+  local agent_id
+  suggested_file_path="$(jq -r '.suggestedFilePath // empty' <<<"$claim_json")"
+  company_id="$(jq -r '.companyId // empty' <<<"$claim_json")"
+  agent_id="$(jq -r '.agentId // empty' <<<"$claim_json")"
 
-  mkdir -p "$workspace_dir" "$skill_dir"
+  local claimed_file="${suggested_file_path/#\~/$HOME}"
+  if [[ -z "$claimed_file" ]]; then
+    if [[ -n "$company_id" && -n "$agent_id" ]]; then
+      claimed_file="${workspace_dir}/paperclip/${company_id}/${agent_id}/claimed-api-key.json"
+    else
+      claimed_file="${workspace_dir}/paperclip-claimed-api-key.json"
+    fi
+  fi
+  local claimed_dir
+  claimed_dir="$(dirname "$claimed_file")"
+  local claimed_raw_file="${claimed_dir}/claimed-api-key.raw.json"
+
+  mkdir -p "$workspace_dir" "$skill_dir" "$claimed_dir"
   local token
   token="$(jq -r '.token // .apiKey // empty' <<<"$claim_json")"
   [[ -n "$token" ]] || fail "claim response missing token/apiKey"
@@ -472,16 +488,17 @@ persist_claimed_key_artifacts() {
   printf "%s\n" "$claim_json" > "$claimed_raw_file"
   chmod 600 "$claimed_raw_file"
 
-  jq -nc --arg token "$token" '{ token: $token, apiKey: $token }' > "$claimed_file"
-  # Keep this readable for OpenClaw runtime users across sandbox/container contexts.
-  chmod 644 "$claimed_file"
+  printf "%s\n" "$claim_json" > "$claimed_file"
+  chmod 600 "$claimed_file"
 
   local container
   container="$(detect_openclaw_container || true)"
   if [[ -n "$container" ]]; then
-    docker exec "$container" sh -lc "mkdir -p /home/node/.openclaw/workspace" >/dev/null 2>&1 || true
-    docker cp "$claimed_file" "${container}:/home/node/.openclaw/workspace/paperclip-claimed-api-key.json" >/dev/null 2>&1 || true
-    docker exec "$container" sh -lc "chmod 644 /home/node/.openclaw/workspace/paperclip-claimed-api-key.json" >/dev/null 2>&1 || true
+    local container_claimed_file
+    container_claimed_file="${claimed_file/#$HOME/\/home\/node}"
+    docker exec "$container" sh -lc "mkdir -p \"$(dirname "$container_claimed_file")\"" >/dev/null 2>&1 || true
+    docker cp "$claimed_file" "${container}:${container_claimed_file}" >/dev/null 2>&1 || true
+    docker exec "$container" sh -lc "chmod 600 \"$container_claimed_file\"" >/dev/null 2>&1 || true
   fi
 
   if [[ "$AUTO_INSTALL_SKILL" == "1" ]]; then

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -52,9 +52,11 @@ describe("buildInviteOnboardingTextDocument", () => {
     expect(text).toContain("headers.x-openclaw-token");
     expect(text).toContain("Do NOT use /v1/responses or /hooks/*");
     expect(text).toContain("set the first reachable candidate as agentDefaultsPayload.paperclipApiUrl");
-    expect(text).toContain("~/.openclaw/workspace/paperclip-claimed-api-key.json");
+    expect(text).toContain("~/.openclaw/workspace/paperclip/company-1/<agent-id>/claimed-api-key.json");
     expect(text).toContain("PAPERCLIP_API_KEY");
     expect(text).toContain("saved token field");
+    expect(text).toContain("suggestedFilePath");
+    expect(text).toContain("companyId");
     expect(text).toContain("Gateway token unexpectedly short");
   });
 

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1509,6 +1509,12 @@ function buildOnboardingConnectionCandidates(input: {
   return Array.from(candidates);
 }
 
+function buildScopedClaimedApiKeyPath(companyId: string | null, agentId: string | null) {
+  const companySegment = companyId && companyId.trim().length > 0 ? companyId.trim() : "<company-id>";
+  const agentSegment = agentId && agentId.trim().length > 0 ? agentId.trim() : "<agent-id>";
+  return `~/.openclaw/workspace/paperclip/${companySegment}/${agentSegment}/claimed-api-key.json`;
+}
+
 function buildInviteOnboardingManifest(
   req: Request,
   token: string,
@@ -1553,8 +1559,10 @@ function buildInviteOnboardingManifest(
       opts.companyName ?? null
     ),
     onboarding: {
-      instructions:
-        "Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the claim response token to ~/.openclaw/workspace/paperclip-claimed-api-key.json and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).",
+      instructions: `Join as an OpenClaw Gateway agent, save your one-time claim secret, wait for board approval, then claim your API key. Save the full claim response to ${buildScopedClaimedApiKeyPath(
+        invite.companyId,
+        "<agent-id>",
+      )} (replace <agent-id> with the claimed agentId) and load PAPERCLIP_API_KEY from that file before starting heartbeat loops. The saved JSON must retain both companyId and agentId so heartbeat preflight can reject cross-company mismatches. You MUST submit adapterType='openclaw_gateway', set agentDefaultsPayload.url to your ws:// or wss:// OpenClaw gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth).`,
       inviteMessage: extractInviteMessage(invite),
       recommendedAdapterType: "openclaw_gateway",
       requiredFields: {
@@ -1760,10 +1768,18 @@ export function buildInviteOnboardingTextDocument(
       "claimSecret": "<one-time-claim-secret>"
     }
 
-    On successful claim, save the full JSON response to:
+    Claim response includes:
+    - token
+    - agentId
+    - companyId
+    - suggestedFilePath
 
-    - ~/.openclaw/workspace/paperclip-claimed-api-key.json
-    chmod 600 ~/.openclaw/workspace/paperclip-claimed-api-key.json
+    On successful claim, save the full JSON response to the suggestedFilePath returned by the claim response. The path template is:
+
+    - ${buildScopedClaimedApiKeyPath(invite.companyId, "<agent-id>")}
+    chmod 600 ${buildScopedClaimedApiKeyPath(invite.companyId, "<agent-id>")}
+
+    Keep the full JSON response intact so the saved file includes both companyId and agentId. Heartbeat preflight should fail fast if either id does not match the wake event.
 
     And set the PAPERCLIP_API_KEY and PAPERCLIP_API_URL in your environment variables as specified here:
     https://docs.openclaw.ai/help/environment
@@ -3978,6 +3994,8 @@ export function accessRoutes(
         keyId: created.id,
         token: created.token,
         agentId: joinRequest.createdAgentId,
+        companyId: joinRequest.companyId,
+        suggestedFilePath: buildScopedClaimedApiKeyPath(joinRequest.companyId, joinRequest.createdAgentId),
         createdAt: created.createdAt
       });
     }

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -156,7 +156,7 @@ export function OpenClawGatewayConfigFields({
               onCommit={(v) => mark("adapterConfig", "claimedApiKeyPath", v || undefined)}
               immediate
               className={inputClass}
-              placeholder="~/.openclaw/workspace/paperclip-claimed-api-key.json"
+              placeholder="~/.openclaw/workspace/paperclip/<companyId>/<agentId>/claimed-api-key.json"
             />
           </Field>
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       "packages/adapters/cursor-local",
       "packages/adapters/gemini-local",
       "packages/adapters/opencode-local",
+      "packages/adapters/openclaw-gateway",
       "packages/adapters/pi-local",
       "server",
       "ui",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies across multiple companies and runtimes.
> - OpenClaw gateway onboarding is part of the bring-your-own-agent path, so its claimed API key flow has to be safe across tenant boundaries.
> - The current onboarding and wake text advertised a single flat claimed-key file under `~/.openclaw/workspace/paperclip-claimed-api-key.json`.
> - That flat path lets a wake for company B silently load a token claimed earlier for company A on the same machine.
> - The installed runtime had already been hotfixed locally, but the real source tree and release surfaces still advertised the unsafe default.
> - This pull request ports the scoped-path and preflight behavior into source, updates the claim response shape, and fixes release-facing docs/tooling so the next package does not regress the collision.
> - The benefit is that multi-company OpenClaw/Paperclip setups default to isolated claimed-key files and fail fast on mismatched company or agent identity.

## What Changed

- Updated `@paperclipai/adapter-openclaw-gateway` wake text to default `claimedApiKeyPath` to `~/.openclaw/workspace/paperclip/<companyId>/<agentId>/claimed-api-key.json`, expose `PAPERCLIP_CLAIMED_API_KEY_PATH`, and add claimed-key preflight / legacy migration guidance.
- Updated OpenClaw onboarding text in `server/src/routes/access.ts` to advertise the scoped path template instead of the flat shared file.
- Extended the claim API response to include `companyId` and `suggestedFilePath` so the saved JSON file can remain self-describing.
- Updated the OpenClaw smoke script to persist the full claim JSON at the scoped path, including container copy behavior and permissions.
- Updated the OpenClaw adapter UI placeholder and adapter docs to reflect the scoped default path.
- Added/updated targeted tests and wired `packages/adapters/openclaw-gateway` into the root Vitest project list.

## Verification

- `pnpm install --frozen-lockfile`
- `./node_modules/.bin/vitest run packages/adapters/openclaw-gateway/src/server/execute.test.ts server/src/__tests__/invite-onboarding-text.test.ts`
- `bash -n scripts/smoke/openclaw-gateway-e2e.sh`

## Risks

- Low risk: behavior only changes the default claimed-key location and onboarding/wake instructions, but any external automation that hard-coded the old flat path will need to follow the legacy migration guidance or set `claimedApiKeyPath` explicitly.

## Model Used

- OpenAI Codex via GPT-5.5 (`gpt-5.5`), medium reasoning, with shell/file editing and local code execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge