### PR TITLE
fix(claude-local): trust Claude success result over SIGTERM exit code

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -770,7 +770,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : null;
     const clearSessionForMaxTurns = isClaudeMaxTurnsResult(parsed);
     const parsedIsError = asBoolean(parsed.is_error, false);
-    const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
+    // When Claude has already emitted a structured success result, the
+    // terminalResultCleanup path tears the process group down with SIGTERM
+    // (exit code 143). Trust Claude's own outcome over the exit code in that
+    // case — otherwise successful heartbeats get re-classified as
+    // claude_transient_upstream and trigger pointless retries.
+    const parsedReportedSuccess =
+      asString(parsed.subtype, "") === "success" && !parsedIsError;
+    const failed = parsedReportedSuccess
+      ? false
+      : (proc.exitCode ?? 0) !== 0 || parsedIsError;
     const errorMessage = failed
       ? describeClaudeFailure(parsed) ?? `Claude exited with code ${proc.exitCode ?? -1}`
       : null;

--- a/server/src/__tests__/claude-local-execute.test.ts
+++ b/server/src/__tests__/claude-local-execute.test.ts
@@ -957,4 +957,61 @@ describe("claude execute", () => {
       await fs.rm(root, { recursive: true, force: true });
     }
   });
+
+  it("treats Claude success results as success even when the process exits non-zero (SIGTERM cleanup)", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-claude-execute-success-sigterm-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "claude");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFailingClaudeCommand(commandPath, {
+      exitCode: 143,
+      resultEvent: {
+        type: "result",
+        subtype: "success",
+        session_id: "claude-session-success-sigterm",
+        is_error: false,
+        result: "Done — heartbeat finished cleanly before terminal cleanup tore the process down.",
+        usage: { input_tokens: 10, cache_read_input_tokens: 0, output_tokens: 5 },
+      },
+    });
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-claude-success-sigterm",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Claude Coder",
+          adapterType: "claude_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(143);
+      expect(result.errorCode).toBeNull();
+      expect(result.errorFamily).toBeNull();
+      expect(result.errorMessage ?? null).toBeNull();
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Heartbeat runs that completed successfully are being misclassified as `claude_transient_upstream` failures whenever the `terminalResultCleanup` path (added in #4129) tears the process group down with SIGTERM (exit code 143) after Claude has already emitted a `subtype: success` result event.

The classification at `packages/adapters/claude-local/src/server/execute.ts` uses:

\`\`\`ts
const failed = (proc.exitCode ?? 0) !== 0 || parsedIsError;
\`\`\`

This ignores Claude's own outcome reporting — so SIGTERM cleanup turns otherwise-clean heartbeats into failures, surfaces them as `claude_transient_upstream` errors, and triggers pointless retries that double the cost.

The cleanup grace is intentionally short (default `5_000` ms via `terminalResultCleanupGraceMs`), but the cleanup tears down the entire process group, not just the parent. Any sub-process — an MCP server, an editor agent, a child shell — that takes more than the grace window to drain after Claude finishes will get SIGTERMed, and the parent's exit code propagates as 143. On a real instance running multiple companies and agents this fires for many normal heartbeats, not just edge cases.

## Fix

When the parsed result reports `subtype === "success"` and is not flagged as an error, treat the run as successful regardless of exit code. Other failure modes still classify correctly because:

- `error_max_turns` → emits `subtype: "error_max_turns"` (still failed)
- `claude_auth_required` → no parsed result yet, hits the earlier `!parsed` branch
- transient upstream / overloaded / out-of-extra-usage → emit `is_error: true` (still failed)

The `parsed`-is-null branch above is unaffected — it already requires `(proc.exitCode ?? 0) !== 0` _and_ a transient-upstream error fingerprint, so a missing parsed result still leads to the right classification.

## Test plan

- [x] New regression test in `server/src/__tests__/claude-local-execute.test.ts`: a Claude command that emits a `subtype: success` result and exits 143 (simulating the SIGTERM cleanup path) → `errorCode === null`, `errorMessage === null`.
- [x] Existing tests still pass:
  - `'out of extra usage' → claude_transient_upstream` (rate-limit)
  - `overloaded → claude_transient_upstream` (no reset metadata)
  - `error_max_turns → not transient`
- [x] `pnpm --filter @paperclipai/adapter-claude-local typecheck` clean.
- [x] Full test file: 13/13 tests pass.

## Notes

The same fix has been deployed on a private fork for the past few hours and has eliminated false-positive `claude_transient_upstream` failures across 5 companies/15 agents (70+ heartbeats, zero false positives in the observation window vs ~7 false positives per 24h previously).

Co-Authored-By: Paperclip <noreply@paperclip.ing>