### PR TITLE
Add Hermes observable adapter

### DIFF
--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -42,6 +42,7 @@ export const LEGACY_SESSIONED_ADAPTER_TYPES = new Set([
   "codex_local",
   "cursor",
   "gemini_local",
+  "hermes_observable",
   "hermes_local",
   "opencode_local",
   "pi_local",
@@ -72,6 +73,11 @@ export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement
     supportsSessionResume: true,
     nativeContextManagement: "unknown",
     defaultSessionCompaction: DEFAULT_SESSION_COMPACTION_POLICY,
+  },
+  hermes_observable: {
+    supportsSessionResume: true,
+    nativeContextManagement: "confirmed",
+    defaultSessionCompaction: ADAPTER_MANAGED_SESSION_POLICY,
   },
   opencode_local: {
     supportsSessionResume: true,

--- a/packages/adapters/hermes-observable/README.md
+++ b/packages/adapters/hermes-observable/README.md
@@ -1,0 +1,86 @@
+# Hermes Observable Adapter
+
+`@paperclipai/adapter-hermes-observable` runs Hermes through the Hermes gateway
+API instead of scraping CLI stdout. That makes Paperclip progress durable and
+observable without patching Hermes internals, Paperclip UI internals, or TTY
+formatting.
+
+## Why This Is More Stable Than CLI Parsing
+
+- The adapter consumes structured SSE events from Hermes instead of inferring
+  state from quiet-mode terminal output.
+- Tool lifecycle correlation uses tool call ids when Hermes provides them.
+- Assistant text deltas stream directly into Paperclip transcript events.
+- Unknown SSE events are ignored safely and can be surfaced in debug mode.
+- A watchdog line is emitted while a run is active so Paperclip no longer looks
+  frozen during long tool execution.
+
+## Registration
+
+This branch already registers the adapter as a built-in Paperclip adapter:
+
+- Server: `server/src/adapters/registry.ts`
+- UI: `ui/src/adapters/registry.ts`
+
+If you need to wire it manually in another Paperclip checkout, add:
+
+```ts
+import {
+  execute,
+  testEnvironment,
+  sessionCodec,
+  listSkills,
+  syncSkills,
+  detectModel,
+  getConfigSchema,
+} from "@paperclipai/adapter-hermes-observable/server";
+import {
+  agentConfigurationDoc,
+  models,
+} from "@paperclipai/adapter-hermes-observable";
+```
+
+and register `hermes_observable` in the server adapter registry plus the UI
+adapter registry.
+
+## Example Agent Config
+
+```json
+{
+  "adapterType": "hermes_observable",
+  "adapterConfig": {
+    "hermesApiBaseUrl": "http://127.0.0.1:8000",
+    "endpointMode": "responses",
+    "model": "anthropic/claude-sonnet-4",
+    "provider": "auto",
+    "timeoutSec": 300,
+    "heartbeatSec": 30,
+    "debugEvents": false,
+    "allowCliFallback": false
+  }
+}
+```
+
+## Setup
+
+The adapter expects a Hermes gateway API server at `hermesApiBaseUrl`.
+
+Minimum local setup:
+
+```bash
+pip install hermes-agent
+API_SERVER_ENABLED=1 API_SERVER_PORT=8000 hermes gateway
+curl -s http://127.0.0.1:8000/health
+curl -s http://127.0.0.1:8000/v1/capabilities
+```
+
+## Stream Harness
+
+Use the small harness to watch raw gateway events and the parsed event names:
+
+```bash
+pnpm exec tsx packages/adapters/hermes-observable/scripts/stream-harness.ts \
+  --base-url http://127.0.0.1:8000 \
+  --mode responses \
+  --input "Summarize the current workspace status."
+```

--- a/packages/adapters/hermes-observable/package.json
+++ b/packages/adapters/hermes-observable/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@paperclipai/adapter-hermes-observable",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/hermes-observable"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist",
+    "scripts"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "hermes-paperclip-adapter": "^0.2.0",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/hermes-observable/scripts/stream-harness.ts
+++ b/packages/adapters/hermes-observable/scripts/stream-harness.ts
@@ -1,0 +1,110 @@
+import process from "node:process";
+
+type Mode = "responses" | "chat_completions";
+
+function readArg(name: string, fallback = ""): string {
+  const index = process.argv.indexOf(`--${name}`);
+  if (index < 0) return fallback;
+  return process.argv[index + 1] ?? fallback;
+}
+
+function createUrl(baseUrl: string, path: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  if (trimmed.endsWith("/v1") && path.startsWith("/v1/")) {
+    return `${trimmed}${path.slice(3)}`;
+  }
+  return `${trimmed}${path}`;
+}
+
+async function consumeSse(body: ReadableStream<Uint8Array>) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    buffer += decoder.decode(value, { stream: !done });
+
+    let splitIndex = buffer.indexOf("\n\n");
+    while (splitIndex >= 0) {
+      const block = buffer.slice(0, splitIndex).replace(/\r$/, "");
+      buffer = buffer.slice(splitIndex + 2);
+      const lines = block.split(/\r?\n/);
+      let eventName = "message";
+      const dataLines: string[] = [];
+      for (const line of lines) {
+        if (!line || line.startsWith(":")) continue;
+        if (line.startsWith("event:")) {
+          eventName = line.slice("event:".length).trim() || "message";
+          continue;
+        }
+        if (line.startsWith("data:")) {
+          dataLines.push(line.slice("data:".length).trimStart());
+        }
+      }
+      if (dataLines.length > 0) {
+        console.log(`\n[event] ${eventName}`);
+        console.log(dataLines.join("\n"));
+      }
+      splitIndex = buffer.indexOf("\n\n");
+    }
+
+    if (done) break;
+  }
+}
+
+async function main() {
+  const baseUrl = readArg("base-url", "http://127.0.0.1:8000");
+  const mode = (readArg("mode", "responses") || "responses") as Mode;
+  const model = readArg("model", "hermes-agent");
+  const input = readArg("input", "Summarize the current workspace status.");
+  const instructions = readArg("instructions", "You are a Paperclip-managed Hermes test harness run.");
+  const conversation = readArg("conversation", "paperclip-harness");
+
+  const url =
+    mode === "chat_completions"
+      ? createUrl(baseUrl, "/v1/chat/completions")
+      : createUrl(baseUrl, "/v1/responses");
+
+  const body =
+    mode === "chat_completions"
+      ? {
+          model,
+          stream: true,
+          messages: [
+            { role: "system", content: instructions },
+            { role: "user", content: input },
+          ],
+        }
+      : {
+          model,
+          stream: true,
+          conversation,
+          instructions,
+          input,
+        };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Accept: "text/event-stream",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok || !response.body) {
+    const errorBody = await response.text();
+    throw new Error(`Request failed: ${response.status} ${response.statusText}\n${errorBody}`);
+  }
+
+  console.log(`[harness] connected to ${url}`);
+  console.log(`[harness] sessionId=${response.headers.get("X-Hermes-Session-Id") ?? "none"}`);
+  console.log(`[harness] sessionKey=${response.headers.get("X-Hermes-Session-Key") ?? "none"}`);
+  await consumeSse(response.body);
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/adapters/hermes-observable/src/cli/format-event.ts
+++ b/packages/adapters/hermes-observable/src/cli/format-event.ts
@@ -1,0 +1,75 @@
+import pc from "picocolors";
+import { HERMES_OBSERVABLE_EVENT_TYPES } from "../shared/constants.js";
+
+function parseJson(line: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(line);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function stringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function printHermesObservableStreamEvent(raw: string, debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  if (line.startsWith("[hermes]")) {
+    console.log(pc.blue(line));
+    return;
+  }
+
+  const parsed = parseJson(line);
+  if (!parsed) {
+    console.log(debug ? pc.gray(line) : line);
+    return;
+  }
+
+  const type = asString(parsed.type);
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.init) {
+    console.log(pc.blue(`Hermes observable initialized (${asString(parsed.endpointMode, "unknown")})`));
+    return;
+  }
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.textDelta) {
+    console.log(pc.green(`assistant: ${asString(parsed.text)}`));
+    return;
+  }
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.toolCall) {
+    console.log(pc.yellow(`tool_call: ${asString(parsed.name, "tool")}`));
+    const input = stringify(parsed.input);
+    if (input) console.log(pc.gray(input));
+    return;
+  }
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.toolResult) {
+    console.log((parsed.isError === true ? pc.red : pc.cyan)(`tool_result: ${asString(parsed.name, "tool")}`));
+    const content = stringify(parsed.content);
+    if (content) console.log((parsed.isError === true ? pc.red : pc.gray)(content));
+    return;
+  }
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.result) {
+    console.log(pc.green("result:"));
+    console.log(asString(parsed.text));
+    return;
+  }
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.error) {
+    console.log(pc.red(asString(parsed.message, line)));
+    return;
+  }
+
+  console.log(debug ? pc.gray(line) : line);
+}

--- a/packages/adapters/hermes-observable/src/cli/index.ts
+++ b/packages/adapters/hermes-observable/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printHermesObservableStreamEvent } from "./format-event.js";

--- a/packages/adapters/hermes-observable/src/index.ts
+++ b/packages/adapters/hermes-observable/src/index.ts
@@ -1,0 +1,47 @@
+import {
+  ADAPTER_LABEL,
+  ADAPTER_TYPE,
+  DEFAULT_ENDPOINT_MODE,
+  DEFAULT_HEARTBEAT_SEC,
+  DEFAULT_HERMES_API_BASE_URL,
+  DEFAULT_TIMEOUT_SEC,
+} from "./shared/constants.js";
+import { models as hermesModels } from "hermes-paperclip-adapter";
+
+export const type = ADAPTER_TYPE;
+export const label = ADAPTER_LABEL;
+
+export const models = hermesModels;
+
+export const agentConfigurationDoc = `# Hermes Observable Configuration
+
+Hermes Observable uses the Hermes gateway API instead of CLI stdout parsing, so
+Paperclip receives structured assistant deltas, tool lifecycle events, and
+watchdog status lines during the run.
+
+## Required
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| hermesApiBaseUrl | string | ${DEFAULT_HERMES_API_BASE_URL} | Base URL for the Hermes gateway API server. |
+| endpointMode | string | ${DEFAULT_ENDPOINT_MODE} | Prefer \`responses\`; falls back to \`chat_completions\` when the gateway does not expose streaming Responses support. |
+
+## Optional
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| model | string | gateway default | Optional request model override. |
+| provider | string | auto | Provider hint returned in Paperclip metadata. |
+| timeoutSec | number | ${DEFAULT_TIMEOUT_SEC} | Whole-run timeout for the gateway request. |
+| heartbeatSec | number | ${DEFAULT_HEARTBEAT_SEC} | Watchdog interval for \`[hermes] still running...\` lines. |
+| debugEvents | boolean | false | Log unknown SSE events and fallback decisions. |
+| allowCliFallback | boolean | false | Only fall back to the legacy CLI adapter when the API is unreachable. |
+| hermesCommand | string | hermes | CLI command used only when \`allowCliFallback\` is enabled. |
+
+## Notes
+
+- The Hermes gateway executes tools on the gateway host.
+- Paperclip API identity is passed through the prompt/runtime context so Hermes
+  can continue using terminal + curl against the Paperclip API.
+- Managed instructions bundles are supported through \`instructionsFilePath\`.
+`;

--- a/packages/adapters/hermes-observable/src/server/config-schema.ts
+++ b/packages/adapters/hermes-observable/src/server/config-schema.ts
@@ -1,0 +1,90 @@
+import type { AdapterConfigSchema } from "@paperclipai/adapter-utils";
+import {
+  DEFAULT_ENDPOINT_MODE,
+  DEFAULT_HEARTBEAT_SEC,
+  DEFAULT_HERMES_API_BASE_URL,
+  DEFAULT_TIMEOUT_SEC,
+  PROVIDER_OPTIONS,
+} from "../shared/constants.js";
+
+export function getConfigSchema(): AdapterConfigSchema {
+  return {
+    fields: [
+      {
+        key: "hermesApiBaseUrl",
+        label: "Hermes API base URL",
+        type: "text",
+        default: DEFAULT_HERMES_API_BASE_URL,
+        required: true,
+        hint: "Hermes gateway root URL. The adapter probes /health and /v1/capabilities here.",
+      },
+      {
+        key: "endpointMode",
+        label: "Endpoint mode",
+        type: "select",
+        default: DEFAULT_ENDPOINT_MODE,
+        options: [
+          { label: "Responses API", value: "responses" },
+          { label: "Chat Completions", value: "chat_completions" },
+        ],
+        hint: "Responses is preferred. Older Hermes builds can use chat completions streaming instead.",
+      },
+      {
+        key: "model",
+        label: "Model override",
+        type: "text",
+        hint: "Optional request model. Leave blank to use the Hermes gateway default.",
+      },
+      {
+        key: "provider",
+        label: "Provider",
+        type: "select",
+        default: "auto",
+        options: PROVIDER_OPTIONS.map((provider) => ({
+          label: provider,
+          value: provider,
+        })),
+        hint: "Provider hint returned in Paperclip result metadata.",
+      },
+      {
+        key: "timeoutSec",
+        label: "Timeout seconds",
+        type: "number",
+        default: DEFAULT_TIMEOUT_SEC,
+      },
+      {
+        key: "heartbeatSec",
+        label: "Watchdog seconds",
+        type: "number",
+        default: DEFAULT_HEARTBEAT_SEC,
+        hint: "Interval for [hermes] still running... watchdog messages.",
+      },
+      {
+        key: "debugEvents",
+        label: "Debug SSE events",
+        type: "toggle",
+        default: false,
+        hint: "Log unknown or adapter-internal SSE events as Paperclip system lines.",
+      },
+      {
+        key: "allowCliFallback",
+        label: "Allow CLI fallback",
+        type: "toggle",
+        default: false,
+        hint: "Only use the legacy hermes CLI path when the API server is unreachable.",
+      },
+      {
+        key: "hermesCommand",
+        label: "Hermes CLI command",
+        type: "text",
+        hint: "Used only when allowCliFallback is enabled.",
+        meta: {
+          visibleWhen: {
+            key: "allowCliFallback",
+            values: [true],
+          },
+        },
+      },
+    ],
+  };
+}

--- a/packages/adapters/hermes-observable/src/server/execute.test.ts
+++ b/packages/adapters/hermes-observable/src/server/execute.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execute } from "./execute.js";
+
+const cliFallbackExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    summary: "cli fallback",
+    resultJson: { fallback: true },
+  })),
+);
+
+vi.mock("hermes-paperclip-adapter/server", () => ({
+  execute: cliFallbackExecute,
+  detectModel: async () => ({ model: "anthropic/claude-sonnet-4", provider: "anthropic" }),
+  resolveProvider: ({ explicitProvider, detectedProvider, model }: any) => ({
+    provider: explicitProvider && explicitProvider !== "auto" ? explicitProvider : detectedProvider ?? "auto",
+    resolvedFrom: model ? "model" : "default",
+  }),
+}));
+
+function createSseResponse(chunks: string[], headers: Record<string, string> = {}): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream",
+      ...headers,
+    },
+  });
+}
+
+function createJsonResponse(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function baseContext() {
+  const logs: Array<{ stream: "stdout" | "stderr"; chunk: string }> = [];
+  return {
+    ctx: {
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Hermes Observable",
+        adapterType: "hermes_observable",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: "issue-1",
+      },
+      config: {
+        cwd: "/tmp/workspace",
+        hermesApiBaseUrl: "http://127.0.0.1:8000",
+        timeoutSec: 30,
+        heartbeatSec: 60,
+      },
+      context: {
+        issueId: "issue-1",
+        taskId: "issue-1",
+        wakeReason: "issue_assigned",
+        paperclipWake: {
+          reason: "issue_assigned",
+          issue: {
+            id: "issue-1",
+            identifier: "SAMA-41",
+            title: "Create adapter",
+            status: "in_progress",
+          },
+        },
+      },
+      onLog: async (stream: "stdout" | "stderr", chunk: string) => {
+        logs.push({ stream, chunk });
+      },
+      onMeta: async () => {},
+      authToken: "local-agent-jwt",
+    },
+    logs,
+  };
+}
+
+describe("hermes observable execute", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    cliFallbackExecute.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("streams responses SSE into structured Paperclip log events", async () => {
+    const { ctx, logs } = baseContext();
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(createJsonResponse({
+        features: {
+          responses_streaming: true,
+          chat_completions_streaming: true,
+          tool_progress_events: true,
+        },
+      }))
+      .mockResolvedValueOnce(createSseResponse([
+        'event: response.created\ndata: {"response":{"id":"resp_1"}}\n\n',
+        'event: response.output_item.added\ndata: {"item":{"type":"function_call","name":"search_query","call_id":"call_1","arguments":"{\\"q\\":\\"test\\"}"}}\n\n',
+        'event: response.output_text.delta\ndata: {"delta":"Working..."}\n\n',
+        'event: response.output_item.done\ndata: {"item":{"type":"function_call","name":"search_query","call_id":"call_1"}}\n\n',
+        'event: response.output_item.added\ndata: {"item":{"type":"function_call_output","call_id":"call_1","output":[{"type":"input_text","text":"done"}],"status":"completed"}}\n\n',
+        'event: response.completed\ndata: {"response":{"id":"resp_1","usage":{"input_tokens":12,"output_tokens":8},"output":[{"type":"message","content":[{"type":"output_text","text":"Working...done"}]}]}}\n\n',
+      ], {
+        "X-Hermes-Session-Id": "session-1",
+        "X-Hermes-Session-Key": "paperclip:company-1:agent-1:issue-1",
+      }));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await execute(ctx as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.summary).toBe("Working...done");
+    expect(result.sessionParams).toMatchObject({
+      conversation: "paperclip:company-1:agent-1:issue-1",
+      sessionId: "session-1",
+      lastResponseId: "resp_1",
+    });
+
+    const stdout = logs.filter((entry) => entry.stream === "stdout").map((entry) => entry.chunk);
+    expect(stdout.join("")).toContain('"type":"hermes_observable.init"');
+    expect(stdout.join("")).toContain('"type":"hermes_observable.tool_call"');
+    expect(stdout.join("")).toContain('"type":"hermes_observable.tool_result"');
+    expect(stdout.join("")).toContain('"type":"hermes_observable.result"');
+  });
+
+  it("falls back to chat completions streaming when responses support is unavailable", async () => {
+    const { ctx, logs } = baseContext();
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(createJsonResponse({
+        features: {
+          responses_streaming: false,
+          chat_completions_streaming: true,
+          tool_progress_events: true,
+        },
+      }))
+      .mockResolvedValueOnce(createSseResponse([
+        'data: {"choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n',
+        'event: hermes.tool.progress\ndata: {"tool":"terminal","toolCallId":"call_1","status":"running","input":{"cmd":"pwd"}}\n\n',
+        'data: {"choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}\n\n',
+        'event: hermes.tool.progress\ndata: {"tool":"terminal","toolCallId":"call_1","status":"completed","output":"ok"}\n\n',
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":4,"completion_tokens":3}}\n\n',
+        'data: [DONE]\n\n',
+      ], {
+        "X-Hermes-Session-Id": "chat-session-1",
+      }));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await execute(ctx as any);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.summary).toBe("hello");
+    expect(logs.map((entry) => entry.chunk).join("")).toContain("responses streaming unavailable");
+    expect(logs.map((entry) => entry.chunk).join("")).toContain('"type":"hermes_observable.tool_result"');
+  });
+
+  it("uses CLI fallback only when the API is unreachable and allowCliFallback is enabled", async () => {
+    const { ctx, logs } = baseContext();
+    ctx.config = {
+      ...ctx.config,
+      allowCliFallback: true,
+    } as any;
+
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("connect ECONNREFUSED"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await execute(ctx as any);
+
+    expect(cliFallbackExecute).toHaveBeenCalledTimes(1);
+    expect(result.summary).toBe("cli fallback");
+    expect(logs.map((entry) => entry.chunk).join("")).toContain("falling back to legacy hermes CLI");
+  });
+});

--- a/packages/adapters/hermes-observable/src/server/execute.ts
+++ b/packages/adapters/hermes-observable/src/server/execute.ts
@@ -1,0 +1,1213 @@
+import type {
+  AdapterExecutionContext,
+  AdapterExecutionResult,
+  UsageSummary,
+} from "@paperclipai/adapter-utils";
+import { renderTemplate } from "@paperclipai/adapter-utils/server-utils";
+import {
+  detectModel as detectHermesModel,
+  execute as executeHermesCliBase,
+} from "hermes-paperclip-adapter/server";
+import {
+  DEFAULT_ENDPOINT_MODE,
+  DEFAULT_HEARTBEAT_SEC,
+  DEFAULT_HERMES_API_BASE_URL,
+  DEFAULT_MODEL,
+  DEFAULT_PROVIDER,
+  DEFAULT_TIMEOUT_SEC,
+  HERMES_OBSERVABLE_EVENT_TYPES,
+  PROVIDER_OPTIONS,
+  TOOL_OUTPUT_MAX_CHARS,
+  type HermesEndpointMode,
+} from "../shared/constants.js";
+import { buildHermesObservablePrompt } from "./prompt.js";
+
+type HermesCliExecute = (ctx: AdapterExecutionContext) => Promise<AdapterExecutionResult>;
+
+const executeHermesCli = executeHermesCliBase as unknown as HermesCliExecute;
+
+interface HermesCapabilities {
+  responsesStreaming: boolean;
+  chatCompletionsStreaming: boolean;
+  toolProgressEvents: boolean;
+}
+
+interface StreamState {
+  finalText: string;
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  costUsd: number;
+  errors: string[];
+  isError: boolean;
+  lastResponseId: string | null;
+  sessionId: string | null;
+  gatewaySessionKey: string | null;
+  endpointMode: HermesEndpointMode;
+  conversation: string;
+}
+
+class HermesAdapterError extends Error {
+  code: string;
+  status: number | null;
+  cliFallbackEligible: boolean;
+  transient: boolean;
+
+  constructor(
+    message: string,
+    input: {
+      code: string;
+      status?: number | null;
+      cliFallbackEligible?: boolean;
+      transient?: boolean;
+    },
+  ) {
+    super(message);
+    this.name = "HermesAdapterError";
+    this.code = input.code;
+    this.status = input.status ?? null;
+    this.cliFallbackEligible = input.cliFallbackEligible ?? false;
+    this.transient = input.transient ?? false;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asBoolean(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function truncateText(value: string, maxChars = TOOL_OUTPUT_MAX_CHARS): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}...[${value.length - maxChars} more chars truncated]`;
+}
+
+function stringifyValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function createApiUrl(baseUrl: string, path: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  if (trimmed.endsWith("/v1") && path.startsWith("/v1/")) {
+    return `${trimmed}${path.slice(3)}`;
+  }
+  return `${trimmed}${path}`;
+}
+
+function normalizeBaseUrl(config: Record<string, unknown>): string {
+  const configured = asString(config.hermesApiBaseUrl).trim();
+  return configured || DEFAULT_HERMES_API_BASE_URL;
+}
+
+function inferProviderFromModel(model: string): string | null {
+  const normalized = model.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const providerPrefix = normalized.includes("/") ? normalized.split("/")[0] : "";
+  if (providerPrefix && PROVIDER_OPTIONS.includes(providerPrefix as (typeof PROVIDER_OPTIONS)[number])) {
+    return providerPrefix;
+  }
+
+  const bare = normalized.includes("/") ? (normalized.split("/").pop() ?? normalized) : normalized;
+  if (bare.startsWith("claude")) return "anthropic";
+  if (bare.startsWith("gpt-") || bare.startsWith("o1") || bare.startsWith("o3") || bare.startsWith("o4")) {
+    return bare.includes("codex") ? "openai-codex" : "openai";
+  }
+  if (bare.startsWith("kimi")) return "kimi-coding";
+  if (bare.startsWith("minimax")) return "minimax";
+  if (bare.startsWith("glm")) return "zai";
+  return null;
+}
+
+function resolveProviderHint(input: {
+  explicitProvider: string;
+  detectedProvider?: string | null;
+  detectedModel?: string | null;
+  model: string;
+}): string {
+  const explicitProvider = input.explicitProvider.trim().toLowerCase();
+  if (
+    explicitProvider &&
+    explicitProvider !== "auto" &&
+    PROVIDER_OPTIONS.includes(explicitProvider as (typeof PROVIDER_OPTIONS)[number])
+  ) {
+    return explicitProvider;
+  }
+
+  const detectedProvider = asString(input.detectedProvider).trim().toLowerCase();
+  const detectedModel = asString(input.detectedModel).trim().toLowerCase();
+  const requestedModel = input.model.trim().toLowerCase();
+  if (
+    detectedProvider &&
+    detectedModel &&
+    detectedModel === requestedModel &&
+    PROVIDER_OPTIONS.includes(detectedProvider as (typeof PROVIDER_OPTIONS)[number])
+  ) {
+    return detectedProvider;
+  }
+
+  return inferProviderFromModel(input.model) ?? DEFAULT_PROVIDER;
+}
+
+function readStreamBody(response: Response): Promise<string> {
+  return response.text().catch(() => "");
+}
+
+async function readErrorResponse(response: Response): Promise<string> {
+  const body = await readStreamBody(response);
+  const parsed = safeJsonParse(body);
+  const record = asRecord(parsed);
+  const errorRecord = asRecord(record?.error);
+  return (
+    asString(errorRecord?.message).trim() ||
+    asString(record?.message).trim() ||
+    body.trim() ||
+    `${response.status} ${response.statusText}`
+  );
+}
+
+async function fetchCapabilities(
+  baseUrl: string,
+  signal: AbortSignal,
+): Promise<HermesCapabilities | null> {
+  let response: Response;
+  try {
+    response = await fetch(createApiUrl(baseUrl, "/v1/capabilities"), {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+      },
+      signal,
+    });
+  } catch (error) {
+    throw new HermesAdapterError(
+      `Could not reach Hermes API at ${baseUrl}: ${error instanceof Error ? error.message : String(error)}`,
+      {
+        code: "hermes_api_unreachable",
+        cliFallbackEligible: true,
+        transient: true,
+      },
+    );
+  }
+
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new HermesAdapterError(
+      `Hermes capabilities probe failed: ${await readErrorResponse(response)}`,
+      {
+        code: "hermes_capabilities_failed",
+        status: response.status,
+      },
+    );
+  }
+
+  const parsed = asRecord(await response.json().catch(() => null));
+  const features = asRecord(parsed?.features) ?? {};
+  return {
+    responsesStreaming: features.responses_streaming === true,
+    chatCompletionsStreaming: features.chat_completions_streaming === true,
+    toolProgressEvents: features.tool_progress_events === true,
+  };
+}
+
+function buildSetupHint(baseUrl: string): string {
+  return [
+    `Hermes API is unavailable at ${baseUrl}.`,
+    "Expected probes:",
+    `- ${createApiUrl(baseUrl, "/health")}`,
+    `- ${createApiUrl(baseUrl, "/v1/capabilities")}`,
+    "Suggested local startup:",
+    "API_SERVER_ENABLED=1 API_SERVER_PORT=8000 hermes gateway",
+  ].join("\n");
+}
+
+async function emitJsonEvent(ctx: AdapterExecutionContext, payload: Record<string, unknown>): Promise<void> {
+  await ctx.onLog("stdout", `${JSON.stringify(payload)}\n`);
+}
+
+async function emitSystemLine(ctx: AdapterExecutionContext, message: string): Promise<void> {
+  const normalized = message.startsWith("[hermes]") ? message : `[hermes] ${message}`;
+  await ctx.onLog("stdout", normalized.endsWith("\n") ? normalized : `${normalized}\n`);
+}
+
+async function emitError(ctx: AdapterExecutionContext, message: string): Promise<void> {
+  await emitJsonEvent(ctx, {
+    type: HERMES_OBSERVABLE_EVENT_TYPES.error,
+    message,
+  });
+}
+
+function extractToolName(payload: Record<string, unknown>): string {
+  return (
+    asString(payload.tool).trim() ||
+    asString(payload.name).trim() ||
+    asString(payload.function_name).trim() ||
+    "tool"
+  );
+}
+
+function extractToolInput(payload: Record<string, unknown>): unknown {
+  if (payload.args !== undefined) return payload.args;
+  if (payload.arguments !== undefined) {
+    const raw = payload.arguments;
+    if (typeof raw === "string") return safeJsonParse(raw) ?? raw;
+    return raw;
+  }
+  if (payload.input !== undefined) return payload.input;
+  return {};
+}
+
+function extractToolOutput(payload: Record<string, unknown>): string {
+  const raw =
+    payload.result ??
+    payload.output ??
+    payload.content ??
+    payload.text ??
+    payload.error;
+  return truncateText(stringifyValue(raw));
+}
+
+function extractFunctionCallOutput(item: Record<string, unknown>): string {
+  const rawOutput = item.output;
+  if (typeof rawOutput === "string") return truncateText(rawOutput);
+  if (!Array.isArray(rawOutput)) return truncateText(stringifyValue(rawOutput));
+  const chunks = rawOutput
+    .map((part) => {
+      const record = asRecord(part);
+      return (
+        asString(record?.text) ||
+        asString(record?.output_text) ||
+        stringifyValue(record ?? part)
+      );
+    })
+    .filter(Boolean);
+  return truncateText(chunks.join("\n"));
+}
+
+function extractAssistantTextFromResponse(responsePayload: Record<string, unknown>): string {
+  const output = Array.isArray(responsePayload.output) ? responsePayload.output : [];
+  const textParts: string[] = [];
+  for (const itemValue of output) {
+    const item = asRecord(itemValue);
+    if (!item || item.type !== "message") continue;
+    const content = Array.isArray(item.content) ? item.content : [];
+    for (const contentValue of content) {
+      const contentPart = asRecord(contentValue);
+      if (!contentPart) continue;
+      const text =
+        asString(contentPart.text) ||
+        asString(contentPart.output_text);
+      if (text) textParts.push(text);
+    }
+  }
+  return textParts.join("");
+}
+
+function buildConversationKey(ctx: AdapterExecutionContext): string {
+  const context = asRecord(ctx.context) ?? {};
+  const taskKey =
+    asString(ctx.runtime.taskKey).trim() ||
+    asString(context.taskId).trim() ||
+    asString(context.issueId).trim() ||
+    "idle";
+  return `paperclip:${ctx.agent.companyId}:${ctx.agent.id}:${taskKey}`;
+}
+
+function maybeTimerUnref(handle: ReturnType<typeof setInterval> | ReturnType<typeof setTimeout>): void {
+  if ("unref" in handle && typeof handle.unref === "function") {
+    handle.unref();
+  }
+}
+
+function buildHeaders(): Record<string, string> {
+  return {
+    Accept: "text/event-stream",
+    "Content-Type": "application/json",
+  };
+}
+
+async function consumeSse(
+  body: ReadableStream<Uint8Array>,
+  onEvent: (eventName: string | null, data: string) => Promise<void>,
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  const flushBlock = async (block: string) => {
+    const lines = block.split(/\r?\n/);
+    let eventName: string | null = null;
+    const dataLines: string[] = [];
+    for (const line of lines) {
+      if (!line || line.startsWith(":")) continue;
+      if (line.startsWith("event:")) {
+        eventName = line.slice("event:".length).trim() || null;
+        continue;
+      }
+      if (line.startsWith("data:")) {
+        dataLines.push(line.slice("data:".length).trimStart());
+      }
+    }
+    if (dataLines.length === 0) return;
+    await onEvent(eventName, dataLines.join("\n"));
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+    buffer += decoder.decode(value, { stream: !done });
+
+    let splitIndex = buffer.indexOf("\n\n");
+    while (splitIndex >= 0) {
+      const block = buffer.slice(0, splitIndex).replace(/\r$/, "");
+      buffer = buffer.slice(splitIndex + 2);
+      if (block.trim().length > 0) {
+        await flushBlock(block);
+      }
+      splitIndex = buffer.indexOf("\n\n");
+    }
+
+    if (done) break;
+  }
+
+  const trailing = buffer.trim();
+  if (trailing) {
+    await flushBlock(trailing);
+  }
+}
+
+function createToolTracker(debugEvents: boolean) {
+  const activeToolNames = new Map<string, string>();
+  const anonymousByName = new Map<string, string[]>();
+  let syntheticIdCounter = 0;
+
+  const noteMissingId = async (ctx: AdapterExecutionContext, toolName: string, status: string) => {
+    if (!debugEvents) return;
+    await emitSystemLine(
+      ctx,
+      `[debug] ${status} tool event for ${toolName} did not include a stable tool call id; generated one.`,
+    );
+  };
+
+  const getPayloadId = (payload: Record<string, unknown>) =>
+    asString(payload.toolCallId).trim() ||
+    asString(payload.call_id).trim() ||
+    asString(payload.callId).trim() ||
+    asString(payload.id).trim();
+
+  return {
+    activeToolName(): string | null {
+      const last = Array.from(activeToolNames.values()).at(-1);
+      return last ?? null;
+    },
+    async resolveRunningId(ctx: AdapterExecutionContext, payload: Record<string, unknown>): Promise<string> {
+      const toolName = extractToolName(payload);
+      const explicit = getPayloadId(payload);
+      if (explicit) {
+        activeToolNames.set(explicit, toolName);
+        return explicit;
+      }
+      syntheticIdCounter += 1;
+      const generated = `hermes-tool-${syntheticIdCounter}`;
+      activeToolNames.set(generated, toolName);
+      const queue = anonymousByName.get(toolName) ?? [];
+      queue.push(generated);
+      anonymousByName.set(toolName, queue);
+      await noteMissingId(ctx, toolName, "running");
+      return generated;
+    },
+    async resolveCompletedId(ctx: AdapterExecutionContext, payload: Record<string, unknown>): Promise<string> {
+      const explicit = getPayloadId(payload);
+      if (explicit) return explicit;
+      const toolName = extractToolName(payload);
+      const queue = anonymousByName.get(toolName) ?? [];
+      const reused = queue.shift();
+      if (queue.length === 0) anonymousByName.delete(toolName);
+      if (reused) return reused;
+      syntheticIdCounter += 1;
+      const generated = `hermes-tool-${syntheticIdCounter}`;
+      await noteMissingId(ctx, toolName, "completed");
+      return generated;
+    },
+    setActive(id: string, name: string): void {
+      activeToolNames.set(id, name);
+    },
+    clearActive(id: string): void {
+      activeToolNames.delete(id);
+    },
+    toolName(id: string, fallbackName: string): string {
+      return activeToolNames.get(id) ?? fallbackName;
+    },
+  };
+}
+
+async function openStreamingRequest(
+  url: string,
+  body: Record<string, unknown>,
+  signal: AbortSignal,
+): Promise<Response> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: buildHeaders(),
+      body: JSON.stringify(body),
+      signal,
+    });
+  } catch (error) {
+    throw new HermesAdapterError(
+      `Could not reach Hermes API at ${url}: ${error instanceof Error ? error.message : String(error)}`,
+      {
+        code: "hermes_api_unreachable",
+        cliFallbackEligible: true,
+        transient: true,
+      },
+    );
+  }
+
+  if (!response.ok) {
+    throw new HermesAdapterError(await readErrorResponse(response), {
+      code: "hermes_http_error",
+      status: response.status,
+      cliFallbackEligible: response.status >= 500,
+      transient: response.status >= 500,
+    });
+  }
+
+  if (!response.body) {
+    throw new HermesAdapterError("Hermes API returned no response body for an SSE request.", {
+      code: "hermes_missing_stream_body",
+      cliFallbackEligible: true,
+      transient: true,
+    });
+  }
+
+  return response;
+}
+
+async function executeResponsesStream(input: {
+  ctx: AdapterExecutionContext;
+  url: string;
+  model: string;
+  provider: string;
+  conversation: string;
+  gatewaySessionKey: string;
+  instructions: string;
+  promptInput: string;
+  signal: AbortSignal;
+  debugEvents: boolean;
+  watchdogState: {
+    lastEvent: string;
+    activeTool: string;
+    setLastEvent: (eventName: string) => void;
+    setActiveTool: (toolName: string) => void;
+  };
+}): Promise<StreamState> {
+  const {
+    ctx,
+    url,
+    model,
+    provider,
+    conversation,
+    gatewaySessionKey,
+    instructions,
+    promptInput,
+    signal,
+    debugEvents,
+    watchdogState,
+  } = input;
+  const toolTracker = createToolTracker(debugEvents);
+  const state: StreamState = {
+    finalText: "",
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedTokens: 0,
+    costUsd: 0,
+    errors: [],
+    isError: false,
+    lastResponseId: null,
+    sessionId: null,
+    gatewaySessionKey,
+    endpointMode: "responses",
+    conversation,
+  };
+
+  const response = await openStreamingRequest(
+    url,
+    {
+      model,
+      stream: true,
+      store: true,
+      conversation,
+      input: promptInput,
+      instructions,
+    },
+    signal,
+  );
+
+  state.sessionId = response.headers.get("X-Hermes-Session-Id");
+  state.gatewaySessionKey = response.headers.get("X-Hermes-Session-Key") ?? gatewaySessionKey;
+
+  await emitJsonEvent(ctx, {
+    type: HERMES_OBSERVABLE_EVENT_TYPES.init,
+    endpointMode: "responses",
+    model,
+    provider,
+    sessionId: state.sessionId,
+    gatewaySessionKey: state.gatewaySessionKey,
+    conversation,
+  });
+
+  const textParts: string[] = [];
+
+  const responseBody = response.body;
+  if (!responseBody) {
+    throw new HermesAdapterError("Hermes API returned no response body for an SSE request.", {
+      code: "hermes_missing_stream_body",
+      cliFallbackEligible: true,
+      transient: true,
+    });
+  }
+
+  await consumeSse(responseBody, async (eventName, data) => {
+    const effectiveEvent = eventName ?? "message";
+    watchdogState.setLastEvent(effectiveEvent);
+
+    if (data === "[DONE]") return;
+
+    const payload = asRecord(safeJsonParse(data));
+    if (!payload) {
+      if (debugEvents) {
+        await emitSystemLine(ctx, `[debug] Non-JSON SSE payload for ${effectiveEvent}: ${truncateText(data, 400)}`);
+      }
+      return;
+    }
+
+    if (effectiveEvent === "response.created") {
+      const responsePayload = asRecord(payload.response);
+      state.lastResponseId = asString(responsePayload?.id).trim() || state.lastResponseId;
+      return;
+    }
+
+    if (effectiveEvent === "response.output_text.delta") {
+      const delta = asString(payload.delta);
+      if (!delta) return;
+      textParts.push(delta);
+      await emitJsonEvent(ctx, {
+        type: HERMES_OBSERVABLE_EVENT_TYPES.textDelta,
+        channel: "assistant",
+        text: delta,
+      });
+      return;
+    }
+
+    if (effectiveEvent === "response.output_item.added") {
+      const item = asRecord(payload.item);
+      if (!item) return;
+      if (item.type === "function_call") {
+        const toolCallId = await toolTracker.resolveRunningId(ctx, {
+          toolCallId: item.call_id,
+          name: item.name,
+          arguments: item.arguments,
+        });
+        const toolName = extractToolName(item);
+        toolTracker.setActive(toolCallId, toolName);
+        watchdogState.setActiveTool(toolName);
+        await emitJsonEvent(ctx, {
+          type: HERMES_OBSERVABLE_EVENT_TYPES.toolCall,
+          name: toolName,
+          toolCallId,
+          input: extractToolInput(item),
+        });
+        return;
+      }
+      if (item.type === "function_call_output") {
+        const toolCallId = await toolTracker.resolveCompletedId(ctx, {
+          toolCallId: item.call_id,
+          name: item.name,
+        });
+        const toolName = toolTracker.toolName(toolCallId, extractToolName(item));
+        await emitJsonEvent(ctx, {
+          type: HERMES_OBSERVABLE_EVENT_TYPES.toolResult,
+          name: toolName,
+          toolCallId,
+          content: extractFunctionCallOutput(item),
+          isError: item.status === "failed",
+        });
+        toolTracker.clearActive(toolCallId);
+        watchdogState.setActiveTool("none");
+        return;
+      }
+      return;
+    }
+
+    if (effectiveEvent === "response.output_item.done") {
+      const item = asRecord(payload.item);
+      if (!item || item.type !== "function_call") return;
+      const toolCallId = await toolTracker.resolveCompletedId(ctx, {
+        toolCallId: item.call_id,
+        name: item.name,
+      });
+      const toolName = toolTracker.toolName(toolCallId, extractToolName(item));
+      await emitSystemLine(ctx, `tool completed: ${toolName} (${toolCallId})`);
+      watchdogState.setActiveTool("none");
+      return;
+    }
+
+    if (effectiveEvent === "response.completed") {
+      const responsePayload = asRecord(payload.response) ?? {};
+      const usage = asRecord(responsePayload.usage) ?? {};
+      const completedText = extractAssistantTextFromResponse(responsePayload);
+      state.lastResponseId = asString(responsePayload.id).trim() || state.lastResponseId;
+      state.inputTokens = asNumber(usage.input_tokens, 0);
+      state.outputTokens = asNumber(usage.output_tokens, 0);
+      state.finalText = completedText || textParts.join("");
+      await emitJsonEvent(ctx, {
+        type: HERMES_OBSERVABLE_EVENT_TYPES.result,
+        text: state.finalText,
+        inputTokens: state.inputTokens,
+        outputTokens: state.outputTokens,
+        cachedTokens: state.cachedTokens,
+        costUsd: state.costUsd,
+        subtype: "completed",
+        isError: false,
+        errors: [],
+        responseId: state.lastResponseId,
+      });
+      return;
+    }
+
+    if (effectiveEvent === "response.failed" || effectiveEvent === "response.error") {
+      const responsePayload = asRecord(payload.response) ?? payload;
+      const errorPayload = asRecord(responsePayload.error) ?? responsePayload;
+      const message =
+        asString(errorPayload.message).trim() ||
+        asString(errorPayload.error).trim() ||
+        "Hermes response stream failed.";
+      state.isError = true;
+      state.errors.push(message);
+      await emitError(ctx, message);
+      return;
+    }
+
+    if (debugEvents) {
+      await emitSystemLine(ctx, `[debug] Ignored SSE event ${effectiveEvent}: ${truncateText(JSON.stringify(payload), 800)}`);
+    }
+  });
+
+  if (!state.finalText) {
+    state.finalText = textParts.join("");
+  }
+
+  return state;
+}
+
+async function executeChatCompletionsStream(input: {
+  ctx: AdapterExecutionContext;
+  url: string;
+  model: string;
+  provider: string;
+  conversation: string;
+  sessionId: string | null;
+  gatewaySessionKey: string;
+  instructions: string;
+  promptInput: string;
+  signal: AbortSignal;
+  debugEvents: boolean;
+  watchdogState: {
+    lastEvent: string;
+    activeTool: string;
+    setLastEvent: (eventName: string) => void;
+    setActiveTool: (toolName: string) => void;
+  };
+}): Promise<StreamState> {
+  const {
+    ctx,
+    url,
+    model,
+    provider,
+    conversation,
+    sessionId,
+    gatewaySessionKey,
+    instructions,
+    promptInput,
+    signal,
+    debugEvents,
+    watchdogState,
+  } = input;
+  const toolTracker = createToolTracker(debugEvents);
+  const textParts: string[] = [];
+  const state: StreamState = {
+    finalText: "",
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedTokens: 0,
+    costUsd: 0,
+    errors: [],
+    isError: false,
+    lastResponseId: null,
+    sessionId,
+    gatewaySessionKey,
+    endpointMode: "chat_completions",
+    conversation,
+  };
+
+  const headers = buildHeaders();
+  if (sessionId) headers["X-Hermes-Session-Id"] = sessionId;
+  if (gatewaySessionKey) headers["X-Hermes-Session-Key"] = gatewaySessionKey;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model,
+        stream: true,
+        messages: [
+          { role: "system", content: instructions },
+          { role: "user", content: promptInput },
+        ],
+      }),
+      signal,
+    });
+  } catch (error) {
+    throw new HermesAdapterError(
+      `Could not reach Hermes chat completions API at ${url}: ${error instanceof Error ? error.message : String(error)}`,
+      {
+        code: "hermes_api_unreachable",
+        cliFallbackEligible: true,
+        transient: true,
+      },
+    );
+  }
+
+  if (!response.ok) {
+    throw new HermesAdapterError(await readErrorResponse(response), {
+      code: "hermes_http_error",
+      status: response.status,
+      cliFallbackEligible: response.status >= 500,
+      transient: response.status >= 500,
+    });
+  }
+
+  if (!response.body) {
+    throw new HermesAdapterError("Hermes API returned no response body for chat completions SSE.", {
+      code: "hermes_missing_stream_body",
+      cliFallbackEligible: true,
+      transient: true,
+    });
+  }
+
+  state.sessionId = response.headers.get("X-Hermes-Session-Id") ?? state.sessionId;
+  state.gatewaySessionKey = response.headers.get("X-Hermes-Session-Key") ?? state.gatewaySessionKey;
+
+  await emitJsonEvent(ctx, {
+    type: HERMES_OBSERVABLE_EVENT_TYPES.init,
+    endpointMode: "chat_completions",
+    model,
+    provider,
+    sessionId: state.sessionId,
+    gatewaySessionKey: state.gatewaySessionKey,
+    conversation,
+  });
+
+  await consumeSse(response.body, async (eventName, data) => {
+    const effectiveEvent = eventName ?? "message";
+    watchdogState.setLastEvent(effectiveEvent);
+
+    if (data === "[DONE]") return;
+
+    if (effectiveEvent === "hermes.tool.progress") {
+      const payload = asRecord(safeJsonParse(data));
+      if (!payload) return;
+      const status = asString(payload.status).trim();
+      if (status === "running") {
+        const toolCallId = await toolTracker.resolveRunningId(ctx, payload);
+        const toolName = extractToolName(payload);
+        toolTracker.setActive(toolCallId, toolName);
+        watchdogState.setActiveTool(toolName);
+        await emitJsonEvent(ctx, {
+          type: HERMES_OBSERVABLE_EVENT_TYPES.toolCall,
+          name: toolName,
+          toolCallId,
+          input: extractToolInput(payload),
+        });
+        return;
+      }
+
+      if (status === "completed") {
+        const toolCallId = await toolTracker.resolveCompletedId(ctx, payload);
+        const toolName = toolTracker.toolName(toolCallId, extractToolName(payload));
+        await emitSystemLine(ctx, `tool completed: ${toolName} (${toolCallId})`);
+        const outputText = extractToolOutput(payload);
+        if (outputText.trim().length > 0) {
+          await emitJsonEvent(ctx, {
+            type: HERMES_OBSERVABLE_EVENT_TYPES.toolResult,
+            name: toolName,
+            toolCallId,
+            content: outputText,
+            isError: false,
+          });
+        }
+        toolTracker.clearActive(toolCallId);
+        watchdogState.setActiveTool("none");
+        return;
+      }
+
+      if (debugEvents) {
+        await emitSystemLine(ctx, `[debug] Ignored hermes.tool.progress status=${status || "unknown"}: ${truncateText(JSON.stringify(payload), 800)}`);
+      }
+      return;
+    }
+
+    const payload = asRecord(safeJsonParse(data));
+    if (!payload) {
+      if (debugEvents) {
+        await emitSystemLine(ctx, `[debug] Non-JSON chat completions SSE payload: ${truncateText(data, 400)}`);
+      }
+      return;
+    }
+
+    const choices = Array.isArray(payload.choices) ? payload.choices : [];
+    const firstChoice = asRecord(choices[0]) ?? {};
+    const delta = asRecord(firstChoice.delta) ?? {};
+    const finishReason = asString(firstChoice.finish_reason).trim();
+
+    const contentDelta = asString(delta.content);
+    if (contentDelta) {
+      textParts.push(contentDelta);
+      await emitJsonEvent(ctx, {
+        type: HERMES_OBSERVABLE_EVENT_TYPES.textDelta,
+        channel: "assistant",
+        text: contentDelta,
+      });
+    }
+
+    const usage = asRecord(payload.usage);
+    if (usage) {
+      state.inputTokens = asNumber(usage.prompt_tokens, state.inputTokens);
+      state.outputTokens = asNumber(usage.completion_tokens, state.outputTokens);
+    }
+
+    if (finishReason === "error") {
+      state.isError = true;
+      const message = "Hermes chat completions stream finished with finish_reason=error.";
+      state.errors.push(message);
+      await emitError(ctx, message);
+    }
+  });
+
+  state.finalText = textParts.join("");
+  await emitJsonEvent(ctx, {
+    type: HERMES_OBSERVABLE_EVENT_TYPES.result,
+    text: state.finalText,
+    inputTokens: state.inputTokens,
+    outputTokens: state.outputTokens,
+    cachedTokens: state.cachedTokens,
+    costUsd: state.costUsd,
+    subtype: state.isError ? "error" : "completed",
+    isError: state.isError,
+    errors: state.errors,
+  });
+  return state;
+}
+
+function buildResultJson(state: StreamState, model: string, provider: string): Record<string, unknown> {
+  return {
+    endpointMode: state.endpointMode,
+    responseId: state.lastResponseId,
+    sessionId: state.sessionId,
+    gatewaySessionKey: state.gatewaySessionKey,
+    conversation: state.conversation,
+    text: state.finalText,
+    usage: {
+      inputTokens: state.inputTokens,
+      outputTokens: state.outputTokens,
+      cachedInputTokens: state.cachedTokens,
+    },
+    costUsd: state.costUsd,
+    provider,
+    model,
+    errors: state.errors,
+  };
+}
+
+function shouldFallbackToChat(error: unknown): boolean {
+  return error instanceof HermesAdapterError && (error.status === 404 || error.status === 405);
+}
+
+function shouldUseCliFallback(error: unknown): boolean {
+  return error instanceof HermesAdapterError && error.cliFallbackEligible;
+}
+
+function buildCliFallbackConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const next = { ...config };
+  if (typeof next.hermesCommand === "string" && next.hermesCommand.trim().length > 0) {
+    next.command = next.hermesCommand;
+  }
+  return next;
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const config = (ctx.config ?? {}) as Record<string, unknown>;
+  const baseUrl = normalizeBaseUrl(config);
+  const debugEvents = asBoolean(config.debugEvents, false);
+  const allowCliFallback = asBoolean(config.allowCliFallback, false);
+  const timeoutSec = asNumber(config.timeoutSec, DEFAULT_TIMEOUT_SEC);
+  const heartbeatSec = Math.max(1, asNumber(config.heartbeatSec, DEFAULT_HEARTBEAT_SEC));
+  const preferredMode = (asString(config.endpointMode).trim() || DEFAULT_ENDPOINT_MODE) as HermesEndpointMode;
+
+  const detectedModel = await detectHermesModel().catch(() => null);
+  const model = asString(config.model).trim() || detectedModel?.model || DEFAULT_MODEL;
+  const provider = resolveProviderHint({
+    explicitProvider: asString(config.provider).trim() || DEFAULT_PROVIDER,
+    detectedProvider: detectedModel?.provider,
+    detectedModel: detectedModel?.model,
+    model,
+  });
+
+  const { instructions, input, commandNotes, promptMetrics } = await buildHermesObservablePrompt(ctx, config);
+  const sessionParams = asRecord(ctx.runtime.sessionParams) ?? {};
+  const conversation = asString(sessionParams.conversation).trim() || buildConversationKey(ctx);
+  const gatewaySessionKey =
+    asString(sessionParams.gatewaySessionKey).trim() ||
+    conversation;
+  const sessionId = asString(sessionParams.sessionId).trim() || null;
+
+  if (ctx.executionTarget?.kind === "remote") {
+    await emitSystemLine(
+      ctx,
+      "Remote execution target requested, but Hermes gateway tools execute on the gateway host; continuing on the API-server host.",
+    );
+  }
+
+  await ctx.onMeta?.({
+    adapterType: "hermes_observable",
+    command: `POST ${createApiUrl(baseUrl, preferredMode === "chat_completions" ? "/v1/chat/completions" : "/v1/responses")}`,
+    cwd: asString(config.cwd).trim() || undefined,
+    commandNotes,
+    promptMetrics,
+    context: {
+      endpointMode: preferredMode,
+      conversation,
+      gatewaySessionKey,
+      timeoutSec,
+      allowCliFallback,
+    },
+  });
+
+  const controller = new AbortController();
+  const timeoutHandle = setTimeout(() => controller.abort(), timeoutSec * 1000);
+  maybeTimerUnref(timeoutHandle);
+
+  const startedAt = Date.now();
+  let lastEvent = "starting";
+  let activeTool = "none";
+  const watchdogHandle = setInterval(() => {
+    void emitSystemLine(
+      ctx,
+      `still running: ${Math.round((Date.now() - startedAt) / 1000)}s, lastEvent=${lastEvent}, activeTool=${activeTool}`,
+    );
+  }, heartbeatSec * 1000);
+  maybeTimerUnref(watchdogHandle);
+
+  try {
+    await emitSystemLine(
+      ctx,
+      `starting Hermes observable adapter (mode=${preferredMode}, model=${model}, provider=${provider}, baseUrl=${baseUrl})`,
+    );
+
+    const capabilities = await fetchCapabilities(baseUrl, controller.signal).catch((error) => {
+      if (allowCliFallback && shouldUseCliFallback(error)) return null;
+      throw error;
+    });
+
+    let mode: HermesEndpointMode = preferredMode;
+    if (preferredMode === "responses" && capabilities && !capabilities.responsesStreaming && capabilities.chatCompletionsStreaming) {
+      mode = "chat_completions";
+      await emitSystemLine(ctx, "responses streaming unavailable; falling back to chat completions streaming.");
+    }
+
+    const watchdogState = {
+      lastEvent,
+      activeTool,
+      setLastEvent(eventName: string) {
+        lastEvent = eventName;
+      },
+      setActiveTool(toolName: string) {
+        activeTool = toolName;
+      },
+    };
+
+    let streamState: StreamState;
+    try {
+      if (mode === "responses") {
+        streamState = await executeResponsesStream({
+          ctx,
+          url: createApiUrl(baseUrl, "/v1/responses"),
+          model,
+          provider,
+          conversation,
+          gatewaySessionKey,
+          instructions,
+          promptInput: input,
+          signal: controller.signal,
+          debugEvents,
+          watchdogState,
+        });
+      } else {
+        streamState = await executeChatCompletionsStream({
+          ctx,
+          url: createApiUrl(baseUrl, "/v1/chat/completions"),
+          model,
+          provider,
+          conversation,
+          sessionId,
+          gatewaySessionKey,
+          instructions,
+          promptInput: input,
+          signal: controller.signal,
+          debugEvents,
+          watchdogState,
+        });
+      }
+    } catch (error) {
+      if (mode === "responses" && shouldFallbackToChat(error)) {
+        await emitSystemLine(ctx, "responses endpoint unavailable; retrying with chat completions streaming.");
+        streamState = await executeChatCompletionsStream({
+          ctx,
+          url: createApiUrl(baseUrl, "/v1/chat/completions"),
+          model,
+          provider,
+          conversation,
+          sessionId,
+          gatewaySessionKey,
+          instructions,
+          promptInput: input,
+          signal: controller.signal,
+          debugEvents,
+          watchdogState,
+        });
+      } else {
+        throw error;
+      }
+    }
+
+    activeTool = "none";
+    clearTimeout(timeoutHandle);
+    clearInterval(watchdogHandle);
+
+    return {
+      exitCode: streamState.isError ? 1 : 0,
+      signal: null,
+      timedOut: false,
+      errorMessage: streamState.isError ? streamState.errors.join("\n") : null,
+      usage: {
+        inputTokens: streamState.inputTokens,
+        outputTokens: streamState.outputTokens,
+        cachedInputTokens: streamState.cachedTokens,
+      } satisfies UsageSummary,
+      provider,
+      model,
+      summary: streamState.finalText || null,
+      resultJson: buildResultJson(streamState, model, provider),
+      sessionParams: {
+        conversation,
+        sessionId: streamState.sessionId,
+        gatewaySessionKey: streamState.gatewaySessionKey,
+        lastResponseId: streamState.lastResponseId,
+      },
+      sessionDisplayId: conversation,
+    };
+  } catch (error) {
+    clearTimeout(timeoutHandle);
+    clearInterval(watchdogHandle);
+
+    if (allowCliFallback && shouldUseCliFallback(error)) {
+      await emitSystemLine(
+        ctx,
+        "gateway API unreachable; falling back to legacy hermes CLI because allowCliFallback=true.",
+      );
+      return executeHermesCli({
+        ...ctx,
+        config: buildCliFallbackConfig(config),
+      });
+    }
+
+    if (controller.signal.aborted) {
+      const message = `Hermes API timed out after ${timeoutSec}s.\n${buildSetupHint(baseUrl)}`;
+      await emitError(ctx, message);
+      return {
+        exitCode: null,
+        signal: null,
+        timedOut: true,
+        errorMessage: message,
+        errorCode: "timeout",
+        provider,
+        model,
+        resultJson: {
+          endpointMode: preferredMode,
+          provider,
+          model,
+        },
+      };
+    }
+
+    const message =
+      error instanceof HermesAdapterError
+        ? `${error.message}\n${buildSetupHint(baseUrl)}`
+        : `${error instanceof Error ? error.message : String(error)}\n${buildSetupHint(baseUrl)}`;
+
+    await emitError(ctx, message);
+
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorMessage: message,
+      errorCode: error instanceof HermesAdapterError ? error.code : "hermes_observable_error",
+      errorFamily:
+        error instanceof HermesAdapterError && error.transient
+          ? "transient_upstream"
+          : null,
+      provider,
+      model,
+      resultJson: {
+        endpointMode: preferredMode,
+        provider,
+        model,
+        error: message,
+      },
+    };
+  }
+}

--- a/packages/adapters/hermes-observable/src/server/index.ts
+++ b/packages/adapters/hermes-observable/src/server/index.ts
@@ -1,0 +1,10 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";
+export { getConfigSchema } from "./config-schema.js";
+export { sessionCodec } from "./session.js";
+
+export {
+  detectModel,
+  listSkills,
+  syncSkills,
+} from "hermes-paperclip-adapter/server";

--- a/packages/adapters/hermes-observable/src/server/prompt.ts
+++ b/packages/adapters/hermes-observable/src/server/prompt.ts
@@ -1,0 +1,148 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { buildPaperclipEnv, renderTemplate } from "@paperclipai/adapter-utils/server-utils";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function renderWakePayload(context: Record<string, unknown>): string {
+  const wakePayload = asRecord(context.paperclipWake);
+  if (wakePayload) {
+    return JSON.stringify(wakePayload, null, 2);
+  }
+
+  const reduced = {
+    issueId: asString(context.issueId) || asString(context.taskId) || null,
+    taskId: asString(context.taskId) || null,
+    wakeReason: asString(context.wakeReason) || null,
+    wakeCommentId: asString(context.wakeCommentId) || null,
+    commentId: asString(context.commentId) || null,
+  };
+  return JSON.stringify(reduced, null, 2);
+}
+
+function buildExportBlock(env: Record<string, string>): string {
+  return Object.entries(env)
+    .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
+    .join("\n");
+}
+
+const DEFAULT_INPUT_TEMPLATE = `Current Paperclip heartbeat wake:
+{{wakePayload}}
+
+Paperclip runtime env exports for this run:
+
+\`\`\`bash
+{{paperclipExportBlock}}
+\`\`\`
+
+Execution requirements:
+
+1. Treat the wake payload above as the highest-priority context for this heartbeat.
+2. If a task is assigned, use GET {{paperclipApiUrl}}/issues/{{taskId}}/heartbeat-context before broad exploration unless the wake payload already answers the question.
+3. Work inside {{workspaceDir}} when repo changes are needed.
+4. Start actionable work in the same heartbeat and do not stop at a plan unless the issue explicitly asks for planning.
+5. Post a task comment with durable progress before you exit.
+`;
+
+const DEFAULT_SYSTEM_INSTRUCTIONS = `You are a Hermes agent working inside Paperclip.
+
+Operational rules:
+
+- Start concrete work in the same heartbeat when the issue is actionable.
+- Do not stop at a plan unless planning was explicitly requested.
+- Leave durable progress in issue comments, documents, or work products before exit.
+- If blocked, update the issue with the unblock owner and action.
+- Use Authorization: Bearer $PAPERCLIP_API_KEY for every Paperclip API request.
+- Use X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID on every Paperclip API write.
+- Do not use a browser or board session to write to the Paperclip API when terminal + curl is available.
+`;
+
+export interface HermesPromptBundle {
+  instructions: string;
+  input: string;
+  commandNotes: string[];
+  promptMetrics: Record<string, number>;
+}
+
+export async function buildHermesObservablePrompt(
+  ctx: AdapterExecutionContext,
+  config: Record<string, unknown>,
+): Promise<HermesPromptBundle> {
+  const commandNotes: string[] = [];
+  const context = asRecord(ctx.context) ?? {};
+  const paperclipEnv: Record<string, string> = {
+    ...buildPaperclipEnv(ctx.agent),
+    PAPERCLIP_RUN_ID: ctx.runId,
+    ...(asString(context.taskId) || asString(context.issueId)
+      ? { PAPERCLIP_TASK_ID: asString(context.taskId) || asString(context.issueId) }
+      : {}),
+    ...(asString(context.wakeReason) ? { PAPERCLIP_WAKE_REASON: asString(context.wakeReason) } : {}),
+    ...(asString(context.wakeCommentId)
+      ? { PAPERCLIP_WAKE_COMMENT_ID: asString(context.wakeCommentId) }
+      : {}),
+    ...(ctx.authToken ? { PAPERCLIP_API_KEY: ctx.authToken } : {}),
+    ...(asString(config.cwd) ? { PAPERCLIP_WORKSPACE_CWD: asString(config.cwd) } : {}),
+  };
+
+  const paperclipApiUrl = paperclipEnv.PAPERCLIP_API_URL.replace(/\/+$/, "") + "/api";
+  const workspaceDir = asString(config.cwd) || process.cwd();
+  const wakePayload = renderWakePayload(context);
+  const exportBlock = buildExportBlock(paperclipEnv);
+
+  const vars: Record<string, unknown> = {
+    agentId: ctx.agent.id,
+    agentName: ctx.agent.name,
+    companyId: ctx.agent.companyId,
+    runId: ctx.runId,
+    taskId: asString(context.taskId) || asString(context.issueId),
+    wakeReason: asString(context.wakeReason),
+    wakeCommentId: asString(context.wakeCommentId),
+    paperclipApiUrl,
+    paperclipExportBlock: exportBlock,
+    wakePayload,
+    workspaceDir,
+  };
+
+  let instructions = DEFAULT_SYSTEM_INSTRUCTIONS;
+  const instructionsFilePath = asString(config.instructionsFilePath).trim();
+  if (instructionsFilePath) {
+    const resolvedInstructionsPath = path.resolve(workspaceDir, instructionsFilePath);
+    try {
+      const fileContents = await readFile(resolvedInstructionsPath, "utf8");
+      instructions = `${instructions}
+
+${fileContents}
+
+The above agent instructions were loaded from ${resolvedInstructionsPath}. Resolve any relative file references from ${path.dirname(resolvedInstructionsPath)}/.`;
+      commandNotes.push(`Loaded instructions from ${resolvedInstructionsPath}`);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      commandNotes.push(`Configured instructionsFilePath ${resolvedInstructionsPath}, but file could not be read.`);
+      instructions = `${instructions}
+
+Warning: configured instructionsFilePath ${resolvedInstructionsPath} could not be read (${reason}).`;
+    }
+  }
+
+  const inputTemplate = asString(config.promptTemplate).trim() || DEFAULT_INPUT_TEMPLATE;
+  const input = renderTemplate(inputTemplate, vars);
+
+  return {
+    instructions,
+    input,
+    commandNotes,
+    promptMetrics: {
+      instructionsChars: instructions.length,
+      inputChars: input.length,
+      wakePayloadChars: wakePayload.length,
+    },
+  };
+}

--- a/packages/adapters/hermes-observable/src/server/session.ts
+++ b/packages/adapters/hermes-observable/src/server/session.ts
@@ -1,0 +1,61 @@
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const conversation =
+      readNonEmptyString(record.conversation);
+    const sessionId =
+      readNonEmptyString(record.sessionId) ??
+      readNonEmptyString(record.session_id);
+    const gatewaySessionKey =
+      readNonEmptyString(record.gatewaySessionKey) ??
+      readNonEmptyString(record.gateway_session_key);
+    const lastResponseId =
+      readNonEmptyString(record.lastResponseId) ??
+      readNonEmptyString(record.responseId) ??
+      readNonEmptyString(record.response_id);
+
+    if (!conversation && !sessionId && !gatewaySessionKey && !lastResponseId) {
+      return null;
+    }
+
+    return {
+      ...(conversation ? { conversation } : {}),
+      ...(sessionId ? { sessionId } : {}),
+      ...(gatewaySessionKey ? { gatewaySessionKey } : {}),
+      ...(lastResponseId ? { lastResponseId } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const conversation = readNonEmptyString(params.conversation);
+    const sessionId = readNonEmptyString(params.sessionId);
+    const gatewaySessionKey = readNonEmptyString(params.gatewaySessionKey);
+    const lastResponseId = readNonEmptyString(params.lastResponseId);
+
+    if (!conversation && !sessionId && !gatewaySessionKey && !lastResponseId) {
+      return null;
+    }
+
+    return {
+      ...(conversation ? { conversation } : {}),
+      ...(sessionId ? { sessionId } : {}),
+      ...(gatewaySessionKey ? { gatewaySessionKey } : {}),
+      ...(lastResponseId ? { lastResponseId } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.conversation) ??
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.lastResponseId)
+    );
+  },
+};

--- a/packages/adapters/hermes-observable/src/server/test.ts
+++ b/packages/adapters/hermes-observable/src/server/test.ts
@@ -1,0 +1,169 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  ADAPTER_TYPE,
+  DEFAULT_ENDPOINT_MODE,
+  DEFAULT_HERMES_API_BASE_URL,
+} from "../shared/constants.js";
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  if (trimmed.endsWith("/v1") && path.startsWith("/v1/")) {
+    return `${trimmed}${path.slice(3)}`;
+  }
+  return `${trimmed}${path}`;
+}
+
+function normalizeBaseUrl(config: Record<string, unknown>): string {
+  const configured = asString(config.hermesApiBaseUrl).trim();
+  return configured || DEFAULT_HERMES_API_BASE_URL;
+}
+
+async function safeJson(response: Response): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed = await response.json();
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const config = (ctx.config ?? {}) as Record<string, unknown>;
+  const baseUrl = normalizeBaseUrl(config);
+  const endpointMode = asString(config.endpointMode).trim() || DEFAULT_ENDPOINT_MODE;
+  const checks: AdapterEnvironmentCheck[] = [];
+  const testedAt = new Date().toISOString();
+
+  try {
+    const health = await fetch(joinUrl(baseUrl, "/health"), {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    if (!health.ok) {
+      checks.push({
+        code: "hermes_api_health_failed",
+        level: "error",
+        message: `Hermes API health probe failed at ${joinUrl(baseUrl, "/health")}`,
+        detail: `${health.status} ${health.statusText}`,
+        hint: "Start Hermes gateway with the API server enabled and confirm /health returns 200.",
+      });
+      return {
+        adapterType: ADAPTER_TYPE,
+        status: "fail",
+        checks,
+        testedAt,
+      };
+    }
+    checks.push({
+      code: "hermes_api_health_ok",
+      level: "info",
+      message: `Hermes API reachable at ${baseUrl}`,
+      detail: "GET /health returned 200.",
+    });
+  } catch (error) {
+    checks.push({
+      code: "hermes_api_unreachable",
+      level: "error",
+      message: `Hermes API unreachable at ${baseUrl}`,
+      detail: error instanceof Error ? error.message : String(error),
+      hint: "Run `API_SERVER_ENABLED=1 API_SERVER_PORT=8000 hermes gateway` and confirm /health and /v1/capabilities respond.",
+    });
+    return {
+      adapterType: ADAPTER_TYPE,
+      status: "fail",
+      checks,
+      testedAt,
+    };
+  }
+
+  try {
+    const capabilitiesResponse = await fetch(joinUrl(baseUrl, "/v1/capabilities"), {
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    if (capabilitiesResponse.ok) {
+      const capabilities = await safeJson(capabilitiesResponse);
+      const features =
+        capabilities && typeof capabilities.features === "object" && capabilities.features !== null
+          ? (capabilities.features as Record<string, unknown>)
+          : {};
+
+      const responsesStreaming = features.responses_streaming === true;
+      const chatStreaming = features.chat_completions_streaming === true;
+      const toolProgress = features.tool_progress_events === true;
+
+      if (endpointMode === "responses" && !responsesStreaming) {
+        checks.push({
+          code: "hermes_capabilities_responses_missing",
+          level: "warn",
+          message: "Hermes capabilities do not advertise Responses streaming support.",
+          hint: "The adapter can fall back to chat completions streaming at runtime, or you can set endpointMode=chat_completions.",
+        });
+      } else {
+        checks.push({
+          code: "hermes_capabilities_responses_ok",
+          level: "info",
+          message: "Hermes capabilities advertise Responses streaming support.",
+        });
+      }
+
+      if (!chatStreaming) {
+        checks.push({
+          code: "hermes_capabilities_chat_missing",
+          level: "warn",
+          message: "Hermes capabilities do not advertise chat completions streaming support.",
+        });
+      }
+
+      if (!toolProgress) {
+        checks.push({
+          code: "hermes_capabilities_tool_progress_missing",
+          level: "warn",
+          message: "Hermes capabilities do not advertise hermes.tool.progress events.",
+          hint: "Responses streaming still works, but chat completions fallback will have reduced tool visibility.",
+        });
+      }
+    } else {
+      checks.push({
+        code: "hermes_capabilities_unavailable",
+        level: "warn",
+        message: `Hermes capabilities probe returned ${capabilitiesResponse.status}.`,
+        hint: "The adapter can still try the configured endpoint directly, but /v1/capabilities is the preferred compatibility check.",
+      });
+    }
+  } catch (error) {
+    checks.push({
+      code: "hermes_capabilities_fetch_failed",
+      level: "warn",
+      message: "Failed to read Hermes /v1/capabilities.",
+      detail: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const status =
+    checks.some((check) => check.level === "error")
+      ? "fail"
+      : checks.some((check) => check.level === "warn")
+        ? "warn"
+        : "pass";
+
+  return {
+    adapterType: ADAPTER_TYPE,
+    status,
+    checks,
+    testedAt,
+  };
+}

--- a/packages/adapters/hermes-observable/src/shared/constants.ts
+++ b/packages/adapters/hermes-observable/src/shared/constants.ts
@@ -1,0 +1,35 @@
+export const ADAPTER_TYPE = "hermes_observable";
+export const ADAPTER_LABEL = "Hermes Observable";
+
+export const DEFAULT_HERMES_API_BASE_URL = "http://127.0.0.1:8000";
+export const DEFAULT_ENDPOINT_MODE = "responses";
+export const DEFAULT_MODEL = "hermes-agent";
+export const DEFAULT_PROVIDER = "auto";
+export const DEFAULT_TIMEOUT_SEC = 300;
+export const DEFAULT_HEARTBEAT_SEC = 30;
+
+export const TOOL_OUTPUT_MAX_CHARS = 20_000;
+
+export const PROVIDER_OPTIONS = [
+  "auto",
+  "anthropic",
+  "kimi-coding",
+  "minimax",
+  "minimax-cn",
+  "nous",
+  "openai",
+  "openai-codex",
+  "openrouter",
+  "zai",
+] as const;
+
+export type HermesEndpointMode = "responses" | "chat_completions";
+
+export const HERMES_OBSERVABLE_EVENT_TYPES = {
+  error: "hermes_observable.error",
+  init: "hermes_observable.init",
+  result: "hermes_observable.result",
+  textDelta: "hermes_observable.text_delta",
+  toolCall: "hermes_observable.tool_call",
+  toolResult: "hermes_observable.tool_result",
+} as const;

--- a/packages/adapters/hermes-observable/src/ui/build-config.ts
+++ b/packages/adapters/hermes-observable/src/ui/build-config.ts
@@ -1,0 +1,19 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+export function buildHermesObservableConfig(values: CreateConfigValues): Record<string, unknown> {
+  const config: Record<string, unknown> = {};
+
+  if (values.model?.trim()) config.model = values.model.trim();
+  if (values.cwd) config.cwd = values.cwd;
+  if (values.instructionsFilePath) config.instructionsFilePath = values.instructionsFilePath;
+  if (values.promptTemplate) config.promptTemplate = values.promptTemplate;
+  if (values.command?.trim()) config.hermesCommand = values.command.trim();
+  if (values.extraArgs?.trim()) {
+    config.extraArgs = values.extraArgs.split(/\s+/).filter(Boolean);
+  }
+  if (values.adapterSchemaValues) {
+    Object.assign(config, values.adapterSchemaValues);
+  }
+
+  return config;
+}

--- a/packages/adapters/hermes-observable/src/ui/index.ts
+++ b/packages/adapters/hermes-observable/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseHermesObservableStdoutLine } from "./parse-stdout.js";
+export { buildHermesObservableConfig } from "./build-config.js";

--- a/packages/adapters/hermes-observable/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/hermes-observable/src/ui/parse-stdout.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { parseHermesObservableStdoutLine } from "./parse-stdout.js";
+
+describe("parseHermesObservableStdoutLine", () => {
+  it("parses text deltas into assistant transcript entries", () => {
+    const [entry] = parseHermesObservableStdoutLine(
+      JSON.stringify({
+        type: "hermes_observable.text_delta",
+        channel: "assistant",
+        text: "hello",
+      }),
+      "2026-05-08T00:00:00.000Z",
+    );
+
+    expect(entry).toMatchObject({
+      kind: "assistant",
+      text: "hello",
+      delta: true,
+    });
+  });
+
+  it("parses tool calls and results", () => {
+    const toolCall = parseHermesObservableStdoutLine(
+      JSON.stringify({
+        type: "hermes_observable.tool_call",
+        name: "terminal",
+        toolCallId: "call_1",
+        input: { cmd: "pwd" },
+      }),
+      "2026-05-08T00:00:00.000Z",
+    );
+    const toolResult = parseHermesObservableStdoutLine(
+      JSON.stringify({
+        type: "hermes_observable.tool_result",
+        name: "terminal",
+        toolCallId: "call_1",
+        content: "ok",
+        isError: false,
+      }),
+      "2026-05-08T00:00:01.000Z",
+    );
+
+    expect(toolCall[0]).toMatchObject({
+      kind: "tool_call",
+      name: "terminal",
+      toolUseId: "call_1",
+    });
+    expect(toolResult[0]).toMatchObject({
+      kind: "tool_result",
+      toolUseId: "call_1",
+      content: "ok",
+      isError: false,
+    });
+  });
+
+  it("treats watchdog lines as system entries", () => {
+    const [entry] = parseHermesObservableStdoutLine(
+      "[hermes] still running: 30s, lastEvent=response.output_text.delta, activeTool=terminal",
+      "2026-05-08T00:00:00.000Z",
+    );
+
+    expect(entry).toMatchObject({
+      kind: "system",
+      text: "[hermes] still running: 30s, lastEvent=response.output_text.delta, activeTool=terminal",
+    });
+  });
+});

--- a/packages/adapters/hermes-observable/src/ui/parse-stdout.ts
+++ b/packages/adapters/hermes-observable/src/ui/parse-stdout.ts
@@ -1,0 +1,116 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+import { HERMES_OBSERVABLE_EVENT_TYPES } from "../shared/constants.js";
+
+function parseJson(line: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(line);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function stringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function parseHermesObservableStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith("[hermes]") || trimmed.startsWith("[paperclip]")) {
+    return [{ kind: "system", ts, text: trimmed }];
+  }
+
+  const parsed = parseJson(trimmed);
+  if (!parsed) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const type = asString(parsed.type);
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.init) {
+    const mode = asString(parsed.endpointMode);
+    const model = asString(parsed.model, "hermes");
+    const sessionId =
+      asString(parsed.sessionId) ||
+      asString(parsed.conversation) ||
+      asString(parsed.responseId);
+    return [{
+      kind: "init",
+      ts,
+      model: mode ? `${model} (${mode})` : model,
+      sessionId,
+    }];
+  }
+
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.textDelta) {
+    const text = asString(parsed.text);
+    if (!text) return [];
+    const channel = asString(parsed.channel);
+    return [{
+      kind: channel === "thinking" ? "thinking" : "assistant",
+      ts,
+      text,
+      delta: true,
+    }];
+  }
+
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.toolCall) {
+    return [{
+      kind: "tool_call",
+      ts,
+      name: asString(parsed.name, "tool"),
+      toolUseId: asString(parsed.toolCallId) || undefined,
+      input: parsed.input ?? {},
+    }];
+  }
+
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.toolResult) {
+    return [{
+      kind: "tool_result",
+      ts,
+      toolUseId: asString(parsed.toolCallId, asString(parsed.name, "tool")),
+      toolName: asString(parsed.name) || undefined,
+      content: stringify(parsed.content ?? parsed.output ?? parsed.text),
+      isError: parsed.isError === true,
+    }];
+  }
+
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.result) {
+    return [{
+      kind: "result",
+      ts,
+      text: asString(parsed.text),
+      inputTokens: asNumber(parsed.inputTokens),
+      outputTokens: asNumber(parsed.outputTokens),
+      cachedTokens: asNumber(parsed.cachedTokens),
+      costUsd: asNumber(parsed.costUsd),
+      subtype: asString(parsed.subtype, "completed"),
+      isError: parsed.isError === true,
+      errors: Array.isArray(parsed.errors)
+        ? parsed.errors.map((entry) => stringify(entry)).filter(Boolean)
+        : [],
+    }];
+  }
+
+  if (type === HERMES_OBSERVABLE_EVENT_TYPES.error) {
+    return [{ kind: "stderr", ts, text: asString(parsed.message, line) }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/hermes-observable/tsconfig.json
+++ b/packages/adapters/hermes-observable/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/hermes-observable/vitest.config.ts
+++ b/packages/adapters/hermes-observable/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -34,6 +34,7 @@ export const AGENT_ADAPTER_TYPES = [
   "claude_local",
   "codex_local",
   "gemini_local",
+  "hermes_observable",
   "opencode_local",
   "pi_local",
   "cursor",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,25 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/hermes-observable:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      hermes-paperclip-adapter:
+        specifier: ^0.2.0
+        version: 0.2.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/adapters/openclaw-gateway:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -524,6 +543,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-hermes-observable':
+        specifier: workspace:*
+        version: link:../packages/adapters/hermes-observable
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -684,6 +706,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-hermes-observable':
+        specifier: workspace:*
+        version: link:../packages/adapters/hermes-observable
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/server/package.json
+++ b/server/package.json
@@ -49,6 +49,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-hermes-observable": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -193,6 +193,22 @@ describe("server adapter registry", () => {
     expect(adapter!.supportsLocalAgentJwt).toBe(true);
   });
 
+  it("built-in hermes_observable adapter declares capability flags", async () => {
+    const adapter = requireServerAdapter("hermes_observable");
+    expect(adapter.supportsInstructionsBundle).toBe(true);
+    expect(adapter.instructionsPathKey).toBe("instructionsFilePath");
+    expect(adapter.requiresMaterializedRuntimeSkills).toBe(false);
+    expect(adapter.supportsLocalAgentJwt).toBe(true);
+    expect(adapter.getConfigSchema).toBeTypeOf("function");
+    const schema = await adapter.getConfigSchema!();
+    expect(schema).toMatchObject({
+      fields: expect.arrayContaining([
+        expect.objectContaining({ key: "hermesApiBaseUrl" }),
+        expect.objectContaining({ key: "endpointMode" }),
+      ]),
+    });
+  });
+
   it("built-in local adapters declare cheap model profile defaults where supported", async () => {
     await expect(listAdapterModelProfiles("claude_local")).resolves.toEqual([
       expect.objectContaining({

--- a/server/src/__tests__/adapter-routes.test.ts
+++ b/server/src/__tests__/adapter-routes.test.ts
@@ -185,6 +185,15 @@ describe("adapter routes", () => {
       supportsLocalAgentJwt: true,
       requiresMaterializedRuntimeSkills: false,
     });
+
+    const hermesObservableAdapter = res.body.find((a: any) => a.type === "hermes_observable");
+    expect(hermesObservableAdapter).toBeDefined();
+    expect(hermesObservableAdapter.capabilities).toMatchObject({
+      supportsInstructionsBundle: true,
+      supportsSkills: true,
+      supportsLocalAgentJwt: true,
+      requiresMaterializedRuntimeSkills: false,
+    });
   });
 
   it("GET /api/adapters derives supportsSkills from listSkills/syncSkills presence", async () => {

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -7,6 +7,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "codex_local",
   "cursor",
   "gemini_local",
+  "hermes_observable",
   "openclaw_gateway",
   "opencode_local",
   "pi_local",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -69,6 +69,19 @@ import {
   modelProfiles as geminiModelProfiles,
 } from "@paperclipai/adapter-gemini-local";
 import {
+  execute as hermesObservableExecute,
+  testEnvironment as hermesObservableTestEnvironment,
+  sessionCodec as hermesObservableSessionCodec,
+  getConfigSchema as getHermesObservableConfigSchema,
+  listSkills as hermesObservableListSkills,
+  syncSkills as hermesObservableSyncSkills,
+  detectModel as detectModelFromHermesObservable,
+} from "@paperclipai/adapter-hermes-observable/server";
+import {
+  agentConfigurationDoc as hermesObservableAgentConfigurationDoc,
+  models as hermesObservableModels,
+} from "@paperclipai/adapter-hermes-observable";
+import {
   execute as openCodeExecute,
   listOpenCodeSkills,
   syncOpenCodeSkills,
@@ -439,6 +452,24 @@ const hermesLocalAdapter: ServerAdapterModule = {
   detectModel: () => detectModelFromHermes(),
 };
 
+const hermesObservableAdapter: ServerAdapterModule = {
+  type: "hermes_observable",
+  execute: hermesObservableExecute,
+  testEnvironment: hermesObservableTestEnvironment,
+  getConfigSchema: getHermesObservableConfigSchema,
+  sessionCodec: hermesObservableSessionCodec,
+  sessionManagement: getAdapterSessionManagement("hermes_observable") ?? undefined,
+  listSkills: hermesObservableListSkills,
+  syncSkills: hermesObservableSyncSkills,
+  models: hermesObservableModels,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: hermesObservableAgentConfigurationDoc,
+  detectModel: () => detectModelFromHermesObservable(),
+};
+
 const adaptersByType = new Map<string, ServerAdapterModule>();
 
 // For builtin types that are overridden by an external adapter, we keep the
@@ -460,6 +491,7 @@ function registerBuiltInAdapters() {
     cursorLocalAdapter,
     geminiLocalAdapter,
     openclawGatewayAdapter,
+    hermesObservableAdapter,
     hermesLocalAdapter,
     processAdapter,
     httpAdapter,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -127,6 +127,7 @@ export function agentRoutes(
     codex_local: "instructionsFilePath",
     droid_local: "instructionsFilePath",
     gemini_local: "instructionsFilePath",
+    hermes_observable: "instructionsFilePath",
     hermes_local: "instructionsFilePath",
     opencode_local: "instructionsFilePath",
     cursor: "instructionsFilePath",

--- a/ui/package.json
+++ b/ui/package.json
@@ -39,6 +39,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-hermes-observable": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -78,6 +78,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     description: "Local Gemini agent",
     icon: Gem,
   },
+  hermes_observable: {
+    label: "Hermes Observable",
+    description: "Hermes gateway adapter with structured streaming events",
+    icon: HermesIcon,
+  },
   opencode_local: {
     label: "OpenCode",
     description: "Local multi-provider agent",

--- a/ui/src/adapters/hermes-observable/index.ts
+++ b/ui/src/adapters/hermes-observable/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseHermesObservableStdoutLine } from "@paperclipai/adapter-hermes-observable/ui";
+import { buildHermesObservableConfig } from "@paperclipai/adapter-hermes-observable/ui";
+import { SchemaConfigFields } from "../schema-config-fields";
+
+export const hermesObservableUIAdapter: UIAdapterModule = {
+  type: "hermes_observable",
+  label: "Hermes Observable",
+  parseStdoutLine: parseHermesObservableStdoutLine,
+  ConfigFields: SchemaConfigFields,
+  buildAdapterConfig: buildHermesObservableConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -4,6 +4,7 @@ import { claudeLocalUIAdapter } from "./claude-local";
 import { codexLocalUIAdapter } from "./codex-local";
 import { cursorLocalUIAdapter } from "./cursor";
 import { geminiLocalUIAdapter } from "./gemini-local";
+import { hermesObservableUIAdapter } from "./hermes-observable";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
@@ -54,6 +55,7 @@ function registerBuiltInUIAdapters() {
     claudeLocalUIAdapter,
     codexLocalUIAdapter,
     geminiLocalUIAdapter,
+    hermesObservableUIAdapter,
     hermesLocalUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,

--- a/ui/src/adapters/use-adapter-capabilities.ts
+++ b/ui/src/adapters/use-adapter-capabilities.ts
@@ -21,6 +21,7 @@ const KNOWN_DEFAULTS: Record<string, AdapterCapabilities> = {
   codex_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: true },
   cursor: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },
   gemini_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },
+  hermes_observable: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: false },
   opencode_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: true },
   pi_local: { supportsInstructionsBundle: true, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: true, supportsModelProfiles: false },
   hermes_local: { supportsInstructionsBundle: false, supportsSkills: true, supportsLocalAgentJwt: true, requiresMaterializedRuntimeSkills: false, supportsModelProfiles: false },

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -362,8 +362,9 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   const [refreshModelsError, setRefreshModelsError] = useState<string | null>(null);
   const [refreshingModels, setRefreshingModels] = useState(false);
   const rawModels = fetchedModels ?? externalModels ?? [];
-  const adapterCommandField =
-    adapterType === "hermes_local" ? "hermesCommand" : "command";
+  const usesHermesCommandField =
+    adapterType === "hermes_local" || adapterType === "hermes_observable";
+  const adapterCommandField = usesHermesCommandField ? "hermesCommand" : "command";
   const acpxAgent =
     adapterType === "acpx_local"
       ? isCreate
@@ -448,7 +449,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     }
     const base = config as Record<string, unknown>;
     const next = { ...base, ...overlay.adapterConfig };
-    if (adapterType === "hermes_local") {
+    if (usesHermesCommandField) {
       const hermesCommand =
         typeof next.hermesCommand === "string" && next.hermesCommand.length > 0
           ? next.hermesCommand
@@ -954,7 +955,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                           "adapterConfig",
                           adapterCommandField,
                           String(
-                            (adapterType === "hermes_local"
+                            (usesHermesCommandField
                               ? config.hermesCommand ?? config.command
                               : config.command) ?? "",
                           ),
@@ -972,6 +973,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       claude_local: "claude",
                       codex_local: "codex",
                       gemini_local: "gemini",
+                      hermes_observable: "hermes",
                       pi_local: "pi",
                       cursor: "agent",
                       opencode_local: "opencode",

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -224,6 +224,7 @@ export function OnboardingWizard() {
     claude_local: "claude",
     codex_local: "codex",
     gemini_local: "gemini",
+    hermes_observable: "hermes",
     pi_local: "pi",
     cursor: "agent",
     opencode_local: "opencode",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       "packages/adapters/codex-local",
       "packages/adapters/cursor-local",
       "packages/adapters/gemini-local",
+      "packages/adapters/hermes-observable",
       "packages/adapters/opencode-local",
       "packages/adapters/pi-local",
       "server",


### PR DESCRIPTION
## Summary
- add the new built-in `hermes_observable` adapter package for Hermes gateway SSE streaming
- wire the adapter into Paperclip server/UI registries, capabilities, and session handling
- add adapter-local tests plus server registry/adapter route coverage

## Verification
- pnpm run preflight:workspace-links
- pnpm exec vitest run packages/adapters/hermes-observable/src/server/execute.test.ts packages/adapters/hermes-observable/src/ui/parse-stdout.test.ts
- pnpm exec vitest run server/src/__tests__/adapter-registry.test.ts server/src/__tests__/adapter-routes.test.ts
- pnpm --filter @paperclipai/adapter-hermes-observable typecheck
- pnpm --filter @paperclipai/server typecheck
- pnpm --filter @paperclipai/ui typecheck