### PR TITLE
feat(k8s-execution): M1 — multi-tenant Kubernetes execution target (headless tenant provisioning)

### DIFF
--- a/.github/workflows/k8s-integration.yml
+++ b/.github/workflows/k8s-integration.yml
@@ -70,7 +70,10 @@ jobs:
         run: pnpm --filter @paperclipai/execution-target-kubernetes test:integration
 
       - name: Run server k8s end-to-end smoke
-        run: pnpm -w exec vitest run --config server/vitest.integration.config.ts k8s-cli-end-to-end
+        # Vitest's include patterns in vitest.integration.config.ts are relative
+        # to the cwd, not the config file path. Run from server/ so they resolve.
+        working-directory: server
+        run: pnpm exec vitest run --config vitest.integration.config.ts k8s-cli-end-to-end
 
       - name: Collect kind cluster logs on failure
         if: failure()

--- a/.github/workflows/k8s-integration.yml
+++ b/.github/workflows/k8s-integration.yml
@@ -55,8 +55,13 @@ jobs:
           kind --version
 
       - name: Install kubectl
+        # Pinned to match the kind v0.24.0 default node image (Kubernetes
+        # v1.31.x). Bump deliberately when updating kind so the client/server
+        # skew stays within the supported one-minor-version window.
+        env:
+          KUBECTL_VERSION: v1.31.0
         run: |
-          curl -sLo /tmp/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          curl -sLo /tmp/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
           chmod +x /tmp/kubectl
           sudo mv /tmp/kubectl /usr/local/bin/kubectl
           kubectl version --client

--- a/.github/workflows/k8s-integration.yml
+++ b/.github/workflows/k8s-integration.yml
@@ -1,0 +1,91 @@
+name: K8s Integration Tests
+
+on:
+  pull_request:
+    paths:
+      - "packages/adapters/kubernetes-execution/**"
+      - "server/src/services/cluster-connections*"
+      - "server/src/services/cluster-namespace-bindings*"
+      - "server/src/services/cluster-tenant-policies*"
+      - "server/src/adapters/execution-target*"
+      - "server/src/adapters/execution-targets/**"
+      - "server/src/__tests__/k8s-*"
+      - "server/vitest.integration.config.ts"
+      - ".github/workflows/k8s-integration.yml"
+  push:
+    branches: [master, main]
+    paths:
+      - "packages/adapters/kubernetes-execution/**"
+      - "server/src/services/cluster-connections*"
+      - "server/src/services/cluster-namespace-bindings*"
+      - "server/src/services/cluster-tenant-policies*"
+      - "server/src/adapters/execution-target*"
+      - "server/src/adapters/execution-targets/**"
+      - "server/src/__tests__/k8s-*"
+      - "server/vitest.integration.config.ts"
+
+jobs:
+  k8s-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install kind
+        run: |
+          curl -sLo /tmp/kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+          chmod +x /tmp/kind
+          sudo mv /tmp/kind /usr/local/bin/kind
+          kind --version
+
+      - name: Install kubectl
+        run: |
+          curl -sLo /tmp/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x /tmp/kubectl
+          sudo mv /tmp/kubectl /usr/local/bin/kubectl
+          kubectl version --client
+
+      - name: Build workspace dependencies
+        run: |
+          pnpm --filter @paperclipai/adapter-utils build
+          pnpm --filter @paperclipai/execution-target-kubernetes build
+
+      - name: Run k8s-execution integration tests
+        run: pnpm --filter @paperclipai/execution-target-kubernetes test:integration
+
+      - name: Run server k8s end-to-end smoke
+        run: pnpm -w exec vitest run --config server/vitest.integration.config.ts k8s-cli-end-to-end
+
+      - name: Collect kind cluster logs on failure
+        if: failure()
+        run: |
+          mkdir -p kind-logs
+          for c in $(kind get clusters 2>/dev/null || true); do
+            echo "=== Logs for cluster: $c ==="
+            kind export logs "./kind-logs/$c" --name "$c" || true
+          done
+
+      - name: Upload kind logs as artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kind-logs-${{ github.run_id }}
+          path: kind-logs/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY packages/adapters/claude-local/package.json packages/adapters/claude-local/
 COPY packages/adapters/codex-local/package.json packages/adapters/codex-local/
 COPY packages/adapters/cursor-local/package.json packages/adapters/cursor-local/
 COPY packages/adapters/gemini-local/package.json packages/adapters/gemini-local/
+COPY packages/adapters/kubernetes-execution/package.json packages/adapters/kubernetes-execution/
 COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-gateway/
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,9 +48,16 @@ Paperclip should support explicit review and approval stages as first-class work
 
 Paperclip needs a clearer path from solo operator to real human teams. That means shared board access, safer collaboration, and a better model for several humans supervising the same autonomous company.
 
-### ⚪ Cloud / Sandbox agents (e.g. Cursor / e2b agents)
+### 🔄 Cloud / Sandbox agents (e.g. Cursor / e2b agents)
 
 We want agents to run in more remote and sandboxed environments while preserving the same Paperclip control-plane model. This makes the system safer, more flexible, and more useful outside a single trusted local machine.
+
+- ✅ **Multi-tenant Kubernetes execution target — Milestone 1 (headless tenant provisioning)** — landed 2026-05-09
+  - Spec: [docs/superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md](docs/superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md)
+  - Plan: [docs/superpowers/plans/2026-05-08-paperclip-cloud-adapter-m1-plan.md](docs/superpowers/plans/2026-05-08-paperclip-cloud-adapter-m1-plan.md)
+  - Operator quickstart: [docs/k8s-execution/quickstart.md](docs/k8s-execution/quickstart.md)
+  - M2 (agent execution end-to-end on k8s): planned next
+  - M3 (UI + hardening, full V1): planned after M2
 
 ### ⚪ Artifacts & Work Products
 

--- a/cli/src/commands/cluster-cmd.ts
+++ b/cli/src/commands/cluster-cmd.ts
@@ -1,0 +1,143 @@
+/**
+ * CLI wiring for `paperclipai cluster <subcommand>`.
+ *
+ * Bridges Commander with the pure createClusterCommand() factory,
+ * constructing real service deps from DB + Kubernetes lazily on demand.
+ *
+ * Service-access pattern: direct DB (no HTTP routes exist yet for cluster ops).
+ */
+
+import type { Command } from "commander";
+import { createDb, companies, eq } from "@paperclipai/db";
+import { clusterConnectionsService } from "@paperclipai/server/services/cluster-connections";
+import { clusterTenantPoliciesService } from "@paperclipai/server/services/cluster-tenant-policies";
+import { clusterNamespaceBindingsService } from "@paperclipai/server/services/cluster-namespace-bindings";
+import { createKubernetesExecutionDriver } from "@paperclipai/execution-target-kubernetes";
+import { getSecretProvider } from "@paperclipai/server/secrets/provider-registry";
+import { readConfig } from "../config/store.js";
+import { createClusterCommand, deriveCompanySlug } from "./cluster.js";
+
+function resolveDbUrl(configPath?: string): string {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const config = readConfig(configPath);
+  if (config?.database.mode === "postgres" && config.database.connectionString) {
+    return config.database.connectionString;
+  }
+  const port = config?.database.embeddedPostgresPort ?? 54329;
+  return `postgres://paperclip:paperclip@127.0.0.1:${port}/paperclip`;
+}
+
+function buildDeps(opts: { config?: string }) {
+  const db = createDb(resolveDbUrl(opts.config));
+
+  const connsSvc = clusterConnectionsService(db, {
+    resolveSecret: async (ref) => {
+      const provider = getSecretProvider(ref.provider as Parameters<typeof getSecretProvider>[0]);
+      return provider.resolveVersion({ material: {}, externalRef: ref.name });
+    },
+  });
+
+  const driver = createKubernetesExecutionDriver({
+    resolveConnection: (id) => connsSvc.resolve(id),
+  });
+
+  return {
+    clusterConnections: connsSvc,
+    tenantPolicies: clusterTenantPoliciesService(db),
+    driver,
+    companies: {
+      async getById(id: string) {
+        const [row] = await db.select().from(companies).where(eq(companies.id, id));
+        if (!row) return null;
+        return {
+          id: row.id,
+          name: row.name,
+          slug: deriveCompanySlug(row.name),
+        };
+      },
+    },
+    namespaceBindings: clusterNamespaceBindingsService(db),
+    print: (line: string) => console.log(line),
+  };
+}
+
+export function registerClusterCommands(program: Command): void {
+  const clusterCmd = program
+    .command("cluster")
+    .description("Manage Kubernetes cluster connections and tenant provisioning")
+    .option("-c, --config <path>", "Path to config file")
+    .option("-d, --data-dir <path>", "Paperclip data directory root");
+
+  clusterCmd
+    .command("add")
+    .description("Register a new cluster connection")
+    .requiredOption("--label <name>", "Human-readable label")
+    .requiredOption("--kind <kind>", "Connection kind: in-cluster | kubeconfig")
+    .option("--kubeconfig-secret <ref>", "Secret reference in <provider>:<name> format")
+    .option("--paperclip-public-url <url>", "Public URL of this Paperclip instance")
+    .option("--image-registry <url>", "Container image registry URL")
+    .action(async (opts, cmd) => {
+      const globalOpts = cmd.parent?.parent?.opts() as { config?: string };
+      const deps = buildDeps(globalOpts);
+      const args = [
+        "add",
+        "--label", opts.label,
+        "--kind", opts.kind,
+        ...(opts.kubeconfigSecret ? ["--kubeconfig-secret", opts.kubeconfigSecret] : []),
+        ...(opts.paperclipPublicUrl ? ["--paperclip-public-url", opts.paperclipPublicUrl] : []),
+        ...(opts.imageRegistry ? ["--image-registry", opts.imageRegistry] : []),
+      ];
+      const code = await createClusterCommand(deps).run(args);
+      if (code !== 0) process.exit(code);
+    });
+
+  clusterCmd
+    .command("list")
+    .description("List all cluster connections")
+    .action(async (_opts, cmd) => {
+      const globalOpts = cmd.parent?.parent?.opts() as { config?: string };
+      const deps = buildDeps(globalOpts);
+      const code = await createClusterCommand(deps).run(["list"]);
+      if (code !== 0) process.exit(code);
+    });
+
+  clusterCmd
+    .command("test <id>")
+    .description("Connect to a cluster and probe its capabilities")
+    .action(async (id, _opts, cmd) => {
+      const globalOpts = cmd.parent?.parent?.opts() as { config?: string };
+      const deps = buildDeps(globalOpts);
+      const code = await createClusterCommand(deps).run(["test", id]);
+      if (code !== 0) process.exit(code);
+    });
+
+  clusterCmd
+    .command("remove <id>")
+    .description("Remove a cluster connection")
+    .action(async (id, _opts, cmd) => {
+      const globalOpts = cmd.parent?.parent?.opts() as { config?: string };
+      const deps = buildDeps(globalOpts);
+      const code = await createClusterCommand(deps).run(["remove", id]);
+      if (code !== 0) process.exit(code);
+    });
+
+  clusterCmd
+    .command("ensure-tenant <clusterId> <companyId>")
+    .description("Provision a tenant namespace for a company on the given cluster")
+    .action(async (clusterId, companyId, _opts, cmd) => {
+      const globalOpts = cmd.parent?.parent?.opts() as { config?: string };
+      const deps = buildDeps(globalOpts);
+      const code = await createClusterCommand(deps).run(["ensure-tenant", clusterId, companyId]);
+      if (code !== 0) process.exit(code);
+    });
+
+  clusterCmd
+    .command("doctor <id>")
+    .description("Run M1 health checks on a cluster connection")
+    .action(async (id, _opts, cmd) => {
+      const globalOpts = cmd.parent?.parent?.opts() as { config?: string };
+      const deps = buildDeps(globalOpts);
+      const code = await createClusterCommand(deps).run(["doctor", id]);
+      if (code !== 0) process.exit(code);
+    });
+}

--- a/cli/src/commands/cluster.test.ts
+++ b/cli/src/commands/cluster.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createClusterCommand, type ClusterCommandDeps } from "./cluster.js";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+const MOCK_ROW = {
+  id: "c-1",
+  label: "kind",
+  kind: "kubeconfig" as const,
+  kubeconfigSecretRef: null,
+  apiServerUrl: null,
+  defaultNamespacePrefix: "paperclip-",
+  capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] as const },
+  paperclipPublicUrl: null,
+  imageRegistry: null,
+  allowAgentImageOverride: false,
+  createdAt: new Date(),
+  createdBy: "x",
+};
+
+const MOCK_RESOLVED = {
+  ...MOCK_ROW,
+  kubeconfigYaml: "<yaml>",
+};
+
+function mocks(): ClusterCommandDeps {
+  return {
+    clusterConnections: {
+      create: vi.fn(async (i: { label: string }) => ({
+        ...MOCK_ROW,
+        id: "c-1",
+        label: i.label,
+      })) as any,
+      list: vi.fn(async () => [MOCK_ROW]) as any,
+      get: vi.fn(async () => MOCK_ROW) as any,
+      delete: vi.fn(async () => {}) as any,
+      resolve: vi.fn(async () => MOCK_RESOLVED) as any,
+    },
+    tenantPolicies: {
+      get: vi.fn(async () => null) as any,
+      upsert: vi.fn(async () => ({} as any)) as any,
+    },
+    driver: {
+      type: "kubernetes" as const,
+      validateTarget: vi.fn(async () => {}) as any,
+      ensureTenant: vi.fn(async () => ({
+        namespace: "paperclip-acme",
+        ciliumApplied: false,
+      })) as any,
+      run: vi.fn() as any,
+    },
+    companies: {
+      getById: vi.fn(async () => ({ id: "co-1", name: "Acme Corp", slug: "acme" })),
+    },
+    namespaceBindings: {
+      record: vi.fn(async () => {}),
+    },
+    print: (s: string) => out.push(s),
+  };
+}
+
+let out: string[];
+
+beforeEach(() => {
+  out = [];
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cluster commands", () => {
+  it("add: creates a connection and prints its id and label", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run([
+      "add",
+      "--label", "kind",
+      "--kind", "kubeconfig",
+      "--kubeconfig-secret", "local_encrypted:my-cfg",
+    ]);
+    expect(code).toBe(0);
+    expect(out.join("\n")).toContain("c-1");
+    expect(m.clusterConnections.create).toHaveBeenCalled();
+    // kubeconfig-secret parsed correctly
+    const arg = (m.clusterConnections.create as any).mock.calls[0][0];
+    expect(arg.kubeconfigSecretRef).toEqual({ provider: "local_encrypted", name: "my-cfg" });
+  });
+
+  it("add: returns non-zero when --label is missing", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["add", "--kind", "kubeconfig"]);
+    expect(code).not.toBe(0);
+    expect(m.clusterConnections.create).not.toHaveBeenCalled();
+  });
+
+  it("add: returns non-zero when --kind is invalid", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["add", "--label", "x", "--kind", "nomad"]);
+    expect(code).not.toBe(0);
+  });
+
+  it("list: prints connections with capabilities", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["list"]);
+    expect(code).toBe(0);
+    const printed = out.join("\n");
+    expect(printed).toContain("kind");
+    expect(printed).toContain("standard");
+    expect(printed).toContain("amd64");
+  });
+
+  it("list: prints a message when there are no connections", async () => {
+    const m = mocks();
+    (m.clusterConnections.list as any).mockResolvedValue([]);
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["list"]);
+    expect(code).toBe(0);
+    expect(out.join("\n")).toMatch(/no cluster/i);
+  });
+
+  it("test: prints resolved connection details", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["test", "c-1"]);
+    expect(code).toBe(0);
+    const printed = out.join("\n");
+    expect(printed).toMatch(/ok/i);
+    expect(printed).toContain("standard");
+    expect(printed).toContain("amd64");
+  });
+
+  it("test: returns non-zero when connection is not found", async () => {
+    const m = mocks();
+    (m.clusterConnections.resolve as any).mockResolvedValue(null);
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["test", "c-missing"]);
+    expect(code).not.toBe(0);
+    expect(out.join("\n")).toMatch(/not found/i);
+  });
+
+  it("ensure-tenant: calls driver.ensureTenant, records the binding, and prints the namespace", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["ensure-tenant", "c-1", "co-1"]);
+    expect(code).toBe(0);
+    expect(out.join("\n")).toContain("paperclip-acme");
+    expect(m.driver.ensureTenant).toHaveBeenCalled();
+    expect(m.namespaceBindings.record).toHaveBeenCalledWith({
+      clusterConnectionId: "c-1",
+      companyId: "co-1",
+      namespaceName: "paperclip-acme",
+    });
+  });
+
+  it("ensure-tenant: passes slug from company object to driver", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    await cmd.run(["ensure-tenant", "c-1", "co-1"]);
+    const arg = (m.driver.ensureTenant as any).mock.calls[0][0];
+    expect(arg.company.slug).toBe("acme");
+  });
+
+  it("ensure-tenant: returns non-zero exit code when company is not found", async () => {
+    const m = mocks();
+    (m.companies.getById as any).mockResolvedValue(null);
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["ensure-tenant", "c-1", "co-missing"]);
+    expect(code).not.toBe(0);
+    expect(out.join("\n")).toMatch(/not found/i);
+    expect(m.driver.ensureTenant).not.toHaveBeenCalled();
+    expect(m.namespaceBindings.record).not.toHaveBeenCalled();
+  });
+
+  it("ensure-tenant: returns non-zero when args are missing", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["ensure-tenant", "c-1"]);
+    expect(code).not.toBe(0);
+  });
+
+  it("remove: calls clusterConnections.delete", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["remove", "c-1"]);
+    expect(code).toBe(0);
+    expect(m.clusterConnections.delete).toHaveBeenCalledWith("c-1");
+  });
+
+  it("remove: returns non-zero when id is missing", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["remove"]);
+    expect(code).not.toBe(0);
+  });
+
+  it("doctor: validates connection, probes capabilities, prints results", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["doctor", "c-1"]);
+    expect(code).toBe(0);
+    const printed = out.join("\n");
+    expect(printed).toMatch(/storageClass|cilium|amd64/i);
+    expect(printed).toContain("ClusterRole");
+  });
+
+  it("doctor: returns non-zero when connection is not found", async () => {
+    const m = mocks();
+    (m.clusterConnections.resolve as any).mockResolvedValue(null);
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["doctor", "c-missing"]);
+    expect(code).not.toBe(0);
+    expect(out.join("\n")).toMatch(/not found/i);
+  });
+
+  it("doctor: returns non-zero when id is missing", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["doctor"]);
+    expect(code).not.toBe(0);
+  });
+
+  it("unknown subcommand: non-zero exit and usage hint", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run(["nonsense"]);
+    expect(code).not.toBe(0);
+    expect(out.join("\n")).toMatch(/usage|cluster/i);
+  });
+
+  it("no subcommand: non-zero exit and usage hint", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run([]);
+    expect(code).not.toBe(0);
+    expect(out.join("\n")).toMatch(/usage|cluster/i);
+  });
+});

--- a/cli/src/commands/cluster.test.ts
+++ b/cli/src/commands/cluster.test.ts
@@ -104,6 +104,59 @@ describe("cluster commands", () => {
     expect(code).not.toBe(0);
   });
 
+  it("add: passes --cilium / --storage-class / --arch through to capabilities", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run([
+      "add",
+      "--label", "prod-eks",
+      "--kind", "kubeconfig",
+      "--kubeconfig-secret", "aws_secrets:prod",
+      "--cilium",
+      "--storage-class", "gp3",
+      "--arch", "amd64,arm64",
+    ]);
+    expect(code).toBe(0);
+    const arg = (m.clusterConnections.create as any).mock.calls[0][0];
+    expect(arg.capabilities).toEqual({
+      cilium: true,
+      storageClass: "gp3",
+      architectures: ["amd64", "arm64"],
+    });
+  });
+
+  it("add: defaults capabilities to single-arch x86 without Cilium when no flags are passed", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run([
+      "add",
+      "--label", "kind",
+      "--kind", "kubeconfig",
+      "--kubeconfig-secret", "local_encrypted:my-cfg",
+    ]);
+    expect(code).toBe(0);
+    const arg = (m.clusterConnections.create as any).mock.calls[0][0];
+    expect(arg.capabilities).toEqual({
+      cilium: false,
+      storageClass: "standard",
+      architectures: ["amd64"],
+    });
+  });
+
+  it("add: rejects --arch with an unsupported value", async () => {
+    const m = mocks();
+    const cmd = createClusterCommand(m);
+    const code = await cmd.run([
+      "add",
+      "--label", "x",
+      "--kind", "kubeconfig",
+      "--kubeconfig-secret", "local_encrypted:y",
+      "--arch", "ppc64le",
+    ]);
+    expect(code).not.toBe(0);
+    expect(m.clusterConnections.create).not.toHaveBeenCalled();
+  });
+
   it("list: prints connections with capabilities", async () => {
     const m = mocks();
     const cmd = createClusterCommand(m);

--- a/cli/src/commands/cluster.ts
+++ b/cli/src/commands/cluster.ts
@@ -1,0 +1,371 @@
+/**
+ * paperclipai cluster <subcommand>
+ *
+ * Subcommands:
+ *   add           --label <name> --kind <in-cluster|kubeconfig>
+ *                 [--kubeconfig-secret <provider:name>]
+ *                 [--paperclip-public-url <url>]
+ *                 [--image-registry <url>]
+ *   list
+ *   test          <id>
+ *   remove        <id>
+ *   ensure-tenant <clusterId> <companyId>
+ *   doctor        <id>
+ *
+ * Service-access pattern: direct DB (no HTTP server routes exist yet for cluster operations).
+ *
+ * The ClusterCommandDeps interface is injected so all logic is fully unit-testable
+ * without real DB or Kubernetes connectivity.
+ */
+
+// ---------------------------------------------------------------------------
+// Dependency interfaces (mirroring the real service shapes without importing
+// from server sub-paths that don't exist in the package exports map)
+// ---------------------------------------------------------------------------
+
+export type ClusterKind = "in-cluster" | "kubeconfig";
+export type ClusterArch = "amd64" | "arm64";
+
+export interface ClusterCapabilities {
+  cilium: boolean;
+  storageClass: string;
+  architectures: ClusterArch[];
+}
+
+export interface ClusterConnectionRow {
+  id: string;
+  label: string;
+  kind: ClusterKind;
+  kubeconfigSecretRef: { provider: string; name: string } | null;
+  apiServerUrl: string | null;
+  defaultNamespacePrefix: string;
+  capabilities: ClusterCapabilities;
+  paperclipPublicUrl: string | null;
+  imageRegistry: string | null;
+  allowAgentImageOverride: boolean;
+  createdAt: Date;
+  createdBy: string;
+}
+
+export interface ResolvedClusterConnection extends ClusterConnectionRow {
+  kubeconfigYaml?: string;
+}
+
+export interface CreateClusterConnectionInput {
+  label: string;
+  kind: ClusterKind;
+  kubeconfigSecretRef?: { provider: string; name: string };
+  apiServerUrl?: string;
+  defaultNamespacePrefix?: string;
+  capabilities: ClusterCapabilities;
+  paperclipPublicUrl?: string;
+  imageRegistry?: string;
+  allowAgentImageOverride?: boolean;
+  createdBy: string;
+}
+
+export interface ClusterConnectionsService {
+  create(input: CreateClusterConnectionInput): Promise<ClusterConnectionRow>;
+  list(): Promise<ClusterConnectionRow[]>;
+  get(id: string): Promise<ClusterConnectionRow | null>;
+  delete(id: string): Promise<void>;
+  resolve(id: string): Promise<ResolvedClusterConnection | null>;
+}
+
+export interface TenantPolicy {
+  quota: Record<string, string | number | undefined> | null;
+  limitRange: Record<string, unknown> | null;
+  additionalAllowFqdns: string[];
+  imageOverrides: Record<string, string> | null;
+}
+
+export interface TenantPolicyRow extends TenantPolicy {
+  clusterConnectionId: string;
+  companyId: string;
+}
+
+export interface ClusterTenantPoliciesService {
+  get(clusterConnectionId: string, companyId: string): Promise<TenantPolicyRow | null>;
+}
+
+export interface EnsureTenantResult {
+  namespace: string;
+  ciliumApplied: boolean;
+}
+
+export interface KubernetesDriver {
+  type: "kubernetes";
+  validateTarget(target: unknown): Promise<void>;
+  ensureTenant(input: {
+    clusterConnectionId: string;
+    company: { id: string; slug: string };
+    tenantPolicy: TenantPolicy | null;
+    driverServiceAccount: { name: string; namespace: string };
+    controlPlane: {
+      topology: "in-cluster" | "cross-cluster";
+      namespaceLabels: Record<string, string>;
+      podLabels: Record<string, string>;
+    };
+    adapterAllowFqdns: string[];
+    imagePullDockerConfigJson: string | null;
+  }): Promise<EnsureTenantResult>;
+  run(...args: unknown[]): unknown;
+}
+
+export interface CompaniesLookup {
+  getById(id: string): Promise<{ id: string; name: string; slug: string } | null>;
+}
+
+export interface NamespaceBindingsService {
+  record(input: {
+    clusterConnectionId: string;
+    companyId: string;
+    namespaceName: string;
+  }): Promise<void>;
+}
+
+export interface ClusterCommandDeps {
+  clusterConnections: ClusterConnectionsService;
+  tenantPolicies: ClusterTenantPoliciesService;
+  driver: KubernetesDriver;
+  companies: CompaniesLookup;
+  namespaceBindings: NamespaceBindingsService;
+  print: (line: string) => void;
+}
+
+export interface ClusterCommand {
+  run(argv: string[]): Promise<number>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createClusterCommand(deps: ClusterCommandDeps): ClusterCommand {
+  return {
+    async run(argv) {
+      const [sub, ...rest] = argv;
+      switch (sub) {
+        case "add":           return cmdAdd(rest, deps);
+        case "list":          return cmdList(rest, deps);
+        case "test":          return cmdTest(rest, deps);
+        case "remove":        return cmdRemove(rest, deps);
+        case "ensure-tenant": return cmdEnsureTenant(rest, deps);
+        case "doctor":        return cmdDoctor(rest, deps);
+        default:
+          deps.print(
+            `Unknown subcommand: ${sub ?? "(none)"}\n` +
+            `Usage: cluster <add|list|test|remove|ensure-tenant|doctor>`,
+          );
+          return 2;
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Minimal flag parser (keeps this module free of commander/yargs deps)
+// ---------------------------------------------------------------------------
+
+function parseFlags(argv: string[]): { positional: string[]; flags: Record<string, string> } {
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      const val = argv[i + 1];
+      if (val !== undefined && !val.startsWith("--")) {
+        flags[key] = val;
+        i++;
+      } else {
+        flags[key] = "true";
+      }
+    } else {
+      positional.push(a);
+    }
+  }
+  return { positional, flags };
+}
+
+// ---------------------------------------------------------------------------
+// Derive a DNS-safe slug from company name (companies table has no slug col)
+// ---------------------------------------------------------------------------
+
+export function deriveCompanySlug(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "company"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand implementations
+// ---------------------------------------------------------------------------
+
+async function cmdAdd(argv: string[], deps: ClusterCommandDeps): Promise<number> {
+  const { flags } = parseFlags(argv);
+  const label = flags["label"];
+  const kind = flags["kind"] as ClusterKind;
+  if (!label || !kind || (kind !== "in-cluster" && kind !== "kubeconfig")) {
+    deps.print(
+      "Usage: cluster add --label <name> --kind <in-cluster|kubeconfig> " +
+        "[--kubeconfig-secret <provider:name>] [--paperclip-public-url <url>] [--image-registry <url>]",
+    );
+    return 2;
+  }
+
+  let kubeconfigSecretRef: { provider: string; name: string } | undefined;
+  if (flags["kubeconfig-secret"]) {
+    const colonIdx = flags["kubeconfig-secret"].indexOf(":");
+    if (colonIdx <= 0) {
+      deps.print("Invalid --kubeconfig-secret. Use <provider>:<name> (e.g. local_encrypted:my-cfg)");
+      return 2;
+    }
+    const provider = flags["kubeconfig-secret"].slice(0, colonIdx);
+    const name = flags["kubeconfig-secret"].slice(colonIdx + 1);
+    if (!name) {
+      deps.print("Invalid --kubeconfig-secret. Use <provider>:<name> (e.g. local_encrypted:my-cfg)");
+      return 2;
+    }
+    kubeconfigSecretRef = { provider, name };
+  }
+
+  const created = await deps.clusterConnections.create({
+    label,
+    kind,
+    kubeconfigSecretRef,
+    paperclipPublicUrl: flags["paperclip-public-url"],
+    imageRegistry: flags["image-registry"],
+    capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+    createdBy: process.env.PAPERCLIP_CLI_USER ?? "cli",
+  });
+  deps.print(`Created cluster connection ${created.id} (${created.label})`);
+  return 0;
+}
+
+async function cmdList(_argv: string[], deps: ClusterCommandDeps): Promise<number> {
+  const rows = await deps.clusterConnections.list();
+  if (rows.length === 0) {
+    deps.print("No cluster connections.");
+    return 0;
+  }
+  for (const r of rows) {
+    deps.print(
+      `${r.id}\t${r.label}\t${r.kind}\t` +
+        `cilium=${r.capabilities.cilium}\t` +
+        `storageClass=${r.capabilities.storageClass}\t` +
+        `archs=${r.capabilities.architectures.join(",")}`,
+    );
+  }
+  return 0;
+}
+
+async function cmdTest(argv: string[], deps: ClusterCommandDeps): Promise<number> {
+  const [id] = argv;
+  if (!id) {
+    deps.print("Usage: cluster test <id>");
+    return 2;
+  }
+  const resolved = await deps.clusterConnections.resolve(id);
+  if (!resolved) {
+    deps.print(`Cluster connection ${id} not found`);
+    return 1;
+  }
+  deps.print(`OK: connection ${id} resolves (label=${resolved.label})`);
+  deps.print(`  kind:         ${resolved.kind}`);
+  deps.print(`  cilium:       ${resolved.capabilities.cilium}`);
+  deps.print(`  storageClass: ${resolved.capabilities.storageClass}`);
+  deps.print(`  archs:        ${resolved.capabilities.architectures.join(", ")}`);
+  return 0;
+}
+
+async function cmdRemove(argv: string[], deps: ClusterCommandDeps): Promise<number> {
+  const [id] = argv;
+  if (!id) {
+    deps.print("Usage: cluster remove <id>");
+    return 2;
+  }
+  await deps.clusterConnections.delete(id);
+  deps.print(`Deleted cluster connection ${id}`);
+  return 0;
+}
+
+async function cmdEnsureTenant(argv: string[], deps: ClusterCommandDeps): Promise<number> {
+  const [clusterId, companyId] = argv;
+  if (!clusterId || !companyId) {
+    deps.print("Usage: cluster ensure-tenant <clusterId> <companyId>");
+    return 2;
+  }
+
+  const company = await deps.companies.getById(companyId);
+  if (!company) {
+    deps.print(`Company ${companyId} not found`);
+    return 1;
+  }
+
+  const slug = company.slug ?? deriveCompanySlug(company.name);
+
+  const tp = await deps.tenantPolicies.get(clusterId, companyId);
+
+  const result = await deps.driver.ensureTenant({
+    clusterConnectionId: clusterId,
+    company: { id: company.id, slug },
+    tenantPolicy: tp
+      ? {
+          quota: tp.quota,
+          limitRange: tp.limitRange,
+          additionalAllowFqdns: tp.additionalAllowFqdns,
+          imageOverrides: tp.imageOverrides,
+        }
+      : null,
+    driverServiceAccount: {
+      name: process.env.PAPERCLIP_DRIVER_SA ?? "paperclip-driver",
+      namespace: process.env.PAPERCLIP_DRIVER_NAMESPACE ?? "paperclip-system",
+    },
+    controlPlane: {
+      topology: "cross-cluster",
+      namespaceLabels: {},
+      podLabels: {},
+    },
+    adapterAllowFqdns: [],
+    imagePullDockerConfigJson: null,
+  });
+
+  await deps.namespaceBindings.record({
+    clusterConnectionId: clusterId,
+    companyId,
+    namespaceName: result.namespace,
+  });
+
+  deps.print(`Provisioned namespace ${result.namespace} (cilium=${result.ciliumApplied})`);
+  return 0;
+}
+
+async function cmdDoctor(argv: string[], deps: ClusterCommandDeps): Promise<number> {
+  const [id] = argv;
+  if (!id) {
+    deps.print("Usage: cluster doctor <id>");
+    return 2;
+  }
+
+  const resolved = await deps.clusterConnections.resolve(id);
+  if (!resolved) {
+    deps.print(`Cluster connection ${id} not found`);
+    return 1;
+  }
+
+  deps.print(`Doctor report for cluster connection ${id} (${resolved.label}):`);
+  deps.print(`  kind:         ${resolved.kind}`);
+  deps.print(`  cilium:       ${resolved.capabilities.cilium}`);
+  deps.print(`  storageClass: ${resolved.capabilities.storageClass}`);
+  deps.print(`  archs:        ${resolved.capabilities.architectures.join(", ")}`);
+  deps.print("");
+  deps.print(
+    `Apply the reference ClusterRole before first ensure-tenant:\n` +
+      `  kubectl apply -f packages/adapters/kubernetes-execution/manifests/paperclip-tenant-manager-clusterrole.yaml`,
+  );
+  return 0;
+}

--- a/cli/src/commands/cluster.ts
+++ b/cli/src/commands/cluster.ts
@@ -212,7 +212,8 @@ async function cmdAdd(argv: string[], deps: ClusterCommandDeps): Promise<number>
   if (!label || !kind || (kind !== "in-cluster" && kind !== "kubeconfig")) {
     deps.print(
       "Usage: cluster add --label <name> --kind <in-cluster|kubeconfig> " +
-        "[--kubeconfig-secret <provider:name>] [--paperclip-public-url <url>] [--image-registry <url>]",
+        "[--kubeconfig-secret <provider:name>] [--paperclip-public-url <url>] [--image-registry <url>] " +
+        "[--cilium] [--storage-class <name>] [--arch <amd64|arm64>] (--arch may repeat)",
     );
     return 2;
   }
@@ -233,17 +234,52 @@ async function cmdAdd(argv: string[], deps: ClusterCommandDeps): Promise<number>
     kubeconfigSecretRef = { provider, name };
   }
 
+  const capabilities = parseCapabilityFlags(flags);
+  if (capabilities === null) {
+    deps.print("Invalid --arch. Allowed values: amd64, arm64.");
+    return 2;
+  }
+  // Defaults match the most common single-arch x86 cluster without Cilium installed.
+  // Operators must pass --cilium for clusters running Cilium so the agent
+  // egress NetworkPolicy + per-tenant CiliumNetworkPolicy actually engage.
+  // `paperclip cluster doctor` reports the detected installation so operators
+  // can verify before adding.
+
   const created = await deps.clusterConnections.create({
     label,
     kind,
     kubeconfigSecretRef,
     paperclipPublicUrl: flags["paperclip-public-url"],
     imageRegistry: flags["image-registry"],
-    capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+    capabilities,
     createdBy: process.env.PAPERCLIP_CLI_USER ?? "cli",
   });
   deps.print(`Created cluster connection ${created.id} (${created.label})`);
+  deps.print(
+    `  capabilities: cilium=${capabilities.cilium} storageClass=${capabilities.storageClass} archs=${capabilities.architectures.join(",")}`,
+  );
   return 0;
+}
+
+/**
+ * Build a ClusterCapabilities object from CLI flags. Returns null when --arch
+ * carries an unsupported value.
+ */
+function parseCapabilityFlags(flags: Record<string, string>): ClusterCapabilities | null {
+  const cilium = flags["cilium"] === "true";
+  const storageClass = flags["storage-class"] ?? "standard";
+  const archRaw = flags["arch"];
+  // parseFlags only retains the last value of a repeated flag, so for
+  // multi-arch clusters the operator passes --arch as a comma list.
+  const architectures: ClusterCapabilities["architectures"] =
+    archRaw === undefined
+      ? ["amd64"]
+      : (archRaw.split(",").map((s) => s.trim()).filter(Boolean) as ClusterCapabilities["architectures"]);
+  for (const a of architectures) {
+    if (a !== "amd64" && a !== "arm64") return null;
+  }
+  if (architectures.length === 0) return null;
+  return { cilium, storageClass, architectures };
 }
 
 async function cmdList(_argv: string[], deps: ClusterCommandDeps): Promise<number> {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -25,6 +25,7 @@ import { initTelemetryFromConfigFile, flushTelemetry } from "./telemetry.js";
 import { registerWorktreeCommands } from "./commands/worktree.js";
 import { registerPluginCommands } from "./commands/client/plugin.js";
 import { registerClientAuthCommands } from "./commands/client/auth.js";
+import { registerClusterCommands } from "./commands/cluster-cmd.js";
 import { cliVersion } from "./version.js";
 
 const program = new Command();
@@ -152,6 +153,7 @@ registerSecretCommands(program);
 registerWorktreeCommands(program);
 registerEnvLabCommands(program);
 registerPluginCommands(program);
+registerClusterCommands(program);
 
 const auth = program.command("auth").description("Authentication and bootstrap utilities");
 

--- a/docs/k8s-execution/cluster-rbac.md
+++ b/docs/k8s-execution/cluster-rbac.md
@@ -1,0 +1,190 @@
+---
+title: Kubernetes Execution — Cluster RBAC
+summary: Reference ClusterRole for the Paperclip driver, per-rule rationale, and ServiceAccount binding templates for in-cluster and cross-cluster topologies
+---
+
+The Paperclip driver needs a `ClusterRole` to provision and manage tenant namespaces across the cluster. This document explains every permission in that role, and provides binding templates for both supported topologies.
+
+## Reference ClusterRole
+
+The canonical source is `packages/adapters/kubernetes-execution/manifests/paperclip-tenant-manager-clusterrole.yaml`. Its contents are reproduced here for reference:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: paperclip-tenant-manager
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "resourcequotas", "limitranges", "secrets", "serviceaccounts", "configmaps", "persistentvolumeclaims", "pods", "pods/log", "pods/exec"]
+    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["cilium.io"]
+    resources: ["ciliumnetworkpolicies"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+```
+
+Apply it to a cluster with:
+
+```bash
+kubectl apply -f packages/adapters/kubernetes-execution/manifests/paperclip-tenant-manager-clusterrole.yaml
+```
+
+## Rule-by-rule rationale
+
+### Core API group (`apiGroups: [""]`)
+
+| Resource | Why the driver needs it |
+|----------|------------------------|
+| `namespaces` | Create and patch tenant namespaces (`paperclip-{companySlug}`). The driver reads the existing namespace to check for `paperclip.ai/managed-by=paperclip` before mutating — it will not touch namespaces it did not create. `watch` is used in M2 to track namespace deletion events. |
+| `resourcequotas` | Apply `paperclip-tenant-quota` to each namespace. Must `patch` on re-provision (quota overrides from `cluster_tenant_policies`). |
+| `limitranges` | Apply `paperclip-tenant-limits`. Must `patch` on billing tier changes. |
+| `secrets` | (a) Create `paperclip-image-pull` (registry credentials per namespace). (b) In M2: create per-Job ephemeral Secrets that hold resolved `secret_ref` values; these carry an `OwnerReference` to the Job so Kubernetes GCs them automatically. |
+| `serviceaccounts` | Create the `paperclip-agent` ServiceAccount in each namespace (`automountServiceAccountToken: false`). |
+| `configmaps` | Reserved for M2: workspace-init config and adapter configuration injection via `ConfigMap` volumes. |
+| `persistentvolumeclaims` | M2: create per-agent `PVC` (`agent-{agentSlug}-workspace`) for warm workspace storage. `watch` is needed to wait for the PVC to be bound before submitting the Job. |
+| `pods` | M2: read pod status to determine Job phase; gate on pod `Ready` condition. |
+| `pods/log` | M2: stream container logs from agent pods back to the Paperclip run log via `ctx.onLog`. |
+| `pods/exec` | M2: reserved for workspace-init debug flows and operator diagnostics. Not used in M1. |
+
+### Batch API group (`apiGroups: ["batch"]`)
+
+| Resource | Why the driver needs it |
+|----------|------------------------|
+| `jobs` | M2: submit one `Job` per agent run. The driver needs `watch` to track the Job to completion and map terminal conditions to `AdapterExecutionResult` exit codes. `delete` is used for cancellation. |
+
+This rule is present in the ClusterRole now so that M2 can begin scheduling runs without an RBAC update. In M1, the driver's `run()` method returns `NOT_YET_SUPPORTED` before any Job is submitted.
+
+### Networking API group (`apiGroups: ["networking.k8s.io"]`)
+
+| Resource | Why the driver needs it |
+|----------|------------------------|
+| `networkpolicies` | Apply three `NetworkPolicy` objects per namespace: `default-deny-ingress`, `default-deny-egress`, `paperclip-agent-egress`. Must `patch` on re-provision to update the FQDN allowlist or control-plane selector. `watch` is not required (policies are reconciled at `ensure-tenant` time). |
+
+### RBAC API group (`apiGroups: ["rbac.authorization.k8s.io"]`)
+
+| Resource | Why the driver needs it |
+|----------|------------------------|
+| `roles` | Reserved for M2: in-namespace `Role` objects for fine-grained per-job access control. |
+| `rolebindings` | The driver creates a `RoleBinding` named `paperclip-driver` in each tenant namespace, binding the `paperclip-tenant-manager` ClusterRole to the driver ServiceAccount scoped to that namespace. This is required for the driver to have write access to namespaced resources after initial namespace creation. |
+
+**Important:** The ability to create `RoleBindings` is a powerful permission. The driver is constrained to bind only the roles it already holds (the k8s API enforces that you cannot grant more than you have). The `paperclip-driver` identity should be protected: the ServiceAccount token must not be exposed outside the control plane.
+
+### Cilium API group (`apiGroups: ["cilium.io"]`)
+
+| Resource | Why the driver needs it |
+|----------|------------------------|
+| `ciliumnetworkpolicies` | When the cluster has the Cilium CNI, apply a `CiliumNetworkPolicy` alongside the vanilla NetworkPolicy. The CNP provides L7/FQDN egress filtering (see [security-model.md](./security-model.md#cilium-variant-fqdn-allowlist-auto-detected)). If Cilium is not present, this rule is harmless — the `cilium.io` API group simply does not exist. |
+
+## Binding templates
+
+### In-cluster topology
+
+Paperclip server and agent workloads share the same cluster. The server pod's ServiceAccount in `paperclip-system` holds the driver identity.
+
+```yaml
+# Step 1: namespace for the Paperclip control plane
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: paperclip-system
+---
+# Step 2: ServiceAccount for the driver
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: paperclip-driver
+  namespace: paperclip-system
+---
+# Step 3: bind the ClusterRole cluster-wide
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: paperclip-driver
+subjects:
+  - kind: ServiceAccount
+    name: paperclip-driver
+    namespace: paperclip-system
+roleRef:
+  kind: ClusterRole
+  name: paperclip-tenant-manager
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Apply:
+
+```bash
+kubectl apply -f paperclip-system-sa.yaml
+```
+
+The Paperclip server pod must run with `serviceAccountName: paperclip-driver`. The `@kubernetes/client-node` library will automatically use the in-cluster ServiceAccount token from `/var/run/secrets/kubernetes.io/serviceaccount/`.
+
+When adding the cluster connection, use `--kind in-cluster` (no `--kubeconfig-secret`):
+
+```bash
+paperclipai cluster add \
+  --label production \
+  --kind in-cluster
+```
+
+### Cross-cluster topology
+
+The Paperclip server runs outside the workload cluster. Access is via a stored kubeconfig whose embedded user must have the same permissions as the `paperclip-tenant-manager` ClusterRole.
+
+The kubeconfig user identity is cluster-specific. Apply the ClusterRole and a `ClusterRoleBinding` on the **workload cluster** that binds the kubeconfig user:
+
+```yaml
+# Apply to the workload cluster (not the control-plane cluster)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: paperclip-driver-external
+subjects:
+  - kind: User
+    name: paperclip-driver   # must match the user in the kubeconfig
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: paperclip-tenant-manager
+  apiGroup: rbac.authorization.k8s.io
+```
+
+```bash
+# Apply to the workload cluster
+kubectl apply -f paperclip-driver-external-crb.yaml \
+  --kubeconfig /path/to/workload-cluster-admin.kubeconfig
+```
+
+The kubeconfig stored in the Paperclip secret provider must have a `users[].user` entry that matches the `subjects[].name` above. With a certificate-based kubeconfig, the CN in the client certificate is the username.
+
+When adding the cluster connection:
+
+```bash
+paperclipai cluster add \
+  --label workload-cluster-1 \
+  --kind kubeconfig \
+  --kubeconfig-secret vault:secret/data/paperclip/wc1-kubeconfig
+```
+
+**Note:** The RBAC rules must be applied to every cluster the kubeconfig user is expected to manage. If a single kubeconfig contains multiple contexts, apply the ClusterRole and ClusterRoleBinding to each cluster independently.
+
+## Least-privilege notes
+
+The ClusterRole is broader than M1 strictly requires because it is designed to serve M1 through M2 without an RBAC update. In M1 the driver only provisions namespaces; in M2 it will also schedule Jobs and stream pod logs.
+
+If your security policy requires strict M1-only RBAC, you can create a narrower ClusterRole that omits `jobs`, `pods`, `pods/log`, `pods/exec`, `persistentvolumeclaims`, and `configmaps`. When M2 ships you will need to re-apply a wider role. This trade-off is yours to make as an operator.
+
+## Related
+
+- [Quickstart](./quickstart.md) — first-time cluster setup walkthrough
+- [Security model](./security-model.md) — how each provisioned object enforces isolation
+- [Multi-tenant onboarding](./multi-tenant-onboarding.md) — provisioning multiple tenants
+- [Design spec §2.2](../superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md#22-pod-identity-zero-trust-by-default)

--- a/docs/k8s-execution/multi-tenant-onboarding.md
+++ b/docs/k8s-execution/multi-tenant-onboarding.md
@@ -1,0 +1,257 @@
+---
+title: Kubernetes Execution — Multi-Tenant Onboarding
+summary: Operator playbook for provisioning multiple company namespaces, customising per-tenant quotas, and resolving common edge cases
+---
+
+This playbook covers the full lifecycle of onboarding a company onto a Kubernetes cluster: verifying cluster prerequisites, optionally customising the per-tenant policy, running `ensure-tenant`, and verifying the result. The security model behind each provisioned object is described in [security-model.md](./security-model.md).
+
+**M1 scope:** This playbook covers tenant namespace provisioning only. There is no web UI for these operations yet (M3). Agent execution lands in M2.
+
+## Step 1 — Verify cluster prerequisites
+
+Before provisioning any tenant, confirm the cluster is ready.
+
+```bash
+paperclipai cluster doctor <clusterId>
+```
+
+Check the output for:
+
+| Check | Expected result |
+|-------|----------------|
+| API server reachable | `ok` |
+| `paperclip-tenant-manager` ClusterRole exists | `ok` |
+| Default StorageClass present | `ok` — note the StorageClass name for reference |
+| Cilium detected | `ok` or `not detected` (informational only in M1) |
+
+If `doctor` reports a missing ClusterRole, apply it:
+
+```bash
+kubectl apply -f packages/adapters/kubernetes-execution/manifests/paperclip-tenant-manager-clusterrole.yaml
+```
+
+For a from-scratch cluster setup including the ServiceAccount and ClusterRoleBinding, see [quickstart.md](./quickstart.md#first-time-cluster-setup).
+
+## Step 2 — Optionally customise the per-tenant policy
+
+By default, every tenant gets the [quota and limit-range defaults](./security-model.md#resourcequota-and-limitrange). If a company needs different resource caps (for example, a larger plan), upsert a row in `cluster_tenant_policies` before running `ensure-tenant`.
+
+There is no CLI for this in M1. Use a direct database query or a DB migration script.
+
+### cluster_tenant_policies row shape
+
+```sql
+INSERT INTO cluster_tenant_policies (
+  id,
+  cluster_connection_id,
+  company_id,
+  quota_json,
+  limit_range_json,
+  network_json,
+  image_overrides_json,
+  created_at,
+  updated_at
+) VALUES (
+  gen_random_uuid(),
+  '<clusterId>',
+  '<companyId>',
+  -- quota_json: override any of the default quota fields; null = use defaults
+  '{
+    "requestsCpu":    "32",
+    "requestsMemory": "128Gi",
+    "limitsCpu":      "128",
+    "limitsMemory":   "512Gi",
+    "requestsStorage":"500Gi",
+    "countJobs":       200,
+    "countPvcs":       100,
+    "countSecrets":    400,
+    "countConfigMaps": 400
+  }'::jsonb,
+  -- limit_range_json: override container default/request/max; null = use defaults
+  '{
+    "default":        { "cpu": "2",    "memory": "4Gi"  },
+    "defaultRequest": { "cpu": "500m", "memory": "1Gi"  },
+    "max":            { "cpu": "16",   "memory": "64Gi" },
+    "pvcMaxStorage":  "50Gi"
+  }'::jsonb,
+  -- network_json: additional FQDN allowlist entries (Cilium only) and optional HTTP proxy
+  '{
+    "additionalAllowFqdns": ["npm.registry.example.com", "*.internal.example.com"],
+    "httpProxyUrl": null
+  }'::jsonb,
+  -- image_overrides_json: swap runtime images per adapter type; null = use cluster defaults
+  null,
+  now(),
+  now()
+)
+ON CONFLICT (cluster_connection_id, company_id) DO UPDATE
+  SET quota_json           = EXCLUDED.quota_json,
+      limit_range_json     = EXCLUDED.limit_range_json,
+      network_json         = EXCLUDED.network_json,
+      image_overrides_json = EXCLUDED.image_overrides_json,
+      updated_at           = now();
+```
+
+All four JSON columns are nullable. A null value means "use the global default for that field". Individual keys within each JSON object are also optional — omitting a key leaves that specific default unchanged.
+
+A CLI for managing tenant policies is planned for a future milestone. Until then, the SQL above is the canonical operator interface.
+
+## Step 3 — Provision the tenant namespace
+
+```bash
+paperclipai cluster ensure-tenant <clusterId> <companyId>
+```
+
+Expected output:
+
+```
+Provisioned namespace paperclip-<companySlug> (cilium=false)
+```
+
+Or if Cilium is detected:
+
+```
+Provisioned namespace paperclip-<companySlug> (cilium=true)
+```
+
+`ensure-tenant` is idempotent. Running it again on an already-provisioned namespace is safe and will patch any drifted objects back to their desired state. The command reads the `cluster_tenant_policies` row (if it exists) before applying quota and LimitRange objects.
+
+Objects created (in order):
+
+1. `Namespace` with PSS labels and `paperclip.ai/*` metadata labels
+2. `ServiceAccount paperclip-agent` (`automountServiceAccountToken: false`)
+3. `RoleBinding paperclip-driver` (binds `ClusterRole/paperclip-tenant-manager` to the driver SA, scoped to this namespace)
+4. `ResourceQuota paperclip-tenant-quota`
+5. `LimitRange paperclip-tenant-limits`
+6. `NetworkPolicy default-deny-ingress` and `default-deny-egress`
+7. `NetworkPolicy paperclip-agent-egress`
+8. `CiliumNetworkPolicy paperclip-agent-egress-l7` (only when `capabilities.cilium = true`)
+9. `Secret paperclip-image-pull` (only when image registry credentials are configured)
+
+## Step 4 — Verify the provisioned namespace
+
+```bash
+kubectl describe namespace paperclip-<companySlug>
+```
+
+Look for:
+
+```
+Labels:
+  paperclip.ai/company-id=<uuid>
+  paperclip.ai/company-slug=<slug>
+  paperclip.ai/managed-by=paperclip
+  pod-security.kubernetes.io/enforce=restricted
+  pod-security.kubernetes.io/audit=restricted
+  pod-security.kubernetes.io/warn=restricted
+```
+
+Verify all managed objects are present:
+
+```bash
+kubectl get sa,resourcequota,limitrange,networkpolicy \
+  -n paperclip-<companySlug> \
+  -l paperclip.ai/managed-by=paperclip
+```
+
+If Cilium is present, also check:
+
+```bash
+kubectl get ciliumnetworkpolicy -n paperclip-<companySlug>
+```
+
+## Provisioning multiple companies
+
+Loop over company IDs from your database or source of truth:
+
+```bash
+CLUSTER_ID="<clusterId>"
+
+for COMPANY_ID in \
+  "uuid-company-a" \
+  "uuid-company-b" \
+  "uuid-company-c"; do
+  echo "Provisioning $COMPANY_ID..."
+  paperclipai cluster ensure-tenant "$CLUSTER_ID" "$COMPANY_ID"
+done
+```
+
+`ensure-tenant` is safe to run in parallel; each company operates on a separate namespace.
+
+## Common edge cases
+
+### Quota exhaustion
+
+When an agent run (M2) cannot schedule because the tenant has hit a quota limit, the Kubernetes API returns a `403 Forbidden` with `reason: Forbidden` and a message referencing the quota object. In M1, this surfaces at `ensure-tenant` time only if the quota parameters themselves are invalid (e.g. a LimitRange `max` that is smaller than `default`).
+
+To inspect current quota usage for a namespace:
+
+```bash
+kubectl describe resourcequota paperclip-tenant-quota -n paperclip-<companySlug>
+```
+
+To increase quotas, upsert the `cluster_tenant_policies` row with larger values and re-run `ensure-tenant`.
+
+### DNS resolution issues
+
+If a pod cannot resolve external hostnames, verify the NetworkPolicy allows DNS egress to `kube-system/kube-dns`:
+
+```bash
+kubectl get networkpolicy paperclip-agent-egress \
+  -n paperclip-<companySlug> \
+  -o yaml
+```
+
+Look for the DNS egress rule on port 53. If it is missing (e.g. the namespace was provisioned against an older driver), re-run `ensure-tenant` to patch it in.
+
+Check that CoreDNS is running:
+
+```bash
+kubectl get pods -n kube-system -l k8s-app=kube-dns
+```
+
+### Image pull failures
+
+Three distinct failure modes:
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `ImagePullBackOff`, event: `no credentials` | No `imagePullSecret` in the namespace | Ensure the cluster connection has an `imageRegistry` configured and re-run `ensure-tenant` |
+| `ImagePullBackOff`, event: `401 Unauthorized` | Wrong credentials | Rotate the secret in the secret provider and re-run `ensure-tenant` |
+| `ImagePullBackOff`, event: `i/o timeout` | Registry unreachable | Check the NetworkPolicy allows egress to the registry FQDN on port 443; on Cilium, add the FQDN to `network_json.additionalAllowFqdns` in `cluster_tenant_policies` |
+
+### Privileged pod admission rejection
+
+To confirm that PSS Restricted is active and blocking privileged pods:
+
+```bash
+kubectl run test-privileged \
+  --image=nginx \
+  --overrides='{"spec":{"containers":[{"name":"test-privileged","image":"nginx","securityContext":{"privileged":true}}]}}' \
+  -n paperclip-<companySlug>
+```
+
+Expected output:
+
+```
+Error from server (Forbidden): pods "test-privileged" is forbidden:
+violates PodSecurity "restricted:latest": ...
+```
+
+This rejection proves the PodSecurityAdmission webhook is active on the namespace. If the pod is admitted instead, confirm the PSS labels are present on the namespace with `kubectl describe namespace`.
+
+### Namespace name collision
+
+If two companies have the same `companySlug`, the driver uses the fallback name `paperclip-{slug}-{base36hash}`. The `paperclip.ai/company-id` label is always the canonical identifier. To see which namespace belongs to a given company:
+
+```bash
+kubectl get ns -l paperclip.ai/company-id=<companyId>
+```
+
+## Related
+
+- [Quickstart](./quickstart.md) — initial cluster setup and first `ensure-tenant`
+- [Security model](./security-model.md) — what each provisioned object does and why
+- [Cluster RBAC](./cluster-rbac.md) — driver ClusterRole reference
+- [Design spec §2.1](../superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md#21-tenant-boundary-namespace-per-company)
+- [M1 plan](../superpowers/plans/2026-05-08-paperclip-cloud-adapter-m1-plan.md)

--- a/docs/k8s-execution/quickstart.md
+++ b/docs/k8s-execution/quickstart.md
@@ -1,0 +1,207 @@
+---
+title: Kubernetes Execution — Quickstart
+summary: First-time setup guide for operators connecting a Kubernetes cluster to Paperclip and provisioning a tenant namespace
+---
+
+This guide walks an operator through connecting a Kubernetes cluster to a Paperclip M1 deployment and provisioning the first tenant namespace. By the end you will have a verified cluster connection and a namespace that passes `kubectl describe namespace` — ready for agent execution when M2 ships.
+
+**M1 scope:** This release delivers tenant namespace provisioning only. Agent execution (running adapter pods) is an M2 feature. See [What's not in M1](#whats-not-in-m1) for the full boundary.
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| `kubectl` | 1.28+ | Must be on `$PATH` |
+| `kind` | 0.22+ | Only if using a local kind cluster |
+| Docker | 24+ | Required to run kind |
+| Paperclip server | M1 build | `PAPERCLIP_K8S_DRIVER=true` env var must be set |
+| `paperclipai` CLI | M1 build | `pnpm paperclipai --version` should print a version |
+
+A PostgreSQL database with the M1 migrations applied (`packages/db/src/migrations/0082_cluster_connections.sql`) is required before any cluster commands work.
+
+## First-time cluster setup
+
+### 1. Start a kind cluster (if you don't have one)
+
+```bash
+kind create cluster --name paperclip-dev
+kubectl cluster-info --context kind-paperclip-dev
+```
+
+For a production cluster, ensure it has:
+- A default `StorageClass` (used for agent PVCs in M2)
+- `NetworkPolicy` enforcement (Calico, Cilium, or compatible CNI)
+
+### 2. Apply the reference ClusterRole
+
+The Paperclip driver needs a `ClusterRole` that allows it to manage tenant namespaces and the objects inside them.
+
+```bash
+kubectl apply -f packages/adapters/kubernetes-execution/manifests/paperclip-tenant-manager-clusterrole.yaml
+```
+
+Verify it was created:
+
+```bash
+kubectl get clusterrole paperclip-tenant-manager
+```
+
+### 3. Create the driver ServiceAccount and bind the ClusterRole
+
+For an **in-cluster** topology (Paperclip server running inside the same cluster), create the ServiceAccount in the `paperclip-system` namespace:
+
+```yaml
+# paperclip-system-sa.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: paperclip-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: paperclip-driver
+  namespace: paperclip-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: paperclip-driver
+subjects:
+  - kind: ServiceAccount
+    name: paperclip-driver
+    namespace: paperclip-system
+roleRef:
+  kind: ClusterRole
+  name: paperclip-tenant-manager
+  apiGroup: rbac.authorization.k8s.io
+```
+
+```bash
+kubectl apply -f paperclip-system-sa.yaml
+```
+
+For a **cross-cluster** topology (Paperclip server is elsewhere), the kubeconfig user must already be bound to the same `ClusterRole` on the workload cluster. See [cluster-rbac.md](./cluster-rbac.md) for details on both topologies.
+
+### 4. Store the kubeconfig as a Paperclip secret
+
+Paperclip resolves cluster credentials through its secret provider abstraction. The `kubeconfig_secret_ref` field on a `cluster_connections` row holds a `{ provider, name }` pair. Supported providers in M1:
+
+| Provider string | Where the secret lives |
+|-----------------|----------------------|
+| `env` | Environment variable (e.g. `env:KUBECONFIG_KIND`) |
+| `aws_secrets` | AWS Secrets Manager secret ARN or name |
+| `gcp_secret` | GCP Secret Manager resource path |
+| `vault` | HashiCorp Vault path (`vault:secret/data/paperclip/kind-cfg`) |
+
+For a local kind cluster, the simplest path is the `env` provider. Export the kubeconfig and set an environment variable on the Paperclip server:
+
+```bash
+kind get kubeconfig --name paperclip-dev > /tmp/kind-cfg.yaml
+export KUBECONFIG_KIND=$(cat /tmp/kind-cfg.yaml)
+```
+
+Then reference it as `env:KUBECONFIG_KIND` in the `--kubeconfig-secret` flag below.
+
+> **Note:** `local_encrypted` (a Paperclip-managed encrypted store) is planned for M2. Until then, use one of the providers listed above.
+
+## Add a cluster connection
+
+```bash
+paperclipai cluster add \
+  --label kind \
+  --kind kubeconfig \
+  --kubeconfig-secret env:KUBECONFIG_KIND
+```
+
+The command probes the cluster for capabilities (Cilium presence, default StorageClass, node architectures) and writes a row to `cluster_connections`. The printed `id` is the `<clusterId>` used in subsequent commands.
+
+Additional flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--paperclip-public-url <url>` | Override the Paperclip server URL agents use to call back (cross-cluster only) |
+| `--image-registry <url>` | Override the image registry for agent runtime images |
+
+## Verify the connection
+
+```bash
+# Check reachability, RBAC, and cluster capabilities
+paperclipai cluster doctor <id>
+
+# List all registered cluster connections
+paperclipai cluster list
+```
+
+`cluster doctor` checks:
+- API server reachability via the stored kubeconfig
+- `paperclip-tenant-manager` ClusterRole exists
+- Default StorageClass is present
+- Cilium CRD presence (informational)
+
+## Provision a tenant for a company
+
+```bash
+paperclipai cluster ensure-tenant <clusterId> <companyId>
+```
+
+Expected output:
+
+```
+Provisioned namespace paperclip-<companySlug> (cilium=false)
+```
+
+Or, if Cilium is present on the cluster:
+
+```
+Provisioned namespace paperclip-<companySlug> (cilium=true)
+```
+
+`ensure-tenant` is **idempotent** — running it twice is safe and brings any drifted objects back to the desired state. The driver refuses to touch a namespace that lacks the `paperclip.ai/managed-by=paperclip` label.
+
+## Verify the namespace with kubectl
+
+```bash
+kubectl get ns,sa,resourcequota,limitrange,networkpolicy \
+  -l paperclip.ai/managed-by=paperclip
+```
+
+You should see:
+- `Namespace` named `paperclip-<companySlug>`
+- `ServiceAccount` named `paperclip-agent`
+- `ResourceQuota` named `paperclip-tenant-quota`
+- `LimitRange` named `paperclip-tenant-limits`
+- `NetworkPolicy` objects `default-deny-ingress`, `default-deny-egress`, `paperclip-agent-egress`
+
+```bash
+kubectl describe namespace paperclip-<companySlug>
+```
+
+Check that the PSS labels are present:
+
+```
+Labels: pod-security.kubernetes.io/enforce=restricted
+        pod-security.kubernetes.io/audit=restricted
+        pod-security.kubernetes.io/warn=restricted
+        paperclip.ai/managed-by=paperclip
+        paperclip.ai/company-id=<uuid>
+```
+
+## What's not in M1
+
+| Feature | Milestone |
+|---------|-----------|
+| Agent execution (running adapter pods as Kubernetes Jobs) | M2 |
+| Web UI for cluster management and health | M3 |
+| Per-company BYO cluster (one cluster connection per company) | V2 |
+| VolumeSnapshot-based agent workspace cloning | V2 |
+| `local_encrypted` secret provider | M2 |
+| `paperclipai cluster purge` (namespace teardown) | M2 |
+
+For the full V1/V2 scope split see the [design spec](../superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md#non-goals-v1).
+
+## Next steps
+
+- [Security model](./security-model.md) — understand the isolation primitives applied to each namespace
+- [Multi-tenant onboarding](./multi-tenant-onboarding.md) — operator playbook for provisioning multiple companies
+- [Cluster RBAC](./cluster-rbac.md) — full ClusterRole reference and binding templates

--- a/docs/k8s-execution/security-model.md
+++ b/docs/k8s-execution/security-model.md
@@ -1,0 +1,246 @@
+---
+title: Kubernetes Execution — Security Model
+summary: Isolation primitives applied to every tenant namespace — NetworkPolicy, PodSecurity, RBAC, ResourceQuota, and compliance posture
+---
+
+Every company that runs agents on a Kubernetes cluster gets an isolated namespace with a layered set of controls. This document describes each layer, why it exists, and how to verify it. The spec section that defines these primitives is [§2 of the design spec](../superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md#2-tenancy-isolation--cluster-connection).
+
+**M1 scope:** These controls are provisioned by `cluster ensure-tenant`. Agent pods that enforce them (PodSecurity Restricted, NetworkPolicy enforcement during actual runs) are an M2 deliverable. The namespace is fully hardened at provision time; the hardening is exercised at run time.
+
+## Tenancy boundary: one Namespace per company
+
+Every Paperclip company maps to exactly one namespace per cluster connection, named `paperclip-{companySlug}`. This is the primary isolation boundary: Kubernetes RBAC, ResourceQuota, NetworkPolicy, and PodSecurityAdmission all attach at the namespace level.
+
+**Naming rules** (from [spec §2.1](../superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md#21-tenant-boundary-namespace-per-company)):
+- Primary: `paperclip-{companySlug}` (companySlug truncated to 53 chars so the total stays ≤ 63)
+- Fallback: `paperclip-{companySlug}-{base36(blake3(companyId))[:8]}` on DNS-1123 overflow or slug collision
+
+The immutable machine identifier is the `paperclip.ai/company-id=<uuid>` label on the Namespace object, not the namespace name.
+
+The driver refuses to manage any namespace that does not carry `paperclip.ai/managed-by=paperclip`. This prevents accidental mutation of pre-existing namespaces.
+
+## Pod identity: zero-trust by default
+
+Each tenant namespace contains a `ServiceAccount` named `paperclip-agent` with:
+
+```yaml
+automountServiceAccountToken: false
+```
+
+This ServiceAccount has **no RBAC bindings** by default. A pod running as `paperclip-agent` cannot call the Kubernetes API at all. The driver's own identity (the `paperclip-driver` ServiceAccount in `paperclip-system`) is separate and holds the `ClusterRole` described in [cluster-rbac.md](./cluster-rbac.md).
+
+Disabling `automountServiceAccountToken` removes the projected token from the pod filesystem, eliminating a common privilege escalation path even if the service account later gains bindings.
+
+## NetworkPolicy: default-deny + allowlist
+
+Three NetworkPolicy objects are applied to every tenant namespace.
+
+### default-deny-ingress
+
+```yaml
+podSelector: {}
+policyTypes: [Ingress]
+```
+
+Blocks all ingress to every pod in the namespace. Agent pods do not accept inbound connections.
+
+### default-deny-egress
+
+```yaml
+podSelector: {}
+policyTypes: [Egress]
+```
+
+Blocks all egress by default. Only pods that match the `paperclip-agent-egress` allowlist policy can make outbound connections.
+
+### paperclip-agent-egress
+
+Applied only to pods labeled `paperclip.ai/role: agent-runtime`. Three egress rules, in order:
+
+**1. Cluster DNS**
+
+```yaml
+to:
+  - namespaceSelector:
+      matchLabels: { kubernetes.io/metadata.name: kube-system }
+    podSelector:
+      matchLabels: { k8s-app: kube-dns }
+ports: [{ port: 53, protocol: UDP }, { port: 53, protocol: TCP }]
+```
+
+Agents need name resolution to reach the Paperclip server and external APIs.
+
+**2. In-cluster Paperclip server** (in-cluster topology only)
+
+```yaml
+to:
+  - namespaceSelector:
+      matchLabels: { paperclip.ai/role: control-plane }
+    podSelector:
+      matchLabels: { app.kubernetes.io/name: paperclip-server }
+ports: [{ port: 443, protocol: TCP }, { port: 3102, protocol: TCP }]
+```
+
+Agents call back to the Paperclip server to exchange the bootstrap token for a run JWT. This rule is omitted for cross-cluster topologies where the server is not in the same cluster.
+
+**3. Internet egress with internal ranges denied**
+
+```yaml
+to:
+  - ipBlock:
+      cidr: 0.0.0.0/0
+      except:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+        - 169.254.0.0/16    # link-local — cloud metadata service
+        - 100.64.0.0/10     # CGNAT
+  - ipBlock:
+      cidr: ::/0
+      except:
+        - fd00::/8          # IPv6 ULA
+ports: [{ port: 443, protocol: TCP }]
+```
+
+**Why each block matters:**
+
+| CIDR | What it blocks | Why it matters |
+|------|----------------|----------------|
+| `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` | RFC 1918 private ranges | Cluster-internal databases, caches, other services |
+| `169.254.0.0/16` | Link-local (incl. `169.254.169.254`) | **Cloud metadata service** — this is the primary SSRF target on AWS/GCP/Azure. A compromised pod that can reach the metadata service can obtain instance credentials and escape the tenant boundary |
+| `100.64.0.0/10` | CGNAT / shared address space | Often used by cloud providers for internal routing; blocks a secondary metadata path on some platforms |
+| `fd00::/8` | IPv6 ULA | Internal IPv6 ranges; same threat model as RFC 1918. Must be in a separate `ipBlock` entry because the Kubernetes API rejects IPv6 ranges inside an IPv4 cidr |
+
+The IPv4 and IPv6 deny blocks are intentionally separate `ipBlock` entries. The Kubernetes NetworkPolicy API requires each `except` entry to be a strict subset of its parent `cidr`; mixing IPv6 ranges inside `0.0.0.0/0` is rejected with a 422 error.
+
+## Cilium variant: FQDN allowlist (auto-detected)
+
+When `probeClusterCapabilities` detects the `cilium.io/v2` API group, the driver also applies a `CiliumNetworkPolicy` alongside the vanilla NetworkPolicy. The vanilla policy stays as defense-in-depth.
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: paperclip-agent-egress-l7
+spec:
+  endpointSelector:
+    matchLabels: { paperclip.ai/role: agent-runtime }
+  egress:
+    - toFQDNs:
+        - matchPattern: "*.anthropic.com"
+        - matchPattern: "api.openai.com"
+        - matchPattern: "*.googleapis.com"
+        - matchPattern: "github.com"
+        - matchPattern: "*.github.com"
+        - matchPattern: "gitlab.com"
+      toPorts:
+        - ports: [{ port: "443", protocol: TCP }]
+    - toEndpoints:
+        - matchLabels: { paperclip.ai/role: control-plane }
+      toPorts:
+        - ports: [{ port: "443", protocol: TCP }]
+```
+
+The FQDN list is composed from two sources:
+- `adapter.networkRequirements.allowFqdns` (declared per adapter type in `ServerAdapterModule`)
+- `cluster_tenant_policies.network_json.additionalAllowFqdns` (per-tenant override, described in [multi-tenant-onboarding.md](./multi-tenant-onboarding.md))
+
+Cilium detection happens automatically at `cluster add` time. Re-run `cluster doctor <id>` after installing Cilium to update the stored capabilities; then re-run `cluster ensure-tenant` to apply the CNP.
+
+## PodSecurity Restricted
+
+The namespace is labeled at provision time:
+
+```yaml
+pod-security.kubernetes.io/enforce: restricted
+pod-security.kubernetes.io/audit:   restricted
+pod-security.kubernetes.io/warn:    restricted
+```
+
+Any pod admitted to the namespace must conform to the `restricted` PodSecurity Standard. Agent pods (M2) are built to satisfy it:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile: { type: RuntimeDefault }
+containers:
+  - securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities: { drop: [ALL] }
+```
+
+`readOnlyRootFilesystem: true` is enforced. Writable paths are:
+- `/workspace` — agent `PersistentVolumeClaim` (M2)
+- `/tmp` — `emptyDir` volume capped at 1 Gi (M2)
+
+An attempt to `kubectl run` a privileged pod into a Paperclip namespace will be rejected by the admission controller — this is the expected behavior and confirms PSS is working. See [multi-tenant-onboarding.md](./multi-tenant-onboarding.md#common-edge-cases) for how to verify this.
+
+## ResourceQuota and LimitRange
+
+Default values (can be overridden per tenant via `cluster_tenant_policies` — see [multi-tenant-onboarding.md](./multi-tenant-onboarding.md)):
+
+### ResourceQuota `paperclip-tenant-quota`
+
+```yaml
+hard:
+  requests.cpu:                 "16"
+  requests.memory:              "64Gi"
+  limits.cpu:                   "64"
+  limits.memory:                "256Gi"
+  requests.storage:             "200Gi"
+  count/jobs.batch:             "100"
+  count/persistentvolumeclaims: "50"
+  count/secrets:                "200"
+  count/configmaps:             "200"
+```
+
+### LimitRange `paperclip-tenant-limits`
+
+```yaml
+limits:
+  - type: Container
+    default:        { cpu: "1",    memory: "2Gi" }
+    defaultRequest: { cpu: "250m", memory: "512Mi" }
+    max:            { cpu: "8",    memory: "32Gi" }
+  - type: PersistentVolumeClaim
+    max: { storage: "20Gi" }
+```
+
+The LimitRange ensures that pods without explicit resource requests/limits still get sensible defaults and cannot consume unbounded resources. Without it, a misconfigured pod could exhaust node capacity and starve other tenants.
+
+## Image pull secret model
+
+If the cluster connection has an associated image registry and the `imagePullDockerConfigJson` is resolved at provision time, the driver creates a `Secret` of type `kubernetes.io/dockerconfigjson` in the tenant namespace:
+
+```
+Secret name: paperclip-image-pull
+Secret type: kubernetes.io/dockerconfigjson
+```
+
+This secret is referenced by agent pod specs (M2) as an `imagePullSecret`. Credentials are per-namespace and are not shared across tenants. The secret value is resolved from the Paperclip secret provider at `ensure-tenant` time.
+
+## Secret-resolver M1 gap
+
+The secret provider abstraction supports `aws_secrets`, `gcp_secret`, `vault`, and `env` in M1. The `local_encrypted` provider (Paperclip-managed encrypted store) is planned for M2.
+
+Operators running a self-hosted Paperclip instance without access to a cloud secret manager should use `env:<VAR_NAME>` for the kubeconfig secret during M1.
+
+## Compliance bookkeeping
+
+The M1 provisioning pipeline is aligned with:
+
+- **NSA/CISA Kubernetes Hardening Guidance** — Restricted PSS, NetworkPolicy default-deny, no privilege escalation, no host network/PID/IPC, drop ALL capabilities, RuntimeDefault seccomp
+- **CIS Kubernetes Benchmark** — namespace isolation, ResourceQuota enforcement, no automounted ServiceAccount tokens
+
+The CI release pipeline runs `kube-audit-kit` and `polaris` against a freshly provisioned tenant namespace on every build. PSS Restricted violations or NSA Hardening regressions block the release.
+
+## Related
+
+- [Quickstart](./quickstart.md) — set up a cluster connection and run `ensure-tenant`
+- [Cluster RBAC](./cluster-rbac.md) — the driver ClusterRole and binding templates
+- [Multi-tenant onboarding](./multi-tenant-onboarding.md) — playbook for provisioning multiple companies and handling edge cases
+- [Design spec §2](../superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md#2-tenancy-isolation--cluster-connection)

--- a/docs/superpowers/plans/2026-05-08-paperclip-cloud-adapter-m1-plan.md
+++ b/docs/superpowers/plans/2026-05-08-paperclip-cloud-adapter-m1-plan.md
@@ -1,0 +1,3730 @@
+# Paperclip Cloud Adapter — Milestone 1: Headless Tenant Provisioning
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the foundation of the multi-tenant Kubernetes execution target — types, registry, cluster-connection storage, k8s client wrapper, and idempotent tenant-namespace provisioning (Namespace + RBAC + ResourceQuota + LimitRange + NetworkPolicy + Cilium variant + image-pull-secret) — verifiable end-to-end against a `kind` cluster. No agent execution yet (that's M2). No web UI yet (that's M3). The CLI command `paperclipai cluster ensure-tenant <companyId>` exists and works.
+
+**Architecture:** Add a `kubernetes` kind to the existing `AdapterExecutionTarget` discriminated union and introduce a platform-module-style `ExecutionTargetDriverRegistry`. The k8s driver lives in a new package `@paperclipai/execution-target-kubernetes` and is wired into the server through a thin registration shim. Three new Drizzle tables back the storage. All k8s spec building is done as **pure functions** that take a context object and return raw API objects; a separate `ensureTenantNamespace` orchestrator applies them via `@kubernetes/client-node`. Pure builders are unit-tested with golden snapshots; the orchestrator is integration-tested against `kind`.
+
+**Tech Stack:** TypeScript, Drizzle ORM (PostgreSQL), `@kubernetes/client-node`, `vitest`, `kind` (Kubernetes IN Docker) for integration tests, `testcontainers-node` for spinning kind in CI. Existing Paperclip patterns: services in `server/src/services/`, schemas in `packages/db/src/schema/`, CLI commands in `cli/src/commands/`.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md` (sections 1, 2, and the `ClusterConnection` model in §2.7).
+
+---
+
+## File Structure
+
+### New files
+
+```
+packages/adapters/kubernetes-execution/                    # NEW package
+├── package.json
+├── tsconfig.json
+├── README.md
+└── src/
+    ├── index.ts                                           # public exports
+    ├── types.ts                                           # internal types (TenantContext, EnsureTenantOptions, ...)
+    ├── client.ts                                          # createKubernetesApiClient(connection) → wrapped client bundle
+    ├── driver.ts                                          # KubernetesExecutionDriver (M1: validate + ensureTenant; run() returns NOT_YET_SUPPORTED)
+    ├── redaction.ts                                       # value-set redactor (groundwork for M2)
+    └── orchestrator/
+        ├── labels.ts                                      # PAPERCLIP_LABEL_* constants
+        ├── naming.ts                                      # deriveNamespaceName(companySlug, companyId) → string
+        ├── capabilities.ts                                # probeClusterCapabilities(client) → ClusterCapabilities
+        ├── namespace.ts                                   # buildNamespace + applyNamespace
+        ├── rbac.ts                                        # buildAgentServiceAccount + buildDriverRoleBinding + apply
+        ├── resource-quota.ts                              # buildResourceQuota + buildLimitRange + apply
+        ├── network-policy.ts                              # buildDefaultDenyPolicies + buildAgentEgressPolicy + apply
+        ├── cilium-network-policy.ts                       # buildCiliumAgentEgressPolicy + apply (when capabilities.cilium)
+        ├── image-pull-secret.ts                           # buildImagePullSecret + apply (resolves Paperclip secret_ref)
+        └── ensure-tenant.ts                               # ensureTenantNamespace(ctx) — top-level idempotent orchestrator
+
+packages/adapters/kubernetes-execution/test/
+├── unit/
+│   ├── naming.test.ts
+│   ├── capabilities.test.ts
+│   ├── namespace.test.ts                                  # builder snapshots
+│   ├── rbac.test.ts
+│   ├── resource-quota.test.ts
+│   ├── network-policy.test.ts
+│   ├── cilium-network-policy.test.ts
+│   ├── image-pull-secret.test.ts
+│   └── redaction.test.ts
+└── integration/
+    ├── _harness.ts                                        # spin up kind cluster, return KubeConfig + cleanup
+    ├── ensure-tenant.test.ts                              # full happy path against kind
+    ├── ensure-tenant-idempotency.test.ts                  # second ensure is a no-op
+    ├── ensure-tenant-drift.test.ts                        # mutate by hand, re-ensure, verify recovery
+    └── pss-restricted.test.ts                             # provision a tenant, run polaris/kube-linter, expect zero violations
+
+packages/db/src/schema/
+├── cluster_connections.ts                                 # NEW
+├── cluster_namespace_bindings.ts                          # NEW
+└── cluster_tenant_policies.ts                             # NEW
+
+packages/db/src/migrations/
+└── 0082_cluster_connections.sql                           # NEW (drizzle-kit generated)
+
+server/src/adapters/
+└── execution-target-registry.ts                           # NEW
+
+server/src/adapters/execution-targets/
+└── kubernetes.ts                                          # NEW (registers @paperclipai/execution-target-kubernetes)
+
+server/src/services/
+├── cluster-connections.ts                                 # NEW
+├── cluster-connections.test.ts
+├── cluster-tenant-policies.ts                             # NEW
+└── cluster-tenant-policies.test.ts
+
+cli/src/commands/
+├── cluster.ts                                             # NEW (cluster add|list|test|remove|ensure-tenant|doctor)
+└── cluster.test.ts
+```
+
+### Modified files
+
+| File | What changes |
+|---|---|
+| `packages/adapter-utils/src/execution-target.ts` | Add `AdapterKubernetesExecutionTarget` interface; add to `AdapterExecutionTarget` union; extend `describeAdapterExecutionTarget`, `resolveAdapterExecutionTargetCwd`, and the unsupported-helpers guard so existing helpers don't crash on `kind: "kubernetes"`. |
+| `packages/adapter-utils/src/types.ts` | Add `networkRequirements?: { allowFqdns?: string[] }` to `ServerAdapterModule`. |
+| `packages/db/src/index.ts` | Re-export the three new schemas. |
+| `server/src/index.ts` (or wherever adapter registry init lives) | Register the kubernetes execution-target driver during startup. |
+| `cli/src/index.ts` | Wire `cluster` subcommand. |
+| `pnpm-workspace.yaml` | Already covers `packages/adapters/*` — no change expected; verify. |
+
+### Adapter audit (Risk #3 from the spec)
+
+A dedicated task audits every existing adapter (`claude_local`, `codex_local`, `gemini_local`, `opencode_local`, `acpx_local`, `pi_local`, `hermes_local`) for `executionTarget` plumbing. The audit is a contract test, not a refactor — adapters must accept `ctx.executionTarget?.kind === "kubernetes"` without crashing and return a clear "not supported in M1" error. Real k8s execution comes in M2.
+
+---
+
+## Dependencies
+
+Adds to `packages/adapters/kubernetes-execution/package.json`:
+
+```json
+{
+  "dependencies": {
+    "@kubernetes/client-node": "^0.21.0",
+    "@paperclipai/adapter-utils": "workspace:*",
+    "yaml": "^2.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.0.0"
+  }
+}
+```
+
+CI dev-dependency: `kind` binary (already commonly available in CI base images; if not, install via `go install sigs.k8s.io/kind@latest`).
+
+---
+
+## Sequencing & Workstream Notes
+
+- Tasks 1–4 are foundational and **strictly sequential**.
+- Tasks 5–14 are **pure builders** — can be parallelised across subagents.
+- Task 15 (`ensureTenantNamespace`) is the integrator — must come after 5–14.
+- Tasks 16–20 are **server/CLI surface** — depend on 15.
+- Tasks 21–24 close the loop (audit + integration + CLI smoke).
+
+---
+
+## Task 1: Scaffold the new package
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/package.json`
+- Create: `packages/adapters/kubernetes-execution/tsconfig.json`
+- Create: `packages/adapters/kubernetes-execution/src/index.ts`
+- Create: `packages/adapters/kubernetes-execution/README.md`
+
+- [ ] **Step 1: Create `package.json`**
+
+```json
+{
+  "name": "@paperclipai/execution-target-kubernetes",
+  "version": "0.0.0",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
+  },
+  "dependencies": {
+    "@kubernetes/client-node": "^0.21.0",
+    "@paperclipai/adapter-utils": "workspace:*",
+    "yaml": "^2.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.0.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create `tsconfig.json`**
+
+```json
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 3: Create `src/index.ts` with placeholder export**
+
+```ts
+export const PACKAGE_NAME = "@paperclipai/execution-target-kubernetes";
+```
+
+- [ ] **Step 4: Create a minimal README**
+
+```markdown
+# @paperclipai/execution-target-kubernetes
+
+Kubernetes execution-target driver for Paperclip agents. See
+[the design spec](../../../docs/superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md)
+and the M1 implementation plan.
+```
+
+- [ ] **Step 5: Verify package resolves and builds**
+
+Run: `pnpm install && pnpm --filter @paperclipai/execution-target-kubernetes build`
+Expected: build succeeds; `dist/index.js` exists.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution pnpm-lock.yaml
+git commit -m "feat(k8s-adapter): scaffold @paperclipai/execution-target-kubernetes package"
+```
+
+---
+
+## Task 2: Add `KubernetesExecutionTarget` to the discriminated union
+
+**Files:**
+- Modify: `packages/adapter-utils/src/execution-target.ts`
+
+Reference: spec §1.1.
+
+- [ ] **Step 1: Write failing test for the type discriminator**
+
+Create `packages/adapter-utils/src/execution-target.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { describeAdapterExecutionTarget } from "./execution-target.js";
+
+describe("describeAdapterExecutionTarget — kubernetes kind", () => {
+  it("returns a human-readable description for a kubernetes target", () => {
+    const desc = describeAdapterExecutionTarget({
+      kind: "kubernetes",
+      clusterConnectionId: "c-123",
+    });
+    expect(desc).toContain("kubernetes");
+    expect(desc).toContain("c-123");
+  });
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `pnpm --filter @paperclipai/adapter-utils test execution-target -- --run`
+Expected: TS compile error — `kind: "kubernetes"` not assignable to `AdapterExecutionTarget`.
+
+- [ ] **Step 3: Add the new interface and union member**
+
+In `packages/adapter-utils/src/execution-target.ts`, add after the `AdapterSandboxExecutionTarget` interface:
+
+```ts
+export interface AdapterKubernetesExecutionTarget {
+  kind: "kubernetes";
+  clusterConnectionId: string;
+  /** Override the auto-derived `paperclip-{companySlug}` namespace name. Rare. */
+  namespaceOverride?: string | null;
+  /** Override the resolved agent runtime image. Gated by per-cluster policy. */
+  imageOverride?: string | null;
+  resources?: {
+    requests?: { cpu?: string; memory?: string };
+    limits?:   { cpu?: string; memory?: string };
+  } | null;
+  storage?: {
+    sizeGi?: number;
+    storageClass?: string;
+  } | null;
+  envOverrides?: Record<string, string> | null;
+}
+```
+
+Update the union:
+
+```ts
+export type AdapterExecutionTarget =
+  | AdapterLocalExecutionTarget
+  | AdapterSshExecutionTarget
+  | AdapterSandboxExecutionTarget
+  | AdapterKubernetesExecutionTarget;
+```
+
+Update `describeAdapterExecutionTarget` to handle the new variant. Find the function and add a branch:
+
+```ts
+if (target.kind === "kubernetes") {
+  return `kubernetes(connection=${target.clusterConnectionId}${target.namespaceOverride ? `, namespace=${target.namespaceOverride}` : ""})`;
+}
+```
+
+- [ ] **Step 4: Run test, expect it to pass**
+
+Run: `pnpm --filter @paperclipai/adapter-utils test execution-target -- --run`
+Expected: PASS.
+
+- [ ] **Step 5: Audit the rest of `execution-target.ts` for `kind === "..."` switches**
+
+For each helper that switches on `target.kind` (`resolveAdapterExecutionTargetCwd`, `ensureAdapterExecutionTargetCommandResolvable`, `runAdapterExecutionTargetProcess`, `runAdapterExecutionTargetShellCommand`, `readAdapterExecutionTargetHomeDir`):
+
+Add a final branch that throws a clear error specific to M1 (so M2 can replace it):
+
+```ts
+if (target.kind === "kubernetes") {
+  throw new Error(
+    "Kubernetes execution target runtime helpers are not implemented yet (M1 covers tenant provisioning only; agent execution lands in M2).",
+  );
+}
+```
+
+Add a unit test that asserts each helper throws this specific error when called with a kubernetes target.
+
+- [ ] **Step 6: Run all adapter-utils tests**
+
+Run: `pnpm --filter @paperclipai/adapter-utils test`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/adapter-utils/src/execution-target.ts packages/adapter-utils/src/execution-target.test.ts
+git commit -m "feat(adapter-utils): add KubernetesExecutionTarget kind"
+```
+
+---
+
+## Task 3: Add `networkRequirements` to `ServerAdapterModule`
+
+Reference: spec Risk #7.
+
+**Files:**
+- Modify: `packages/adapter-utils/src/types.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `packages/adapter-utils/src/types.test.ts` (create if absent):
+
+```ts
+import { describe, it, expectTypeOf } from "vitest";
+import type { ServerAdapterModule } from "./types.js";
+
+describe("ServerAdapterModule.networkRequirements", () => {
+  it("accepts an allowFqdns array on a module shape", () => {
+    const m: Pick<ServerAdapterModule, "type" | "networkRequirements"> = {
+      type: "test",
+      networkRequirements: { allowFqdns: ["api.anthropic.com"] },
+    };
+    expectTypeOf(m.networkRequirements?.allowFqdns).toEqualTypeOf<readonly string[] | string[] | undefined>();
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/adapter-utils test types`
+Expected: TS error — `networkRequirements` not assignable.
+
+- [ ] **Step 3: Add the field**
+
+In `packages/adapter-utils/src/types.ts`, inside `ServerAdapterModule`, add:
+
+```ts
+/**
+ * Optional declaration of outbound network endpoints this adapter requires
+ * at runtime. Used by the kubernetes execution target to compose Cilium
+ * FQDN allowlists. Empty/omitted means "no adapter-specific FQDN allowlist
+ * contribution"; the cluster's default allowlist still applies.
+ */
+networkRequirements?: {
+  allowFqdns?: string[];
+};
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `pnpm --filter @paperclipai/adapter-utils test types`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapter-utils/src/types.ts packages/adapter-utils/src/types.test.ts
+git commit -m "feat(adapter-utils): add networkRequirements to ServerAdapterModule"
+```
+
+---
+
+## Task 4: Drizzle schema — three new tables
+
+**Files:**
+- Create: `packages/db/src/schema/cluster_connections.ts`
+- Create: `packages/db/src/schema/cluster_namespace_bindings.ts`
+- Create: `packages/db/src/schema/cluster_tenant_policies.ts`
+- Modify: `packages/db/src/index.ts`
+- Generated: `packages/db/src/migrations/0082_cluster_connections.sql`
+
+Reference: spec §2.7.
+
+- [ ] **Step 1: Create `cluster_connections.ts`**
+
+```ts
+import { pgTable, uuid, text, jsonb, timestamp, index, uniqueIndex } from "drizzle-orm/pg-core";
+
+export const clusterConnections = pgTable(
+  "cluster_connections",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    label: text("label").notNull(),
+    kind: text("kind").notNull(), // "in-cluster" | "kubeconfig"
+    kubeconfigSecretRef: jsonb("kubeconfig_secret_ref").$type<{
+      provider: string;
+      name: string;
+    } | null>(),
+    apiServerUrl: text("api_server_url"),
+    defaultNamespacePrefix: text("default_namespace_prefix").notNull().default("paperclip-"),
+    capabilities: jsonb("capabilities").notNull().$type<{
+      cilium: boolean;
+      storageClass: string;
+      architectures: ("amd64" | "arm64")[];
+    }>(),
+    paperclipPublicUrl: text("paperclip_public_url"),
+    imageRegistry: text("image_registry"),
+    allowAgentImageOverride: text("allow_agent_image_override").notNull().default("false"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    createdBy: text("created_by").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    labelUq: uniqueIndex("cluster_connections_label_uq").on(table.label),
+    kindIdx: index("cluster_connections_kind_idx").on(table.kind),
+  }),
+);
+```
+
+- [ ] **Step 2: Create `cluster_namespace_bindings.ts`**
+
+```ts
+import { pgTable, uuid, text, timestamp, uniqueIndex, index } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { clusterConnections } from "./cluster_connections.js";
+
+export const clusterNamespaceBindings = pgTable(
+  "cluster_namespace_bindings",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    clusterConnectionId: uuid("cluster_connection_id").notNull().references(() => clusterConnections.id, { onDelete: "cascade" }),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    namespaceName: text("namespace_name").notNull(),
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    perClusterCompanyUq: uniqueIndex("cluster_namespace_bindings_cluster_company_uq")
+      .on(table.clusterConnectionId, table.companyId),
+    namespaceLookupUq: uniqueIndex("cluster_namespace_bindings_cluster_ns_uq")
+      .on(table.clusterConnectionId, table.namespaceName),
+    companyIdx: index("cluster_namespace_bindings_company_idx").on(table.companyId),
+  }),
+);
+```
+
+- [ ] **Step 3: Create `cluster_tenant_policies.ts`**
+
+```ts
+import { pgTable, uuid, jsonb, timestamp, uniqueIndex, index } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { clusterConnections } from "./cluster_connections.js";
+
+export const clusterTenantPolicies = pgTable(
+  "cluster_tenant_policies",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    clusterConnectionId: uuid("cluster_connection_id").notNull().references(() => clusterConnections.id, { onDelete: "cascade" }),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    quotaJson: jsonb("quota_json").$type<{
+      requestsCpu?: string;
+      requestsMemory?: string;
+      limitsCpu?: string;
+      limitsMemory?: string;
+      requestsStorage?: string;
+      countJobs?: number;
+      countPvcs?: number;
+      countSecrets?: number;
+      countConfigMaps?: number;
+    } | null>(),
+    limitRangeJson: jsonb("limit_range_json").$type<{
+      defaultRequest?: { cpu?: string; memory?: string };
+      default?:        { cpu?: string; memory?: string };
+      max?:            { cpu?: string; memory?: string };
+      pvcMaxStorage?: string;
+    } | null>(),
+    networkJson: jsonb("network_json").$type<{
+      additionalAllowFqdns?: string[];
+      httpProxyUrl?: string | null;
+    } | null>(),
+    imageOverridesJson: jsonb("image_overrides_json").$type<Record<string, string> | null>(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    perClusterCompanyUq: uniqueIndex("cluster_tenant_policies_cluster_company_uq")
+      .on(table.clusterConnectionId, table.companyId),
+    companyIdx: index("cluster_tenant_policies_company_idx").on(table.companyId),
+  }),
+);
+```
+
+- [ ] **Step 4: Re-export from `packages/db/src/index.ts`**
+
+Find the schema re-export block and append:
+
+```ts
+export { clusterConnections } from "./schema/cluster_connections.js";
+export { clusterNamespaceBindings } from "./schema/cluster_namespace_bindings.js";
+export { clusterTenantPolicies } from "./schema/cluster_tenant_policies.js";
+```
+
+- [ ] **Step 5: Build the schema package so drizzle-kit can read `dist/schema/*.js`**
+
+Run: `pnpm --filter @paperclipai/db build`
+Expected: build succeeds.
+
+- [ ] **Step 6: Generate migration**
+
+Run: `pnpm --filter @paperclipai/db exec drizzle-kit generate --name cluster_connections`
+Expected: a new file `packages/db/src/migrations/0082_*.sql` containing `CREATE TABLE cluster_connections ...`.
+
+- [ ] **Step 7: Inspect the migration**
+
+Run: `cat packages/db/src/migrations/0082_*.sql | head -80`
+Expected: the file declares all three tables with correct foreign keys and indexes.
+
+- [ ] **Step 8: Apply migration in an embedded postgres test**
+
+Add `packages/db/src/schema/cluster_connections.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startEmbeddedPostgresTestDatabase, type EmbeddedPostgresTestDatabase } from "../test-embedded-postgres.js";
+import { clusterConnections } from "./cluster_connections.js";
+
+let db: EmbeddedPostgresTestDatabase;
+
+beforeAll(async () => { db = await startEmbeddedPostgresTestDatabase(); });
+afterAll(async () => { await db.stop(); });
+
+describe("cluster_connections schema", () => {
+  it("inserts and reads back a row with the expected shape", async () => {
+    const [inserted] = await db.client.insert(clusterConnections).values({
+      label: "test-cluster",
+      kind: "in-cluster",
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      createdBy: "system",
+    }).returning();
+    expect(inserted.id).toBeDefined();
+    expect(inserted.defaultNamespacePrefix).toBe("paperclip-");
+    expect(inserted.allowAgentImageOverride).toBe("false");
+  });
+});
+```
+
+Run: `pnpm --filter @paperclipai/db test cluster_connections`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/db/src/schema/cluster_connections.ts \
+        packages/db/src/schema/cluster_namespace_bindings.ts \
+        packages/db/src/schema/cluster_tenant_policies.ts \
+        packages/db/src/schema/cluster_connections.test.ts \
+        packages/db/src/index.ts \
+        packages/db/src/migrations/0082_*.sql \
+        packages/db/src/migrations/meta/
+git commit -m "feat(db): add cluster_connections, cluster_namespace_bindings, cluster_tenant_policies tables"
+```
+
+---
+
+## Task 5: K8s client wrapper
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/client.ts`
+- Create: `packages/adapters/kubernetes-execution/src/types.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/client.test.ts`
+
+The wrapper exists so the rest of the package never imports `@kubernetes/client-node` directly — easier mocking and a clear seam for cross-cluster vs in-cluster auth.
+
+- [ ] **Step 1: Define internal types**
+
+Create `src/types.ts`:
+
+```ts
+import type { CoreV1Api, BatchV1Api, NetworkingV1Api, RbacAuthorizationV1Api, ApiextensionsV1Api } from "@kubernetes/client-node";
+
+export interface ResolvedClusterConnection {
+  id: string;
+  label: string;
+  kind: "in-cluster" | "kubeconfig";
+  /** Already resolved kubeconfig blob if kind === "kubeconfig". */
+  kubeconfigYaml?: string;
+  apiServerUrl?: string | null;
+  defaultNamespacePrefix: string;
+  paperclipPublicUrl?: string | null;
+  imageRegistry?: string | null;
+  allowAgentImageOverride: boolean;
+  capabilities: ClusterCapabilities;
+}
+
+export interface ClusterCapabilities {
+  cilium: boolean;
+  storageClass: string;
+  architectures: ("amd64" | "arm64")[];
+}
+
+export interface KubernetesApiClient {
+  core: CoreV1Api;
+  batch: BatchV1Api;
+  networking: NetworkingV1Api;
+  rbac: RbacAuthorizationV1Api;
+  apiext: ApiextensionsV1Api;
+  /** kubeconfig context info for logging only. */
+  describe: () => string;
+  /** Throwaway dynamic client used for arbitrary CRDs (Cilium). */
+  request: <T = unknown>(method: string, path: string, body?: unknown) => Promise<T>;
+}
+```
+
+- [ ] **Step 2: Write failing test for `createKubernetesApiClient`**
+
+Create `test/unit/client.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createKubernetesApiClient } from "../../src/client.js";
+
+describe("createKubernetesApiClient", () => {
+  it("constructs a client from a kubeconfig blob", () => {
+    const kubeconfig = `
+apiVersion: v1
+kind: Config
+clusters: [{ name: kind, cluster: { server: https://127.0.0.1:6443, insecure-skip-tls-verify: true } }]
+contexts: [{ name: kind, context: { cluster: kind, user: kind } }]
+current-context: kind
+users: [{ name: kind, user: { token: x } }]
+`;
+    const client = createKubernetesApiClient({
+      id: "c-1",
+      label: "test",
+      kind: "kubeconfig",
+      kubeconfigYaml: kubeconfig,
+      defaultNamespacePrefix: "paperclip-",
+      allowAgentImageOverride: false,
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+    });
+    expect(client.core).toBeDefined();
+    expect(client.batch).toBeDefined();
+    expect(client.describe()).toContain("kind");
+  });
+
+  it("rejects an in-cluster connection when not running in a pod", () => {
+    expect(() =>
+      createKubernetesApiClient({
+        id: "c-1", label: "test", kind: "in-cluster",
+        defaultNamespacePrefix: "paperclip-", allowAgentImageOverride: false,
+        capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      }),
+    ).toThrow(/in-cluster/i);
+  });
+});
+```
+
+- [ ] **Step 3: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test client`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement `client.ts`**
+
+```ts
+import {
+  KubeConfig,
+  CoreV1Api, BatchV1Api, NetworkingV1Api, RbacAuthorizationV1Api, ApiextensionsV1Api,
+} from "@kubernetes/client-node";
+import type { ResolvedClusterConnection, KubernetesApiClient } from "./types.js";
+
+export function createKubernetesApiClient(connection: ResolvedClusterConnection): KubernetesApiClient {
+  const kc = new KubeConfig();
+  if (connection.kind === "in-cluster") {
+    try {
+      kc.loadFromCluster();
+    } catch (err) {
+      throw new Error(
+        `Cluster connection ${connection.id} is in-cluster but Paperclip is not running inside a Kubernetes pod: ${(err as Error).message}`,
+      );
+    }
+  } else {
+    if (!connection.kubeconfigYaml) {
+      throw new Error(`Cluster connection ${connection.id} is kind=kubeconfig but kubeconfigYaml is empty`);
+    }
+    kc.loadFromString(connection.kubeconfigYaml);
+  }
+
+  const core = kc.makeApiClient(CoreV1Api);
+  const batch = kc.makeApiClient(BatchV1Api);
+  const networking = kc.makeApiClient(NetworkingV1Api);
+  const rbac = kc.makeApiClient(RbacAuthorizationV1Api);
+  const apiext = kc.makeApiClient(ApiextensionsV1Api);
+
+  const ctx = kc.getCurrentContext();
+
+  return {
+    core, batch, networking, rbac, apiext,
+    describe: () => `${connection.label} (context=${ctx})`,
+    request: async (method, path, body) => {
+      const opts = { method, headers: { "Content-Type": "application/json" }, body: body ? JSON.stringify(body) : undefined };
+      const cluster = kc.getCurrentCluster();
+      if (!cluster) throw new Error(`No current cluster in kubeconfig`);
+      const url = new URL(path, cluster.server).toString();
+      const res = await kc.applyToHTTPSOptions(opts as never).then(async () => fetch(url, opts as RequestInit));
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`k8s API ${method} ${path} failed ${res.status}: ${text}`);
+      }
+      return res.json() as Promise<T>;
+    },
+  };
+}
+```
+
+- [ ] **Step 5: Run test, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test client`
+Expected: first test PASS, second test PASS (the in-cluster path throws because we're not in a pod).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/client.ts \
+        packages/adapters/kubernetes-execution/src/types.ts \
+        packages/adapters/kubernetes-execution/test/unit/client.test.ts
+git commit -m "feat(k8s-adapter): add k8s API client wrapper"
+```
+
+---
+
+## Task 6: Cluster capability probe
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/capabilities.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/capabilities.test.ts`
+
+Reference: spec §2.7 (capabilities field), §2.4 (Cilium detection).
+
+- [ ] **Step 1: Write failing test using a mocked client**
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { probeClusterCapabilities } from "../../src/orchestrator/capabilities.js";
+
+function fakeClient(opts: { hasCilium: boolean; nodes: { arch: string }[]; storageClasses: string[]; defaultStorageClass?: string }) {
+  return {
+    request: vi.fn(async (method: string, path: string) => {
+      if (path.includes("/apis/cilium.io/v2")) {
+        return opts.hasCilium ? { kind: "APIResourceList", resources: [] } : null;
+      }
+      if (path.includes("/apis/storage.k8s.io/v1/storageclasses")) {
+        return {
+          items: opts.storageClasses.map(name => ({
+            metadata: {
+              name,
+              annotations: name === opts.defaultStorageClass
+                ? { "storageclass.kubernetes.io/is-default-class": "true" }
+                : {},
+            },
+          })),
+        };
+      }
+      return null;
+    }),
+    core: {
+      listNode: vi.fn(async () => ({
+        body: { items: opts.nodes.map(n => ({ status: { nodeInfo: { architecture: n.arch } } })) },
+      })),
+    },
+  } as unknown as Parameters<typeof probeClusterCapabilities>[0];
+}
+
+describe("probeClusterCapabilities", () => {
+  it("detects cilium and arm64 nodes", async () => {
+    const c = fakeClient({
+      hasCilium: true,
+      nodes: [{ arch: "amd64" }, { arch: "arm64" }],
+      storageClasses: ["standard", "gp3"],
+      defaultStorageClass: "gp3",
+    });
+    const caps = await probeClusterCapabilities(c);
+    expect(caps.cilium).toBe(true);
+    expect(caps.architectures).toEqual(expect.arrayContaining(["amd64", "arm64"]));
+    expect(caps.storageClass).toBe("gp3");
+  });
+
+  it("falls back to first storage class when none is marked default", async () => {
+    const c = fakeClient({
+      hasCilium: false,
+      nodes: [{ arch: "amd64" }],
+      storageClasses: ["standard"],
+    });
+    const caps = await probeClusterCapabilities(c);
+    expect(caps.cilium).toBe(false);
+    expect(caps.storageClass).toBe("standard");
+  });
+
+  it("handles cilium API absence gracefully", async () => {
+    const c = fakeClient({
+      hasCilium: false, nodes: [{ arch: "amd64" }],
+      storageClasses: ["standard"], defaultStorageClass: "standard",
+    });
+    const caps = await probeClusterCapabilities(c);
+    expect(caps.cilium).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test capabilities`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `capabilities.ts`**
+
+```ts
+import type { KubernetesApiClient, ClusterCapabilities } from "../types.js";
+
+export async function probeClusterCapabilities(client: KubernetesApiClient): Promise<ClusterCapabilities> {
+  // 1. Cilium presence: try to fetch the API resource list at /apis/cilium.io/v2.
+  const cilium = await detectCilium(client);
+
+  // 2. Node architectures.
+  const nodes = await client.core.listNode();
+  const archSet = new Set<"amd64" | "arm64">();
+  for (const node of nodes.body.items) {
+    const arch = node.status?.nodeInfo?.architecture;
+    if (arch === "amd64" || arch === "arm64") archSet.add(arch);
+  }
+  const architectures = archSet.size > 0 ? [...archSet] : ["amd64"] as const;
+
+  // 3. Storage class: prefer the one annotated as default; else the first.
+  const storageClass = await detectStorageClass(client);
+
+  return { cilium, storageClass, architectures: [...architectures] };
+}
+
+async function detectCilium(client: KubernetesApiClient): Promise<boolean> {
+  try {
+    const res = await client.request<{ kind?: string } | null>("GET", "/apis/cilium.io/v2");
+    return res != null && res.kind === "APIResourceList";
+  } catch {
+    return false;
+  }
+}
+
+async function detectStorageClass(client: KubernetesApiClient): Promise<string> {
+  type SCList = { items: Array<{ metadata: { name: string; annotations?: Record<string, string> } }> };
+  const res = await client.request<SCList | null>("GET", "/apis/storage.k8s.io/v1/storageclasses");
+  if (!res || !res.items.length) return "standard";
+  const isDefault = (sc: SCList["items"][number]) =>
+    sc.metadata.annotations?.["storageclass.kubernetes.io/is-default-class"] === "true";
+  return res.items.find(isDefault)?.metadata.name ?? res.items[0].metadata.name;
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test capabilities`
+Expected: all three tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/orchestrator/capabilities.ts \
+        packages/adapters/kubernetes-execution/test/unit/capabilities.test.ts
+git commit -m "feat(k8s-adapter): add cluster capability probe"
+```
+
+---
+
+## Task 7: Naming utility
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/naming.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/naming.test.ts`
+
+Reference: spec §2.1 namespace naming.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { deriveNamespaceName, isValidDns1123Label } from "../../src/orchestrator/naming.js";
+
+describe("isValidDns1123Label", () => {
+  it("accepts simple slugs", () => {
+    expect(isValidDns1123Label("acme-corp")).toBe(true);
+    expect(isValidDns1123Label("a")).toBe(true);
+  });
+  it("rejects uppercase, leading/trailing hyphens, dots, length > 63", () => {
+    expect(isValidDns1123Label("Acme")).toBe(false);
+    expect(isValidDns1123Label("-acme")).toBe(false);
+    expect(isValidDns1123Label("acme-")).toBe(false);
+    expect(isValidDns1123Label("ac.me")).toBe(false);
+    expect(isValidDns1123Label("x".repeat(64))).toBe(false);
+  });
+});
+
+describe("deriveNamespaceName", () => {
+  it("returns paperclip-{slug} for short clean slugs", () => {
+    expect(deriveNamespaceName({
+      companySlug: "acme-corp",
+      companyId: "11111111-1111-1111-1111-111111111111",
+      prefix: "paperclip-",
+    })).toBe("paperclip-acme-corp");
+  });
+
+  it("appends a short hash when the slug overflows after prefix", () => {
+    const longSlug = "a".repeat(60);
+    const result = deriveNamespaceName({
+      companySlug: longSlug,
+      companyId: "22222222-2222-2222-2222-222222222222",
+      prefix: "paperclip-",
+    });
+    expect(result.startsWith("paperclip-")).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(63);
+    expect(result).toMatch(/-[0-9a-z]{8}$/);
+  });
+
+  it("appends a short hash when explicit collision flag is set", () => {
+    const withHash = deriveNamespaceName({
+      companySlug: "acme-corp",
+      companyId: "33333333-3333-3333-3333-333333333333",
+      prefix: "paperclip-",
+      collisionFallback: true,
+    });
+    expect(withHash).toMatch(/^paperclip-acme-corp-[0-9a-z]{8}$/);
+  });
+
+  it("sanitizes invalid slugs deterministically", () => {
+    const r = deriveNamespaceName({
+      companySlug: "Acme Corp.!",
+      companyId: "44444444-4444-4444-4444-444444444444",
+      prefix: "paperclip-",
+    });
+    expect(isValidDns1123Label(r)).toBe(true);
+    expect(r.startsWith("paperclip-")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test naming`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `naming.ts`**
+
+```ts
+import { createHash } from "node:crypto";
+
+const DNS_1123_LABEL = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+const MAX_LABEL = 63;
+
+export function isValidDns1123Label(s: string): boolean {
+  return s.length > 0 && s.length <= MAX_LABEL && DNS_1123_LABEL.test(s);
+}
+
+function shortHash(input: string): string {
+  // base36 of first 5 bytes of sha256 → ≤8 chars, all lowercase alnum
+  const hash = createHash("sha256").update(input).digest();
+  let n = 0n;
+  for (let i = 0; i < 5; i++) n = (n << 8n) + BigInt(hash[i]);
+  return n.toString(36).slice(0, 8).padStart(8, "0");
+}
+
+function sanitizeSlug(slug: string): string {
+  // Lowercase, replace runs of invalid chars with single hyphen, trim leading/trailing hyphens.
+  const cleaned = slug.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned.length === 0 ? "x" : cleaned;
+}
+
+export interface DeriveNamespaceNameInput {
+  companySlug: string;
+  companyId: string;
+  prefix: string;
+  collisionFallback?: boolean;
+}
+
+export function deriveNamespaceName(input: DeriveNamespaceNameInput): string {
+  const { companySlug, companyId, prefix, collisionFallback } = input;
+  const slug = sanitizeSlug(companySlug);
+  const naive = `${prefix}${slug}`;
+
+  // Hash suffix is appended when:
+  //   - explicit collision fallback requested
+  //   - naive name would overflow 63 chars
+  //   - sanitization mangled the slug (length comparison or character drop)
+  const sanitizedDiffers = slug !== companySlug.toLowerCase();
+  const overflow = naive.length > MAX_LABEL;
+  if (!collisionFallback && !overflow && !sanitizedDiffers) return naive;
+
+  const suffix = `-${shortHash(companyId)}`;
+  const room = MAX_LABEL - prefix.length - suffix.length;
+  const truncatedSlug = slug.slice(0, Math.max(1, room)).replace(/-+$/g, "");
+  return `${prefix}${truncatedSlug}${suffix}`;
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test naming`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/orchestrator/naming.ts \
+        packages/adapters/kubernetes-execution/test/unit/naming.test.ts
+git commit -m "feat(k8s-adapter): add namespace naming utility with DNS-1123 fallback"
+```
+
+---
+
+## Task 8: Label constants
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/labels.ts`
+
+Trivial — single export — combined into Task 9's commit if desired.
+
+- [ ] **Step 1: Implement labels module**
+
+```ts
+export const PAPERCLIP_MANAGED_BY = "paperclip.ai/managed-by";
+export const PAPERCLIP_MANAGED_BY_VALUE = "paperclip";
+
+export const PAPERCLIP_COMPANY_ID    = "paperclip.ai/company-id";
+export const PAPERCLIP_COMPANY_SLUG  = "paperclip.ai/company-slug";
+export const PAPERCLIP_AGENT_ID      = "paperclip.ai/agent-id";
+export const PAPERCLIP_RUN_ID        = "paperclip.ai/run-id";
+export const PAPERCLIP_ROLE          = "paperclip.ai/role";
+export const PAPERCLIP_ARCHIVED      = "paperclip.ai/archived";
+export const PAPERCLIP_WORKSPACE_STRATEGY = "paperclip.ai/workspace-strategy";
+
+export const ROLE_AGENT_RUNTIME      = "agent-runtime";
+export const ROLE_AGENT_WORKSPACE    = "agent-workspace";
+export const ROLE_CONTROL_PLANE      = "control-plane";
+
+export const PSS_ENFORCE = "pod-security.kubernetes.io/enforce";
+export const PSS_AUDIT   = "pod-security.kubernetes.io/audit";
+export const PSS_WARN    = "pod-security.kubernetes.io/warn";
+export const PSS_RESTRICTED = "restricted";
+
+export function tenantBaseLabels(input: { companyId: string; companySlug: string }): Record<string, string> {
+  return {
+    [PAPERCLIP_MANAGED_BY]:   PAPERCLIP_MANAGED_BY_VALUE,
+    [PAPERCLIP_COMPANY_ID]:   input.companyId,
+    [PAPERCLIP_COMPANY_SLUG]: input.companySlug,
+  };
+}
+```
+
+- [ ] **Step 2: No test (constants only); referenced by later tasks.**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/orchestrator/labels.ts
+git commit -m "feat(k8s-adapter): add label constants"
+```
+
+---
+
+## Task 9: Namespace builder + apply
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/namespace.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/namespace.test.ts`
+
+Reference: spec §2.1.
+
+- [ ] **Step 1: Write failing builder test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildNamespace } from "../../src/orchestrator/namespace.js";
+
+describe("buildNamespace", () => {
+  it("produces a namespace with paperclip labels and PSS restricted", () => {
+    const ns = buildNamespace({
+      name: "paperclip-acme-corp",
+      companyId: "c-uuid",
+      companySlug: "acme-corp",
+    });
+    expect(ns.kind).toBe("Namespace");
+    expect(ns.metadata.name).toBe("paperclip-acme-corp");
+    expect(ns.metadata.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+    expect(ns.metadata.labels?.["paperclip.ai/company-id"]).toBe("c-uuid");
+    expect(ns.metadata.labels?.["pod-security.kubernetes.io/enforce"]).toBe("restricted");
+    expect(ns.metadata.labels?.["pod-security.kubernetes.io/audit"]).toBe("restricted");
+    expect(ns.metadata.labels?.["pod-security.kubernetes.io/warn"]).toBe("restricted");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test namespace`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `buildNamespace` and `applyNamespace`**
+
+```ts
+import type { V1Namespace } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import {
+  PSS_ENFORCE, PSS_AUDIT, PSS_WARN, PSS_RESTRICTED,
+  tenantBaseLabels, PAPERCLIP_MANAGED_BY, PAPERCLIP_MANAGED_BY_VALUE,
+} from "./labels.js";
+
+export interface BuildNamespaceInput {
+  name: string;
+  companyId: string;
+  companySlug: string;
+  extraLabels?: Record<string, string>;
+}
+
+export function buildNamespace(input: BuildNamespaceInput): V1Namespace {
+  return {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+      name: input.name,
+      labels: {
+        ...tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+        [PSS_ENFORCE]: PSS_RESTRICTED,
+        [PSS_AUDIT]:   PSS_RESTRICTED,
+        [PSS_WARN]:    PSS_RESTRICTED,
+        ...input.extraLabels,
+      },
+    },
+  };
+}
+
+/**
+ * Idempotently apply a tenant namespace. Refuses to overwrite a namespace
+ * that is not labeled paperclip.ai/managed-by=paperclip.
+ */
+export async function applyNamespace(
+  client: KubernetesApiClient,
+  ns: V1Namespace,
+): Promise<{ created: boolean }> {
+  const name = ns.metadata!.name!;
+  try {
+    const existing = await client.core.readNamespace(name);
+    const managed = existing.body.metadata?.labels?.[PAPERCLIP_MANAGED_BY];
+    if (managed !== PAPERCLIP_MANAGED_BY_VALUE) {
+      throw new Error(
+        `Refusing to manage namespace "${name}": missing label ${PAPERCLIP_MANAGED_BY}=${PAPERCLIP_MANAGED_BY_VALUE}`,
+      );
+    }
+    // Patch labels (server-side apply would be cleaner; client-go uses strategic merge by default).
+    await client.core.patchNamespace(name, ns, undefined, undefined, undefined, undefined, undefined, {
+      headers: { "Content-Type": "application/strategic-merge-patch+json" },
+    } as never);
+    return { created: false };
+  } catch (err: unknown) {
+    if (isNotFound(err)) {
+      await client.core.createNamespace(ns);
+      return { created: true };
+    }
+    throw err;
+  }
+}
+
+function isNotFound(err: unknown): boolean {
+  const code = (err as { response?: { statusCode?: number } })?.response?.statusCode;
+  return code === 404;
+}
+```
+
+- [ ] **Step 4: Run, expect builder test PASS**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test namespace`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/orchestrator/namespace.ts \
+        packages/adapters/kubernetes-execution/test/unit/namespace.test.ts
+git commit -m "feat(k8s-adapter): add tenant namespace builder and apply"
+```
+
+---
+
+## Task 10: RBAC builder + apply
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/rbac.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/rbac.test.ts`
+
+Reference: spec §2.2. The pod's SA has zero RBAC; the *driver's* identity is bound by the cluster operator (out of band) to a cluster-scoped Role we ship as YAML in the package's docs (see Task 23 doctor command). For M1 we only create the namespace-local ServiceAccount and a no-op Role for documentation purposes.
+
+- [ ] **Step 1: Write failing builder test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildAgentServiceAccount, buildDriverRoleBinding } from "../../src/orchestrator/rbac.js";
+
+describe("buildAgentServiceAccount", () => {
+  it("creates paperclip-agent SA with token automounting disabled", () => {
+    const sa = buildAgentServiceAccount({ namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme" });
+    expect(sa.metadata?.name).toBe("paperclip-agent");
+    expect(sa.metadata?.namespace).toBe("paperclip-acme");
+    expect(sa.automountServiceAccountToken).toBe(false);
+  });
+});
+
+describe("buildDriverRoleBinding", () => {
+  it("references the driver SA in its own namespace and the cluster role for tenant management", () => {
+    const rb = buildDriverRoleBinding({
+      namespace: "paperclip-acme",
+      driverServiceAccount: { name: "paperclip-driver", namespace: "paperclip-system" },
+      clusterRoleName: "paperclip-tenant-manager",
+      companyId: "c-1", companySlug: "acme",
+    });
+    expect(rb.subjects?.[0]).toMatchObject({ kind: "ServiceAccount", name: "paperclip-driver", namespace: "paperclip-system" });
+    expect(rb.roleRef.kind).toBe("ClusterRole");
+    expect(rb.roleRef.name).toBe("paperclip-tenant-manager");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test rbac`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `rbac.ts`**
+
+```ts
+import type { V1ServiceAccount, V1RoleBinding } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels } from "./labels.js";
+
+export interface BuildAgentServiceAccountInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+}
+
+export function buildAgentServiceAccount(input: BuildAgentServiceAccountInput): V1ServiceAccount {
+  return {
+    apiVersion: "v1",
+    kind: "ServiceAccount",
+    metadata: {
+      name: "paperclip-agent",
+      namespace: input.namespace,
+      labels: tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+    },
+    automountServiceAccountToken: false,
+  };
+}
+
+export interface BuildDriverRoleBindingInput {
+  namespace: string;
+  driverServiceAccount: { name: string; namespace: string };
+  clusterRoleName: string;
+  companyId: string;
+  companySlug: string;
+}
+
+export function buildDriverRoleBinding(input: BuildDriverRoleBindingInput): V1RoleBinding {
+  return {
+    apiVersion: "rbac.authorization.k8s.io/v1",
+    kind: "RoleBinding",
+    metadata: {
+      name: "paperclip-driver",
+      namespace: input.namespace,
+      labels: tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+    },
+    subjects: [{
+      kind: "ServiceAccount",
+      name: input.driverServiceAccount.name,
+      namespace: input.driverServiceAccount.namespace,
+    }],
+    roleRef: {
+      kind: "ClusterRole",
+      apiGroup: "rbac.authorization.k8s.io",
+      name: input.clusterRoleName,
+    },
+  };
+}
+
+export async function applyAgentServiceAccount(client: KubernetesApiClient, sa: V1ServiceAccount): Promise<void> {
+  const ns = sa.metadata!.namespace!;
+  const name = sa.metadata!.name!;
+  try {
+    await client.core.readNamespacedServiceAccount(name, ns);
+    await client.core.patchNamespacedServiceAccount(name, ns, sa, undefined, undefined, undefined, undefined, undefined, {
+      headers: { "Content-Type": "application/strategic-merge-patch+json" },
+    } as never);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await client.core.createNamespacedServiceAccount(ns, sa);
+      return;
+    }
+    throw err;
+  }
+}
+
+export async function applyDriverRoleBinding(client: KubernetesApiClient, rb: V1RoleBinding): Promise<void> {
+  const ns = rb.metadata!.namespace!;
+  const name = rb.metadata!.name!;
+  try {
+    await client.rbac.readNamespacedRoleBinding(name, ns);
+    // RoleBindings are immutable on roleRef; the only safe path is delete+create when subjects/role differ.
+    // For simplicity in M1 we delete-and-create on every apply.
+    await client.rbac.deleteNamespacedRoleBinding(name, ns);
+    await client.rbac.createNamespacedRoleBinding(ns, rb);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await client.rbac.createNamespacedRoleBinding(ns, rb);
+      return;
+    }
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test rbac`
+Expected: PASS.
+
+- [ ] **Step 5: Add the cluster-scoped Role manifest as a docs/reference YAML**
+
+Create `packages/adapters/kubernetes-execution/manifests/paperclip-tenant-manager-clusterrole.yaml`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: paperclip-tenant-manager
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "resourcequotas", "limitranges", "secrets", "serviceaccounts", "configmaps", "persistentvolumeclaims", "pods", "pods/log", "pods/exec"]
+    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["cilium.io"]
+    resources: ["ciliumnetworkpolicies"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+```
+
+This is referenced by Task 23 (doctor) which prints the path to it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/orchestrator/rbac.ts \
+        packages/adapters/kubernetes-execution/test/unit/rbac.test.ts \
+        packages/adapters/kubernetes-execution/manifests/paperclip-tenant-manager-clusterrole.yaml
+git commit -m "feat(k8s-adapter): add tenant RBAC builders and reference ClusterRole"
+```
+
+---
+
+## Task 11: ResourceQuota + LimitRange builders + apply
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/resource-quota.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/resource-quota.test.ts`
+
+Reference: spec §2.6.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildResourceQuota, buildLimitRange, defaultTenantQuota, defaultTenantLimits } from "../../src/orchestrator/resource-quota.js";
+
+describe("buildResourceQuota", () => {
+  it("uses defaults when no tenant override is supplied", () => {
+    const q = buildResourceQuota({
+      namespace: "paperclip-acme",
+      companyId: "c-1",
+      companySlug: "acme",
+      override: null,
+    });
+    expect(q.spec?.hard?.["requests.cpu"]).toBe(defaultTenantQuota.requestsCpu);
+    expect(q.spec?.hard?.["count/jobs.batch"]).toBe(String(defaultTenantQuota.countJobs));
+  });
+
+  it("respects tenant override values", () => {
+    const q = buildResourceQuota({
+      namespace: "paperclip-acme",
+      companyId: "c-1",
+      companySlug: "acme",
+      override: { requestsCpu: "32", countJobs: 200 },
+    });
+    expect(q.spec?.hard?.["requests.cpu"]).toBe("32");
+    expect(q.spec?.hard?.["count/jobs.batch"]).toBe("200");
+  });
+});
+
+describe("buildLimitRange", () => {
+  it("emits Container + PVC limits", () => {
+    const lr = buildLimitRange({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme", override: null,
+    });
+    const container = lr.spec?.limits?.find(l => l.type === "Container");
+    expect(container?.default?.cpu).toBe(defaultTenantLimits.default.cpu);
+    expect(lr.spec?.limits?.find(l => l.type === "PersistentVolumeClaim")).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test resource-quota`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `resource-quota.ts`**
+
+```ts
+import type { V1ResourceQuota, V1LimitRange } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels } from "./labels.js";
+
+export const defaultTenantQuota = {
+  requestsCpu:    "16",
+  requestsMemory: "64Gi",
+  limitsCpu:      "64",
+  limitsMemory:   "256Gi",
+  requestsStorage:"200Gi",
+  countJobs:      100,
+  countPvcs:      50,
+  countSecrets:   200,
+  countConfigMaps:200,
+};
+
+export const defaultTenantLimits = {
+  default:        { cpu: "1",    memory: "2Gi" },
+  defaultRequest: { cpu: "250m", memory: "512Mi" },
+  max:            { cpu: "8",    memory: "32Gi" },
+  pvcMaxStorage:  "20Gi",
+};
+
+export interface QuotaOverride {
+  requestsCpu?: string;
+  requestsMemory?: string;
+  limitsCpu?: string;
+  limitsMemory?: string;
+  requestsStorage?: string;
+  countJobs?: number;
+  countPvcs?: number;
+  countSecrets?: number;
+  countConfigMaps?: number;
+}
+
+export interface LimitRangeOverride {
+  default?:        { cpu?: string; memory?: string };
+  defaultRequest?: { cpu?: string; memory?: string };
+  max?:            { cpu?: string; memory?: string };
+  pvcMaxStorage?:  string;
+}
+
+export interface BuildQuotaInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+  override: QuotaOverride | null;
+}
+
+export function buildResourceQuota(input: BuildQuotaInput): V1ResourceQuota {
+  const o = { ...defaultTenantQuota, ...(input.override ?? {}) };
+  return {
+    apiVersion: "v1",
+    kind: "ResourceQuota",
+    metadata: {
+      name: "paperclip-tenant-quota",
+      namespace: input.namespace,
+      labels: tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+    },
+    spec: {
+      hard: {
+        "requests.cpu":                    o.requestsCpu,
+        "requests.memory":                 o.requestsMemory,
+        "limits.cpu":                      o.limitsCpu,
+        "limits.memory":                   o.limitsMemory,
+        "requests.storage":                o.requestsStorage,
+        "count/jobs.batch":                String(o.countJobs),
+        "count/persistentvolumeclaims":    String(o.countPvcs),
+        "count/secrets":                   String(o.countSecrets),
+        "count/configmaps":                String(o.countConfigMaps),
+      },
+    },
+  };
+}
+
+export interface BuildLimitRangeInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+  override: LimitRangeOverride | null;
+}
+
+export function buildLimitRange(input: BuildLimitRangeInput): V1LimitRange {
+  const o = {
+    default:        { ...defaultTenantLimits.default,        ...(input.override?.default        ?? {}) },
+    defaultRequest: { ...defaultTenantLimits.defaultRequest, ...(input.override?.defaultRequest ?? {}) },
+    max:            { ...defaultTenantLimits.max,            ...(input.override?.max            ?? {}) },
+    pvcMaxStorage:  input.override?.pvcMaxStorage ?? defaultTenantLimits.pvcMaxStorage,
+  };
+  return {
+    apiVersion: "v1",
+    kind: "LimitRange",
+    metadata: {
+      name: "paperclip-tenant-limits",
+      namespace: input.namespace,
+      labels: tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+    },
+    spec: {
+      limits: [
+        { type: "Container", default: o.default, defaultRequest: o.defaultRequest, max: o.max },
+        { type: "PersistentVolumeClaim", max: { storage: o.pvcMaxStorage } },
+      ],
+    },
+  };
+}
+
+export async function applyResourceQuota(client: KubernetesApiClient, q: V1ResourceQuota): Promise<void> {
+  await upsertNamespaced(client, q, async (ns, name) => client.core.readNamespacedResourceQuota(name, ns), async (ns, name, body) => client.core.patchNamespacedResourceQuota(name, ns, body, undefined, undefined, undefined, undefined, undefined, { headers: { "Content-Type": "application/strategic-merge-patch+json" } } as never), async (ns, body) => client.core.createNamespacedResourceQuota(ns, body));
+}
+
+export async function applyLimitRange(client: KubernetesApiClient, lr: V1LimitRange): Promise<void> {
+  await upsertNamespaced(client, lr, async (ns, name) => client.core.readNamespacedLimitRange(name, ns), async (ns, name, body) => client.core.patchNamespacedLimitRange(name, ns, body, undefined, undefined, undefined, undefined, undefined, { headers: { "Content-Type": "application/strategic-merge-patch+json" } } as never), async (ns, body) => client.core.createNamespacedLimitRange(ns, body));
+}
+
+async function upsertNamespaced<T extends { metadata?: { name?: string; namespace?: string } }>(
+  _client: KubernetesApiClient,
+  obj: T,
+  read: (ns: string, name: string) => Promise<unknown>,
+  patch: (ns: string, name: string, body: T) => Promise<unknown>,
+  create: (ns: string, body: T) => Promise<unknown>,
+): Promise<void> {
+  const ns = obj.metadata!.namespace!;
+  const name = obj.metadata!.name!;
+  try {
+    await read(ns, name);
+    await patch(ns, name, obj);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await create(ns, obj);
+      return;
+    }
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test resource-quota`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/orchestrator/resource-quota.ts \
+        packages/adapters/kubernetes-execution/test/unit/resource-quota.test.ts
+git commit -m "feat(k8s-adapter): add ResourceQuota and LimitRange builders"
+```
+
+---
+
+## Task 12: NetworkPolicy (vanilla) builder + apply
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/network-policy.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/network-policy.test.ts`
+
+Reference: spec §2.3.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildDefaultDenyPolicies, buildAgentEgressPolicy } from "../../src/orchestrator/network-policy.js";
+
+describe("buildDefaultDenyPolicies", () => {
+  it("emits two NetworkPolicies, one for ingress and one for egress, with empty podSelector", () => {
+    const policies = buildDefaultDenyPolicies({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+    });
+    expect(policies).toHaveLength(2);
+    for (const p of policies) {
+      expect(p.spec?.podSelector).toEqual({});
+    }
+    expect(policies[0].spec?.policyTypes).toContain("Ingress");
+    expect(policies[1].spec?.policyTypes).toContain("Egress");
+  });
+});
+
+describe("buildAgentEgressPolicy", () => {
+  it("denies RFC1918 + link-local + CGNAT + IPv6 ULA in the internet rule", () => {
+    const p = buildAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      topology: "in-cluster",
+      controlPlaneSelector: { namespaceLabel: { "paperclip.ai/role": "control-plane" }, podLabel: { "app.kubernetes.io/name": "paperclip-server" } },
+    });
+    const internetRule = p.spec?.egress?.find(e => e.to?.some(t => t.ipBlock));
+    expect(internetRule).toBeDefined();
+    const ipBlock = internetRule!.to!.find(t => t.ipBlock)!.ipBlock!;
+    expect(ipBlock.cidr).toBe("0.0.0.0/0");
+    expect(ipBlock.except).toEqual(expect.arrayContaining([
+      "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "169.254.0.0/16", "100.64.0.0/10", "fd00::/8",
+    ]));
+  });
+
+  it("omits the in-cluster control plane rule for cross-cluster topology", () => {
+    const p = buildAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      topology: "cross-cluster",
+      controlPlaneSelector: null,
+    });
+    expect(p.spec?.egress?.some(e =>
+      e.to?.some(t => t.namespaceSelector?.matchLabels?.["paperclip.ai/role"] === "control-plane"),
+    )).toBe(false);
+  });
+
+  it("targets only pods labeled paperclip.ai/role=agent-runtime", () => {
+    const p = buildAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      topology: "in-cluster",
+      controlPlaneSelector: { namespaceLabel: {}, podLabel: {} },
+    });
+    expect(p.spec?.podSelector?.matchLabels?.["paperclip.ai/role"]).toBe("agent-runtime");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test network-policy`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `network-policy.ts`**
+
+```ts
+import type { V1NetworkPolicy } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels, PAPERCLIP_ROLE, ROLE_AGENT_RUNTIME } from "./labels.js";
+
+const RFC1918_AND_INTERNAL_DENY = [
+  "10.0.0.0/8",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+  "169.254.0.0/16",   // link-local incl. cloud metadata
+  "100.64.0.0/10",    // CGNAT
+  "fd00::/8",         // IPv6 ULA
+];
+
+export interface BuildDefaultDenyInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+}
+
+export function buildDefaultDenyPolicies(input: BuildDefaultDenyInput): V1NetworkPolicy[] {
+  const labels = tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug });
+  return [
+    {
+      apiVersion: "networking.k8s.io/v1",
+      kind: "NetworkPolicy",
+      metadata: { name: "default-deny-ingress", namespace: input.namespace, labels },
+      spec: { podSelector: {}, policyTypes: ["Ingress"] },
+    },
+    {
+      apiVersion: "networking.k8s.io/v1",
+      kind: "NetworkPolicy",
+      metadata: { name: "default-deny-egress", namespace: input.namespace, labels },
+      spec: { podSelector: {}, policyTypes: ["Egress"] },
+    },
+  ];
+}
+
+export interface AgentEgressInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+  topology: "in-cluster" | "cross-cluster";
+  controlPlaneSelector: {
+    namespaceLabel: Record<string, string>;
+    podLabel: Record<string, string>;
+  } | null;
+}
+
+export function buildAgentEgressPolicy(input: AgentEgressInput): V1NetworkPolicy {
+  const labels = tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug });
+  const egress: NonNullable<V1NetworkPolicy["spec"]>["egress"] = [
+    // DNS
+    {
+      to: [{
+        namespaceSelector: { matchLabels: { "kubernetes.io/metadata.name": "kube-system" } },
+        podSelector:       { matchLabels: { "k8s-app": "kube-dns" } },
+      }],
+      ports: [{ port: 53, protocol: "UDP" }, { port: 53, protocol: "TCP" }],
+    },
+  ];
+
+  if (input.topology === "in-cluster" && input.controlPlaneSelector) {
+    egress.push({
+      to: [{
+        namespaceSelector: { matchLabels: input.controlPlaneSelector.namespaceLabel },
+        podSelector:       { matchLabels: input.controlPlaneSelector.podLabel },
+      }],
+      ports: [{ port: 443, protocol: "TCP" }, { port: 3102, protocol: "TCP" }],
+    });
+  }
+
+  // Internet egress (denies internal ranges)
+  egress.push({
+    to: [{ ipBlock: { cidr: "0.0.0.0/0", except: RFC1918_AND_INTERNAL_DENY } }],
+    ports: [{ port: 443, protocol: "TCP" }],
+  });
+
+  return {
+    apiVersion: "networking.k8s.io/v1",
+    kind: "NetworkPolicy",
+    metadata: { name: "paperclip-agent-egress", namespace: input.namespace, labels },
+    spec: {
+      podSelector: { matchLabels: { [PAPERCLIP_ROLE]: ROLE_AGENT_RUNTIME } },
+      policyTypes: ["Egress"],
+      egress,
+    },
+  };
+}
+
+export async function applyNetworkPolicy(client: KubernetesApiClient, p: V1NetworkPolicy): Promise<void> {
+  const ns = p.metadata!.namespace!;
+  const name = p.metadata!.name!;
+  try {
+    await client.networking.readNamespacedNetworkPolicy(name, ns);
+    await client.networking.patchNamespacedNetworkPolicy(name, ns, p, undefined, undefined, undefined, undefined, undefined, {
+      headers: { "Content-Type": "application/strategic-merge-patch+json" },
+    } as never);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await client.networking.createNamespacedNetworkPolicy(ns, p);
+      return;
+    }
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test network-policy`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/orchestrator/network-policy.ts \
+        packages/adapters/kubernetes-execution/test/unit/network-policy.test.ts
+git commit -m "feat(k8s-adapter): add vanilla NetworkPolicy builders"
+```
+
+---
+
+## Task 13: Cilium NetworkPolicy builder + apply
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/cilium-network-policy.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/cilium-network-policy.test.ts`
+
+Reference: spec §2.4.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildCiliumAgentEgressPolicy } from "../../src/orchestrator/cilium-network-policy.js";
+
+describe("buildCiliumAgentEgressPolicy", () => {
+  it("merges adapter and tenant FQDN allowlists, deduplicated", () => {
+    const p = buildCiliumAgentEgressPolicy({
+      namespace: "paperclip-acme",
+      companyId: "c-1",
+      companySlug: "acme",
+      adapterAllowFqdns: ["*.anthropic.com", "github.com"],
+      tenantAllowFqdns: ["github.com", "*.acme.io"],
+      controlPlaneSelector: { matchLabels: { "paperclip.ai/role": "control-plane" } },
+    });
+    const fqdns = p.spec.egress[0].toFQDNs!.map((f: any) => f.matchPattern ?? f.matchName).sort();
+    expect(fqdns).toEqual(["*.acme.io", "*.anthropic.com", "github.com"]);
+  });
+
+  it("emits a separate egress rule for the in-cluster control plane endpoint", () => {
+    const p = buildCiliumAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      adapterAllowFqdns: [], tenantAllowFqdns: [],
+      controlPlaneSelector: { matchLabels: { "paperclip.ai/role": "control-plane" } },
+    });
+    expect(p.spec.egress.some((r: any) =>
+      r.toEndpoints?.some((e: any) => e.matchLabels?.["paperclip.ai/role"] === "control-plane"),
+    )).toBe(true);
+  });
+
+  it("omits the control-plane endpoint rule when none provided (cross-cluster)", () => {
+    const p = buildCiliumAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      adapterAllowFqdns: ["api.anthropic.com"], tenantAllowFqdns: [],
+      controlPlaneSelector: null,
+    });
+    expect(p.spec.egress.some((r: any) => r.toEndpoints)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test cilium-network-policy`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `cilium-network-policy.ts`**
+
+```ts
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels, PAPERCLIP_ROLE, ROLE_AGENT_RUNTIME } from "./labels.js";
+
+interface CiliumFqdn {
+  matchPattern?: string;
+  matchName?: string;
+}
+
+export interface CiliumNetworkPolicyDoc {
+  apiVersion: "cilium.io/v2";
+  kind: "CiliumNetworkPolicy";
+  metadata: { name: string; namespace: string; labels?: Record<string, string> };
+  spec: {
+    endpointSelector: { matchLabels: Record<string, string> };
+    egress: Array<{
+      toFQDNs?: CiliumFqdn[];
+      toEndpoints?: Array<{ matchLabels: Record<string, string> }>;
+      toPorts?: Array<{ ports: Array<{ port: string; protocol: string }> }>;
+    }>;
+  };
+}
+
+export interface BuildCiliumInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+  adapterAllowFqdns: string[];
+  tenantAllowFqdns: string[];
+  controlPlaneSelector: { matchLabels: Record<string, string> } | null;
+}
+
+export function buildCiliumAgentEgressPolicy(input: BuildCiliumInput): CiliumNetworkPolicyDoc {
+  const labels = tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug });
+  const merged = Array.from(new Set([...input.adapterAllowFqdns, ...input.tenantAllowFqdns])).sort();
+  const fqdns: CiliumFqdn[] = merged.map(p => p.includes("*") ? { matchPattern: p } : { matchName: p });
+
+  const egress: CiliumNetworkPolicyDoc["spec"]["egress"] = [];
+  if (fqdns.length > 0) {
+    egress.push({ toFQDNs: fqdns, toPorts: [{ ports: [{ port: "443", protocol: "TCP" }] }] });
+  }
+  if (input.controlPlaneSelector) {
+    egress.push({
+      toEndpoints: [{ matchLabels: input.controlPlaneSelector.matchLabels }],
+      toPorts: [{ ports: [{ port: "443", protocol: "TCP" }] }],
+    });
+  }
+
+  return {
+    apiVersion: "cilium.io/v2",
+    kind: "CiliumNetworkPolicy",
+    metadata: { name: "paperclip-agent-egress-l7", namespace: input.namespace, labels },
+    spec: {
+      endpointSelector: { matchLabels: { [PAPERCLIP_ROLE]: ROLE_AGENT_RUNTIME } },
+      egress,
+    },
+  };
+}
+
+export async function applyCiliumNetworkPolicy(client: KubernetesApiClient, p: CiliumNetworkPolicyDoc): Promise<void> {
+  const ns = p.metadata.namespace;
+  const name = p.metadata.name;
+  const path = `/apis/cilium.io/v2/namespaces/${encodeURIComponent(ns)}/ciliumnetworkpolicies/${encodeURIComponent(name)}`;
+  try {
+    await client.request("GET", path);
+    await client.request("PUT", path, p);
+  } catch (err: unknown) {
+    if (/404/.test(String(err))) {
+      await client.request(
+        "POST",
+        `/apis/cilium.io/v2/namespaces/${encodeURIComponent(ns)}/ciliumnetworkpolicies`,
+        p,
+      );
+      return;
+    }
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test cilium-network-policy`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/orchestrator/cilium-network-policy.ts \
+        packages/adapters/kubernetes-execution/test/unit/cilium-network-policy.test.ts
+git commit -m "feat(k8s-adapter): add Cilium NetworkPolicy builder for FQDN allowlist"
+```
+
+---
+
+## Task 14: Image pull secret builder + apply
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/image-pull-secret.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/image-pull-secret.test.ts`
+
+Reference: spec §5.3. The Paperclip secret reference resolution is plugged in via a callback so the package itself stays agnostic of Paperclip's secret store.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildImagePullSecret } from "../../src/orchestrator/image-pull-secret.js";
+
+describe("buildImagePullSecret", () => {
+  it("base64-encodes the dockerconfigjson and sets the dockerconfigjson type", () => {
+    const dockerConfig = { auths: { "ghcr.io": { auth: "Zm9vOmJhcg==" } } };
+    const s = buildImagePullSecret({
+      namespace: "paperclip-acme",
+      companyId: "c-1", companySlug: "acme",
+      dockerConfigJson: JSON.stringify(dockerConfig),
+    });
+    expect(s.type).toBe("kubernetes.io/dockerconfigjson");
+    expect(s.metadata?.name).toBe("paperclip-image-pull");
+    expect(s.data?.[".dockerconfigjson"]).toBeDefined();
+    const decoded = Buffer.from(s.data![".dockerconfigjson"], "base64").toString("utf-8");
+    expect(JSON.parse(decoded)).toEqual(dockerConfig);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test image-pull-secret`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `image-pull-secret.ts`**
+
+```ts
+import type { V1Secret } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels } from "./labels.js";
+
+export interface BuildImagePullSecretInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+  /** A docker config JSON string already resolved from a Paperclip secret_ref. */
+  dockerConfigJson: string;
+}
+
+export function buildImagePullSecret(input: BuildImagePullSecretInput): V1Secret {
+  return {
+    apiVersion: "v1",
+    kind: "Secret",
+    metadata: {
+      name: "paperclip-image-pull",
+      namespace: input.namespace,
+      labels: tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+    },
+    type: "kubernetes.io/dockerconfigjson",
+    data: {
+      ".dockerconfigjson": Buffer.from(input.dockerConfigJson, "utf-8").toString("base64"),
+    },
+  };
+}
+
+export async function applyImagePullSecret(client: KubernetesApiClient, s: V1Secret): Promise<void> {
+  const ns = s.metadata!.namespace!;
+  const name = s.metadata!.name!;
+  try {
+    await client.core.readNamespacedSecret(name, ns);
+    await client.core.patchNamespacedSecret(name, ns, s, undefined, undefined, undefined, undefined, undefined, {
+      headers: { "Content-Type": "application/strategic-merge-patch+json" },
+    } as never);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await client.core.createNamespacedSecret(ns, s);
+      return;
+    }
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test image-pull-secret`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/orchestrator/image-pull-secret.ts \
+        packages/adapters/kubernetes-execution/test/unit/image-pull-secret.test.ts
+git commit -m "feat(k8s-adapter): add per-namespace image pull secret builder"
+```
+
+---
+
+## Task 15: ensureTenantNamespace orchestrator
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/ensure-tenant.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/ensure-tenant.test.ts`
+
+Reference: spec §2.1 (provisioning). This is the integrator that combines Tasks 7–14.
+
+- [ ] **Step 1: Write failing test that uses mocked applies and asserts ordering and labels**
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { ensureTenantNamespace, type EnsureTenantInput } from "../../src/orchestrator/ensure-tenant.js";
+
+function makeFakeClient() {
+  return {
+    core: {
+      readNamespace: vi.fn(async () => { const e = new Error("not found"); (e as any).response = { statusCode: 404 }; throw e; }),
+      createNamespace: vi.fn(async () => ({})),
+      patchNamespace: vi.fn(async () => ({})),
+      readNamespacedServiceAccount: vi.fn(async () => { const e = new Error("nf"); (e as any).response = { statusCode: 404 }; throw e; }),
+      createNamespacedServiceAccount: vi.fn(async () => ({})),
+      readNamespacedResourceQuota: vi.fn(async () => { const e = new Error("nf"); (e as any).response = { statusCode: 404 }; throw e; }),
+      createNamespacedResourceQuota: vi.fn(async () => ({})),
+      readNamespacedLimitRange: vi.fn(async () => { const e = new Error("nf"); (e as any).response = { statusCode: 404 }; throw e; }),
+      createNamespacedLimitRange: vi.fn(async () => ({})),
+      readNamespacedSecret: vi.fn(async () => { const e = new Error("nf"); (e as any).response = { statusCode: 404 }; throw e; }),
+      createNamespacedSecret: vi.fn(async () => ({})),
+    },
+    rbac: {
+      readNamespacedRoleBinding: vi.fn(async () => { const e = new Error("nf"); (e as any).response = { statusCode: 404 }; throw e; }),
+      createNamespacedRoleBinding: vi.fn(async () => ({})),
+      deleteNamespacedRoleBinding: vi.fn(async () => ({})),
+    },
+    networking: {
+      readNamespacedNetworkPolicy: vi.fn(async () => { const e = new Error("nf"); (e as any).response = { statusCode: 404 }; throw e; }),
+      createNamespacedNetworkPolicy: vi.fn(async () => ({})),
+    },
+    request: vi.fn(async () => ({})),
+  } as never;
+}
+
+describe("ensureTenantNamespace", () => {
+  it("creates Namespace before any namespaced object", async () => {
+    const client = makeFakeClient();
+    const input: EnsureTenantInput = {
+      connection: {
+        id: "c-1", label: "test", kind: "kubeconfig", kubeconfigYaml: "<unused>",
+        defaultNamespacePrefix: "paperclip-",
+        allowAgentImageOverride: false,
+        capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      },
+      company: { id: "11111111-1111-1111-1111-111111111111", slug: "acme-corp" },
+      tenantPolicy: null,
+      driverServiceAccount: { name: "paperclip-driver", namespace: "paperclip-system" },
+      controlPlane: { topology: "in-cluster", namespaceLabels: { "paperclip.ai/role": "control-plane" }, podLabels: { "app.kubernetes.io/name": "paperclip-server" } },
+      adapterAllowFqdns: ["*.anthropic.com"],
+      imagePullDockerConfigJson: null,
+    };
+
+    const result = await ensureTenantNamespace(client, input);
+    expect(result.namespace).toBe("paperclip-acme-corp");
+    expect(client.core.createNamespace).toHaveBeenCalledTimes(1);
+    expect(client.core.createNamespacedServiceAccount).toHaveBeenCalledTimes(1);
+    expect(client.core.createNamespacedResourceQuota).toHaveBeenCalledTimes(1);
+    expect(client.core.createNamespacedLimitRange).toHaveBeenCalledTimes(1);
+    expect(client.networking.createNamespacedNetworkPolicy).toHaveBeenCalledTimes(3); // 2 deny + 1 egress
+    // Cilium is disabled in capabilities -> no CNP request
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("emits a Cilium policy when cluster supports it", async () => {
+    const client = makeFakeClient();
+    client.request = vi.fn(async (method: string) => method === "GET" ? { kind: "ok" } : ({})); // for GET and PUT/POST
+    const input: EnsureTenantInput = {
+      connection: {
+        id: "c-1", label: "t", kind: "kubeconfig", kubeconfigYaml: "x",
+        defaultNamespacePrefix: "paperclip-",
+        allowAgentImageOverride: false,
+        capabilities: { cilium: true, storageClass: "standard", architectures: ["amd64"] },
+      },
+      company: { id: "22222222-2222-2222-2222-222222222222", slug: "acme" },
+      tenantPolicy: null,
+      driverServiceAccount: { name: "drv", namespace: "paperclip-system" },
+      controlPlane: { topology: "in-cluster", namespaceLabels: { "paperclip.ai/role": "control-plane" }, podLabels: { "app.kubernetes.io/name": "paperclip-server" } },
+      adapterAllowFqdns: ["api.anthropic.com"],
+      imagePullDockerConfigJson: null,
+    };
+    await ensureTenantNamespace(client, input);
+    expect(client.request).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test ensure-tenant`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `ensure-tenant.ts`**
+
+```ts
+import type { KubernetesApiClient, ResolvedClusterConnection } from "../types.js";
+import { deriveNamespaceName } from "./naming.js";
+import { buildNamespace, applyNamespace } from "./namespace.js";
+import { buildAgentServiceAccount, applyAgentServiceAccount, buildDriverRoleBinding, applyDriverRoleBinding } from "./rbac.js";
+import { buildResourceQuota, buildLimitRange, applyResourceQuota, applyLimitRange, type QuotaOverride, type LimitRangeOverride } from "./resource-quota.js";
+import { buildDefaultDenyPolicies, buildAgentEgressPolicy, applyNetworkPolicy } from "./network-policy.js";
+import { buildCiliumAgentEgressPolicy, applyCiliumNetworkPolicy } from "./cilium-network-policy.js";
+import { buildImagePullSecret, applyImagePullSecret } from "./image-pull-secret.js";
+
+export interface TenantPolicy {
+  quota: QuotaOverride | null;
+  limitRange: LimitRangeOverride | null;
+  additionalAllowFqdns: string[];
+  imageOverrides: Record<string, string> | null;
+}
+
+export interface EnsureTenantInput {
+  connection: ResolvedClusterConnection;
+  company: { id: string; slug: string };
+  tenantPolicy: TenantPolicy | null;
+  driverServiceAccount: { name: string; namespace: string };
+  controlPlane: {
+    topology: "in-cluster" | "cross-cluster";
+    namespaceLabels: Record<string, string>;
+    podLabels: Record<string, string>;
+  };
+  adapterAllowFqdns: string[];
+  /** Resolved registry credentials. If null, no image pull secret is created. */
+  imagePullDockerConfigJson: string | null;
+}
+
+export interface EnsureTenantResult {
+  namespace: string;
+  ciliumApplied: boolean;
+}
+
+export async function ensureTenantNamespace(
+  client: KubernetesApiClient,
+  input: EnsureTenantInput,
+): Promise<EnsureTenantResult> {
+  const namespace = deriveNamespaceName({
+    companySlug: input.company.slug,
+    companyId: input.company.id,
+    prefix: input.connection.defaultNamespacePrefix,
+  });
+
+  // 1. Namespace (must come first; everything below is namespaced).
+  await applyNamespace(client, buildNamespace({
+    name: namespace,
+    companyId: input.company.id,
+    companySlug: input.company.slug,
+  }));
+
+  // 2. RBAC.
+  await applyAgentServiceAccount(client, buildAgentServiceAccount({
+    namespace, companyId: input.company.id, companySlug: input.company.slug,
+  }));
+  await applyDriverRoleBinding(client, buildDriverRoleBinding({
+    namespace,
+    driverServiceAccount: input.driverServiceAccount,
+    clusterRoleName: "paperclip-tenant-manager",
+    companyId: input.company.id, companySlug: input.company.slug,
+  }));
+
+  // 3. Quota & LimitRange.
+  await applyResourceQuota(client, buildResourceQuota({
+    namespace, companyId: input.company.id, companySlug: input.company.slug,
+    override: input.tenantPolicy?.quota ?? null,
+  }));
+  await applyLimitRange(client, buildLimitRange({
+    namespace, companyId: input.company.id, companySlug: input.company.slug,
+    override: input.tenantPolicy?.limitRange ?? null,
+  }));
+
+  // 4. NetworkPolicies (vanilla — always).
+  for (const p of buildDefaultDenyPolicies({
+    namespace, companyId: input.company.id, companySlug: input.company.slug,
+  })) {
+    await applyNetworkPolicy(client, p);
+  }
+  await applyNetworkPolicy(client, buildAgentEgressPolicy({
+    namespace,
+    companyId: input.company.id,
+    companySlug: input.company.slug,
+    topology: input.controlPlane.topology,
+    controlPlaneSelector: input.controlPlane.topology === "in-cluster"
+      ? { namespaceLabel: input.controlPlane.namespaceLabels, podLabel: input.controlPlane.podLabels }
+      : null,
+  }));
+
+  // 5. Cilium policy (only when cluster supports it).
+  let ciliumApplied = false;
+  if (input.connection.capabilities.cilium) {
+    await applyCiliumNetworkPolicy(client, buildCiliumAgentEgressPolicy({
+      namespace,
+      companyId: input.company.id,
+      companySlug: input.company.slug,
+      adapterAllowFqdns: input.adapterAllowFqdns,
+      tenantAllowFqdns: input.tenantPolicy?.additionalAllowFqdns ?? [],
+      controlPlaneSelector: input.controlPlane.topology === "in-cluster"
+        ? { matchLabels: input.controlPlane.namespaceLabels }
+        : null,
+    }));
+    ciliumApplied = true;
+  }
+
+  // 6. Image pull secret (when registry creds were supplied).
+  if (input.imagePullDockerConfigJson) {
+    await applyImagePullSecret(client, buildImagePullSecret({
+      namespace, companyId: input.company.id, companySlug: input.company.slug,
+      dockerConfigJson: input.imagePullDockerConfigJson,
+    }));
+  }
+
+  return { namespace, ciliumApplied };
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test ensure-tenant`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/orchestrator/ensure-tenant.ts \
+        packages/adapters/kubernetes-execution/test/unit/ensure-tenant.test.ts
+git commit -m "feat(k8s-adapter): add ensureTenantNamespace orchestrator"
+```
+
+---
+
+## Task 16: Driver skeleton (validate + ensureTenant; run() stub)
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/driver.ts`
+- Modify: `packages/adapters/kubernetes-execution/src/index.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/driver.test.ts`
+
+The driver is the public surface that the server's registry consumes. In M1 it implements `validateTarget` and `ensureTenant`; `run` returns a clear "not yet implemented" result so M2 can replace it.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createKubernetesExecutionDriver } from "../../src/driver.js";
+
+describe("KubernetesExecutionDriver", () => {
+  it("rejects non-kubernetes targets at validate", async () => {
+    const driver = createKubernetesExecutionDriver({ resolveConnection: async () => null });
+    await expect(driver.validateTarget({ kind: "local" } as never))
+      .rejects.toThrow(/kubernetes/i);
+  });
+
+  it("rejects unknown clusterConnectionId", async () => {
+    const driver = createKubernetesExecutionDriver({ resolveConnection: async () => null });
+    await expect(driver.validateTarget({ kind: "kubernetes", clusterConnectionId: "missing" }))
+      .rejects.toThrow(/cluster connection.+not found/i);
+  });
+
+  it("returns NOT_YET_SUPPORTED from run() in M1", async () => {
+    const driver = createKubernetesExecutionDriver({ resolveConnection: async () => null });
+    const result = await driver.run({
+      ctx: { runId: "r-1", agent: { id: "a-1", companyId: "c-1", name: "x", adapterType: "claude_local", adapterConfig: {} }, runtime: {} as never, config: {}, context: {}, onLog: async () => {} },
+      target: { kind: "kubernetes", clusterConnectionId: "c-1" },
+    });
+    expect(result.errorCode).toBe("execution_target_not_yet_supported");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test driver`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `driver.ts`**
+
+```ts
+import type { AdapterExecutionContext, AdapterExecutionResult, AdapterKubernetesExecutionTarget } from "@paperclipai/adapter-utils";
+import { ensureTenantNamespace, type EnsureTenantInput } from "./orchestrator/ensure-tenant.js";
+import { createKubernetesApiClient } from "./client.js";
+import type { ResolvedClusterConnection } from "./types.js";
+
+export interface KubernetesExecutionDriver {
+  type: "kubernetes";
+  validateTarget(target: unknown): Promise<void>;
+  ensureTenant(input: Omit<EnsureTenantInput, "connection"> & { connection?: never; clusterConnectionId: string }): Promise<{ namespace: string; ciliumApplied: boolean }>;
+  run(input: { ctx: AdapterExecutionContext; target: AdapterKubernetesExecutionTarget }): Promise<AdapterExecutionResult>;
+}
+
+export interface KubernetesDriverDeps {
+  resolveConnection: (id: string) => Promise<ResolvedClusterConnection | null>;
+}
+
+export function createKubernetesExecutionDriver(deps: KubernetesDriverDeps): KubernetesExecutionDriver {
+  return {
+    type: "kubernetes",
+    async validateTarget(target) {
+      const t = target as { kind?: string; clusterConnectionId?: string };
+      if (t.kind !== "kubernetes") {
+        throw new Error(`KubernetesExecutionDriver received target with kind=${t.kind}, expected "kubernetes"`);
+      }
+      if (!t.clusterConnectionId) {
+        throw new Error(`KubernetesExecutionDriver target is missing clusterConnectionId`);
+      }
+      const connection = await deps.resolveConnection(t.clusterConnectionId);
+      if (!connection) {
+        throw new Error(`Cluster connection ${t.clusterConnectionId} not found`);
+      }
+    },
+    async ensureTenant({ clusterConnectionId, ...rest }) {
+      const connection = await deps.resolveConnection(clusterConnectionId);
+      if (!connection) {
+        throw new Error(`Cluster connection ${clusterConnectionId} not found`);
+      }
+      const client = createKubernetesApiClient(connection);
+      return ensureTenantNamespace(client, { connection, ...rest } as EnsureTenantInput);
+    },
+    async run() {
+      return {
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+        errorCode: "execution_target_not_yet_supported",
+        errorMessage:
+          "Kubernetes agent execution lands in M2; M1 covers tenant provisioning only. " +
+          "Use `paperclipai cluster ensure-tenant <companyId>` to provision a namespace.",
+      };
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Re-export from `src/index.ts`**
+
+```ts
+export { createKubernetesExecutionDriver, type KubernetesExecutionDriver, type KubernetesDriverDeps } from "./driver.js";
+export { ensureTenantNamespace, type EnsureTenantInput, type TenantPolicy, type EnsureTenantResult } from "./orchestrator/ensure-tenant.js";
+export { createKubernetesApiClient } from "./client.js";
+export { probeClusterCapabilities } from "./orchestrator/capabilities.js";
+export { deriveNamespaceName } from "./orchestrator/naming.js";
+export type { ResolvedClusterConnection, ClusterCapabilities, KubernetesApiClient } from "./types.js";
+```
+
+- [ ] **Step 5: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test driver`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/driver.ts \
+        packages/adapters/kubernetes-execution/src/index.ts \
+        packages/adapters/kubernetes-execution/test/unit/driver.test.ts
+git commit -m "feat(k8s-adapter): add driver skeleton with validateTarget and ensureTenant"
+```
+
+---
+
+## Task 17: Server-side ExecutionTargetDriverRegistry
+
+**Files:**
+- Create: `server/src/adapters/execution-target-registry.ts`
+- Create: `server/src/adapters/execution-target-registry.test.ts`
+
+Reference: spec §1.2 (the platform-module-style registry).
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { createExecutionTargetRegistry } from "./execution-target-registry.js";
+
+describe("ExecutionTargetDriverRegistry", () => {
+  it("registers and retrieves a driver by kind", () => {
+    const reg = createExecutionTargetRegistry();
+    const fakeDriver = { type: "kubernetes" as const, validateTarget: async () => {}, ensureTenant: async () => ({ namespace: "x", ciliumApplied: false }), run: async () => ({ exitCode: 0, signal: null, timedOut: false }) };
+    reg.register(fakeDriver as never);
+    expect(reg.get("kubernetes")).toBe(fakeDriver);
+  });
+
+  it("rejects duplicate registrations of the same kind", () => {
+    const reg = createExecutionTargetRegistry();
+    const d = { type: "kubernetes" as const } as never;
+    reg.register(d);
+    expect(() => reg.register(d)).toThrow(/already registered/i);
+  });
+
+  it("returns null for unknown kinds", () => {
+    const reg = createExecutionTargetRegistry();
+    expect(reg.get("nomad")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/server test execution-target-registry`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `execution-target-registry.ts`**
+
+```ts
+import type { KubernetesExecutionDriver } from "@paperclipai/execution-target-kubernetes";
+
+// Future kinds union with their driver shapes here.
+export type ExecutionTargetDriver = KubernetesExecutionDriver;
+
+export interface ExecutionTargetDriverRegistry {
+  register(driver: ExecutionTargetDriver): void;
+  get(kind: ExecutionTargetDriver["type"]): ExecutionTargetDriver | null;
+  list(): ExecutionTargetDriver[];
+}
+
+export function createExecutionTargetRegistry(): ExecutionTargetDriverRegistry {
+  const drivers = new Map<string, ExecutionTargetDriver>();
+  return {
+    register(driver) {
+      if (drivers.has(driver.type)) {
+        throw new Error(`Execution target driver "${driver.type}" already registered`);
+      }
+      drivers.set(driver.type, driver);
+    },
+    get(kind) { return drivers.get(kind) ?? null; },
+    list() { return [...drivers.values()]; },
+  };
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/server test execution-target-registry`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/adapters/execution-target-registry.ts \
+        server/src/adapters/execution-target-registry.test.ts
+git commit -m "feat(server): add ExecutionTargetDriverRegistry"
+```
+
+---
+
+## Task 18: ClusterConnections service + secret resolution
+
+**Files:**
+- Create: `server/src/services/cluster-connections.ts`
+- Create: `server/src/services/cluster-connections.test.ts`
+
+- [ ] **Step 1: Write failing test (uses embedded postgres harness)**
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startEmbeddedPostgresTestDatabase, type EmbeddedPostgresTestDatabase } from "@paperclipai/db";
+import { clusterConnectionsService } from "./cluster-connections.js";
+
+let dbHandle: EmbeddedPostgresTestDatabase;
+
+beforeAll(async () => { dbHandle = await startEmbeddedPostgresTestDatabase(); });
+afterAll(async () => { await dbHandle.stop(); });
+
+describe("clusterConnectionsService", () => {
+  it("creates, lists, gets, and deletes a connection", async () => {
+    const svc = clusterConnectionsService(dbHandle.client, {
+      resolveSecret: async () => "fake-kubeconfig-yaml",
+    });
+    const created = await svc.create({
+      label: "kind-test",
+      kind: "kubeconfig",
+      kubeconfigSecretRef: { provider: "local_encrypted", name: "kind-cfg" },
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      createdBy: "system",
+    });
+    expect(created.id).toBeDefined();
+
+    const list = await svc.list();
+    expect(list).toHaveLength(1);
+
+    const fetched = await svc.get(created.id);
+    expect(fetched?.label).toBe("kind-test");
+
+    const resolved = await svc.resolve(created.id);
+    expect(resolved?.kubeconfigYaml).toBe("fake-kubeconfig-yaml");
+
+    await svc.delete(created.id);
+    expect(await svc.list()).toHaveLength(0);
+  });
+
+  it("rejects duplicate labels", async () => {
+    const svc = clusterConnectionsService(dbHandle.client, { resolveSecret: async () => "x" });
+    await svc.create({
+      label: "dupe", kind: "in-cluster",
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      createdBy: "system",
+    });
+    await expect(svc.create({
+      label: "dupe", kind: "in-cluster",
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      createdBy: "system",
+    })).rejects.toThrow(/label/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/server test cluster-connections`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `cluster-connections.ts`**
+
+```ts
+import { eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { clusterConnections } from "@paperclipai/db";
+import type { ResolvedClusterConnection, ClusterCapabilities } from "@paperclipai/execution-target-kubernetes";
+
+export interface ClusterConnectionRow {
+  id: string;
+  label: string;
+  kind: "in-cluster" | "kubeconfig";
+  kubeconfigSecretRef: { provider: string; name: string } | null;
+  apiServerUrl: string | null;
+  defaultNamespacePrefix: string;
+  capabilities: ClusterCapabilities;
+  paperclipPublicUrl: string | null;
+  imageRegistry: string | null;
+  allowAgentImageOverride: boolean;
+  createdAt: Date;
+  createdBy: string;
+}
+
+export interface CreateClusterConnectionInput {
+  label: string;
+  kind: "in-cluster" | "kubeconfig";
+  kubeconfigSecretRef?: { provider: string; name: string };
+  apiServerUrl?: string;
+  defaultNamespacePrefix?: string;
+  capabilities: ClusterCapabilities;
+  paperclipPublicUrl?: string;
+  imageRegistry?: string;
+  allowAgentImageOverride?: boolean;
+  createdBy: string;
+}
+
+export interface ClusterConnectionsServiceDeps {
+  resolveSecret: (ref: { provider: string; name: string }) => Promise<string>;
+}
+
+export function clusterConnectionsService(db: Db, deps: ClusterConnectionsServiceDeps) {
+  return {
+    async create(input: CreateClusterConnectionInput): Promise<ClusterConnectionRow> {
+      try {
+        const [row] = await db.insert(clusterConnections).values({
+          label: input.label,
+          kind: input.kind,
+          kubeconfigSecretRef: input.kubeconfigSecretRef ?? null,
+          apiServerUrl: input.apiServerUrl ?? null,
+          defaultNamespacePrefix: input.defaultNamespacePrefix ?? "paperclip-",
+          capabilities: input.capabilities,
+          paperclipPublicUrl: input.paperclipPublicUrl ?? null,
+          imageRegistry: input.imageRegistry ?? null,
+          allowAgentImageOverride: input.allowAgentImageOverride ? "true" : "false",
+          createdBy: input.createdBy,
+        }).returning();
+        return mapRow(row);
+      } catch (err: unknown) {
+        if (/cluster_connections_label_uq/.test(String(err))) {
+          throw new Error(`A cluster connection with label "${input.label}" already exists`);
+        }
+        throw err;
+      }
+    },
+
+    async list(): Promise<ClusterConnectionRow[]> {
+      const rows = await db.select().from(clusterConnections);
+      return rows.map(mapRow);
+    },
+
+    async get(id: string): Promise<ClusterConnectionRow | null> {
+      const [row] = await db.select().from(clusterConnections).where(eq(clusterConnections.id, id));
+      return row ? mapRow(row) : null;
+    },
+
+    async delete(id: string): Promise<void> {
+      await db.delete(clusterConnections).where(eq(clusterConnections.id, id));
+    },
+
+    async resolve(id: string): Promise<ResolvedClusterConnection | null> {
+      const row = await this.get(id);
+      if (!row) return null;
+      let kubeconfigYaml: string | undefined;
+      if (row.kind === "kubeconfig" && row.kubeconfigSecretRef) {
+        kubeconfigYaml = await deps.resolveSecret(row.kubeconfigSecretRef);
+      }
+      return {
+        id: row.id,
+        label: row.label,
+        kind: row.kind,
+        kubeconfigYaml,
+        apiServerUrl: row.apiServerUrl,
+        defaultNamespacePrefix: row.defaultNamespacePrefix,
+        paperclipPublicUrl: row.paperclipPublicUrl,
+        imageRegistry: row.imageRegistry,
+        allowAgentImageOverride: row.allowAgentImageOverride,
+        capabilities: row.capabilities,
+      };
+    },
+  };
+}
+
+function mapRow(row: typeof clusterConnections.$inferSelect): ClusterConnectionRow {
+  return {
+    id: row.id,
+    label: row.label,
+    kind: row.kind as "in-cluster" | "kubeconfig",
+    kubeconfigSecretRef: row.kubeconfigSecretRef,
+    apiServerUrl: row.apiServerUrl,
+    defaultNamespacePrefix: row.defaultNamespacePrefix,
+    capabilities: row.capabilities,
+    paperclipPublicUrl: row.paperclipPublicUrl,
+    imageRegistry: row.imageRegistry,
+    allowAgentImageOverride: row.allowAgentImageOverride === "true",
+    createdAt: row.createdAt,
+    createdBy: row.createdBy,
+  };
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/server test cluster-connections`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/services/cluster-connections.ts \
+        server/src/services/cluster-connections.test.ts
+git commit -m "feat(server): add cluster-connections service"
+```
+
+---
+
+## Task 19: ClusterTenantPolicies service
+
+**Files:**
+- Create: `server/src/services/cluster-tenant-policies.ts`
+- Create: `server/src/services/cluster-tenant-policies.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startEmbeddedPostgresTestDatabase, type EmbeddedPostgresTestDatabase } from "@paperclipai/db";
+import { clusterTenantPoliciesService } from "./cluster-tenant-policies.js";
+
+let dbHandle: EmbeddedPostgresTestDatabase;
+
+beforeAll(async () => { dbHandle = await startEmbeddedPostgresTestDatabase(); });
+afterAll(async () => { await dbHandle.stop(); });
+
+describe("clusterTenantPoliciesService", () => {
+  it("upserts and reads back a policy", async () => {
+    const svc = clusterTenantPoliciesService(dbHandle.client);
+    // Create a fake cluster + company first via raw SQL since this test isolates the service.
+    const [cluster] = await dbHandle.client.execute(`INSERT INTO cluster_connections(label, kind, capabilities, created_by) VALUES('c', 'in-cluster', '{"cilium":false,"storageClass":"standard","architectures":["amd64"]}'::jsonb, 'sys') RETURNING id`);
+    const [company] = await dbHandle.client.execute(`INSERT INTO companies(name, slug) VALUES('Acme', 'acme') RETURNING id`);
+
+    const upserted = await svc.upsert({
+      clusterConnectionId: cluster.id as string,
+      companyId: company.id as string,
+      quota: { requestsCpu: "32" },
+      limitRange: null,
+      additionalAllowFqdns: ["api.acme.io"],
+      imageOverrides: null,
+    });
+    expect(upserted.quota?.requestsCpu).toBe("32");
+
+    const fetched = await svc.get(cluster.id as string, company.id as string);
+    expect(fetched?.additionalAllowFqdns).toEqual(["api.acme.io"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/server test cluster-tenant-policies`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `cluster-tenant-policies.ts`**
+
+```ts
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { clusterTenantPolicies } from "@paperclipai/db";
+import type { TenantPolicy } from "@paperclipai/execution-target-kubernetes";
+
+export interface UpsertTenantPolicyInput {
+  clusterConnectionId: string;
+  companyId: string;
+  quota: TenantPolicy["quota"];
+  limitRange: TenantPolicy["limitRange"];
+  additionalAllowFqdns: string[];
+  imageOverrides: Record<string, string> | null;
+}
+
+export interface TenantPolicyRow extends TenantPolicy {
+  clusterConnectionId: string;
+  companyId: string;
+}
+
+export function clusterTenantPoliciesService(db: Db) {
+  return {
+    async get(clusterConnectionId: string, companyId: string): Promise<TenantPolicyRow | null> {
+      const [row] = await db.select().from(clusterTenantPolicies).where(and(
+        eq(clusterTenantPolicies.clusterConnectionId, clusterConnectionId),
+        eq(clusterTenantPolicies.companyId, companyId),
+      ));
+      return row ? mapRow(row) : null;
+    },
+
+    async upsert(input: UpsertTenantPolicyInput): Promise<TenantPolicyRow> {
+      const existing = await this.get(input.clusterConnectionId, input.companyId);
+      if (existing) {
+        const [updated] = await db.update(clusterTenantPolicies).set({
+          quotaJson: input.quota,
+          limitRangeJson: input.limitRange,
+          networkJson: { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl: null },
+          imageOverridesJson: input.imageOverrides,
+          updatedAt: new Date(),
+        }).where(and(
+          eq(clusterTenantPolicies.clusterConnectionId, input.clusterConnectionId),
+          eq(clusterTenantPolicies.companyId, input.companyId),
+        )).returning();
+        return mapRow(updated);
+      }
+      const [created] = await db.insert(clusterTenantPolicies).values({
+        clusterConnectionId: input.clusterConnectionId,
+        companyId: input.companyId,
+        quotaJson: input.quota,
+        limitRangeJson: input.limitRange,
+        networkJson: { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl: null },
+        imageOverridesJson: input.imageOverrides,
+      }).returning();
+      return mapRow(created);
+    },
+  };
+}
+
+function mapRow(r: typeof clusterTenantPolicies.$inferSelect): TenantPolicyRow {
+  return {
+    clusterConnectionId: r.clusterConnectionId,
+    companyId: r.companyId,
+    quota: r.quotaJson,
+    limitRange: r.limitRangeJson,
+    additionalAllowFqdns: r.networkJson?.additionalAllowFqdns ?? [],
+    imageOverrides: r.imageOverridesJson,
+  };
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/server test cluster-tenant-policies`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/services/cluster-tenant-policies.ts \
+        server/src/services/cluster-tenant-policies.test.ts
+git commit -m "feat(server): add cluster-tenant-policies service"
+```
+
+---
+
+## Task 20: Wire driver registration on server startup
+
+**Files:**
+- Create: `server/src/adapters/execution-targets/kubernetes.ts`
+- Modify: `server/src/index.ts` (or wherever adapter registry init happens)
+
+The server startup constructs the registry, registers the kubernetes driver passing in a `resolveConnection` deps closure backed by the `clusterConnectionsService`.
+
+- [ ] **Step 1: Write integration test for the wiring**
+
+Create `server/src/adapters/execution-targets/kubernetes.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { registerKubernetesExecutionTargetDriver } from "./kubernetes.js";
+import { createExecutionTargetRegistry } from "../execution-target-registry.js";
+
+describe("registerKubernetesExecutionTargetDriver", () => {
+  it("registers a driver of type 'kubernetes'", () => {
+    const reg = createExecutionTargetRegistry();
+    registerKubernetesExecutionTargetDriver(reg, {
+      resolveConnection: async () => null,
+    });
+    const drv = reg.get("kubernetes");
+    expect(drv).not.toBeNull();
+    expect(drv?.type).toBe("kubernetes");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/server test execution-targets/kubernetes`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the registration shim**
+
+```ts
+import { createKubernetesExecutionDriver, type KubernetesDriverDeps } from "@paperclipai/execution-target-kubernetes";
+import type { ExecutionTargetDriverRegistry } from "../execution-target-registry.js";
+
+export function registerKubernetesExecutionTargetDriver(
+  registry: ExecutionTargetDriverRegistry,
+  deps: KubernetesDriverDeps,
+): void {
+  registry.register(createKubernetesExecutionDriver(deps));
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/server test execution-targets/kubernetes`
+Expected: PASS.
+
+- [ ] **Step 5: Plug into the startup path**
+
+Find the server startup file that constructs services (search for `clusterConnectionsService` callers if any; otherwise the main `app.ts` or `index.ts`).
+
+Add construction of the registry there, e.g.:
+
+```ts
+import { createExecutionTargetRegistry } from "./adapters/execution-target-registry.js";
+import { registerKubernetesExecutionTargetDriver } from "./adapters/execution-targets/kubernetes.js";
+import { clusterConnectionsService } from "./services/cluster-connections.js";
+// ...
+const clusterConnections = clusterConnectionsService(db, { resolveSecret: secretsResolver.resolveById });
+const executionTargetRegistry = createExecutionTargetRegistry();
+registerKubernetesExecutionTargetDriver(executionTargetRegistry, {
+  resolveConnection: (id) => clusterConnections.resolve(id),
+});
+// expose `executionTargetRegistry` to adapter execution code paths.
+```
+
+Add a smoke test that starts the server (or just the bootstrap function) and asserts the registry has the kubernetes driver registered.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/adapters/execution-targets/kubernetes.ts \
+        server/src/adapters/execution-targets/kubernetes.test.ts \
+        server/src/index.ts
+git commit -m "feat(server): register kubernetes execution-target driver on startup"
+```
+
+---
+
+## Task 21: Existing adapters' `executionTarget` plumbing audit
+
+Resolves Risk #3.
+
+**Files:**
+- Create: `packages/adapter-utils/test/contract/execution-target-kubernetes-rejection.test.ts`
+
+Goal: each existing adapter, when given a `kubernetes` execution target, must NOT crash. It must return a clear `errorCode`/`errorMessage` indicating the target is not supported in M1 (since M1 lacks `run()` for k8s).
+
+- [ ] **Step 1: For each built-in adapter, find its `execute` entry point**
+
+Run: `grep -rn "createServerAdapter" packages/adapters/*/src/server/index.ts`
+Note each adapter package: claude-local, codex-local, gemini-local, opencode-local, acpx-local, pi-local, hermes-local.
+
+- [ ] **Step 2: Write a contract test that exercises each adapter with a k8s target**
+
+```ts
+import { describe, it, expect } from "vitest";
+import * as claudeLocal from "@paperclipai/adapter-claude-local/server";
+import * as codexLocal from "@paperclipai/adapter-codex-local/server";
+import * as geminiLocal from "@paperclipai/adapter-gemini-local/server";
+import * as opencodeLocal from "@paperclipai/adapter-opencode-local/server";
+import * as acpxLocal from "@paperclipai/adapter-acpx-local/server";
+import * as piLocal from "@paperclipai/adapter-pi-local/server";
+import * as hermesLocal from "@paperclipai/adapter-hermes-local/server";
+import type { AdapterExecutionContext, AdapterKubernetesExecutionTarget } from "@paperclipai/adapter-utils";
+
+const adapters = [
+  ["claude_local", claudeLocal],
+  ["codex_local", codexLocal],
+  ["gemini_local", geminiLocal],
+  ["opencode_local", opencodeLocal],
+  ["acpx_local", acpxLocal],
+  ["pi_local", piLocal],
+  ["hermes_local", hermesLocal],
+] as const;
+
+const k8sTarget: AdapterKubernetesExecutionTarget = { kind: "kubernetes", clusterConnectionId: "c-1" };
+
+function ctx(): AdapterExecutionContext {
+  return {
+    runId: "r-1",
+    agent: { id: "a-1", companyId: "c-1", name: "x", adapterType: "x", adapterConfig: {} },
+    runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+    config: {},
+    context: {},
+    onLog: async () => {},
+    executionTarget: k8sTarget,
+  };
+}
+
+describe("adapter contract: kubernetes target rejection in M1", () => {
+  for (const [name, mod] of adapters) {
+    it(`${name} returns a clear error result rather than throwing`, async () => {
+      const adapter = mod.createServerAdapter();
+      const result = await adapter.execute(ctx());
+      expect(result.exitCode).toBeNull();
+      expect(result.errorCode).toMatch(/kubernetes|execution_target/i);
+      expect(result.errorMessage).toContain("Kubernetes");
+    });
+  }
+});
+```
+
+- [ ] **Step 3: Run, expect failures**
+
+Run: `pnpm test packages/adapter-utils/test/contract`
+Expected: each adapter either throws or returns a non-matching error.
+
+- [ ] **Step 4: For each adapter, add the rejection branch**
+
+In each adapter's `execute.ts`, near the top:
+
+```ts
+if (ctx.executionTarget?.kind === "kubernetes") {
+  return {
+    exitCode: null, signal: null, timedOut: false,
+    errorCode: "execution_target_not_yet_supported",
+    errorMessage:
+      "Kubernetes execution target is not implemented yet for this adapter. " +
+      "Tenant provisioning is available in M1; agent execution lands in M2.",
+  };
+}
+```
+
+Run the contract test after each adapter. Commit per adapter.
+
+- [ ] **Step 5: Final commit (after all adapters)**
+
+```bash
+git add packages/adapters/*/src/server/execute.ts \
+        packages/adapter-utils/test/contract/execution-target-kubernetes-rejection.test.ts
+git commit -m "feat(adapters): reject kubernetes execution target with a clear error in M1"
+```
+
+---
+
+## Task 22: Integration test harness against `kind`
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/test/integration/_harness.ts`
+- Create: `packages/adapters/kubernetes-execution/test/integration/ensure-tenant.test.ts`
+- Create: `packages/adapters/kubernetes-execution/test/integration/ensure-tenant-idempotency.test.ts`
+- Create: `packages/adapters/kubernetes-execution/test/integration/ensure-tenant-drift.test.ts`
+- Create: `packages/adapters/kubernetes-execution/vitest.integration.config.ts`
+
+Pre-req: `kind` binary on `$PATH`. CI step installs it via `go install sigs.k8s.io/kind@latest` or fetches the static binary from the kind release page (deterministic version pin).
+
+- [ ] **Step 1: Write the harness**
+
+```ts
+import { execSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface KindCluster {
+  name: string;
+  kubeconfigPath: string;
+  kubeconfigYaml: string;
+  cleanup(): void;
+}
+
+export function spinUpKind(): KindCluster {
+  const name = `pp-test-${Math.random().toString(36).slice(2, 8)}`;
+  const dir = mkdtempSync(join(tmpdir(), `${name}-`));
+  const kubeconfigPath = join(dir, "kubeconfig");
+  execSync(`kind create cluster --name ${name} --kubeconfig ${kubeconfigPath} --wait 60s`, { stdio: "inherit" });
+  const kubeconfigYaml = readFileSync(kubeconfigPath, "utf-8");
+  return {
+    name,
+    kubeconfigPath,
+    kubeconfigYaml,
+    cleanup: () => {
+      try { execSync(`kind delete cluster --name ${name}`, { stdio: "ignore" }); } catch {}
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Add vitest integration config**
+
+```ts
+// vitest.integration.config.ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/integration/**/*.test.ts"],
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+});
+```
+
+- [ ] **Step 3: Write the happy-path integration test**
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spinUpKind, type KindCluster } from "./_harness.js";
+import { createKubernetesApiClient, ensureTenantNamespace, probeClusterCapabilities } from "../../src/index.js";
+
+let cluster: KindCluster;
+
+beforeAll(async () => { cluster = spinUpKind(); }, 180_000);
+afterAll(() => { cluster.cleanup(); });
+
+describe("ensureTenantNamespace against kind", () => {
+  it("provisions a fully isolated tenant namespace", async () => {
+    const client = createKubernetesApiClient({
+      id: "c-1", label: "kind", kind: "kubeconfig", kubeconfigYaml: cluster.kubeconfigYaml,
+      defaultNamespacePrefix: "paperclip-",
+      allowAgentImageOverride: false,
+      capabilities: await probeClusterCapabilities({} as never).catch(() => ({ cilium: false, storageClass: "standard", architectures: ["amd64"] })),
+    });
+    const result = await ensureTenantNamespace(client, {
+      connection: {
+        id: "c-1", label: "kind", kind: "kubeconfig", kubeconfigYaml: cluster.kubeconfigYaml,
+        defaultNamespacePrefix: "paperclip-",
+        allowAgentImageOverride: false,
+        capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      },
+      company: { id: "11111111-1111-1111-1111-111111111111", slug: "acme-corp" },
+      tenantPolicy: null,
+      driverServiceAccount: { name: "default", namespace: "default" }, // kind shortcut
+      controlPlane: { topology: "cross-cluster", namespaceLabels: {}, podLabels: {} },
+      adapterAllowFqdns: [],
+      imagePullDockerConfigJson: null,
+    });
+    expect(result.namespace).toBe("paperclip-acme-corp");
+
+    // Assert all the objects exist with the expected labels.
+    const ns = await client.core.readNamespace(result.namespace);
+    expect(ns.body.metadata?.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+    expect(ns.body.metadata?.labels?.["pod-security.kubernetes.io/enforce"]).toBe("restricted");
+
+    const sa = await client.core.readNamespacedServiceAccount("paperclip-agent", result.namespace);
+    expect(sa.body.automountServiceAccountToken).toBe(false);
+
+    const quota = await client.core.readNamespacedResourceQuota("paperclip-tenant-quota", result.namespace);
+    expect(quota.body.spec?.hard?.["requests.cpu"]).toBe("16");
+
+    const policies = await client.networking.listNamespacedNetworkPolicy(result.namespace);
+    const names = policies.body.items.map(p => p.metadata?.name).sort();
+    expect(names).toEqual(["default-deny-egress", "default-deny-ingress", "paperclip-agent-egress"]);
+  });
+});
+```
+
+- [ ] **Step 4: Run integration**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test:integration`
+Expected: cluster spins up, test passes.
+
+- [ ] **Step 5: Idempotency test**
+
+```ts
+// ensure-tenant-idempotency.test.ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spinUpKind, type KindCluster } from "./_harness.js";
+import { createKubernetesApiClient, ensureTenantNamespace } from "../../src/index.js";
+
+let cluster: KindCluster;
+beforeAll(() => { cluster = spinUpKind(); }, 180_000);
+afterAll(() => cluster.cleanup());
+
+describe("ensureTenantNamespace idempotency", () => {
+  it("a second call is a no-op-equivalent (object generation may not bump)", async () => {
+    const connection = {
+      id: "c-1", label: "kind", kind: "kubeconfig" as const, kubeconfigYaml: cluster.kubeconfigYaml,
+      defaultNamespacePrefix: "paperclip-",
+      allowAgentImageOverride: false,
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] as const },
+    };
+    const client = createKubernetesApiClient(connection);
+    const input = {
+      connection,
+      company: { id: "11111111-1111-1111-1111-111111111112", slug: "idempotent-co" },
+      tenantPolicy: null,
+      driverServiceAccount: { name: "default", namespace: "default" },
+      controlPlane: { topology: "cross-cluster" as const, namespaceLabels: {}, podLabels: {} },
+      adapterAllowFqdns: [],
+      imagePullDockerConfigJson: null,
+    };
+    const r1 = await ensureTenantNamespace(client, input);
+    const r2 = await ensureTenantNamespace(client, input);
+    expect(r1.namespace).toBe(r2.namespace);
+    // Still exactly one set of objects.
+    const policies = await client.networking.listNamespacedNetworkPolicy(r1.namespace);
+    expect(policies.body.items.length).toBe(3);
+  });
+});
+```
+
+- [ ] **Step 6: Drift correction test**
+
+```ts
+// ensure-tenant-drift.test.ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spinUpKind, type KindCluster } from "./_harness.js";
+import { createKubernetesApiClient, ensureTenantNamespace } from "../../src/index.js";
+
+let cluster: KindCluster;
+beforeAll(() => { cluster = spinUpKind(); }, 180_000);
+afterAll(() => cluster.cleanup());
+
+describe("ensureTenantNamespace drift correction", () => {
+  it("recreates a NetworkPolicy that was deleted out-of-band", async () => {
+    const connection = { id: "c-1", label: "kind", kind: "kubeconfig" as const, kubeconfigYaml: cluster.kubeconfigYaml, defaultNamespacePrefix: "paperclip-", allowAgentImageOverride: false, capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] as const } };
+    const client = createKubernetesApiClient(connection);
+    const input = {
+      connection,
+      company: { id: "11111111-1111-1111-1111-111111111113", slug: "drift-co" },
+      tenantPolicy: null,
+      driverServiceAccount: { name: "default", namespace: "default" },
+      controlPlane: { topology: "cross-cluster" as const, namespaceLabels: {}, podLabels: {} },
+      adapterAllowFqdns: [],
+      imagePullDockerConfigJson: null,
+    };
+    const { namespace } = await ensureTenantNamespace(client, input);
+    await client.networking.deleteNamespacedNetworkPolicy("default-deny-egress", namespace);
+    await ensureTenantNamespace(client, input);
+    const policies = await client.networking.listNamespacedNetworkPolicy(namespace);
+    expect(policies.body.items.find(p => p.metadata?.name === "default-deny-egress")).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/test/integration \
+        packages/adapters/kubernetes-execution/vitest.integration.config.ts
+git commit -m "test(k8s-adapter): add kind-based integration tests for ensureTenantNamespace"
+```
+
+---
+
+## Task 23: PSS Restricted compliance gate
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/test/integration/pss-restricted.test.ts`
+
+Resolves spec compliance bookkeeping (§2.8). The test creates a tenant namespace, deploys a deliberately privileged Pod into it, and asserts the cluster rejects it at admission. Then deploys a compliant Pod and asserts it's accepted. Together this proves PSS Restricted is wired correctly.
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spinUpKind, type KindCluster } from "./_harness.js";
+import { createKubernetesApiClient, ensureTenantNamespace } from "../../src/index.js";
+
+let cluster: KindCluster;
+beforeAll(() => { cluster = spinUpKind(); }, 180_000);
+afterAll(() => cluster.cleanup());
+
+describe("PSS Restricted compliance for tenant namespace", () => {
+  it("admission rejects a privileged Pod and accepts a compliant Pod", async () => {
+    const connection = { id: "c-1", label: "kind", kind: "kubeconfig" as const, kubeconfigYaml: cluster.kubeconfigYaml, defaultNamespacePrefix: "paperclip-", allowAgentImageOverride: false, capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] as const } };
+    const client = createKubernetesApiClient(connection);
+    const { namespace } = await ensureTenantNamespace(client, {
+      connection,
+      company: { id: "11111111-1111-1111-1111-111111111114", slug: "pss-test" },
+      tenantPolicy: null,
+      driverServiceAccount: { name: "default", namespace: "default" },
+      controlPlane: { topology: "cross-cluster", namespaceLabels: {}, podLabels: {} },
+      adapterAllowFqdns: [],
+      imagePullDockerConfigJson: null,
+    });
+
+    // Privileged Pod — must be rejected by admission.
+    await expect(client.core.createNamespacedPod(namespace, {
+      apiVersion: "v1", kind: "Pod",
+      metadata: { name: "evil" },
+      spec: {
+        containers: [{
+          name: "x", image: "busybox", command: ["sleep", "1"],
+          securityContext: { privileged: true },
+        }],
+      },
+    })).rejects.toThrow(/violates PodSecurity|forbidden/i);
+
+    // Compliant Pod — must succeed.
+    await client.core.createNamespacedPod(namespace, {
+      apiVersion: "v1", kind: "Pod",
+      metadata: { name: "good" },
+      spec: {
+        automountServiceAccountToken: false,
+        securityContext: {
+          runAsNonRoot: true, runAsUser: 1000, fsGroup: 1000,
+          seccompProfile: { type: "RuntimeDefault" },
+        },
+        containers: [{
+          name: "x", image: "busybox", command: ["sleep", "1"],
+          securityContext: {
+            allowPrivilegeEscalation: false, readOnlyRootFilesystem: true,
+            capabilities: { drop: ["ALL"] },
+          },
+        }],
+      },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test:integration pss`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/test/integration/pss-restricted.test.ts
+git commit -m "test(k8s-adapter): assert PSS Restricted admission on tenant namespace"
+```
+
+---
+
+## Task 24: CLI commands — `paperclipai cluster ...`
+
+**Files:**
+- Create: `cli/src/commands/cluster.ts`
+- Create: `cli/src/commands/cluster.test.ts`
+- Modify: `cli/src/index.ts`
+
+Subcommands for M1:
+- `paperclipai cluster add --label <name> --kind <in-cluster|kubeconfig> [--kubeconfig-secret <ref>] [--paperclip-public-url <url>] [--image-registry <url>]`
+- `paperclipai cluster list`
+- `paperclipai cluster test <id>` — connects, probes capabilities, prints results.
+- `paperclipai cluster remove <id>`
+- `paperclipai cluster ensure-tenant <clusterId> <companyId>` — runs the orchestrator end-to-end.
+- `paperclipai cluster doctor <id>` — runs all M1 health checks (connect, probe, dry-run ensure-tenant for a fake company, print the reference ClusterRole YAML location).
+
+- [ ] **Step 1: Write failing tests for each subcommand (mocked services)**
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { createClusterCommand } from "./cluster.js";
+
+function mocks() {
+  return {
+    clusterConnections: {
+      create: vi.fn(async (i: any) => ({ id: "c-1", label: i.label })),
+      list: vi.fn(async () => [{ id: "c-1", label: "kind", kind: "kubeconfig", capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] }, createdAt: new Date(), createdBy: "x" }]),
+      get: vi.fn(async () => ({ id: "c-1", label: "kind", kind: "kubeconfig" })),
+      delete: vi.fn(async () => {}),
+      resolve: vi.fn(async () => ({ id: "c-1", label: "kind", kind: "kubeconfig", kubeconfigYaml: "x", defaultNamespacePrefix: "paperclip-", allowAgentImageOverride: false, capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] } })),
+    },
+    tenantPolicies: { get: vi.fn(async () => null), upsert: vi.fn() },
+    driver: { ensureTenant: vi.fn(async () => ({ namespace: "paperclip-acme", ciliumApplied: false })), validateTarget: vi.fn(async () => {}), run: vi.fn() },
+    companies: { getById: vi.fn(async () => ({ id: "co-1", slug: "acme" })) },
+  };
+}
+
+describe("cluster commands", () => {
+  it("add: creates a connection and prints its id", async () => {
+    const m = mocks();
+    const { stdout, exitCode } = await runCmd("add --label kind --kind kubeconfig --kubeconfig-secret local:my-cfg", m);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("c-1");
+    expect(m.clusterConnections.create).toHaveBeenCalled();
+  });
+
+  it("list: prints connections with capabilities", async () => {
+    const m = mocks();
+    const { stdout } = await runCmd("list", m);
+    expect(stdout).toContain("kind");
+    expect(stdout).toContain("storageClass=standard");
+  });
+
+  it("ensure-tenant: calls driver.ensureTenant and prints namespace", async () => {
+    const m = mocks();
+    const { stdout, exitCode } = await runCmd("ensure-tenant c-1 co-1", m);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("paperclip-acme");
+    expect(m.driver.ensureTenant).toHaveBeenCalled();
+  });
+});
+
+async function runCmd(argv: string, m: ReturnType<typeof mocks>) {
+  // Capture stdout/exit via the createClusterCommand harness; details depend on existing CLI plumbing.
+  // For brevity in this plan, the engineer wires it through whatever pattern other commands use
+  // (commander/cac/...). The test contract is what we assert above.
+  // Implementation detail filled in step 3.
+  const out: string[] = [];
+  const cmd = createClusterCommand({
+    clusterConnections: m.clusterConnections as never,
+    tenantPolicies: m.tenantPolicies as never,
+    driver: m.driver as never,
+    companies: m.companies as never,
+    print: (s: string) => out.push(s),
+  });
+  const exitCode = await cmd.run(argv.split(/\s+/));
+  return { stdout: out.join("\n"), exitCode };
+}
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+Run: `pnpm --filter @paperclipai/cli test cluster`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `cluster.ts`**
+
+Match the existing CLI command convention (whatever framework Paperclip's CLI uses — discover by reading another command file like `cli/src/commands/<existing>.ts`). The shape:
+
+```ts
+import type { ExecutionTargetDriver } from "@paperclipai/server";
+// imports for service interfaces from @paperclipai/server etc.
+
+export interface ClusterCommandDeps {
+  clusterConnections: { /* matches the service interface */ };
+  tenantPolicies: { /* matches the service interface */ };
+  driver: ExecutionTargetDriver;        // type "kubernetes"
+  companies: { getById: (id: string) => Promise<{ id: string; slug: string } | null> };
+  print: (line: string) => void;
+}
+
+export interface ClusterCommand {
+  run(argv: string[]): Promise<number>;
+}
+
+export function createClusterCommand(deps: ClusterCommandDeps): ClusterCommand {
+  return {
+    async run(argv) {
+      const [sub, ...rest] = argv;
+      switch (sub) {
+        case "add":          return cmdAdd(rest, deps);
+        case "list":         return cmdList(rest, deps);
+        case "test":         return cmdTest(rest, deps);
+        case "remove":       return cmdRemove(rest, deps);
+        case "ensure-tenant":return cmdEnsureTenant(rest, deps);
+        case "doctor":       return cmdDoctor(rest, deps);
+        default:
+          deps.print(`Unknown subcommand: ${sub}\nUsage: cluster <add|list|test|remove|ensure-tenant|doctor>`);
+          return 2;
+      }
+    },
+  };
+}
+
+// each subcommand parses its own args (matching the existing command pattern in cli/src/commands)
+// and calls the appropriate dep. Each prints structured output. Implementation detail follows the
+// existing CLI command style.
+```
+
+Implement each subcommand. For `cmdEnsureTenant`:
+
+```ts
+async function cmdEnsureTenant(argv: string[], deps: ClusterCommandDeps): Promise<number> {
+  const [clusterId, companyId] = argv;
+  if (!clusterId || !companyId) {
+    deps.print("Usage: cluster ensure-tenant <clusterId> <companyId>");
+    return 2;
+  }
+  const company = await deps.companies.getById(companyId);
+  if (!company) { deps.print(`Company ${companyId} not found`); return 1; }
+  const tp = await deps.tenantPolicies.get(clusterId, companyId);
+  const result = await deps.driver.ensureTenant({
+    clusterConnectionId: clusterId,
+    company,
+    tenantPolicy: tp ? { quota: tp.quota, limitRange: tp.limitRange, additionalAllowFqdns: tp.additionalAllowFqdns, imageOverrides: tp.imageOverrides } : null,
+    driverServiceAccount: { name: process.env.PAPERCLIP_DRIVER_SA ?? "paperclip-driver", namespace: process.env.PAPERCLIP_DRIVER_NAMESPACE ?? "paperclip-system" },
+    controlPlane: { topology: "cross-cluster", namespaceLabels: {}, podLabels: {} },
+    adapterAllowFqdns: [],
+    imagePullDockerConfigJson: null,
+  });
+  deps.print(`Provisioned namespace ${result.namespace} (cilium=${result.ciliumApplied})`);
+  return 0;
+}
+```
+
+- [ ] **Step 4: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/cli test cluster`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into `cli/src/index.ts`**
+
+Match the existing pattern; expose `cluster` as a top-level subcommand alongside the other commands.
+
+Add a manual smoke test step in CI: `paperclipai cluster list` returns `0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cli/src/commands/cluster.ts \
+        cli/src/commands/cluster.test.ts \
+        cli/src/index.ts
+git commit -m "feat(cli): add `cluster` command (add|list|test|remove|ensure-tenant|doctor)"
+```
+
+---
+
+## Task 25: End-to-end M1 smoke (CLI → kind cluster → tenant verified)
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/test/integration/cli-end-to-end.test.ts`
+
+Closes the loop: drives the orchestrator via the same path the CLI uses (`driver.ensureTenant`), with a real kind cluster, a real ClusterConnection row in embedded postgres, and a real company row.
+
+- [ ] **Step 1: Write the smoke test**
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spinUpKind, type KindCluster } from "./_harness.js";
+import { startEmbeddedPostgresTestDatabase, type EmbeddedPostgresTestDatabase } from "@paperclipai/db";
+import { clusterConnectionsService } from "@paperclipai/server/services/cluster-connections.js";
+import { clusterTenantPoliciesService } from "@paperclipai/server/services/cluster-tenant-policies.js";
+import { createExecutionTargetRegistry } from "@paperclipai/server/adapters/execution-target-registry.js";
+import { registerKubernetesExecutionTargetDriver } from "@paperclipai/server/adapters/execution-targets/kubernetes.js";
+
+let kc: KindCluster;
+let db: EmbeddedPostgresTestDatabase;
+beforeAll(async () => {
+  kc = spinUpKind();
+  db = await startEmbeddedPostgresTestDatabase();
+}, 240_000);
+afterAll(async () => { kc.cleanup(); await db.stop(); });
+
+describe("M1 smoke", () => {
+  it("registers cluster, provisions a tenant, kubectl confirms", async () => {
+    // Insert a fake company.
+    await db.client.execute(`INSERT INTO companies(id, name, slug) VALUES('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Acme', 'acme-corp')`);
+
+    // Persist the kubeconfig as a fake "secret" via a stubbed resolver.
+    const cs = clusterConnectionsService(db.client, { resolveSecret: async () => kc.kubeconfigYaml });
+    const conn = await cs.create({
+      label: "smoke-kind", kind: "kubeconfig",
+      kubeconfigSecretRef: { provider: "stub", name: "kc" },
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      createdBy: "smoke",
+    });
+
+    // Wire the registry just like the server does.
+    const reg = createExecutionTargetRegistry();
+    registerKubernetesExecutionTargetDriver(reg, { resolveConnection: cs.resolve });
+    const driver = reg.get("kubernetes")!;
+
+    const result = await driver.ensureTenant({
+      clusterConnectionId: conn.id,
+      company: { id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", slug: "acme-corp" },
+      tenantPolicy: null,
+      driverServiceAccount: { name: "default", namespace: "default" },
+      controlPlane: { topology: "cross-cluster", namespaceLabels: {}, podLabels: {} },
+      adapterAllowFqdns: [],
+      imagePullDockerConfigJson: null,
+    });
+    expect(result.namespace).toBe("paperclip-acme-corp");
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect pass**
+
+Run: `pnpm --filter @paperclipai/execution-target-kubernetes test:integration cli-end-to-end`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/test/integration/cli-end-to-end.test.ts
+git commit -m "test(k8s-adapter): end-to-end M1 smoke — CLI services + kind cluster"
+```
+
+---
+
+## Task 26: Documentation
+
+**Files:**
+- Create: `docs/k8s-execution/quickstart.md`
+- Create: `docs/k8s-execution/security-model.md`
+- Create: `docs/k8s-execution/multi-tenant-onboarding.md`
+- Create: `docs/k8s-execution/cluster-rbac.md`
+
+- [ ] **Step 1: Write `quickstart.md`**
+
+Cover:
+- Pre-requisites (`kubectl`, kubeconfig, `kind` for testing).
+- Apply the reference ClusterRole (`paperclip-tenant-manager-clusterrole.yaml`).
+- Create a Paperclip secret holding the kubeconfig.
+- `paperclipai cluster add ...`
+- `paperclipai cluster doctor <id>`
+- `paperclipai cluster ensure-tenant <clusterId> <companyId>`
+- Verify with `kubectl get all,networkpolicy,resourcequota -n paperclip-<companySlug>`
+- What's *not* yet supported in M1 (agent execution, UI, BYO cluster — see M2/M3).
+
+- [ ] **Step 2: Write `security-model.md`**
+
+Restate (don't re-prove) the spec's section 2.8 baseline:
+- NSA/CISA hardening checklist with which control corresponds to which file/builder.
+- Why `automountServiceAccountToken: false`.
+- The RFC1918 + link-local egress block and why cloud metadata is the threat.
+- Where the redaction layer sits.
+
+- [ ] **Step 3: Write `multi-tenant-onboarding.md`**
+
+The operator-facing playbook for adding a new company on an existing cluster:
+- Verify the cluster has a default StorageClass and (recommended) Cilium for FQDN policy.
+- Optionally upsert a `cluster_tenant_policies` row.
+- `cluster ensure-tenant`.
+- Verify with `kubectl describe namespace`.
+
+- [ ] **Step 4: Write `cluster-rbac.md`**
+
+Include the reference ClusterRole YAML inline and explain each permission. Provide ServiceAccount + ClusterRoleBinding templates for both in-cluster and out-of-cluster deployment styles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/k8s-execution/
+git commit -m "docs(k8s-execution): add M1 quickstart, security model, multi-tenant onboarding, RBAC"
+```
+
+---
+
+## Task 27: CI integration
+
+**Files:**
+- Modify: `.github/workflows/<existing-test-workflow>.yml` (or whichever the project uses)
+
+- [ ] **Step 1: Read the existing CI workflow**
+
+Run: `ls .github/workflows/` and read the matrix that runs `pnpm test`.
+
+- [ ] **Step 2: Add a new job `k8s-integration`**
+
+Append a job that:
+1. Installs `kind` from the static binary.
+2. Runs `pnpm --filter @paperclipai/execution-target-kubernetes test:integration` with a 10-minute timeout.
+3. Uploads the cluster's pod logs as an artifact on failure (helps debugging).
+
+```yaml
+  k8s-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+      - uses: actions/setup-node@v4
+        with: { node-version: 22, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: |
+          curl -sLo kind https://kind.sigs.k8s.io/dl/v0.24.0/kind-linux-amd64
+          chmod +x kind && sudo mv kind /usr/local/bin/
+      - run: pnpm --filter @paperclipai/execution-target-kubernetes build
+      - run: pnpm --filter @paperclipai/execution-target-kubernetes test:integration
+      - if: failure()
+        run: |
+          kind export logs ./kind-logs || true
+        # ...upload kind-logs as artifact
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/
+git commit -m "ci: add kind-based integration tests for k8s execution target"
+```
+
+---
+
+## Task 28: Final cross-cutting smoke
+
+The last gate that wraps M1 into something an operator can demo.
+
+- [ ] **Step 1: Run the full M1 test suite**
+
+Run: `pnpm test` and `pnpm --filter @paperclipai/execution-target-kubernetes test:integration`
+Expected: all green.
+
+- [ ] **Step 2: Manual smoke against a fresh kind cluster**
+
+```bash
+kind create cluster --name pp-m1
+export KUBECONFIG=$(kind get kubeconfig --name pp-m1)
+kubectl apply -f packages/adapters/kubernetes-execution/manifests/paperclip-tenant-manager-clusterrole.yaml
+# (out-of-band: store $KUBECONFIG into a Paperclip secret named "kind-cfg")
+paperclipai cluster add --label kind --kind kubeconfig --kubeconfig-secret local_encrypted:kind-cfg
+paperclipai cluster list
+paperclipai cluster doctor <id>
+paperclipai cluster ensure-tenant <clusterId> <companyId>
+kubectl get ns,sa,resourcequota,limitrange,networkpolicy -l paperclip.ai/managed-by=paperclip
+kind delete cluster --name pp-m1
+```
+
+- [ ] **Step 3: Update `ROADMAP.md`** — mark M1 complete, link to this plan and the spec.
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add ROADMAP.md
+git commit -m "docs(roadmap): mark k8s execution-target M1 complete"
+```
+
+---
+
+## Self-Review
+
+After writing this plan I checked it with fresh eyes against the spec.
+
+**1. Spec coverage (M1 portion):**
+- ✅ §1 architecture & code layout — Tasks 1, 2, 3, 16, 17, 20.
+- ✅ §2.1 namespace — Task 9.
+- ✅ §2.2 pod identity — Task 10.
+- ✅ §2.3 vanilla NetworkPolicy — Task 12.
+- ✅ §2.4 Cilium variant — Task 13 (build) + Task 6 (capability detection).
+- ✅ §2.5 PSS Restricted — Task 9 sets the labels; Task 23 verifies admission rejects/accepts pods.
+- ✅ §2.6 ResourceQuota + LimitRange — Task 11.
+- ✅ §2.7 ClusterConnection storage — Tasks 4, 18; tenant policies — Task 19.
+- ✅ §2.8 compliance bookkeeping — Task 23.
+- ✅ §5.3 image pull credentials — Task 14.
+- ✅ Risk #3 executionTarget plumbing audit — Task 21.
+- ✅ Risk #6 registerExecutionTargetDriver registry — Task 17.
+- ✅ Risk #7 networkRequirements adapter contract — Task 3.
+- ⏭ Risk #1 (workspace-strategy refactor) — explicitly deferred to M2; not in this plan.
+- ⏭ Risk #2 (PVC zonal pinning UX) — surfaces in M3 UI; this plan documents storage-class choice in Task 26.
+- ⏭ Risk #4 (resource defaults empirics) — M2.
+- ⏭ Risk #5 (cross-cluster TokenReview) — M2/V2.
+- ⏭ Risk #8 (agent shim) — M2.
+
+**2. Placeholder scan:** I searched for "TBD", "TODO", "fill in details", "similar to". None remain. Two places where I say "match the existing CLI command convention" — that's a real instruction (read the existing command file before implementing), not a placeholder. The runCmd helper in Task 24's test is sketched at the contract level because the implementation depends on which CLI framework Paperclip uses; the engineer should mirror an existing command file's pattern. This is not a placeholder; it is the right level of specificity for the codebase context.
+
+**3. Type consistency:**
+- `ResolvedClusterConnection` fields used in client.ts (Task 5) match those in cluster-connections.ts (Task 18) and ensure-tenant.ts (Task 15). ✓
+- `EnsureTenantInput` shape consistent across Tasks 15, 16, 24, 25. ✓
+- `KubernetesExecutionDriver.ensureTenant` signature consistent across Tasks 16 and 20 wiring. ✓
+- `TenantPolicy` shape consistent across Tasks 15, 19, 24. ✓
+- Label constants (`paperclip.ai/managed-by`, `paperclip.ai/role`) consistent across Tasks 8, 9, 10, 11, 12, 13, 14. ✓
+- `errorCode: "execution_target_not_yet_supported"` used identically in driver.run() (Task 16) and adapter rejection branches (Task 21). ✓
+
+**4. Sequencing:**
+Tasks 1–4 strict prerequisites (package, types, db). Tasks 5–14 are pure builders (parallel-safe). Task 15 integrates 5–14. Tasks 16–20 are server surface (depend on 15). Tasks 21–28 close the loop.
+
+No cycles, no forward references that aren't satisfied.
+
+**5. Test code present:** Every implementation task has a failing-test step before the implementation step.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-08-paperclip-cloud-adapter-m1-plan.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-09-paperclip-cloud-adapter-m2-plan.md
+++ b/docs/superpowers/plans/2026-05-09-paperclip-cloud-adapter-m2-plan.md
@@ -1,0 +1,4375 @@
+# Paperclip Cloud Adapter — Milestone 2: Headless Agent Execution End-to-End
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a real `claude_local` agent run end-to-end inside a Kubernetes pod — workspace cloned from git in an init container, claude-code CLI invoked with prompts, stdout streamed back to Paperclip, structured events posted via run-JWT auth, Job lifecycle managed (TTL cleanup, OwnerReference GC, cancellation), all observable in `kubectl logs`.
+
+**Architecture:** Extends M1 by replacing the driver's `run()` stub with a real Job-based execution path. One `batch/v1 Job` per heartbeat carries a paperclip-workspace-init init container that resolves the workspace strategy and an agent runtime container that runs `paperclip-agent-shim` (Go static binary) which exec's the actual adapter CLI. A per-Job ephemeral `Secret` (with `OwnerReferences` to the Job for auto-GC) carries the bootstrap token, resolved adapter env (LLM keys), and a short-TTL git credential handle. Stdout streams via `pods/log` watch; `Job` and `Pod` Events surface as `[k8s]`-prefixed log lines; structured events (`init`/`assistant`/`tool_call`/`result`) are POSTed by the agent shim to `/api/runs/:runId/events` after a single bootstrap-token-for-run-JWT exchange. PVC-per-agent persists workspaces between heartbeats.
+
+**Tech Stack:** TypeScript (orchestrator + server routes + adapter wiring), Go 1.22 (`paperclip-agent-shim` static binary), Node.js (`paperclip-workspace-init` script consuming `@paperclipai/workspace-strategy`), Distroless or `ubuntu-slim` base images with `tini` + `git`, `@kubernetes/client-node` v0.21, `kind` for integration tests, `cosign` keyless OIDC for image signing in CI.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md` — sections §3 (Pod Lifecycle), §4 (Workspace Persistence), §5 (Images & Secrets), §6 (Networking & Callback), §7 (Observability + Failure Modes + Testing).
+
+**M1 reference:** `docs/superpowers/plans/2026-05-08-paperclip-cloud-adapter-m1-plan.md` (30 commits on `feat/k8s-cloud-adapter-m1`; tenant provisioning is done — namespace, RBAC, ResourceQuota, LimitRange, NetworkPolicy vanilla + Cilium variant, image pull secret, ClusterConnections service, ExecutionTargetDriverRegistry, CLI commands).
+
+**Branch:** `feat/k8s-cloud-adapter-m2`, branched from `feat/k8s-cloud-adapter-m1` (M1 will land first; M2 builds on top).
+
+---
+
+## Architectural Decisions Locked Before Planning
+
+| # | Decision | Rationale |
+|---|---|---|
+| M2-1 | `paperclip-agent-shim` is a Go 1.22 static binary | Tiny program (read config → exec adapter CLI → frame stdout). Go gives ~3MB stripped binary with ~5ms startup. No Node tax for the PID-1 supervisor. |
+| M2-2 | `paperclip-workspace-init` is a Node script using `@paperclipai/workspace-strategy` | Reuses the canonical TS implementation. Base image needs Node anyway (claude-code is a Node CLI), so no extra cost. Avoids reimplementing git workflow logic in Go. |
+| M2-3 | Workspace strategy is extracted to `@paperclipai/workspace-strategy` | One implementation consumed by both the server local-adapter path AND the init container. Real refactor; ~3-5 days. Risk #1 resolved. |
+| M2-4 | Bootstrap-token-only auth in M2; full TokenReview deferred to V2 | Same auth path the cursor-cloud adapter ships. Bootstrap token TTL = 10 min, single-use, bound to Job UID. Risk #5 resolved (with explicit V2 follow-up). |
+| M2-5 | Resource defaults measured during M2 implementation; tuning in same PR | When the end-to-end test runs real claude_local heartbeats we capture p50/p95/p99 CPU/memory and adjust `LimitRange` defaults in the same commit. Risk #4 resolved. |
+| M2-6 | Single adapter coverage in M2 — `claude_local` only | The other six adapters (codex/gemini/opencode/acpx/pi/cursor) keep their M1 rejection branch and gain k8s execution in M3. Tightens M2 scope. |
+| M2-7 | One image family member in M2 — `agent-runtime-base` + `agent-runtime-claude` | M3 builds the rest. Multi-arch (amd64+arm64) shipped from day one. |
+| M2-8 | No sidecars in V1 (per spec §3.3); log streaming via `pods/log` watch | Spec decision; M2 honors it. |
+
+---
+
+## Scope Note
+
+M2 is one coherent vertical slice — it produces a real, demonstrable capability ("the hired agent works on Kubernetes") that can ship and be merged. The plan is large because the slice is wide (Go binary + Node script + image build + 5 server routes + 6 orchestrator builders + driver implementation + claude_local wiring + 4 integration tests + image CI), but it's not split because the slice has no internal cut-points where partial completion would be useful — without callbacks, the Job runs blindly; without orchestrator extensions, the routes have nothing to talk to; etc.
+
+Operators who want to try M2 mid-development can run individual integration tests, but the merge unit is the whole slice.
+
+---
+
+## File Structure
+
+### New packages
+
+```
+packages/workspace-strategy/                              # NEW
+├── package.json                                          # @paperclipai/workspace-strategy
+├── tsconfig.json
+└── src/
+    ├── index.ts                                          # public exports
+    ├── types.ts                                          # WorkspaceStrategySpec, WorkspaceStrategyKind
+    ├── execute.ts                                        # executeStrategy(spec, root, deps) — top-level dispatch
+    ├── git-clone.ts                                      # cold + warm git-clone strategy
+    ├── git-worktree.ts                                   # bare clone + worktree-add strategy
+    ├── existing-path.ts                                  # validation-time rejector for k8s; no-op for local
+    └── git-runner.ts                                     # tiny shell wrapper around `git` (testable)
+```
+
+### New Go binary
+
+```
+tools/agent-shim/                                         # NEW Go static binary
+├── go.mod
+├── go.sum
+├── main.go                                               # PID-1 supervisor: parse config, exec adapter CLI, frame stdout
+├── runtime_command.go                                    # AdapterRuntimeCommandSpec parsing
+├── stdout_framer.go                                      # structured-event framing for UI parsers
+├── callback_client.go                                    # POST /api/runs/:runId/events with run JWT
+├── bootstrap_exchange.go                                 # POST /api/agent-auth/exchange to get run JWT
+└── main_test.go
+```
+
+### New Node script
+
+```
+tools/workspace-init/                                     # NEW Node script
+├── package.json                                          # @paperclipai/workspace-init (private)
+├── tsconfig.json
+└── src/
+    ├── index.ts                                          # entrypoint: parse strategy spec, exchange bootstrap token, run strategy
+    └── git-credentials.ts                                # POST /api/workspace/git-credentials
+```
+
+### New runtime images
+
+```
+docker/agent-runtime/                                     # NEW
+├── Dockerfile.base                                       # ubuntu-22.04 + node-22 + git + tini + nonroot uid 1000 + agent-shim + workspace-init
+├── Dockerfile.claude                                     # extends base + @anthropic-ai/claude-code CLI pinned
+├── buildx-bake.hcl                                       # multi-arch (amd64+arm64) build config
+└── README.md
+```
+
+### Orchestrator extensions
+
+```
+packages/adapters/kubernetes-execution/
+├── src/
+│   ├── orchestrator/
+│   │   ├── pvc.ts                                        # NEW (PVC-per-agent builder + apply)
+│   │   ├── secret.ts                                     # NEW (per-Job ephemeral Secret materializer)
+│   │   ├── job.ts                                        # NEW (Job spec builder: init + main containers, volumes)
+│   │   ├── log-stream.ts                                 # NEW (pods/log watch → onLog with reconnect)
+│   │   ├── event-watch.ts                                # NEW (Job/Pod Events watch → onLog with [k8s] prefix)
+│   │   ├── cancellation.ts                               # NEW (Job delete with grace + foreground propagation)
+│   │   └── failure-mapping.ts                            # NEW (k8s state → AdapterExecutionResult error codes)
+│   ├── redaction.ts                                      # MODIFIED (real implementation; was groundwork in M1)
+│   ├── driver.ts                                         # MODIFIED (real run() implementation replacing M1 stub)
+│   └── bootstrap/
+│       └── token.ts                                      # NEW (driver-side wrapper around server bootstrap-token API)
+└── test/
+    ├── unit/
+    │   ├── pvc.test.ts
+    │   ├── secret.test.ts                                # incl. redaction key extraction
+    │   ├── job.test.ts                                   # Job spec golden snapshots
+    │   ├── log-stream.test.ts                            # mocked pods/log watch
+    │   ├── event-watch.test.ts
+    │   ├── cancellation.test.ts
+    │   ├── failure-mapping.test.ts
+    │   └── redaction.test.ts
+    └── integration/
+        ├── job-lifecycle.test.ts                         # busybox Job: submit → run → log capture → cleanup
+        ├── claude-end-to-end.test.ts                     # real claude_local against fake LLM
+        ├── failure-modes.test.ts                         # ImagePullBackOff, OOM, timeout
+        └── empirical-measurement.test.ts                 # records CPU/memory; commits results
+```
+
+### Server-side auth + callbacks
+
+```
+server/src/services/
+├── bootstrap-tokens.ts                                   # NEW (mint, validate, single-use, bound to Job UID)
+├── bootstrap-tokens.test.ts
+├── run-jwt.ts                                            # NEW (mint, validate run-scoped JWT)
+└── run-jwt.test.ts
+
+server/src/routes/
+├── agent-auth-exchange.ts                                # NEW POST /api/agent-auth/exchange
+├── agent-auth-exchange.test.ts
+├── runs-events.ts                                        # NEW POST /api/runs/:runId/events
+├── runs-events.test.ts
+├── workspace-git-credentials.ts                          # NEW POST /api/workspace/git-credentials
+└── workspace-git-credentials.test.ts
+```
+
+### Adapter wiring
+
+```
+packages/adapters/claude-local/src/server/
+└── execute.ts                                            # MODIFIED (route to k8s when target.kind === "kubernetes")
+```
+
+### Documentation
+
+```
+docs/k8s-execution/
+├── running-agents.md                                     # NEW (operator: how to run a claude_local agent on k8s)
+├── building-images.md                                    # NEW (developer: image build pipeline)
+├── debugging-stuck-pods.md                               # NEW (operator: kubectl recipes for stuck/failed runs)
+└── auth-callback-flow.md                                 # NEW (developer: bootstrap-token → run-JWT lifecycle)
+```
+
+### CI
+
+```
+.github/workflows/
+├── k8s-images.yml                                        # NEW (build + push agent-runtime images, multi-arch, signed)
+└── k8s-integration.yml                                   # MODIFIED (add new integration tests)
+```
+
+---
+
+## Sequencing & Workstream Notes
+
+- **Phase A (Tasks 1–4)** — Workspace-strategy extract. Sequential; affects existing server code paths.
+- **Phase B (Tasks 5–10)** — Go agent-shim + Node workspace-init + runtime images. Parallelisable across agents after A is done. Phase B doesn't touch server; tests run in their own packages.
+- **Phase C (Tasks 11–16)** — Server bootstrap-token + run-JWT services + 3 callback routes. Independent of A/B; parallel-safe.
+- **Phase D (Tasks 17–22)** — Orchestrator extensions (PVC/Secret/Job/log-stream/event-watch/cancellation/failure-mapping). Pure builders + apply functions. Parallelisable after Phase B types exist.
+- **Phase E (Tasks 23–24)** — Driver `run()` implementation + claude_local wiring. Depends on B/C/D.
+- **Phase F (Tasks 25–28)** — End-to-end integration tests + empirical measurement + failure-mode coverage. Depends on E.
+- **Phase G (Tasks 29–30)** — Image CI + docs + ROADMAP. Independent of E/F.
+
+Total: 30 tasks. Each is 2–6 TDD-discipline steps.
+
+---
+
+## Phase A — Workspace Strategy Extract (Tasks 1–4)
+
+### Task 1: Scaffold `@paperclipai/workspace-strategy` package
+
+**Files:**
+- Create: `packages/workspace-strategy/package.json`
+- Create: `packages/workspace-strategy/tsconfig.json`
+- Create: `packages/workspace-strategy/src/index.ts`
+
+- [ ] **Step 1: Create `package.json`**
+
+```json
+{
+  "name": "@paperclipai/workspace-strategy",
+  "version": "0.0.0",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}
+```
+
+- [ ] **Step 2: Create `tsconfig.json`** matching sibling style (see `packages/adapters/kubernetes-execution/tsconfig.json`)
+
+- [ ] **Step 3: Create `src/index.ts` placeholder** with `export const PACKAGE_NAME = "@paperclipai/workspace-strategy";`
+
+- [ ] **Step 4: Verify `pnpm install && pnpm --filter @paperclipai/workspace-strategy build` succeeds**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/workspace-strategy pnpm-lock.yaml
+git commit -m "feat(workspace-strategy): scaffold package"
+```
+
+### Task 2: Define `WorkspaceStrategySpec` types and JSON schema
+
+**Files:**
+- Create: `packages/workspace-strategy/src/types.ts`
+- Create: `packages/workspace-strategy/src/types.test.ts`
+
+- [ ] **Step 1: Failing test asserting the union shape and serialization round-trip**
+
+```ts
+// packages/workspace-strategy/src/types.test.ts
+import { describe, it, expect, expectTypeOf } from "vitest";
+import { type WorkspaceStrategySpec, parseWorkspaceStrategySpec, serializeWorkspaceStrategySpec } from "./index.js";
+
+describe("WorkspaceStrategySpec", () => {
+  it("accepts a git-clone variant", () => {
+    const spec: WorkspaceStrategySpec = {
+      kind: "git-clone",
+      url: "https://github.com/acme/repo.git",
+      ref: "main",
+      resetOnCorrupt: true,
+    };
+    expectTypeOf(spec.kind).toEqualTypeOf<"git-clone" | "git-worktree" | "existing-path" | "none">();
+  });
+
+  it("round-trips git-clone via serialize/parse", () => {
+    const spec: WorkspaceStrategySpec = {
+      kind: "git-clone", url: "https://github.com/acme/repo.git", ref: "main", resetOnCorrupt: true,
+    };
+    const json = serializeWorkspaceStrategySpec(spec);
+    expect(JSON.parse(json)).toMatchObject({ kind: "git-clone", url: spec.url, ref: spec.ref });
+    const parsed = parseWorkspaceStrategySpec(json);
+    expect(parsed).toEqual(spec);
+  });
+
+  it("rejects an unknown kind", () => {
+    expect(() => parseWorkspaceStrategySpec(JSON.stringify({ kind: "bogus" }))).toThrow(/unknown kind/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+`pnpm --filter @paperclipai/workspace-strategy test types`
+
+- [ ] **Step 3: Implement `src/types.ts`**
+
+```ts
+export type WorkspaceStrategyKind = "git-clone" | "git-worktree" | "existing-path" | "none";
+
+export interface GitCloneStrategy {
+  kind: "git-clone";
+  url: string;
+  ref: string;            // branch | tag | sha
+  resetOnCorrupt?: boolean;
+}
+
+export interface GitWorktreeStrategy {
+  kind: "git-worktree";
+  url: string;
+  ref: string;
+  worktreeName: string;   // becomes /workspace/<worktreeName> on disk
+  resetOnCorrupt?: boolean;
+}
+
+export interface ExistingPathStrategy {
+  kind: "existing-path";
+  hostPath: string;       // not supported on k8s; rejected at config-validation time
+}
+
+export interface NoneStrategy { kind: "none"; }
+
+export type WorkspaceStrategySpec =
+  | GitCloneStrategy | GitWorktreeStrategy | ExistingPathStrategy | NoneStrategy;
+
+export function serializeWorkspaceStrategySpec(spec: WorkspaceStrategySpec): string {
+  return JSON.stringify(spec);
+}
+
+export function parseWorkspaceStrategySpec(json: string): WorkspaceStrategySpec {
+  const parsed = JSON.parse(json) as { kind?: unknown };
+  if (typeof parsed.kind !== "string") {
+    throw new Error(`Invalid workspace strategy: missing kind`);
+  }
+  switch (parsed.kind) {
+    case "git-clone":     return parsed as GitCloneStrategy;
+    case "git-worktree":  return parsed as GitWorktreeStrategy;
+    case "existing-path": return parsed as ExistingPathStrategy;
+    case "none":          return parsed as NoneStrategy;
+    default:
+      throw new Error(`Invalid workspace strategy: unknown kind "${parsed.kind}"`);
+  }
+}
+```
+
+Re-export from `src/index.ts`:
+
+```ts
+export {
+  type WorkspaceStrategyKind, type WorkspaceStrategySpec,
+  type GitCloneStrategy, type GitWorktreeStrategy, type ExistingPathStrategy, type NoneStrategy,
+  serializeWorkspaceStrategySpec, parseWorkspaceStrategySpec,
+} from "./types.js";
+```
+
+- [ ] **Step 4: Run, expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/workspace-strategy/src/types.ts \
+        packages/workspace-strategy/src/types.test.ts \
+        packages/workspace-strategy/src/index.ts
+git commit -m "feat(workspace-strategy): add WorkspaceStrategySpec types and JSON schema"
+```
+
+### Task 3: Implement `executeStrategy` with git-runner abstraction
+
+**Files:**
+- Create: `packages/workspace-strategy/src/git-runner.ts`
+- Create: `packages/workspace-strategy/src/execute.ts`
+- Create: `packages/workspace-strategy/src/git-clone.ts`
+- Create: `packages/workspace-strategy/src/git-worktree.ts`
+- Create: `packages/workspace-strategy/test/execute.test.ts`
+
+- [ ] **Step 1: Failing test for git-clone happy path with mocked git-runner**
+
+```ts
+// packages/workspace-strategy/test/execute.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { executeStrategy } from "../src/index.js";
+
+function makeFakeRunner() {
+  return {
+    run: vi.fn(async (cmd: string, args: string[], opts?: { cwd?: string }) => ({
+      exitCode: 0, stdout: "", stderr: "",
+    })),
+  };
+}
+
+describe("executeStrategy", () => {
+  it("runs git clone for a cold workspace (empty directory)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ws-"));
+    try {
+      const git = makeFakeRunner();
+      await executeStrategy(
+        { kind: "git-clone", url: "https://github.com/acme/repo.git", ref: "main" },
+        root,
+        { git, getGitCredentials: async () => ({ username: "x-access-token", password: "ghp_test" }) },
+      );
+      expect(git.run).toHaveBeenCalledWith("git", expect.arrayContaining(["clone"]), expect.any(Object));
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("runs git fetch + reset for a warm workspace (.git exists)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ws-"));
+    try {
+      // Simulate warm by creating a .git directory.
+      const fs = await import("node:fs/promises");
+      await fs.mkdir(join(root, ".git"), { recursive: true });
+      const git = makeFakeRunner();
+      await executeStrategy(
+        { kind: "git-clone", url: "https://github.com/acme/repo.git", ref: "main" },
+        root,
+        { git, getGitCredentials: async () => ({ username: "x-access-token", password: "ghp_test" }) },
+      );
+      const calls = git.run.mock.calls.map(c => c[1].join(" "));
+      expect(calls.some(c => c.includes("fetch"))).toBe(true);
+      expect(calls.some(c => c.includes("reset --hard"))).toBe(true);
+      expect(calls.some(c => c.includes("clone"))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects existing-path strategy (not supported in non-local execution)", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ws-"));
+    try {
+      await expect(executeStrategy(
+        { kind: "existing-path", hostPath: "/some/path" } as never,
+        root,
+        { git: makeFakeRunner(), getGitCredentials: async () => ({ username: "", password: "" }), allowExistingPath: false },
+      )).rejects.toThrow(/existing-path|not supported/i);
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+
+  it("no-op for kind=none", async () => {
+    const root = mkdtempSync(join(tmpdir(), "ws-"));
+    try {
+      const git = makeFakeRunner();
+      await executeStrategy({ kind: "none" }, root, { git, getGitCredentials: async () => ({ username: "", password: "" }) });
+      expect(git.run).not.toHaveBeenCalled();
+    } finally { rmSync(root, { recursive: true, force: true }); }
+  });
+});
+```
+
+- [ ] **Step 2: Run, expect failure**
+
+- [ ] **Step 3: Implement `git-runner.ts`**
+
+```ts
+import { spawn } from "node:child_process";
+
+export interface GitRunResult { exitCode: number; stdout: string; stderr: string; }
+
+export interface GitRunner {
+  run(cmd: string, args: string[], opts?: { cwd?: string; env?: Record<string, string> }): Promise<GitRunResult>;
+}
+
+export const realGitRunner: GitRunner = {
+  async run(cmd, args, opts) {
+    return new Promise((resolve) => {
+      const child = spawn(cmd, args, { cwd: opts?.cwd, env: { ...process.env, ...(opts?.env ?? {}) } });
+      let stdout = "", stderr = "";
+      child.stdout.on("data", (d) => { stdout += d.toString(); });
+      child.stderr.on("data", (d) => { stderr += d.toString(); });
+      child.on("close", (code) => resolve({ exitCode: code ?? -1, stdout, stderr }));
+    });
+  },
+};
+```
+
+- [ ] **Step 4: Implement `git-clone.ts`**
+
+```ts
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { GitCloneStrategy } from "./types.js";
+import type { GitRunner } from "./git-runner.js";
+
+export interface GitCloneDeps {
+  git: GitRunner;
+  getGitCredentials(): Promise<{ username: string; password: string }>;
+}
+
+export async function executeGitClone(
+  spec: GitCloneStrategy,
+  root: string,
+  deps: GitCloneDeps,
+): Promise<void> {
+  const creds = await deps.getGitCredentials();
+  const env = {
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_ASKPASS: "/bin/true",
+    GIT_USERNAME: creds.username,
+    GIT_PASSWORD: creds.password,
+  };
+
+  const isWarm = existsSync(join(root, ".git"));
+  if (!isWarm) {
+    const url = injectCreds(spec.url, creds);
+    const r = await deps.git.run("git", ["clone", "--branch", spec.ref, url, "."], { cwd: root, env });
+    if (r.exitCode !== 0) {
+      throw new Error(`git clone failed (${r.exitCode}): ${r.stderr}`);
+    }
+    return;
+  }
+
+  // Warm path: fetch + reset --hard
+  const fetched = await deps.git.run("git", ["fetch", "origin", spec.ref], { cwd: root, env });
+  if (fetched.exitCode !== 0) {
+    throw new Error(`git fetch failed (${fetched.exitCode}): ${fetched.stderr}`);
+  }
+  const reset = await deps.git.run("git", ["reset", "--hard", `origin/${spec.ref}`], { cwd: root, env });
+  if (reset.exitCode !== 0 && spec.resetOnCorrupt) {
+    // Last-resort: blow away and re-clone.
+    const fs = await import("node:fs/promises");
+    await fs.rm(root, { recursive: true, force: true });
+    await fs.mkdir(root, { recursive: true });
+    return executeGitClone(spec, root, deps);
+  }
+  if (reset.exitCode !== 0) {
+    throw new Error(`git reset --hard origin/${spec.ref} failed: ${reset.stderr}`);
+  }
+}
+
+function injectCreds(url: string, creds: { username: string; password: string }): string {
+  if (!url.startsWith("https://")) return url;
+  const u = new URL(url);
+  u.username = encodeURIComponent(creds.username);
+  u.password = encodeURIComponent(creds.password);
+  return u.toString();
+}
+```
+
+- [ ] **Step 5: Implement `git-worktree.ts` and `execute.ts` dispatcher**
+
+```ts
+// git-worktree.ts
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import type { GitWorktreeStrategy } from "./types.js";
+import type { GitRunner } from "./git-runner.js";
+
+export interface GitWorktreeDeps {
+  git: GitRunner;
+  getGitCredentials(): Promise<{ username: string; password: string }>;
+}
+
+export async function executeGitWorktree(
+  spec: GitWorktreeStrategy,
+  root: string,
+  deps: GitWorktreeDeps,
+): Promise<void> {
+  const creds = await deps.getGitCredentials();
+  const env = {
+    GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "/bin/true",
+    GIT_USERNAME: creds.username, GIT_PASSWORD: creds.password,
+  };
+  const bareDir = join(root, ".bare");
+  const worktreeDir = join(root, spec.worktreeName);
+
+  if (!existsSync(bareDir)) {
+    const url = spec.url.startsWith("https://")
+      ? new URL(spec.url).toString().replace(/^https:\/\//, `https://${encodeURIComponent(creds.username)}:${encodeURIComponent(creds.password)}@`)
+      : spec.url;
+    const r = await deps.git.run("git", ["clone", "--bare", url, bareDir], { env });
+    if (r.exitCode !== 0) throw new Error(`git clone --bare failed: ${r.stderr}`);
+  } else {
+    const r = await deps.git.run("git", ["fetch", "origin"], { cwd: bareDir, env });
+    if (r.exitCode !== 0) throw new Error(`git fetch failed: ${r.stderr}`);
+  }
+
+  if (!existsSync(worktreeDir)) {
+    const r = await deps.git.run("git", ["worktree", "add", "-f", worktreeDir, spec.ref], { cwd: bareDir, env });
+    if (r.exitCode !== 0) throw new Error(`git worktree add failed: ${r.stderr}`);
+  } else {
+    const r = await deps.git.run("git", ["reset", "--hard", `origin/${spec.ref}`], { cwd: worktreeDir, env });
+    if (r.exitCode !== 0) throw new Error(`git reset --hard failed: ${r.stderr}`);
+  }
+}
+```
+
+```ts
+// execute.ts
+import type { WorkspaceStrategySpec } from "./types.js";
+import { executeGitClone, type GitCloneDeps } from "./git-clone.js";
+import { executeGitWorktree, type GitWorktreeDeps } from "./git-worktree.js";
+
+export interface ExecuteStrategyDeps extends GitCloneDeps, GitWorktreeDeps {
+  /** When true (server-local execution), existing-path is allowed; when false (k8s), it's rejected. */
+  allowExistingPath?: boolean;
+}
+
+export async function executeStrategy(
+  spec: WorkspaceStrategySpec,
+  root: string,
+  deps: ExecuteStrategyDeps,
+): Promise<void> {
+  switch (spec.kind) {
+    case "git-clone":     return executeGitClone(spec, root, deps);
+    case "git-worktree":  return executeGitWorktree(spec, root, deps);
+    case "existing-path":
+      if (deps.allowExistingPath === false) {
+        throw new Error(
+          `Workspace strategy "existing-path" is not supported on this execution target ` +
+          `(host paths can't be projected into a remote pod). Use git-clone or git-worktree.`,
+        );
+      }
+      return; // local execution treats hostPath as already-prepared.
+    case "none":          return;
+  }
+}
+```
+
+Re-export from `index.ts`:
+
+```ts
+export { executeStrategy, type ExecuteStrategyDeps } from "./execute.js";
+export { realGitRunner, type GitRunner, type GitRunResult } from "./git-runner.js";
+```
+
+- [ ] **Step 6: Run tests, expect PASS**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/workspace-strategy/src/git-runner.ts \
+        packages/workspace-strategy/src/git-clone.ts \
+        packages/workspace-strategy/src/git-worktree.ts \
+        packages/workspace-strategy/src/execute.ts \
+        packages/workspace-strategy/src/index.ts \
+        packages/workspace-strategy/test/execute.test.ts
+git commit -m "feat(workspace-strategy): implement executeStrategy with git-clone, git-worktree, none, and existing-path rejection"
+```
+
+### Task 4: Update server callers to use the new package
+
+**Files (audit):**
+- Find existing workspace strategy code in `server/src/services/` (search `workspace-strategy`, `workspace_strategy`, `WorkspaceStrategy`)
+- Modify each caller to import from `@paperclipai/workspace-strategy`
+- Add `@paperclipai/workspace-strategy` as a workspace dep to `server/package.json`
+- Delete the old in-server implementation OR shrink it to a thin wrapper that calls the package
+
+- [ ] **Step 1: Locate existing strategy code**
+
+Run: `grep -rn "workspace.strategy\|WorkspaceStrategy" server/src/ | head -30`
+
+Note every file that defines or consumes the strategy.
+
+- [ ] **Step 2: Add workspace-strategy as workspace dep on server**
+
+Update `server/package.json`:
+
+```json
+"dependencies": {
+  ...
+  "@paperclipai/workspace-strategy": "workspace:*"
+}
+```
+
+Run `pnpm install`.
+
+- [ ] **Step 3: Replace internal strategy logic with package imports**
+
+For each caller, replace local imports with:
+
+```ts
+import { executeStrategy, type WorkspaceStrategySpec, parseWorkspaceStrategySpec, serializeWorkspaceStrategySpec } from "@paperclipai/workspace-strategy";
+```
+
+Pass `allowExistingPath: true` when calling from local execution code paths.
+
+- [ ] **Step 4: Run server tests, confirm no regressions**
+
+```bash
+pnpm -w exec vitest run server/src
+```
+
+- [ ] **Step 5: If tests fail, the package's behavior diverges from the original**
+
+Fix the package to match the original behavior, NOT the call sites. Add tests that capture the divergent behavior so future changes don't re-introduce.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src server/package.json pnpm-lock.yaml
+git commit -m "refactor(server): consume @paperclipai/workspace-strategy for workspace bootstrap"
+```
+
+---
+
+## Phase B — Runtime Binaries + Images (Tasks 5–10)
+
+### Task 5: `paperclip-agent-shim` Go static binary
+
+**Files:**
+- Create: `tools/agent-shim/go.mod`
+- Create: `tools/agent-shim/main.go`
+- Create: `tools/agent-shim/runtime_command.go`
+- Create: `tools/agent-shim/stdout_framer.go`
+- Create: `tools/agent-shim/main_test.go`
+
+The shim does the following at runtime, in order:
+1. Read `/run/paperclip/runtime-command.json` (projected by orchestrator) — the `AdapterRuntimeCommandSpec`.
+2. Read `/run/paperclip/prompt.txt` — the rendered prompt (stdin for the adapter CLI).
+3. Resolve the adapter command (e.g. `claude-code`).
+4. Frame stdout into structured events for the UI parser (passes through unchanged in V1; adapter CLIs already emit framed output).
+5. Exec-replace itself into the adapter CLI so SIGTERM propagates correctly (Go's `syscall.Exec`).
+
+- [ ] **Step 1: `go.mod`**
+
+```
+module github.com/paperclipai/paperclip/tools/agent-shim
+
+go 1.22
+```
+
+- [ ] **Step 2: `runtime_command.go`**
+
+```go
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+type RuntimeCommandSpec struct {
+	Command        string   `json:"command"`
+	Args           []string `json:"args"`
+	DetectCommand  string   `json:"detectCommand,omitempty"`
+	InstallCommand string   `json:"installCommand,omitempty"`
+}
+
+func loadRuntimeCommandSpec(path string) (*RuntimeCommandSpec, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var spec RuntimeCommandSpec
+	if err := json.Unmarshal(b, &spec); err != nil {
+		return nil, err
+	}
+	if spec.Command == "" {
+		return nil, errors.New("runtime-command.json has empty 'command'")
+	}
+	return &spec, nil
+}
+```
+
+- [ ] **Step 3: `stdout_framer.go`** (V1 passes through; structure for future framing)
+
+```go
+package main
+
+import (
+	"bufio"
+	"io"
+	"os"
+)
+
+// streamWithFraming copies src to dst, optionally injecting framing prefixes.
+// V1: pass-through. Adapter CLIs already emit JSON-line events.
+func streamWithFraming(src io.Reader, dst io.Writer) error {
+	scanner := bufio.NewScanner(src)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024) // accept up to 4MB lines
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if _, err := dst.Write(line); err != nil {
+			return err
+		}
+		if _, err := dst.Write([]byte{'\n'}); err != nil {
+			return err
+		}
+		if f, ok := dst.(*os.File); ok {
+			_ = f.Sync()
+		}
+	}
+	return scanner.Err()
+}
+```
+
+- [ ] **Step 4: `main.go`** with PID-1 supervision via syscall.Exec
+
+```go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+const (
+	defaultRuntimeCommandPath = "/run/paperclip/runtime-command.json"
+)
+
+func main() {
+	specPath := flag.String("spec", defaultRuntimeCommandPath, "path to AdapterRuntimeCommandSpec JSON")
+	adapterType := flag.String("adapter", "", "adapter type (informational; e.g. claude_local)")
+	flag.Parse()
+
+	spec, err := loadRuntimeCommandSpec(*specPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[shim] cannot read runtime command spec: %v\n", err)
+		os.Exit(2)
+	}
+
+	resolved, err := exec.LookPath(spec.Command)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[shim] adapter command %q not found in PATH (adapter=%s)\n", spec.Command, *adapterType)
+		os.Exit(127)
+	}
+
+	// Build argv (resolved binary as argv[0])
+	argv := append([]string{resolved}, spec.Args...)
+
+	// syscall.Exec replaces this process; SIGTERM from k8s reaches the adapter directly.
+	if err := syscall.Exec(resolved, argv, os.Environ()); err != nil {
+		fmt.Fprintf(os.Stderr, "[shim] exec %q failed: %v\n", resolved, err)
+		os.Exit(126)
+	}
+}
+```
+
+- [ ] **Step 5: `main_test.go`** — exercise spec parsing + framer
+
+```go
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadRuntimeCommandSpec_OK(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "spec.json")
+	_ = os.WriteFile(p, []byte(`{"command":"claude-code","args":["--print"]}`), 0o600)
+	spec, err := loadRuntimeCommandSpec(p)
+	if err != nil {
+		t.Fatalf("expected ok, got %v", err)
+	}
+	if spec.Command != "claude-code" || len(spec.Args) != 1 {
+		t.Fatalf("unexpected spec: %+v", spec)
+	}
+}
+
+func TestLoadRuntimeCommandSpec_MissingCommand(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "spec.json")
+	_ = os.WriteFile(p, []byte(`{"command":""}`), 0o600)
+	if _, err := loadRuntimeCommandSpec(p); err == nil {
+		t.Fatal("expected error for empty command")
+	}
+}
+
+func TestStreamWithFraming_PassThrough(t *testing.T) {
+	in := strings.NewReader("a\nb\nc\n")
+	var out bytes.Buffer
+	if err := streamWithFraming(in, &out); err != nil {
+		t.Fatal(err)
+	}
+	if got := out.String(); got != "a\nb\nc\n" {
+		t.Fatalf("unexpected: %q", got)
+	}
+}
+```
+
+- [ ] **Step 6: Build and run tests**
+
+```bash
+cd tools/agent-shim
+go test ./...
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags='-s -w' -o ./bin/paperclip-agent-shim-amd64 .
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -ldflags='-s -w' -o ./bin/paperclip-agent-shim-arm64 .
+ls -l ./bin
+```
+
+Expected binary sizes ≤ 5MB.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/agent-shim
+git commit -m "feat(agent-shim): Go static PID-1 supervisor for adapter CLIs"
+```
+
+### Task 6: `paperclip-workspace-init` Node script
+
+**Files:**
+- Create: `tools/workspace-init/package.json`
+- Create: `tools/workspace-init/tsconfig.json`
+- Create: `tools/workspace-init/src/index.ts`
+- Create: `tools/workspace-init/src/git-credentials.ts`
+- Create: `tools/workspace-init/test/index.test.ts`
+
+This script:
+1. Reads `PAPERCLIP_WORKSPACE_STRATEGY` (JSON env or file path) and `PAPERCLIP_WORKSPACE_ROOT` (default `/workspace`).
+2. Reads `BOOTSTRAP_TOKEN` and `PAPERCLIP_PUBLIC_URL` from env.
+3. Calls `executeStrategy(spec, root, deps)` from `@paperclipai/workspace-strategy`. The `getGitCredentials` dep posts to `/api/workspace/git-credentials` with the bootstrap token to receive a short-TTL HTTPS basic-auth token pair.
+4. Writes `.paperclip-workspace-state.json` marker on success.
+5. Exits 0 on success, non-zero with structured error on failure.
+
+- [ ] **Step 1: `package.json`**
+
+```json
+{
+  "name": "@paperclipai/workspace-init",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "bin": { "paperclip-workspace-init": "./dist/index.js" },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@paperclipai/workspace-strategy": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}
+```
+
+- [ ] **Step 2: `src/git-credentials.ts`**
+
+```ts
+export interface GitCredentialsClient {
+  fetch(): Promise<{ username: string; password: string }>;
+}
+
+export function createGitCredentialsClient(input: {
+  paperclipPublicUrl: string;
+  runJwt: string;
+  repoUrl: string;
+}): GitCredentialsClient {
+  return {
+    async fetch() {
+      const res = await fetch(`${input.paperclipPublicUrl}/api/workspace/git-credentials`, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${input.runJwt}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ repoUrl: input.repoUrl }),
+      });
+      if (!res.ok) {
+        throw new Error(`git-credentials fetch failed (${res.status}): ${await res.text()}`);
+      }
+      const body = (await res.json()) as { username?: string; password?: string };
+      if (!body.username || !body.password) {
+        throw new Error("git-credentials response missing username/password");
+      }
+      return { username: body.username, password: body.password };
+    },
+  };
+}
+```
+
+- [ ] **Step 3: `src/index.ts`**
+
+```ts
+#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  executeStrategy,
+  realGitRunner,
+  parseWorkspaceStrategySpec,
+} from "@paperclipai/workspace-strategy";
+import { createGitCredentialsClient } from "./git-credentials.js";
+
+async function exchangeBootstrapToken(input: { paperclipPublicUrl: string; bootstrapToken: string }): Promise<string> {
+  const res = await fetch(`${input.paperclipPublicUrl}/api/agent-auth/exchange`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ bootstrapToken: input.bootstrapToken }),
+  });
+  if (!res.ok) throw new Error(`bootstrap exchange failed (${res.status}): ${await res.text()}`);
+  const body = (await res.json()) as { runJwt?: string };
+  if (!body.runJwt) throw new Error("exchange response missing runJwt");
+  return body.runJwt;
+}
+
+async function main() {
+  const root = process.env.PAPERCLIP_WORKSPACE_ROOT ?? "/workspace";
+  const strategyJson = process.env.PAPERCLIP_WORKSPACE_STRATEGY;
+  const bootstrapToken = process.env.BOOTSTRAP_TOKEN;
+  const publicUrl = process.env.PAPERCLIP_PUBLIC_URL;
+
+  if (!strategyJson) throw new Error("PAPERCLIP_WORKSPACE_STRATEGY not set");
+  if (!bootstrapToken) throw new Error("BOOTSTRAP_TOKEN not set");
+  if (!publicUrl) throw new Error("PAPERCLIP_PUBLIC_URL not set");
+
+  const spec = parseWorkspaceStrategySpec(strategyJson);
+  const repoUrl = "url" in spec ? spec.url : "";
+  const runJwt = await exchangeBootstrapToken({ paperclipPublicUrl: publicUrl, bootstrapToken });
+  const creds = createGitCredentialsClient({ paperclipPublicUrl: publicUrl, runJwt, repoUrl });
+
+  await executeStrategy(spec, root, {
+    git: realGitRunner,
+    getGitCredentials: () => creds.fetch(),
+    allowExistingPath: false,
+  });
+
+  writeFileSync(join(root, ".paperclip-workspace-state.json"), JSON.stringify({
+    kind: spec.kind,
+    completedAt: new Date().toISOString(),
+  }, null, 2), { mode: 0o600 });
+
+  console.log(`[workspace-init] ${spec.kind} completed at ${root}`);
+}
+
+main().catch((err) => {
+  console.error(`[workspace-init] failed: ${(err as Error).message}`);
+  process.exitCode = 1;
+});
+```
+
+- [ ] **Step 4: Test with stubbed fetch**
+
+```ts
+// test/index.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createGitCredentialsClient } from "../src/git-credentials.js";
+
+describe("createGitCredentialsClient", () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it("posts to /api/workspace/git-credentials and returns username/password", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ username: "x", password: "y" }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const c = createGitCredentialsClient({ paperclipPublicUrl: "https://pp", runJwt: "jwt", repoUrl: "https://github.com/acme/repo.git" });
+    const r = await c.fetch();
+    expect(r).toEqual({ username: "x", password: "y" });
+    expect(fetchMock).toHaveBeenCalledWith("https://pp/api/workspace/git-credentials", expect.objectContaining({
+      method: "POST",
+      headers: expect.objectContaining({ "Authorization": "Bearer jwt" }),
+    }));
+  });
+
+  it("throws on non-2xx", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("nope", { status: 500 })));
+    const c = createGitCredentialsClient({ paperclipPublicUrl: "https://pp", runJwt: "jwt", repoUrl: "" });
+    await expect(c.fetch()).rejects.toThrow(/500/);
+  });
+
+  it("throws when response is missing username/password", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({}), { status: 200 })));
+    const c = createGitCredentialsClient({ paperclipPublicUrl: "https://pp", runJwt: "jwt", repoUrl: "" });
+    await expect(c.fetch()).rejects.toThrow(/missing username/);
+  });
+});
+```
+
+- [ ] **Step 5: Build and run**
+
+```bash
+pnpm install
+pnpm --filter @paperclipai/workspace-init build
+pnpm --filter @paperclipai/workspace-init test
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/workspace-init pnpm-lock.yaml
+git commit -m "feat(workspace-init): Node script bootstrapping the per-Job workspace via @paperclipai/workspace-strategy"
+```
+
+### Task 7: `agent-runtime-base` Dockerfile
+
+**Files:**
+- Create: `docker/agent-runtime/Dockerfile.base`
+
+The base image carries: ubuntu-22.04 (small) + Node 22 + git + tini + non-root uid/gid 1000 + the two binaries (`paperclip-agent-shim` and `paperclip-workspace-init`). It does NOT bundle any adapter CLI — that's per-adapter image work.
+
+- [ ] **Step 1: Write the Dockerfile**
+
+```dockerfile
+# syntax=docker/dockerfile:1.6
+ARG NODE_VERSION=22
+ARG TARGETARCH
+
+# ---------- Stage 1: build agent-shim ----------
+FROM golang:1.22-bookworm AS shim-build
+ARG TARGETARCH
+WORKDIR /src
+COPY tools/agent-shim/ ./
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} \
+    go build -ldflags='-s -w' -o /out/paperclip-agent-shim .
+
+# ---------- Stage 2: build workspace-init (Node) ----------
+FROM node:${NODE_VERSION}-bookworm-slim AS wsinit-build
+WORKDIR /src
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
+COPY packages/workspace-strategy/ ./packages/workspace-strategy/
+COPY tools/workspace-init/ ./tools/workspace-init/
+RUN corepack enable && pnpm install --frozen-lockfile \
+    && pnpm --filter @paperclipai/workspace-strategy build \
+    && pnpm --filter @paperclipai/workspace-init build
+
+# ---------- Stage 3: runtime base image ----------
+FROM ubuntu:22.04 AS base
+ARG NODE_VERSION
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl git tini gnupg \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g 1000 paperclip \
+    && useradd -u 1000 -g 1000 -d /home/paperclip -m -s /bin/bash paperclip
+
+COPY --from=shim-build   /out/paperclip-agent-shim       /usr/local/bin/paperclip-agent-shim
+COPY --from=wsinit-build /src/tools/workspace-init/dist  /opt/paperclip/workspace-init
+COPY --from=wsinit-build /src/node_modules               /opt/paperclip/node_modules
+
+# Convenience launcher so the init container can just run `paperclip-workspace-init`
+RUN printf '#!/bin/sh\nexec node --enable-source-maps /opt/paperclip/workspace-init/index.js "$@"\n' \
+      > /usr/local/bin/paperclip-workspace-init \
+    && chmod +x /usr/local/bin/paperclip-workspace-init
+
+USER 1000:1000
+WORKDIR /workspace
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/usr/local/bin/paperclip-agent-shim"]
+```
+
+- [ ] **Step 2: Build it locally and inspect**
+
+```bash
+docker buildx build --platform linux/amd64 \
+  -f docker/agent-runtime/Dockerfile.base \
+  -t paperclipai/agent-runtime-base:dev .
+docker run --rm paperclipai/agent-runtime-base:dev /usr/local/bin/paperclip-agent-shim --help || true
+docker run --rm paperclipai/agent-runtime-base:dev /usr/local/bin/paperclip-workspace-init --help 2>&1 | head -3 || true
+docker image inspect paperclipai/agent-runtime-base:dev --format '{{.Size}}'
+```
+
+Expected: build succeeds; image size < 700 MB (stretch goal: < 400 MB; tighten later).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/agent-runtime/Dockerfile.base
+git commit -m "feat(agent-runtime): base image with tini, git, node, agent-shim, workspace-init"
+```
+
+### Task 8: `agent-runtime-claude` Dockerfile
+
+**Files:**
+- Create: `docker/agent-runtime/Dockerfile.claude`
+
+- [ ] **Step 1: Dockerfile**
+
+```dockerfile
+# syntax=docker/dockerfile:1.6
+ARG BASE_TAG=dev
+FROM paperclipai/agent-runtime-base:${BASE_TAG}
+
+USER root
+RUN npm install -g @anthropic-ai/claude-code@latest \
+    && chown -R 1000:1000 /usr/lib/node_modules \
+    || true
+USER 1000:1000
+
+# Verify the CLI is on PATH for the shim's exec.LookPath
+RUN command -v claude-code >/dev/null 2>&1 || (echo "claude-code not on PATH"; exit 1)
+```
+
+- [ ] **Step 2: Build and verify**
+
+```bash
+docker buildx build --platform linux/amd64 \
+  -f docker/agent-runtime/Dockerfile.claude \
+  --build-arg BASE_TAG=dev \
+  -t paperclipai/agent-runtime-claude:dev .
+docker run --rm paperclipai/agent-runtime-claude:dev claude-code --version
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/agent-runtime/Dockerfile.claude
+git commit -m "feat(agent-runtime): claude image with @anthropic-ai/claude-code CLI"
+```
+
+### Task 9: Multi-arch buildx config
+
+**Files:**
+- Create: `docker/agent-runtime/buildx-bake.hcl`
+
+- [ ] **Step 1: Bake file**
+
+```hcl
+group "default" {
+  targets = ["base", "claude"]
+}
+
+variable "VERSION" { default = "dev" }
+variable "REGISTRY" { default = "ghcr.io/paperclipai" }
+
+target "base" {
+  context = "."
+  dockerfile = "docker/agent-runtime/Dockerfile.base"
+  platforms = ["linux/amd64", "linux/arm64"]
+  tags = ["${REGISTRY}/agent-runtime-base:${VERSION}"]
+}
+
+target "claude" {
+  context = "."
+  dockerfile = "docker/agent-runtime/Dockerfile.claude"
+  platforms = ["linux/amd64", "linux/arm64"]
+  tags = ["${REGISTRY}/agent-runtime-claude:${VERSION}"]
+  contexts = {
+    "paperclipai/agent-runtime-base:${VERSION}" = "target:base"
+  }
+}
+```
+
+- [ ] **Step 2: Local dry-run build**
+
+```bash
+docker buildx bake -f docker/agent-runtime/buildx-bake.hcl --print
+```
+
+Expected: prints rendered targets; no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/agent-runtime/buildx-bake.hcl
+git commit -m "feat(agent-runtime): multi-arch buildx config for base + claude images"
+```
+
+### Task 10: README for the runtime image family
+
+**Files:**
+- Create: `docker/agent-runtime/README.md`
+
+- [ ] **Step 1: Write the README**
+
+Cover:
+- Image family and naming convention (`agent-runtime-{adapterType}:{paperclipVersion}`).
+- How to build locally (`docker buildx bake`).
+- The non-root user (`uid=1000`), the `tini` PID-1, the `WORKDIR=/workspace`.
+- The role of `paperclip-agent-shim` (PID-1 supervisor) and `paperclip-workspace-init` (init container script).
+- How to add a new adapter image (mirror Dockerfile.claude, install the CLI globally).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docker/agent-runtime/README.md
+git commit -m "docs(agent-runtime): document image family conventions"
+```
+
+---
+
+## Phase C — Server Auth + Callback Routes (Tasks 11–16)
+
+Spec §6.6. Three endpoints, one bootstrap-token service, one run-JWT service. Routes are HTTPS-only in production; rate limits apply.
+
+### Task 11: `bootstrapTokensService`
+
+**Files:**
+- Create: `server/src/services/bootstrap-tokens.ts`
+- Create: `server/src/services/bootstrap-tokens.test.ts`
+
+The service mints single-use, short-TTL bootstrap tokens bound to: `agentId`, `companyId`, `runId`, `jobUid` (k8s Job uid), `expiresAt` (10 min default). Storage: in-memory cache + Postgres backing for crash safety. Validation consumes the token (single-use).
+
+- [ ] **Step 1: DB schema for backing storage**
+
+Append a new schema file `packages/db/src/schema/bootstrap_tokens.ts`:
+
+```ts
+import { pgTable, uuid, text, timestamp, index } from "drizzle-orm/pg-core";
+
+export const bootstrapTokens = pgTable(
+  "bootstrap_tokens",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    tokenHash: text("token_hash").notNull(),     // sha256 of the token string
+    agentId: uuid("agent_id").notNull(),
+    companyId: uuid("company_id").notNull(),
+    runId: text("run_id").notNull(),
+    jobUid: text("job_uid").notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    consumedAt: timestamp("consumed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    tokenHashIdx: index("bootstrap_tokens_token_hash_idx").on(t.tokenHash),
+    runIdIdx:     index("bootstrap_tokens_run_id_idx").on(t.runId),
+    expiresIdx:   index("bootstrap_tokens_expires_idx").on(t.expiresAt),
+  }),
+);
+```
+
+Re-export from `packages/db/src/index.ts`. Generate migration:
+
+```bash
+pnpm --filter @paperclipai/db build
+pnpm --filter @paperclipai/db exec drizzle-kit generate --name bootstrap_tokens
+```
+
+- [ ] **Step 2: Failing test**
+
+```ts
+// server/src/services/bootstrap-tokens.test.ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startEmbeddedPostgresTestDatabase, type EmbeddedPostgresTestDatabase, createDb } from "@paperclipai/db";
+import type { Db } from "@paperclipai/db";
+import { bootstrapTokensService } from "./bootstrap-tokens.js";
+
+let dbHandle: EmbeddedPostgresTestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+  dbHandle = await startEmbeddedPostgresTestDatabase("paperclip-bs-tokens-");
+  db = createDb(dbHandle.connectionString);
+});
+afterAll(async () => { await dbHandle.cleanup(); });
+
+describe("bootstrapTokensService", () => {
+  it("mints a token, validates it once, then rejects replay", async () => {
+    const svc = bootstrapTokensService(db);
+    const minted = await svc.mint({
+      agentId: "11111111-1111-1111-1111-111111111111",
+      companyId: "22222222-2222-2222-2222-222222222222",
+      runId: "r-1", jobUid: "job-uid-1",
+      ttlSeconds: 600,
+    });
+    expect(minted.token).toMatch(/^bst_/);
+
+    const v1 = await svc.validateAndConsume(minted.token);
+    expect(v1.ok).toBe(true);
+    if (v1.ok) {
+      expect(v1.binding.runId).toBe("r-1");
+      expect(v1.binding.jobUid).toBe("job-uid-1");
+    }
+
+    const v2 = await svc.validateAndConsume(minted.token);
+    expect(v2.ok).toBe(false);
+    if (!v2.ok) expect(v2.reason).toBe("already_consumed");
+  });
+
+  it("rejects an expired token", async () => {
+    const svc = bootstrapTokensService(db);
+    const minted = await svc.mint({
+      agentId: "11111111-1111-1111-1111-111111111112",
+      companyId: "22222222-2222-2222-2222-222222222223",
+      runId: "r-2", jobUid: "job-uid-2",
+      ttlSeconds: 1,
+    });
+    await new Promise((r) => setTimeout(r, 1100));
+    const v = await svc.validateAndConsume(minted.token);
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("expired");
+  });
+
+  it("rejects an unknown token with reason=not_found", async () => {
+    const svc = bootstrapTokensService(db);
+    const v = await svc.validateAndConsume("bst_thisisnotreal");
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("not_found");
+  });
+});
+```
+
+- [ ] **Step 3: Implement `bootstrap-tokens.ts`**
+
+```ts
+import { createHash, randomBytes } from "node:crypto";
+import { eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { bootstrapTokens } from "@paperclipai/db";
+
+export interface BootstrapTokenBinding {
+  agentId: string;
+  companyId: string;
+  runId: string;
+  jobUid: string;
+}
+
+export interface MintInput extends BootstrapTokenBinding {
+  ttlSeconds: number;
+}
+
+export interface MintResult {
+  token: string;
+  expiresAt: Date;
+}
+
+export type ValidateResult =
+  | { ok: true; binding: BootstrapTokenBinding }
+  | { ok: false; reason: "not_found" | "expired" | "already_consumed" };
+
+export interface BootstrapTokensService {
+  mint(input: MintInput): Promise<MintResult>;
+  validateAndConsume(token: string): Promise<ValidateResult>;
+}
+
+function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export function bootstrapTokensService(db: Db): BootstrapTokensService {
+  return {
+    async mint(input) {
+      const raw = randomBytes(32).toString("base64url");
+      const token = `bst_${raw}`;
+      const expiresAt = new Date(Date.now() + input.ttlSeconds * 1000);
+      await db.insert(bootstrapTokens).values({
+        tokenHash: hashToken(token),
+        agentId: input.agentId,
+        companyId: input.companyId,
+        runId: input.runId,
+        jobUid: input.jobUid,
+        expiresAt,
+      });
+      return { token, expiresAt };
+    },
+
+    async validateAndConsume(token) {
+      const hash = hashToken(token);
+      const [row] = await db.select().from(bootstrapTokens).where(eq(bootstrapTokens.tokenHash, hash));
+      if (!row) return { ok: false, reason: "not_found" };
+      if (row.consumedAt) return { ok: false, reason: "already_consumed" };
+      if (row.expiresAt.getTime() <= Date.now()) return { ok: false, reason: "expired" };
+      await db.update(bootstrapTokens).set({ consumedAt: new Date() }).where(eq(bootstrapTokens.id, row.id));
+      return {
+        ok: true,
+        binding: { agentId: row.agentId, companyId: row.companyId, runId: row.runId, jobUid: row.jobUid },
+      };
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/db/src/schema/bootstrap_tokens.ts \
+        packages/db/src/migrations \
+        packages/db/src/index.ts \
+        server/src/services/bootstrap-tokens.ts \
+        server/src/services/bootstrap-tokens.test.ts
+git commit -m "feat(server): bootstrap tokens service (single-use, bound to Job UID)"
+```
+
+### Task 12: `runJwtService`
+
+**Files:**
+- Create: `server/src/services/run-jwt.ts`
+- Create: `server/src/services/run-jwt.test.ts`
+
+The run JWT is a HS256-signed token bound to `runId`, `agentId`, `companyId`, `jobUid`. TTL = 1 hour. Signing key comes from `process.env.PAPERCLIP_RUN_JWT_SECRET` (32 random bytes; rotated per release in production).
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// server/src/services/run-jwt.test.ts
+import { describe, it, expect } from "vitest";
+import { runJwtService } from "./run-jwt.js";
+
+const secret = "0".repeat(32);
+
+describe("runJwtService", () => {
+  it("mints and verifies a token", () => {
+    const svc = runJwtService(secret);
+    const t = svc.mint({ runId: "r-1", agentId: "a-1", companyId: "c-1", jobUid: "j-1", ttlSeconds: 60 });
+    const v = svc.verify(t);
+    expect(v.ok).toBe(true);
+    if (v.ok) {
+      expect(v.claims.runId).toBe("r-1");
+      expect(v.claims.jobUid).toBe("j-1");
+    }
+  });
+
+  it("rejects a tampered token", () => {
+    const svc = runJwtService(secret);
+    const t = svc.mint({ runId: "r-1", agentId: "a-1", companyId: "c-1", jobUid: "j-1", ttlSeconds: 60 });
+    const tampered = t.slice(0, -2) + "AA";
+    const v = svc.verify(tampered);
+    expect(v.ok).toBe(false);
+  });
+
+  it("rejects an expired token", async () => {
+    const svc = runJwtService(secret);
+    const t = svc.mint({ runId: "r-1", agentId: "a-1", companyId: "c-1", jobUid: "j-1", ttlSeconds: 0 });
+    await new Promise((r) => setTimeout(r, 1100));
+    const v = svc.verify(t);
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("expired");
+  });
+});
+```
+
+- [ ] **Step 2: Implement `run-jwt.ts`**
+
+```ts
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export interface RunJwtClaims {
+  runId: string;
+  agentId: string;
+  companyId: string;
+  jobUid: string;
+  exp: number; // unix seconds
+}
+
+export interface MintInput extends Omit<RunJwtClaims, "exp"> { ttlSeconds: number; }
+
+export type VerifyResult =
+  | { ok: true; claims: RunJwtClaims }
+  | { ok: false; reason: "malformed" | "bad_signature" | "expired" };
+
+export interface RunJwtService {
+  mint(input: MintInput): string;
+  verify(token: string): VerifyResult;
+}
+
+function b64url(input: Buffer | string): string {
+  return Buffer.from(input).toString("base64url");
+}
+function b64urlDecode(input: string): Buffer {
+  return Buffer.from(input, "base64url");
+}
+
+export function runJwtService(secret: string): RunJwtService {
+  const key = Buffer.from(secret);
+  return {
+    mint(input) {
+      const header = { alg: "HS256", typ: "JWT" };
+      const claims: RunJwtClaims = {
+        runId: input.runId,
+        agentId: input.agentId,
+        companyId: input.companyId,
+        jobUid: input.jobUid,
+        exp: Math.floor(Date.now() / 1000) + input.ttlSeconds,
+      };
+      const headerEncoded = b64url(JSON.stringify(header));
+      const claimsEncoded = b64url(JSON.stringify(claims));
+      const signing = `${headerEncoded}.${claimsEncoded}`;
+      const sig = createHmac("sha256", key).update(signing).digest();
+      return `${signing}.${b64url(sig)}`;
+    },
+    verify(token) {
+      const parts = token.split(".");
+      if (parts.length !== 3) return { ok: false, reason: "malformed" };
+      const [headerEncoded, claimsEncoded, sigEncoded] = parts;
+      const expectedSig = createHmac("sha256", key).update(`${headerEncoded}.${claimsEncoded}`).digest();
+      const givenSig = b64urlDecode(sigEncoded);
+      if (givenSig.length !== expectedSig.length || !timingSafeEqual(givenSig, expectedSig)) {
+        return { ok: false, reason: "bad_signature" };
+      }
+      let claims: RunJwtClaims;
+      try {
+        claims = JSON.parse(b64urlDecode(claimsEncoded).toString("utf-8")) as RunJwtClaims;
+      } catch {
+        return { ok: false, reason: "malformed" };
+      }
+      if (claims.exp <= Math.floor(Date.now() / 1000)) return { ok: false, reason: "expired" };
+      return { ok: true, claims };
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Run test, expect PASS**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/services/run-jwt.ts server/src/services/run-jwt.test.ts
+git commit -m "feat(server): HS256 run-scoped JWT service"
+```
+
+### Task 13: `POST /api/agent-auth/exchange` route
+
+**Files:**
+- Create: `server/src/routes/agent-auth-exchange.ts`
+- Create: `server/src/routes/agent-auth-exchange.test.ts`
+- Modify: server route registration to mount the new route
+
+The route accepts `{ bootstrapToken: string }`, validates+consumes via `bootstrapTokensService`, mints a run JWT via `runJwtService`, returns `{ runJwt, expiresAt }`. Rate limit: 10/min/companyId, 1000/day/companyId.
+
+- [ ] **Step 1: Failing test (uses the existing route test pattern in this repo — read 1-2 existing route tests first to mirror it)**
+
+```ts
+// server/src/routes/agent-auth-exchange.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { createAgentAuthExchangeRoute, type AgentAuthExchangeDeps } from "./agent-auth-exchange.js";
+
+function deps(overrides?: Partial<AgentAuthExchangeDeps>): AgentAuthExchangeDeps {
+  return {
+    bootstrapTokens: {
+      validateAndConsume: vi.fn(async () => ({
+        ok: true as const,
+        binding: { agentId: "a-1", companyId: "c-1", runId: "r-1", jobUid: "j-1" },
+      })),
+      mint: vi.fn(),
+    },
+    runJwt: {
+      mint: vi.fn(() => "fake.jwt.value"),
+      verify: vi.fn(),
+    },
+    runJwtTtlSeconds: 3600,
+    ...overrides,
+  };
+}
+
+describe("POST /api/agent-auth/exchange", () => {
+  it("returns runJwt + expiresAt on success", async () => {
+    const handler = createAgentAuthExchangeRoute(deps());
+    const res = await handler({ bootstrapToken: "bst_abc" });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ runJwt: "fake.jwt.value", expiresAt: expect.any(String) });
+  });
+
+  it("returns 400 token_already_consumed on replay", async () => {
+    const handler = createAgentAuthExchangeRoute(deps({
+      bootstrapTokens: {
+        validateAndConsume: async () => ({ ok: false as const, reason: "already_consumed" as const }),
+        mint: vi.fn(),
+      },
+    }));
+    const res = await handler({ bootstrapToken: "bst_abc" });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "token_already_consumed" });
+  });
+
+  it("returns 400 token_expired", async () => {
+    const handler = createAgentAuthExchangeRoute(deps({
+      bootstrapTokens: {
+        validateAndConsume: async () => ({ ok: false as const, reason: "expired" as const }),
+        mint: vi.fn(),
+      },
+    }));
+    const res = await handler({ bootstrapToken: "bst_abc" });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "token_expired" });
+  });
+
+  it("returns 400 invalid_token for unknown tokens", async () => {
+    const handler = createAgentAuthExchangeRoute(deps({
+      bootstrapTokens: {
+        validateAndConsume: async () => ({ ok: false as const, reason: "not_found" as const }),
+        mint: vi.fn(),
+      },
+    }));
+    const res = await handler({ bootstrapToken: "bst_xyz" });
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "invalid_token" });
+  });
+
+  it("returns 400 missing_token when body lacks bootstrapToken", async () => {
+    const handler = createAgentAuthExchangeRoute(deps());
+    const res = await handler({} as never);
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 2: Implement `agent-auth-exchange.ts`** (framework-neutral handler)
+
+```ts
+import type { BootstrapTokensService } from "../services/bootstrap-tokens.js";
+import type { RunJwtService } from "../services/run-jwt.js";
+
+export interface AgentAuthExchangeDeps {
+  bootstrapTokens: BootstrapTokensService;
+  runJwt: RunJwtService;
+  runJwtTtlSeconds: number;
+}
+
+export interface ExchangeResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+export function createAgentAuthExchangeRoute(deps: AgentAuthExchangeDeps) {
+  return async (body: { bootstrapToken?: string }): Promise<ExchangeResponse> => {
+    if (!body || typeof body.bootstrapToken !== "string") {
+      return { status: 400, body: { error: "missing_token" } };
+    }
+    const v = await deps.bootstrapTokens.validateAndConsume(body.bootstrapToken);
+    if (!v.ok) {
+      const errorCode =
+        v.reason === "already_consumed" ? "token_already_consumed" :
+        v.reason === "expired"          ? "token_expired"          : "invalid_token";
+      return { status: 400, body: { error: errorCode } };
+    }
+    const runJwt = deps.runJwt.mint({
+      runId: v.binding.runId,
+      agentId: v.binding.agentId,
+      companyId: v.binding.companyId,
+      jobUid: v.binding.jobUid,
+      ttlSeconds: deps.runJwtTtlSeconds,
+    });
+    const expiresAt = new Date(Date.now() + deps.runJwtTtlSeconds * 1000).toISOString();
+    return { status: 200, body: { runJwt, expiresAt } };
+  };
+}
+```
+
+- [ ] **Step 3: Mount on the server's HTTP framework**
+
+Read `server/src/app.ts` (or wherever routes are registered) to see how routes mount. Add the route, calling `createAgentAuthExchangeRoute({ bootstrapTokens, runJwt, runJwtTtlSeconds: 3600 })`. Apply rate limits using whatever middleware the rest of the codebase uses (search for "rateLimit" or similar).
+
+- [ ] **Step 4: Run tests + integration smoke (curl against dev server) + commit**
+
+```bash
+pnpm -w exec vitest run server/src/routes/agent-auth-exchange
+git add server/src/routes/agent-auth-exchange.ts \
+        server/src/routes/agent-auth-exchange.test.ts \
+        server/src/app.ts
+git commit -m "feat(server): POST /api/agent-auth/exchange (bootstrap token → run JWT)"
+```
+
+### Task 14: `POST /api/runs/:runId/events` route
+
+**Files:**
+- Create: `server/src/routes/runs-events.ts`
+- Create: `server/src/routes/runs-events.test.ts`
+
+The route ingests structured events posted by the agent shim (`init`/`status`/`assistant`/`tool_call`/`tool_result`/`result`/`stderr`/`system`/`stdout`/`thinking`). Auth: bearer run-JWT (must match `:runId` URL param). Body: a JSON event object. Storage: writes to the existing `heartbeat_run_events` table (or whichever table currently captures run events; verify by reading `packages/db/src/schema/`).
+
+- [ ] **Step 1: Identify the run-events table**
+
+```bash
+grep -rn "heartbeat_run_events\|runEvents" packages/db/src/schema/ server/src/services | head -20
+```
+
+Note the table name and its columns.
+
+- [ ] **Step 2: Failing test**
+
+```ts
+// server/src/routes/runs-events.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { createRunsEventsRoute, type RunsEventsDeps } from "./runs-events.js";
+
+function deps(overrides?: Partial<RunsEventsDeps>): RunsEventsDeps {
+  return {
+    runJwt: { verify: vi.fn(() => ({ ok: true as const, claims: { runId: "r-1", agentId: "a-1", companyId: "c-1", jobUid: "j-1", exp: 9_999_999_999 } })), mint: vi.fn() },
+    appendRunEvent: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+describe("POST /api/runs/:runId/events", () => {
+  it("appends an event when JWT runId matches URL runId", async () => {
+    const d = deps();
+    const handler = createRunsEventsRoute(d);
+    const res = await handler({
+      params: { runId: "r-1" },
+      headers: { authorization: "Bearer fake.jwt" },
+      body: { type: "assistant", ts: "2026-05-09T00:00:00Z", text: "hello" },
+    });
+    expect(res.status).toBe(204);
+    expect(d.appendRunEvent).toHaveBeenCalledWith(expect.objectContaining({
+      runId: "r-1",
+      type: "assistant",
+    }));
+  });
+
+  it("rejects 401 when Authorization header missing", async () => {
+    const handler = createRunsEventsRoute(deps());
+    const res = await handler({ params: { runId: "r-1" }, headers: {}, body: {} });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects 403 when JWT runId differs from URL runId", async () => {
+    const handler = createRunsEventsRoute(deps());
+    const res = await handler({ params: { runId: "r-2" }, headers: { authorization: "Bearer fake.jwt" }, body: { type: "assistant", text: "x" } });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects 400 when body is missing 'type'", async () => {
+    const handler = createRunsEventsRoute(deps());
+    const res = await handler({ params: { runId: "r-1" }, headers: { authorization: "Bearer fake.jwt" }, body: { text: "x" } });
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 3: Implement `runs-events.ts`**
+
+```ts
+import type { RunJwtService } from "../services/run-jwt.js";
+
+export interface RunEventInput {
+  runId: string;
+  type: string;
+  ts: string;
+  payload: Record<string, unknown>;
+}
+
+export interface RunsEventsDeps {
+  runJwt: RunJwtService;
+  appendRunEvent: (input: RunEventInput) => Promise<void>;
+}
+
+export interface RouteRequest {
+  params: { runId: string };
+  headers: { authorization?: string };
+  body: { type?: string; ts?: string; [k: string]: unknown };
+}
+
+export interface RouteResponse {
+  status: number;
+  body?: Record<string, unknown>;
+}
+
+export function createRunsEventsRoute(deps: RunsEventsDeps) {
+  return async (req: RouteRequest): Promise<RouteResponse> => {
+    const auth = req.headers.authorization;
+    if (!auth?.startsWith("Bearer ")) return { status: 401, body: { error: "missing_authorization" } };
+    const v = deps.runJwt.verify(auth.slice("Bearer ".length));
+    if (!v.ok) return { status: 401, body: { error: "invalid_jwt" } };
+    if (v.claims.runId !== req.params.runId) {
+      return { status: 403, body: { error: "run_id_mismatch" } };
+    }
+    if (typeof req.body.type !== "string") {
+      return { status: 400, body: { error: "missing_event_type" } };
+    }
+    await deps.appendRunEvent({
+      runId: v.claims.runId,
+      type: req.body.type,
+      ts: typeof req.body.ts === "string" ? req.body.ts : new Date().toISOString(),
+      payload: req.body,
+    });
+    return { status: 204 };
+  };
+}
+```
+
+- [ ] **Step 4: Mount + commit**
+
+```bash
+pnpm -w exec vitest run server/src/routes/runs-events
+git add server/src/routes/runs-events.ts server/src/routes/runs-events.test.ts server/src/app.ts
+git commit -m "feat(server): POST /api/runs/:runId/events (run JWT-authed event ingestion)"
+```
+
+### Task 15: `POST /api/workspace/git-credentials` route
+
+**Files:**
+- Create: `server/src/routes/workspace-git-credentials.ts`
+- Create: `server/src/routes/workspace-git-credentials.test.ts`
+
+Issues short-TTL git credentials (HTTPS basic-auth username/password) bound to a specific repo URL and the calling run JWT. Implementation strategy: GitHub-style `x-access-token` username with a token derived from a GitHub App installation token, OR a per-tenant deploy token from a Paperclip secret. Read `server/src/services/` to find existing git-token plumbing if any; otherwise return a stubbed error and document the integration as a follow-up.
+
+- [ ] **Step 1: Investigate existing git auth**
+
+```bash
+grep -rn "github.*token\|deploy.*key\|git.*credential" server/src | head -20
+```
+
+If a service exists (e.g. `githubAppService`, `gitCredentialsProvider`), wire to it. If not, ship the route returning `503 git_credentials_not_configured` and document this as a deployment requirement.
+
+- [ ] **Step 2: Failing test (covering both wired and unwired paths)**
+
+```ts
+// server/src/routes/workspace-git-credentials.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { createWorkspaceGitCredentialsRoute, type WorkspaceGitCredentialsDeps } from "./workspace-git-credentials.js";
+
+function deps(overrides?: Partial<WorkspaceGitCredentialsDeps>): WorkspaceGitCredentialsDeps {
+  return {
+    runJwt: { verify: vi.fn(() => ({ ok: true as const, claims: { runId: "r-1", agentId: "a-1", companyId: "c-1", jobUid: "j-1", exp: 9_999_999_999 } })), mint: vi.fn() },
+    issueGitCredentials: vi.fn(async () => ({ ok: true as const, username: "x-access-token", password: "ghs_test", expiresAt: "2026-06-01T00:00:00Z" })),
+    ...overrides,
+  };
+}
+
+describe("POST /api/workspace/git-credentials", () => {
+  it("returns username/password for an authorized run", async () => {
+    const handler = createWorkspaceGitCredentialsRoute(deps());
+    const res = await handler({
+      headers: { authorization: "Bearer fake.jwt" },
+      body: { repoUrl: "https://github.com/acme/repo.git" },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ username: "x-access-token", password: "ghs_test" });
+  });
+
+  it("returns 503 when issuer is not configured", async () => {
+    const handler = createWorkspaceGitCredentialsRoute(deps({
+      issueGitCredentials: async () => ({ ok: false as const, reason: "not_configured" as const }),
+    }));
+    const res = await handler({ headers: { authorization: "Bearer fake.jwt" }, body: { repoUrl: "https://github.com/acme/repo.git" } });
+    expect(res.status).toBe(503);
+  });
+
+  it("rejects 401 without a JWT", async () => {
+    const handler = createWorkspaceGitCredentialsRoute(deps());
+    const res = await handler({ headers: {}, body: { repoUrl: "x" } });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects 400 missing repoUrl", async () => {
+    const handler = createWorkspaceGitCredentialsRoute(deps());
+    const res = await handler({ headers: { authorization: "Bearer fake.jwt" }, body: {} });
+    expect(res.status).toBe(400);
+  });
+});
+```
+
+- [ ] **Step 3: Implement `workspace-git-credentials.ts`**
+
+```ts
+import type { RunJwtService } from "../services/run-jwt.js";
+
+export type IssueGitCredentialsResult =
+  | { ok: true; username: string; password: string; expiresAt: string }
+  | { ok: false; reason: "not_configured" | "denied" | "internal_error" };
+
+export interface WorkspaceGitCredentialsDeps {
+  runJwt: RunJwtService;
+  issueGitCredentials: (input: { runId: string; companyId: string; repoUrl: string }) => Promise<IssueGitCredentialsResult>;
+}
+
+export function createWorkspaceGitCredentialsRoute(deps: WorkspaceGitCredentialsDeps) {
+  return async (req: { headers: { authorization?: string }; body: { repoUrl?: string } }) => {
+    const auth = req.headers.authorization;
+    if (!auth?.startsWith("Bearer ")) return { status: 401, body: { error: "missing_authorization" } };
+    const v = deps.runJwt.verify(auth.slice(7));
+    if (!v.ok) return { status: 401, body: { error: "invalid_jwt" } };
+    if (typeof req.body.repoUrl !== "string" || req.body.repoUrl.length === 0) {
+      return { status: 400, body: { error: "missing_repo_url" } };
+    }
+    const r = await deps.issueGitCredentials({
+      runId: v.claims.runId,
+      companyId: v.claims.companyId,
+      repoUrl: req.body.repoUrl,
+    });
+    if (!r.ok) {
+      const status = r.reason === "not_configured" ? 503 : r.reason === "denied" ? 403 : 500;
+      return { status, body: { error: r.reason } };
+    }
+    return { status: 200, body: { username: r.username, password: r.password, expiresAt: r.expiresAt } };
+  };
+}
+```
+
+- [ ] **Step 4: Wire `issueGitCredentials` to existing infrastructure (if any) or stub with `not_configured`. Mount route. Commit.**
+
+```bash
+git add server/src/routes/workspace-git-credentials.ts server/src/routes/workspace-git-credentials.test.ts server/src/app.ts
+git commit -m "feat(server): POST /api/workspace/git-credentials (run JWT-authed git creds)"
+```
+
+### Task 16: Wire all three routes to the live app, add rate limits
+
+- [ ] **Step 1: Verify route mounting** by running the dev server and curling each endpoint.
+
+```bash
+pnpm dev:server &
+sleep 3
+curl -s -X POST http://localhost:3102/api/agent-auth/exchange -H 'Content-Type: application/json' -d '{}'
+# expect 400 missing_token
+```
+
+- [ ] **Step 2: Add rate limits**
+
+If the codebase has an existing rate-limit middleware, apply 10/min/companyId on `/api/agent-auth/exchange`, 1000/min/run on `/api/runs/:runId/events`. If not, document the gap as a follow-up.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/src
+git commit -m "feat(server): apply rate limits to k8s callback routes"
+```
+
+---
+
+## Phase D — Orchestrator Extensions (Tasks 17–22)
+
+All in `packages/adapters/kubernetes-execution/`. Pure builders + `apply` functions, mirroring the M1 pattern. Each builder is unit-tested with golden snapshots; integration coverage comes in Phase F.
+
+### Task 17: PVC builder + apply
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/pvc.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/pvc.test.ts`
+
+Spec §4.1.
+
+- [ ] **Step 1: Failing test**
+
+```ts
+// test/unit/pvc.test.ts
+import { describe, it, expect } from "vitest";
+import { buildAgentWorkspacePvc } from "../../src/orchestrator/pvc.js";
+
+describe("buildAgentWorkspacePvc", () => {
+  it("creates a PVC with paperclip labels and the requested storage class + size", () => {
+    const pvc = buildAgentWorkspacePvc({
+      namespace: "paperclip-acme",
+      agentId: "a-1",
+      agentSlug: "a-acme",
+      companyId: "c-1",
+      companySlug: "acme",
+      storageClass: "gp3",
+      sizeGi: 20,
+      strategyKey: "git-clone",
+    });
+    expect(pvc.kind).toBe("PersistentVolumeClaim");
+    expect(pvc.metadata?.name).toBe("agent-a-acme-workspace");
+    expect(pvc.metadata?.labels?.["paperclip.ai/role"]).toBe("agent-workspace");
+    expect(pvc.metadata?.labels?.["paperclip.ai/agent-id"]).toBe("a-1");
+    expect(pvc.spec?.accessModes).toEqual(["ReadWriteOnce"]);
+    expect(pvc.spec?.storageClassName).toBe("gp3");
+    expect(pvc.spec?.resources?.requests?.storage).toBe("20Gi");
+    expect(pvc.metadata?.annotations?.["paperclip.ai/workspace-strategy"]).toBe("git-clone");
+  });
+
+  it("defaults to 10Gi when sizeGi is not specified", () => {
+    const pvc = buildAgentWorkspacePvc({
+      namespace: "paperclip-acme", agentId: "a-1", agentSlug: "a-acme",
+      companyId: "c-1", companySlug: "acme",
+      storageClass: "standard", strategyKey: "none",
+    });
+    expect(pvc.spec?.resources?.requests?.storage).toBe("10Gi");
+  });
+});
+```
+
+- [ ] **Step 2: Implement `pvc.ts`**
+
+```ts
+import type { V1PersistentVolumeClaim } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import {
+  tenantBaseLabels, PAPERCLIP_AGENT_ID, PAPERCLIP_ROLE, ROLE_AGENT_WORKSPACE,
+  PAPERCLIP_WORKSPACE_STRATEGY,
+} from "./labels.js";
+
+export interface BuildAgentWorkspacePvcInput {
+  namespace: string;
+  agentId: string;
+  agentSlug: string;
+  companyId: string;
+  companySlug: string;
+  storageClass: string;
+  sizeGi?: number;
+  strategyKey: string;
+}
+
+export function buildAgentWorkspacePvc(input: BuildAgentWorkspacePvcInput): V1PersistentVolumeClaim {
+  const sizeGi = input.sizeGi ?? 10;
+  return {
+    apiVersion: "v1",
+    kind: "PersistentVolumeClaim",
+    metadata: {
+      name: `agent-${input.agentSlug}-workspace`,
+      namespace: input.namespace,
+      labels: {
+        ...tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+        [PAPERCLIP_AGENT_ID]: input.agentId,
+        [PAPERCLIP_ROLE]: ROLE_AGENT_WORKSPACE,
+      },
+      annotations: {
+        [PAPERCLIP_WORKSPACE_STRATEGY]: input.strategyKey,
+        "paperclip.ai/created-at": new Date().toISOString(),
+      },
+    },
+    spec: {
+      accessModes: ["ReadWriteOnce"],
+      storageClassName: input.storageClass,
+      resources: { requests: { storage: `${sizeGi}Gi` } },
+    },
+  };
+}
+
+export async function applyAgentWorkspacePvc(
+  client: KubernetesApiClient, pvc: V1PersistentVolumeClaim,
+): Promise<{ existed: boolean }> {
+  const ns = pvc.metadata!.namespace!;
+  const name = pvc.metadata!.name!;
+  try {
+    await client.core.readNamespacedPersistentVolumeClaim(name, ns);
+    // PVC spec is immutable in critical fields (storage size CAN be expanded; class CAN'T change).
+    // We don't patch on subsequent runs — the existing PVC carries forward.
+    return { existed: true };
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await client.core.createNamespacedPersistentVolumeClaim(ns, pvc);
+      return { existed: false };
+    }
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+pnpm --filter @paperclipai/execution-target-kubernetes test pvc
+git add packages/adapters/kubernetes-execution/src/orchestrator/pvc.ts \
+        packages/adapters/kubernetes-execution/test/unit/pvc.test.ts
+git commit -m "feat(k8s-adapter): PVC-per-agent builder + apply"
+```
+
+### Task 18: Per-Job ephemeral Secret materializer with redaction
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/secret.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/secret.test.ts`
+- Modify: `packages/adapters/kubernetes-execution/src/redaction.ts` (replace M1 stub with real impl)
+- Create: `packages/adapters/kubernetes-execution/test/unit/redaction.test.ts`
+
+Spec §5.4. The Secret carries `BOOTSTRAP_TOKEN`, adapter env (LLM keys), and the run JWT placeholder. OwnerReference points to the Job (auto-GC on TTL). Redaction layer captures the value-set so log/error paths can scrub them.
+
+- [ ] **Step 1: Implement redaction module first (used by Secret-builder for safety)**
+
+```ts
+// src/redaction.ts
+export interface Redactor {
+  redact(input: string): string;
+  values(): readonly string[];
+}
+
+export function createRedactor(values: ReadonlyArray<string | undefined | null>): Redactor {
+  const set = new Set<string>();
+  for (const v of values) {
+    if (typeof v === "string" && v.length >= 8) set.add(v);
+  }
+  // Sort longest-first so we don't redact a substring before its enclosing string.
+  const sorted = [...set].sort((a, b) => b.length - a.length);
+  return {
+    values() { return sorted; },
+    redact(input: string) {
+      let out = input;
+      for (const v of sorted) {
+        if (v.length === 0) continue;
+        // Escape regex metacharacters
+        const pattern = new RegExp(v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
+        out = out.replace(pattern, "<redacted>");
+      }
+      return out;
+    },
+  };
+}
+
+export const noopRedactor: Redactor = {
+  redact: (s) => s,
+  values: () => [],
+};
+```
+
+```ts
+// test/unit/redaction.test.ts
+import { describe, it, expect } from "vitest";
+import { createRedactor } from "../../src/redaction.js";
+
+describe("createRedactor", () => {
+  it("redacts secret values that appear in input", () => {
+    const r = createRedactor(["sk-abcdefgh1234", "ghs_xyzabc12345"]);
+    expect(r.redact("ANTHROPIC_API_KEY=sk-abcdefgh1234")).toBe("ANTHROPIC_API_KEY=<redacted>");
+    expect(r.redact("hello ghs_xyzabc12345 world")).toBe("hello <redacted> world");
+  });
+
+  it("ignores values shorter than 8 chars (avoids false positives)", () => {
+    const r = createRedactor(["short"]);
+    expect(r.redact("the short fox")).toBe("the short fox");
+  });
+
+  it("redacts longest-first so substrings inside larger secrets aren't masked first", () => {
+    const r = createRedactor(["abcd1234", "abcd1234efgh"]);
+    expect(r.redact("seen abcd1234efgh once")).toBe("seen <redacted> once");
+  });
+
+  it("filters undefined/null entries", () => {
+    const r = createRedactor([undefined, null, "actualsecret123"]);
+    expect(r.redact("actualsecret123 leaked")).toBe("<redacted> leaked");
+  });
+});
+```
+
+- [ ] **Step 2: Implement Secret builder**
+
+```ts
+// src/orchestrator/secret.ts
+import type { V1Secret, V1OwnerReference } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels, PAPERCLIP_RUN_ID } from "./labels.js";
+
+export interface BuildEphemeralSecretInput {
+  namespace: string;
+  agentSlug: string;
+  runUlid: string;
+  companyId: string;
+  companySlug: string;
+  runId: string;
+  /** Plaintext key/value pairs to materialize. Will be base64-encoded. */
+  data: Record<string, string>;
+  /** OwnerReference to the Job so the Secret is auto-GC'd with TTL. */
+  ownerJob: { name: string; uid: string };
+}
+
+export function buildEphemeralSecret(input: BuildEphemeralSecretInput): V1Secret {
+  const ownerReferences: V1OwnerReference[] = [{
+    apiVersion: "batch/v1",
+    kind: "Job",
+    name: input.ownerJob.name,
+    uid: input.ownerJob.uid,
+    controller: true,
+    blockOwnerDeletion: true,
+  }];
+
+  const data: Record<string, string> = {};
+  for (const [k, v] of Object.entries(input.data)) {
+    data[k] = Buffer.from(v, "utf-8").toString("base64");
+  }
+
+  return {
+    apiVersion: "v1",
+    kind: "Secret",
+    type: "Opaque",
+    metadata: {
+      name: `agent-${input.agentSlug}-run-${input.runUlid}-env`,
+      namespace: input.namespace,
+      labels: {
+        ...tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+        [PAPERCLIP_RUN_ID]: input.runId,
+      },
+      ownerReferences,
+    },
+    data,
+  };
+}
+
+/**
+ * Apply the Secret. NOT idempotent on update — Secrets are created once per run and never updated.
+ * If a Secret with the same name exists (collision impossible with ULIDs but defensive), this throws.
+ */
+export async function applyEphemeralSecret(client: KubernetesApiClient, secret: V1Secret): Promise<void> {
+  const ns = secret.metadata!.namespace!;
+  await client.core.createNamespacedSecret(ns, secret);
+}
+
+/**
+ * Best-effort delete used when Job creation fails AFTER Secret creation but BEFORE
+ * the Job's OwnerReference is established.
+ */
+export async function deleteEphemeralSecret(client: KubernetesApiClient, namespace: string, name: string): Promise<void> {
+  try {
+    await client.core.deleteNamespacedSecret(name, namespace);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) return;
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 3: Failing tests**
+
+```ts
+// test/unit/secret.test.ts
+import { describe, it, expect } from "vitest";
+import { buildEphemeralSecret } from "../../src/orchestrator/secret.js";
+
+describe("buildEphemeralSecret", () => {
+  it("base64-encodes all data values", () => {
+    const s = buildEphemeralSecret({
+      namespace: "paperclip-acme",
+      agentSlug: "a-acme", runUlid: "01H...", companyId: "c-1", companySlug: "acme",
+      runId: "r-1",
+      data: { BOOTSTRAP_TOKEN: "bst_abc", ANTHROPIC_API_KEY: "sk-test123456" },
+      ownerJob: { name: "agent-a-acme-run-01H", uid: "fake-uid" },
+    });
+    expect(s.type).toBe("Opaque");
+    expect(s.data?.["BOOTSTRAP_TOKEN"]).toBe(Buffer.from("bst_abc").toString("base64"));
+    expect(s.data?.["ANTHROPIC_API_KEY"]).toBe(Buffer.from("sk-test123456").toString("base64"));
+  });
+
+  it("attaches an OwnerReference to the Job", () => {
+    const s = buildEphemeralSecret({
+      namespace: "paperclip-acme", agentSlug: "a", runUlid: "01H",
+      companyId: "c-1", companySlug: "acme", runId: "r-1",
+      data: {}, ownerJob: { name: "agent-a-run-01H", uid: "abc-uid" },
+    });
+    const owner = s.metadata?.ownerReferences?.[0];
+    expect(owner?.kind).toBe("Job");
+    expect(owner?.uid).toBe("abc-uid");
+    expect(owner?.controller).toBe(true);
+    expect(owner?.blockOwnerDeletion).toBe(true);
+  });
+
+  it("includes paperclip.ai/run-id label", () => {
+    const s = buildEphemeralSecret({
+      namespace: "paperclip-acme", agentSlug: "a", runUlid: "01H",
+      companyId: "c-1", companySlug: "acme", runId: "run-42",
+      data: {}, ownerJob: { name: "x", uid: "y" },
+    });
+    expect(s.metadata?.labels?.["paperclip.ai/run-id"]).toBe("run-42");
+  });
+});
+```
+
+- [ ] **Step 4: Run, expect PASS, commit**
+
+```bash
+pnpm --filter @paperclipai/execution-target-kubernetes test secret redaction
+git add packages/adapters/kubernetes-execution/src/orchestrator/secret.ts \
+        packages/adapters/kubernetes-execution/src/redaction.ts \
+        packages/adapters/kubernetes-execution/test/unit/secret.test.ts \
+        packages/adapters/kubernetes-execution/test/unit/redaction.test.ts
+git commit -m "feat(k8s-adapter): per-Job ephemeral Secret materializer with value-set redactor"
+```
+
+### Task 19: Job spec builder
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/job.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/job.test.ts`
+
+Spec §3.1, §3.2, §3.3. The Job spec is the largest single object in M2 — init container, main container, volumes, security context, podFailurePolicy, etc. Tests use golden snapshots.
+
+- [ ] **Step 1: Implement `job.ts`** (write before tests for snapshots)
+
+```ts
+import type { V1Job, V1Container, V1Volume } from "@kubernetes/client-node";
+import {
+  tenantBaseLabels, PAPERCLIP_AGENT_ID, PAPERCLIP_RUN_ID, PAPERCLIP_ROLE, ROLE_AGENT_RUNTIME,
+} from "./labels.js";
+
+export interface BuildJobInput {
+  namespace: string;
+  agentId: string;
+  agentSlug: string;
+  runId: string;
+  runUlid: string;
+  companyId: string;
+  companySlug: string;
+  adapterType: string;
+  /** Image for the main container (e.g. ghcr.io/paperclipai/agent-runtime-claude:vX.Y.Z) */
+  image: string;
+  /** Image for the init container (always agent-runtime-base; baked-in workspace-init). */
+  initImage: string;
+  imagePullSecrets?: string[];
+  pvcName: string;
+  envSecretName: string;
+  /** Resource requests/limits for the main container. */
+  resources?: {
+    requests?: { cpu?: string; memory?: string };
+    limits?:   { cpu?: string; memory?: string };
+  };
+  /** Hard ceiling for the run; clamped against ResourceQuota.maxRunSeconds upstream. */
+  activeDeadlineSeconds: number;
+  ttlSecondsAfterFinished: number;
+  /** Workspace strategy serialized as JSON for the init container. */
+  workspaceStrategyJson: string;
+  paperclipPublicUrl: string;
+  /** Trace context propagated into the pod. */
+  traceparent?: string;
+}
+
+export function buildAgentJob(input: BuildJobInput): V1Job {
+  const labels = {
+    ...tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+    [PAPERCLIP_AGENT_ID]: input.agentId,
+    [PAPERCLIP_RUN_ID]:   input.runId,
+    [PAPERCLIP_ROLE]:     ROLE_AGENT_RUNTIME,
+  };
+
+  const volumes: V1Volume[] = [
+    { name: "workspace", persistentVolumeClaim: { claimName: input.pvcName } },
+    { name: "tmp", emptyDir: { sizeLimit: "1Gi" } },
+    { name: "env", secret: { secretName: input.envSecretName, defaultMode: 0o400 } },
+  ];
+
+  const restrictedSecurity = {
+    runAsNonRoot: true,
+    runAsUser: 1000,
+    runAsGroup: 1000,
+    fsGroup: 1000,
+    seccompProfile: { type: "RuntimeDefault" as const },
+  };
+
+  const containerSecurity = {
+    allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: true,
+    capabilities: { drop: ["ALL"] },
+  };
+
+  const initContainer: V1Container = {
+    name: "workspace-init",
+    image: input.initImage,
+    command: ["/usr/local/bin/paperclip-workspace-init"],
+    env: [
+      { name: "PAPERCLIP_WORKSPACE_STRATEGY", value: input.workspaceStrategyJson },
+      { name: "PAPERCLIP_WORKSPACE_ROOT", value: "/workspace" },
+      { name: "PAPERCLIP_RUN_ID", value: input.runId },
+      { name: "PAPERCLIP_PUBLIC_URL", value: input.paperclipPublicUrl },
+      { name: "BOOTSTRAP_TOKEN", valueFrom: { secretKeyRef: { name: input.envSecretName, key: "BOOTSTRAP_TOKEN" } } },
+    ],
+    volumeMounts: [
+      { name: "workspace", mountPath: "/workspace" },
+      { name: "tmp", mountPath: "/tmp" },
+    ],
+    securityContext: containerSecurity,
+    resources: {
+      requests: { cpu: "200m", memory: "256Mi" },
+      limits:   { cpu: "2",    memory: "1Gi"  },
+    },
+  };
+
+  const mainContainer: V1Container = {
+    name: "agent",
+    image: input.image,
+    imagePullPolicy: "IfNotPresent",
+    workingDir: "/workspace",
+    command: ["/usr/bin/tini", "--"],
+    args: ["/usr/local/bin/paperclip-agent-shim", "--adapter", input.adapterType],
+    env: [
+      { name: "PAPERCLIP_RUN_ID", value: input.runId },
+      { name: "PAPERCLIP_PUBLIC_URL", value: input.paperclipPublicUrl },
+      { name: "BOOTSTRAP_TOKEN", valueFrom: { secretKeyRef: { name: input.envSecretName, key: "BOOTSTRAP_TOKEN" } } },
+      ...(input.traceparent ? [{ name: "TRACEPARENT", value: input.traceparent }] : []),
+    ],
+    envFrom: [{ secretRef: { name: input.envSecretName } }],
+    volumeMounts: [
+      { name: "workspace", mountPath: "/workspace" },
+      { name: "tmp", mountPath: "/tmp" },
+      { name: "env", mountPath: "/run/paperclip/env", readOnly: true },
+    ],
+    resources: input.resources ?? {},
+    securityContext: containerSecurity,
+  };
+
+  return {
+    apiVersion: "batch/v1",
+    kind: "Job",
+    metadata: {
+      name: `agent-${input.agentSlug}-run-${input.runUlid}`,
+      namespace: input.namespace,
+      labels,
+    },
+    spec: {
+      backoffLimit: 0,
+      ttlSecondsAfterFinished: input.ttlSecondsAfterFinished,
+      activeDeadlineSeconds: input.activeDeadlineSeconds,
+      completions: 1,
+      parallelism: 1,
+      podFailurePolicy: {
+        rules: [
+          { action: "FailJob", onPodConditions: [{ type: "PodHasNetwork", status: "False" }] },
+          { action: "FailJob", onExitCodes: { containerName: "agent", operator: "In", values: [137] } },
+        ],
+      },
+      template: {
+        metadata: {
+          labels,
+          annotations: { "paperclip.ai/job-spec-version": "v1" },
+        },
+        spec: {
+          automountServiceAccountToken: false,
+          serviceAccountName: "paperclip-agent",
+          restartPolicy: "Never",
+          enableServiceLinks: false,
+          terminationGracePeriodSeconds: 30,
+          securityContext: restrictedSecurity,
+          imagePullSecrets: input.imagePullSecrets?.map((name) => ({ name })) ?? [],
+          initContainers: [initContainer],
+          containers: [mainContainer],
+          volumes,
+        },
+      },
+    },
+  };
+}
+
+/** Apply (create) the Job. Returns the server-assigned UID for OwnerReference wiring. */
+export async function createAgentJob(client: import("../types.js").KubernetesApiClient, job: V1Job): Promise<{ name: string; uid: string }> {
+  const created = await client.batch.createNamespacedJob(job.metadata!.namespace!, job);
+  return { name: created.body.metadata!.name!, uid: created.body.metadata!.uid! };
+}
+```
+
+- [ ] **Step 2: Tests with golden snapshots**
+
+```ts
+// test/unit/job.test.ts
+import { describe, it, expect } from "vitest";
+import { buildAgentJob } from "../../src/orchestrator/job.js";
+
+const baseInput = {
+  namespace: "paperclip-acme",
+  agentId: "a-uuid", agentSlug: "a-acme",
+  runId: "r-1", runUlid: "01HZZZ",
+  companyId: "c-uuid", companySlug: "acme",
+  adapterType: "claude_local",
+  image: "ghcr.io/paperclipai/agent-runtime-claude:v1",
+  initImage: "ghcr.io/paperclipai/agent-runtime-base:v1",
+  imagePullSecrets: ["paperclip-image-pull"],
+  pvcName: "agent-a-acme-workspace",
+  envSecretName: "agent-a-acme-run-01HZZZ-env",
+  activeDeadlineSeconds: 1800,
+  ttlSecondsAfterFinished: 300,
+  workspaceStrategyJson: '{"kind":"git-clone","url":"https://github.com/acme/repo.git","ref":"main"}',
+  paperclipPublicUrl: "https://paperclip.example.com",
+};
+
+describe("buildAgentJob", () => {
+  it("matches the golden snapshot", () => {
+    expect(buildAgentJob(baseInput)).toMatchSnapshot();
+  });
+
+  it("sets backoffLimit=0 (Paperclip owns retries)", () => {
+    expect(buildAgentJob(baseInput).spec?.backoffLimit).toBe(0);
+  });
+
+  it("sets activeDeadlineSeconds from input", () => {
+    expect(buildAgentJob(baseInput).spec?.activeDeadlineSeconds).toBe(1800);
+  });
+
+  it("disables ServiceAccount token auto-mount", () => {
+    const job = buildAgentJob(baseInput);
+    expect(job.spec?.template.spec?.automountServiceAccountToken).toBe(false);
+  });
+
+  it("uses tini as PID 1 with paperclip-agent-shim as the args", () => {
+    const main = buildAgentJob(baseInput).spec?.template.spec?.containers.find((c) => c.name === "agent");
+    expect(main?.command).toEqual(["/usr/bin/tini", "--"]);
+    expect(main?.args?.[0]).toBe("/usr/local/bin/paperclip-agent-shim");
+  });
+
+  it("agent container has restricted PSS context", () => {
+    const main = buildAgentJob(baseInput).spec?.template.spec?.containers.find((c) => c.name === "agent");
+    expect(main?.securityContext?.allowPrivilegeEscalation).toBe(false);
+    expect(main?.securityContext?.readOnlyRootFilesystem).toBe(true);
+    expect(main?.securityContext?.capabilities?.drop).toEqual(["ALL"]);
+  });
+
+  it("init container projects PAPERCLIP_WORKSPACE_STRATEGY env", () => {
+    const init = buildAgentJob(baseInput).spec?.template.spec?.initContainers?.find((c) => c.name === "workspace-init");
+    expect(init?.env?.find((e) => e.name === "PAPERCLIP_WORKSPACE_STRATEGY")?.value).toBe(baseInput.workspaceStrategyJson);
+  });
+
+  it("emits an imagePullSecrets entry when supplied", () => {
+    const job = buildAgentJob(baseInput);
+    expect(job.spec?.template.spec?.imagePullSecrets).toEqual([{ name: "paperclip-image-pull" }]);
+  });
+});
+```
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+pnpm --filter @paperclipai/execution-target-kubernetes test job
+git add packages/adapters/kubernetes-execution/src/orchestrator/job.ts \
+        packages/adapters/kubernetes-execution/test/unit/job.test.ts \
+        packages/adapters/kubernetes-execution/test/unit/__snapshots__
+git commit -m "feat(k8s-adapter): Job spec builder (init + main containers, volumes, restricted PSS)"
+```
+
+### Task 20: Pod log streaming
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/log-stream.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/log-stream.test.ts`
+
+Spec §3.4. Watches `pods/log` for the Job's pod, line-buffers, forwards to `onLog("stdout", chunk)`. Reconnects with `sinceTime` on transient errors so we don't double-buffer.
+
+- [ ] **Step 1: Implement**
+
+```ts
+// src/orchestrator/log-stream.ts
+import { Watch, Log } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+
+export interface LogStreamHandle {
+  abort(): void;
+  done: Promise<void>;
+}
+
+export interface StartLogStreamInput {
+  client: KubernetesApiClient;
+  namespace: string;
+  podName: string;
+  containerName: string;
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+}
+
+export function startLogStream(input: StartLogStreamInput): LogStreamHandle {
+  const controller = new AbortController();
+  let resolveDone!: () => void;
+  const done = new Promise<void>((res) => { resolveDone = res; });
+
+  const start = async () => {
+    let lastTimestamp: string | undefined;
+    while (!controller.signal.aborted) {
+      try {
+        const path = `/api/v1/namespaces/${encodeURIComponent(input.namespace)}/pods/${encodeURIComponent(input.podName)}/log` +
+                     `?container=${encodeURIComponent(input.containerName)}&follow=true&timestamps=true` +
+                     (lastTimestamp ? `&sinceTime=${encodeURIComponent(lastTimestamp)}` : "");
+        const response = await fetch(`${process.env.PAPERCLIP_K8S_API_OVERRIDE ?? ""}${path}`, {
+          method: "GET",
+          signal: controller.signal,
+        });
+        if (!response.ok || !response.body) break;
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        while (!controller.signal.aborted) {
+          const { value, done: streamDone } = await reader.read();
+          if (streamDone) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+          for (const line of lines) {
+            const sep = line.indexOf(" ");
+            if (sep > 0) {
+              const ts = line.slice(0, sep);
+              lastTimestamp = ts;
+              await input.onLog("stdout", line.slice(sep + 1));
+            } else {
+              await input.onLog("stdout", line);
+            }
+          }
+        }
+        if (controller.signal.aborted) break;
+        await new Promise((r) => setTimeout(r, 500));
+      } catch (err) {
+        if (controller.signal.aborted) break;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+    resolveDone();
+  };
+
+  // Kick off in the background, swallowing errors (the loop above handles reconnects).
+  start().catch(() => { /* noop; aborted */ });
+
+  return { abort: () => controller.abort(), done };
+}
+```
+
+NOTE: The `fetch` call above bypasses the typed client because `pods/log` streams aren't well-typed. The `client.request` helper from M1's `client.ts` injects auth headers; this implementation re-uses that path. If the fetch shape doesn't apply auth correctly, route through `client.request` and adapt accordingly. The implementation should use `client.request("GET", path)` style to inherit auth.
+
+(See Step 2 for a corrected version using `client.request`.)
+
+- [ ] **Step 2: Replace fetch with client.request and add response-stream handling**
+
+```ts
+// (Replace the fetch loop with this once verified the existing client.request returns a stream-capable response)
+//
+// The right shape: extend KubernetesApiClient with a `requestStream` method that returns a Response,
+// THEN consume Response.body. M1's client.request returns parsed JSON. M2 adds streaming support.
+```
+
+Update `packages/adapters/kubernetes-execution/src/types.ts` to add `requestStream`:
+
+```ts
+export interface KubernetesApiClient {
+  // ... existing fields ...
+  requestStream(method: string, path: string): Promise<Response>;
+}
+```
+
+Update `packages/adapters/kubernetes-execution/src/client.ts` to implement `requestStream`. It mirrors `request` but doesn't `.json()` the response.
+
+- [ ] **Step 3: Failing test using a mocked client.requestStream**
+
+```ts
+// test/unit/log-stream.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { startLogStream } from "../../src/orchestrator/log-stream.js";
+
+function makeReadableBody(lines: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(line));
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("startLogStream", () => {
+  it("forwards each newline-terminated line to onLog after stripping the leading timestamp", async () => {
+    const collected: string[] = [];
+    const mockClient = {
+      requestStream: vi.fn(async () => new Response(makeReadableBody([
+        "2026-05-09T00:00:00Z hello\n",
+        "2026-05-09T00:00:01Z world\n",
+      ]))),
+    } as unknown as Parameters<typeof startLogStream>[0]["client"];
+
+    const handle = startLogStream({
+      client: mockClient, namespace: "ns", podName: "pod", containerName: "agent",
+      onLog: async (_s, chunk) => { collected.push(chunk); },
+    });
+    await new Promise((r) => setTimeout(r, 100));
+    handle.abort();
+    await handle.done;
+    expect(collected).toEqual(["hello", "world"]);
+  });
+
+  it("reconnects on stream end while not aborted", async () => {
+    const calls: string[][] = [["2026-05-09T00:00:00Z first\n"]];
+    let callIdx = 0;
+    const mockClient = {
+      requestStream: vi.fn(async () => {
+        const lines = calls[Math.min(callIdx++, calls.length - 1)] ?? [];
+        return new Response(makeReadableBody(lines));
+      }),
+    } as unknown as Parameters<typeof startLogStream>[0]["client"];
+
+    const collected: string[] = [];
+    const handle = startLogStream({
+      client: mockClient, namespace: "ns", podName: "pod", containerName: "agent",
+      onLog: async (_s, chunk) => { collected.push(chunk); },
+    });
+    await new Promise((r) => setTimeout(r, 200));
+    handle.abort();
+    await handle.done;
+    expect(collected).toContain("first");
+    expect(mockClient.requestStream).toHaveBeenCalledTimes(expect.any(Number));
+  });
+});
+```
+
+- [ ] **Step 4: Refactor `log-stream.ts` to use `client.requestStream`** instead of raw fetch. Run tests, commit.
+
+```bash
+pnpm --filter @paperclipai/execution-target-kubernetes test log-stream
+git add packages/adapters/kubernetes-execution/src/orchestrator/log-stream.ts \
+        packages/adapters/kubernetes-execution/src/types.ts \
+        packages/adapters/kubernetes-execution/src/client.ts \
+        packages/adapters/kubernetes-execution/test/unit/log-stream.test.ts
+git commit -m "feat(k8s-adapter): pods/log streaming with reconnect via sinceTime"
+```
+
+### Task 21: K8s Events watch + cancellation handler
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/event-watch.ts`
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/cancellation.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/event-watch.test.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/cancellation.test.ts`
+
+Events watch surfaces `Job`/`Pod` warnings (`ImagePullBackOff`, `FailedScheduling`, etc.) into `onLog("stdout", "[k8s] " + reason)`. Cancellation deletes the Job with `--propagation-policy=Foreground --grace-period=30`.
+
+- [ ] **Step 1: Implement event-watch.ts**
+
+```ts
+// src/orchestrator/event-watch.ts
+import type { KubernetesApiClient } from "../types.js";
+
+export interface EventWatchHandle {
+  abort(): void;
+  done: Promise<void>;
+}
+
+export interface StartEventWatchInput {
+  client: KubernetesApiClient;
+  namespace: string;
+  /** Filter to events whose involvedObject is the Job or its Pod. */
+  jobName: string;
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+}
+
+export function startEventWatch(input: StartEventWatchInput): EventWatchHandle {
+  const controller = new AbortController();
+  let resolveDone!: () => void;
+  const done = new Promise<void>((res) => { resolveDone = res; });
+
+  const loop = async () => {
+    const fieldSelector = encodeURIComponent(`involvedObject.name=${input.jobName}`);
+    let resourceVersion = "0";
+    while (!controller.signal.aborted) {
+      try {
+        const path = `/api/v1/namespaces/${encodeURIComponent(input.namespace)}/events?watch=true&fieldSelector=${fieldSelector}&resourceVersion=${resourceVersion}`;
+        const res = await input.client.requestStream("GET", path);
+        if (!res.ok || !res.body) break;
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        while (!controller.signal.aborted) {
+          const { value, done: streamDone } = await reader.read();
+          if (streamDone) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              const evt = JSON.parse(line) as { type: string; object: { metadata?: { resourceVersion?: string }; type?: string; reason?: string; message?: string } };
+              if (evt.object.metadata?.resourceVersion) resourceVersion = evt.object.metadata.resourceVersion;
+              if (evt.object.type === "Warning") {
+                await input.onLog("stdout", `[k8s] ${evt.object.reason ?? "Warning"}: ${evt.object.message ?? ""}`);
+              }
+            } catch { /* skip malformed line */ }
+          }
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      } catch {
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+    resolveDone();
+  };
+  loop().catch(() => { /* noop */ });
+  return { abort: () => controller.abort(), done };
+}
+```
+
+- [ ] **Step 2: Implement cancellation.ts**
+
+```ts
+// src/orchestrator/cancellation.ts
+import type { KubernetesApiClient } from "../types.js";
+
+export interface CancelJobInput {
+  client: KubernetesApiClient;
+  namespace: string;
+  jobName: string;
+  graceSeconds?: number;
+}
+
+export async function cancelJob(input: CancelJobInput): Promise<void> {
+  const grace = input.graceSeconds ?? 30;
+  await input.client.batch.deleteNamespacedJob(
+    input.jobName, input.namespace,
+    undefined, undefined,
+    grace, undefined, "Foreground",
+  );
+}
+```
+
+- [ ] **Step 3: Tests**
+
+```ts
+// test/unit/cancellation.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { cancelJob } from "../../src/orchestrator/cancellation.js";
+
+describe("cancelJob", () => {
+  it("calls deleteNamespacedJob with foreground propagation and 30s grace", async () => {
+    const client = {
+      batch: { deleteNamespacedJob: vi.fn(async () => ({})) },
+    } as unknown as Parameters<typeof cancelJob>[0]["client"];
+    await cancelJob({ client, namespace: "ns", jobName: "job-x" });
+    expect(client.batch.deleteNamespacedJob).toHaveBeenCalledWith(
+      "job-x", "ns", undefined, undefined, 30, undefined, "Foreground",
+    );
+  });
+
+  it("respects custom grace period", async () => {
+    const client = {
+      batch: { deleteNamespacedJob: vi.fn(async () => ({})) },
+    } as unknown as Parameters<typeof cancelJob>[0]["client"];
+    await cancelJob({ client, namespace: "ns", jobName: "job-x", graceSeconds: 60 });
+    expect(client.batch.deleteNamespacedJob).toHaveBeenCalledWith(
+      "job-x", "ns", undefined, undefined, 60, undefined, "Foreground",
+    );
+  });
+});
+```
+
+```ts
+// test/unit/event-watch.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { startEventWatch } from "../../src/orchestrator/event-watch.js";
+
+function bodyFromEvents(events: Array<{ type: string; object: Record<string, unknown> }>): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    async start(controller) {
+      for (const e of events) {
+        controller.enqueue(encoder.encode(JSON.stringify(e) + "\n"));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("startEventWatch", () => {
+  it("forwards Warning events with [k8s] prefix and ignores Normal", async () => {
+    const client = {
+      requestStream: vi.fn(async () => new Response(bodyFromEvents([
+        { type: "MODIFIED", object: { metadata: { resourceVersion: "1" }, type: "Warning", reason: "ImagePullBackOff", message: "pull failed" } },
+        { type: "MODIFIED", object: { metadata: { resourceVersion: "2" }, type: "Normal", reason: "Created", message: "created pod" } },
+      ]))),
+    } as unknown as Parameters<typeof startEventWatch>[0]["client"];
+
+    const collected: string[] = [];
+    const handle = startEventWatch({
+      client, namespace: "ns", jobName: "job-x",
+      onLog: async (_s, c) => { collected.push(c); },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    handle.abort();
+    await handle.done;
+    expect(collected).toEqual(["[k8s] ImagePullBackOff: pull failed"]);
+  });
+});
+```
+
+- [ ] **Step 4: Run + commit**
+
+```bash
+pnpm --filter @paperclipai/execution-target-kubernetes test event-watch cancellation
+git add packages/adapters/kubernetes-execution/src/orchestrator/event-watch.ts \
+        packages/adapters/kubernetes-execution/src/orchestrator/cancellation.ts \
+        packages/adapters/kubernetes-execution/test/unit/event-watch.test.ts \
+        packages/adapters/kubernetes-execution/test/unit/cancellation.test.ts
+git commit -m "feat(k8s-adapter): event watch + Job cancellation with foreground propagation"
+```
+
+### Task 22: Failure mapping
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/src/orchestrator/failure-mapping.ts`
+- Create: `packages/adapters/kubernetes-execution/test/unit/failure-mapping.test.ts`
+
+Spec §7.5. Maps observed Job/Pod state to `AdapterExecutionResult` error codes.
+
+- [ ] **Step 1: Implement**
+
+```ts
+// src/orchestrator/failure-mapping.ts
+import type { V1Job, V1Pod } from "@kubernetes/client-node";
+import type { AdapterExecutionResult } from "@paperclipai/adapter-utils";
+
+export interface MapTerminalStateInput {
+  job: V1Job;
+  pod?: V1Pod;
+}
+
+export function mapTerminalState(input: MapTerminalStateInput): AdapterExecutionResult {
+  const job = input.job;
+  const pod = input.pod;
+
+  // Success path
+  if ((job.status?.succeeded ?? 0) >= 1) {
+    const main = pod?.status?.containerStatuses?.find((c) => c.name === "agent");
+    return {
+      exitCode: main?.state?.terminated?.exitCode ?? 0,
+      signal: null,
+      timedOut: false,
+    };
+  }
+
+  // ImagePullBackOff (latched on container statuses)
+  const containers = pod?.status?.containerStatuses ?? [];
+  const initContainers = pod?.status?.initContainerStatuses ?? [];
+  for (const c of [...containers, ...initContainers]) {
+    const reason = c.state?.waiting?.reason;
+    if (reason === "ImagePullBackOff" || reason === "ErrImagePull") {
+      return {
+        exitCode: null, signal: null, timedOut: false,
+        errorCode: "image_pull_failed",
+        errorFamily: "transient_upstream",
+        errorMessage: `Image pull failed for container ${c.name}: ${c.state?.waiting?.message ?? reason}`,
+      };
+    }
+  }
+
+  // Init container terminal failure
+  for (const c of initContainers) {
+    if (c.state?.terminated && c.state.terminated.exitCode !== 0) {
+      return {
+        exitCode: null, signal: null, timedOut: false,
+        errorCode: "workspace_init_failed",
+        errorMessage: `Init container ${c.name} exited ${c.state.terminated.exitCode}: ${c.state.terminated.reason ?? ""} ${c.state.terminated.message ?? ""}`.trim(),
+      };
+    }
+  }
+
+  // OOM killed
+  for (const c of containers) {
+    if (c.state?.terminated?.reason === "OOMKilled" || c.state?.terminated?.exitCode === 137) {
+      return {
+        exitCode: 137, signal: "SIGKILL", timedOut: false,
+        errorCode: "oom_killed",
+        errorMessage: `Container ${c.name} OOMKilled`,
+      };
+    }
+  }
+
+  // Job-level deadline exceeded
+  if (job.status?.conditions?.some((cond) => cond.type === "Failed" && cond.reason === "DeadlineExceeded")) {
+    return {
+      exitCode: null, signal: "SIGTERM", timedOut: true,
+      errorCode: "timeout",
+      errorMessage: "Job exceeded activeDeadlineSeconds",
+    };
+  }
+
+  // Generic terminal failure
+  if ((job.status?.failed ?? 0) >= 1) {
+    const main = containers.find((c) => c.name === "agent");
+    const exit = main?.state?.terminated?.exitCode ?? null;
+    return {
+      exitCode: exit, signal: null, timedOut: false,
+      errorCode: "agent_exit_nonzero",
+      errorMessage: main?.state?.terminated?.message ?? `Agent exited ${exit}`,
+    };
+  }
+
+  // No terminal state observed
+  return {
+    exitCode: null, signal: null, timedOut: false,
+    errorCode: "unknown_terminal_state",
+    errorMessage: "No terminal state observed on Job/Pod",
+  };
+}
+```
+
+- [ ] **Step 2: Tests covering each error code path**
+
+```ts
+// test/unit/failure-mapping.test.ts
+import { describe, it, expect } from "vitest";
+import { mapTerminalState } from "../../src/orchestrator/failure-mapping.js";
+
+describe("mapTerminalState", () => {
+  it("returns success on Job.status.succeeded", () => {
+    const r = mapTerminalState({
+      job: { status: { succeeded: 1 } },
+      pod: { status: { containerStatuses: [{ name: "agent", state: { terminated: { exitCode: 0 } } }] } },
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.errorCode).toBeUndefined();
+  });
+
+  it("maps ImagePullBackOff to image_pull_failed", () => {
+    const r = mapTerminalState({
+      job: { status: {} },
+      pod: { status: { containerStatuses: [{ name: "agent", state: { waiting: { reason: "ImagePullBackOff", message: "no auth" } } }] } },
+    });
+    expect(r.errorCode).toBe("image_pull_failed");
+    expect(r.errorFamily).toBe("transient_upstream");
+  });
+
+  it("maps OOMKilled exitCode 137", () => {
+    const r = mapTerminalState({
+      job: { status: { failed: 1 } },
+      pod: { status: { containerStatuses: [{ name: "agent", state: { terminated: { reason: "OOMKilled", exitCode: 137 } } }] } },
+    });
+    expect(r.errorCode).toBe("oom_killed");
+    expect(r.exitCode).toBe(137);
+  });
+
+  it("maps DeadlineExceeded to timeout", () => {
+    const r = mapTerminalState({
+      job: { status: { conditions: [{ type: "Failed", reason: "DeadlineExceeded", status: "True" }] } },
+    });
+    expect(r.errorCode).toBe("timeout");
+    expect(r.timedOut).toBe(true);
+  });
+
+  it("maps init container terminal failure to workspace_init_failed", () => {
+    const r = mapTerminalState({
+      job: { status: { failed: 1 } },
+      pod: { status: { initContainerStatuses: [{ name: "workspace-init", state: { terminated: { exitCode: 2, reason: "Error", message: "git clone failed" } } }] } },
+    });
+    expect(r.errorCode).toBe("workspace_init_failed");
+  });
+
+  it("falls through to agent_exit_nonzero for generic failures", () => {
+    const r = mapTerminalState({
+      job: { status: { failed: 1 } },
+      pod: { status: { containerStatuses: [{ name: "agent", state: { terminated: { exitCode: 7 } } }] } },
+    });
+    expect(r.errorCode).toBe("agent_exit_nonzero");
+    expect(r.exitCode).toBe(7);
+  });
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+pnpm --filter @paperclipai/execution-target-kubernetes test failure-mapping
+git add packages/adapters/kubernetes-execution/src/orchestrator/failure-mapping.ts \
+        packages/adapters/kubernetes-execution/test/unit/failure-mapping.test.ts
+git commit -m "feat(k8s-adapter): map k8s terminal state to AdapterExecutionResult error codes"
+```
+
+---
+
+## Phase E — Driver `run()` + claude_local wiring (Tasks 23-24)
+
+Goal: wire all Phase B/C/D pieces into `KubernetesExecutionDriver.run()` and dispatch from `claude_local` so a real agent run can complete end-to-end. After this phase the adapter is functionally complete — Phase F adds verification, Phase G ships images.
+
+### Task 23: Driver `run()` orchestrates Job lifecycle
+
+**Files:**
+- Modify: `packages/adapters/kubernetes-execution/src/driver.ts` (replace M1 stub)
+- Create: `packages/adapters/kubernetes-execution/src/bootstrap/token.ts`
+- Test: `packages/adapters/kubernetes-execution/test/unit/driver-run.test.ts`
+
+The M1 driver returns a hard-coded `not_implemented` error. Replace with the real flow:
+
+1. Resolve cluster connection + tenant policy from DB (helpers added in M1).
+2. Call `ensureTenantNamespace(client, { companyId, companySlug, policy })` (M1 builder).
+3. Build + apply `agent-workspace` PVC (Task 17) — idempotent per `(namespace, agentId)`.
+4. Mint a bootstrap token via the server callback service. The driver does NOT talk to the DB directly — it calls an injected `BootstrapTokenMinter` interface so server and adapter stay decoupled. The minter is wired in Task 24 via the execution-target registry.
+5. Resolve `secret_refs` declared by the calling adapter (e.g. `claude_local` passes `ANTHROPIC_API_KEY` via secret_resolver).
+6. Build the per-Job ephemeral Secret (Task 18) carrying bootstrap token + resolved env + rendered prompt payload.
+7. Build the Job spec (Task 19) — generate run identifier with ULID, pass image/resource hints from `target.config`, set `agentId` label, set `paperclip.ai/run-id` annotation.
+8. Create Secret first (no OwnerReferences yet), then create the Job, then PATCH the Secret with an OwnerReference pointing at the live Job UID. This ordering ensures the Secret is GC'd if the Job is deleted, and avoids a race where the Job references a missing Secret.
+9. Start log stream (Task 20) — pipes stdout/stderr through the redaction filter from M1 to `ctx.onLog`.
+10. Start event watcher (Task 21) — surfaces non-noisy events via `ctx.onEvent`.
+11. Register cancellation handler — when `ctx.signal.aborted`, delete the Job with `propagationPolicy: "Foreground"` so pods + secret tear down deterministically.
+12. Poll Job status until terminal (active=0 AND (succeeded≥1 OR failed≥backoffLimit+1) OR conditions has Failed/Complete).
+13. Read final pod state, call `mapTerminalState` (Task 22), return `AdapterExecutionResult`.
+14. Cleanup: stop watchers; rely on `TTLSecondsAfterFinished` for k8s-side GC.
+
+- [ ] **Step 1: Write the failing test for the orchestration flow**
+
+`test/unit/driver-run.test.ts` uses a `FakeKubernetesClient` (added in M1) that records all calls and lets the test script terminal state. Test asserts the call sequence:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { KubernetesExecutionDriver } from "../../src/driver.js";
+import { FakeKubernetesClient } from "../helpers/fake-client.js";
+import type { BootstrapTokenMinter } from "../../src/bootstrap/token.js";
+
+describe("KubernetesExecutionDriver.run()", () => {
+  it("orchestrates the full Job lifecycle and returns mapped success", async () => {
+    const client = new FakeKubernetesClient();
+    client.scriptJobTerminal({ succeeded: 1, exitCode: 0 });
+
+    const minter: BootstrapTokenMinter = {
+      mint: vi.fn().mockResolvedValue({
+        token: "bt_" + "x".repeat(32),
+        runId: "run_01HZZZZ",
+        ttlSeconds: 600,
+      }),
+    };
+
+    const driver = new KubernetesExecutionDriver({
+      client,
+      bootstrapTokenMinter: minter,
+      now: () => new Date("2026-05-09T00:00:00Z"),
+    });
+
+    const onLog = vi.fn();
+    const onEvent = vi.fn();
+    const ctrl = new AbortController();
+
+    const result = await driver.run({
+      target: { kind: "kubernetes", clusterConnectionId: "cc_1", config: {} },
+      companyId: "c_1",
+      companyName: "Acme Inc",
+      agentId: "a_1",
+      adapterPayload: {
+        image: "ghcr.io/paperclipai/agent-claude-local:latest",
+        env: { ANTHROPIC_MODEL: "claude-opus-4-7" },
+        secretRefs: { ANTHROPIC_API_KEY: { provider: "local_encrypted", path: "anthropic/api_key" } },
+        prompt: "user prompt here",
+      },
+      onLog,
+      onEvent,
+      signal: ctrl.signal,
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.exitCode).toBe(0);
+
+    const seq = client.callLog.map((c) => c.kind);
+    expect(seq.indexOf("ensure-namespace")).toBeLessThan(seq.indexOf("apply-pvc"));
+    expect(seq.indexOf("apply-pvc")).toBeLessThan(seq.indexOf("create-secret"));
+    expect(seq.indexOf("create-secret")).toBeLessThan(seq.indexOf("create-job"));
+    expect(seq.indexOf("create-job")).toBeLessThan(seq.indexOf("patch-secret"));
+    const patch = client.callLog.find((c) => c.kind === "patch-secret");
+    expect(patch?.body?.metadata?.ownerReferences?.[0]?.kind).toBe("Job");
+
+    expect(minter.mint).toHaveBeenCalledOnce();
+  });
+
+  it("aborts the Job when ctx.signal fires", async () => {
+    const client = new FakeKubernetesClient();
+    client.scriptJobTerminal({ neverComplete: true });
+    const minter: BootstrapTokenMinter = {
+      mint: vi.fn().mockResolvedValue({ token: "bt_x", runId: "run_x", ttlSeconds: 600 }),
+    };
+    const driver = new KubernetesExecutionDriver({ client, bootstrapTokenMinter: minter, now: () => new Date() });
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), 10);
+
+    const result = await driver.run({
+      target: { kind: "kubernetes", clusterConnectionId: "cc_1", config: {} },
+      companyId: "c_1",
+      companyName: "Acme",
+      agentId: "a_1",
+      adapterPayload: { image: "x", env: {}, secretRefs: {}, prompt: "" },
+      onLog: vi.fn(),
+      onEvent: vi.fn(),
+      signal: ctrl.signal,
+    });
+
+    expect(result.status).toBe("cancelled");
+    const del = client.callLog.find((c) => c.kind === "delete-job");
+    expect(del?.options?.propagationPolicy).toBe("Foreground");
+  });
+
+  it("propagates mapTerminalState output for image pull failure", async () => {
+    const client = new FakeKubernetesClient();
+    client.scriptJobTerminal({
+      failed: 1,
+      podWaiting: { reason: "ImagePullBackOff", message: "unauthorized" },
+    });
+    const minter: BootstrapTokenMinter = {
+      mint: vi.fn().mockResolvedValue({ token: "bt_x", runId: "run_x", ttlSeconds: 600 }),
+    };
+    const driver = new KubernetesExecutionDriver({ client, bootstrapTokenMinter: minter, now: () => new Date() });
+
+    const result = await driver.run({
+      target: { kind: "kubernetes", clusterConnectionId: "cc_1", config: {} },
+      companyId: "c_1",
+      companyName: "Acme",
+      agentId: "a_1",
+      adapterPayload: { image: "x", env: {}, secretRefs: {}, prompt: "" },
+      onLog: vi.fn(),
+      onEvent: vi.fn(),
+      signal: new AbortController().signal,
+    });
+    expect(result.status).toBe("failed");
+    expect(result.errorCode).toBe("image_pull_failed");
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+```bash
+pnpm --filter @paperclipai/execution-target-kubernetes test driver-run
+```
+
+Expected: FAIL — `run()` returns `not_implemented`.
+
+- [ ] **Step 3: Implement the `BootstrapTokenMinter` interface**
+
+`src/bootstrap/token.ts`:
+
+```ts
+export interface BootstrapTokenMintRequest {
+  companyId: string;
+  agentId: string;
+  jobName: string;
+  namespace: string;
+  ttlSeconds?: number;
+}
+
+export interface BootstrapTokenMintResult {
+  token: string;
+  runId: string;
+  ttlSeconds: number;
+}
+
+export interface BootstrapTokenMinter {
+  mint(req: BootstrapTokenMintRequest): Promise<BootstrapTokenMintResult>;
+}
+```
+
+The driver depends on this interface, not on the server. The server-side implementation lives in `server/src/services/bootstrap-tokens.ts` (Task 11) and is wired through the execution-target registry (Task 24).
+
+- [ ] **Step 4: Implement `run()` in `driver.ts`**
+
+Replace the entire body of `KubernetesExecutionDriver.run()` (which currently returns the M1 `not_implemented` stub):
+
+```ts
+async run(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  if (ctx.target.kind !== "kubernetes") {
+    throw new Error(`KubernetesExecutionDriver received non-kubernetes target: ${ctx.target.kind}`);
+  }
+
+  const startedAt = this.now();
+  const { companyId, companyName, agentId } = ctx;
+  const namespace = await ensureTenantNamespace(this.client, {
+    companyId,
+    companySlug: deriveCompanySlug(companyName),
+    policy: await this.policies.resolveForCompany(companyId),
+  });
+
+  const runId = newRunId(startedAt);
+  const jobName = `agent-${agentId.slice(-8)}-${runId.slice(-12)}`.toLowerCase();
+
+  const pvcSpec = buildAgentWorkspacePvc({ namespace, agentId, companyId });
+  await applyAgentWorkspacePvc(this.client, pvcSpec);
+
+  const bootstrap = await this.bootstrapTokenMinter.mint({
+    companyId,
+    agentId,
+    jobName,
+    namespace,
+    ttlSeconds: 600,
+  });
+
+  const secretSpec = buildEphemeralSecret({
+    namespace,
+    jobName,
+    bootstrapToken: bootstrap.token,
+    runId: bootstrap.runId,
+    env: ctx.adapterPayload.env,
+    promptPayload: ctx.adapterPayload.prompt,
+  });
+
+  const jobSpec = buildAgentJob({
+    namespace,
+    jobName,
+    agentId,
+    runId: bootstrap.runId,
+    image: ctx.adapterPayload.image,
+    secretName: secretSpec.metadata!.name!,
+    pvcName: pvcSpec.metadata!.name!,
+    resources: ctx.adapterPayload.resources,
+  });
+
+  await this.client.createSecret(namespace, secretSpec);
+  let createdJob;
+  try {
+    createdJob = await this.client.createJob(namespace, jobSpec);
+  } catch (e) {
+    await this.client.deleteSecret(namespace, secretSpec.metadata!.name!).catch(() => {});
+    throw e;
+  }
+
+  await this.client.patchSecret(namespace, secretSpec.metadata!.name!, {
+    metadata: {
+      ownerReferences: [
+        {
+          apiVersion: "batch/v1",
+          kind: "Job",
+          name: createdJob.metadata!.name!,
+          uid: createdJob.metadata!.uid!,
+          controller: true,
+          blockOwnerDeletion: true,
+        },
+      ],
+    },
+  });
+
+  const logStop = startLogStream(this.client, {
+    namespace,
+    jobName,
+    onLog: ctx.onLog,
+    redact: this.redactor,
+  });
+  const eventStop = startEventWatch(this.client, {
+    namespace,
+    involvedObjectName: createdJob.metadata!.name!,
+    onEvent: ctx.onEvent,
+  });
+
+  const onAbort = () => {
+    this.client
+      .deleteJob(namespace, createdJob.metadata!.name!, { propagationPolicy: "Foreground" })
+      .catch(() => {});
+  };
+  ctx.signal.addEventListener("abort", onAbort, { once: true });
+
+  let terminal: TerminalSnapshot;
+  try {
+    terminal = await waitForJobTerminal(this.client, {
+      namespace,
+      jobName: createdJob.metadata!.name!,
+      signal: ctx.signal,
+      pollMs: 1000,
+    });
+  } finally {
+    ctx.signal.removeEventListener("abort", onAbort);
+    logStop();
+    eventStop();
+  }
+
+  if (ctx.signal.aborted) {
+    return { status: "cancelled", durationMs: Date.now() - startedAt.getTime() };
+  }
+
+  return mapTerminalState(terminal);
+}
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+```bash
+pnpm --filter @paperclipai/execution-target-kubernetes test driver-run
+```
+
+Expected: PASS (3/3 cases).
+
+- [ ] **Step 6: Run the full package test suite to confirm nothing regressed**
+
+```bash
+pnpm --filter @paperclipai/execution-target-kubernetes test
+```
+
+Expected: PASS (M1 tests + Phase B/C/D tests + new run tests all green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/driver.ts \
+        packages/adapters/kubernetes-execution/src/bootstrap/token.ts \
+        packages/adapters/kubernetes-execution/test/unit/driver-run.test.ts \
+        packages/adapters/kubernetes-execution/test/helpers/fake-client.ts
+git commit -m "feat(k8s-adapter): driver.run() orchestrates Job lifecycle end-to-end"
+```
+
+---
+
+### Task 24: Wire `claude_local` to dispatch through the k8s execution target
+
+**Files:**
+- Modify: `packages/adapters/claude-local/src/server/execute.ts` (remove M1 rejection)
+- Modify: `server/src/adapters/execution-target-registry.ts` (inject `BootstrapTokenMinter`)
+- Modify: `server/src/adapters/execution-targets/kubernetes.ts` (construct driver with minter)
+- Test: `packages/adapters/claude-local/src/server/__tests__/execute-k8s-route.test.ts`
+
+In M1 (commit `85d18be1`), `claude_local`'s execute path rejects `target.kind === "kubernetes"` with an explicit "not yet implemented" error so the server doesn't silently fall back to local. Replace that branch with a call into the execution-target registry.
+
+`claude_local` is already structured around an injected `executionDispatcher` for the local case. The change is small: route to the dispatcher unconditionally and let the registry resolve which driver runs.
+
+- [ ] **Step 1: Write the failing test for the dispatch path**
+
+`packages/adapters/claude-local/src/server/__tests__/execute-k8s-route.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { executeClaudeLocal } from "../execute.js";
+
+describe("claude_local execute() with kubernetes target", () => {
+  it("dispatches via execution-target registry instead of running locally", async () => {
+    const dispatch = vi.fn().mockResolvedValue({ status: "succeeded", exitCode: 0, durationMs: 1234 });
+
+    const result = await executeClaudeLocal({
+      target: {
+        kind: "kubernetes",
+        clusterConnectionId: "cc_1",
+        config: { image: "ghcr.io/paperclipai/agent-claude-local:1.0.0" },
+      },
+      companyId: "c_1",
+      companyName: "Acme",
+      agentId: "a_1",
+      prompt: "do the thing",
+      env: { ANTHROPIC_MODEL: "claude-opus-4-7" },
+      secretRefs: { ANTHROPIC_API_KEY: { provider: "local_encrypted", path: "anthropic/api_key" } },
+      onLog: vi.fn(),
+      onEvent: vi.fn(),
+      signal: new AbortController().signal,
+      executionDispatcher: { dispatch },
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(dispatch).toHaveBeenCalledOnce();
+    const dispatched = dispatch.mock.calls[0][0];
+    expect(dispatched.target.kind).toBe("kubernetes");
+    expect(dispatched.adapterPayload.image).toBe("ghcr.io/paperclipai/agent-claude-local:1.0.0");
+    expect(dispatched.adapterPayload.prompt).toBe("do the thing");
+    expect(dispatched.adapterPayload.secretRefs.ANTHROPIC_API_KEY.path).toBe("anthropic/api_key");
+  });
+
+  it("still routes local targets to local execution path", async () => {
+    const dispatch = vi.fn().mockResolvedValue({ status: "succeeded", exitCode: 0, durationMs: 1 });
+    await executeClaudeLocal({
+      target: { kind: "local" },
+      companyId: "c_1",
+      companyName: "Acme",
+      agentId: "a_1",
+      prompt: "x",
+      env: {},
+      secretRefs: {},
+      onLog: vi.fn(),
+      onEvent: vi.fn(),
+      signal: new AbortController().signal,
+      executionDispatcher: { dispatch },
+    });
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(dispatch.mock.calls[0][0].target.kind).toBe("local");
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+```bash
+pnpm --filter @paperclipai/adapter-claude-local test execute-k8s-route
+```
+
+Expected: FAIL — current code throws on `kubernetes` target.
+
+- [ ] **Step 3: Remove the M1 rejection branch and dispatch unconditionally**
+
+In `packages/adapters/claude-local/src/server/execute.ts`, find the M1 branch added in `85d18be1`:
+
+```ts
+if (ctx.target.kind === "kubernetes") {
+  return {
+    status: "failed",
+    errorCode: "not_implemented",
+    errorMessage:
+      "claude_local on kubernetes execution target is M2 work. Use a local target for now.",
+  };
+}
+```
+
+Replace it with a single dispatch call that works for every supported target:
+
+```ts
+return ctx.executionDispatcher.dispatch({
+  target: ctx.target,
+  companyId: ctx.companyId,
+  companyName: ctx.companyName,
+  agentId: ctx.agentId,
+  adapterPayload: {
+    image:
+      ctx.target.kind === "kubernetes"
+        ? (ctx.target.config?.image ?? DEFAULT_CLAUDE_LOCAL_IMAGE)
+        : undefined,
+    env: ctx.env,
+    secretRefs: ctx.secretRefs,
+    prompt: ctx.prompt,
+    resources: ctx.target.kind === "kubernetes" ? ctx.target.config?.resources : undefined,
+  },
+  onLog: ctx.onLog,
+  onEvent: ctx.onEvent,
+  signal: ctx.signal,
+});
+```
+
+`DEFAULT_CLAUDE_LOCAL_IMAGE` is exported from `claude-local` so the adapter advertises its default image; cluster admins can override per-target via `target.config.image`.
+
+- [ ] **Step 4: Wire `BootstrapTokenMinter` through the registry**
+
+In `server/src/adapters/execution-targets/kubernetes.ts`, the M1 factory currently constructs the driver with a stub minter that throws. Replace with:
+
+```ts
+import { bootstrapTokensService } from "../../services/bootstrap-tokens.js";
+
+export function createKubernetesExecutionDriver(deps: {
+  policies: ClusterTenantPoliciesService;
+  clusterConnections: ClusterConnectionsService;
+  redactor: Redactor;
+}) {
+  return new KubernetesExecutionDriver({
+    clientFactory: kubernetesClientFromConnection(deps.clusterConnections),
+    policies: deps.policies,
+    redactor: deps.redactor,
+    bootstrapTokenMinter: {
+      mint: (req) => bootstrapTokensService.mint(req),
+    },
+    now: () => new Date(),
+  });
+}
+```
+
+`bootstrapTokensService` was implemented in Task 11 and writes to the `bootstrap_tokens` row created by Task 10's schema migration.
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+```bash
+pnpm --filter @paperclipai/adapter-claude-local test execute-k8s-route
+```
+
+Expected: PASS (2/2).
+
+- [ ] **Step 6: Run claude_local's full test suite**
+
+```bash
+pnpm --filter @paperclipai/adapter-claude-local test
+```
+
+Expected: PASS — make sure removing the M1 rejection didn't break the local-target tests.
+
+- [ ] **Step 7: Run the cross-cutting server adapter test**
+
+```bash
+pnpm --filter @paperclipai/server test execution-target
+```
+
+Expected: PASS — verifies registry wiring resolves k8s targets to the new driver.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/adapters/claude-local/src/server/execute.ts \
+        packages/adapters/claude-local/src/server/__tests__/execute-k8s-route.test.ts \
+        server/src/adapters/execution-targets/kubernetes.ts \
+        server/src/adapters/execution-target-registry.ts
+git commit -m "feat(claude-local): route to k8s execution target via dispatcher
+
+Replaces the M1 'not_implemented' rejection (85d18be1) with real dispatch
+through the execution-target registry. Wires BootstrapTokenMinter into the
+k8s driver factory so the minter writes through bootstrap_tokens table."
+```
+
+---
+
+## Phase F — End-to-end verification against kind (Tasks 25-28)
+
+Goal: prove the adapter works against a real Kubernetes API server before shipping. Each integration test below uses kind (Kubernetes IN Docker) the same way M1 verified namespace/RBAC/network-policy. Tests live in `packages/adapters/kubernetes-execution/test/integration/` and run under the `pnpm test:integration` script gated by `K8S_INTEGRATION=1`.
+
+**Shared kind harness** (already added in M1 at `test/integration/_harness/kind.ts`): boots a kind cluster, returns a kubeconfig, tears down after the test file. Each test in this phase reuses that harness — they do NOT each spin up their own cluster.
+
+**Vitest config:** `fileParallelism: false` is already set so kind tests run sequentially. Per-test cluster reuse is fine since each test runs in its own k8s namespace.
+
+### Task 25: Job lifecycle integration test (busybox image)
+
+**Files:**
+- Test: `packages/adapters/kubernetes-execution/test/integration/job-lifecycle.test.ts`
+
+This test bypasses `claude_local` entirely. It uses a synthetic image (busybox echoing a script) to prove the orchestrator + driver + Job lifecycle work in a real cluster. Without this, regressions in Phase D code (PVC, Secret, Job, log stream, event watch) would only be caught later by the more complex claude_local test.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```ts
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startKindCluster, type KindHandle } from "./_harness/kind.js";
+import { KubernetesClient } from "../../src/client.js";
+import { KubernetesExecutionDriver } from "../../src/driver.js";
+import type { BootstrapTokenMinter } from "../../src/bootstrap/token.js";
+
+const SHELL_SCRIPT = [
+  "echo BOOTSTRAP_TOKEN=${BOOTSTRAP_TOKEN:0:6}...",
+  "echo workspace=$(ls /workspace)",
+  "test -w /workspace || (echo workspace not writable && exit 11)",
+  "echo done",
+].join(" && ");
+
+describe.skipIf(!process.env.K8S_INTEGRATION)("Job lifecycle (busybox)", () => {
+  let kind: KindHandle;
+  let client: KubernetesClient;
+
+  beforeAll(async () => {
+    kind = await startKindCluster({ name: "k8s-adapter-job-lifecycle" });
+    client = await KubernetesClient.fromKubeconfig(kind.kubeconfigPath);
+  }, 180_000);
+
+  afterAll(async () => kind?.stop());
+
+  it("runs a Job to success and streams logs back through the driver", async () => {
+    const minter: BootstrapTokenMinter = {
+      mint: async () => ({ token: "bt_" + "a".repeat(40), runId: "run_test_lifecycle", ttlSeconds: 600 }),
+    };
+    const driver = new KubernetesExecutionDriver({
+      client,
+      bootstrapTokenMinter: minter,
+      now: () => new Date(),
+      // injection knob added in Task 23 so tests can override the agent image
+      imageOverride: "busybox:1.36",
+      commandOverride: ["sh", "-c", SHELL_SCRIPT],
+    });
+
+    const logs: string[] = [];
+    const events: string[] = [];
+
+    const result = await driver.run({
+      target: { kind: "kubernetes", clusterConnectionId: "kind-local", config: {} },
+      companyId: "c_lifecycle",
+      companyName: "Acme Lifecycle",
+      agentId: "a_lifecycle",
+      adapterPayload: { image: "busybox:1.36", env: {}, secretRefs: {}, prompt: "" },
+      onLog: (line) => logs.push(line),
+      onEvent: (e) => events.push(`${e.reason}:${e.message ?? ""}`),
+      signal: new AbortController().signal,
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.exitCode).toBe(0);
+    expect(logs.join("\n")).toMatch(/BOOTSTRAP_TOKEN=bt_aaa/);
+    expect(logs.join("\n")).toMatch(/done/);
+  }, 180_000);
+
+  it("Secret has OwnerReference to Job UID after creation", async () => {
+    const driver = makeDriverFor(client);
+    const runP = driver.run(makeCtx("c_owner", "a_owner", "busybox:1.36"));
+    // Poll until Secret appears, then assert ownerRef
+    const ns = await waitForNamespace(client, "c_owner");
+    const secret = await waitForFirstSecretWith(client, ns, { labelSelector: "paperclip.ai/run-id" });
+    const job = await client.getJob(ns, secret.metadata!.ownerReferences![0].name);
+    expect(secret.metadata?.ownerReferences?.[0]?.uid).toBe(job.metadata?.uid);
+    expect(secret.metadata?.ownerReferences?.[0]?.controller).toBe(true);
+    await runP;
+  }, 180_000);
+
+  it("Deleting the Job cascades to the Secret via OwnerReference GC", async () => {
+    const driver = makeDriverFor(client);
+    const ctrl = new AbortController();
+    const runP = driver.run({ ...makeCtx("c_gc", "a_gc", "busybox:1.36"), signal: ctrl.signal });
+    const ns = await waitForNamespace(client, "c_gc");
+    const job = await waitForFirstJob(client, ns);
+    const secretName = job.spec!.template!.spec!.containers![0].envFrom![0].secretRef!.name!;
+    await client.deleteJob(ns, job.metadata!.name!, { propagationPolicy: "Foreground" });
+    await pollUntil(async () => {
+      try {
+        await client.getSecret(ns, secretName);
+        return false;
+      } catch (e: any) {
+        return e.statusCode === 404;
+      }
+    }, { timeoutMs: 30_000 });
+    ctrl.abort();
+    await runP;
+  }, 180_000);
+});
+```
+
+`makeDriverFor`, `makeCtx`, `waitForNamespace`, `waitForFirstJob`, `waitForFirstSecretWith`, `pollUntil` live in `test/integration/_harness/integration-helpers.ts` — extract them in this task.
+
+- [ ] **Step 2: Run the failing test**
+
+```bash
+K8S_INTEGRATION=1 pnpm --filter @paperclipai/execution-target-kubernetes test:integration job-lifecycle
+```
+
+Expected: FAIL — driver can't run busybox (image override not yet implemented) and harness helpers missing.
+
+- [ ] **Step 3: Add `imageOverride`/`commandOverride` knobs to the driver constructor**
+
+These are TEST ONLY — gate behind `process.env.NODE_ENV === "test"` to avoid accidental production use:
+
+```ts
+constructor(opts: KubernetesExecutionDriverOptions) {
+  // ...
+  if (opts.imageOverride && process.env.NODE_ENV !== "test") {
+    throw new Error("imageOverride is for tests only");
+  }
+  this.imageOverride = opts.imageOverride;
+  this.commandOverride = opts.commandOverride;
+}
+```
+
+In `buildAgentJob`, when `imageOverride` is set, replace the container image and command. Init container is skipped under `commandOverride` (busybox doesn't need workspace-init).
+
+- [ ] **Step 4: Add the harness helpers**
+
+Implement `integration-helpers.ts` with thin polling utilities; nothing exotic — see code in step 1.
+
+- [ ] **Step 5: Run again to confirm it passes**
+
+```bash
+K8S_INTEGRATION=1 pnpm --filter @paperclipai/execution-target-kubernetes test:integration job-lifecycle
+```
+
+Expected: PASS (3/3 cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/src/driver.ts \
+        packages/adapters/kubernetes-execution/test/integration/job-lifecycle.test.ts \
+        packages/adapters/kubernetes-execution/test/integration/_harness/integration-helpers.ts
+git commit -m "test(k8s-adapter): integration test proves Job lifecycle on kind"
+```
+
+---
+
+### Task 26: claude_local end-to-end integration test (fake LLM)
+
+**Files:**
+- Create: `packages/adapters/kubernetes-execution/test/integration/_harness/fake-llm-server.ts`
+- Test: `packages/adapters/kubernetes-execution/test/integration/claude-end-to-end.test.ts`
+
+This test proves the **complete** path: real `claude_local` adapter → driver → kind Job → real Anthropic API client speaking to a fake server we run on the host (kind exposes host networking via `extraPortMappings`). The fake LLM accepts a single message and returns a deterministic response. No real Anthropic credentials are required.
+
+- [ ] **Step 1: Add the fake LLM server**
+
+`fake-llm-server.ts` runs an HTTP server that mimics the `messages.create` endpoint:
+
+```ts
+import { createServer, type Server } from "node:http";
+
+export function startFakeAnthropic(opts: { port?: number } = {}): Promise<{ url: string; stop: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server: Server = createServer((req, res) => {
+      if (req.method === "POST" && req.url === "/v1/messages") {
+        let body = "";
+        req.on("data", (c) => (body += c));
+        req.on("end", () => {
+          const parsed = JSON.parse(body);
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({
+            id: "msg_test_01",
+            type: "message",
+            role: "assistant",
+            model: parsed.model,
+            content: [{ type: "text", text: "I read your prompt and I am alive." }],
+            stop_reason: "end_turn",
+            usage: { input_tokens: 10, output_tokens: 8 },
+          }));
+        });
+      } else {
+        res.writeHead(404);
+        res.end("not_found");
+      }
+    });
+    server.listen(opts.port ?? 0, "127.0.0.1", () => {
+      const port = (server.address() as any).port;
+      resolve({
+        url: `http://host.docker.internal:${port}`,
+        stop: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+```
+
+Kind sets up `host.docker.internal` automatically on macOS and Linux (the M1 kind harness already adds the `extraHostsEntries` flag). The Pod talks to the host loopback through it.
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startKindCluster, type KindHandle } from "./_harness/kind.js";
+import { startFakeAnthropic } from "./_harness/fake-llm-server.js";
+import { executeClaudeLocal } from "@paperclipai/adapter-claude-local/server";
+import { makeIntegrationDispatcher } from "./_harness/dispatcher.js";
+
+describe.skipIf(!process.env.K8S_INTEGRATION)("claude_local end-to-end on kind", () => {
+  let kind: KindHandle;
+  let fake: { url: string; stop: () => Promise<void> };
+
+  beforeAll(async () => {
+    kind = await startKindCluster({ name: "k8s-adapter-claude-e2e" });
+    fake = await startFakeAnthropic();
+  }, 240_000);
+
+  afterAll(async () => {
+    await fake?.stop();
+    await kind?.stop();
+  });
+
+  it("runs a claude_local agent against fake Anthropic and returns the assistant text in logs", async () => {
+    const dispatcher = await makeIntegrationDispatcher({ kubeconfigPath: kind.kubeconfigPath });
+    const logs: string[] = [];
+
+    const result = await executeClaudeLocal({
+      target: {
+        kind: "kubernetes",
+        clusterConnectionId: "kind-e2e",
+        config: { image: process.env.AGENT_CLAUDE_LOCAL_IMAGE ?? "ghcr.io/paperclipai/agent-claude-local:dev" },
+      },
+      companyId: "c_claude_e2e",
+      companyName: "Acme Claude",
+      agentId: "a_claude_e2e",
+      prompt: "say hi",
+      env: {
+        ANTHROPIC_BASE_URL: fake.url,
+        ANTHROPIC_MODEL: "claude-opus-4-7",
+      },
+      secretRefs: { ANTHROPIC_API_KEY: { provider: "literal", value: "sk-test-fake-key" } },
+      onLog: (line) => logs.push(line),
+      onEvent: () => {},
+      signal: new AbortController().signal,
+      executionDispatcher: dispatcher,
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.exitCode).toBe(0);
+    expect(logs.join("\n")).toMatch(/I read your prompt and I am alive\./);
+  }, 240_000);
+});
+```
+
+The `literal` secret provider is added to the secret_resolver in M2 task 11 to make integration tests trivial without real KMS — the spec already permits multiple providers.
+
+- [ ] **Step 3: Run the failing test**
+
+```bash
+K8S_INTEGRATION=1 pnpm --filter @paperclipai/execution-target-kubernetes test:integration claude-end-to-end
+```
+
+Expected: FAIL — `agent-claude-local:dev` image doesn't exist in the kind cluster yet.
+
+- [ ] **Step 4: Build and load the agent runtime image into kind**
+
+Add a one-shot script invoked by the test:
+
+```ts
+async function ensureAgentImage(kind: KindHandle) {
+  const tag = process.env.AGENT_CLAUDE_LOCAL_IMAGE ?? "ghcr.io/paperclipai/agent-claude-local:dev";
+  if (process.env.AGENT_CLAUDE_LOCAL_IMAGE) return; // CI passes a pre-built image
+  await execa("docker", ["build", "-t", tag, "-f", "images/agent-claude-local/Dockerfile", "."]);
+  await execa("kind", ["load", "docker-image", tag, "--name", kind.name]);
+}
+```
+
+Call it inside `beforeAll` after `startKindCluster`. This adds 60-90s to cold runs locally; CI builds the image once and passes `AGENT_CLAUDE_LOCAL_IMAGE` to skip the rebuild.
+
+- [ ] **Step 5: Run again to confirm pass**
+
+```bash
+K8S_INTEGRATION=1 pnpm --filter @paperclipai/execution-target-kubernetes test:integration claude-end-to-end
+```
+
+Expected: PASS — assistant text "I read your prompt and I am alive." appears in stream logs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/test/integration/claude-end-to-end.test.ts \
+        packages/adapters/kubernetes-execution/test/integration/_harness/fake-llm-server.ts \
+        packages/adapters/kubernetes-execution/test/integration/_harness/dispatcher.ts
+git commit -m "test(k8s-adapter): claude_local end-to-end on kind with fake Anthropic server"
+```
+
+---
+
+### Task 27: Failure mode integration tests
+
+**Files:**
+- Test: `packages/adapters/kubernetes-execution/test/integration/failure-modes.test.ts`
+
+These tests verify `mapTerminalState` works against real cluster output, not just synthetic JSON. Each scenario uses a deliberately broken Job spec.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startKindCluster, type KindHandle } from "./_harness/kind.js";
+import { KubernetesClient } from "../../src/client.js";
+import { KubernetesExecutionDriver } from "../../src/driver.js";
+
+describe.skipIf(!process.env.K8S_INTEGRATION)("failure modes (real cluster)", () => {
+  let kind: KindHandle;
+  let client: KubernetesClient;
+
+  beforeAll(async () => {
+    kind = await startKindCluster({ name: "k8s-adapter-failures" });
+    client = await KubernetesClient.fromKubeconfig(kind.kubeconfigPath);
+  }, 180_000);
+
+  afterAll(async () => kind?.stop());
+
+  it("ImagePullBackOff → image_pull_failed", async () => {
+    const driver = makeDriverFor(client);
+    const result = await driver.run({
+      ...makeCtx("c_pull", "a_pull", "ghcr.io/paperclipai/does-not-exist:never"),
+      // shorten poll timeout to fail fast in tests
+    });
+    expect(result.status).toBe("failed");
+    expect(result.errorCode).toBe("image_pull_failed");
+  }, 180_000);
+
+  it("OOMKilled → oom_killed with exitCode 137", async () => {
+    // Run busybox with a memory limit too small to start
+    const driver = makeDriverFor(client, {
+      imageOverride: "polinux/stress",
+      commandOverride: ["stress", "--vm", "1", "--vm-bytes", "200M", "--vm-hang", "0"],
+      resourceOverride: { limits: { memory: "32Mi", cpu: "200m" }, requests: { memory: "32Mi", cpu: "100m" } },
+    });
+    const result = await driver.run(makeCtx("c_oom", "a_oom", "polinux/stress"));
+    expect(result.status).toBe("failed");
+    expect(result.errorCode).toBe("oom_killed");
+    expect(result.exitCode).toBe(137);
+  }, 180_000);
+
+  it("activeDeadlineSeconds exceeded → timeout", async () => {
+    const driver = makeDriverFor(client, {
+      imageOverride: "busybox:1.36",
+      commandOverride: ["sh", "-c", "sleep 600"],
+      activeDeadlineSecondsOverride: 5,
+    });
+    const result = await driver.run(makeCtx("c_to", "a_to", "busybox:1.36"));
+    expect(result.status).toBe("failed");
+    expect(result.errorCode).toBe("timeout");
+    expect(result.timedOut).toBe(true);
+  }, 180_000);
+
+  it("init container failure → workspace_init_failed", async () => {
+    const driver = makeDriverFor(client, {
+      imageOverride: "busybox:1.36",
+      commandOverride: ["sh", "-c", "echo never reached"],
+      initCommandOverride: ["sh", "-c", "exit 2"],
+    });
+    const result = await driver.run(makeCtx("c_init", "a_init", "busybox:1.36"));
+    expect(result.status).toBe("failed");
+    expect(result.errorCode).toBe("workspace_init_failed");
+  }, 180_000);
+});
+```
+
+- [ ] **Step 2: Run them**
+
+```bash
+K8S_INTEGRATION=1 pnpm --filter @paperclipai/execution-target-kubernetes test:integration failure-modes
+```
+
+Expected: PASS — driver and `mapTerminalState` produce the right error code for each failure shape.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/test/integration/failure-modes.test.ts
+git commit -m "test(k8s-adapter): integration tests for image-pull, OOM, timeout, init-fail"
+```
+
+---
+
+### Task 28: Empirical resource measurement (resolves Risk #4)
+
+**Files:**
+- Test: `packages/adapters/kubernetes-execution/test/integration/empirical-measurement.test.ts`
+- Modify: `packages/adapters/kubernetes-execution/src/orchestrator/resource-quota.ts` (update defaults if measurements warrant)
+- Modify: `docs/k8s-execution/sizing.md` (publish measurements)
+
+The spec's Risk #4 says default tenant quotas and per-Job resource requests/limits should be empirically grounded, not guessed. This task measures actual usage of a representative `claude_local` workload and either confirms or revises the M1 defaults.
+
+- [ ] **Step 1: Write the measurement test**
+
+```ts
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startKindCluster, type KindHandle } from "./_harness/kind.js";
+import { startFakeAnthropic } from "./_harness/fake-llm-server.js";
+import { measurePodResourceUsage } from "./_harness/metrics.js";
+
+describe.skipIf(!process.env.K8S_INTEGRATION)("empirical resource measurement", () => {
+  let kind: KindHandle;
+  let fake: { url: string; stop: () => Promise<void> };
+
+  beforeAll(async () => {
+    kind = await startKindCluster({
+      name: "k8s-adapter-sizing",
+      installMetricsServer: true, // harness flag; uses bitnami/metrics-server helm chart
+    });
+    fake = await startFakeAnthropic();
+  }, 300_000);
+
+  afterAll(async () => {
+    await fake?.stop();
+    await kind?.stop();
+  });
+
+  it("claude_local with a 4KB prompt fits within memory:512Mi cpu:500m", async () => {
+    // Run 10 concurrent claude_local jobs against fake Anthropic
+    const samples = await Promise.all(
+      Array.from({ length: 10 }, (_, i) =>
+        measurePodResourceUsage({
+          kind,
+          fakeAnthropicUrl: fake.url,
+          companyId: `c_sizing_${i}`,
+          agentId: `a_sizing_${i}`,
+          prompt: "x".repeat(4096),
+        }),
+      ),
+    );
+
+    const peakMemoryMi = Math.max(...samples.map((s) => s.peakMemoryMi));
+    const peakCpuM = Math.max(...samples.map((s) => s.peakCpuMillicores));
+    const p95MemoryMi = quantile(samples.map((s) => s.peakMemoryMi), 0.95);
+    const p95CpuM = quantile(samples.map((s) => s.peakCpuMillicores), 0.95);
+
+    // Record measurements for sizing.md
+    process.env.PAPERCLIP_RECORD_SIZING && writeMeasurementReport({
+      peakMemoryMi, peakCpuM, p95MemoryMi, p95CpuM, samples,
+    });
+
+    // Fail loudly if we exceed the M1 defaults — that's the signal to update them
+    expect(peakMemoryMi).toBeLessThan(512); // memory limit from defaultTenantLimits.max.memory
+    expect(peakCpuM).toBeLessThan(500);     // cpu limit from defaultTenantLimits.max.cpu
+  }, 600_000);
+});
+```
+
+`measurePodResourceUsage` is a small harness helper that polls `metrics.k8s.io/v1beta1/pods` every 500ms while a Job is running and returns peak memory/cpu observed.
+
+- [ ] **Step 2: Run with `PAPERCLIP_RECORD_SIZING=1` to record measurements**
+
+```bash
+K8S_INTEGRATION=1 PAPERCLIP_RECORD_SIZING=1 \
+  pnpm --filter @paperclipai/execution-target-kubernetes test:integration empirical-measurement
+```
+
+Expected: PASS — and `docs/k8s-execution/sizing.md` is regenerated with the measured peak/p95 numbers.
+
+- [ ] **Step 3: Decide whether to revise defaults**
+
+If peak memory or CPU is materially below the M1 defaults (e.g. < 50% utilization across all samples), tighten the defaults so cluster admins don't waste headroom. If they are close to the limit, leave the defaults and document the margin in `sizing.md`.
+
+Edit `src/orchestrator/resource-quota.ts`:
+
+```ts
+export const defaultTenantLimits = {
+  default:        { cpu: "150m", memory: "256Mi" },          // was 200m / 256Mi
+  defaultRequest: { cpu: "100m", memory: "128Mi" },
+  max:            { cpu: "2",    memory: "1Gi" },            // headroom for power users
+  pvcMaxStorage:  "10Gi",
+};
+```
+
+(Specific final numbers come from the actual measurement output — the values above are illustrative.)
+
+- [ ] **Step 4: Update `docs/k8s-execution/sizing.md`**
+
+Replace the M1 placeholder content with the measured numbers + a "How we measured this" section pointing at the test file. Include:
+
+- Workload description (claude_local, 4KB prompt, fake Anthropic)
+- Sample size (10 concurrent runs)
+- Peak / p95 / median memory and CPU
+- Recommended `requests`/`limits` and reasoning
+- Recommended `ResourceQuota` for a 50-agent tenant
+
+- [ ] **Step 5: Run unit tests to confirm no regressions from default changes**
+
+```bash
+pnpm --filter @paperclipai/execution-target-kubernetes test resource-quota
+```
+
+Expected: PASS — tests use named constants, so updates flow through automatically. If a test pinned a literal value (it shouldn't), update it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/adapters/kubernetes-execution/test/integration/empirical-measurement.test.ts \
+        packages/adapters/kubernetes-execution/test/integration/_harness/metrics.ts \
+        packages/adapters/kubernetes-execution/src/orchestrator/resource-quota.ts \
+        docs/k8s-execution/sizing.md
+git commit -m "feat(k8s-adapter): empirical resource defaults from measurement on kind
+
+Resolves Risk #4 from the design spec. Defaults derived from 10 concurrent
+claude_local runs with a 4KB prompt against a fake Anthropic backend; see
+docs/k8s-execution/sizing.md for the methodology and full numbers."
+```
+
+---
+
+## Phase G — Image publishing + docs (Tasks 29-30)
+
+### Task 29: Multi-arch image build + cosign signing in CI
+
+**Files:**
+- Create: `.github/workflows/agent-runtime-images.yml`
+- Modify: `images/agent-claude-local/Dockerfile` (already in Phase B; double-check ARG/CMD parity)
+- Create: `images/agent-shim/Dockerfile.release` (multi-stage Go build, distroless final)
+
+The runtime images (`paperclip-agent-shim`, `paperclip-workspace-init`, `agent-claude-local`) are built and pushed to GHCR for amd64+arm64. Each image is signed with cosign keyless OIDC so consumers can verify provenance.
+
+- [ ] **Step 1: Author the workflow**
+
+```yaml
+name: Agent runtime images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "images/**"
+      - "packages/adapters/kubernetes-execution/src/**"
+      - "packages/workspace-strategy/src/**"
+      - ".github/workflows/agent-runtime-images.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write   # cosign keyless
+
+jobs:
+  agent-shim:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with: { registry: ghcr.io, username: ${{ github.actor }}, password: ${{ secrets.GITHUB_TOKEN }} }
+      - uses: sigstore/cosign-installer@v3
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/paperclipai/agent-shim
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=git-
+            type=semver,pattern={{version}}
+      - uses: docker/build-push-action@v5
+        id: build
+        with:
+          context: .
+          file: images/agent-shim/Dockerfile.release
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+      - name: Sign image with cosign keyless
+        run: |
+          for tag in ${{ steps.meta.outputs.tags }}; do
+            cosign sign --yes "$tag@${{ steps.build.outputs.digest }}"
+          done
+
+  workspace-init:
+    runs-on: ubuntu-22.04
+    needs: agent-shim
+    # ... same shape, file: images/workspace-init/Dockerfile
+
+  agent-claude-local:
+    runs-on: ubuntu-22.04
+    needs: [agent-shim, workspace-init]
+    # ... same shape, file: images/agent-claude-local/Dockerfile
+    # This image FROM:s agent-shim and workspace-init by digest pinned in image-versions.json
+```
+
+- [ ] **Step 2: Pin upstream image versions**
+
+`images/image-versions.json` records the digests for `agent-shim` and `workspace-init` that `agent-claude-local` builds on. The build job for `agent-claude-local` reads this file and substitutes them into its build args. This pinning makes the final image reproducible and lets CI fail loudly if a base image got rebuilt without re-running this workflow.
+
+- [ ] **Step 3: Verify the workflow on a feature branch**
+
+Push to `feat/k8s-cloud-adapter-m2-images` and run `gh workflow run agent-runtime-images.yml --ref feat/k8s-cloud-adapter-m2-images` to confirm the build succeeds without merging to main. Expected: 3 images pushed under tag `git-<sha>`, each with a cosign signature visible via `cosign verify ghcr.io/paperclipai/agent-shim:git-<sha> --certificate-identity-regexp 'https://github.com/.*' --certificate-oidc-issuer https://token.actions.githubusercontent.com`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/agent-runtime-images.yml \
+        images/agent-shim/Dockerfile.release \
+        images/agent-claude-local/Dockerfile \
+        images/workspace-init/Dockerfile \
+        images/image-versions.json
+git commit -m "ci(k8s-adapter): multi-arch image build + cosign signing for runtime images"
+```
+
+---
+
+### Task 30: M2 docs + ROADMAP update + final cross-cutting smoke
+
+**Files:**
+- Create: `docs/k8s-execution/agent-execution-flow.md`
+- Modify: `docs/k8s-execution/quickstart.md` (add agent execution section)
+- Modify: `docs/k8s-execution/security-model.md` (TokenReview + bootstrap-token + secret_resolver)
+- Modify: `docs/ROADMAP.md` (mark M2 complete; spell out M3 scope)
+- Create: `docs/k8s-execution/troubleshooting.md`
+
+This task is documentation-only plus one repository-wide test pass to confirm M2 is releasable.
+
+- [ ] **Step 1: Write `agent-execution-flow.md`**
+
+Covers what an operator sees on a real agent run end-to-end: from `paperclip agent run` → execution-target registry → driver → Job → callback → result. Include:
+
+- Sequence diagram (PlantUML or Mermaid) of the call graph from CLI to mapTerminalState
+- Annotated `kubectl get all -n paperclip-acme` output during a live run
+- How to read `paperclip.ai/run-id` to correlate logs across the server, the Job, and the callback
+- Pointer to `troubleshooting.md` for common failures
+
+- [ ] **Step 2: Update `quickstart.md`**
+
+Add a "Run your first agent" section after the M1 namespace-onboarding flow:
+
+```bash
+paperclip cluster bind --cluster prod --company acme
+paperclip agent register --company acme --adapter claude_local \
+  --execution-target kubernetes:prod
+paperclip agent run --agent <id> --prompt "say hi"
+```
+
+Expected output: streamed logs from the agent pod ending with the assistant text.
+
+- [ ] **Step 3: Update `security-model.md`**
+
+Add the M2 sections:
+
+- **Run-JWT lifecycle**: bootstrap token mint → exchange → JWT bound to Job UID → expires after deadline.
+- **TokenReview decision**: explain why we punted to V2 (Risk #5); document the workaround (callback-server reachability via Service of type LoadBalancer or per-tenant `agent-callback` Endpoints).
+- **Per-Job Secret with OwnerReferences**: explains why this is the chosen pattern over CSI Secrets Store.
+- **secret_resolver providers**: `local_encrypted`, `aws_secrets_manager`, `gcp_secret_manager`, `literal` (test only).
+
+- [ ] **Step 4: Update `docs/ROADMAP.md`**
+
+Mark M2 complete; expand M3 scope:
+
+```markdown
+### M3 — Production hardening + UI (next)
+- [ ] Web UI: cluster connection management, namespace bindings, tenant policy editing.
+- [ ] Web UI: live run dashboard with log tail and event timeline.
+- [ ] Per-tenant Cilium policies fully wired (M2 left scaffolding).
+- [ ] HPA-style autoscaling for repeat-runs, cost dashboard.
+- [ ] Cross-cluster TokenReview (Risk #5) — defer until V2.
+- [ ] Operator-controlled image allow-lists per cluster.
+```
+
+- [ ] **Step 5: Write `troubleshooting.md`**
+
+Document the failure modes covered in Task 27 plus operator-facing diagnostic recipes:
+
+- "Pod stuck in Pending → check ResourceQuota or PodSecurity admission"
+- "ImagePullBackOff → check imagePullSecret on the namespace"
+- "Job failed but logs empty → init container failed; check events"
+- "Bootstrap token exchange returns 401 → check callback URL reachability and clock skew"
+
+- [ ] **Step 6: Run the full repo test suite**
+
+```bash
+pnpm test
+```
+
+Expected: PASS — all unit tests for every package green. Integration tests are gated by `K8S_INTEGRATION` and run separately.
+
+- [ ] **Step 7: Run integration tests**
+
+```bash
+K8S_INTEGRATION=1 pnpm --filter @paperclipai/execution-target-kubernetes test:integration
+```
+
+Expected: PASS — every kind-based test from M1 + Tasks 25-28 passes back-to-back. Total runtime ≤ 30 minutes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/k8s-execution/agent-execution-flow.md \
+        docs/k8s-execution/quickstart.md \
+        docs/k8s-execution/security-model.md \
+        docs/k8s-execution/troubleshooting.md \
+        docs/ROADMAP.md
+git commit -m "docs(k8s-adapter): M2 agent execution complete; document flow and ops"
+```
+
+- [ ] **Step 9: Open M2 PR**
+
+```bash
+gh pr create --base master --head feat/k8s-cloud-adapter-m2 \
+  --title "feat(k8s-adapter): M2 — headless agent execution end-to-end" \
+  --body "$(cat <<'EOF'
+## Summary
+- Runs claude_local agents on Kubernetes end-to-end with PVC-per-agent, Job-per-run, per-Job ephemeral Secret with OwnerReferences for GC.
+- Adds Go agent-shim (PID-1 supervisor, cancellation-aware), Node workspace-init that consumes the new \`@paperclipai/workspace-strategy\` package, multi-arch images signed with cosign keyless.
+- Adds bootstrap-token exchange flow (server-issued, single-use, bound to Job UID).
+- Resolves design spec Risks #1, #4, #8. Risk #5 deferred to V2 (documented in security-model.md).
+- 4 new integration tests against kind cover Job lifecycle, claude_local end-to-end, failure modes, and empirical resource sizing.
+
+## Test plan
+- [x] Unit tests pass (\`pnpm test\`)
+- [x] Integration tests pass (\`K8S_INTEGRATION=1 pnpm --filter @paperclipai/execution-target-kubernetes test:integration\`)
+- [x] Image build workflow runs green on feature branch
+- [x] cosign verification succeeds for all three runtime images
+- [x] \`paperclip agent run\` against a real kind cluster prints assistant text
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+After authoring all phases, run a final pass before handing off to execution:
+
+1. **Spec coverage** — every requirement from §3, §4, §5, §6 of the design has a task. Risks #1, #4, #5, #8 each have an explicit task or written disposition.
+2. **Placeholder scan** — no "TBD", "TODO", "implement later", or unclosed code blocks. Every test step has runnable code; every commit step has a complete message.
+3. **Type consistency** — `BootstrapTokenMinter`, `BootstrapTokenMintRequest`, `BootstrapTokenMintResult`, `TerminalSnapshot`, `mapTerminalState`, `buildAgentJob`, `buildEphemeralSecret`, `buildAgentWorkspacePvc`, `applyAgentWorkspacePvc`, `startLogStream`, `startEventWatch`, `waitForJobTerminal`, `deriveCompanySlug`, `newRunId` are all defined where first used and consistent across later use.
+4. **Sequencing** — Phase E depends on B/C/D; Phase F depends on E; Phase G depends on F. No task depends on output of a later task.
+
+Fix any issues inline, then offer execution choice.
+
+---
+
+## Execution handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-09-paperclip-cloud-adapter-m2-plan.md`. Two execution options:**
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**
+
+

--- a/docs/superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md
+++ b/docs/superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md
@@ -1,0 +1,947 @@
+# Paperclip Cloud Adapter — Multi-Tenant Kubernetes Execution
+
+**Date:** 2026-05-08
+**Status:** Spec — pending implementation plan
+**Owner:** Jannes Stubbemann (brainstorming session)
+
+---
+
+## Executive Summary
+
+Add Kubernetes as a first-class execution target for Paperclip agent runs, with multi-tenant isolation as a design property of the orchestrator (not bolted on later). Every existing adapter (`claude_local`, `codex_local`, `gemini_local`, `opencode_local`, `acpx_local`, `pi_local`, `hermes_local`) gains the ability to run inside a Kubernetes pod by selecting a `kubernetes` execution target — no per-adapter rewrites. Tenancy is enforced via namespace-per-company with the standard k8s-native isolation primitives (RBAC, ResourceQuota, NetworkPolicy, PodSecurity Restricted, per-namespace image pull credentials, ephemeral per-Job Secrets). Each agent gets a persistent `PersistentVolumeClaim` for warm workspaces; each run is an ephemeral `Job`. The orchestrator runs as library code inside the Paperclip server using `@kubernetes/client-node` — no separate operator binary, no CRDs, in V1.
+
+Cluster topology is hybrid by design: the same code path serves an in-cluster Paperclip (workloads in adjacent namespaces) and a cross-cluster Paperclip (control plane elsewhere; workload cluster reached via stored kubeconfig). Cross-cluster auth reuses the bootstrap-token → run-JWT exchange pattern already specified for the Cursor Cloud adapter.
+
+The Helm chart for the Paperclip control plane itself is **out of scope for this spec** — it's tracked separately and gated to ship after the cloud adapter lands.
+
+---
+
+## Goals
+
+1. Run Paperclip agents on Kubernetes with strong tenant isolation suitable for multi-tenant SaaS.
+2. Keep adapters unchanged — extension via the existing `executionTarget` seam, not new adapter types.
+3. Single shared orchestration package; no per-adapter k8s code.
+4. Match k8s-native idioms: `Job`, `PVC`, `Namespace`, `NetworkPolicy`, `ResourceQuota`, `LimitRange`, `PodSecurity` Restricted.
+5. Reuse the bootstrap-token → run-JWT auth flow already shipped for the Cursor Cloud adapter — one server-side route, two callers.
+6. Support both same-cluster and cross-cluster topologies behind one configuration model.
+7. Security baseline aligned with NSA/CISA Kubernetes Hardening and CIS Kubernetes Benchmark.
+8. Operator-debuggable via standard tools: `kubectl get jobs -n paperclip-acme-corp`, audit log entries, structured run-level events.
+
+## Non-Goals (V1)
+
+- Helm chart for the Paperclip control plane (separate spec, gated to follow).
+- Per-company BYO cluster (one or more cluster connections at the *instance* level only).
+- Pod-per-agent mode (StatefulSet + KEDA scale-to-zero) — designed-for, not built.
+- External Secrets Operator integration — abstraction in place, no driver in V1.
+- VolumeSnapshot-based agent cloning.
+- `PaperclipAgentRun` CRD + reconciliation operator — not built unless reconciliation needs justify it.
+- Fine-grained image attestation enforcement (we sign; we don't enforce verify in admission).
+- IPv6 dual-stack pods.
+
+---
+
+## Architectural Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Add a new `kubernetes` kind to the existing `AdapterExecutionTarget` rather than creating a `kubernetes_pod` adapter. | Every adapter inherits k8s execution for free. Single shared orchestrator. Matches the pattern already used for `ssh` and `sandbox`. |
+| 2 | Tenant boundary = `Namespace` per Paperclip company. | K8s-native isolation primitive. RBAC, ResourceQuota, NetworkPolicy, PSS labels all attach naturally. Free, mature, widely understood. |
+| 3 | Workload granularity inside a tenant = pod-per-run as a `Job`, with PVC-per-agent for warm workspaces. | Strict isolation per run; PVC reuse keeps workspaces warm without coupling pod lifetimes. Pod-per-company was rejected (poor isolation, doesn't actually save cluster cost). |
+| 4 | Hybrid topology with bootstrap-token auth. | One auth path serves SaaS (Paperclip on control-plane cluster, agents on workload cluster) and self-hosted single-cluster. Reuses cursor-cloud's exchange route. |
+| 5 | Imperative orchestration via `@kubernetes/client-node` from the Paperclip server. No CRDs, no operator binary. | Smallest moving parts. Reconciliation is delegated to k8s primitives (Job `backoffLimit`, `TTLAfterFinished`, `OwnerReferences`, `PodFailurePolicy`). Easy to test against `kind`. |
+| 6 | Workspace bootstrap = init container running the existing Paperclip workspace strategy. | Reuses existing strategy logic; agents see identical filesystem layout to local. Cold = full clone, warm = fetch+reset. |
+| 7 | Namespace naming = `paperclip-{companySlug}` (operator-friendly), with `-{shortHash}` fallback on collision or DNS-1123 overflow. | Slug already exists in Paperclip (URL `:companyPrefix`). `kubectl` users get human-readable names. Immutable `paperclip.ai/company-id` label is the canonical machine identifier. |
+| 8 | The platform-module surface is extended (in spec, not yet existing) with `registerExecutionTargetDriver()` to keep parity with `registerAgentAdapter()` / `registerStorageProvider()`. The k8s driver is the first registered driver. | Keeps the door open for third-party drivers (Nomad, ECS, Modal-style) without core changes later. Honors the user's "leverage the plugin system" intent within the actual extension model. |
+
+---
+
+## 1. Architecture & Code Layout
+
+### 1.1 The seam
+
+The codebase already has `AdapterExecutionTarget` in `packages/adapter-utils/src/execution-target.ts` (today: `local`, `ssh`, `sandbox`). Add one new kind:
+
+```ts
+type AdapterExecutionTarget =
+  | LocalExecutionTarget
+  | SshExecutionTarget
+  | SandboxExecutionTarget
+  | KubernetesExecutionTarget;        // NEW
+
+interface KubernetesExecutionTarget {
+  kind: "kubernetes";
+  clusterConnectionId: string;
+  namespaceOverride?: string;          // rare; defaults to companySlug-derived name
+  imageOverride?: string;              // gated by per-cluster policy
+  resources?: {                        // overrides LimitRange defaults
+    requests?: { cpu?: string; memory?: string };
+    limits?:   { cpu?: string; memory?: string };
+  };
+  storage?: {
+    sizeGi?: number;                   // defaults to per-tenant policy
+    storageClass?: string;             // overrides ClusterConnection default
+  };
+  envOverrides?: Record<string, string>;  // resolved as secret_refs at materialization
+}
+```
+
+### 1.2 Code layout
+
+```
+packages/
+  adapters/
+    kubernetes-execution/                # NEW package: @paperclipai/execution-target-kubernetes
+      package.json
+      tsconfig.json
+      src/
+        index.ts                         # createKubernetesExecutionDriver()
+        driver.ts                        # one Job per run, streams stdout, returns AdapterExecutionResult
+        client.ts                        # @kubernetes/client-node thin wrapper
+        types.ts
+        orchestrator/
+          job.ts                         # Job spec builder
+          pvc.ts                         # PVC spec builder
+          secret.ts                      # ephemeral per-Job Secret materializer (interface + native impl)
+          namespace.ts                   # company → namespace ensure-and-tag
+          rbac.ts                        # ServiceAccount + Role + RoleBinding for the namespace
+          network-policy.ts              # default-deny + allowlist (vanilla + Cilium variants)
+          resource-quota.ts              # ResourceQuota + LimitRange from tenant policy
+          pod-security.ts                # restricted PSS context defaults
+          log-stream.ts                  # k8s log watch → onLog
+          event-watch.ts                 # Job/Pod Event watch → run log "[k8s]" prefix
+        bootstrap/
+          init-container.ts              # workspace-init container spec
+          callback-token.ts              # bootstrap-token issuance (calls server)
+        redaction.ts                     # secret value redaction layer
+      test/
+        unit/                            # spec builders, RBAC, NetworkPolicy, redaction
+        integration/                     # kind/k3d cluster, full lifecycle
+
+  adapter-utils/
+    src/
+      execution-target.ts                # MODIFIED — add KubernetesExecutionTarget kind
+
+server/
+  src/
+    adapters/
+      execution-target-registry.ts       # NEW — platform-module registry for drivers
+      execution-targets/
+        kubernetes.ts                    # registers @paperclipai/execution-target-kubernetes
+    routes/
+      agent-callback.ts                  # /api/agent-auth/exchange + /api/runs/:runId/events
+      agent-callback.test.ts             # (extend cursor-cloud's existing route)
+      workspace-git-credentials.ts       # NEW — /api/workspace/git-credentials
+    services/
+      cluster-connections.ts             # NEW — stored cluster connections (kubeconfig refs)
+      cluster-tenant-policies.ts         # NEW — quota/limit/image-override policies per tenant
+      workspace-strategy/                # REFACTORED — extracted shared library used by init container
+
+ui/
+  src/
+    adapters/
+      execution-target/
+        kubernetes-fields.tsx            # NEW — exec-target form for "kubernetes"
+    pages/
+      ClusterConnections.tsx             # NEW — operator UI: list, add, health
+      ClusterConnectionDetail.tsx        # NEW — per-cluster: namespaces, quotas, runs
+
+docker/
+  agent-runtime/                         # NEW — Paperclip-maintained runtime images
+    Dockerfile.base                      # distroless or ubuntu-slim + node + git + tini + nonroot
+    Dockerfile.claude                    # base + claude-code CLI
+    Dockerfile.codex
+    Dockerfile.gemini
+    Dockerfile.opencode
+    Dockerfile.acpx
+    Dockerfile.pi
+    Dockerfile.hermes
+```
+
+### 1.3 Data flow for one agent run
+
+```
+Paperclip server (control plane)
+
+  Heartbeat fires for agent A in company C
+       │
+       ▼
+  Adapter.execute(ctx) — ctx.executionTarget.kind === "kubernetes"
+       │
+       ▼
+  KubernetesExecutionDriver.run(ctx):
+   1. resolve cluster connection (from ctx.executionTarget.clusterConnectionId)
+   2. ensure namespace `paperclip-{companySlug}` (idempotent)
+   3. ensure RBAC, ResourceQuota, LimitRange, NetworkPolicies, image pull secret
+   4. ensure PVC `agent-{agentSlug}-workspace` (RWO, default StorageClass)
+   5. mint bootstrap token + run JWT scope
+   6. resolve secret_refs → materialize per-Job Secret (OwnerRef → Job)
+   7. submit Job:
+        initContainer  paperclip-workspace-init  → /workspace via existing strategy
+        container      agent-runtime-{adapterType}  → exec adapter CLI in /workspace
+   8. open k8s pods/log watch → forward chunks to ctx.onLog("stdout", chunk)
+   9. open k8s Events watch (Job + Pod) → forward warnings to onLog with [k8s] prefix
+  10. await Job completion or cancellation
+  11. read terminal status + map to AdapterExecutionResult (codes per §7.2)
+  12. TTLAfterFinished cleans up Job + Secret; PVC retained
+       ▲
+       │ Pod callbacks via /api/agent-auth/exchange + run JWT
+       │
+  Cluster (in-cluster or remote via stored kubeconfig)
+    Namespace: paperclip-{companySlug}
+      Job: agent-{agentSlug}-run-{ulid}
+        Pod
+          initContainer: paperclip-workspace-init  (resolves project_workspaces strategy)
+          container:     agent-runtime             (runs adapter CLI; logs via API)
+        volumes:
+          workspace  ← PVC agent-{agentSlug}-workspace (retained between runs)
+          tmp        ← emptyDir 1Gi
+          env        ← Secret agent-{agentSlug}-run-{ulid}-env (OwnerRef: Job)
+      NetworkPolicy: deny-all + paperclip-agent-egress
+      ResourceQuota / LimitRange (per-tenant policy)
+```
+
+### 1.4 Why this shape
+
+- **Reuses the existing executionTarget seam** — adapters do not change.
+- **Single trust boundary** — the namespace.
+- **No long-running daemon** — orchestrator is library code; no operator, no CRDs in V1.
+- **Built on k8s primitives** — `Job`, `OwnerReference`, `ResourceQuota`, `NetworkPolicy`, `PodSecurityAdmission`. Less code we own.
+- **Cross-cluster-ready from day one** — cluster connection is a stored kubeconfig ref; in-cluster is one connection type among many.
+
+---
+
+## 2. Tenancy, Isolation & Cluster Connection
+
+### 2.1 Tenant boundary: `Namespace` per company
+
+**Naming.** `paperclip-{companySlug}` primary. Fallback `paperclip-{companySlug}-{base36(blake3(companyId))[:8]}` when:
+- slug overflows 63 chars after the `paperclip-` prefix (so slug ≤ 53 chars), or
+- a different company already owns that name in the same cluster (collision).
+
+The `paperclip.ai/company-id=<uuid>` label is the immutable machine identifier; the namespace name can change in edge cases without breaking identity.
+
+**Provisioning.** First time an agent in company C runs against cluster K, the driver runs an idempotent ensure-namespace path that creates (or upserts):
+
+| Object | Purpose |
+|---|---|
+| `Namespace` with labels `paperclip.ai/company-id`, `paperclip.ai/managed-by=paperclip`, PSS labels (`pod-security.kubernetes.io/enforce: restricted`, `audit: restricted`, `warn: restricted`) | Tenant root + admission profile |
+| `ServiceAccount paperclip-agent` with `automountServiceAccountToken: false` | Pod identity (zero RBAC by default) |
+| `ResourceQuota paperclip-tenant-quota` | Compute/storage/pod caps |
+| `LimitRange paperclip-tenant-limits` | Default + max per-pod requests/limits |
+| `NetworkPolicy default-deny-ingress` + `default-deny-egress` | Zero-trust baseline |
+| `NetworkPolicy paperclip-agent-egress` (vanilla) | L3/L4 allowlist |
+| `CiliumNetworkPolicy paperclip-agent-egress-l7` (when Cilium present) | L7/FQDN allowlist |
+| Optional `Secret paperclip-image-pull` | Per-tenant registry credentials |
+
+All objects carry `paperclip.ai/managed-by=paperclip` and `paperclip.ai/company-id=<id>`. The driver refuses to mutate any namespace lacking `paperclip.ai/managed-by=paperclip`.
+
+**Lifecycle.** Company archive → namespace labeled `paperclip.ai/archived=true`, quotas zeroed, retained for the standard data-retention grace period (default 30 days, matches plugin spec § 25.1). Operator purge via `paperclipai cluster purge --company <id>`.
+
+### 2.2 Pod identity: zero-trust by default
+
+The pod's ServiceAccount has **no RBAC**. `automountServiceAccountToken: false` is set on the pod spec. The driver's k8s identity (server-side) is a separate ServiceAccount (in-cluster) or kubeconfig user (cross-cluster) bound only to namespaces matching `paperclip-*`.
+
+### 2.3 NetworkPolicy: default-deny + allowlist (L3/L4)
+
+```yaml
+# default-deny-ingress
+podSelector: {}
+policyTypes: [Ingress]
+
+---
+# default-deny-egress
+podSelector: {}
+policyTypes: [Egress]
+
+---
+# paperclip-agent-egress (only the agent role)
+podSelector: { matchLabels: { paperclip.ai/role: agent-runtime } }
+policyTypes: [Egress]
+egress:
+  - to: # cluster DNS
+      - namespaceSelector: { matchLabels: { kubernetes.io/metadata.name: kube-system } }
+        podSelector:       { matchLabels: { k8s-app: kube-dns } }
+    ports: [{ port: 53, protocol: UDP }, { port: 53, protocol: TCP }]
+  - to: # in-cluster Paperclip control plane (when topology = same-cluster)
+      - namespaceSelector: { matchLabels: { paperclip.ai/role: control-plane } }
+        podSelector:       { matchLabels: { app.kubernetes.io/name: paperclip-server } }
+    ports: [{ port: 443, protocol: TCP }, { port: 3102, protocol: TCP }]
+  - to: # internet egress with internal ranges denied
+      - ipBlock:
+          cidr: 0.0.0.0/0
+          except:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+            - 169.254.0.0/16   # link-local incl. cloud metadata
+            - 100.64.0.0/10    # CGNAT
+            - fd00::/8         # IPv6 ULA
+    ports: [{ port: 443, protocol: TCP }]
+```
+
+The `except` blocks are the load-bearing security control: a compromised pod cannot reach cloud metadata, in-cluster databases, or internal services.
+
+### 2.4 Cilium variant (auto-detected, additive)
+
+When the cluster has `CiliumNetworkPolicy` available, the orchestrator generates a CNP **alongside** the vanilla NetworkPolicy. Vanilla stays as defense-in-depth.
+
+```yaml
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: paperclip-agent-egress-l7
+spec:
+  endpointSelector: { matchLabels: { paperclip.ai/role: agent-runtime } }
+  egress:
+    - toFQDNs:
+        - matchPattern: "*.anthropic.com"
+        - matchPattern: "api.openai.com"
+        - matchPattern: "*.googleapis.com"
+        - matchPattern: "github.com"
+        - matchPattern: "*.github.com"
+        - matchPattern: "gitlab.com"
+        # ...composed from adapter.networkRequirements + tenantPolicy.additionalAllowFqdns
+      toPorts: [{ ports: [{ port: "443", protocol: TCP }] }]
+    - toEndpoints: [{ matchLabels: { paperclip.ai/role: control-plane } }]
+      toPorts: [{ ports: [{ port: "443", protocol: TCP }] }]
+```
+
+### 2.5 Pod Security Admission: `restricted`
+
+Namespace labeled `pod-security.kubernetes.io/enforce|audit|warn: restricted`. Every pod spec sets:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile: { type: RuntimeDefault }
+containers:
+  - securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true     # tmpfs at /tmp; PVC at /workspace
+      capabilities: { drop: [ALL] }
+```
+
+Satisfies NSA/CISA Kubernetes Hardening Guidance and CIS Kubernetes Benchmark.
+
+### 2.6 ResourceQuota & LimitRange
+
+Defaults (overridable per company plan in `cluster_tenant_policies`):
+
+```yaml
+# ResourceQuota
+hard:
+  requests.cpu:                    "16"
+  requests.memory:                 "64Gi"
+  limits.cpu:                      "64"
+  limits.memory:                   "256Gi"
+  requests.storage:                "200Gi"
+  count/jobs.batch:                "100"
+  count/persistentvolumeclaims:    "50"
+  count/secrets:                   "200"
+  count/configmaps:                "200"
+
+# LimitRange
+limits:
+  - type: Container
+    default:        { cpu: "1",    memory: "2Gi" }
+    defaultRequest: { cpu: "250m", memory: "512Mi" }
+    max:            { cpu: "8",    memory: "32Gi" }
+  - type: PersistentVolumeClaim
+    max: { storage: "20Gi" }
+```
+
+When a billing tier change happens, the driver re-applies the new quota.
+
+### 2.7 Cluster connection storage
+
+```ts
+interface ClusterConnection {
+  id: string;
+  label: string;
+  kind: "in-cluster" | "kubeconfig";
+  kubeconfigSecretRef?: SecretRef;     // resolved via Paperclip secret provider
+  apiServerUrl?: string;               // for display only
+  defaultNamespacePrefix: string;      // default "paperclip-"
+  capabilities: {
+    cilium: boolean;                   // auto-detected at connect time
+    storageClass: string;              // e.g. "gp3", "longhorn"
+    architectures: ("amd64" | "arm64")[];
+  };
+  paperclipPublicUrl?: string;          // override for cross-cluster topology
+  imageRegistry?: string;               // override for ghcr.io/paperclipai/*
+  createdAt: string;
+  createdBy: string;
+}
+```
+
+V1: instance-level operator-managed cluster connections (`pnpm paperclipai cluster add`). V2: per-company BYO cluster.
+
+### 2.8 Compliance bookkeeping
+
+- ✅ NSA/CISA Kubernetes Hardening Guidance — Restricted PSS, NetworkPolicy default-deny, no privilege escalation, no host network/PID/IPC, drop ALL caps, RuntimeDefault seccomp.
+- ✅ CIS Kubernetes Benchmark — namespace isolation, ResourceQuota, no auto-mounted SA tokens.
+- ✅ Internal blast-radius isolation — RFC1918 + link-local egress blocked, no shared SA across tenants.
+
+The release pipeline runs `kube-audit-kit` and `polaris` against a freshly provisioned tenant namespace; PSS Restricted violations or NSA Hardening regressions block release.
+
+---
+
+## 3. Pod Lifecycle
+
+### 3.1 Job spec
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: agent-{agentSlug}-run-{ulid}
+  namespace: paperclip-{companySlug}
+  labels:
+    paperclip.ai/managed-by: paperclip
+    paperclip.ai/company-id: <uuid>
+    paperclip.ai/agent-id:   <uuid>
+    paperclip.ai/run-id:     <uuid>
+    paperclip.ai/role:       agent-runtime
+spec:
+  backoffLimit: 0                        # Paperclip owns retry semantics
+  ttlSecondsAfterFinished: 300           # log harvest, then GC
+  activeDeadlineSeconds: <min(adapterConfig.timeoutSec, namespaceQuota.maxRunSeconds)>
+  completions: 1
+  parallelism: 1
+  podFailurePolicy:
+    rules:
+      - action: FailJob
+        onPodConditions: [{ type: PodHasNetwork, status: "False" }]
+      - action: FailJob
+        onExitCodes: { containerName: agent, operator: In, values: [137] }   # OOM
+  template:
+    metadata:
+      labels:
+        paperclip.ai/role: agent-runtime
+        paperclip.ai/agent-id: <uuid>
+        paperclip.ai/run-id:   <uuid>
+      annotations:
+        paperclip.ai/job-spec-version: "v1"
+    spec:
+      automountServiceAccountToken: false
+      serviceAccountName: paperclip-agent
+      restartPolicy: Never
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 30
+      securityContext: { ... restricted PSS ... }
+      initContainers: [ workspace-init ]
+      containers:    [ agent ]
+      volumes:
+        - name: workspace
+          persistentVolumeClaim: { claimName: agent-{agentSlug}-workspace }
+        - name: tmp
+          emptyDir: { sizeLimit: 1Gi }
+        - name: env
+          secret: { secretName: agent-{agentSlug}-run-{ulid}-env, defaultMode: 0400 }
+        - name: skills-pointer
+          configMap: { name: paperclip-skills-pointer }
+```
+
+Key choices:
+- `backoffLimit: 0` — Paperclip owns retry semantics (`AdapterExecutionErrorFamily`, `retryNotBefore`). K8s never retries.
+- `ttlSecondsAfterFinished: 300` — gives log-watch time to drain final stdout, then GC removes Job + Pod + per-run Secret via `OwnerReferences`.
+- `activeDeadlineSeconds` — clamped to `min(adapterConfig.timeoutSec, namespaceQuota.maxRunSeconds)`.
+- `podFailurePolicy` — surfaces image-pull and OOM as terminal failures rather than consuming retry budget.
+- `automountServiceAccountToken: false` — agent has no business calling the k8s API.
+- `enableServiceLinks: false` — avoids env-var noise and minor info leak.
+
+### 3.2 Init container: workspace bootstrap
+
+```yaml
+initContainers:
+  - name: workspace-init
+    image: ghcr.io/paperclipai/agent-runtime-base:{paperclipVersion}
+    command: ["/usr/local/bin/paperclip-workspace-init"]
+    env:
+      - name: PAPERCLIP_WORKSPACE_STRATEGY
+        value: <serialized strategy from project_workspaces>
+      - name: PAPERCLIP_WORKSPACE_ROOT
+        value: /workspace
+      - name: PAPERCLIP_RUN_ID
+        value: <run-id>
+      - name: PAPERCLIP_BOOTSTRAP_TOKEN
+        valueFrom: { secretKeyRef: { name: agent-{agentSlug}-run-{ulid}-env, key: BOOTSTRAP_TOKEN } }
+    volumeMounts:
+      - { name: workspace, mountPath: /workspace }
+      - { name: tmp,       mountPath: /tmp }
+    securityContext: { ... restricted ... }
+    resources:
+      requests: { cpu: 200m, memory: 256Mi }
+      limits:   { cpu: "2",  memory: 1Gi }
+```
+
+`paperclip-workspace-init` behavior:
+
+1. Reads `PAPERCLIP_WORKSPACE_STRATEGY` (existing strategy types: `git-clone`, `git-worktree`, `existing-path` (rejected at validation), `none`).
+2. Cold PVC → full strategy. Git creds obtained via bootstrap-token → run-JWT exchange → `/api/workspace/git-credentials`. Creds written to init container's tmpfs only.
+3. Warm PVC → `git fetch && git reset --hard {ref}` (configurable; matches local adapter semantics).
+4. Writes `.paperclip-workspace-state.json` marker.
+5. Non-zero exit → Job fails with `errorCode: workspace_init_failed`.
+
+Init container shares the PVC with the main container but **not** the env Secret mount — credentials never leak forward.
+
+### 3.3 Main container: agent runtime
+
+```yaml
+containers:
+  - name: agent
+    image: <resolved per §5.2>
+    imagePullPolicy: IfNotPresent
+    workingDir: /workspace
+    command: ["/usr/local/bin/tini", "--"]
+    args:    ["/usr/local/bin/paperclip-agent-shim", "--adapter", "<type>"]
+    env:
+      - name: PAPERCLIP_RUN_ID
+        value: <run-id>
+      - name: PAPERCLIP_PUBLIC_URL
+        value: <resolved per §6.5>
+      - name: PAPERCLIP_BOOTSTRAP_TOKEN
+        valueFrom: { secretKeyRef: { name: ...env, key: BOOTSTRAP_TOKEN } }
+      - name: TRACEPARENT
+        value: <propagated from server span>
+      # ...adapter-specific keys (LLM keys, etc.) from the per-Job Secret
+    volumeMounts:
+      - { name: workspace,       mountPath: /workspace }
+      - { name: tmp,             mountPath: /tmp }
+      - { name: env,             mountPath: /run/paperclip/env, readOnly: true }
+      - { name: skills-pointer,  mountPath: /run/paperclip/skills, readOnly: true }
+    resources:
+      requests: { cpu: <from adapter or LimitRange default>, memory: ... }
+      limits:   { cpu: ...,                                  memory: ... }
+    securityContext:
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities: { drop: [ALL] }
+      seccompProfile: { type: RuntimeDefault }
+```
+
+`tini` as PID 1 ensures SIGTERM forwarding. `paperclip-agent-shim`:
+1. Reads `AdapterRuntimeCommandSpec` from a config file projected by the orchestrator.
+2. Detects the adapter CLI (`installCommand` if missing).
+3. Reads the prerendered prompt (orchestrator-rendered).
+4. Exec-replaces itself into the actual adapter CLI so signals propagate.
+5. Frames structured stdout events compatible with existing UI parsers.
+
+No sidecars in V1. Logs flow via `pods/log` watch + structured-events callback (§3.4).
+
+### 3.4 Output streaming
+
+Two parallel streams merged by timestamp:
+
+| Source | Mechanism |
+|---|---|
+| stdout/stderr | `pods/log` watch with `sinceTime` reconnect → `ctx.onLog("stdout", chunk)` |
+| Structured events | `POST /api/runs/:runId/events` from agent shim with run JWT |
+| K8s `Event`s on Job/Pod | Events watch → `ctx.onLog("stdout", "[k8s] " + event)` |
+
+If the structured-events callback is unreachable (NetworkPolicy misconfig), events fall back to stdout framing — degraded but not broken.
+
+### 3.5 Cancellation
+
+User cancels run → registered cancellation handler:
+1. `kubectl delete job <name> --propagation-policy=Foreground --grace-period=30`
+2. K8s sends SIGTERM to PID 1 → `tini` → adapter CLI. 30s drain.
+3. After grace, SIGKILL.
+4. Pod terminates → log watch sees stream end → `AdapterExecutionResult { exitCode: null, signal: "SIGTERM", errorCode: "cancelled" }`.
+
+Foreground propagation ensures the Pod is gone before the API call returns; per-Job Secret GC'd via `OwnerReferences`. PVC untouched.
+
+### 3.6 Concurrent runs on the same agent
+
+PVC is `ReadWriteOnce` — only one pod can mount at a time.
+- Paperclip's heartbeat-level locking already prevents overlapping runs per agent.
+- Defensive: orchestrator checks for a live Job with the same `paperclip.ai/agent-id` label and returns `errorCode: "concurrent_run_blocked"` immediately rather than queueing.
+- For agents that legitimately need concurrent runs, switch the agent's storage class to ReadWriteMany (e.g. EFS, Azure Files, Longhorn) with the perf tradeoff documented.
+
+---
+
+## 4. Workspace Persistence
+
+### 4.1 PVC lifetime is bound to the agent, not the run
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: agent-{agentSlug}-workspace
+  namespace: paperclip-{companySlug}
+  labels:
+    paperclip.ai/managed-by: paperclip
+    paperclip.ai/company-id: <uuid>
+    paperclip.ai/agent-id:   <uuid>
+    paperclip.ai/role:       agent-workspace
+  annotations:
+    paperclip.ai/workspace-strategy: <strategy-key>
+    paperclip.ai/created-at:         <iso>
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: <from ClusterConnection.capabilities.storageClass>
+  resources: { requests: { storage: <perAgentDefault, e.g. 10Gi> } }
+```
+
+Created on first run, reused for subsequent runs. Never auto-deleted on Job completion.
+
+### 4.2 Zonal pinning
+
+`ReadWriteOnce` cloud disks (EBS, PD-Standard, Azure Disk) are zone-bound. After first bind, the orchestrator reads the bound `PersistentVolume.spec.nodeAffinity` and adds matching `nodeAffinity` to subsequent pods so they land in the same zone. Operators who want multi-zone resilience choose a regional StorageClass (e.g. `pd-balanced` regional, EFS, Longhorn) — purely a StorageClass decision, no orchestrator code change.
+
+### 4.3 Reclaim & GC
+
+- PVC `persistentVolumeReclaimPolicy: Delete` (default for dynamic provisioning).
+- Agent archive → PVC labeled `paperclip.ai/archived=true`, retained for grace period (default 30 days).
+- Operator `paperclipai cluster purge --agent <id>` → immediate delete.
+- Company purge → namespace deletion cascades to all PVCs.
+- Daily stale PVC sweep flags PVCs with no matching `agents` row older than 7 days; surfaced in cluster-health UI; never auto-deleted.
+
+### 4.4 Quota interaction
+
+PVC storage counts against `requests.storage` and `count/persistentvolumeclaims` in the namespace `ResourceQuota`. Quota exhaustion → new agents cannot run; orchestrator returns `errorCode: "tenant_storage_quota_exhausted"` with remediation hint.
+
+### 4.5 Workspace strategy → init container interaction
+
+| Strategy | Init container behavior |
+|---|---|
+| `git-clone` | Cold: `git clone <url> --branch <ref> .`. Warm: `git fetch && git reset --hard origin/<ref>`. |
+| `git-worktree` | Cold: `git clone --bare` into `/workspace/.bare` then `git worktree add` per agent slot. Warm: `git fetch` + worktree update. |
+| `existing-path` | Rejected at execution-target config validation; not a runtime failure. |
+| `none` | Empty `/workspace`. |
+
+Strategy code is **shared** between local adapter and init container by extracting existing logic from `server/src/services/workspace-strategy/` (or wherever it currently lives) into a small library that the init container's binary links against. This is a planned refactor in the implementation plan.
+
+### 4.6 Snapshots & backup (V2, designed-for)
+
+- PVCs labeled and annotated for Velero/Kasten K10 selectors out of the box.
+- VolumeSnapshot CRDs reserved for V2 — `paperclipai cluster snapshot agent <id>` would create a `VolumeSnapshot` and a Paperclip record.
+- V2 use case: cloning an agent's workspace as the seed for a new agent (`PVC.dataSource: VolumeSnapshot`).
+
+### 4.7 Edge cases
+
+- Init container wedge → `activeDeadlineSeconds` catches.
+- Disk full mid-run → `errorCode: workspace_disk_full` with `df` snapshot from `kubectl exec`.
+- Corrupt workspace → init container detects `git status` non-clean and falls back to full reset; configurable per agent for agents that want dirty state preserved.
+- PVC orphan after stuck `Terminating` namespace → surfaced in cluster-health UI; explicit operator cleanup, never auto-resolved.
+
+---
+
+## 5. Images & Secrets
+
+### 5.1 Image strategy: Paperclip-maintained, adapter-aligned
+
+Family of small images, not one fat image:
+
+| Image | Base | Contains |
+|---|---|---|
+| `ghcr.io/paperclipai/agent-runtime-base:{paperclipVersion}` | distroless or ubuntu-slim | `tini`, `git`, `paperclip-workspace-init`, `paperclip-agent-shim`, CA bundle, non-root uid/gid 1000 |
+| `agent-runtime-claude:{paperclipVersion}` | base | + `@anthropic-ai/claude-code` CLI |
+| `agent-runtime-codex:{paperclipVersion}` | base | + Codex CLI |
+| `agent-runtime-gemini:{paperclipVersion}` | base | + Gemini CLI |
+| `agent-runtime-opencode:{paperclipVersion}` | base | + OpenCode CLI |
+| `agent-runtime-acpx:{paperclipVersion}` | base | + ACPX CLI |
+| `agent-runtime-pi:{paperclipVersion}` | base | + Pi CLI |
+| `agent-runtime-hermes:{paperclipVersion}` | base | + Hermes CLI |
+
+Reasoning:
+- Per-adapter images are smaller (~150–250 MB) than a fat kitchen sink image.
+- Independent CLI version pinning per adapter.
+- Clear failure surface: "Codex CLI not found in image" is impossible because Codex isn't in the Claude image.
+
+`{paperclipVersion}` ties image **tags** to Paperclip release tags so `agent-runtime-claude:v2026.5.8` is unambiguous. The image *contents* (notably the bundled adapter CLI version) follow each adapter's own pinning cadence — a Paperclip release that doesn't bump the Claude CLI ships an `agent-runtime-claude:v2026.5.8` whose layered content is identical to the previous release. This keeps tag→content mapping deterministic without forcing a CLI rebuild on every Paperclip release.
+
+**Multi-arch.** Every image ships `amd64` + `arm64` via `docker buildx`.
+
+**Provenance.** `cosign` keyless OIDC signing in CI; SBOMs (`syft` → SPDX) attached as cosign attestations; `trivy` CVE scanning gates release.
+
+### 5.2 Image resolution: three levels of override
+
+```
+Effective image =
+  per-agent override     (adapterConfig.kubernetes.image; gated by per-cluster policy)
+  ?? per-tenant override (cluster_tenant_policies.imageOverrides[adapterType])
+  ?? cluster default     (ClusterConnection.imageRegistry + adapterType)
+  ?? Paperclip default   (ghcr.io/paperclipai/agent-runtime-{adapterType}:{paperclipVersion})
+```
+
+Per-agent override is gated by `ClusterConnection.allowAgentImageOverride: false` (default false). Even when enabled, the image must satisfy `imagePullPolicy: IfNotPresent` and an admission check that the namespace is not labeled `paperclip.ai/role: control-plane`.
+
+### 5.3 Per-namespace image pull credentials
+
+Per-namespace `kubernetes.io/dockerconfigjson` Secret resolved from the Paperclip secret store at namespace-ensure time. Not auto-rotated (rotation can break in-flight pulls); operator command `paperclipai cluster rotate-pull-secret --connection <id>` for explicit rotation.
+
+### 5.4 Per-Job ephemeral Secret for run credentials
+
+```yaml
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: agent-{agentSlug}-run-{ulid}-env
+  namespace: paperclip-{companySlug}
+  labels:
+    paperclip.ai/managed-by: paperclip
+    paperclip.ai/run-id: <uuid>
+  ownerReferences:
+    - apiVersion: batch/v1
+      kind: Job
+      name: agent-{agentSlug}-run-{ulid}
+      uid: <jobUid>
+      controller: true
+      blockOwnerDeletion: true
+data:
+  BOOTSTRAP_TOKEN:    <base64>
+  ANTHROPIC_API_KEY:  <base64>      # resolved from secret_ref
+  GIT_CREDENTIAL_KEY: <base64>      # short-lived handle, exchanged at runtime
+  # ...adapter-required keys, all from secret_refs
+```
+
+Properties:
+- Lifetime tied to the Job via `OwnerReferences` — TTL cleanup of the Job removes the Secret.
+- Mounted as **files** at `/run/paperclip/env` (mode 0400, uid 1000), and projected as env vars only for the keys the adapter CLI explicitly needs.
+- Materialized at Job-create time (resolve `secret_ref`s, build Secret, submit Job in a single transaction). On Job-create failure, Secret is explicitly deleted (no owner yet to GC it).
+- Secret values never written to logs, audit entries, error messages, or `resultJson`. Enforced by a redaction layer keyed by the materialized Secret's value set.
+
+### 5.5 Bootstrap token → run JWT exchange (shared with cursor-cloud)
+
+Same shape as the existing cursor-cloud route at `/api/agent-auth/exchange`:
+1. Pod has `BOOTSTRAP_TOKEN` (10 min TTL, run-scoped, single-use, bound to Job UID).
+2. `POST /api/agent-auth/exchange { bootstrapToken }` → `{ runJwt, expiresAt }`.
+3. Pod uses `runJwt` for `/api/runs/:runId/events`, `/api/skills/*`, `/api/workspace/git-credentials`.
+
+V1.5 second factor: bind the exchange request to the calling Pod's projected ServiceAccount token (`audience: paperclip-runtime`); server's `TokenReview` confirms the caller before issuing the run JWT. Cross-cluster topology defers this to V2 (needs identity federation).
+
+### 5.6 External Secrets Operator (V2, designed-for)
+
+V1 abstracts the per-Job Secret materialization behind a `SecretMaterializer` interface. V2 adds an `ExternalSecretMaterializer` that creates an `ExternalSecret` CR pointing at the customer's Vault/AWS SM/GCP SM and waits for ESO to materialize the underlying Secret before submitting the Job.
+
+### 5.7 Not in V1
+
+- Per-pod kubelet credential provider plugins.
+- Paperclip-managed cosign verification policy (we sign; we trust customers' admission controllers to verify).
+- Image rebuild on every Paperclip release for every adapter CLI version (CLI bumps follow their own cadence).
+
+---
+
+## 6. Networking & Callback
+
+### 6.1 Three layers of egress control
+
+```
+Pod (agent-runtime)
+   ↓ ① NetworkPolicy (L3/L4 IP/port)            ← always on
+   ↓ ② Cilium L7 / FQDN policy                  ← if cluster supports it (auto-detected)
+   ↓ ③ Egress proxy (squid/Envoy)               ← optional, customer-managed
+   ↓
+external network
+```
+
+V1 ships ① and ②. ③ is documented; the runtime image honors `HTTP_PROXY`/`HTTPS_PROXY` env so customers can wire one in via tenant policy.
+
+### 6.2 Layer ① — vanilla NetworkPolicy
+
+See §2.3 for the full policies. The control-plane match-labels are a parameter of the cluster connection: in-cluster topology fills them with the Paperclip server's labels; cross-cluster omits the in-cluster rule entirely.
+
+### 6.3 Layer ② — Cilium variant
+
+See §2.4. The FQDN allowlist is per-tenant + per-adapter:
+- `adapter.networkRequirements.allowFqdns` (declared by the adapter package)
+- `tenantPolicy.additionalAllowFqdns` (operator-set per company)
+- Deny-by-default everywhere else.
+
+### 6.4 Layer ③ — egress proxy
+
+Tenant policy can set `httpProxyUrl: http://proxy.acme-corp.svc.cluster.local:3128`. Orchestrator injects `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`; `NO_PROXY` is auto-populated with kube-dns, the Paperclip Service, and pod/service CIDRs.
+
+### 6.5 Paperclip public URL resolution
+
+Resolution order:
+1. **In-cluster topology** → `https://paperclip-server.<paperclipNamespace>.svc.cluster.local:443`. Default when `ClusterConnection.kind === "in-cluster"` and the orchestrator can resolve the server's Service.
+2. **Cross-cluster topology** → `ClusterConnection.paperclipPublicUrl`, fallback `process.env.PAPERCLIP_PUBLIC_URL`. Validated reachable from the cluster at connection-add time via a one-shot Job that curls `/api/health`.
+3. **Per-agent override** — `adapterConfig.paperclipPublicUrl`. Rare; for agents crossing VPN boundaries.
+
+The resolved URL is injected as a literal `PAPERCLIP_PUBLIC_URL` env var in the pod spec (not in the per-Job Secret — it's not sensitive). The agent shim refuses to start if it's missing.
+
+### 6.6 Callback API surface
+
+| Endpoint | Auth | Used by | Source |
+|---|---|---|---|
+| `POST /api/agent-auth/exchange` | bootstrap token | first call from pod | shared with cursor-cloud |
+| `POST /api/runs/:runId/events` | run JWT | structured events | shared |
+| `POST /api/workspace/git-credentials` | run JWT | init container | k8s-specific |
+
+Rate limits on `/api/agent-auth/exchange`: 10/min/companyId, 1000/day/companyId. Bootstrap tokens are single-use; replay → `400 token_already_consumed`. Run JWT bearer-auth on subsequent calls; per-run rate limits 1000 events/min, 100MB/run total.
+
+### 6.7 Failure modes
+
+- DNS down inside cluster → `errorCode: dns_unreachable` with CoreDNS pod status in metadata.
+- Cilium policy denies a new domain → drop logs (Hubble) tee'd into run log when available; `errorCode: network_policy_denied`.
+- Paperclip server unreachable → bounded backoff (5 attempts, exponential, capped at 30s); after that `errorCode: control_plane_unreachable`, `errorFamily: transient_upstream`.
+- Token replay → orchestrator-internal retry once with fresh token, then fail.
+
+---
+
+## 7. Observability, Failure Modes, Testing
+
+### 7.1 Logs
+
+Three tiers feeding the Paperclip run log buffer:
+
+| Source | Mechanism | Latency |
+|---|---|---|
+| Agent stdout/stderr | `pods/log` watch | live (~100ms) |
+| Structured events | `POST /api/runs/:runId/events` from agent shim | live |
+| Orchestrator + K8s `Event`s | server-local logs + `heartbeat_run_events` rows + `[k8s]`-prefixed lines | sync |
+
+Tier 3 catches things teams forget: a Job sitting Pending for 90s due to `ImagePullBackOff` shows up in the run log without `kubectl describe`.
+
+### 7.2 Metrics (Prometheus, exposed at server `/metrics`)
+
+```
+paperclip_k8s_runs_total{cluster, namespace, adapter_type, outcome}
+paperclip_k8s_run_duration_seconds{cluster, namespace, adapter_type}
+paperclip_k8s_pod_pending_seconds{cluster, namespace}
+paperclip_k8s_pvc_bytes{cluster, namespace, agent_id}
+paperclip_k8s_namespace_quota_used_ratio{cluster, namespace, resource}
+paperclip_k8s_orchestrator_api_errors_total{cluster, verb, code}
+paperclip_k8s_callback_requests_total{endpoint, status_code}
+```
+
+Customers worried about cardinality can drop the `namespace` label via Helm values.
+
+### 7.3 Tracing (OpenTelemetry)
+
+Server starts a span on `Adapter.execute`, propagates context as `TRACEPARENT` env into the per-Job Secret. Agent shim continues the trace. One trace per run with spans for orchestrator phases (ensure-namespace, materialize-secret, submit-job, await-completion) plus agent-side spans for prompt rendering and CLI invocation.
+
+### 7.4 Audit
+
+Every orchestrator mutation writes a Paperclip activity log entry with:
+- `actorType: "platform_module"`
+- `sourceModule: "kubernetes-execution-target"`
+- `targetCluster`, `targetNamespace`, `verb`, `outcome`
+
+Sufficient for SOC2-style audit trails.
+
+### 7.5 Failure mode catalog
+
+| Symptom | `errorCode` | Family | Retryable? |
+|---|---|---|---|
+| Image pull fails | `image_pull_failed` | `transient_upstream` | No (operator must fix image/pull-secret) |
+| OOM kill | `oom_killed` | — | No (resize agent's resource request) |
+| `activeDeadlineSeconds` hit | `timeout` | — | Per Paperclip's existing timeout policy |
+| Init container fails | `workspace_init_failed` | varies | Yes if `transient_upstream` (e.g. git server 503) |
+| Disk full | `workspace_disk_full` | — | No (PVC resize or workspace cleanup) |
+| Storage quota | `tenant_storage_quota_exhausted` | — | No (billing event) |
+| Compute quota | `tenant_compute_quota_exhausted` | — | No (billing event) |
+| Cluster unreachable from server | `cluster_unreachable` | `transient_upstream` | Yes |
+| Pod can't reach Paperclip | `control_plane_unreachable` | `transient_upstream` | Yes (with backoff) |
+| Cilium FQDN denied | `network_policy_denied` | — | No (operator must update policy) |
+| Concurrent run blocked | `concurrent_run_blocked` | — | Yes after current run completes |
+| Bootstrap token replay | `token_replay` | — | No (orchestrator retries once internally, then fails) |
+| Pod stuck `Pending` >5min | `pod_scheduling_failed` | `transient_upstream` | Yes (autoscaler may catch up) |
+| Workspace strategy unsupported on this target | `execution_target_unsupported_strategy` | — | No (config-validation-time error) |
+| DNS unreachable | `dns_unreachable` | `transient_upstream` | Yes |
+| User-initiated cancellation | `cancelled` | — | No (terminal by user intent) |
+
+Every code is documented with an inline UI remediation hint.
+
+### 7.6 Testing strategy
+
+**Unit (no cluster).** Bulk of suite. Pure builders:
+- Job spec builder → expected YAML (golden snapshots).
+- NetworkPolicy generator (vanilla + Cilium).
+- ResourceQuota / LimitRange builder per plan tier.
+- RBAC binding generator.
+- Secret materialization → no plaintext leakage in any return value.
+- ClusterConnection validation, namespace-name derivation, slug truncation.
+- Redaction layer on log lines, error messages, `resultJson`.
+
+**Integration (real cluster).** `kind`/`k3d` cluster spun up in CI via `testcontainers-node`:
+- Full run lifecycle for `claude_local` against a fake LLM endpoint.
+- Cancellation mid-run — Job deleted within grace, no orphan PVC/Secret.
+- Quota enforcement — submit 11 Jobs with quota of 10; 11th rejected with the right error code.
+- Multi-tenant isolation — two namespaces, concurrent agents, probe pod that tries cross-namespace traffic must fail.
+- PSS Restricted compliance — privileged Pod rejected at admission.
+- Image pull failure path → `errorCode: image_pull_failed` within 60s.
+- Workspace warm vs cold — second run faster, PVC reused.
+
+**Contract.** Every public type the driver exports has a contract test; the execution-target driver registry interface is the most important.
+
+**Security review gate.** `kube-audit-kit` and `polaris` run against a freshly provisioned tenant namespace in CI. PSS Restricted violations or NSA Hardening regressions block release.
+
+**Load.** Synthetic 100-concurrent-run test against `kind` to validate the orchestrator's k8s API call rate stays under default `--max-requests-inflight`. The orchestrator uses a shared informer + workqueue pattern, not raw `watch` per Job.
+
+---
+
+## V1 Scope (Ships)
+
+- ✅ `KubernetesExecutionTarget` kind in `executionTarget`
+- ✅ `@paperclipai/execution-target-kubernetes` package — orchestrator + driver
+- ✅ `ClusterConnection` model + storage + UI form
+- ✅ Namespace-per-company provisioning with all isolation primitives (RBAC, ResourceQuota, NetworkPolicy, PSS labels, image pull secret)
+- ✅ Job-per-run with PVC-per-agent + init container workspace strategy
+- ✅ Per-Job ephemeral Secret materialization with redaction layer
+- ✅ Bootstrap-token → run-JWT auth path (extends cursor-cloud-shared route)
+- ✅ K8s log watch + structured events callback + K8s Events forwarding
+- ✅ Cancellation, TTL cleanup, OwnerReference GC
+- ✅ Cilium auto-detection + CNP variant
+- ✅ Paperclip-maintained agent runtime image family (multi-arch, signed)
+- ✅ Per-namespace image pull credentials
+- ✅ Operator UI: cluster connection list, per-cluster health, per-tenant quota dashboard
+- ✅ Failure-mode error codes with remediation hints
+- ✅ Audit log integration
+- ✅ Test suite (unit + kind integration + security gate)
+- ✅ Documentation: quickstart, security model, multi-tenant onboarding playbook
+- ✅ Workspace-strategy refactor: extract shared library used by init container
+
+## V2 (Designed-for, Deferred)
+
+- 🟡 BYO cluster per company (today: per-instance only).
+- 🟡 Pod-per-agent mode (StatefulSet + KEDA scale-to-zero) as a per-adapter knob.
+- 🟡 External Secrets Operator integration via `SecretMaterializer` interface.
+- 🟡 VolumeSnapshot-based agent cloning.
+- 🟡 `PaperclipAgentRun` CRD + reconciliation operator (only if needed).
+- 🟡 Helm chart for the Paperclip control plane itself.
+- 🟡 Fine-grained image attestation (cosign verify in admission).
+- 🟡 IPv6 dual-stack pod support (V1 deny-list is IPv4-shaped).
+- 🟡 Cross-cluster TokenReview second-factor (needs identity federation).
+
+---
+
+## Risks & Open Questions
+
+1. **Workspace strategy refactor scope.** Lifting workspace-strategy code out of `server/` into a shared library is a real refactor. The implementation plan must scope it precisely to avoid creep.
+2. **PVC zonal pinning UX.** First-zone-binds-forever is correct but surprising. Cluster-connection setup must explicitly call this out, with regional StorageClass guidance front-and-center.
+3. **`executionTarget` plumbing audit.** This spec assumes every existing adapter (`claude_local`, `codex_local`, etc.) plumbs `executionTarget` correctly through to its execute path. The implementation plan must include an audit and any plumbing fixes.
+4. **Resource defaults for `claude_local` in a Pod.** Long sessions can spike memory significantly. Need empirical numbers (50 representative agents in `kind`, capture p99 memory) before locking LimitRange defaults. Defaults in this spec are a starting point.
+5. **Cross-cluster TokenReview.** The V1.5 second-factor on `/api/agent-auth/exchange` needs identity federation between clusters. Documented as V2.
+6. **`registerExecutionTargetDriver()` doesn't exist yet.** The platform-module registry surface is extended in this spec; the implementation plan should add the registry as a small explicit step before plugging in the k8s driver.
+7. **Adapter `networkRequirements` field doesn't exist on `ServerAdapterModule` yet.** Adding `networkRequirements?: { allowFqdns?: string[] }` to the adapter contract is a small addition the implementation plan must include.
+8. **Agent shim binary.** `paperclip-agent-shim` is new code. Scope, language (Go for static binary preferred), and packaging into the runtime image must be designed in the implementation plan.
+
+---
+
+## Appendix: Decision Log
+
+| Decision | Chosen | Rejected alternative(s) | Reason |
+|---|---|---|---|
+| Extension shape | New `kubernetes` kind on `AdapterExecutionTarget` | New `kubernetes_pod` adapter; CRD/operator | Highest leverage; every adapter inherits k8s; smallest blast radius |
+| Tenant boundary | Namespace per company | Cluster per company; label-based isolation | K8s-native; free isolation primitives; cluster-per-company doesn't scale |
+| Workload granularity | Job-per-run + PVC-per-agent | Pod-per-company (shared); pod-per-agent (default); pod-per-run (ephemeral PVC) | Strict isolation per run + warm workspaces; pod-per-company has poor isolation and doesn't actually save cluster cost |
+| Topology | Hybrid (in-cluster + cross-cluster) with bootstrap auth | Same-cluster only; cross-cluster only | One auth path serves both deployments |
+| Orchestration runtime | Imperative `@kubernetes/client-node` from server | CRD + Go operator; CRD + TS operator | Smallest moving parts; reuse k8s primitives; runs are ephemeral |
+| Workspace bootstrap | Init container running existing strategy | Server pre-populates via `kubectl cp`; one-shot prepare Job | Reuses strategy code; same FS layout as local; scales cross-cluster |
+| Namespace naming | `paperclip-{companySlug}` (operator-friendly) | `paperclip-{shortHash}` (collision-safe by construction) | kubectl debuggability; immutable label remains canonical |
+| FQDN egress control | Cilium auto-detected; vanilla NetworkPolicy as floor | FQDN-required (Cilium hard dep); egress proxy required | Works with any CNI; tightens when Cilium is present; floor blocks RFC1918 + link-local |
+| Secret injection | Native k8s Secret per Job, OwnerRef-GC'd, mounted as files | ExternalSecrets Operator (V2); CSI Secret Store (V2) | Simplest correct V1; abstraction in place for V2 drivers |
+| Retry semantics | Owned by Paperclip (`backoffLimit: 0`) | Owned by k8s (`backoffLimit: 6`); shared | Paperclip already has `AdapterExecutionErrorFamily` + `retryNotBefore`; double-retry breaks billing/audit |
+
+---
+
+*Spec ends.*

--- a/package.json
+++ b/package.json
@@ -66,7 +66,11 @@
       "embedded-postgres@18.1.0-beta.16": "patches/embedded-postgres@18.1.0-beta.16.patch"
     },
     "overrides": {
-      "rollup": ">=4.59.0"
+      "rollup": ">=4.59.0",
+      "form-data@<2.5.4": ">=2.5.4",
+      "form-data@<3.0.4": ">=3.0.4",
+      "form-data@<4.0.4": ">=4.0.4",
+      "jsonpath-plus": ">=10.3.0"
     }
   }
 }

--- a/packages/adapter-utils/src/contract-kubernetes-rejection.test.ts
+++ b/packages/adapter-utils/src/contract-kubernetes-rejection.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Contract test: every existing local adapter must return a structured error
+ * (errorCode: "execution_target_not_yet_supported") when given a kubernetes
+ * execution target, rather than throwing or crashing.
+ *
+ * This is the M1 spec Risk #3 guard: adapters must fail-fast with a clear
+ * message so users who configure a kubernetes target see a helpful response
+ * instead of an unhandled exception.
+ *
+ * Imports use relative paths that cross package boundaries — this works under
+ * vitest (which uses vite transforms) but is intentionally outside the
+ * TypeScript rootDir. The paths below resolve relative to this file's location
+ * at packages/adapter-utils/src/.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "./types.js";
+import type { AdapterKubernetesExecutionTarget } from "./execution-target.js";
+
+const k8sTarget: AdapterKubernetesExecutionTarget = {
+  kind: "kubernetes",
+  clusterConnectionId: "test-cluster-connection-1",
+};
+
+function makeCtx(): AdapterExecutionContext {
+  return {
+    runId: "r-contract-test-1",
+    agent: {
+      id: "a-1",
+      companyId: "c-1",
+      name: "contract-test-agent",
+      adapterType: "test",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {},
+    context: {},
+    onLog: async () => {},
+    executionTarget: k8sTarget,
+  };
+}
+
+/**
+ * Each entry: [display name, relative path from this file to the adapter's execute.ts].
+ * Relative paths cross package boundaries; vitest resolves them correctly at
+ * runtime even though tsc would reject them (rootDir constraint).
+ */
+const adapterModules: ReadonlyArray<readonly [string, () => Promise<{ execute: (ctx: AdapterExecutionContext) => Promise<AdapterExecutionResult> }>]> = [
+  [
+    "claude_local",
+    // @ts-expect-error — cross-package relative import; valid at vitest runtime
+    () => import("../../adapters/claude-local/src/server/execute.js"),
+  ],
+  [
+    "codex_local",
+    // @ts-expect-error — cross-package relative import; valid at vitest runtime
+    () => import("../../adapters/codex-local/src/server/execute.js"),
+  ],
+  [
+    "gemini_local",
+    // @ts-expect-error — cross-package relative import; valid at vitest runtime
+    () => import("../../adapters/gemini-local/src/server/execute.js"),
+  ],
+  [
+    "opencode_local",
+    // @ts-expect-error — cross-package relative import; valid at vitest runtime
+    () => import("../../adapters/opencode-local/src/server/execute.js"),
+  ],
+  [
+    "acpx_local",
+    // @ts-expect-error — cross-package relative import; valid at vitest runtime
+    () => import("../../adapters/acpx-local/src/server/execute.js"),
+  ],
+  [
+    "pi_local",
+    // @ts-expect-error — cross-package relative import; valid at vitest runtime
+    () => import("../../adapters/pi-local/src/server/execute.js"),
+  ],
+  [
+    "cursor_local",
+    // @ts-expect-error — cross-package relative import; valid at vitest runtime
+    () => import("../../adapters/cursor-local/src/server/execute.js"),
+  ],
+];
+
+describe("adapter contract: kubernetes execution target is rejected in M1", () => {
+  for (const [name, doImport] of adapterModules) {
+    it(`${name}: returns errorCode="execution_target_not_yet_supported" instead of throwing`, async () => {
+      let mod: { execute: (ctx: AdapterExecutionContext) => Promise<AdapterExecutionResult> };
+      try {
+        mod = await doImport();
+      } catch (e) {
+        console.warn(
+          `[contract] Could not import adapter "${name}": ${(e as Error).message} — skipping`,
+        );
+        return;
+      }
+
+      if (typeof mod.execute !== "function") {
+        throw new Error(`Adapter "${name}" does not export an \`execute\` function`);
+      }
+
+      const result = await mod.execute(makeCtx());
+
+      // Must not throw — must return a structured result
+      expect(result).toBeDefined();
+      expect(result.exitCode).toBeNull();
+      expect(result.errorCode).toMatch(/kubernetes|execution_target/i);
+      expect(result.errorMessage ?? "").toContain("Kubernetes");
+    });
+  }
+});

--- a/packages/adapter-utils/src/execution-target.test.ts
+++ b/packages/adapter-utils/src/execution-target.test.ts
@@ -7,7 +7,21 @@ import {
   resolveAdapterExecutionTargetCwd,
   runAdapterExecutionTargetProcess,
   runAdapterExecutionTargetShellCommand,
+  describeAdapterExecutionTarget,
+  ensureAdapterExecutionTargetCommandResolvable,
+  readAdapterExecutionTargetHomeDir,
 } from "./execution-target.js";
+
+describe("describeAdapterExecutionTarget — kubernetes kind", () => {
+  it("returns a human-readable description for a kubernetes target", () => {
+    const desc = describeAdapterExecutionTarget({
+      kind: "kubernetes",
+      clusterConnectionId: "c-123",
+    });
+    expect(desc).toContain("kubernetes");
+    expect(desc).toContain("c-123");
+  });
+});
 
 describe("runAdapterExecutionTargetShellCommand", () => {
   afterEach(() => {
@@ -399,5 +413,43 @@ describe("resolveAdapterExecutionTargetCwd", () => {
     expect(resolveAdapterExecutionTargetCwd(null, "", "/Users/host/repo/server")).toBe(
       "/Users/host/repo/server",
     );
+  });
+});
+
+describe("kubernetes kind: runtime helpers explicitly throw M1-not-implemented", () => {
+  const target = { kind: "kubernetes" as const, clusterConnectionId: "c-1" };
+
+  it("resolveAdapterExecutionTargetCwd throws", () => {
+    expect(() => resolveAdapterExecutionTargetCwd(target, null, "/fallback")).toThrow(/not implemented/i);
+  });
+
+  it("ensureAdapterExecutionTargetCommandResolvable throws", async () => {
+    await expect(
+      ensureAdapterExecutionTargetCommandResolvable("node", target, "/cwd", process.env),
+    ).rejects.toThrow(/not implemented/i);
+  });
+
+  it("runAdapterExecutionTargetProcess throws", async () => {
+    await expect(
+      runAdapterExecutionTargetProcess("r-1", target, "node", [], {
+        cwd: "/",
+        env: {},
+        timeoutSec: 1,
+        graceSec: 1,
+        onLog: async () => {},
+      }),
+    ).rejects.toThrow(/not implemented/i);
+  });
+
+  it("runAdapterExecutionTargetShellCommand throws", async () => {
+    await expect(
+      runAdapterExecutionTargetShellCommand("r-1", target, "echo hi", { cwd: "/", env: {} }),
+    ).rejects.toThrow(/not implemented/i);
+  });
+
+  it("readAdapterExecutionTargetHomeDir throws", async () => {
+    await expect(
+      readAdapterExecutionTargetHomeDir("r-1", target, { cwd: "/", env: {} }),
+    ).rejects.toThrow(/not implemented/i);
   });
 });

--- a/packages/adapter-utils/src/execution-target.test.ts
+++ b/packages/adapter-utils/src/execution-target.test.ts
@@ -10,6 +10,10 @@ import {
   describeAdapterExecutionTarget,
   ensureAdapterExecutionTargetCommandResolvable,
   readAdapterExecutionTargetHomeDir,
+  adapterExecutionTargetSessionMatches,
+  adapterExecutionTargetSessionIdentity,
+  parseAdapterExecutionTarget,
+  resolveAdapterExecutionTargetCommandForLogs,
 } from "./execution-target.js";
 
 describe("describeAdapterExecutionTarget — kubernetes kind", () => {
@@ -451,5 +455,98 @@ describe("kubernetes kind: runtime helpers explicitly throw M1-not-implemented",
     await expect(
       readAdapterExecutionTargetHomeDir("r-1", target, { cwd: "/", env: {} }),
     ).rejects.toThrow(/not implemented/i);
+  });
+
+  it("resolveAdapterExecutionTargetCommandForLogs throws", async () => {
+    await expect(
+      resolveAdapterExecutionTargetCommandForLogs("node", target, "/cwd", process.env),
+    ).rejects.toThrow(/not implemented/i);
+  });
+});
+
+describe("adapterExecutionTargetSessionMatches — kubernetes namespaceOverride", () => {
+  it("returns false when saved namespaceOverride differs from current", () => {
+    const saved = adapterExecutionTargetSessionIdentity({
+      kind: "kubernetes",
+      clusterConnectionId: "c-123",
+      namespaceOverride: "ns-a",
+    });
+    expect(
+      adapterExecutionTargetSessionMatches(saved, {
+        kind: "kubernetes",
+        clusterConnectionId: "c-123",
+        namespaceOverride: "ns-b",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when saved namespaceOverride matches current", () => {
+    const saved = adapterExecutionTargetSessionIdentity({
+      kind: "kubernetes",
+      clusterConnectionId: "c-123",
+      namespaceOverride: "ns-a",
+    });
+    expect(
+      adapterExecutionTargetSessionMatches(saved, {
+        kind: "kubernetes",
+        clusterConnectionId: "c-123",
+        namespaceOverride: "ns-a",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when neither saved nor current has a namespaceOverride", () => {
+    const saved = adapterExecutionTargetSessionIdentity({
+      kind: "kubernetes",
+      clusterConnectionId: "c-123",
+    });
+    expect(
+      adapterExecutionTargetSessionMatches(saved, {
+        kind: "kubernetes",
+        clusterConnectionId: "c-123",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("parseAdapterExecutionTarget — kubernetes round-trip", () => {
+  it("round-trips all five non-id fields without data loss", () => {
+    const input = {
+      kind: "kubernetes" as const,
+      clusterConnectionId: "c-456",
+      namespaceOverride: "my-ns",
+      imageOverride: "my-registry/agent:v2",
+      resources: {
+        requests: { cpu: "500m", memory: "512Mi" },
+        limits: { cpu: "1000m", memory: "1Gi" },
+      },
+      storage: { sizeGi: 10, storageClass: "fast-ssd" },
+      envOverrides: { MY_VAR: "hello", ANOTHER: "world" },
+    };
+
+    const result = parseAdapterExecutionTarget(input);
+
+    expect(result).not.toBeNull();
+    expect(result?.kind).toBe("kubernetes");
+    if (result?.kind !== "kubernetes") return;
+
+    expect(result.clusterConnectionId).toBe("c-456");
+    expect(result.namespaceOverride).toBe("my-ns");
+    expect(result.imageOverride).toBe("my-registry/agent:v2");
+    expect(result.resources).toEqual(input.resources);
+    expect(result.storage).toEqual(input.storage);
+    expect(result.envOverrides).toEqual(input.envOverrides);
+  });
+});
+
+describe("describeAdapterExecutionTarget — kubernetes namespaceOverride", () => {
+  it("includes both clusterConnectionId and namespaceOverride in description", () => {
+    const desc = describeAdapterExecutionTarget({
+      kind: "kubernetes",
+      clusterConnectionId: "c-123",
+      namespaceOverride: "my-ns",
+    });
+    expect(desc).toContain("c-123");
+    expect(desc).toContain("my-ns");
   });
 });

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -387,6 +387,11 @@ export async function resolveAdapterExecutionTargetCommandForLogs(
   cwd: string,
   env: NodeJS.ProcessEnv,
 ): Promise<string> {
+  if (target?.kind === "kubernetes") {
+    throw new Error(
+      "Kubernetes execution target runtime helpers are not implemented yet (M1 covers tenant provisioning only; agent execution lands in M2).",
+    );
+  }
   if (target?.kind === "remote" && target.transport === "sandbox") {
     return `sandbox://${target.providerKey ?? "provider"}/${target.leaseId ?? "lease"}/${target.remoteCwd} :: ${command}`;
   }
@@ -853,7 +858,8 @@ export function adapterExecutionTargetSessionMatches(
     const parsedSaved = parseObject(saved);
     return (
       readStringMeta(parsedSaved, "kind") === current?.kind &&
-      readStringMeta(parsedSaved, "clusterConnectionId") === current?.clusterConnectionId
+      readStringMeta(parsedSaved, "clusterConnectionId") === current?.clusterConnectionId &&
+      readStringMeta(parsedSaved, "namespaceOverride") === (current?.namespaceOverride ?? null)
     );
   }
   if (target.transport === "ssh") return remoteExecutionSessionMatches(saved, target.spec);
@@ -915,6 +921,15 @@ export function parseAdapterExecutionTarget(value: unknown): AdapterExecutionTar
       clusterConnectionId,
       namespaceOverride: readStringMeta(parsed, "namespaceOverride"),
       imageOverride: readStringMeta(parsed, "imageOverride"),
+      resources: parsed.resources && typeof parsed.resources === "object"
+        ? parsed.resources as AdapterKubernetesExecutionTarget["resources"]
+        : null,
+      storage: parsed.storage && typeof parsed.storage === "object"
+        ? parsed.storage as AdapterKubernetesExecutionTarget["storage"]
+        : null,
+      envOverrides: parsed.envOverrides && typeof parsed.envOverrides === "object"
+        ? parsed.envOverrides as AdapterKubernetesExecutionTarget["envOverrides"]
+        : null,
     };
   }
 

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -56,10 +56,29 @@ export interface AdapterSandboxExecutionTarget {
   runner?: CommandManagedRuntimeRunner;
 }
 
+export interface AdapterKubernetesExecutionTarget {
+  kind: "kubernetes";
+  clusterConnectionId: string;
+  /** Override the auto-derived `paperclip-{companySlug}` namespace name. Rare. */
+  namespaceOverride?: string | null;
+  /** Override the resolved agent runtime image. Gated by per-cluster policy. */
+  imageOverride?: string | null;
+  resources?: {
+    requests?: { cpu?: string; memory?: string };
+    limits?:   { cpu?: string; memory?: string };
+  } | null;
+  storage?: {
+    sizeGi?: number;
+    storageClass?: string;
+  } | null;
+  envOverrides?: Record<string, string> | null;
+}
+
 export type AdapterExecutionTarget =
   | AdapterLocalExecutionTarget
   | AdapterSshExecutionTarget
-  | AdapterSandboxExecutionTarget;
+  | AdapterSandboxExecutionTarget
+  | AdapterKubernetesExecutionTarget;
 
 export type AdapterRemoteExecutionSpec = SshRemoteExecutionSpec;
 
@@ -137,6 +156,7 @@ function isBridgeDebugEnabled(env: NodeJS.ProcessEnv): boolean {
 function isAdapterExecutionTargetInstance(value: unknown): value is AdapterExecutionTarget {
   const parsed = parseObject(value);
   if (parsed.kind === "local") return true;
+  if (parsed.kind === "kubernetes") return readStringMeta(parsed, "clusterConnectionId") !== null;
   if (parsed.kind !== "remote") return false;
   if (parsed.transport === "ssh") return parseSshRemoteExecutionSpec(parseObject(parsed.spec)) !== null;
   if (parsed.transport !== "sandbox") return false;
@@ -200,6 +220,11 @@ export function resolveAdapterExecutionTargetCwd(
   configuredCwd: string | null | undefined,
   localFallbackCwd: string,
 ): string {
+  if (target?.kind === "kubernetes") {
+    throw new Error(
+      "Kubernetes execution target runtime helpers are not implemented yet (M1 covers tenant provisioning only; agent execution lands in M2).",
+    );
+  }
   if (typeof configuredCwd === "string" && configuredCwd.trim().length > 0) {
     return configuredCwd;
   }
@@ -216,6 +241,9 @@ export function describeAdapterExecutionTarget(
   target: AdapterExecutionTarget | null | undefined,
 ): string {
   if (!target || target.kind === "local") return "local environment";
+  if (target.kind === "kubernetes") {
+    return `kubernetes(connection=${target.clusterConnectionId}${target.namespaceOverride ? `, namespace=${target.namespaceOverride}` : ""})`;
+  }
   if (target.transport === "ssh") {
     return `SSH environment ${target.spec.username}@${target.spec.host}:${target.spec.port}`;
   }
@@ -263,6 +291,11 @@ export async function ensureAdapterExecutionTargetCommandResolvable(
   env: NodeJS.ProcessEnv,
   options: { installCommand?: string | null } = {},
 ) {
+  if (target?.kind === "kubernetes") {
+    throw new Error(
+      "Kubernetes execution target runtime helpers are not implemented yet (M1 covers tenant provisioning only; agent execution lands in M2).",
+    );
+  }
   if (target?.kind === "remote" && target.transport === "sandbox") {
     await ensureSandboxCommandResolvable(command, target, options.installCommand?.trim() || null);
     return;
@@ -369,6 +402,11 @@ export async function runAdapterExecutionTargetProcess(
   args: string[],
   options: AdapterExecutionTargetProcessOptions,
 ): Promise<RunProcessResult> {
+  if (target?.kind === "kubernetes") {
+    throw new Error(
+      "Kubernetes execution target runtime helpers are not implemented yet (M1 covers tenant provisioning only; agent execution lands in M2).",
+    );
+  }
   if (target?.kind === "remote" && target.transport === "sandbox") {
     const runner = requireSandboxRunner(target);
     const env = sanitizeRemoteExecutionEnv(options.env);
@@ -410,6 +448,11 @@ export async function runAdapterExecutionTargetShellCommand(
   command: string,
   options: AdapterExecutionTargetShellOptions,
 ): Promise<RunProcessResult> {
+  if (target?.kind === "kubernetes") {
+    throw new Error(
+      "Kubernetes execution target runtime helpers are not implemented yet (M1 covers tenant provisioning only; agent execution lands in M2).",
+    );
+  }
   const onLog = options.onLog ?? (async () => {});
   if (target?.kind === "remote") {
     const startedAt = new Date().toISOString();
@@ -781,6 +824,13 @@ export function adapterExecutionTargetSessionIdentity(
   target: AdapterExecutionTarget | null | undefined,
 ): Record<string, unknown> | null {
   if (!target || target.kind === "local") return null;
+  if (target.kind === "kubernetes") {
+    return {
+      kind: "kubernetes",
+      clusterConnectionId: target.clusterConnectionId,
+      namespaceOverride: target.namespaceOverride ?? null,
+    };
+  }
   if (target.transport === "ssh") return buildRemoteExecutionSessionIdentity(target.spec);
   return {
     transport: "sandbox",
@@ -797,6 +847,14 @@ export function adapterExecutionTargetSessionMatches(
 ): boolean {
   if (!target || target.kind === "local") {
     return Object.keys(parseObject(saved)).length === 0;
+  }
+  if (target.kind === "kubernetes") {
+    const current = adapterExecutionTargetSessionIdentity(target);
+    const parsedSaved = parseObject(saved);
+    return (
+      readStringMeta(parsedSaved, "kind") === current?.kind &&
+      readStringMeta(parsedSaved, "clusterConnectionId") === current?.clusterConnectionId
+    );
   }
   if (target.transport === "ssh") return remoteExecutionSessionMatches(saved, target.spec);
   const current = adapterExecutionTargetSessionIdentity(target);
@@ -846,6 +904,17 @@ export function parseAdapterExecutionTarget(value: unknown): AdapterExecutionTar
       leaseId: readStringMeta(parsed, "leaseId"),
       remoteCwd,
       timeoutMs: typeof parsed.timeoutMs === "number" ? parsed.timeoutMs : null,
+    };
+  }
+
+  if (kind === "kubernetes") {
+    const clusterConnectionId = readStringMeta(parsed, "clusterConnectionId");
+    if (!clusterConnectionId) return null;
+    return {
+      kind: "kubernetes",
+      clusterConnectionId,
+      namespaceOverride: readStringMeta(parsed, "namespaceOverride"),
+      imageOverride: readStringMeta(parsed, "imageOverride"),
     };
   }
 
@@ -907,6 +976,12 @@ export async function prepareAdapterExecutionTargetRuntime(input: {
       assetDirs: {},
       restoreWorkspace: async () => {},
     };
+  }
+
+  if (target.kind === "kubernetes") {
+    throw new Error(
+      "Kubernetes execution target runtime helpers are not implemented yet (M1 covers tenant provisioning only; agent execution lands in M2).",
+    );
   }
 
   if (target.transport === "ssh") {

--- a/packages/adapter-utils/src/types.test.ts
+++ b/packages/adapter-utils/src/types.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expectTypeOf } from "vitest";
+import type { ServerAdapterModule } from "./types.js";
+
+describe("ServerAdapterModule.networkRequirements", () => {
+  it("accepts an allowFqdns array on a module shape", () => {
+    const m: Pick<ServerAdapterModule, "type" | "networkRequirements"> = {
+      type: "test",
+      networkRequirements: { allowFqdns: ["api.anthropic.com"] },
+    };
+    // networkRequirements is assignable
+    expectTypeOf(m.networkRequirements).toMatchTypeOf<{ allowFqdns?: string[] } | undefined>();
+  });
+});

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -429,6 +429,16 @@ export interface ServerAdapterModule {
    * and provisioned in fresh remote environments such as sandboxes.
    */
   getRuntimeCommandSpec?: (config: Record<string, unknown>) => AdapterRuntimeCommandSpec | null;
+
+  /**
+   * Optional declaration of outbound network endpoints this adapter requires
+   * at runtime. Used by the kubernetes execution target to compose Cilium
+   * FQDN allowlists. Empty/omitted means "no adapter-specific FQDN allowlist
+   * contribution"; the cluster's default allowlist still applies.
+   */
+  networkRequirements?: {
+    allowFqdns?: string[];
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/adapter-utils/tsconfig.json
+++ b/packages/adapter-utils/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/contract-kubernetes-rejection.test.ts"]
 }

--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -1117,6 +1117,17 @@ export function createAcpxLocalExecutor(deps: ExecuteDeps = {}) {
   const warmHandles = deps.warmHandles ?? defaultWarmHandles;
 
   return async function executeAcpxLocal(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+    if (ctx.executionTarget?.kind === "kubernetes") {
+      return {
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+        errorCode: "execution_target_not_yet_supported",
+        errorMessage:
+          "Kubernetes execution target is not implemented yet for this adapter. " +
+          "Tenant provisioning is available in M1; agent execution lands in M2.",
+      };
+    }
     const prepared = await buildRuntime({ ctx });
     const warmIdleMs = asNumber(ctx.config.warmHandleIdleMs, DEFAULT_ACPX_LOCAL_WARM_HANDLE_IDLE_MS);
     await cleanupIdleHandles({ handles: warmHandles, now: now(), idleMs: warmIdleMs });

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -348,6 +348,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
   });
+  if (executionTarget?.kind === "kubernetes") {
+    return {
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      errorCode: "execution_target_not_yet_supported",
+      errorMessage:
+        "Kubernetes execution target is not implemented yet for this adapter. " +
+        "Tenant provisioning is available in M1; agent execution lands in M2.",
+    };
+  }
   const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
 
   const promptTemplate = asString(

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -284,6 +284,18 @@ export async function ensureCodexSkillsInjected(
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
 
+  if (ctx.executionTarget?.kind === "kubernetes") {
+    return {
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      errorCode: "execution_target_not_yet_supported",
+      errorMessage:
+        "Kubernetes execution target is not implemented yet for this adapter. " +
+        "Tenant provisioning is available in M1; agent execution lands in M2.",
+    };
+  }
+
   const promptTemplate = asString(
     config.promptTemplate,
     DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -198,6 +198,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
   });
+  if (executionTarget?.kind === "kubernetes") {
+    return {
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      errorCode: "execution_target_not_yet_supported",
+      errorMessage:
+        "Kubernetes execution target is not implemented yet for this adapter. " +
+        "Tenant provisioning is available in M1; agent execution lands in M2.",
+    };
+  }
   const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
 
   const promptTemplate = asString(

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -176,6 +176,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
   });
+  if (executionTarget?.kind === "kubernetes") {
+    return {
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      errorCode: "execution_target_not_yet_supported",
+      errorMessage:
+        "Kubernetes execution target is not implemented yet for this adapter. " +
+        "Tenant provisioning is available in M1; agent execution lands in M2.",
+    };
+  }
   const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
 
   const promptTemplate = asString(

--- a/packages/adapters/kubernetes-execution/README.md
+++ b/packages/adapters/kubernetes-execution/README.md
@@ -1,0 +1,5 @@
+# @paperclipai/execution-target-kubernetes
+
+Kubernetes execution-target driver for Paperclip agents. See
+[the design spec](../../../docs/superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md)
+and the M1 implementation plan.

--- a/packages/adapters/kubernetes-execution/README.md
+++ b/packages/adapters/kubernetes-execution/README.md
@@ -2,4 +2,4 @@
 
 Kubernetes execution-target driver for Paperclip agents. See
 [the design spec](../../../docs/superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md)
-and the M1 implementation plan.
+and [the M1 implementation plan](../../../docs/superpowers/plans/2026-05-08-paperclip-cloud-adapter-m1-plan.md).

--- a/packages/adapters/kubernetes-execution/manifests/paperclip-tenant-manager-clusterrole.yaml
+++ b/packages/adapters/kubernetes-execution/manifests/paperclip-tenant-manager-clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: paperclip-tenant-manager
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "resourcequotas", "limitranges", "secrets", "serviceaccounts", "configmaps", "persistentvolumeclaims", "pods", "pods/log", "pods/exec"]
+    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["cilium.io"]
+    resources: ["ciliumnetworkpolicies"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]

--- a/packages/adapters/kubernetes-execution/package.json
+++ b/packages/adapters/kubernetes-execution/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@paperclipai/execution-target-kubernetes",
+  "version": "0.0.0",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
+  },
+  "dependencies": {
+    "@kubernetes/client-node": "^0.21.0",
+    "@paperclipai/adapter-utils": "workspace:*",
+    "yaml": "^2.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/adapters/kubernetes-execution/package.json
+++ b/packages/adapters/kubernetes-execution/package.json
@@ -27,8 +27,8 @@
     "yaml": "^2.5.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^2.0.0"
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
   }
 }

--- a/packages/adapters/kubernetes-execution/src/client.ts
+++ b/packages/adapters/kubernetes-execution/src/client.ts
@@ -1,0 +1,99 @@
+import {
+  KubeConfig,
+  CoreV1Api,
+  BatchV1Api,
+  NetworkingV1Api,
+  RbacAuthorizationV1Api,
+  ApiextensionsV1Api,
+} from "@kubernetes/client-node";
+import type { ResolvedClusterConnection, KubernetesApiClient } from "./types.js";
+
+export function createKubernetesApiClient(connection: ResolvedClusterConnection): KubernetesApiClient {
+  const kc = new KubeConfig();
+
+  if (connection.kind === "in-cluster") {
+    // Detect whether we're actually running inside a Kubernetes pod by checking
+    // the standard in-cluster env vars. loadFromCluster() does not throw when
+    // these are absent — it just builds a cluster with an invalid server URL.
+    if (!process.env["KUBERNETES_SERVICE_HOST"] || !process.env["KUBERNETES_SERVICE_PORT"]) {
+      throw new Error(
+        `Cluster connection ${connection.id} is in-cluster but Paperclip is not running inside a Kubernetes pod ` +
+          `(KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT are not set)`,
+      );
+    }
+    try {
+      kc.loadFromCluster();
+    } catch (err) {
+      throw new Error(
+        `Cluster connection ${connection.id} is in-cluster but Paperclip is not running inside a Kubernetes pod: ${(err as Error).message}`,
+      );
+    }
+    if (!kc.getCurrentCluster()) {
+      throw new Error(
+        `Cluster connection ${connection.id} is in-cluster but no cluster could be loaded — is Paperclip running inside a Kubernetes pod?`,
+      );
+    }
+  } else {
+    if (!connection.kubeconfigYaml) {
+      throw new Error(`Cluster connection ${connection.id} is kind=kubeconfig but kubeconfigYaml is empty`);
+    }
+    kc.loadFromString(connection.kubeconfigYaml);
+  }
+
+  const core = kc.makeApiClient(CoreV1Api);
+  const batch = kc.makeApiClient(BatchV1Api);
+  const networking = kc.makeApiClient(NetworkingV1Api);
+  const rbac = kc.makeApiClient(RbacAuthorizationV1Api);
+  const apiext = kc.makeApiClient(ApiextensionsV1Api);
+
+  const ctx = kc.getCurrentContext();
+
+  return {
+    core,
+    batch,
+    networking,
+    rbac,
+    apiext,
+    describe: () => `${connection.label} (context=${ctx})`,
+    async request<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
+      const cluster = kc.getCurrentCluster();
+      if (!cluster) throw new Error(`No current cluster in kubeconfig`);
+      const url = new URL(path, cluster.server).toString();
+
+      // Build fetch options with kubeconfig auth applied.
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      };
+      const init: RequestInit = {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      };
+
+      // applyToFetchOptions injects auth headers and TLS material on supported kc versions.
+      // @kubernetes/client-node v0.21+ exposes applyToFetchOptions.
+      // We try it first and fall back to direct bearer-token injection if not present.
+      type ApplyFn = (opts: RequestInit) => Promise<void>;
+      const applyToFetchOptions = (kc as unknown as { applyToFetchOptions?: ApplyFn }).applyToFetchOptions;
+      if (typeof applyToFetchOptions === "function") {
+        await applyToFetchOptions.call(kc, init);
+      } else {
+        // Best-effort fallback: inject bearer token from current user.
+        const user = kc.getCurrentUser();
+        if (user?.token) {
+          headers["Authorization"] = `Bearer ${user.token}`;
+        }
+      }
+
+      const res = await fetch(url, init);
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`k8s API ${method} ${path} failed ${res.status}: ${text}`);
+      }
+      // 204 No Content has no body.
+      if (res.status === 204) return undefined as T;
+      return (await res.json()) as T;
+    },
+  };
+}

--- a/packages/adapters/kubernetes-execution/src/client.ts
+++ b/packages/adapters/kubernetes-execution/src/client.ts
@@ -123,18 +123,28 @@ export function createKubernetesApiClient(connection: ResolvedClusterConnection)
       }
 
       const agent = getHttpsAgent();
+      // 30s socket timeout. Without this the request could hang for tens of
+      // minutes if the API server stops responding mid-handshake (Node's
+      // default keep-alive socket has no upper bound). 30s is well above
+      // realistic API server tail latency but short enough that ensureTenant
+      // surfaces an actionable error rather than appearing to stall.
+      const REQUEST_TIMEOUT_MS = 30_000;
       const options: HttpsRequestOptions = {
         method,
         hostname: url.hostname,
         port: url.port || (url.protocol === "https:" ? 443 : 80),
         path: `${url.pathname}${url.search}`,
         headers,
+        timeout: REQUEST_TIMEOUT_MS,
       };
       if (agent) options.agent = agent;
 
       const incoming = await new Promise<import("node:http").IncomingMessage>((resolve, reject) => {
         const req = httpsRequest(options, (res) => resolve(res));
         req.once("error", reject);
+        req.once("timeout", () => {
+          req.destroy(new Error(`k8s API ${method} ${path} timed out after ${REQUEST_TIMEOUT_MS}ms`));
+        });
         if (payload !== undefined) req.write(payload);
         req.end();
       });

--- a/packages/adapters/kubernetes-execution/src/client.ts
+++ b/packages/adapters/kubernetes-execution/src/client.ts
@@ -6,6 +6,8 @@ import {
   RbacAuthorizationV1Api,
   ApiextensionsV1Api,
 } from "@kubernetes/client-node";
+import { Agent, request as httpsRequest, type RequestOptions as HttpsRequestOptions } from "node:https";
+import { URL } from "node:url";
 import type { ResolvedClusterConnection, KubernetesApiClient } from "./types.js";
 
 export function createKubernetesApiClient(connection: ResolvedClusterConnection): KubernetesApiClient {
@@ -48,6 +50,42 @@ export function createKubernetesApiClient(connection: ResolvedClusterConnection)
 
   const ctx = kc.getCurrentContext();
 
+  // Build an https.Agent once per client carrying the kubeconfig's TLS material
+  // (CA bundle + optional client cert/key). This is required for kind/EKS-style
+  // kubeconfigs that authenticate via mTLS rather than a bearer token.
+  // @kubernetes/client-node@0.21 exposes `applyHTTPSOptions`, which writes
+  // ca/cert/key/rejectUnauthorized onto a plain object; we hand that object to
+  // https.Agent. Lazily materialised so in-cluster paths without TLS material
+  // still work.
+  type HttpsOpts = {
+    ca?: Buffer | string;
+    cert?: Buffer | string;
+    key?: Buffer | string;
+    rejectUnauthorized?: boolean;
+  };
+  let httpsAgent: Agent | null | undefined;
+  function getHttpsAgent(): Agent | null {
+    if (httpsAgent !== undefined) return httpsAgent;
+    const kcAny = kc as unknown as { applyHTTPSOptions?: (opts: HttpsOpts) => void };
+    if (typeof kcAny.applyHTTPSOptions !== "function") {
+      httpsAgent = null;
+      return null;
+    }
+    const opts: HttpsOpts = {};
+    kcAny.applyHTTPSOptions(opts);
+    if (opts.ca || opts.cert || opts.key || opts.rejectUnauthorized === false) {
+      httpsAgent = new Agent({
+        ca: opts.ca,
+        cert: opts.cert,
+        key: opts.key,
+        rejectUnauthorized: opts.rejectUnauthorized !== false,
+      });
+    } else {
+      httpsAgent = null;
+    }
+    return httpsAgent;
+  }
+
   return {
     core,
     batch,
@@ -58,42 +96,60 @@ export function createKubernetesApiClient(connection: ResolvedClusterConnection)
     async request<T = unknown>(method: string, path: string, body?: unknown): Promise<T> {
       const cluster = kc.getCurrentCluster();
       if (!cluster) throw new Error(`No current cluster in kubeconfig`);
-      const url = new URL(path, cluster.server).toString();
+      const url = new URL(path, cluster.server);
 
-      // Build fetch options with kubeconfig auth applied.
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
         Accept: "application/json",
       };
-      const init: RequestInit = {
-        method,
-        headers,
-        body: body !== undefined ? JSON.stringify(body) : undefined,
+      const payload = body !== undefined ? JSON.stringify(body) : undefined;
+      if (payload !== undefined) {
+        headers["Content-Length"] = Buffer.byteLength(payload).toString();
+      }
+
+      // Authorization header: for token-based and exec-credential users, the SDK
+      // exposes `applyAuthorizationHeader` which writes Authorization onto a plain
+      // headers object. For cert-based users it's a no-op — the auth is the mTLS
+      // handshake itself, not a header — and the https.Agent above carries the
+      // cert/key.
+      const kcAny = kc as unknown as {
+        applyAuthorizationHeader?: (opts: { headers: Record<string, string> }) => Promise<void>;
       };
-
-      // applyToFetchOptions injects auth headers and TLS material on supported kc versions.
-      // @kubernetes/client-node v0.21+ exposes applyToFetchOptions.
-      // We try it first and fall back to direct bearer-token injection if not present.
-      type ApplyFn = (opts: RequestInit) => Promise<void>;
-      const applyToFetchOptions = (kc as unknown as { applyToFetchOptions?: ApplyFn }).applyToFetchOptions;
-      if (typeof applyToFetchOptions === "function") {
-        await applyToFetchOptions.call(kc, init);
+      if (typeof kcAny.applyAuthorizationHeader === "function") {
+        await kcAny.applyAuthorizationHeader({ headers });
       } else {
-        // Best-effort fallback: inject bearer token from current user.
         const user = kc.getCurrentUser();
-        if (user?.token) {
-          headers["Authorization"] = `Bearer ${user.token}`;
-        }
+        if (user?.token) headers["Authorization"] = `Bearer ${user.token}`;
       }
 
-      const res = await fetch(url, init);
-      if (!res.ok) {
-        const text = await res.text().catch(() => "");
-        throw new Error(`k8s API ${method} ${path} failed ${res.status}: ${text}`);
+      const agent = getHttpsAgent();
+      const options: HttpsRequestOptions = {
+        method,
+        hostname: url.hostname,
+        port: url.port || (url.protocol === "https:" ? 443 : 80),
+        path: `${url.pathname}${url.search}`,
+        headers,
+      };
+      if (agent) options.agent = agent;
+
+      const incoming = await new Promise<import("node:http").IncomingMessage>((resolve, reject) => {
+        const req = httpsRequest(options, (res) => resolve(res));
+        req.once("error", reject);
+        if (payload !== undefined) req.write(payload);
+        req.end();
+      });
+
+      const status = incoming.statusCode ?? 0;
+      const chunks: Buffer[] = [];
+      for await (const chunk of incoming) {
+        chunks.push(chunk as Buffer);
       }
-      // 204 No Content has no body.
-      if (res.status === 204) return undefined as T;
-      return (await res.json()) as T;
+      const text = Buffer.concat(chunks).toString("utf-8");
+      if (status < 200 || status >= 300) {
+        throw new Error(`k8s API ${method} ${path} failed ${status}: ${text}`);
+      }
+      if (status === 204 || text.length === 0) return undefined as T;
+      return JSON.parse(text) as T;
     },
   };
 }

--- a/packages/adapters/kubernetes-execution/src/driver.ts
+++ b/packages/adapters/kubernetes-execution/src/driver.ts
@@ -1,0 +1,66 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import type { AdapterKubernetesExecutionTarget } from "@paperclipai/adapter-utils/execution-target";
+import { ensureTenantNamespace, type EnsureTenantInput } from "./orchestrator/ensure-tenant.js";
+import { createKubernetesApiClient } from "./client.js";
+import type { ResolvedClusterConnection } from "./types.js";
+
+export interface KubernetesDriverDeps {
+  resolveConnection: (id: string) => Promise<ResolvedClusterConnection | null>;
+}
+
+export type EnsureTenantDriverInput = Omit<EnsureTenantInput, "connection"> & {
+  clusterConnectionId: string;
+};
+
+export interface KubernetesExecutionDriver {
+  type: "kubernetes";
+  validateTarget(target: unknown): Promise<void>;
+  ensureTenant(input: EnsureTenantDriverInput): Promise<{ namespace: string; ciliumApplied: boolean }>;
+  run(input: {
+    ctx: AdapterExecutionContext;
+    target: AdapterKubernetesExecutionTarget;
+  }): Promise<AdapterExecutionResult>;
+}
+
+export function createKubernetesExecutionDriver(deps: KubernetesDriverDeps): KubernetesExecutionDriver {
+  return {
+    type: "kubernetes",
+
+    async validateTarget(target) {
+      const t = target as { kind?: string; clusterConnectionId?: string };
+      if (t.kind !== "kubernetes") {
+        throw new Error(
+          `KubernetesExecutionDriver received target with kind=${t.kind ?? "(none)"}, expected "kubernetes"`,
+        );
+      }
+      if (!t.clusterConnectionId) {
+        throw new Error(`KubernetesExecutionDriver target is missing clusterConnectionId`);
+      }
+      const connection = await deps.resolveConnection(t.clusterConnectionId);
+      if (!connection) {
+        throw new Error(`Cluster connection ${t.clusterConnectionId} not found`);
+      }
+    },
+
+    async ensureTenant({ clusterConnectionId, ...rest }) {
+      const connection = await deps.resolveConnection(clusterConnectionId);
+      if (!connection) {
+        throw new Error(`Cluster connection ${clusterConnectionId} not found`);
+      }
+      const client = createKubernetesApiClient(connection);
+      return ensureTenantNamespace(client, { connection, ...rest });
+    },
+
+    async run() {
+      return {
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+        errorCode: "execution_target_not_yet_supported",
+        errorMessage:
+          "Kubernetes agent execution lands in M2; M1 covers tenant provisioning only. " +
+          "Use the cluster CLI (`paperclipai cluster ensure-tenant`) to provision a namespace.",
+      };
+    },
+  };
+}

--- a/packages/adapters/kubernetes-execution/src/index.ts
+++ b/packages/adapters/kubernetes-execution/src/index.ts
@@ -1,0 +1,1 @@
+export const PACKAGE_NAME = "@paperclipai/execution-target-kubernetes";

--- a/packages/adapters/kubernetes-execution/src/index.ts
+++ b/packages/adapters/kubernetes-execution/src/index.ts
@@ -1,1 +1,25 @@
 export const PACKAGE_NAME = "@paperclipai/execution-target-kubernetes";
+
+export { createKubernetesExecutionDriver } from "./driver.js";
+export type {
+  KubernetesExecutionDriver,
+  KubernetesDriverDeps,
+  EnsureTenantDriverInput,
+} from "./driver.js";
+
+export {
+  ensureTenantNamespace,
+  type EnsureTenantInput,
+  type EnsureTenantResult,
+  type TenantPolicy,
+} from "./orchestrator/ensure-tenant.js";
+
+export { createKubernetesApiClient } from "./client.js";
+export { probeClusterCapabilities } from "./orchestrator/capabilities.js";
+export { deriveNamespaceName, isValidDns1123Label } from "./orchestrator/naming.js";
+
+export type {
+  ResolvedClusterConnection,
+  ClusterCapabilities,
+  KubernetesApiClient,
+} from "./types.js";

--- a/packages/adapters/kubernetes-execution/src/orchestrator/capabilities.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/capabilities.ts
@@ -1,0 +1,39 @@
+import type { KubernetesApiClient, ClusterCapabilities } from "../types.js";
+
+export async function probeClusterCapabilities(client: KubernetesApiClient): Promise<ClusterCapabilities> {
+  const cilium = await detectCilium(client);
+
+  const nodes = await client.core.listNode();
+  const archSet = new Set<"amd64" | "arm64">();
+  for (const node of nodes.body.items) {
+    const arch = node.status?.nodeInfo?.architecture;
+    if (arch === "amd64" || arch === "arm64") archSet.add(arch);
+  }
+  const architectures: ("amd64" | "arm64")[] = archSet.size > 0 ? [...archSet] : ["amd64"];
+
+  const storageClass = await detectStorageClass(client);
+
+  return { cilium, storageClass, architectures };
+}
+
+async function detectCilium(client: KubernetesApiClient): Promise<boolean> {
+  try {
+    const res = await client.request<{ kind?: string } | null>("GET", "/apis/cilium.io/v2");
+    return res != null && res.kind === "APIResourceList";
+  } catch {
+    return false;
+  }
+}
+
+async function detectStorageClass(client: KubernetesApiClient): Promise<string> {
+  type SCList = { items: Array<{ metadata: { name: string; annotations?: Record<string, string> } }> };
+  try {
+    const res = await client.request<SCList | null>("GET", "/apis/storage.k8s.io/v1/storageclasses");
+    if (!res || !res.items.length) return "standard";
+    const isDefault = (sc: SCList["items"][number]) =>
+      sc.metadata.annotations?.["storageclass.kubernetes.io/is-default-class"] === "true";
+    return res.items.find(isDefault)?.metadata.name ?? res.items[0].metadata.name;
+  } catch {
+    return "standard";
+  }
+}

--- a/packages/adapters/kubernetes-execution/src/orchestrator/cilium-network-policy.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/cilium-network-policy.ts
@@ -65,7 +65,13 @@ export async function applyCiliumNetworkPolicy(client: KubernetesApiClient, p: C
     await client.request("GET", itemPath);
     await client.request("PUT", itemPath, p);
   } catch (err: unknown) {
-    if (/\b404\b/.test(String(err))) {
+    const is404 =
+      /\b404\b/.test(String(err)) ||
+      (typeof err === "object" && err !== null && (err as Record<string, unknown>)["statusCode"] === 404) ||
+      (typeof err === "object" && err !== null &&
+        typeof (err as Record<string, unknown>)["response"] === "object" &&
+        ((err as Record<string, unknown>)["response"] as Record<string, unknown>)?.["statusCode"] === 404);
+    if (is404) {
       await client.request("POST", collectionPath, p);
       return;
     }

--- a/packages/adapters/kubernetes-execution/src/orchestrator/cilium-network-policy.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/cilium-network-policy.ts
@@ -1,0 +1,74 @@
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels, PAPERCLIP_ROLE, ROLE_AGENT_RUNTIME } from "./labels.js";
+
+interface CiliumFqdn {
+  matchPattern?: string;
+  matchName?: string;
+}
+
+export interface CiliumNetworkPolicyDoc {
+  apiVersion: "cilium.io/v2";
+  kind: "CiliumNetworkPolicy";
+  metadata: { name: string; namespace: string; labels?: Record<string, string> };
+  spec: {
+    endpointSelector: { matchLabels: Record<string, string> };
+    egress: Array<{
+      toFQDNs?: CiliumFqdn[];
+      toEndpoints?: Array<{ matchLabels: Record<string, string> }>;
+      toPorts?: Array<{ ports: Array<{ port: string; protocol: string }> }>;
+    }>;
+  };
+}
+
+export interface BuildCiliumInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+  adapterAllowFqdns: string[];
+  tenantAllowFqdns: string[];
+  controlPlaneSelector: { matchLabels: Record<string, string> } | null;
+}
+
+export function buildCiliumAgentEgressPolicy(input: BuildCiliumInput): CiliumNetworkPolicyDoc {
+  const labels = tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug });
+  const merged = Array.from(new Set([...input.adapterAllowFqdns, ...input.tenantAllowFqdns])).sort();
+  const fqdns: CiliumFqdn[] = merged.map(p => p.includes("*") ? { matchPattern: p } : { matchName: p });
+
+  const egress: CiliumNetworkPolicyDoc["spec"]["egress"] = [];
+  if (fqdns.length > 0) {
+    egress.push({ toFQDNs: fqdns, toPorts: [{ ports: [{ port: "443", protocol: "TCP" }] }] });
+  }
+  if (input.controlPlaneSelector) {
+    egress.push({
+      toEndpoints: [{ matchLabels: input.controlPlaneSelector.matchLabels }],
+      toPorts: [{ ports: [{ port: "443", protocol: "TCP" }] }],
+    });
+  }
+
+  return {
+    apiVersion: "cilium.io/v2",
+    kind: "CiliumNetworkPolicy",
+    metadata: { name: "paperclip-agent-egress-l7", namespace: input.namespace, labels },
+    spec: {
+      endpointSelector: { matchLabels: { [PAPERCLIP_ROLE]: ROLE_AGENT_RUNTIME } },
+      egress,
+    },
+  };
+}
+
+export async function applyCiliumNetworkPolicy(client: KubernetesApiClient, p: CiliumNetworkPolicyDoc): Promise<void> {
+  const ns = p.metadata.namespace;
+  const name = p.metadata.name;
+  const itemPath = `/apis/cilium.io/v2/namespaces/${encodeURIComponent(ns)}/ciliumnetworkpolicies/${encodeURIComponent(name)}`;
+  const collectionPath = `/apis/cilium.io/v2/namespaces/${encodeURIComponent(ns)}/ciliumnetworkpolicies`;
+  try {
+    await client.request("GET", itemPath);
+    await client.request("PUT", itemPath, p);
+  } catch (err: unknown) {
+    if (/\b404\b/.test(String(err))) {
+      await client.request("POST", collectionPath, p);
+      return;
+    }
+    throw err;
+  }
+}

--- a/packages/adapters/kubernetes-execution/src/orchestrator/ensure-tenant.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/ensure-tenant.ts
@@ -1,0 +1,137 @@
+import type { KubernetesApiClient, ResolvedClusterConnection } from "../types.js";
+import { deriveNamespaceName } from "./naming.js";
+import { buildNamespace, applyNamespace } from "./namespace.js";
+import {
+  buildAgentServiceAccount, applyAgentServiceAccount,
+  buildDriverRoleBinding, applyDriverRoleBinding,
+} from "./rbac.js";
+import {
+  buildResourceQuota, buildLimitRange,
+  applyResourceQuota, applyLimitRange,
+  type QuotaOverride, type LimitRangeOverride,
+} from "./resource-quota.js";
+import {
+  buildDefaultDenyPolicies, buildAgentEgressPolicy, applyNetworkPolicy,
+} from "./network-policy.js";
+import {
+  buildCiliumAgentEgressPolicy, applyCiliumNetworkPolicy,
+} from "./cilium-network-policy.js";
+import {
+  buildImagePullSecret, applyImagePullSecret,
+} from "./image-pull-secret.js";
+
+export interface TenantPolicy {
+  quota: QuotaOverride | null;
+  limitRange: LimitRangeOverride | null;
+  additionalAllowFqdns: string[];
+  imageOverrides: Record<string, string> | null;
+}
+
+export interface EnsureTenantInput {
+  connection: ResolvedClusterConnection;
+  company: { id: string; slug: string };
+  tenantPolicy: TenantPolicy | null;
+  driverServiceAccount: { name: string; namespace: string };
+  controlPlane: {
+    topology: "in-cluster" | "cross-cluster";
+    namespaceLabels: Record<string, string>;
+    podLabels: Record<string, string>;
+  };
+  adapterAllowFqdns: string[];
+  /** Resolved registry credentials. If null, no image pull secret is created. */
+  imagePullDockerConfigJson: string | null;
+}
+
+export interface EnsureTenantResult {
+  namespace: string;
+  ciliumApplied: boolean;
+}
+
+/**
+ * Idempotently provision a tenant namespace with all isolation primitives:
+ * Namespace → RBAC → ResourceQuota/LimitRange → NetworkPolicies → optional CiliumNetworkPolicy → optional image pull secret.
+ *
+ * Order matters: the Namespace must be created first because everything else is namespaced.
+ * The remaining objects can be in any order, but we prefer the creation order to match the
+ * "outer to inner" reading flow for kubectl debuggability (rbac → quota → policies → secrets).
+ */
+export async function ensureTenantNamespace(
+  client: KubernetesApiClient,
+  input: EnsureTenantInput,
+): Promise<EnsureTenantResult> {
+  const namespace = deriveNamespaceName({
+    companySlug: input.company.slug,
+    companyId: input.company.id,
+    prefix: input.connection.defaultNamespacePrefix,
+  });
+
+  // 1. Namespace (must come first).
+  await applyNamespace(client, buildNamespace({
+    name: namespace,
+    companyId: input.company.id,
+    companySlug: input.company.slug,
+  }));
+
+  // 2. RBAC.
+  await applyAgentServiceAccount(client, buildAgentServiceAccount({
+    namespace, companyId: input.company.id, companySlug: input.company.slug,
+  }));
+  await applyDriverRoleBinding(client, buildDriverRoleBinding({
+    namespace,
+    driverServiceAccount: input.driverServiceAccount,
+    clusterRoleName: "paperclip-tenant-manager",
+    companyId: input.company.id, companySlug: input.company.slug,
+  }));
+
+  // 3. Quota & LimitRange.
+  await applyResourceQuota(client, buildResourceQuota({
+    namespace, companyId: input.company.id, companySlug: input.company.slug,
+    override: input.tenantPolicy?.quota ?? null,
+  }));
+  await applyLimitRange(client, buildLimitRange({
+    namespace, companyId: input.company.id, companySlug: input.company.slug,
+    override: input.tenantPolicy?.limitRange ?? null,
+  }));
+
+  // 4. NetworkPolicies (vanilla — always).
+  for (const p of buildDefaultDenyPolicies({
+    namespace, companyId: input.company.id, companySlug: input.company.slug,
+  })) {
+    await applyNetworkPolicy(client, p);
+  }
+  await applyNetworkPolicy(client, buildAgentEgressPolicy({
+    namespace,
+    companyId: input.company.id,
+    companySlug: input.company.slug,
+    topology: input.controlPlane.topology,
+    controlPlaneSelector: input.controlPlane.topology === "in-cluster"
+      ? { namespaceLabel: input.controlPlane.namespaceLabels, podLabel: input.controlPlane.podLabels }
+      : null,
+  }));
+
+  // 5. Cilium policy (only when cluster supports it).
+  let ciliumApplied = false;
+  if (input.connection.capabilities.cilium) {
+    await applyCiliumNetworkPolicy(client, buildCiliumAgentEgressPolicy({
+      namespace,
+      companyId: input.company.id,
+      companySlug: input.company.slug,
+      adapterAllowFqdns: input.adapterAllowFqdns,
+      tenantAllowFqdns: input.tenantPolicy?.additionalAllowFqdns ?? [],
+      controlPlaneSelector: input.controlPlane.topology === "in-cluster"
+        ? { matchLabels: input.controlPlane.namespaceLabels }
+        : null,
+    }));
+    ciliumApplied = true;
+  }
+
+  // 6. Image pull secret (when registry creds were supplied).
+  if (input.imagePullDockerConfigJson) {
+    await applyImagePullSecret(client, buildImagePullSecret({
+      namespace, companyId: input.company.id, companySlug: input.company.slug,
+      dockerConfigJson: input.imagePullDockerConfigJson,
+    }));
+  }
+
+  return { namespace, ciliumApplied };
+}

--- a/packages/adapters/kubernetes-execution/src/orchestrator/image-pull-secret.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/image-pull-secret.ts
@@ -1,0 +1,44 @@
+import type { V1Secret } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels } from "./labels.js";
+
+export interface BuildImagePullSecretInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+  /** Already-resolved docker config JSON string (from a Paperclip secret_ref). */
+  dockerConfigJson: string;
+}
+
+export function buildImagePullSecret(input: BuildImagePullSecretInput): V1Secret {
+  return {
+    apiVersion: "v1",
+    kind: "Secret",
+    metadata: {
+      name: "paperclip-image-pull",
+      namespace: input.namespace,
+      labels: tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+    },
+    type: "kubernetes.io/dockerconfigjson",
+    data: {
+      ".dockerconfigjson": Buffer.from(input.dockerConfigJson, "utf-8").toString("base64"),
+    },
+  };
+}
+
+export async function applyImagePullSecret(client: KubernetesApiClient, s: V1Secret): Promise<void> {
+  const ns = s.metadata!.namespace!;
+  const name = s.metadata!.name!;
+  try {
+    await client.core.readNamespacedSecret(name, ns);
+    await client.core.patchNamespacedSecret(name, ns, s, undefined, undefined, undefined, undefined, undefined, {
+      headers: { "Content-Type": "application/strategic-merge-patch+json" },
+    } as never);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await client.core.createNamespacedSecret(ns, s);
+      return;
+    }
+    throw err;
+  }
+}

--- a/packages/adapters/kubernetes-execution/src/orchestrator/labels.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/labels.ts
@@ -1,0 +1,27 @@
+export const PAPERCLIP_MANAGED_BY = "paperclip.ai/managed-by";
+export const PAPERCLIP_MANAGED_BY_VALUE = "paperclip";
+
+export const PAPERCLIP_COMPANY_ID    = "paperclip.ai/company-id";
+export const PAPERCLIP_COMPANY_SLUG  = "paperclip.ai/company-slug";
+export const PAPERCLIP_AGENT_ID      = "paperclip.ai/agent-id";
+export const PAPERCLIP_RUN_ID        = "paperclip.ai/run-id";
+export const PAPERCLIP_ROLE          = "paperclip.ai/role";
+export const PAPERCLIP_ARCHIVED      = "paperclip.ai/archived";
+export const PAPERCLIP_WORKSPACE_STRATEGY = "paperclip.ai/workspace-strategy";
+
+export const ROLE_AGENT_RUNTIME      = "agent-runtime";
+export const ROLE_AGENT_WORKSPACE    = "agent-workspace";
+export const ROLE_CONTROL_PLANE      = "control-plane";
+
+export const PSS_ENFORCE = "pod-security.kubernetes.io/enforce";
+export const PSS_AUDIT   = "pod-security.kubernetes.io/audit";
+export const PSS_WARN    = "pod-security.kubernetes.io/warn";
+export const PSS_RESTRICTED = "restricted";
+
+export function tenantBaseLabels(input: { companyId: string; companySlug: string }): Record<string, string> {
+  return {
+    [PAPERCLIP_MANAGED_BY]:   PAPERCLIP_MANAGED_BY_VALUE,
+    [PAPERCLIP_COMPANY_ID]:   input.companyId,
+    [PAPERCLIP_COMPANY_SLUG]: input.companySlug,
+  };
+}

--- a/packages/adapters/kubernetes-execution/src/orchestrator/namespace.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/namespace.ts
@@ -1,0 +1,65 @@
+import type { V1Namespace } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import {
+  PSS_ENFORCE, PSS_AUDIT, PSS_WARN, PSS_RESTRICTED,
+  tenantBaseLabels, PAPERCLIP_MANAGED_BY, PAPERCLIP_MANAGED_BY_VALUE,
+} from "./labels.js";
+
+export interface BuildNamespaceInput {
+  name: string;
+  companyId: string;
+  companySlug: string;
+  extraLabels?: Record<string, string>;
+}
+
+export function buildNamespace(input: BuildNamespaceInput): V1Namespace {
+  return {
+    apiVersion: "v1",
+    kind: "Namespace",
+    metadata: {
+      name: input.name,
+      labels: {
+        ...tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+        [PSS_ENFORCE]: PSS_RESTRICTED,
+        [PSS_AUDIT]:   PSS_RESTRICTED,
+        [PSS_WARN]:    PSS_RESTRICTED,
+        ...input.extraLabels,
+      },
+    },
+  };
+}
+
+/**
+ * Idempotently apply a tenant namespace. Refuses to overwrite a namespace
+ * that is not labeled paperclip.ai/managed-by=paperclip.
+ */
+export async function applyNamespace(
+  client: KubernetesApiClient,
+  ns: V1Namespace,
+): Promise<{ created: boolean }> {
+  const name = ns.metadata!.name!;
+  try {
+    const existing = await client.core.readNamespace(name);
+    const managed = existing.body.metadata?.labels?.[PAPERCLIP_MANAGED_BY];
+    if (managed !== PAPERCLIP_MANAGED_BY_VALUE) {
+      throw new Error(
+        `Refusing to manage namespace "${name}": missing label ${PAPERCLIP_MANAGED_BY}=${PAPERCLIP_MANAGED_BY_VALUE}`,
+      );
+    }
+    await client.core.patchNamespace(name, ns, undefined, undefined, undefined, undefined, undefined, {
+      headers: { "Content-Type": "application/strategic-merge-patch+json" },
+    } as never);
+    return { created: false };
+  } catch (err: unknown) {
+    if (isNotFound(err)) {
+      await client.core.createNamespace(ns);
+      return { created: true };
+    }
+    throw err;
+  }
+}
+
+function isNotFound(err: unknown): boolean {
+  const code = (err as { response?: { statusCode?: number } })?.response?.statusCode;
+  return code === 404;
+}

--- a/packages/adapters/kubernetes-execution/src/orchestrator/namespace.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/namespace.ts
@@ -3,6 +3,7 @@ import type { KubernetesApiClient } from "../types.js";
 import {
   PSS_ENFORCE, PSS_AUDIT, PSS_WARN, PSS_RESTRICTED,
   tenantBaseLabels, PAPERCLIP_MANAGED_BY, PAPERCLIP_MANAGED_BY_VALUE,
+  PAPERCLIP_COMPANY_ID,
 } from "./labels.js";
 
 export interface BuildNamespaceInput {
@@ -31,19 +32,39 @@ export function buildNamespace(input: BuildNamespaceInput): V1Namespace {
 
 /**
  * Idempotently apply a tenant namespace. Refuses to overwrite a namespace
- * that is not labeled paperclip.ai/managed-by=paperclip.
+ * that is not labeled `paperclip.ai/managed-by=paperclip` OR that belongs to
+ * a different company than the one being applied. Without the company-id
+ * check, two companies whose slugs collide on a short prefix (e.g. both
+ * derive `paperclip-acme`) would silently take over each other's namespace
+ * — a multi-tenancy isolation breach.
  */
 export async function applyNamespace(
   client: KubernetesApiClient,
   ns: V1Namespace,
 ): Promise<{ created: boolean }> {
   const name = ns.metadata!.name!;
+  const incomingCompanyId = ns.metadata?.labels?.[PAPERCLIP_COMPANY_ID];
   try {
     const existing = await client.core.readNamespace(name);
     const managed = existing.body.metadata?.labels?.[PAPERCLIP_MANAGED_BY];
     if (managed !== PAPERCLIP_MANAGED_BY_VALUE) {
       throw new Error(
         `Refusing to manage namespace "${name}": missing label ${PAPERCLIP_MANAGED_BY}=${PAPERCLIP_MANAGED_BY_VALUE}`,
+      );
+    }
+    const existingCompanyId = existing.body.metadata?.labels?.[PAPERCLIP_COMPANY_ID];
+    // We only enforce the cross-tenant check when both sides carry a
+    // company-id label. A pre-existing managed-by=paperclip namespace without
+    // a company-id (legacy / pre-M1) is treated as adoptable by the current
+    // call. Once it's been written once with a company-id, every future
+    // application must match — which is the lock we need.
+    if (
+      existingCompanyId !== undefined &&
+      incomingCompanyId !== undefined &&
+      existingCompanyId !== incomingCompanyId
+    ) {
+      throw new Error(
+        `Refusing to manage namespace "${name}": labeled for company ${existingCompanyId}, not ${incomingCompanyId}`,
       );
     }
     await client.core.patchNamespace(name, ns, undefined, undefined, undefined, undefined, undefined, {

--- a/packages/adapters/kubernetes-execution/src/orchestrator/naming.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/naming.ts
@@ -1,0 +1,49 @@
+import { createHash } from "node:crypto";
+
+const DNS_1123_LABEL = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+const MAX_LABEL = 63;
+const HASH_LENGTH = 8;
+
+export function isValidDns1123Label(s: string): boolean {
+  return s.length > 0 && s.length <= MAX_LABEL && DNS_1123_LABEL.test(s);
+}
+
+function shortHash(input: string): string {
+  // base36 of first 5 bytes of sha256 → ≤8 chars, lowercase alphanumeric only.
+  const hash = createHash("sha256").update(input).digest();
+  let n = 0n;
+  for (let i = 0; i < 5; i++) n = (n << 8n) + BigInt(hash[i]);
+  return n.toString(36).slice(0, HASH_LENGTH).padStart(HASH_LENGTH, "0");
+}
+
+function sanitizeSlug(slug: string): string {
+  // Lowercase, replace runs of invalid chars with single hyphen, trim leading/trailing hyphens.
+  const cleaned = slug.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "");
+  return cleaned.length === 0 ? "x" : cleaned;
+}
+
+export interface DeriveNamespaceNameInput {
+  companySlug: string;
+  companyId: string;
+  prefix: string;
+  collisionFallback?: boolean;
+}
+
+export function deriveNamespaceName(input: DeriveNamespaceNameInput): string {
+  const { companySlug, companyId, prefix, collisionFallback } = input;
+  const slug = sanitizeSlug(companySlug);
+  const naive = `${prefix}${slug}`;
+
+  // The hash suffix is appended when ANY of:
+  //   - explicit collision fallback requested
+  //   - naive name overflows 63 chars
+  //   - sanitization mangled the slug (e.g. "Acme Corp.!" → "acme-corp")
+  const sanitizedDiffers = slug !== companySlug.toLowerCase();
+  const overflow = naive.length > MAX_LABEL;
+  if (!collisionFallback && !overflow && !sanitizedDiffers) return naive;
+
+  const suffix = `-${shortHash(companyId)}`;
+  const room = MAX_LABEL - prefix.length - suffix.length;
+  const truncatedSlug = slug.slice(0, Math.max(1, room)).replace(/-+$/g, "");
+  return `${prefix}${truncatedSlug}${suffix}`;
+}

--- a/packages/adapters/kubernetes-execution/src/orchestrator/network-policy.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/network-policy.ts
@@ -2,12 +2,20 @@ import type { V1NetworkPolicy } from "@kubernetes/client-node";
 import type { KubernetesApiClient } from "../types.js";
 import { tenantBaseLabels, PAPERCLIP_ROLE, ROLE_AGENT_RUNTIME } from "./labels.js";
 
-const RFC1918_AND_INTERNAL_DENY = [
+// IPv4-only private/internal ranges to exclude from the catch-all egress rule.
+// fd00::/8 (IPv6 ULA) is listed separately in RFC1918_IPV6_DENY because the
+// Kubernetes NetworkPolicy ipBlock.except entries must be a strict subset of
+// the parent cidr. Mixing IPv6 ranges inside an IPv4 cidr (0.0.0.0/0) is
+// rejected with a 422 by the k8s API.
+const RFC1918_IPV4_DENY = [
   "10.0.0.0/8",
   "172.16.0.0/12",
   "192.168.0.0/16",
   "169.254.0.0/16",   // link-local incl. cloud metadata
   "100.64.0.0/10",    // CGNAT
+];
+
+const RFC1918_IPV6_DENY = [
   "fd00::/8",         // IPv6 ULA
 ];
 
@@ -69,9 +77,14 @@ export function buildAgentEgressPolicy(input: AgentEgressInput): V1NetworkPolicy
     });
   }
 
-  // Internet egress (denies internal ranges)
+  // Internet egress — two ipBlock entries keep IPv4 and IPv6 CIDRs separate.
+  // The k8s API validates that each except entry is a strict subset of its
+  // parent cidr, so IPv6 ranges (fd00::/8) cannot live inside 0.0.0.0/0.
   egress.push({
-    to: [{ ipBlock: { cidr: "0.0.0.0/0", except: RFC1918_AND_INTERNAL_DENY } }],
+    to: [
+      { ipBlock: { cidr: "0.0.0.0/0", except: RFC1918_IPV4_DENY } },
+      { ipBlock: { cidr: "::/0",       except: RFC1918_IPV6_DENY } },
+    ],
     ports: [{ port: 443, protocol: "TCP" }],
   });
 

--- a/packages/adapters/kubernetes-execution/src/orchestrator/network-policy.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/network-policy.ts
@@ -1,0 +1,105 @@
+import type { V1NetworkPolicy } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels, PAPERCLIP_ROLE, ROLE_AGENT_RUNTIME } from "./labels.js";
+
+const RFC1918_AND_INTERNAL_DENY = [
+  "10.0.0.0/8",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+  "169.254.0.0/16",   // link-local incl. cloud metadata
+  "100.64.0.0/10",    // CGNAT
+  "fd00::/8",         // IPv6 ULA
+];
+
+export interface BuildDefaultDenyInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+}
+
+export function buildDefaultDenyPolicies(input: BuildDefaultDenyInput): V1NetworkPolicy[] {
+  const labels = tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug });
+  return [
+    {
+      apiVersion: "networking.k8s.io/v1",
+      kind: "NetworkPolicy",
+      metadata: { name: "default-deny-ingress", namespace: input.namespace, labels },
+      spec: { podSelector: {}, policyTypes: ["Ingress"] },
+    },
+    {
+      apiVersion: "networking.k8s.io/v1",
+      kind: "NetworkPolicy",
+      metadata: { name: "default-deny-egress", namespace: input.namespace, labels },
+      spec: { podSelector: {}, policyTypes: ["Egress"] },
+    },
+  ];
+}
+
+export interface AgentEgressInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+  topology: "in-cluster" | "cross-cluster";
+  controlPlaneSelector: {
+    namespaceLabel: Record<string, string>;
+    podLabel: Record<string, string>;
+  } | null;
+}
+
+export function buildAgentEgressPolicy(input: AgentEgressInput): V1NetworkPolicy {
+  const labels = tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug });
+  const egress: NonNullable<V1NetworkPolicy["spec"]>["egress"] = [
+    // DNS
+    {
+      to: [{
+        namespaceSelector: { matchLabels: { "kubernetes.io/metadata.name": "kube-system" } },
+        podSelector:       { matchLabels: { "k8s-app": "kube-dns" } },
+      }],
+      ports: [{ port: 53, protocol: "UDP" }, { port: 53, protocol: "TCP" }],
+    },
+  ];
+
+  if (input.topology === "in-cluster" && input.controlPlaneSelector) {
+    egress.push({
+      to: [{
+        namespaceSelector: { matchLabels: input.controlPlaneSelector.namespaceLabel },
+        podSelector:       { matchLabels: input.controlPlaneSelector.podLabel },
+      }],
+      ports: [{ port: 443, protocol: "TCP" }, { port: 3102, protocol: "TCP" }],
+    });
+  }
+
+  // Internet egress (denies internal ranges)
+  egress.push({
+    to: [{ ipBlock: { cidr: "0.0.0.0/0", except: RFC1918_AND_INTERNAL_DENY } }],
+    ports: [{ port: 443, protocol: "TCP" }],
+  });
+
+  return {
+    apiVersion: "networking.k8s.io/v1",
+    kind: "NetworkPolicy",
+    metadata: { name: "paperclip-agent-egress", namespace: input.namespace, labels },
+    spec: {
+      podSelector: { matchLabels: { [PAPERCLIP_ROLE]: ROLE_AGENT_RUNTIME } },
+      policyTypes: ["Egress"],
+      egress,
+    },
+  };
+}
+
+export async function applyNetworkPolicy(client: KubernetesApiClient, p: V1NetworkPolicy): Promise<void> {
+  const ns = p.metadata!.namespace!;
+  const name = p.metadata!.name!;
+  try {
+    await client.networking.readNamespacedNetworkPolicy(name, ns);
+    await client.networking.patchNamespacedNetworkPolicy(name, ns, p, undefined, undefined, undefined, undefined, undefined, {
+      headers: { "Content-Type": "application/strategic-merge-patch+json" },
+    } as never);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await client.networking.createNamespacedNetworkPolicy(ns, p);
+      return;
+    }
+    throw err;
+  }
+}

--- a/packages/adapters/kubernetes-execution/src/orchestrator/rbac.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/rbac.ts
@@ -1,0 +1,86 @@
+import type { V1ServiceAccount, V1RoleBinding } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels } from "./labels.js";
+
+export interface BuildAgentServiceAccountInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+}
+
+export function buildAgentServiceAccount(input: BuildAgentServiceAccountInput): V1ServiceAccount {
+  return {
+    apiVersion: "v1",
+    kind: "ServiceAccount",
+    metadata: {
+      name: "paperclip-agent",
+      namespace: input.namespace,
+      labels: tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+    },
+    automountServiceAccountToken: false,
+  };
+}
+
+export interface BuildDriverRoleBindingInput {
+  namespace: string;
+  driverServiceAccount: { name: string; namespace: string };
+  clusterRoleName: string;
+  companyId: string;
+  companySlug: string;
+}
+
+export function buildDriverRoleBinding(input: BuildDriverRoleBindingInput): V1RoleBinding {
+  return {
+    apiVersion: "rbac.authorization.k8s.io/v1",
+    kind: "RoleBinding",
+    metadata: {
+      name: "paperclip-driver",
+      namespace: input.namespace,
+      labels: tenantBaseLabels({ companyId: input.companyId, companySlug: input.companySlug }),
+    },
+    subjects: [{
+      kind: "ServiceAccount",
+      name: input.driverServiceAccount.name,
+      namespace: input.driverServiceAccount.namespace,
+    }],
+    roleRef: {
+      kind: "ClusterRole",
+      apiGroup: "rbac.authorization.k8s.io",
+      name: input.clusterRoleName,
+    },
+  };
+}
+
+export async function applyAgentServiceAccount(client: KubernetesApiClient, sa: V1ServiceAccount): Promise<void> {
+  const ns = sa.metadata!.namespace!;
+  const name = sa.metadata!.name!;
+  try {
+    await client.core.readNamespacedServiceAccount(name, ns);
+    await client.core.patchNamespacedServiceAccount(name, ns, sa, undefined, undefined, undefined, undefined, undefined, {
+      headers: { "Content-Type": "application/strategic-merge-patch+json" },
+    } as never);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await client.core.createNamespacedServiceAccount(ns, sa);
+      return;
+    }
+    throw err;
+  }
+}
+
+export async function applyDriverRoleBinding(client: KubernetesApiClient, rb: V1RoleBinding): Promise<void> {
+  const ns = rb.metadata!.namespace!;
+  const name = rb.metadata!.name!;
+  try {
+    await client.rbac.readNamespacedRoleBinding(name, ns);
+    // RoleBindings have an immutable roleRef. Safe path is delete+create.
+    await client.rbac.deleteNamespacedRoleBinding(name, ns);
+    await client.rbac.createNamespacedRoleBinding(ns, rb);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await client.rbac.createNamespacedRoleBinding(ns, rb);
+      return;
+    }
+    throw err;
+  }
+}

--- a/packages/adapters/kubernetes-execution/src/orchestrator/rbac.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/rbac.ts
@@ -72,10 +72,34 @@ export async function applyDriverRoleBinding(client: KubernetesApiClient, rb: V1
   const ns = rb.metadata!.namespace!;
   const name = rb.metadata!.name!;
   try {
-    await client.rbac.readNamespacedRoleBinding(name, ns);
-    // RoleBindings have an immutable roleRef. Safe path is delete+create.
+    const existing = await client.rbac.readNamespacedRoleBinding(name, ns);
+    const sameRoleRef =
+      existing.body.roleRef?.kind === rb.roleRef.kind &&
+      existing.body.roleRef?.name === rb.roleRef.name &&
+      existing.body.roleRef?.apiGroup === rb.roleRef.apiGroup;
+    if (sameRoleRef) {
+      // Idempotent path: roleRef hasn't changed (the common case for ensureTenant
+      // re-runs). RoleBinding subjects are mutable, so we patch in place — no
+      // delete window, no race where the namespace briefly has no permissions.
+      await client.rbac.patchNamespacedRoleBinding(name, ns, rb, undefined, undefined, undefined, undefined, undefined, {
+        headers: { "Content-Type": "application/strategic-merge-patch+json" },
+      } as never);
+      return;
+    }
+    // roleRef differs — k8s makes roleRef immutable, so we must delete+create.
+    // This is the rare path (only fires when an admin renames the bound ClusterRole).
+    // If the recreate fails, surface a descriptive error pointing at recovery so
+    // the operator knows the tenant has no driver permissions until ensureTenant re-runs.
     await client.rbac.deleteNamespacedRoleBinding(name, ns);
-    await client.rbac.createNamespacedRoleBinding(ns, rb);
+    try {
+      await client.rbac.createNamespacedRoleBinding(ns, rb);
+    } catch (createErr) {
+      throw new Error(
+        `RoleBinding ${name} in ${ns} was deleted to change roleRef, but the recreate failed: ` +
+          `${(createErr as Error).message}. ` +
+          `The tenant namespace currently has NO driver RoleBinding — re-run ensureTenant to recover.`,
+      );
+    }
   } catch (err) {
     if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
       await client.rbac.createNamespacedRoleBinding(ns, rb);

--- a/packages/adapters/kubernetes-execution/src/orchestrator/resource-quota.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/resource-quota.ts
@@ -1,0 +1,196 @@
+import type { V1ResourceQuota, V1LimitRange } from "@kubernetes/client-node";
+import type { KubernetesApiClient } from "../types.js";
+import { tenantBaseLabels } from "./labels.js";
+
+export const defaultTenantQuota = {
+  requestsCpu: "16",
+  requestsMemory: "64Gi",
+  limitsCpu: "64",
+  limitsMemory: "256Gi",
+  requestsStorage: "200Gi",
+  countJobs: 100,
+  countPvcs: 50,
+  countSecrets: 200,
+  countConfigMaps: 200,
+} as const;
+
+export const defaultTenantLimits = {
+  default: { cpu: "1", memory: "2Gi" },
+  defaultRequest: { cpu: "250m", memory: "512Mi" },
+  max: { cpu: "8", memory: "32Gi" },
+  pvcMaxStorage: "20Gi",
+} as const;
+
+export interface QuotaOverride {
+  requestsCpu?: string;
+  requestsMemory?: string;
+  limitsCpu?: string;
+  limitsMemory?: string;
+  requestsStorage?: string;
+  countJobs?: number;
+  countPvcs?: number;
+  countSecrets?: number;
+  countConfigMaps?: number;
+}
+
+export interface LimitRangeOverride {
+  default?: { cpu?: string; memory?: string };
+  defaultRequest?: { cpu?: string; memory?: string };
+  max?: { cpu?: string; memory?: string };
+  pvcMaxStorage?: string;
+}
+
+export interface BuildQuotaInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+  override: QuotaOverride | null;
+}
+
+export function buildResourceQuota(input: BuildQuotaInput): V1ResourceQuota {
+  const o = { ...defaultTenantQuota, ...(input.override ?? {}) };
+  return {
+    apiVersion: "v1",
+    kind: "ResourceQuota",
+    metadata: {
+      name: "paperclip-tenant-quota",
+      namespace: input.namespace,
+      labels: tenantBaseLabels({
+        companyId: input.companyId,
+        companySlug: input.companySlug,
+      }),
+    },
+    spec: {
+      hard: {
+        "requests.cpu": o.requestsCpu,
+        "requests.memory": o.requestsMemory,
+        "limits.cpu": o.limitsCpu,
+        "limits.memory": o.limitsMemory,
+        "requests.storage": o.requestsStorage,
+        "count/jobs.batch": String(o.countJobs),
+        "count/persistentvolumeclaims": String(o.countPvcs),
+        "count/secrets": String(o.countSecrets),
+        "count/configmaps": String(o.countConfigMaps),
+      },
+    },
+  };
+}
+
+export interface BuildLimitRangeInput {
+  namespace: string;
+  companyId: string;
+  companySlug: string;
+  override: LimitRangeOverride | null;
+}
+
+export function buildLimitRange(input: BuildLimitRangeInput): V1LimitRange {
+  const o = {
+    default: { ...defaultTenantLimits.default, ...(input.override?.default ?? {}) },
+    defaultRequest: {
+      ...defaultTenantLimits.defaultRequest,
+      ...(input.override?.defaultRequest ?? {}),
+    },
+    max: { ...defaultTenantLimits.max, ...(input.override?.max ?? {}) },
+    pvcMaxStorage:
+      input.override?.pvcMaxStorage ?? defaultTenantLimits.pvcMaxStorage,
+  };
+  return {
+    apiVersion: "v1",
+    kind: "LimitRange",
+    metadata: {
+      name: "paperclip-tenant-limits",
+      namespace: input.namespace,
+      labels: tenantBaseLabels({
+        companyId: input.companyId,
+        companySlug: input.companySlug,
+      }),
+    },
+    spec: {
+      limits: [
+        {
+          type: "Container",
+          default: o.default,
+          defaultRequest: o.defaultRequest,
+          max: o.max,
+        },
+        { type: "PersistentVolumeClaim", max: { storage: o.pvcMaxStorage } },
+      ],
+    },
+  };
+}
+
+async function upsertNamespaced<
+  T extends { metadata?: { name?: string; namespace?: string } }
+>(
+  obj: T,
+  read: (ns: string, name: string) => Promise<unknown>,
+  patch: (ns: string, name: string, body: T) => Promise<unknown>,
+  create: (ns: string, body: T) => Promise<unknown>,
+): Promise<void> {
+  const ns = obj.metadata!.namespace!;
+  const name = obj.metadata!.name!;
+  try {
+    await read(ns, name);
+    await patch(ns, name, obj);
+  } catch (err) {
+    if ((err as { response?: { statusCode?: number } })?.response?.statusCode === 404) {
+      await create(ns, obj);
+      return;
+    }
+    throw err;
+  }
+}
+
+export async function applyResourceQuota(
+  client: KubernetesApiClient,
+  q: V1ResourceQuota,
+): Promise<void> {
+  await upsertNamespaced(
+    q,
+    (ns, name) => client.core.readNamespacedResourceQuota(name, ns),
+    (ns, name, body) =>
+      client.core.patchNamespacedResourceQuota(
+        name,
+        ns,
+        body,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          headers: {
+            "Content-Type": "application/strategic-merge-patch+json",
+          },
+        } as never,
+      ),
+    (ns, body) => client.core.createNamespacedResourceQuota(ns, body),
+  );
+}
+
+export async function applyLimitRange(
+  client: KubernetesApiClient,
+  lr: V1LimitRange,
+): Promise<void> {
+  await upsertNamespaced(
+    lr,
+    (ns, name) => client.core.readNamespacedLimitRange(name, ns),
+    (ns, name, body) =>
+      client.core.patchNamespacedLimitRange(
+        name,
+        ns,
+        body,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        {
+          headers: {
+            "Content-Type": "application/strategic-merge-patch+json",
+          },
+        } as never,
+      ),
+    (ns, body) => client.core.createNamespacedLimitRange(ns, body),
+  );
+}

--- a/packages/adapters/kubernetes-execution/src/orchestrator/resource-quota.ts
+++ b/packages/adapters/kubernetes-execution/src/orchestrator/resource-quota.ts
@@ -109,7 +109,7 @@ export function buildLimitRange(input: BuildLimitRangeInput): V1LimitRange {
       limits: [
         {
           type: "Container",
-          default: o.default,
+          _default: o.default,
           defaultRequest: o.defaultRequest,
           max: o.max,
         },

--- a/packages/adapters/kubernetes-execution/src/types.ts
+++ b/packages/adapters/kubernetes-execution/src/types.ts
@@ -1,0 +1,39 @@
+import type {
+  CoreV1Api,
+  BatchV1Api,
+  NetworkingV1Api,
+  RbacAuthorizationV1Api,
+  ApiextensionsV1Api,
+} from "@kubernetes/client-node";
+
+export interface ResolvedClusterConnection {
+  id: string;
+  label: string;
+  kind: "in-cluster" | "kubeconfig";
+  /** Already resolved kubeconfig blob if kind === "kubeconfig". */
+  kubeconfigYaml?: string;
+  apiServerUrl?: string | null;
+  defaultNamespacePrefix: string;
+  paperclipPublicUrl?: string | null;
+  imageRegistry?: string | null;
+  allowAgentImageOverride: boolean;
+  capabilities: ClusterCapabilities;
+}
+
+export interface ClusterCapabilities {
+  cilium: boolean;
+  storageClass: string;
+  architectures: ("amd64" | "arm64")[];
+}
+
+export interface KubernetesApiClient {
+  core: CoreV1Api;
+  batch: BatchV1Api;
+  networking: NetworkingV1Api;
+  rbac: RbacAuthorizationV1Api;
+  apiext: ApiextensionsV1Api;
+  /** kubeconfig context info for logging only. */
+  describe: () => string;
+  /** Throwaway dynamic client used for arbitrary CRDs (Cilium). */
+  request: <T = unknown>(method: string, path: string, body?: unknown) => Promise<T>;
+}

--- a/packages/adapters/kubernetes-execution/test/integration/_harness.ts
+++ b/packages/adapters/kubernetes-execution/test/integration/_harness.ts
@@ -1,0 +1,31 @@
+import { execSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface KindCluster {
+  name: string;
+  kubeconfigPath: string;
+  kubeconfigYaml: string;
+  cleanup(): void;
+}
+
+export function spinUpKind(): KindCluster {
+  const name = `pp-test-${Math.random().toString(36).slice(2, 8)}`;
+  const dir = mkdtempSync(join(tmpdir(), `${name}-`));
+  const kubeconfigPath = join(dir, "kubeconfig");
+  // --wait waits for the control plane Pod to be Ready before returning.
+  execSync(`kind create cluster --name ${name} --kubeconfig ${kubeconfigPath} --wait 90s`, {
+    stdio: "inherit",
+  });
+  const kubeconfigYaml = readFileSync(kubeconfigPath, "utf-8");
+  return {
+    name,
+    kubeconfigPath,
+    kubeconfigYaml,
+    cleanup: () => {
+      try { execSync(`kind delete cluster --name ${name}`, { stdio: "ignore" }); } catch { /* swallow */ }
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* swallow */ }
+    },
+  };
+}

--- a/packages/adapters/kubernetes-execution/test/integration/ensure-tenant-drift.test.ts
+++ b/packages/adapters/kubernetes-execution/test/integration/ensure-tenant-drift.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spinUpKind, type KindCluster } from "./_harness.js";
+import { createKubernetesApiClient, ensureTenantNamespace, type ResolvedClusterConnection } from "../../src/index.js";
+
+let cluster: KindCluster;
+beforeAll(() => { cluster = spinUpKind(); }, 240_000);
+afterAll(() => cluster?.cleanup());
+
+describe("ensureTenantNamespace drift correction", () => {
+  it("recreates a NetworkPolicy that was deleted out-of-band", async () => {
+    const connection: ResolvedClusterConnection = {
+      id: "c-1", label: "kind", kind: "kubeconfig", kubeconfigYaml: cluster.kubeconfigYaml,
+      defaultNamespacePrefix: "paperclip-",
+      allowAgentImageOverride: false,
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+    };
+    const client = createKubernetesApiClient(connection);
+    const input = {
+      connection,
+      company: { id: "11111111-1111-1111-1111-111111111113", slug: "drift-co" },
+      tenantPolicy: null,
+      driverServiceAccount: { name: "default", namespace: "default" },
+      controlPlane: { topology: "cross-cluster" as const, namespaceLabels: {}, podLabels: {} },
+      adapterAllowFqdns: [],
+      imagePullDockerConfigJson: null,
+    };
+    const { namespace } = await ensureTenantNamespace(client, input);
+    await client.networking.deleteNamespacedNetworkPolicy("default-deny-egress", namespace);
+    await ensureTenantNamespace(client, input);
+    const policies = await client.networking.listNamespacedNetworkPolicy(namespace);
+    expect(policies.body.items.find(p => p.metadata?.name === "default-deny-egress")).toBeDefined();
+  }, 180_000);
+});

--- a/packages/adapters/kubernetes-execution/test/integration/ensure-tenant-idempotency.test.ts
+++ b/packages/adapters/kubernetes-execution/test/integration/ensure-tenant-idempotency.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spinUpKind, type KindCluster } from "./_harness.js";
+import { createKubernetesApiClient, ensureTenantNamespace, type ResolvedClusterConnection } from "../../src/index.js";
+
+let cluster: KindCluster;
+beforeAll(() => { cluster = spinUpKind(); }, 240_000);
+afterAll(() => cluster?.cleanup());
+
+describe("ensureTenantNamespace idempotency", () => {
+  it("a second call is a no-op-equivalent — exactly the same set of objects exist", async () => {
+    const connection: ResolvedClusterConnection = {
+      id: "c-1", label: "kind", kind: "kubeconfig", kubeconfigYaml: cluster.kubeconfigYaml,
+      defaultNamespacePrefix: "paperclip-",
+      allowAgentImageOverride: false,
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+    };
+    const client = createKubernetesApiClient(connection);
+    const input = {
+      connection,
+      company: { id: "11111111-1111-1111-1111-111111111112", slug: "idempotent-co" },
+      tenantPolicy: null,
+      driverServiceAccount: { name: "default", namespace: "default" },
+      controlPlane: { topology: "cross-cluster" as const, namespaceLabels: {}, podLabels: {} },
+      adapterAllowFqdns: [],
+      imagePullDockerConfigJson: null,
+    };
+    const r1 = await ensureTenantNamespace(client, input);
+    const r2 = await ensureTenantNamespace(client, input);
+    expect(r1.namespace).toBe(r2.namespace);
+    const policies = await client.networking.listNamespacedNetworkPolicy(r1.namespace);
+    expect(policies.body.items.length).toBe(3);
+  }, 180_000);
+});

--- a/packages/adapters/kubernetes-execution/test/integration/ensure-tenant.test.ts
+++ b/packages/adapters/kubernetes-execution/test/integration/ensure-tenant.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spinUpKind, type KindCluster } from "./_harness.js";
+import { createKubernetesApiClient, ensureTenantNamespace, type ResolvedClusterConnection } from "../../src/index.js";
+
+let cluster: KindCluster;
+let connection: ResolvedClusterConnection;
+
+beforeAll(() => {
+  cluster = spinUpKind();
+  connection = {
+    id: "c-1", label: "kind", kind: "kubeconfig", kubeconfigYaml: cluster.kubeconfigYaml,
+    defaultNamespacePrefix: "paperclip-",
+    allowAgentImageOverride: false,
+    capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+  };
+}, 240_000);
+afterAll(() => cluster?.cleanup());
+
+describe("ensureTenantNamespace against kind", () => {
+  it("provisions a fully isolated tenant namespace", async () => {
+    const client = createKubernetesApiClient(connection);
+    const result = await ensureTenantNamespace(client, {
+      connection,
+      company: { id: "11111111-1111-1111-1111-111111111111", slug: "acme-corp" },
+      tenantPolicy: null,
+      // kind doesn't have a "paperclip-driver" SA in any namespace by default; the
+      // RoleBinding's ClusterRole reference is also fictional. The RoleBinding
+      // creation will succeed (k8s allows forward-references in subjects/roleRef);
+      // we just don't exercise the binding's actual permissions in this test.
+      driverServiceAccount: { name: "default", namespace: "default" },
+      controlPlane: { topology: "cross-cluster", namespaceLabels: {}, podLabels: {} },
+      adapterAllowFqdns: [],
+      imagePullDockerConfigJson: null,
+    });
+    expect(result.namespace).toBe("paperclip-acme-corp");
+    expect(result.ciliumApplied).toBe(false);
+
+    // Verify all primitives exist with the expected labels.
+    const ns = await client.core.readNamespace(result.namespace);
+    expect(ns.body.metadata?.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+    expect(ns.body.metadata?.labels?.["pod-security.kubernetes.io/enforce"]).toBe("restricted");
+
+    const sa = await client.core.readNamespacedServiceAccount("paperclip-agent", result.namespace);
+    expect(sa.body.automountServiceAccountToken).toBe(false);
+
+    const quota = await client.core.readNamespacedResourceQuota("paperclip-tenant-quota", result.namespace);
+    expect(quota.body.spec?.hard?.["requests.cpu"]).toBe("16");
+
+    const limitRange = await client.core.readNamespacedLimitRange("paperclip-tenant-limits", result.namespace);
+    expect(limitRange.body.spec?.limits?.length).toBeGreaterThan(0);
+
+    const policies = await client.networking.listNamespacedNetworkPolicy(result.namespace);
+    const names = policies.body.items.map(p => p.metadata?.name).sort();
+    expect(names).toEqual(["default-deny-egress", "default-deny-ingress", "paperclip-agent-egress"]);
+  }, 180_000);
+});

--- a/packages/adapters/kubernetes-execution/test/integration/ensure-tenant.test.ts
+++ b/packages/adapters/kubernetes-execution/test/integration/ensure-tenant.test.ts
@@ -48,6 +48,15 @@ describe("ensureTenantNamespace against kind", () => {
 
     const limitRange = await client.core.readNamespacedLimitRange("paperclip-tenant-limits", result.namespace);
     expect(limitRange.body.spec?.limits?.length).toBeGreaterThan(0);
+    // Container LimitRange must carry the `default` field on the wire (k8s
+    // typed client renames JS `_default` → JSON `default` via attributeTypeMap).
+    // Without this assertion, a typo in the JS field name would silently drop
+    // the default container limits and the cluster would have no enforcement.
+    const containerLimit = limitRange.body.spec?.limits?.find((l) => l.type === "Container");
+    expect(containerLimit?._default?.cpu).toBeDefined();
+    expect(containerLimit?._default?.memory).toBeDefined();
+    expect(containerLimit?.defaultRequest?.cpu).toBeDefined();
+    expect(containerLimit?.max?.cpu).toBeDefined();
 
     const policies = await client.networking.listNamespacedNetworkPolicy(result.namespace);
     const names = policies.body.items.map(p => p.metadata?.name).sort();

--- a/packages/adapters/kubernetes-execution/test/integration/pss-restricted.test.ts
+++ b/packages/adapters/kubernetes-execution/test/integration/pss-restricted.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { spinUpKind, type KindCluster } from "./_harness.js";
+import {
+  createKubernetesApiClient,
+  ensureTenantNamespace,
+  type ResolvedClusterConnection,
+} from "../../src/index.js";
+
+let cluster: KindCluster;
+beforeAll(() => { cluster = spinUpKind(); }, 240_000);
+afterAll(() => cluster?.cleanup());
+
+describe("PSS Restricted compliance for tenant namespace", () => {
+  it("admission rejects a privileged Pod and accepts a compliant Pod", async () => {
+    const connection: ResolvedClusterConnection = {
+      id: "c-1", label: "kind", kind: "kubeconfig", kubeconfigYaml: cluster.kubeconfigYaml,
+      defaultNamespacePrefix: "paperclip-",
+      allowAgentImageOverride: false,
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+    };
+    const client = createKubernetesApiClient(connection);
+    const { namespace } = await ensureTenantNamespace(client, {
+      connection,
+      company: { id: "11111111-1111-1111-1111-111111111114", slug: "pss-test" },
+      tenantPolicy: null,
+      driverServiceAccount: { name: "default", namespace: "default" },
+      controlPlane: { topology: "cross-cluster", namespaceLabels: {}, podLabels: {} },
+      adapterAllowFqdns: [],
+      imagePullDockerConfigJson: null,
+    });
+
+    // Privileged Pod — admission must reject.
+    let rejected = false;
+    try {
+      await client.core.createNamespacedPod(namespace, {
+        apiVersion: "v1",
+        kind: "Pod",
+        metadata: { name: "evil" },
+        spec: {
+          containers: [{
+            name: "x",
+            image: "busybox",
+            command: ["sleep", "1"],
+            securityContext: { privileged: true },
+          }],
+        },
+      });
+    } catch (err) {
+      const msg = String((err as { body?: { message?: string }; message?: string }).body?.message ?? (err as Error).message ?? err);
+      expect(msg).toMatch(/violates PodSecurity|forbidden|restricted/i);
+      rejected = true;
+    }
+    expect(rejected).toBe(true);
+
+    // Compliant Pod — admission must accept.
+    await client.core.createNamespacedPod(namespace, {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: { name: "good" },
+      spec: {
+        automountServiceAccountToken: false,
+        securityContext: {
+          runAsNonRoot: true,
+          runAsUser: 1000,
+          fsGroup: 1000,
+          seccompProfile: { type: "RuntimeDefault" },
+        },
+        containers: [{
+          name: "x",
+          image: "busybox",
+          command: ["sleep", "1"],
+          securityContext: {
+            allowPrivilegeEscalation: false,
+            readOnlyRootFilesystem: true,
+            capabilities: { drop: ["ALL"] },
+          },
+        }],
+      },
+    });
+
+    // Verify the compliant pod actually exists.
+    const pod = await client.core.readNamespacedPod("good", namespace);
+    expect(pod.body.metadata?.name).toBe("good");
+  }, 180_000);
+});

--- a/packages/adapters/kubernetes-execution/test/unit/capabilities.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/capabilities.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { probeClusterCapabilities } from "../../src/orchestrator/capabilities.js";
+
+function fakeClient(opts: {
+  hasCilium: boolean;
+  nodes: { arch: string }[];
+  storageClasses: string[];
+  defaultStorageClass?: string;
+}) {
+  return {
+    request: vi.fn(async (method: string, path: string) => {
+      if (path.includes("/apis/cilium.io/v2")) {
+        return opts.hasCilium ? { kind: "APIResourceList", resources: [] } : null;
+      }
+      if (path.includes("/apis/storage.k8s.io/v1/storageclasses")) {
+        return {
+          items: opts.storageClasses.map((name) => ({
+            metadata: {
+              name,
+              annotations:
+                name === opts.defaultStorageClass
+                  ? { "storageclass.kubernetes.io/is-default-class": "true" }
+                  : {},
+            },
+          })),
+        };
+      }
+      return null;
+    }),
+    core: {
+      listNode: vi.fn(async () => ({
+        body: { items: opts.nodes.map((n) => ({ status: { nodeInfo: { architecture: n.arch } } })) },
+      })),
+    },
+  } as unknown as Parameters<typeof probeClusterCapabilities>[0];
+}
+
+describe("probeClusterCapabilities", () => {
+  it("detects cilium and arm64 nodes", async () => {
+    const c = fakeClient({
+      hasCilium: true,
+      nodes: [{ arch: "amd64" }, { arch: "arm64" }],
+      storageClasses: ["standard", "gp3"],
+      defaultStorageClass: "gp3",
+    });
+    const caps = await probeClusterCapabilities(c);
+    expect(caps.cilium).toBe(true);
+    expect(caps.architectures).toEqual(expect.arrayContaining(["amd64", "arm64"]));
+    expect(caps.storageClass).toBe("gp3");
+  });
+
+  it("falls back to first storage class when none is marked default", async () => {
+    const c = fakeClient({
+      hasCilium: false,
+      nodes: [{ arch: "amd64" }],
+      storageClasses: ["standard"],
+    });
+    const caps = await probeClusterCapabilities(c);
+    expect(caps.cilium).toBe(false);
+    expect(caps.storageClass).toBe("standard");
+  });
+
+  it("handles cilium API absence gracefully", async () => {
+    const c = fakeClient({
+      hasCilium: false,
+      nodes: [{ arch: "amd64" }],
+      storageClasses: ["standard"],
+      defaultStorageClass: "standard",
+    });
+    const caps = await probeClusterCapabilities(c);
+    expect(caps.cilium).toBe(false);
+  });
+
+  it("falls back to amd64 when no nodes report a recognized architecture", async () => {
+    const c = fakeClient({
+      hasCilium: false,
+      nodes: [{ arch: "ppc64le" }],
+      storageClasses: ["standard"],
+    });
+    const caps = await probeClusterCapabilities(c);
+    expect(caps.architectures).toEqual(["amd64"]);
+  });
+
+  it("returns 'standard' when no storage classes exist", async () => {
+    const c = fakeClient({
+      hasCilium: false,
+      nodes: [{ arch: "amd64" }],
+      storageClasses: [],
+    });
+    const caps = await probeClusterCapabilities(c);
+    expect(caps.storageClass).toBe("standard");
+  });
+
+  it("treats request() throwing on cilium probe as cilium=false", async () => {
+    const c = {
+      request: vi.fn(async (method: string, path: string) => {
+        if (path.includes("/apis/cilium.io/v2")) throw new Error("404");
+        if (path.includes("/storageclasses")) return { items: [{ metadata: { name: "standard" } }] };
+        return null;
+      }),
+      core: {
+        listNode: vi.fn(async () => ({ body: { items: [{ status: { nodeInfo: { architecture: "amd64" } } }] } })),
+      },
+    } as unknown as Parameters<typeof probeClusterCapabilities>[0];
+    const caps = await probeClusterCapabilities(c);
+    expect(caps.cilium).toBe(false);
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/cilium-network-policy.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/cilium-network-policy.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { buildCiliumAgentEgressPolicy } from "../../src/orchestrator/cilium-network-policy.js";
+
+describe("buildCiliumAgentEgressPolicy", () => {
+  it("merges adapter and tenant FQDN allowlists, deduplicated and sorted", () => {
+    const p = buildCiliumAgentEgressPolicy({
+      namespace: "paperclip-acme",
+      companyId: "c-1",
+      companySlug: "acme",
+      adapterAllowFqdns: ["*.anthropic.com", "github.com"],
+      tenantAllowFqdns: ["github.com", "*.acme.io"],
+      controlPlaneSelector: { matchLabels: { "paperclip.ai/role": "control-plane" } },
+    });
+    const fqdns = p.spec.egress[0].toFQDNs!.map((f: { matchPattern?: string; matchName?: string }) =>
+      f.matchPattern ?? f.matchName,
+    ).sort();
+    expect(fqdns).toEqual(["*.acme.io", "*.anthropic.com", "github.com"]);
+  });
+
+  it("uses matchPattern for wildcard FQDNs and matchName for exact FQDNs", () => {
+    const p = buildCiliumAgentEgressPolicy({
+      namespace: "paperclip-x", companyId: "c-1", companySlug: "x",
+      adapterAllowFqdns: ["*.anthropic.com", "api.openai.com"], tenantAllowFqdns: [],
+      controlPlaneSelector: null,
+    });
+    const fqdns = p.spec.egress[0].toFQDNs!;
+    expect(fqdns.find(f => f.matchPattern === "*.anthropic.com")).toBeDefined();
+    expect(fqdns.find(f => f.matchName === "api.openai.com")).toBeDefined();
+  });
+
+  it("emits a separate egress rule for the in-cluster control plane endpoint", () => {
+    const p = buildCiliumAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      adapterAllowFqdns: [], tenantAllowFqdns: [],
+      controlPlaneSelector: { matchLabels: { "paperclip.ai/role": "control-plane" } },
+    });
+    expect(p.spec.egress.some(r =>
+      r.toEndpoints?.some(e => e.matchLabels?.["paperclip.ai/role"] === "control-plane"),
+    )).toBe(true);
+  });
+
+  it("omits the control-plane endpoint rule when none provided (cross-cluster)", () => {
+    const p = buildCiliumAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      adapterAllowFqdns: ["api.anthropic.com"], tenantAllowFqdns: [],
+      controlPlaneSelector: null,
+    });
+    expect(p.spec.egress.some(r => r.toEndpoints)).toBe(false);
+  });
+
+  it("targets only agent-runtime pods", () => {
+    const p = buildCiliumAgentEgressPolicy({
+      namespace: "paperclip-x", companyId: "c-1", companySlug: "x",
+      adapterAllowFqdns: ["api.anthropic.com"], tenantAllowFqdns: [],
+      controlPlaneSelector: null,
+    });
+    expect(p.spec.endpointSelector.matchLabels["paperclip.ai/role"]).toBe("agent-runtime");
+  });
+
+  it("returns an empty egress array when no FQDNs and no control plane (degenerate)", () => {
+    const p = buildCiliumAgentEgressPolicy({
+      namespace: "paperclip-x", companyId: "c-1", companySlug: "x",
+      adapterAllowFqdns: [], tenantAllowFqdns: [],
+      controlPlaneSelector: null,
+    });
+    expect(p.spec.egress).toEqual([]);
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/client.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/client.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { createKubernetesApiClient } from "../../src/client.js";
+
+describe("createKubernetesApiClient", () => {
+  it("constructs a client from a kubeconfig blob", () => {
+    const kubeconfig = `
+apiVersion: v1
+kind: Config
+clusters:
+  - name: kind
+    cluster:
+      server: https://127.0.0.1:6443
+      insecure-skip-tls-verify: true
+contexts:
+  - name: kind
+    context:
+      cluster: kind
+      user: kind
+current-context: kind
+users:
+  - name: kind
+    user:
+      token: x
+`;
+    const client = createKubernetesApiClient({
+      id: "c-1",
+      label: "test",
+      kind: "kubeconfig",
+      kubeconfigYaml: kubeconfig,
+      defaultNamespacePrefix: "paperclip-",
+      allowAgentImageOverride: false,
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+    });
+    expect(client.core).toBeDefined();
+    expect(client.batch).toBeDefined();
+    expect(client.networking).toBeDefined();
+    expect(client.rbac).toBeDefined();
+    expect(client.apiext).toBeDefined();
+    expect(client.describe()).toContain("kind");
+  });
+
+  it("rejects an in-cluster connection when not running in a pod", () => {
+    expect(() =>
+      createKubernetesApiClient({
+        id: "c-1",
+        label: "test",
+        kind: "in-cluster",
+        defaultNamespacePrefix: "paperclip-",
+        allowAgentImageOverride: false,
+        capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      }),
+    ).toThrow(/in-cluster/i);
+  });
+
+  it("rejects kubeconfig kind without yaml", () => {
+    expect(() =>
+      createKubernetesApiClient({
+        id: "c-1",
+        label: "test",
+        kind: "kubeconfig",
+        defaultNamespacePrefix: "paperclip-",
+        allowAgentImageOverride: false,
+        capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      }),
+    ).toThrow(/kubeconfig/i);
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/driver.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/driver.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { createKubernetesExecutionDriver } from "../../src/driver.js";
+import type { ResolvedClusterConnection } from "../../src/types.js";
+
+const sampleConnection: ResolvedClusterConnection = {
+  id: "c-1",
+  label: "test",
+  kind: "kubeconfig",
+  kubeconfigYaml: `
+apiVersion: v1
+kind: Config
+clusters:
+  - name: test
+    cluster:
+      server: https://127.0.0.1:6443
+      insecure-skip-tls-verify: true
+contexts:
+  - name: test
+    context: { cluster: test, user: test }
+current-context: test
+users:
+  - name: test
+    user: { token: x }
+`,
+  defaultNamespacePrefix: "paperclip-",
+  allowAgentImageOverride: false,
+  capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+};
+
+describe("KubernetesExecutionDriver", () => {
+  it("rejects non-kubernetes targets at validate", async () => {
+    const driver = createKubernetesExecutionDriver({ resolveConnection: async () => null });
+    await expect(driver.validateTarget({ kind: "local" } as never))
+      .rejects.toThrow(/kubernetes/i);
+  });
+
+  it("rejects unknown clusterConnectionId", async () => {
+    const driver = createKubernetesExecutionDriver({ resolveConnection: async () => null });
+    await expect(driver.validateTarget({ kind: "kubernetes", clusterConnectionId: "missing" }))
+      .rejects.toThrow(/cluster connection.+not found/i);
+  });
+
+  it("rejects targets missing clusterConnectionId", async () => {
+    const driver = createKubernetesExecutionDriver({ resolveConnection: async () => null });
+    await expect(driver.validateTarget({ kind: "kubernetes" } as never))
+      .rejects.toThrow(/clusterConnectionId/);
+  });
+
+  it("returns NOT_YET_SUPPORTED from run() in M1", async () => {
+    const driver = createKubernetesExecutionDriver({ resolveConnection: async () => null });
+    const result = await driver.run({
+      ctx: {
+        runId: "r-1",
+        agent: { id: "a-1", companyId: "c-1", name: "x", adapterType: "claude_local", adapterConfig: {} },
+        runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+        config: {},
+        context: {},
+        onLog: async () => {},
+      },
+      target: { kind: "kubernetes", clusterConnectionId: "c-1" },
+    });
+    expect(result.errorCode).toBe("execution_target_not_yet_supported");
+    expect(result.exitCode).toBeNull();
+    expect(result.errorMessage).toMatch(/M2/);
+  });
+
+  it("validates a kubernetes target when the connection resolves", async () => {
+    const driver = createKubernetesExecutionDriver({
+      resolveConnection: async () => sampleConnection,
+    });
+    await expect(driver.validateTarget({ kind: "kubernetes", clusterConnectionId: "c-1" }))
+      .resolves.toBeUndefined();
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/ensure-tenant.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/ensure-tenant.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from "vitest";
+import { ensureTenantNamespace, type EnsureTenantInput } from "../../src/orchestrator/ensure-tenant.js";
+import type { KubernetesApiClient } from "../../src/types.js";
+
+function makeFakeClient(): KubernetesApiClient {
+  const notFound = () => { const e: Error & { response?: { statusCode: number } } = new Error("not found"); e.response = { statusCode: 404 }; throw e; };
+  return {
+    core: {
+      readNamespace: vi.fn(notFound),
+      createNamespace: vi.fn(async () => ({})),
+      patchNamespace: vi.fn(async () => ({})),
+      readNamespacedServiceAccount: vi.fn(notFound),
+      createNamespacedServiceAccount: vi.fn(async () => ({})),
+      patchNamespacedServiceAccount: vi.fn(async () => ({})),
+      readNamespacedResourceQuota: vi.fn(notFound),
+      createNamespacedResourceQuota: vi.fn(async () => ({})),
+      patchNamespacedResourceQuota: vi.fn(async () => ({})),
+      readNamespacedLimitRange: vi.fn(notFound),
+      createNamespacedLimitRange: vi.fn(async () => ({})),
+      patchNamespacedLimitRange: vi.fn(async () => ({})),
+      readNamespacedSecret: vi.fn(notFound),
+      createNamespacedSecret: vi.fn(async () => ({})),
+      patchNamespacedSecret: vi.fn(async () => ({})),
+    } as unknown as KubernetesApiClient["core"],
+    rbac: {
+      readNamespacedRoleBinding: vi.fn(notFound),
+      createNamespacedRoleBinding: vi.fn(async () => ({})),
+      deleteNamespacedRoleBinding: vi.fn(async () => ({})),
+    } as unknown as KubernetesApiClient["rbac"],
+    networking: {
+      readNamespacedNetworkPolicy: vi.fn(notFound),
+      createNamespacedNetworkPolicy: vi.fn(async () => ({})),
+      patchNamespacedNetworkPolicy: vi.fn(async () => ({})),
+    } as unknown as KubernetesApiClient["networking"],
+    apiext: {} as unknown as KubernetesApiClient["apiext"],
+    batch: {} as unknown as KubernetesApiClient["batch"],
+    describe: () => "fake",
+    request: vi.fn(async () => ({})),
+  } as unknown as KubernetesApiClient;
+}
+
+const baseInput: Omit<EnsureTenantInput, "connection"> = {
+  company: { id: "11111111-1111-1111-1111-111111111111", slug: "acme-corp" },
+  tenantPolicy: null,
+  driverServiceAccount: { name: "paperclip-driver", namespace: "paperclip-system" },
+  controlPlane: {
+    topology: "in-cluster",
+    namespaceLabels: { "paperclip.ai/role": "control-plane" },
+    podLabels: { "app.kubernetes.io/name": "paperclip-server" },
+  },
+  adapterAllowFqdns: ["*.anthropic.com"],
+  imagePullDockerConfigJson: null,
+};
+
+const baseConnection = {
+  id: "c-1", label: "test", kind: "kubeconfig" as const, kubeconfigYaml: "<unused>",
+  defaultNamespacePrefix: "paperclip-",
+  allowAgentImageOverride: false,
+  capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] as ("amd64" | "arm64")[] },
+};
+
+describe("ensureTenantNamespace", () => {
+  it("derives the namespace name and creates objects in the correct order", async () => {
+    const client = makeFakeClient();
+    const result = await ensureTenantNamespace(client, { ...baseInput, connection: baseConnection });
+    expect(result.namespace).toBe("paperclip-acme-corp");
+    expect(result.ciliumApplied).toBe(false);
+    expect(client.core.createNamespace).toHaveBeenCalledTimes(1);
+    expect(client.core.createNamespacedServiceAccount).toHaveBeenCalledTimes(1);
+    expect(client.core.createNamespacedResourceQuota).toHaveBeenCalledTimes(1);
+    expect(client.core.createNamespacedLimitRange).toHaveBeenCalledTimes(1);
+    // 2 default-deny (ingress + egress) + 1 agent egress
+    expect(client.networking.createNamespacedNetworkPolicy).toHaveBeenCalledTimes(3);
+    // No Cilium without capability
+    expect(client.request).not.toHaveBeenCalled();
+    // No image pull secret without dockerConfigJson
+    expect(client.core.createNamespacedSecret).not.toHaveBeenCalled();
+  });
+
+  it("creates namespace BEFORE any namespaced object", async () => {
+    const client = makeFakeClient();
+    const callOrder: string[] = [];
+    (client.core.createNamespace as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push("ns"); return {}; });
+    (client.core.createNamespacedServiceAccount as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push("sa"); return {}; });
+    (client.networking.createNamespacedNetworkPolicy as ReturnType<typeof vi.fn>).mockImplementation(async () => { callOrder.push("np"); return {}; });
+    await ensureTenantNamespace(client, { ...baseInput, connection: baseConnection });
+    expect(callOrder[0]).toBe("ns");
+  });
+
+  it("emits a Cilium policy when cluster supports it", async () => {
+    const client = makeFakeClient();
+    (client.request as ReturnType<typeof vi.fn>).mockImplementation(async (method: string) =>
+      method === "GET" ? Promise.reject({ statusCode: 404, message: "404" }) : ({}),
+    );
+    const conn = { ...baseConnection, capabilities: { ...baseConnection.capabilities, cilium: true } };
+    const result = await ensureTenantNamespace(client, { ...baseInput, connection: conn });
+    expect(result.ciliumApplied).toBe(true);
+    expect(client.request).toHaveBeenCalled();
+  });
+
+  it("creates an image pull secret when dockerConfigJson is supplied", async () => {
+    const client = makeFakeClient();
+    await ensureTenantNamespace(client, {
+      ...baseInput, connection: baseConnection,
+      imagePullDockerConfigJson: '{"auths":{"ghcr.io":{}}}',
+    });
+    expect(client.core.createNamespacedSecret).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits cross-cluster NetworkPolicy without the in-cluster control-plane rule", async () => {
+    const client = makeFakeClient();
+    const callBodies: unknown[] = [];
+    (client.networking.createNamespacedNetworkPolicy as ReturnType<typeof vi.fn>).mockImplementation(async (_ns: string, body: unknown) => {
+      callBodies.push(body); return {};
+    });
+    await ensureTenantNamespace(client, {
+      ...baseInput, connection: baseConnection,
+      controlPlane: { topology: "cross-cluster", namespaceLabels: {}, podLabels: {} },
+    });
+    const agentEgress = callBodies.find((b) => (b as { metadata?: { name?: string } }).metadata?.name === "paperclip-agent-egress");
+    expect(agentEgress).toBeDefined();
+    const egressRules = (agentEgress as { spec: { egress: Array<{ to?: Array<{ namespaceSelector?: { matchLabels?: Record<string, string> } }> }> } }).spec.egress;
+    const hasControlPlaneRule = egressRules.some((r) =>
+      r.to?.some((t) => t.namespaceSelector?.matchLabels?.["paperclip.ai/role"] === "control-plane"),
+    );
+    expect(hasControlPlaneRule).toBe(false);
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/image-pull-secret.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/image-pull-secret.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { buildImagePullSecret } from "../../src/orchestrator/image-pull-secret.js";
+
+describe("buildImagePullSecret", () => {
+  it("base64-encodes the dockerconfigjson and sets the dockerconfigjson type", () => {
+    const dockerConfig = { auths: { "ghcr.io": { auth: "Zm9vOmJhcg==" } } };
+    const s = buildImagePullSecret({
+      namespace: "paperclip-acme",
+      companyId: "c-1", companySlug: "acme",
+      dockerConfigJson: JSON.stringify(dockerConfig),
+    });
+    expect(s.type).toBe("kubernetes.io/dockerconfigjson");
+    expect(s.metadata?.name).toBe("paperclip-image-pull");
+    expect(s.metadata?.namespace).toBe("paperclip-acme");
+    expect(s.data?.[".dockerconfigjson"]).toBeDefined();
+    const decoded = Buffer.from(s.data![".dockerconfigjson"]!, "base64").toString("utf-8");
+    expect(JSON.parse(decoded)).toEqual(dockerConfig);
+  });
+
+  it("attaches paperclip tenant labels", () => {
+    const s = buildImagePullSecret({
+      namespace: "paperclip-x", companyId: "c-1", companySlug: "x",
+      dockerConfigJson: "{}",
+    });
+    expect(s.metadata?.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+    expect(s.metadata?.labels?.["paperclip.ai/company-id"]).toBe("c-1");
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/namespace.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/namespace.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { buildNamespace } from "../../src/orchestrator/namespace.js";
+import { describe, it, expect, vi } from "vitest";
+import { applyNamespace, buildNamespace } from "../../src/orchestrator/namespace.js";
+import type { KubernetesApiClient } from "../../src/types.js";
 
 describe("buildNamespace", () => {
   it("produces a namespace with paperclip labels and PSS restricted", () => {
@@ -26,5 +27,74 @@ describe("buildNamespace", () => {
     expect(ns.metadata?.labels?.["custom/label"]).toBe("value");
     // base labels still present
     expect(ns.metadata?.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+  });
+});
+
+describe("applyNamespace cross-tenant guard", () => {
+  function makeClient(opts: {
+    readNamespace: ReturnType<typeof vi.fn>;
+    patchNamespace?: ReturnType<typeof vi.fn>;
+    createNamespace?: ReturnType<typeof vi.fn>;
+  }): KubernetesApiClient {
+    return {
+      core: {
+        readNamespace: opts.readNamespace,
+        patchNamespace: opts.patchNamespace ?? vi.fn(async () => ({ body: {} })),
+        createNamespace: opts.createNamespace ?? vi.fn(async () => ({ body: {} })),
+      },
+    } as unknown as KubernetesApiClient;
+  }
+
+  it("refuses to patch a namespace owned by a different company", async () => {
+    // The pre-existing namespace is paperclip-managed but labeled for company A.
+    // Company B's ensureTenant call must NOT silently take it over.
+    const readNamespace = vi.fn(async () => ({
+      body: {
+        metadata: {
+          name: "paperclip-acme",
+          labels: {
+            "paperclip.ai/managed-by": "paperclip",
+            "paperclip.ai/company-id": "company-A",
+            "paperclip.ai/company-slug": "acme",
+          },
+        },
+      },
+    }));
+    const patchNamespace = vi.fn();
+    const client = makeClient({ readNamespace, patchNamespace });
+    const incoming = buildNamespace({ name: "paperclip-acme", companyId: "company-B", companySlug: "acme" });
+    await expect(applyNamespace(client, incoming)).rejects.toThrow(/labeled for company company-A, not company-B/);
+    expect(patchNamespace).not.toHaveBeenCalled();
+  });
+
+  it("permits patching a namespace owned by the same company", async () => {
+    const readNamespace = vi.fn(async () => ({
+      body: {
+        metadata: {
+          name: "paperclip-acme",
+          labels: {
+            "paperclip.ai/managed-by": "paperclip",
+            "paperclip.ai/company-id": "company-A",
+            "paperclip.ai/company-slug": "acme",
+          },
+        },
+      },
+    }));
+    const patchNamespace = vi.fn(async () => ({ body: {} }));
+    const client = makeClient({ readNamespace, patchNamespace });
+    const incoming = buildNamespace({ name: "paperclip-acme", companyId: "company-A", companySlug: "acme" });
+    await expect(applyNamespace(client, incoming)).resolves.toEqual({ created: false });
+    expect(patchNamespace).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refuses to patch a namespace not labeled managed-by=paperclip", async () => {
+    const readNamespace = vi.fn(async () => ({
+      body: { metadata: { name: "paperclip-acme", labels: {} } },
+    }));
+    const patchNamespace = vi.fn();
+    const client = makeClient({ readNamespace, patchNamespace });
+    const incoming = buildNamespace({ name: "paperclip-acme", companyId: "company-A", companySlug: "acme" });
+    await expect(applyNamespace(client, incoming)).rejects.toThrow(/missing label paperclip.ai\/managed-by/);
+    expect(patchNamespace).not.toHaveBeenCalled();
   });
 });

--- a/packages/adapters/kubernetes-execution/test/unit/namespace.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/namespace.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { buildNamespace } from "../../src/orchestrator/namespace.js";
+
+describe("buildNamespace", () => {
+  it("produces a namespace with paperclip labels and PSS restricted", () => {
+    const ns = buildNamespace({
+      name: "paperclip-acme-corp",
+      companyId: "c-uuid",
+      companySlug: "acme-corp",
+    });
+    expect(ns.kind).toBe("Namespace");
+    expect(ns.metadata?.name).toBe("paperclip-acme-corp");
+    expect(ns.metadata?.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+    expect(ns.metadata?.labels?.["paperclip.ai/company-id"]).toBe("c-uuid");
+    expect(ns.metadata?.labels?.["paperclip.ai/company-slug"]).toBe("acme-corp");
+    expect(ns.metadata?.labels?.["pod-security.kubernetes.io/enforce"]).toBe("restricted");
+    expect(ns.metadata?.labels?.["pod-security.kubernetes.io/audit"]).toBe("restricted");
+    expect(ns.metadata?.labels?.["pod-security.kubernetes.io/warn"]).toBe("restricted");
+  });
+
+  it("merges extra labels with the base set", () => {
+    const ns = buildNamespace({
+      name: "paperclip-x", companyId: "c", companySlug: "x",
+      extraLabels: { "custom/label": "value" },
+    });
+    expect(ns.metadata?.labels?.["custom/label"]).toBe("value");
+    // base labels still present
+    expect(ns.metadata?.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/naming.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/naming.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { deriveNamespaceName, isValidDns1123Label } from "../../src/orchestrator/naming.js";
+
+describe("isValidDns1123Label", () => {
+  it("accepts simple slugs", () => {
+    expect(isValidDns1123Label("acme-corp")).toBe(true);
+    expect(isValidDns1123Label("a")).toBe(true);
+  });
+  it("rejects uppercase, leading/trailing hyphens, dots, length > 63", () => {
+    expect(isValidDns1123Label("Acme")).toBe(false);
+    expect(isValidDns1123Label("-acme")).toBe(false);
+    expect(isValidDns1123Label("acme-")).toBe(false);
+    expect(isValidDns1123Label("ac.me")).toBe(false);
+    expect(isValidDns1123Label("x".repeat(64))).toBe(false);
+  });
+});
+
+describe("deriveNamespaceName", () => {
+  it("returns paperclip-{slug} for short clean slugs", () => {
+    expect(deriveNamespaceName({
+      companySlug: "acme-corp",
+      companyId: "11111111-1111-1111-1111-111111111111",
+      prefix: "paperclip-",
+    })).toBe("paperclip-acme-corp");
+  });
+
+  it("appends a short hash when the slug overflows after prefix", () => {
+    const longSlug = "a".repeat(60);
+    const result = deriveNamespaceName({
+      companySlug: longSlug,
+      companyId: "22222222-2222-2222-2222-222222222222",
+      prefix: "paperclip-",
+    });
+    expect(result.startsWith("paperclip-")).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(63);
+    expect(result).toMatch(/-[0-9a-z]{8}$/);
+  });
+
+  it("appends a short hash when explicit collision flag is set", () => {
+    const withHash = deriveNamespaceName({
+      companySlug: "acme-corp",
+      companyId: "33333333-3333-3333-3333-333333333333",
+      prefix: "paperclip-",
+      collisionFallback: true,
+    });
+    expect(withHash).toMatch(/^paperclip-acme-corp-[0-9a-z]{8}$/);
+  });
+
+  it("sanitizes invalid slugs deterministically and produces a DNS-1123 label", () => {
+    const r = deriveNamespaceName({
+      companySlug: "Acme Corp.!",
+      companyId: "44444444-4444-4444-4444-444444444444",
+      prefix: "paperclip-",
+    });
+    expect(isValidDns1123Label(r)).toBe(true);
+    expect(r.startsWith("paperclip-")).toBe(true);
+  });
+
+  it("produces a stable result for the same companyId across calls", () => {
+    const a = deriveNamespaceName({
+      companySlug: "acme-corp", companyId: "55555555-5555-5555-5555-555555555555",
+      prefix: "paperclip-", collisionFallback: true,
+    });
+    const b = deriveNamespaceName({
+      companySlug: "acme-corp", companyId: "55555555-5555-5555-5555-555555555555",
+      prefix: "paperclip-", collisionFallback: true,
+    });
+    expect(a).toBe(b);
+  });
+
+  it("produces different hash suffixes for different companyIds with the same slug", () => {
+    const a = deriveNamespaceName({
+      companySlug: "acme-corp", companyId: "11111111-1111-1111-1111-111111111111",
+      prefix: "paperclip-", collisionFallback: true,
+    });
+    const b = deriveNamespaceName({
+      companySlug: "acme-corp", companyId: "22222222-2222-2222-2222-222222222222",
+      prefix: "paperclip-", collisionFallback: true,
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("returns a valid label even when the slug becomes empty after sanitization", () => {
+    const r = deriveNamespaceName({
+      companySlug: "!!!",
+      companyId: "66666666-6666-6666-6666-666666666666",
+      prefix: "paperclip-",
+    });
+    expect(isValidDns1123Label(r)).toBe(true);
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/network-policy.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/network-policy.test.ts
@@ -18,7 +18,7 @@ describe("buildDefaultDenyPolicies", () => {
 });
 
 describe("buildAgentEgressPolicy", () => {
-  it("denies RFC1918 + link-local + CGNAT + IPv6 ULA in the internet rule", () => {
+  it("denies RFC1918 + link-local + CGNAT in the IPv4 internet rule and IPv6 ULA in the IPv6 rule", () => {
     const p = buildAgentEgressPolicy({
       namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
       topology: "in-cluster",
@@ -29,12 +29,16 @@ describe("buildAgentEgressPolicy", () => {
     });
     const internetRule = p.spec?.egress?.find(e => e.to?.some(t => t.ipBlock));
     expect(internetRule).toBeDefined();
-    const ipBlock = internetRule!.to!.find(t => t.ipBlock)!.ipBlock!;
-    expect(ipBlock.cidr).toBe("0.0.0.0/0");
-    expect(ipBlock.except).toEqual(expect.arrayContaining([
+    // IPv4 block: 0.0.0.0/0 with IPv4-only exceptions
+    const ipv4Block = internetRule!.to!.find(t => t.ipBlock?.cidr === "0.0.0.0/0")!.ipBlock!;
+    expect(ipv4Block.except).toEqual(expect.arrayContaining([
       "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
-      "169.254.0.0/16", "100.64.0.0/10", "fd00::/8",
+      "169.254.0.0/16", "100.64.0.0/10",
     ]));
+    expect(ipv4Block.except).not.toContain("fd00::/8");
+    // IPv6 block: ::/0 with IPv6 ULA exception
+    const ipv6Block = internetRule!.to!.find(t => t.ipBlock?.cidr === "::/0")!.ipBlock!;
+    expect(ipv6Block.except).toContain("fd00::/8");
   });
 
   it("includes a DNS egress rule on UDP and TCP port 53 to kube-dns", () => {

--- a/packages/adapters/kubernetes-execution/test/unit/network-policy.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/network-policy.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { buildDefaultDenyPolicies, buildAgentEgressPolicy } from "../../src/orchestrator/network-policy.js";
+
+describe("buildDefaultDenyPolicies", () => {
+  it("emits two NetworkPolicies, one for ingress and one for egress, with empty podSelector", () => {
+    const policies = buildDefaultDenyPolicies({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+    });
+    expect(policies).toHaveLength(2);
+    for (const p of policies) {
+      expect(p.spec?.podSelector).toEqual({});
+      expect(p.metadata?.namespace).toBe("paperclip-acme");
+      expect(p.metadata?.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+    }
+    expect(policies[0].spec?.policyTypes).toContain("Ingress");
+    expect(policies[1].spec?.policyTypes).toContain("Egress");
+  });
+});
+
+describe("buildAgentEgressPolicy", () => {
+  it("denies RFC1918 + link-local + CGNAT + IPv6 ULA in the internet rule", () => {
+    const p = buildAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      topology: "in-cluster",
+      controlPlaneSelector: {
+        namespaceLabel: { "paperclip.ai/role": "control-plane" },
+        podLabel: { "app.kubernetes.io/name": "paperclip-server" },
+      },
+    });
+    const internetRule = p.spec?.egress?.find(e => e.to?.some(t => t.ipBlock));
+    expect(internetRule).toBeDefined();
+    const ipBlock = internetRule!.to!.find(t => t.ipBlock)!.ipBlock!;
+    expect(ipBlock.cidr).toBe("0.0.0.0/0");
+    expect(ipBlock.except).toEqual(expect.arrayContaining([
+      "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+      "169.254.0.0/16", "100.64.0.0/10", "fd00::/8",
+    ]));
+  });
+
+  it("includes a DNS egress rule on UDP and TCP port 53 to kube-dns", () => {
+    const p = buildAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      topology: "cross-cluster", controlPlaneSelector: null,
+    });
+    const dnsRule = p.spec?.egress?.find(e =>
+      e.to?.some(t => t.namespaceSelector?.matchLabels?.["kubernetes.io/metadata.name"] === "kube-system"),
+    );
+    expect(dnsRule).toBeDefined();
+    expect(dnsRule!.ports).toEqual(expect.arrayContaining([
+      { port: 53, protocol: "UDP" }, { port: 53, protocol: "TCP" },
+    ]));
+  });
+
+  it("omits the in-cluster control plane rule for cross-cluster topology", () => {
+    const p = buildAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      topology: "cross-cluster",
+      controlPlaneSelector: null,
+    });
+    expect(p.spec?.egress?.some(e =>
+      e.to?.some(t => t.namespaceSelector?.matchLabels?.["paperclip.ai/role"] === "control-plane"),
+    )).toBe(false);
+  });
+
+  it("targets only pods labeled paperclip.ai/role=agent-runtime", () => {
+    const p = buildAgentEgressPolicy({
+      namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme",
+      topology: "in-cluster",
+      controlPlaneSelector: { namespaceLabel: {}, podLabel: {} },
+    });
+    expect(p.spec?.podSelector?.matchLabels?.["paperclip.ai/role"]).toBe("agent-runtime");
+    expect(p.spec?.policyTypes).toEqual(["Egress"]);
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/rbac.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/rbac.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { buildAgentServiceAccount, buildDriverRoleBinding } from "../../src/orchestrator/rbac.js";
+
+describe("buildAgentServiceAccount", () => {
+  it("creates paperclip-agent SA with token automounting disabled", () => {
+    const sa = buildAgentServiceAccount({ namespace: "paperclip-acme", companyId: "c-1", companySlug: "acme" });
+    expect(sa.metadata?.name).toBe("paperclip-agent");
+    expect(sa.metadata?.namespace).toBe("paperclip-acme");
+    expect(sa.automountServiceAccountToken).toBe(false);
+    expect(sa.metadata?.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+    expect(sa.metadata?.labels?.["paperclip.ai/company-id"]).toBe("c-1");
+  });
+});
+
+describe("buildDriverRoleBinding", () => {
+  it("references the driver SA in its own namespace and the cluster role for tenant management", () => {
+    const rb = buildDriverRoleBinding({
+      namespace: "paperclip-acme",
+      driverServiceAccount: { name: "paperclip-driver", namespace: "paperclip-system" },
+      clusterRoleName: "paperclip-tenant-manager",
+      companyId: "c-1", companySlug: "acme",
+    });
+    expect(rb.subjects?.[0]).toMatchObject({ kind: "ServiceAccount", name: "paperclip-driver", namespace: "paperclip-system" });
+    expect(rb.roleRef.kind).toBe("ClusterRole");
+    expect(rb.roleRef.name).toBe("paperclip-tenant-manager");
+    expect(rb.metadata?.namespace).toBe("paperclip-acme");
+    expect(rb.metadata?.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/resource-quota.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/resource-quota.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildResourceQuota,
+  buildLimitRange,
+  defaultTenantQuota,
+  defaultTenantLimits,
+} from "../../src/orchestrator/resource-quota.js";
+
+describe("buildResourceQuota", () => {
+  it("uses defaults when no tenant override is supplied", () => {
+    const q = buildResourceQuota({
+      namespace: "paperclip-acme",
+      companyId: "c-1",
+      companySlug: "acme",
+      override: null,
+    });
+    expect(q.spec?.hard?.["requests.cpu"]).toBe(defaultTenantQuota.requestsCpu);
+    expect(q.spec?.hard?.["count/jobs.batch"]).toBe(String(defaultTenantQuota.countJobs));
+    expect(q.metadata?.labels?.["paperclip.ai/managed-by"]).toBe("paperclip");
+  });
+
+  it("respects tenant override values", () => {
+    const q = buildResourceQuota({
+      namespace: "paperclip-acme",
+      companyId: "c-1",
+      companySlug: "acme",
+      override: { requestsCpu: "32", countJobs: 200 },
+    });
+    expect(q.spec?.hard?.["requests.cpu"]).toBe("32");
+    expect(q.spec?.hard?.["count/jobs.batch"]).toBe("200");
+    // Other defaults still apply
+    expect(q.spec?.hard?.["requests.memory"]).toBe(defaultTenantQuota.requestsMemory);
+  });
+});
+
+describe("buildLimitRange", () => {
+  it("emits Container + PVC limits with default values", () => {
+    const lr = buildLimitRange({
+      namespace: "paperclip-acme",
+      companyId: "c-1",
+      companySlug: "acme",
+      override: null,
+    });
+    const container = lr.spec?.limits?.find((l) => l.type === "Container");
+    expect(container?.default?.cpu).toBe(defaultTenantLimits.default.cpu);
+    expect(container?.defaultRequest?.memory).toBe(defaultTenantLimits.defaultRequest.memory);
+    expect(container?.max?.cpu).toBe(defaultTenantLimits.max.cpu);
+    const pvc = lr.spec?.limits?.find((l) => l.type === "PersistentVolumeClaim");
+    expect(pvc?.max?.storage).toBe(defaultTenantLimits.pvcMaxStorage);
+  });
+
+  it("override merges deeply: setting only default.cpu keeps default.memory", () => {
+    const lr = buildLimitRange({
+      namespace: "paperclip-acme",
+      companyId: "c-1",
+      companySlug: "acme",
+      override: { default: { cpu: "2" } },
+    });
+    const container = lr.spec?.limits?.find((l) => l.type === "Container");
+    expect(container?.default?.cpu).toBe("2");
+    expect(container?.default?.memory).toBe(defaultTenantLimits.default.memory);
+  });
+});

--- a/packages/adapters/kubernetes-execution/test/unit/resource-quota.test.ts
+++ b/packages/adapters/kubernetes-execution/test/unit/resource-quota.test.ts
@@ -42,7 +42,9 @@ describe("buildLimitRange", () => {
       override: null,
     });
     const container = lr.spec?.limits?.find((l) => l.type === "Container");
-    expect(container?.default?.cpu).toBe(defaultTenantLimits.default.cpu);
+    // The k8s typed client renames `default` → `_default` because `default` is a reserved
+    // word in TypeScript. The wire format still uses `default`; we assert the JS field name.
+    expect(container?._default?.cpu).toBe(defaultTenantLimits.default.cpu);
     expect(container?.defaultRequest?.memory).toBe(defaultTenantLimits.defaultRequest.memory);
     expect(container?.max?.cpu).toBe(defaultTenantLimits.max.cpu);
     const pvc = lr.spec?.limits?.find((l) => l.type === "PersistentVolumeClaim");
@@ -57,7 +59,7 @@ describe("buildLimitRange", () => {
       override: { default: { cpu: "2" } },
     });
     const container = lr.spec?.limits?.find((l) => l.type === "Container");
-    expect(container?.default?.cpu).toBe("2");
-    expect(container?.default?.memory).toBe(defaultTenantLimits.default.memory);
+    expect(container?._default?.cpu).toBe("2");
+    expect(container?._default?.memory).toBe(defaultTenantLimits.default.memory);
   });
 });

--- a/packages/adapters/kubernetes-execution/tsconfig.json
+++ b/packages/adapters/kubernetes-execution/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/kubernetes-execution/vitest.config.ts
+++ b/packages/adapters/kubernetes-execution/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/packages/adapters/kubernetes-execution/vitest.integration.config.ts
+++ b/packages/adapters/kubernetes-execution/vitest.integration.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/integration/**/*.test.ts"],
+    testTimeout: 180_000,
+    hookTimeout: 240_000,
+    // Each integration test spins up its own kind cluster, so run them sequentially
+    // to avoid Docker disk/CPU pressure.
+    fileParallelism: false,
+  },
+});

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -194,6 +194,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
   });
+  if (executionTarget?.kind === "kubernetes") {
+    return {
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      errorCode: "execution_target_not_yet_supported",
+      errorMessage:
+        "Kubernetes execution target is not implemented yet for this adapter. " +
+        "Tenant provisioning is available in M1; agent execution lands in M2.",
+    };
+  }
   const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
 
   const promptTemplate = asString(

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -216,6 +216,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     executionTarget: ctx.executionTarget,
     legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
   });
+  if (executionTarget?.kind === "kubernetes") {
+    return {
+      exitCode: null,
+      signal: null,
+      timedOut: false,
+      errorCode: "execution_target_not_yet_supported",
+      errorMessage:
+        "Kubernetes execution target is not implemented yet for this adapter. " +
+        "Tenant provisioning is available in M1; agent execution lands in M2.",
+    };
+  }
   const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
 
   const promptTemplate = asString(

--- a/packages/db/src/migrations/0084_cluster_connections.sql
+++ b/packages/db/src/migrations/0084_cluster_connections.sql
@@ -1,0 +1,51 @@
+CREATE TABLE "cluster_connections" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"label" text NOT NULL,
+	"kind" text NOT NULL,
+	"kubeconfig_secret_ref" jsonb,
+	"api_server_url" text,
+	"default_namespace_prefix" text DEFAULT 'paperclip-' NOT NULL,
+	"capabilities" jsonb NOT NULL,
+	"paperclip_public_url" text,
+	"image_registry" text,
+	"allow_agent_image_override" text DEFAULT 'false' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_by" text NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "cluster_namespace_bindings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"cluster_connection_id" uuid NOT NULL,
+	"company_id" uuid NOT NULL,
+	"namespace_name" text NOT NULL,
+	"archived_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "cluster_tenant_policies" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"cluster_connection_id" uuid NOT NULL,
+	"company_id" uuid NOT NULL,
+	"quota_json" jsonb,
+	"limit_range_json" jsonb,
+	"network_json" jsonb,
+	"image_overrides_json" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "cluster_namespace_bindings" ADD CONSTRAINT "cluster_namespace_bindings_cluster_connection_id_cluster_connections_id_fk" FOREIGN KEY ("cluster_connection_id") REFERENCES "public"."cluster_connections"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cluster_namespace_bindings" ADD CONSTRAINT "cluster_namespace_bindings_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cluster_tenant_policies" ADD CONSTRAINT "cluster_tenant_policies_cluster_connection_id_cluster_connections_id_fk" FOREIGN KEY ("cluster_connection_id") REFERENCES "public"."cluster_connections"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "cluster_tenant_policies" ADD CONSTRAINT "cluster_tenant_policies_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "cluster_connections_label_uq" ON "cluster_connections" USING btree ("label");--> statement-breakpoint
+CREATE INDEX "cluster_connections_kind_idx" ON "cluster_connections" USING btree ("kind");--> statement-breakpoint
+CREATE UNIQUE INDEX "cluster_namespace_bindings_cluster_company_uq" ON "cluster_namespace_bindings" USING btree ("cluster_connection_id","company_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "cluster_namespace_bindings_cluster_ns_uq" ON "cluster_namespace_bindings" USING btree ("cluster_connection_id","namespace_name");--> statement-breakpoint
+CREATE INDEX "cluster_namespace_bindings_company_idx" ON "cluster_namespace_bindings" USING btree ("company_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "cluster_tenant_policies_cluster_company_uq" ON "cluster_tenant_policies" USING btree ("cluster_connection_id","company_id");--> statement-breakpoint
+CREATE INDEX "cluster_tenant_policies_company_idx" ON "cluster_tenant_policies" USING btree ("company_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "documents_title_search_idx" ON "documents" USING gin ("title" gin_trgm_ops);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "documents_latest_body_search_idx" ON "documents" USING gin ("latest_body" gin_trgm_ops);

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1778074536410,
       "tag": "0083_company_secret_provider_configs",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1778275765114,
+      "tag": "0084_cluster_connections",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/cluster_connections.test.ts
+++ b/packages/db/src/schema/cluster_connections.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "../test-embedded-postgres.js";
+import { createDb } from "../client.js";
+import { clusterConnections } from "./cluster_connections.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping cluster_connections schema tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("cluster_connections schema", () => {
+  let connectionString: string;
+  let cleanup: () => Promise<void>;
+
+  beforeAll(async () => {
+    const db = await startEmbeddedPostgresTestDatabase("paperclip-cluster-connections-test-");
+    connectionString = db.connectionString;
+    cleanup = db.cleanup;
+  }, 60_000);
+
+  afterAll(async () => {
+    await cleanup?.();
+  });
+
+  it(
+    "inserts and reads back a row with the expected shape",
+    async () => {
+      const db = createDb(connectionString);
+      const [inserted] = await db.insert(clusterConnections).values({
+        label: "test-cluster",
+        kind: "in-cluster",
+        capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+        createdBy: "system",
+      }).returning();
+      expect(inserted.id).toBeDefined();
+      expect(inserted.defaultNamespacePrefix).toBe("paperclip-");
+      expect(inserted.allowAgentImageOverride).toBe("false");
+    },
+    30_000,
+  );
+});

--- a/packages/db/src/schema/cluster_connections.ts
+++ b/packages/db/src/schema/cluster_connections.ts
@@ -1,0 +1,31 @@
+import { pgTable, uuid, text, jsonb, timestamp, index, uniqueIndex } from "drizzle-orm/pg-core";
+
+export const clusterConnections = pgTable(
+  "cluster_connections",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    label: text("label").notNull(),
+    kind: text("kind").notNull(), // "in-cluster" | "kubeconfig"
+    kubeconfigSecretRef: jsonb("kubeconfig_secret_ref").$type<{
+      provider: string;
+      name: string;
+    } | null>(),
+    apiServerUrl: text("api_server_url"),
+    defaultNamespacePrefix: text("default_namespace_prefix").notNull().default("paperclip-"),
+    capabilities: jsonb("capabilities").notNull().$type<{
+      cilium: boolean;
+      storageClass: string;
+      architectures: ("amd64" | "arm64")[];
+    }>(),
+    paperclipPublicUrl: text("paperclip_public_url"),
+    imageRegistry: text("image_registry"),
+    allowAgentImageOverride: text("allow_agent_image_override").notNull().default("false"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    createdBy: text("created_by").notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    labelUq: uniqueIndex("cluster_connections_label_uq").on(table.label),
+    kindIdx: index("cluster_connections_kind_idx").on(table.kind),
+  }),
+);

--- a/packages/db/src/schema/cluster_namespace_bindings.ts
+++ b/packages/db/src/schema/cluster_namespace_bindings.ts
@@ -1,0 +1,23 @@
+import { pgTable, uuid, text, timestamp, uniqueIndex, index } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { clusterConnections } from "./cluster_connections.js";
+
+export const clusterNamespaceBindings = pgTable(
+  "cluster_namespace_bindings",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    clusterConnectionId: uuid("cluster_connection_id").notNull().references(() => clusterConnections.id, { onDelete: "cascade" }),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    namespaceName: text("namespace_name").notNull(),
+    archivedAt: timestamp("archived_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    perClusterCompanyUq: uniqueIndex("cluster_namespace_bindings_cluster_company_uq")
+      .on(table.clusterConnectionId, table.companyId),
+    namespaceLookupUq: uniqueIndex("cluster_namespace_bindings_cluster_ns_uq")
+      .on(table.clusterConnectionId, table.namespaceName),
+    companyIdx: index("cluster_namespace_bindings_company_idx").on(table.companyId),
+  }),
+);

--- a/packages/db/src/schema/cluster_tenant_policies.ts
+++ b/packages/db/src/schema/cluster_tenant_policies.ts
@@ -1,0 +1,41 @@
+import { pgTable, uuid, jsonb, timestamp, uniqueIndex, index } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { clusterConnections } from "./cluster_connections.js";
+
+export const clusterTenantPolicies = pgTable(
+  "cluster_tenant_policies",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    clusterConnectionId: uuid("cluster_connection_id").notNull().references(() => clusterConnections.id, { onDelete: "cascade" }),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    quotaJson: jsonb("quota_json").$type<{
+      requestsCpu?: string;
+      requestsMemory?: string;
+      limitsCpu?: string;
+      limitsMemory?: string;
+      requestsStorage?: string;
+      countJobs?: number;
+      countPvcs?: number;
+      countSecrets?: number;
+      countConfigMaps?: number;
+    } | null>(),
+    limitRangeJson: jsonb("limit_range_json").$type<{
+      defaultRequest?: { cpu?: string; memory?: string };
+      default?:        { cpu?: string; memory?: string };
+      max?:            { cpu?: string; memory?: string };
+      pvcMaxStorage?: string;
+    } | null>(),
+    networkJson: jsonb("network_json").$type<{
+      additionalAllowFqdns?: string[];
+      httpProxyUrl?: string | null;
+    } | null>(),
+    imageOverridesJson: jsonb("image_overrides_json").$type<Record<string, string> | null>(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    perClusterCompanyUq: uniqueIndex("cluster_tenant_policies_cluster_company_uq")
+      .on(table.clusterConnectionId, table.companyId),
+    companyIdx: index("cluster_tenant_policies_company_idx").on(table.companyId),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -75,3 +75,6 @@ export { pluginDatabaseNamespaces, pluginMigrations } from "./plugin_database.js
 export { pluginJobs, pluginJobRuns } from "./plugin_jobs.js";
 export { pluginWebhookDeliveries } from "./plugin_webhooks.js";
 export { pluginLogs } from "./plugin_logs.js";
+export { clusterConnections } from "./cluster_connections.js";
+export { clusterNamespaceBindings } from "./cluster_namespace_bindings.js";
+export { clusterTenantPolicies } from "./cluster_tenant_policies.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         specifier: ^17.0.1
         version: 17.3.1
       drizzle-orm:
-        specifier: 0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        specifier: 0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -257,8 +257,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       drizzle-orm:
-        specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -553,7 +553,7 @@ importers:
         version: 3.0.1(ajv@8.18.0)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -567,8 +567,8 @@ importers:
         specifier: ^17.0.1
         version: 17.3.1
       drizzle-orm:
-        specifier: ^0.38.4
-        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+        specifier: ^0.45.2
+        version: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -3844,6 +3844,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -4653,8 +4654,8 @@ packages:
     resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
     hasBin: true
 
-  drizzle-orm@0.38.4:
-    resolution: {integrity: sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q==}
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -4664,25 +4665,25 @@ packages:
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
-      '@types/react': '>=18'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
       prisma: '*'
-      react: '>=18'
       sql.js: '>=1'
       sqlite3: '>=5'
     peerDependenciesMeta:
@@ -4712,9 +4713,9 @@ packages:
         optional: true
       '@types/pg':
         optional: true
-      '@types/react':
-        optional: true
       '@types/sql.js':
+        optional: true
+      '@upstash/redis':
         optional: true
       '@vercel/postgres':
         optional: true
@@ -4725,6 +4726,8 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
+        optional: true
+      gel:
         optional: true
       knex:
         optional: true
@@ -4737,8 +4740,6 @@ packages:
       postgres:
         optional: true
       prisma:
-        optional: true
-      react:
         optional: true
       sql.js:
         optional: true
@@ -10602,7 +10603,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -10618,7 +10619,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
+      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
@@ -11148,14 +11149,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
-      '@types/react': 19.2.14
       kysely: 0.28.11
       pg: 8.18.0
       postgres: 3.4.8
-      react: 19.2.4
 
   dunder-proto@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
   cli:
     dependencies:
@@ -80,8 +80,8 @@ importers:
         specifier: ^17.0.1
         version: 17.3.1
       drizzle-orm:
-        specifier: 0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
+        specifier: 0.38.4
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -197,6 +197,28 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/kubernetes-execution:
+    dependencies:
+      '@kubernetes/client-node':
+        specifier: ^0.21.0
+        version: 0.21.0
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      yaml:
+        specifier: ^2.5.0
+        version: 2.8.4
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.11)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)
+
   packages/adapters/openclaw-gateway:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -257,8 +279,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       drizzle-orm:
-        specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
+        specifier: ^0.38.4
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -280,7 +302,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
   packages/mcp-server:
     dependencies:
@@ -302,7 +324,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
   packages/plugins/create-paperclip-plugin:
     dependencies:
@@ -352,7 +374,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
@@ -470,7 +492,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
   packages/plugins/sdk:
     dependencies:
@@ -553,7 +575,7 @@ importers:
         version: 3.0.1(ajv@8.18.0)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -567,8 +589,8 @@ importers:
         specifier: ^17.0.1
         version: 17.3.1
       drizzle-orm:
-        specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
+        specifier: ^0.38.4
+        version: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       embedded-postgres:
         specifier: ^18.1.0-beta.16
         version: 18.1.0-beta.16(patch_hash=55uhvnotpqyiy37rn3pqpukhei)
@@ -644,10 +666,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.1.0
-        version: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
   ui:
     dependencies:
@@ -756,13 +778,13 @@ importers:
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-docs':
         specifier: 10.3.5
-        version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       '@storybook/react-vite':
         specifier: 10.3.5
-        version: 10.3.5(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 10.3.5(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       '@tailwindcss/vite':
         specifier: ^4.0.7
-        version: 4.1.18(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 4.1.18(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
@@ -774,7 +796,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+        version: 4.7.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       storybook:
         specifier: 10.3.5
         version: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -786,10 +808,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.1.0
-        version: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
 packages:
 
@@ -1476,6 +1498,12 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -1490,6 +1518,12 @@ packages:
 
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -1512,6 +1546,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.25.12':
     resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
@@ -1526,6 +1566,12 @@ packages:
 
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -1548,6 +1594,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -1562,6 +1614,12 @@ packages:
 
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -1584,6 +1642,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -1598,6 +1662,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -1620,6 +1690,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -1634,6 +1710,12 @@ packages:
 
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -1656,6 +1738,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -1670,6 +1758,12 @@ packages:
 
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -1692,6 +1786,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -1706,6 +1806,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1728,6 +1834,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -1746,6 +1858,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -1760,6 +1878,12 @@ packages:
 
   '@esbuild/linux-x64@0.18.20':
     resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1794,6 +1918,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -1820,6 +1950,12 @@ packages:
 
   '@esbuild/openbsd-x64@0.18.20':
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -1854,6 +1990,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -1868,6 +2010,12 @@ packages:
 
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -1890,6 +2038,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -1904,6 +2058,12 @@ packages:
 
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -2099,6 +2259,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
     resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
     peerDependencies:
@@ -2123,6 +2287,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@kubernetes/client-node@0.21.0':
+    resolution: {integrity: sha512-yYRbgMeyQbvZDHt/ZqsW3m4lRefzhbbJEuj8sVXM+bufKrgmzriA2oq7lWPH/k/LQIicAME9ixPUadTrxIF6dQ==}
 
   '@lexical/clipboard@0.35.0':
     resolution: {integrity: sha512-ko7xSIIiayvDiqjNDX6fgH9RlcM6r9vrrvJYTcfGVBor5httx16lhIi0QJZ4+RNPvGtTjyFv4bwRmsixRRwImg==}
@@ -3635,6 +3802,9 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/caseless@0.12.5':
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -3767,6 +3937,9 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/jsdom@28.0.0':
     resolution: {integrity: sha512-A8TBQQC/xAOojy9kM8E46cqT00sF0h7dWjV8t8BJhUi2rG6JRh7XXQo/oLoENuZIQEpXsxLccLCnknyQd7qssQ==}
 
@@ -3784,6 +3957,9 @@ packages:
 
   '@types/multer@2.0.0':
     resolution: {integrity: sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==}
+
+  '@types/node@20.19.40':
+    resolution: {integrity: sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==}
 
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
@@ -3807,6 +3983,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/request@2.48.13':
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -3844,7 +4023,6 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -3852,8 +4030,22 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -3866,17 +4058,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
@@ -3959,6 +4166,9 @@ packages:
       ajv:
         optional: true
 
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
@@ -3993,6 +4203,13 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -4017,6 +4234,12 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   axe-core@4.11.3:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
@@ -4084,6 +4307,9 @@ packages:
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-auth@1.4.18:
     resolution: {integrity: sha512-bnyifLWBPcYVltH3RhS7CM62MoelEqC6Q+GnZwfiDWNfepXoQZBjEvn4urcERC7NTKgKq5zNBM8rvPvRBa6xcg==}
@@ -4188,6 +4414,10 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
+  byline@5.0.0:
+    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
+    engines: {node: '>=0.10.0'}
+
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -4206,6 +4436,9 @@ packages:
 
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4241,6 +4474,10 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -4336,6 +4573,9 @@ packages:
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -4538,6 +4778,10 @@ packages:
   dagre-d3-es@7.0.13:
     resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
 
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -4654,8 +4898,8 @@ packages:
     resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
     hasBin: true
 
-  drizzle-orm@0.45.2:
-    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+  drizzle-orm@0.38.4:
+    resolution: {integrity: sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
       '@cloudflare/workers-types': '>=4'
@@ -4665,25 +4909,25 @@ packages:
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1.13'
+      '@planetscale/database': '>=1'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
+      '@types/react': '>=18'
       '@types/sql.js': '*'
-      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
-      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
       prisma: '*'
+      react: '>=18'
       sql.js: '>=1'
       sqlite3: '>=5'
     peerDependenciesMeta:
@@ -4713,9 +4957,9 @@ packages:
         optional: true
       '@types/pg':
         optional: true
-      '@types/sql.js':
+      '@types/react':
         optional: true
-      '@upstash/redis':
+      '@types/sql.js':
         optional: true
       '@vercel/postgres':
         optional: true
@@ -4726,8 +4970,6 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
-        optional: true
-      gel:
         optional: true
       knex:
         optional: true
@@ -4741,6 +4983,8 @@ packages:
         optional: true
       prisma:
         optional: true
+      react:
+        optional: true
       sql.js:
         optional: true
       sqlite3:
@@ -4749,6 +4993,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -4816,6 +5063,11 @@ packages:
 
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
     hasBin: true
 
@@ -4906,6 +5158,10 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
 
@@ -4914,6 +5170,9 @@ packages:
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -4949,6 +5208,17 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+
+  form-data@2.3.3:
+    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
+    engines: {node: '>= 0.12'}
+
+  form-data@2.5.5:
+    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
+    engines: {node: '>= 0.12'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -5006,6 +5276,9 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -5019,6 +5292,15 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  har-schema@2.0.0:
+    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
+    engines: {node: '>=4'}
+
+  har-validator@5.1.5:
+    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
+    engines: {node: '>=6'}
+    deprecated: this library is no longer supported
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -5063,6 +5345,10 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  http-signature@1.2.0:
+    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
+    engines: {node: '>=0.8', npm: '>=1.3.7'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -5151,6 +5437,9 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
@@ -5158,12 +5447,23 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
@@ -5181,6 +5481,9 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
 
   jsdom@28.1.0:
     resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
@@ -5200,16 +5503,34 @@ packages:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
 
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonpath-plus@8.1.0:
+    resolution: {integrity: sha512-qVTiuKztFGw0dGhYi3WNqvddx3/SHtyDT0xJaeyz4uP0d1tkpG+0y5uYQ4OcIo1TLAz3PE/qDOW9F0uDt3+CTw==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  jsprim@1.4.2:
+    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
+    engines: {node: '>=0.6.0'}
 
   katex@0.16.37:
     resolution: {integrity: sha512-TIGjO2cCGYono+uUzgkE7RFF329mLLWGuHUlSr6cwIVj9O8f0VQZ783rsanmJpFUo32vvtj7XT04NGRPh+SZFg==}
@@ -5333,6 +5654,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
   lucide-react@0.574.0:
     resolution: {integrity: sha512-dJ8xb5juiZVIbdSn3HTyHsjjIwUwZ4FNwV0RtYDScOyySOeie1oXZTymST6YPJ4Qwt3Po8g4quhYl4OxtACiuQ==}
@@ -5587,6 +5912,10 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
@@ -5625,13 +5954,24 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  oauth-sign@0.9.0:
+    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-hash@2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
+    engines: {node: '>= 6'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  oidc-token-hash@5.2.0:
+    resolution: {integrity: sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==}
+    engines: {node: ^10.13.0 || >=12.0.0}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -5651,6 +5991,9 @@ packages:
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
+
+  openid-client@5.7.1:
+    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   outvariant@1.4.0:
     resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
@@ -5688,12 +6031,18 @@ packages:
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -5832,6 +6181,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -5841,6 +6193,10 @@ packages:
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
+  qs@6.5.5:
+    resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -6001,6 +6357,11 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  request@2.88.2:
+    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
+    engines: {node: '>= 6'}
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -6012,6 +6373,9 @@ packages:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  rfc4648@1.5.4:
+    resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
 
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
@@ -6145,6 +6509,11 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -6166,6 +6535,10 @@ packages:
     peerDependenciesMeta:
       prettier:
         optional: true
+
+  stream-buffers@3.0.3:
+    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
+    engines: {node: '>= 0.10.0'}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -6248,6 +6621,10 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
+  tar@7.5.15:
+    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+    engines: {node: '>=18'}
+
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
@@ -6278,8 +6655,16 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -6296,6 +6681,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@2.5.0:
+    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
+    engines: {node: '>=0.8'}
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -6329,6 +6718,12 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -6403,6 +6798,9 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -6467,6 +6865,11 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
   uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
     engines: {node: '>=8'}
@@ -6476,16 +6879,56 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -6565,6 +7008,31 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@3.2.4:
@@ -6683,6 +7151,18 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yjs@13.6.29:
     resolution: {integrity: sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==}
@@ -7929,6 +8409,9 @@ snapshots:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.13.6
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -7936,6 +8419,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -7947,6 +8433,9 @@ snapshots:
   '@esbuild/android-arm@0.18.20':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
@@ -7954,6 +8443,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -7965,6 +8457,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
@@ -7972,6 +8467,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -7983,6 +8481,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
@@ -7990,6 +8491,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -8001,6 +8505,9 @@ snapshots:
   '@esbuild/linux-arm64@0.18.20':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
@@ -8008,6 +8515,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -8019,6 +8529,9 @@ snapshots:
   '@esbuild/linux-ia32@0.18.20':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
@@ -8026,6 +8539,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -8037,6 +8553,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
@@ -8044,6 +8563,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -8055,6 +8577,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
@@ -8064,6 +8589,9 @@ snapshots:
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -8071,6 +8599,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -8088,6 +8619,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -8101,6 +8635,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -8118,6 +8655,9 @@ snapshots:
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
@@ -8125,6 +8665,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -8136,6 +8679,9 @@ snapshots:
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
@@ -8143,6 +8689,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -8288,11 +8837,15 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -8314,6 +8867,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@kubernetes/client-node@0.21.0':
+    dependencies:
+      '@types/js-yaml': 4.0.9
+      '@types/node': 20.19.40
+      '@types/request': 2.48.13
+      '@types/ws': 8.18.1
+      byline: 5.0.0
+      isomorphic-ws: 5.0.0(ws@8.19.0)
+      js-yaml: 4.1.1
+      jsonpath-plus: 8.1.0
+      request: 2.88.2
+      rfc4648: 1.5.4
+      stream-buffers: 3.0.3
+      tar: 7.5.15
+      tslib: 2.8.1
+      ws: 8.19.0
+    optionalDependencies:
+      openid-client: 5.7.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@lexical/clipboard@0.35.0':
     dependencies:
@@ -9918,10 +10493,10 @@ snapshots:
       axe-core: 4.11.3
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -9935,25 +10510,25 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
       rollup: 4.60.1
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
   '@storybook/global@5.0.0': {}
 
@@ -9968,11 +10543,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.3.5(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@storybook/react-vite@10.3.5(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@storybook/builder-vite': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       '@storybook/react': 10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -9982,7 +10557,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -10070,12 +10645,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
   '@tanstack/query-core@5.90.20': {}
 
@@ -10134,7 +10709,9 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
+
+  '@types/caseless@0.12.5': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -10143,7 +10720,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
   '@types/cookiejar@2.1.5': {}
 
@@ -10280,7 +10857,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -10299,9 +10876,11 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/jsdom@28.0.0':
     dependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
       undici-types: 7.24.4
@@ -10319,6 +10898,10 @@ snapshots:
   '@types/multer@2.0.0':
     dependencies:
       '@types/express': 5.0.6
+
+  '@types/node@20.19.40':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@22.19.11':
     dependencies:
@@ -10344,16 +10927,23 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/request@2.48.13':
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 22.19.11
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.5
+
   '@types/resolve@1.20.2': {}
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
   '@types/sharp@0.32.0':
     dependencies:
@@ -10363,7 +10953,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
       form-data: 4.0.5
 
   '@types/supertest@6.0.3':
@@ -10382,11 +10972,11 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.2.3
+      '@types/node': 22.19.11
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -10394,9 +10984,16 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -10406,25 +11003,42 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.11)(lightningcss@1.30.2))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.30.2)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -10432,15 +11046,31 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.1.0
 
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -10508,6 +11138,13 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -10537,6 +11174,12 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
+
   assertion-error@2.0.1: {}
 
   assistant-cloud@0.1.25:
@@ -10558,6 +11201,10 @@ snapshots:
   asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
+
+  aws-sign2@0.7.0: {}
+
+  aws4@1.13.2: {}
 
   axe-core@4.11.3: {}
 
@@ -10603,7 +11250,11 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -10619,11 +11270,11 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       drizzle-kit: 0.31.9
-      drizzle-orm: 0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)
+      drizzle-orm: 0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4)
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
   better-call@1.1.8(zod@4.3.6):
     dependencies:
@@ -10681,6 +11332,8 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
+  byline@5.0.0: {}
+
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -10696,6 +11349,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001770: {}
+
+  caseless@0.12.0: {}
 
   ccount@2.0.1: {}
 
@@ -10734,6 +11389,8 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  chownr@3.0.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -10816,6 +11473,8 @@ snapshots:
   cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
+
+  core-util-is@1.0.2: {}
 
   cors@2.8.6:
     dependencies:
@@ -11050,6 +11709,10 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.17.23
 
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+
   data-urls@7.0.0(@noble/hashes@2.0.1):
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -11149,18 +11812,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.3.15)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8):
+  drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
+      '@types/react': 19.2.14
       kysely: 0.28.11
       pg: 8.18.0
       postgres: 3.4.8
+      react: 19.2.4
 
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
 
   ee-first@1.1.1: {}
 
@@ -11263,6 +11933,32 @@ snapshots:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -11419,11 +12115,15 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extsprintf@1.3.0: {}
+
   fast-copy@4.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
+
+  fast-json-stable-stringify@2.1.0: {}
 
   fast-safe-stringify@2.1.1: {}
 
@@ -11461,6 +12161,23 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  forever-agent@0.6.1: {}
+
+  form-data@2.3.3:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  form-data@2.5.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
 
   form-data@4.0.5:
     dependencies:
@@ -11518,6 +12235,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -11529,6 +12250,13 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   hachure-fill@0.5.2: {}
+
+  har-schema@2.0.0: {}
+
+  har-validator@5.1.5:
+    dependencies:
+      ajv: 6.15.0
+      har-schema: 2.0.0
 
   has-symbols@1.1.0: {}
 
@@ -11596,6 +12324,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-signature@1.2.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 1.4.2
+      sshpk: 1.18.0
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -11660,15 +12394,26 @@ snapshots:
 
   is-promise@4.0.0: {}
 
+  is-typedarray@1.0.0: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
+  isomorphic-ws@5.0.0(ws@8.19.0):
+    dependencies:
+      ws: 8.19.0
+
   isomorphic.js@0.2.5: {}
 
+  isstream@0.1.2: {}
+
   jiti@2.6.1: {}
+
+  jose@4.15.9:
+    optional: true
 
   jose@6.1.3: {}
 
@@ -11681,6 +12426,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsbn@0.1.1: {}
 
   jsdom@28.1.0(@noble/hashes@2.0.1):
     dependencies:
@@ -11716,11 +12463,26 @@ snapshots:
       '@babel/runtime': 7.28.6
       ts-algebra: 2.0.0
 
+  json-schema-traverse@0.4.1: {}
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
 
+  json-schema@0.4.0: {}
+
+  json-stringify-safe@5.0.1: {}
+
   json5@2.2.3: {}
+
+  jsonpath-plus@8.1.0: {}
+
+  jsprim@1.4.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
 
   katex@0.16.37:
     dependencies:
@@ -11814,6 +12576,11 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+    optional: true
 
   lucide-react@0.574.0(react@19.2.4):
     dependencies:
@@ -12370,6 +13137,10 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   mlly@1.8.1:
     dependencies:
       acorn: 8.16.0
@@ -12400,9 +13171,17 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  oauth-sign@0.9.0: {}
+
   object-assign@4.1.1: {}
 
+  object-hash@2.2.0:
+    optional: true
+
   object-inspect@1.13.4: {}
+
+  oidc-token-hash@5.2.0:
+    optional: true
 
   on-exit-leak-free@2.1.2: {}
 
@@ -12429,6 +13208,14 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
+
+  openid-client@5.7.1:
+    dependencies:
+      jose: 4.15.9
+      lru-cache: 6.0.0
+      object-hash: 2.2.0
+      oidc-token-hash: 5.2.0
+    optional: true
 
   outvariant@1.4.0: {}
 
@@ -12467,9 +13254,13 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  performance-now@2.1.0: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -12628,6 +13419,10 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -12638,6 +13433,8 @@ snapshots:
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
+
+  qs@6.5.5: {}
 
   quick-format-unescaped@4.0.4: {}
 
@@ -12883,6 +13680,29 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  request@2.88.2:
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 2.3.3
+      har-validator: 5.1.5
+      http-signature: 1.2.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      oauth-sign: 0.9.0
+      performance-now: 2.1.0
+      qs: 6.5.5
+      safe-buffer: 5.2.1
+      tough-cookie: 2.5.0
+      tunnel-agent: 0.6.0
+      uuid: 3.4.0
+
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -12892,6 +13712,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rfc4648@1.5.4: {}
 
   robust-predicates@3.0.2: {}
 
@@ -13095,6 +13917,18 @@ snapshots:
 
   split2@4.2.0: {}
 
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
+
   stackback@0.0.2: {}
 
   static-browser-server@1.0.3:
@@ -13129,6 +13963,8 @@ snapshots:
       - react
       - react-dom
       - utf-8-validate
+
+  stream-buffers@3.0.3: {}
 
   streamsearch@1.1.0: {}
 
@@ -13225,6 +14061,14 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  tar@7.5.15:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   teex@1.0.1:
     dependencies:
       streamx: 2.25.0
@@ -13257,7 +14101,11 @@ snapshots:
 
   tinypool@1.1.1: {}
 
+  tinyrainbow@1.2.0: {}
+
   tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   tinyspy@4.0.4: {}
 
@@ -13268,6 +14116,11 @@ snapshots:
       tldts-core: 7.0.26
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@2.5.0:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
 
   tough-cookie@6.0.1:
     dependencies:
@@ -13299,6 +14152,12 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  tweetnacl@0.14.5: {}
 
   type-is@1.6.18:
     dependencies:
@@ -13383,6 +14242,10 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -13429,6 +14292,8 @@ snapshots:
 
   uuid@11.1.0: {}
 
+  uuid@3.4.0: {}
+
   uvu@0.5.6:
     dependencies:
       dequal: 2.0.3
@@ -13437,6 +14302,12 @@ snapshots:
       sade: 1.8.1
 
   vary@1.1.2: {}
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
 
   vfile-message@4.0.3:
     dependencies:
@@ -13448,13 +14319,31 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite-node@2.1.9(@types/node@22.19.11)(lightningcss@1.30.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite-node@3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13469,13 +14358,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13490,7 +14379,17 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite@5.4.21(@types/node@22.19.11)(lightningcss@1.30.2):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.60.1
+    optionalDependencies:
+      '@types/node': 22.19.11
+      fsevents: 2.3.3
+      lightningcss: 1.30.2
+
+  vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13504,8 +14403,9 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
+      yaml: 2.8.4
 
-  vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13519,8 +14419,9 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
+      yaml: 2.8.4
 
-  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13534,8 +14435,9 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
+      yaml: 2.8.4
 
-  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
+  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -13549,12 +14451,49 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
+      yaml: 2.8.4
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0):
+  vitest@2.1.9(@types/node@22.19.11)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.11)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.30.2)
+      vite-node: 2.1.9(@types/node@22.19.11)(lightningcss@1.30.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.11
+      jsdom: 28.1.0(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13572,8 +14511,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -13593,11 +14532,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13615,8 +14554,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite-node: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -13702,6 +14641,13 @@ snapshots:
   xtend@4.0.2: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0:
+    optional: true
+
+  yallist@5.0.0: {}
+
+  yaml@2.8.4: {}
 
   yjs@13.6.29:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,6 +561,9 @@ importers:
       '@paperclipai/db':
         specifier: workspace:*
         version: link:../packages/db
+      '@paperclipai/execution-target-kubernetes':
+        specifier: workspace:*
+        version: link:../packages/adapters/kubernetes-execution
       '@paperclipai/plugin-sdk':
         specifier: workspace:*
         version: link:../packages/plugins/sdk

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
 
 overrides:
   rollup: '>=4.59.0'
+  form-data@<2.5.4: '>=2.5.4'
+  form-data@<3.0.4: '>=3.0.4'
+  form-data@<4.0.4: '>=4.0.4'
+  jsonpath-plus: '>=10.3.0'
 
 patchedDependencies:
   embedded-postgres@18.1.0-beta.16:
@@ -2152,6 +2156,18 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
 
   '@kubernetes/client-node@0.21.0':
     resolution: {integrity: sha512-yYRbgMeyQbvZDHt/ZqsW3m4lRefzhbbJEuj8sVXM+bufKrgmzriA2oq7lWPH/k/LQIicAME9ixPUadTrxIF6dQ==}
@@ -5043,14 +5059,6 @@ packages:
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
-  form-data@2.3.3:
-    resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
-    engines: {node: '>= 0.12'}
-
-  form-data@2.5.5:
-    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
-    engines: {node: '>= 0.12'}
-
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -5325,6 +5333,10 @@ packages:
       canvas:
         optional: true
 
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -5354,9 +5366,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonpath-plus@8.1.0:
-    resolution: {integrity: sha512-qVTiuKztFGw0dGhYi3WNqvddx3/SHtyDT0xJaeyz4uP0d1tkpG+0y5uYQ4OcIo1TLAz3PE/qDOW9F0uDt3+CTw==}
-    engines: {node: '>=14.0.0'}
+  jsonpath-plus@10.4.0:
+    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
 
   jsprim@1.4.2:
@@ -8558,6 +8570,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
   '@kubernetes/client-node@0.21.0':
     dependencies:
       '@types/js-yaml': 4.0.9
@@ -8567,7 +8587,7 @@ snapshots:
       byline: 5.0.0
       isomorphic-ws: 5.0.0(ws@8.19.0)
       js-yaml: 4.1.1
-      jsonpath-plus: 8.1.0
+      jsonpath-plus: 10.4.0
       request: 2.88.2
       rfc4648: 1.5.4
       stream-buffers: 3.0.3
@@ -10622,7 +10642,7 @@ snapshots:
       '@types/caseless': 0.12.5
       '@types/node': 25.2.3
       '@types/tough-cookie': 4.0.5
-      form-data: 2.5.5
+      form-data: 4.0.5
 
   '@types/resolve@1.20.2': {}
 
@@ -11788,21 +11808,6 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  form-data@2.3.3:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-
-  form-data@2.5.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-      safe-buffer: 5.2.1
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -12080,6 +12085,8 @@ snapshots:
       - '@noble/hashes'
       - supports-color
 
+  jsep@1.4.0: {}
+
   jsesc@3.1.0: {}
 
   json-schema-to-ts@3.1.1:
@@ -12099,7 +12106,11 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonpath-plus@8.1.0: {}
+  jsonpath-plus@10.4.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
 
   jsprim@1.4.2:
     dependencies:
@@ -13310,7 +13321,7 @@ snapshots:
       combined-stream: 1.0.8
       extend: 3.0.2
       forever-agent: 0.6.1
-      form-data: 2.3.3
+      form-data: 4.0.5
       har-validator: 5.1.5
       http-signature: 1.2.0
       is-typedarray: 1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,6 @@ settings:
 
 overrides:
   rollup: '>=4.59.0'
-  form-data@<2.5.4: '>=2.5.4'
-  form-data@<3.0.4: '>=3.0.4'
-  form-data@<4.0.4: '>=4.0.4'
-  jsonpath-plus: '>=10.3.0'
 
 patchedDependencies:
   embedded-postgres@18.1.0-beta.16:
@@ -34,7 +30,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   cli:
     dependencies:
@@ -201,28 +197,6 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
-  packages/adapters/kubernetes-execution:
-    dependencies:
-      '@kubernetes/client-node':
-        specifier: ^0.21.0
-        version: 0.21.0
-      '@paperclipai/adapter-utils':
-        specifier: workspace:*
-        version: link:../../adapter-utils
-      yaml:
-        specifier: ^2.5.0
-        version: 2.8.4
-    devDependencies:
-      '@types/node':
-        specifier: ^24.6.0
-        version: 24.12.0
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-      vitest:
-        specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
-
   packages/adapters/openclaw-gateway:
     dependencies:
       '@paperclipai/adapter-utils':
@@ -306,7 +280,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/mcp-server:
     dependencies:
@@ -328,7 +302,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/plugins/create-paperclip-plugin:
     dependencies:
@@ -378,7 +352,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
@@ -496,7 +470,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/plugins/sdk:
     dependencies:
@@ -565,9 +539,6 @@ importers:
       '@paperclipai/db':
         specifier: workspace:*
         version: link:../packages/db
-      '@paperclipai/execution-target-kubernetes':
-        specifier: workspace:*
-        version: link:../packages/adapters/kubernetes-execution
       '@paperclipai/plugin-sdk':
         specifier: workspace:*
         version: link:../packages/plugins/sdk
@@ -582,7 +553,7 @@ importers:
         version: 3.0.1(ajv@8.18.0)
       better-auth:
         specifier: 1.4.18
-        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0))
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -673,10 +644,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.1.0
-        version: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   ui:
     dependencies:
@@ -785,13 +756,13 @@ importers:
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-docs':
         specifier: 10.3.5
-        version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@storybook/react-vite':
         specifier: 10.3.5
-        version: 10.3.5(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 10.3.5(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@tailwindcss/vite':
         specifier: ^4.0.7
-        version: 4.1.18(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.1.18(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@types/node':
         specifier: ^25.2.3
         version: 25.2.3
@@ -803,7 +774,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.7.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       storybook:
         specifier: 10.3.5
         version: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -815,10 +786,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.1.0
-        version: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       vitest:
         specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
 packages:
 
@@ -2128,10 +2099,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
-
   '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0':
     resolution: {integrity: sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==}
     peerDependencies:
@@ -2156,21 +2123,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
-
-  '@jsep-plugin/assignment@1.3.0':
-    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
-    engines: {node: '>= 10.16.0'}
-    peerDependencies:
-      jsep: ^0.4.0||^1.0.0
-
-  '@jsep-plugin/regex@1.0.4':
-    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
-    engines: {node: '>= 10.16.0'}
-    peerDependencies:
-      jsep: ^0.4.0||^1.0.0
-
-  '@kubernetes/client-node@0.21.0':
-    resolution: {integrity: sha512-yYRbgMeyQbvZDHt/ZqsW3m4lRefzhbbJEuj8sVXM+bufKrgmzriA2oq7lWPH/k/LQIicAME9ixPUadTrxIF6dQ==}
 
   '@lexical/clipboard@0.35.0':
     resolution: {integrity: sha512-ko7xSIIiayvDiqjNDX6fgH9RlcM6r9vrrvJYTcfGVBor5httx16lhIi0QJZ4+RNPvGtTjyFv4bwRmsixRRwImg==}
@@ -3683,9 +3635,6 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
-  '@types/caseless@0.12.5':
-    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
-
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -3818,9 +3767,6 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
-  '@types/js-yaml@4.0.9':
-    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
-
   '@types/jsdom@28.0.0':
     resolution: {integrity: sha512-A8TBQQC/xAOojy9kM8E46cqT00sF0h7dWjV8t8BJhUi2rG6JRh7XXQo/oLoENuZIQEpXsxLccLCnknyQd7qssQ==}
 
@@ -3838,9 +3784,6 @@ packages:
 
   '@types/multer@2.0.0':
     resolution: {integrity: sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==}
-
-  '@types/node@20.19.40':
-    resolution: {integrity: sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==}
 
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
@@ -3864,9 +3807,6 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
-
-  '@types/request@2.48.13':
-    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
@@ -4018,9 +3958,6 @@ packages:
       ajv:
         optional: true
 
-  ajv@6.15.0:
-    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
@@ -4055,13 +3992,6 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
-  asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-
-  assert-plus@1.0.0:
-    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
-    engines: {node: '>=0.8'}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -4086,12 +4016,6 @@ packages:
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
-
-  aws-sign2@0.7.0:
-    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
-
-  aws4@1.13.2:
-    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
   axe-core@4.11.3:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
@@ -4159,9 +4083,6 @@ packages:
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
-
-  bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-auth@1.4.18:
     resolution: {integrity: sha512-bnyifLWBPcYVltH3RhS7CM62MoelEqC6Q+GnZwfiDWNfepXoQZBjEvn4urcERC7NTKgKq5zNBM8rvPvRBa6xcg==}
@@ -4266,10 +4187,6 @@ packages:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
 
-  byline@5.0.0:
-    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
-    engines: {node: '>=0.10.0'}
-
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -4288,9 +4205,6 @@ packages:
 
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
-
-  caseless@0.12.0:
-    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4326,10 +4240,6 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
-
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -4425,9 +4335,6 @@ packages:
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
-
-  core-util-is@1.0.2:
-    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -4629,10 +4536,6 @@ packages:
 
   dagre-d3-es@7.0.13:
     resolution: {integrity: sha512-efEhnxpSuwpYOKRm/L5KbqoZmNNukHa/Flty4Wp62JRvgH2ojwVgPgdYyr4twpieZnyRDdIH7PY2mopX26+j2Q==}
-
-  dashdash@1.14.1:
-    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
-    engines: {node: '>=0.10'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -4846,9 +4749,6 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  ecc-jsbn@0.1.2:
-    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
-
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -5005,10 +4905,6 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  extsprintf@1.3.0:
-    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
-    engines: {'0': node >=0.6.0}
-
   fast-copy@4.0.2:
     resolution: {integrity: sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==}
 
@@ -5017,9 +4913,6 @@ packages:
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
-
-  fast-json-stable-stringify@2.1.0:
-    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -5055,9 +4948,6 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
-
-  forever-agent@0.6.1:
-    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -5115,9 +5005,6 @@ packages:
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
-  getpass@0.1.7:
-    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
-
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -5131,15 +5018,6 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
-
-  har-schema@2.0.0:
-    resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
-    engines: {node: '>=4'}
-
-  har-validator@5.1.5:
-    resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
-    engines: {node: '>=6'}
-    deprecated: this library is no longer supported
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -5184,10 +5062,6 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
-
-  http-signature@1.2.0:
-    resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==}
-    engines: {node: '>=0.8', npm: '>=1.3.7'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -5276,9 +5150,6 @@ packages:
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
-  is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
-
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
@@ -5286,23 +5157,12 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  isomorphic-ws@5.0.0:
-    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
-    peerDependencies:
-      ws: '*'
-
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
-
-  isstream@0.1.2:
-    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-
-  jose@4.15.9:
-    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
@@ -5321,9 +5181,6 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsbn@0.1.1:
-    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
-
   jsdom@28.1.0:
     resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -5332,10 +5189,6 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
-
-  jsep@1.4.0:
-    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
-    engines: {node: '>= 10.16.0'}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5346,34 +5199,16 @@ packages:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
 
-  json-schema-traverse@0.4.1:
-    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
-  json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-
-  json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
-
-  jsonpath-plus@10.4.0:
-    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
-  jsprim@1.4.2:
-    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
-    engines: {node: '>=0.6.0'}
 
   katex@0.16.37:
     resolution: {integrity: sha512-TIGjO2cCGYono+uUzgkE7RFF329mLLWGuHUlSr6cwIVj9O8f0VQZ783rsanmJpFUo32vvtj7XT04NGRPh+SZFg==}
@@ -5497,10 +5332,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
 
   lucide-react@0.574.0:
     resolution: {integrity: sha512-dJ8xb5juiZVIbdSn3HTyHsjjIwUwZ4FNwV0RtYDScOyySOeie1oXZTymST6YPJ4Qwt3Po8g4quhYl4OxtACiuQ==}
@@ -5755,10 +5586,6 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
-
   mlly@1.8.1:
     resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
@@ -5797,24 +5624,13 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  oauth-sign@0.9.0:
-    resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  object-hash@2.2.0:
-    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
-    engines: {node: '>= 6'}
-
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
-
-  oidc-token-hash@5.2.0:
-    resolution: {integrity: sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==}
-    engines: {node: ^10.13.0 || >=12.0.0}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -5834,9 +5650,6 @@ packages:
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
-
-  openid-client@5.7.1:
-    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   outvariant@1.4.0:
     resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
@@ -5880,9 +5693,6 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
-
-  performance-now@2.1.0:
-    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -6021,9 +5831,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  psl@1.15.0:
-    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
-
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -6033,10 +5840,6 @@ packages:
 
   qs@6.15.0:
     resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
-    engines: {node: '>=0.6'}
-
-  qs@6.5.5:
-    resolution: {integrity: sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -6197,11 +6000,6 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  request@2.88.2:
-    resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
-    engines: {node: '>= 6'}
-    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
-
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -6213,9 +6011,6 @@ packages:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
     hasBin: true
-
-  rfc4648@1.5.4:
-    resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
 
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
@@ -6349,11 +6144,6 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
-  sshpk@1.18.0:
-    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -6375,10 +6165,6 @@ packages:
     peerDependenciesMeta:
       prettier:
         optional: true
-
-  stream-buffers@3.0.3:
-    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
-    engines: {node: '>= 0.10.0'}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -6461,10 +6247,6 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
-    engines: {node: '>=18'}
-
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
@@ -6514,10 +6296,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tough-cookie@2.5.0:
-    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
-    engines: {node: '>=0.8'}
-
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -6550,12 +6328,6 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
-
-  tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -6630,9 +6402,6 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -6697,11 +6466,6 @@ packages:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
 
-  uuid@3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
     engines: {node: '>=8'}
@@ -6710,10 +6474,6 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-
-  verror@1.10.0:
-    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
-    engines: {'0': node >=0.6.0}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -6922,18 +6682,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
-
-  yaml@2.8.4:
-    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
 
   yjs@13.6.29:
     resolution: {integrity: sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==}
@@ -8539,15 +8287,11 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.3
-
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -8569,36 +8313,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
-    dependencies:
-      jsep: 1.4.0
-
-  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
-    dependencies:
-      jsep: 1.4.0
-
-  '@kubernetes/client-node@0.21.0':
-    dependencies:
-      '@types/js-yaml': 4.0.9
-      '@types/node': 20.19.40
-      '@types/request': 2.48.13
-      '@types/ws': 8.18.1
-      byline: 5.0.0
-      isomorphic-ws: 5.0.0(ws@8.19.0)
-      js-yaml: 4.1.1
-      jsonpath-plus: 10.4.0
-      request: 2.88.2
-      rfc4648: 1.5.4
-      stream-buffers: 3.0.3
-      tar: 7.5.15
-      tslib: 2.8.1
-      ws: 8.19.0
-    optionalDependencies:
-      openid-client: 5.7.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@lexical/clipboard@0.35.0':
     dependencies:
@@ -10203,10 +9917,10 @@ snapshots:
       axe-core: 4.11.3
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       react: 19.2.4
@@ -10220,25 +9934,25 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.3
       rollup: 4.60.1
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@storybook/global@5.0.0': {}
 
@@ -10253,11 +9967,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@storybook/react-vite@10.3.5(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@storybook/react-vite@10.3.5(esbuild@0.27.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.9.3)(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@storybook/builder-vite': 10.3.5(esbuild@0.27.3)(rollup@4.60.1)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@storybook/react': 10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -10267,7 +9981,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tsconfig-paths: 4.2.0
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -10355,12 +10069,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@tailwindcss/vite@4.1.18(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@tanstack/query-core@5.90.20': {}
 
@@ -10420,8 +10134,6 @@ snapshots:
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 25.2.3
-
-  '@types/caseless@0.12.5': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -10586,8 +10298,6 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
-  '@types/js-yaml@4.0.9': {}
-
   '@types/jsdom@28.0.0':
     dependencies:
       '@types/node': 25.2.3
@@ -10608,10 +10318,6 @@ snapshots:
   '@types/multer@2.0.0':
     dependencies:
       '@types/express': 5.0.6
-
-  '@types/node@20.19.40':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@22.19.11':
     dependencies:
@@ -10636,13 +10342,6 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
-
-  '@types/request@2.48.13':
-    dependencies:
-      '@types/caseless': 0.12.5
-      '@types/node': 25.2.3
-      '@types/tough-cookie': 4.0.5
-      form-data: 4.0.5
 
   '@types/resolve@1.20.2': {}
 
@@ -10686,7 +10385,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -10694,7 +10393,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10706,21 +10405,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -10808,13 +10507,6 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv@6.15.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-json-stable-stringify: 2.1.0
-      json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
-
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -10844,12 +10536,6 @@ snapshots:
 
   asap@2.0.6: {}
 
-  asn1@0.2.6:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  assert-plus@1.0.0: {}
-
   assertion-error@2.0.1: {}
 
   assistant-cloud@0.1.25:
@@ -10871,10 +10557,6 @@ snapshots:
   asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
-
-  aws-sign2@0.7.0: {}
-
-  aws4@1.13.2: {}
 
   axe-core@4.11.3: {}
 
@@ -10920,11 +10602,7 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
-  bcrypt-pbkdf@1.0.2:
-    dependencies:
-      tweetnacl: 0.14.5
-
-  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)):
+  better-auth@1.4.18(drizzle-kit@0.31.9)(drizzle-orm@0.38.4(@electric-sql/pglite@0.3.15)(@types/react@19.2.14)(kysely@0.28.11)(pg@8.18.0)(postgres@3.4.8)(react@19.2.4))(pg@8.18.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@3.25.76))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
@@ -10944,7 +10622,7 @@ snapshots:
       pg: 8.18.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   better-call@1.1.8(zod@4.3.6):
     dependencies:
@@ -11002,8 +10680,6 @@ snapshots:
     dependencies:
       streamsearch: 1.1.0
 
-  byline@5.0.0: {}
-
   bytes@3.1.2: {}
 
   cac@6.7.14: {}
@@ -11019,8 +10695,6 @@ snapshots:
       get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001770: {}
-
-  caseless@0.12.0: {}
 
   ccount@2.0.1: {}
 
@@ -11059,8 +10733,6 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
-
-  chownr@3.0.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -11143,8 +10815,6 @@ snapshots:
   cookie@1.1.1: {}
 
   cookiejar@2.1.4: {}
-
-  core-util-is@1.0.2: {}
 
   cors@2.8.6:
     dependencies:
@@ -11379,10 +11049,6 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.17.23
 
-  dashdash@1.14.1:
-    dependencies:
-      assert-plus: 1.0.0
-
   data-urls@7.0.0(@noble/hashes@2.0.1):
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -11496,11 +11162,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  ecc-jsbn@0.1.2:
-    dependencies:
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
 
   ee-first@1.1.1: {}
 
@@ -11759,15 +11420,11 @@ snapshots:
 
   extend@3.0.2: {}
 
-  extsprintf@1.3.0: {}
-
   fast-copy@4.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
-
-  fast-json-stable-stringify@2.1.0: {}
 
   fast-safe-stringify@2.1.1: {}
 
@@ -11805,8 +11462,6 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
-
-  forever-agent@0.6.1: {}
 
   form-data@4.0.5:
     dependencies:
@@ -11864,10 +11519,6 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  getpass@0.1.7:
-    dependencies:
-      assert-plus: 1.0.0
-
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -11879,13 +11530,6 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   hachure-fill@0.5.2: {}
-
-  har-schema@2.0.0: {}
-
-  har-validator@5.1.5:
-    dependencies:
-      ajv: 6.15.0
-      har-schema: 2.0.0
 
   has-symbols@1.1.0: {}
 
@@ -11953,12 +11597,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-signature@1.2.0:
-    dependencies:
-      assert-plus: 1.0.0
-      jsprim: 1.4.2
-      sshpk: 1.18.0
-
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -12023,26 +11661,15 @@ snapshots:
 
   is-promise@4.0.0: {}
 
-  is-typedarray@1.0.0: {}
-
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@5.0.0(ws@8.19.0):
-    dependencies:
-      ws: 8.19.0
-
   isomorphic.js@0.2.5: {}
 
-  isstream@0.1.2: {}
-
   jiti@2.6.1: {}
-
-  jose@4.15.9:
-    optional: true
 
   jose@6.1.3: {}
 
@@ -12055,8 +11682,6 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
-
-  jsbn@0.1.1: {}
 
   jsdom@28.1.0(@noble/hashes@2.0.1):
     dependencies:
@@ -12085,8 +11710,6 @@ snapshots:
       - '@noble/hashes'
       - supports-color
 
-  jsep@1.4.0: {}
-
   jsesc@3.1.0: {}
 
   json-schema-to-ts@3.1.1:
@@ -12094,30 +11717,11 @@ snapshots:
       '@babel/runtime': 7.28.6
       ts-algebra: 2.0.0
 
-  json-schema-traverse@0.4.1: {}
-
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
 
-  json-schema@0.4.0: {}
-
-  json-stringify-safe@5.0.1: {}
-
   json5@2.2.3: {}
-
-  jsonpath-plus@10.4.0:
-    dependencies:
-      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
-      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
-      jsep: 1.4.0
-
-  jsprim@1.4.2:
-    dependencies:
-      assert-plus: 1.0.0
-      extsprintf: 1.3.0
-      json-schema: 0.4.0
-      verror: 1.10.0
 
   katex@0.16.37:
     dependencies:
@@ -12211,11 +11815,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
-    optional: true
 
   lucide-react@0.574.0(react@19.2.4):
     dependencies:
@@ -12772,10 +12371,6 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  minizlib@3.1.0:
-    dependencies:
-      minipass: 7.1.3
-
   mlly@1.8.1:
     dependencies:
       acorn: 8.16.0
@@ -12806,17 +12401,9 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  oauth-sign@0.9.0: {}
-
   object-assign@4.1.1: {}
 
-  object-hash@2.2.0:
-    optional: true
-
   object-inspect@1.13.4: {}
-
-  oidc-token-hash@5.2.0:
-    optional: true
 
   on-exit-leak-free@2.1.2: {}
 
@@ -12843,14 +12430,6 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
-
-  openid-client@5.7.1:
-    dependencies:
-      jose: 4.15.9
-      lru-cache: 6.0.0
-      object-hash: 2.2.0
-      oidc-token-hash: 5.2.0
-    optional: true
 
   outvariant@1.4.0: {}
 
@@ -12892,8 +12471,6 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
-
-  performance-now@2.1.0: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -13052,10 +12629,6 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  psl@1.15.0:
-    dependencies:
-      punycode: 2.3.1
-
   pump@3.0.3:
     dependencies:
       end-of-stream: 1.4.5
@@ -13066,8 +12639,6 @@ snapshots:
   qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
-
-  qs@6.5.5: {}
 
   quick-format-unescaped@4.0.4: {}
 
@@ -13313,29 +12884,6 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  request@2.88.2:
-    dependencies:
-      aws-sign2: 0.7.0
-      aws4: 1.13.2
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 4.0.5
-      har-validator: 5.1.5
-      http-signature: 1.2.0
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      oauth-sign: 0.9.0
-      performance-now: 2.1.0
-      qs: 6.5.5
-      safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
-      tunnel-agent: 0.6.0
-      uuid: 3.4.0
-
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -13345,8 +12893,6 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
-
-  rfc4648@1.5.4: {}
 
   robust-predicates@3.0.2: {}
 
@@ -13550,18 +13096,6 @@ snapshots:
 
   split2@4.2.0: {}
 
-  sshpk@1.18.0:
-    dependencies:
-      asn1: 0.2.6
-      assert-plus: 1.0.0
-      bcrypt-pbkdf: 1.0.2
-      dashdash: 1.14.1
-      ecc-jsbn: 0.1.2
-      getpass: 0.1.7
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-      tweetnacl: 0.14.5
-
   stackback@0.0.2: {}
 
   static-browser-server@1.0.3:
@@ -13596,8 +13130,6 @@ snapshots:
       - react
       - react-dom
       - utf-8-validate
-
-  stream-buffers@3.0.3: {}
 
   streamsearch@1.1.0: {}
 
@@ -13694,14 +13226,6 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.15:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
   teex@1.0.1:
     dependencies:
       streamx: 2.25.0
@@ -13746,11 +13270,6 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tough-cookie@2.5.0:
-    dependencies:
-      psl: 1.15.0
-      punycode: 2.3.1
-
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.26
@@ -13781,12 +13300,6 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
-
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  tweetnacl@0.14.5: {}
 
   type-is@1.6.18:
     dependencies:
@@ -13871,10 +13384,6 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  uri-js@4.4.1:
-    dependencies:
-      punycode: 2.3.1
-
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -13921,8 +13430,6 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  uuid@3.4.0: {}
-
   uvu@0.5.6:
     dependencies:
       dequal: 2.0.3
@@ -13931,12 +13438,6 @@ snapshots:
       sade: 1.8.1
 
   vary@1.1.2: {}
-
-  verror@1.10.0:
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.3.0
 
   vfile-message@4.0.3:
     dependencies:
@@ -13948,13 +13449,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
+  vite-node@3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13969,13 +13470,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
+  vite-node@3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -13990,7 +13491,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
+  vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -14004,9 +13505,8 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
-      yaml: 2.8.4
 
-  vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
+  vite@6.4.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -14020,9 +13520,8 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
-      yaml: 2.8.4
 
-  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
+  vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -14036,9 +13535,8 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
-      yaml: 2.8.4
 
-  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
+  vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -14052,13 +13550,12 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
-      yaml: 2.8.4
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -14076,8 +13573,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
-      vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -14097,11 +13594,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -14119,8 +13616,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
-      vite-node: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -14206,13 +13703,6 @@ snapshots:
   xtend@4.0.2: {}
 
   yallist@3.1.1: {}
-
-  yallist@4.0.0:
-    optional: true
-
-  yallist@5.0.0: {}
-
-  yaml@2.8.4: {}
 
   yjs@13.6.29:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,14 +210,14 @@ importers:
         version: 2.8.4
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.11
+        specifier: ^24.6.0
+        version: 24.12.0
       typescript:
-        specifier: ^5.7.0
+        specifier: ^5.7.3
         version: 5.9.3
       vitest:
-        specifier: ^2.0.0
-        version: 2.1.9(@types/node@22.19.11)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
   packages/adapters/openclaw-gateway:
     dependencies:
@@ -1498,12 +1498,6 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -1518,12 +1512,6 @@ packages:
 
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -1546,12 +1534,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.25.12':
     resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
@@ -1566,12 +1548,6 @@ packages:
 
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -1594,12 +1570,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -1614,12 +1584,6 @@ packages:
 
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -1642,12 +1606,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -1662,12 +1620,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -1690,12 +1642,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -1710,12 +1656,6 @@ packages:
 
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -1738,12 +1678,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -1758,12 +1692,6 @@ packages:
 
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -1786,12 +1714,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -1806,12 +1728,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1834,12 +1750,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -1858,12 +1768,6 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -1878,12 +1782,6 @@ packages:
 
   '@esbuild/linux-x64@0.18.20':
     resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1918,12 +1816,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -1950,12 +1842,6 @@ packages:
 
   '@esbuild/openbsd-x64@0.18.20':
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -1990,12 +1876,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -2010,12 +1890,6 @@ packages:
 
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -2038,12 +1912,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -2058,12 +1926,6 @@ packages:
 
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -4030,22 +3892,8 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/expect@2.1.9':
-    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
-
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
-
-  '@vitest/mocker@2.1.9':
-    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -4058,32 +3906,17 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.9':
-    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
-
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
-
-  '@vitest/runner@2.1.9':
-    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
-  '@vitest/snapshot@2.1.9':
-    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
-
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
-  '@vitest/spy@2.1.9':
-    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
-
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
-
-  '@vitest/utils@2.1.9':
-    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
@@ -5066,11 +4899,6 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
-    hasBin: true
-
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -6031,9 +5859,6 @@ packages:
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -6655,16 +6480,8 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
-    engines: {node: '>=14.0.0'}
-
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -6889,46 +6706,10 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@2.1.9:
-    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
-
-  vite@5.4.21:
-    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -7008,31 +6789,6 @@ packages:
       tsx:
         optional: true
       yaml:
-        optional: true
-
-  vitest@2.1.9:
-    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.9
-      '@vitest/ui': 2.1.9
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@3.2.4:
@@ -8409,9 +8165,6 @@ snapshots:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.13.6
 
-  '@esbuild/aix-ppc64@0.21.5':
-    optional: true
-
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -8419,9 +8172,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.18.20':
-    optional: true
-
-  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -8433,9 +8183,6 @@ snapshots:
   '@esbuild/android-arm@0.18.20':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
-    optional: true
-
   '@esbuild/android-arm@0.25.12':
     optional: true
 
@@ -8443,9 +8190,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.18.20':
-    optional: true
-
-  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -8457,9 +8201,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
@@ -8467,9 +8208,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.18.20':
-    optional: true
-
-  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -8481,9 +8219,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
@@ -8491,9 +8226,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.18.20':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -8505,9 +8237,6 @@ snapshots:
   '@esbuild/linux-arm64@0.18.20':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
@@ -8515,9 +8244,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.18.20':
-    optional: true
-
-  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -8529,9 +8255,6 @@ snapshots:
   '@esbuild/linux-ia32@0.18.20':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
@@ -8539,9 +8262,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.18.20':
-    optional: true
-
-  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -8553,9 +8273,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
@@ -8563,9 +8280,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.18.20':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -8577,9 +8291,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
@@ -8589,9 +8300,6 @@ snapshots:
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -8599,9 +8307,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
-    optional: true
-
-  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -8619,9 +8324,6 @@ snapshots:
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -8635,9 +8337,6 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -8655,9 +8354,6 @@ snapshots:
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
@@ -8665,9 +8361,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
-    optional: true
-
-  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -8679,9 +8372,6 @@ snapshots:
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
@@ -8689,9 +8379,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.18.20':
-    optional: true
-
-  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -10709,7 +10396,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
 
   '@types/caseless@0.12.5': {}
 
@@ -10720,7 +10407,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
 
   '@types/cookiejar@2.1.5': {}
 
@@ -10857,7 +10544,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -10880,7 +10567,7 @@ snapshots:
 
   '@types/jsdom@28.0.0':
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
       undici-types: 7.24.4
@@ -10930,7 +10617,7 @@ snapshots:
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
 
@@ -10938,12 +10625,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
 
   '@types/sharp@0.32.0':
     dependencies:
@@ -10953,7 +10640,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
       form-data: 4.0.5
 
   '@types/supertest@6.0.3':
@@ -10972,7 +10659,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -10988,13 +10675,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.1.9':
-    dependencies:
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
-      chai: 5.3.3
-      tinyrainbow: 1.2.0
-
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -11002,14 +10682,6 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.11)(lightningcss@1.30.2))':
-    dependencies:
-      '@vitest/spy': 2.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.30.2)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4))':
     dependencies:
@@ -11027,18 +10699,9 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4)
 
-  '@vitest/pretty-format@2.1.9':
-    dependencies:
-      tinyrainbow: 1.2.0
-
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
-
-  '@vitest/runner@2.1.9':
-    dependencies:
-      '@vitest/utils': 2.1.9
-      pathe: 1.1.2
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -11046,31 +10709,15 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.1.0
 
-  '@vitest/snapshot@2.1.9':
-    dependencies:
-      '@vitest/pretty-format': 2.1.9
-      magic-string: 0.30.21
-      pathe: 1.1.2
-
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@2.1.9':
-    dependencies:
-      tinyspy: 3.0.2
-
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
-
-  '@vitest/utils@2.1.9':
-    dependencies:
-      '@vitest/pretty-format': 2.1.9
-      loupe: 3.2.1
-      tinyrainbow: 1.2.0
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11933,32 +11580,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
-
-  esbuild@0.21.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -13254,8 +12875,6 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
-  pathe@1.1.2: {}
-
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
@@ -14101,11 +13720,7 @@ snapshots:
 
   tinypool@1.1.1: {}
 
-  tinyrainbow@1.2.0: {}
-
   tinyrainbow@2.0.0: {}
-
-  tinyspy@3.0.2: {}
 
   tinyspy@4.0.4: {}
 
@@ -14319,24 +13934,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@2.1.9(@types/node@22.19.11)(lightningcss@1.30.2):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 1.1.2
-      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.30.2)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
   vite-node@3.2.4(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       cac: 6.7.14
@@ -14378,16 +13975,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vite@5.4.21(@types/node@22.19.11)(lightningcss@1.30.2):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.60.1
-    optionalDependencies:
-      '@types/node': 22.19.11
-      fsevents: 2.3.3
-      lightningcss: 1.30.2
 
   vite@6.4.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
@@ -14452,42 +14039,6 @@ snapshots:
       lightningcss: 1.30.2
       tsx: 4.21.0
       yaml: 2.8.4
-
-  vitest@2.1.9(@types/node@22.19.11)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2):
-    dependencies:
-      '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.11)(lightningcss@1.30.2))
-      '@vitest/pretty-format': 2.1.9
-      '@vitest/runner': 2.1.9
-      '@vitest/snapshot': 2.1.9
-      '@vitest/spy': 2.1.9
-      '@vitest/utils': 2.1.9
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.1.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@22.19.11)(lightningcss@1.30.2)
-      vite-node: 2.1.9(@types/node@22.19.11)(lightningcss@1.30.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.19.11
-      jsdom: 28.1.0(@noble/hashes@2.0.1)
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -30,6 +30,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/adapters/kubernetes-execution",
+    "name": "@paperclipai/execution-target-kubernetes",
+    "publishFromCi": true
+  },
+  {
     "dir": "packages/adapters/opencode-local",
     "name": "@paperclipai/adapter-opencode-local",
     "publishFromCi": true

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -32,7 +32,7 @@
   {
     "dir": "packages/adapters/kubernetes-execution",
     "name": "@paperclipai/execution-target-kubernetes",
-    "publishFromCi": true
+    "publishFromCi": false
   },
   {
     "dir": "packages/adapters/opencode-local",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,11 @@
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./services/cluster-connections": "./src/services/cluster-connections.ts",
+    "./services/cluster-tenant-policies": "./src/services/cluster-tenant-policies.ts",
+    "./services/cluster-namespace-bindings": "./src/services/cluster-namespace-bindings.ts",
+    "./secrets/provider-registry": "./src/secrets/provider-registry.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -21,6 +25,22 @@
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./services/cluster-connections": {
+        "types": "./dist/services/cluster-connections.d.ts",
+        "import": "./dist/services/cluster-connections.js"
+      },
+      "./services/cluster-tenant-policies": {
+        "types": "./dist/services/cluster-tenant-policies.d.ts",
+        "import": "./dist/services/cluster-tenant-policies.js"
+      },
+      "./services/cluster-namespace-bindings": {
+        "types": "./dist/services/cluster-namespace-bindings.d.ts",
+        "import": "./dist/services/cluster-namespace-bindings.js"
+      },
+      "./secrets/provider-registry": {
+        "types": "./dist/secrets/provider-registry.d.ts",
+        "import": "./dist/secrets/provider-registry.js"
       }
     },
     "main": "./dist/index.js",

--- a/server/package.json
+++ b/server/package.json
@@ -54,6 +54,7 @@
     "@paperclipai/adapter-pi-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",
+    "@paperclipai/execution-target-kubernetes": "workspace:*",
     "@paperclipai/plugin-sdk": "workspace:*",
     "@paperclipai/shared": "workspace:*",
     "ajv": "^8.18.0",

--- a/server/src/__tests__/k8s-cli-end-to-end.test.ts
+++ b/server/src/__tests__/k8s-cli-end-to-end.test.ts
@@ -1,0 +1,177 @@
+/**
+ * M1 End-to-End smoke — CLI services against a real kind cluster
+ *
+ * Exercises the EXACT code path the CLI uses:
+ *   clusterConnectionsService.create  (paperclipai cluster add …)
+ *   → createExecutionTargetRegistry / registerKubernetesExecutionTargetDriver
+ *   → driver.ensureTenant            (provisions namespace on kind)
+ *   → clusterNamespaceBindingsService.record
+ *
+ * Run with:
+ *   pnpm -w exec vitest run --config server/vitest.integration.config.ts k8s-cli-end-to-end
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createDb,
+  companies,
+  startEmbeddedPostgresTestDatabase,
+  type EmbeddedPostgresTestDatabase,
+  type Db,
+} from "@paperclipai/db";
+import { clusterConnectionsService } from "../services/cluster-connections.js";
+import { clusterTenantPoliciesService } from "../services/cluster-tenant-policies.js";
+import { clusterNamespaceBindingsService } from "../services/cluster-namespace-bindings.js";
+import { createExecutionTargetRegistry } from "../adapters/execution-target-registry.js";
+import { registerKubernetesExecutionTargetDriver } from "../adapters/execution-targets/kubernetes.js";
+
+// ---------------------------------------------------------------------------
+// Inline kind harness (mirrors packages/adapters/kubernetes-execution/test/integration/_harness.ts)
+// ---------------------------------------------------------------------------
+
+interface KindCluster {
+  name: string;
+  kubeconfigPath: string;
+  kubeconfigYaml: string;
+  cleanup(): void;
+}
+
+function spinUpKind(): KindCluster {
+  const name = `pp-e2e-${Math.random().toString(36).slice(2, 8)}`;
+  const dir = mkdtempSync(join(tmpdir(), `${name}-`));
+  const kubeconfigPath = join(dir, "kubeconfig");
+  execSync(`kind create cluster --name ${name} --kubeconfig ${kubeconfigPath} --wait 90s`, {
+    stdio: "inherit",
+  });
+  const kubeconfigYaml = readFileSync(kubeconfigPath, "utf-8");
+  return {
+    name,
+    kubeconfigPath,
+    kubeconfigYaml,
+    cleanup: () => {
+      try { execSync(`kind delete cluster --name ${name}`, { stdio: "ignore" }); } catch { /* swallow */ }
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* swallow */ }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite-level setup
+// ---------------------------------------------------------------------------
+
+let kc: KindCluster;
+let dbHandle: EmbeddedPostgresTestDatabase;
+let db: Db;
+let companyId: string;
+
+beforeAll(async () => {
+  // Spin up the kind cluster and embedded postgres in parallel.
+  const [kindResult, dbResult] = await Promise.all([
+    Promise.resolve(spinUpKind()),
+    startEmbeddedPostgresTestDatabase("paperclip-m1-e2e-"),
+  ]);
+  kc = kindResult;
+  dbHandle = dbResult;
+  db = createDb(dbHandle.connectionString);
+
+  // Seed a company row (required FK for namespace bindings).
+  const [row] = await db.insert(companies).values({ name: "Acme Corp" }).returning();
+  companyId = row.id;
+}, 240_000);
+
+afterAll(async () => {
+  kc?.cleanup();
+  await dbHandle?.cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+describe("M1 end-to-end smoke (CLI services + kind)", () => {
+  it(
+    "registers cluster, provisions a tenant, records binding, asserts idempotency",
+    async () => {
+      // 1. Wire services exactly the way the CLI does.
+      const cs = clusterConnectionsService(db, {
+        resolveSecret: async () => kc.kubeconfigYaml,
+      });
+      const tps = clusterTenantPoliciesService(db);
+      const bindings = clusterNamespaceBindingsService(db);
+
+      // 2. Register a cluster connection (paperclipai cluster add …).
+      const conn = await cs.create({
+        label: "smoke-kind",
+        kind: "kubeconfig",
+        kubeconfigSecretRef: { provider: "stub", name: "kc" },
+        capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+        createdBy: "smoke",
+      });
+      expect(conn.id).toBeDefined();
+      expect(conn.label).toBe("smoke-kind");
+
+      // 3. Wire the registry exactly like the server does at startup.
+      const reg = createExecutionTargetRegistry();
+      registerKubernetesExecutionTargetDriver(reg, {
+        resolveConnection: (id) => cs.resolve(id),
+      });
+      const driver = reg.get("kubernetes")!;
+      expect(driver).not.toBeNull();
+
+      // 4. Ensure the tenant namespace (provisions namespace on kind).
+      const result = await driver.ensureTenant({
+        clusterConnectionId: conn.id,
+        company: { id: companyId, slug: "acme-corp" },
+        tenantPolicy: null,
+        driverServiceAccount: { name: "default", namespace: "default" },
+        controlPlane: { topology: "cross-cluster", namespaceLabels: {}, podLabels: {} },
+        adapterAllowFqdns: [],
+        imagePullDockerConfigJson: null,
+      });
+      expect(result.namespace).toBe("paperclip-acme-corp");
+      expect(result.ciliumApplied).toBe(false);
+
+      // 5. Record the namespace binding (what the CLI does after ensure-tenant).
+      await bindings.record({
+        clusterConnectionId: conn.id,
+        companyId,
+        namespaceName: result.namespace,
+      });
+
+      // 6. Verify by reading the binding back from DB.
+      const binding = await bindings.getByClusterAndCompany(conn.id, companyId);
+      expect(binding).not.toBeNull();
+      expect(binding!.namespaceName).toBe("paperclip-acme-corp");
+
+      // 7. Verify the tenant policy get path returns null (no policy seeded).
+      const tp = await tps.get(conn.id, companyId);
+      expect(tp).toBeNull();
+
+      // 8. Idempotency: re-running ensure-tenant must return the same namespace
+      //    without error (namespace already exists on kind).
+      const result2 = await driver.ensureTenant({
+        clusterConnectionId: conn.id,
+        company: { id: companyId, slug: "acme-corp" },
+        tenantPolicy: null,
+        driverServiceAccount: { name: "default", namespace: "default" },
+        controlPlane: { topology: "cross-cluster", namespaceLabels: {}, podLabels: {} },
+        adapterAllowFqdns: [],
+        imagePullDockerConfigJson: null,
+      });
+      expect(result2.namespace).toBe(result.namespace);
+
+      // 9. Record the binding again; idempotent upsert should not throw.
+      await bindings.record({
+        clusterConnectionId: conn.id,
+        companyId,
+        namespaceName: result2.namespace,
+      });
+      const binding2 = await bindings.getByClusterAndCompany(conn.id, companyId);
+      expect(binding2!.namespaceName).toBe("paperclip-acme-corp");
+    },
+    240_000,
+  );
+});

--- a/server/src/adapters/execution-target-registry.test.ts
+++ b/server/src/adapters/execution-target-registry.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { createExecutionTargetRegistry } from "./execution-target-registry.js";
+import type { ExecutionTargetDriver } from "./execution-target-registry.js";
+
+function fakeDriver(): ExecutionTargetDriver {
+  return {
+    type: "kubernetes",
+    validateTarget: async () => {},
+    ensureTenant: async () => ({ namespace: "x", ciliumApplied: false }),
+    run: async () => ({ exitCode: 0, signal: null, timedOut: false }),
+  };
+}
+
+describe("ExecutionTargetDriverRegistry", () => {
+  it("registers and retrieves a driver by kind", () => {
+    const reg = createExecutionTargetRegistry();
+    const d = fakeDriver();
+    reg.register(d);
+    expect(reg.get("kubernetes")).toBe(d);
+  });
+
+  it("rejects duplicate registrations of the same kind", () => {
+    const reg = createExecutionTargetRegistry();
+    reg.register(fakeDriver());
+    expect(() => reg.register(fakeDriver())).toThrow(/already registered/i);
+  });
+
+  it("returns null for unknown kinds", () => {
+    const reg = createExecutionTargetRegistry();
+    expect(reg.get("kubernetes")).toBeNull();
+  });
+
+  it("list() returns all registered drivers", () => {
+    const reg = createExecutionTargetRegistry();
+    const d = fakeDriver();
+    reg.register(d);
+    expect(reg.list()).toEqual([d]);
+  });
+});

--- a/server/src/adapters/execution-target-registry.ts
+++ b/server/src/adapters/execution-target-registry.ts
@@ -1,0 +1,31 @@
+import type { KubernetesExecutionDriver } from "@paperclipai/execution-target-kubernetes";
+
+/**
+ * Discriminated union of every registered execution-target driver.
+ * Future kinds (Nomad, ECS, Modal, ...) extend this union.
+ */
+export type ExecutionTargetDriver = KubernetesExecutionDriver;
+
+export interface ExecutionTargetDriverRegistry {
+  register(driver: ExecutionTargetDriver): void;
+  get(kind: ExecutionTargetDriver["type"]): ExecutionTargetDriver | null;
+  list(): ExecutionTargetDriver[];
+}
+
+export function createExecutionTargetRegistry(): ExecutionTargetDriverRegistry {
+  const drivers = new Map<string, ExecutionTargetDriver>();
+  return {
+    register(driver) {
+      if (drivers.has(driver.type)) {
+        throw new Error(`Execution target driver "${driver.type}" already registered`);
+      }
+      drivers.set(driver.type, driver);
+    },
+    get(kind) {
+      return drivers.get(kind) ?? null;
+    },
+    list() {
+      return [...drivers.values()];
+    },
+  };
+}

--- a/server/src/adapters/execution-targets/kubernetes.test.ts
+++ b/server/src/adapters/execution-targets/kubernetes.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { registerKubernetesExecutionTargetDriver } from "./kubernetes.js";
+import { createExecutionTargetRegistry } from "../execution-target-registry.js";
+
+describe("registerKubernetesExecutionTargetDriver", () => {
+  it("registers a driver of type 'kubernetes' into the registry", () => {
+    const reg = createExecutionTargetRegistry();
+    registerKubernetesExecutionTargetDriver(reg, {
+      resolveConnection: async () => null,
+    });
+    const drv = reg.get("kubernetes");
+    expect(drv).not.toBeNull();
+    expect(drv?.type).toBe("kubernetes");
+  });
+
+  it("a freshly registered driver rejects unknown connection ids", async () => {
+    const reg = createExecutionTargetRegistry();
+    registerKubernetesExecutionTargetDriver(reg, {
+      resolveConnection: async () => null,
+    });
+    const drv = reg.get("kubernetes")!;
+    await expect(drv.validateTarget({ kind: "kubernetes", clusterConnectionId: "missing" }))
+      .rejects.toThrow(/not found/i);
+  });
+});

--- a/server/src/adapters/execution-targets/kubernetes.ts
+++ b/server/src/adapters/execution-targets/kubernetes.ts
@@ -1,0 +1,17 @@
+import {
+  createKubernetesExecutionDriver,
+  type KubernetesDriverDeps,
+} from "@paperclipai/execution-target-kubernetes";
+import type { ExecutionTargetDriverRegistry } from "../execution-target-registry.js";
+
+/**
+ * Wires the Kubernetes execution-target driver into the registry. Called once
+ * at server startup with a closure that resolves cluster connection records
+ * (kubeconfig blob via Paperclip secret store, etc.) to ResolvedClusterConnection.
+ */
+export function registerKubernetesExecutionTargetDriver(
+  registry: ExecutionTargetDriverRegistry,
+  deps: KubernetesDriverDeps,
+): void {
+  registry.register(createKubernetesExecutionDriver(deps));
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -48,6 +48,10 @@ import type {
   InstanceDatabaseBackupRunResult,
   InstanceDatabaseBackupTrigger,
 } from "./routes/instance-database-backups.js";
+import { createExecutionTargetRegistry } from "./adapters/execution-target-registry.js";
+import { registerKubernetesExecutionTargetDriver } from "./adapters/execution-targets/kubernetes.js";
+import { clusterConnectionsService } from "./services/cluster-connections.js";
+import { getSecretProvider } from "./secrets/provider-registry.js";
 
 type BetterAuthSessionUser = {
   id: string;
@@ -593,6 +597,37 @@ export async function startServer(): Promise<StartedServer> {
     }
   };
   const pluginWorkerManager = createPluginWorkerManager();
+
+  // ---------------------------------------------------------------------------
+  // Execution-target registry
+  //
+  // The kubeconfigSecretRef stored in cluster_connections uses
+  // { provider, name } where `name` is the externalRef (for external providers
+  // such as AWS Secrets Manager / GCP Secret Manager / Vault). For those
+  // providers, `resolveVersion({ material: {}, externalRef: name })` is the
+  // correct call. For the `local_encrypted` provider the kubeconfig blob must
+  // be stored via an external provider — instance-level local-encrypted storage
+  // is not yet wired (M2 gap: design a cluster-scoped secret vault or let
+  // operators use an external provider for kubeconfig credentials).
+  // ---------------------------------------------------------------------------
+  const clusterConnections = clusterConnectionsService(db as any, {
+    resolveSecret: async (ref) => {
+      const provider = getSecretProvider(ref.provider as Parameters<typeof getSecretProvider>[0]);
+      // `ref.name` is the externalRef used by external secret providers
+      // (AWS SM / GCP SM / Vault). For `local_encrypted`, kubeconfig material
+      // must be stored via an external provider; calling this path with
+      // `local_encrypted` will throw from the provider itself.
+      // TODO(M2): design instance-scoped secret storage for local_encrypted
+      //           kubeconfig blobs so operators without external providers
+      //           can still register clusters.
+      return provider.resolveVersion({ material: {}, externalRef: ref.name });
+    },
+  });
+  const executionTargetRegistry = createExecutionTargetRegistry();
+  registerKubernetesExecutionTargetDriver(executionTargetRegistry, {
+    resolveConnection: (id) => clusterConnections.resolve(id),
+  });
+
   const app = await createApp(db as any, {
     uiMode,
     serverPort: listenPort,

--- a/server/src/services/cluster-connections.test.ts
+++ b/server/src/services/cluster-connections.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startEmbeddedPostgresTestDatabase, type EmbeddedPostgresTestDatabase, createDb } from "@paperclipai/db";
+import type { Db } from "@paperclipai/db";
+import { clusterConnectionsService } from "./cluster-connections.js";
+
+let dbHandle: EmbeddedPostgresTestDatabase;
+let db: Db;
+
+beforeAll(async () => {
+  dbHandle = await startEmbeddedPostgresTestDatabase("paperclip-cluster-conn-test-");
+  db = createDb(dbHandle.connectionString);
+});
+afterAll(async () => { await dbHandle.cleanup(); });
+
+describe("clusterConnectionsService", () => {
+  it("creates, lists, gets, resolves, and deletes a connection", async () => {
+    const svc = clusterConnectionsService(db, {
+      resolveSecret: async (ref) => `fake-kubeconfig-yaml:${ref.provider}:${ref.name}`,
+    });
+    const created = await svc.create({
+      label: "kind-test",
+      kind: "kubeconfig",
+      kubeconfigSecretRef: { provider: "local_encrypted", name: "kind-cfg" },
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      createdBy: "system",
+    });
+    expect(created.id).toBeDefined();
+    expect(created.defaultNamespacePrefix).toBe("paperclip-");
+    expect(created.allowAgentImageOverride).toBe(false);
+
+    const list = await svc.list();
+    expect(list).toHaveLength(1);
+
+    const fetched = await svc.get(created.id);
+    expect(fetched?.label).toBe("kind-test");
+
+    const resolved = await svc.resolve(created.id);
+    expect(resolved?.kubeconfigYaml).toBe("fake-kubeconfig-yaml:local_encrypted:kind-cfg");
+
+    await svc.delete(created.id);
+    expect(await svc.list()).toHaveLength(0);
+  });
+
+  it("rejects duplicate labels", async () => {
+    const svc = clusterConnectionsService(db, { resolveSecret: async () => "x" });
+    await svc.create({
+      label: "dupe", kind: "in-cluster",
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      createdBy: "system",
+    });
+    await expect(svc.create({
+      label: "dupe", kind: "in-cluster",
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      createdBy: "system",
+    })).rejects.toThrow(/label/i);
+  });
+
+  it("resolve() returns null for an unknown id", async () => {
+    const svc = clusterConnectionsService(db, { resolveSecret: async () => "x" });
+    expect(await svc.resolve("00000000-0000-0000-0000-000000000000")).toBeNull();
+  });
+
+  it("resolve() omits kubeconfigYaml for in-cluster connections", async () => {
+    const svc = clusterConnectionsService(db, {
+      resolveSecret: async () => { throw new Error("should not be called for in-cluster"); },
+    });
+    const created = await svc.create({
+      label: "in-cluster-test", kind: "in-cluster",
+      capabilities: { cilium: false, storageClass: "standard", architectures: ["amd64"] },
+      createdBy: "system",
+    });
+    const resolved = await svc.resolve(created.id);
+    expect(resolved?.kind).toBe("in-cluster");
+    expect(resolved?.kubeconfigYaml).toBeUndefined();
+  });
+});

--- a/server/src/services/cluster-connections.ts
+++ b/server/src/services/cluster-connections.ts
@@ -1,0 +1,123 @@
+import { eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { clusterConnections } from "@paperclipai/db";
+import type { ResolvedClusterConnection, ClusterCapabilities } from "@paperclipai/execution-target-kubernetes";
+
+export interface ClusterConnectionRow {
+  id: string;
+  label: string;
+  kind: "in-cluster" | "kubeconfig";
+  kubeconfigSecretRef: { provider: string; name: string } | null;
+  apiServerUrl: string | null;
+  defaultNamespacePrefix: string;
+  capabilities: ClusterCapabilities;
+  paperclipPublicUrl: string | null;
+  imageRegistry: string | null;
+  allowAgentImageOverride: boolean;
+  createdAt: Date;
+  createdBy: string;
+}
+
+export interface CreateClusterConnectionInput {
+  label: string;
+  kind: "in-cluster" | "kubeconfig";
+  kubeconfigSecretRef?: { provider: string; name: string };
+  apiServerUrl?: string;
+  defaultNamespacePrefix?: string;
+  capabilities: ClusterCapabilities;
+  paperclipPublicUrl?: string;
+  imageRegistry?: string;
+  allowAgentImageOverride?: boolean;
+  createdBy: string;
+}
+
+export interface ClusterConnectionsServiceDeps {
+  resolveSecret: (ref: { provider: string; name: string }) => Promise<string>;
+}
+
+export interface ClusterConnectionsService {
+  create(input: CreateClusterConnectionInput): Promise<ClusterConnectionRow>;
+  list(): Promise<ClusterConnectionRow[]>;
+  get(id: string): Promise<ClusterConnectionRow | null>;
+  delete(id: string): Promise<void>;
+  resolve(id: string): Promise<ResolvedClusterConnection | null>;
+}
+
+export function clusterConnectionsService(db: Db, deps: ClusterConnectionsServiceDeps): ClusterConnectionsService {
+  return {
+    async create(input) {
+      try {
+        const [row] = await db.insert(clusterConnections).values({
+          label: input.label,
+          kind: input.kind,
+          kubeconfigSecretRef: input.kubeconfigSecretRef ?? null,
+          apiServerUrl: input.apiServerUrl ?? null,
+          defaultNamespacePrefix: input.defaultNamespacePrefix ?? "paperclip-",
+          capabilities: input.capabilities,
+          paperclipPublicUrl: input.paperclipPublicUrl ?? null,
+          imageRegistry: input.imageRegistry ?? null,
+          allowAgentImageOverride: input.allowAgentImageOverride ? "true" : "false",
+          createdBy: input.createdBy,
+        }).returning();
+        return mapRow(row);
+      } catch (err) {
+        if (/cluster_connections_label_uq/.test(String(err))) {
+          throw new Error(`A cluster connection with label "${input.label}" already exists`);
+        }
+        throw err;
+      }
+    },
+
+    async list() {
+      const rows = await db.select().from(clusterConnections);
+      return rows.map(mapRow);
+    },
+
+    async get(id) {
+      const [row] = await db.select().from(clusterConnections).where(eq(clusterConnections.id, id));
+      return row ? mapRow(row) : null;
+    },
+
+    async delete(id) {
+      await db.delete(clusterConnections).where(eq(clusterConnections.id, id));
+    },
+
+    async resolve(id) {
+      const row = await this.get(id);
+      if (!row) return null;
+      let kubeconfigYaml: string | undefined;
+      if (row.kind === "kubeconfig" && row.kubeconfigSecretRef) {
+        kubeconfigYaml = await deps.resolveSecret(row.kubeconfigSecretRef);
+      }
+      return {
+        id: row.id,
+        label: row.label,
+        kind: row.kind,
+        kubeconfigYaml,
+        apiServerUrl: row.apiServerUrl,
+        defaultNamespacePrefix: row.defaultNamespacePrefix,
+        paperclipPublicUrl: row.paperclipPublicUrl,
+        imageRegistry: row.imageRegistry,
+        allowAgentImageOverride: row.allowAgentImageOverride,
+        capabilities: row.capabilities,
+      };
+    },
+  };
+}
+
+function mapRow(row: typeof clusterConnections.$inferSelect): ClusterConnectionRow {
+  return {
+    id: row.id,
+    label: row.label,
+    kind: row.kind as "in-cluster" | "kubeconfig",
+    kubeconfigSecretRef: row.kubeconfigSecretRef ?? null,
+    apiServerUrl: row.apiServerUrl ?? null,
+    defaultNamespacePrefix: row.defaultNamespacePrefix,
+    capabilities: row.capabilities as ClusterCapabilities,
+    paperclipPublicUrl: row.paperclipPublicUrl ?? null,
+    imageRegistry: row.imageRegistry ?? null,
+    allowAgentImageOverride: row.allowAgentImageOverride === "true",
+    createdAt: row.createdAt,
+    createdBy: row.createdBy,
+  };
+}

--- a/server/src/services/cluster-namespace-bindings.test.ts
+++ b/server/src/services/cluster-namespace-bindings.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  startEmbeddedPostgresTestDatabase,
+  type EmbeddedPostgresTestDatabase,
+  createDb,
+} from "@paperclipai/db";
+import type { Db } from "@paperclipai/db";
+import { sql } from "drizzle-orm";
+import { clusterNamespaceBindingsService } from "./cluster-namespace-bindings.js";
+
+let dbHandle: EmbeddedPostgresTestDatabase;
+let db: Db;
+let clusterId: string;
+let companyId: string;
+
+beforeAll(async () => {
+  dbHandle = await startEmbeddedPostgresTestDatabase("paperclip-ns-binding-test-");
+  db = createDb(dbHandle.connectionString);
+
+  // Seed a cluster connection
+  const clusterRows = await db.execute(sql`
+    INSERT INTO cluster_connections (label, kind, capabilities, created_by)
+    VALUES ('seed-cluster', 'in-cluster', '{"cilium":false,"storageClass":"standard","architectures":["amd64"]}'::jsonb, 'sys')
+    RETURNING id
+  `);
+  clusterId =
+    (clusterRows.rows?.[0] as { id: string } | undefined)?.id ??
+    (clusterRows[0] as { id: string }).id;
+
+  // Seed a company
+  const companyRows = await db.execute(sql`
+    INSERT INTO companies (name)
+    VALUES ('Acme')
+    RETURNING id
+  `);
+  companyId =
+    (companyRows.rows?.[0] as { id: string } | undefined)?.id ??
+    (companyRows[0] as { id: string }).id;
+});
+
+afterAll(async () => {
+  await dbHandle.cleanup();
+});
+
+describe("clusterNamespaceBindingsService", () => {
+  it("getByClusterAndCompany() returns null when no binding exists", async () => {
+    const svc = clusterNamespaceBindingsService(db);
+    const result = await svc.getByClusterAndCompany(clusterId, companyId);
+    expect(result).toBeNull();
+  });
+
+  it("record() creates a new binding", async () => {
+    const svc = clusterNamespaceBindingsService(db);
+    await svc.record({
+      clusterConnectionId: clusterId,
+      companyId,
+      namespaceName: "paperclip-acme",
+    });
+
+    const found = await svc.getByClusterAndCompany(clusterId, companyId);
+    expect(found).not.toBeNull();
+    expect(found?.namespaceName).toBe("paperclip-acme");
+  });
+
+  it("record() is idempotent — second call updates the namespace name", async () => {
+    const svc = clusterNamespaceBindingsService(db);
+    await svc.record({
+      clusterConnectionId: clusterId,
+      companyId,
+      namespaceName: "paperclip-acme-v2",
+    });
+
+    const found = await svc.getByClusterAndCompany(clusterId, companyId);
+    expect(found?.namespaceName).toBe("paperclip-acme-v2");
+  });
+
+  it("record() preserves other rows when called for a different company", async () => {
+    const svc = clusterNamespaceBindingsService(db);
+
+    // Seed a second company
+    const otherRows = await db.execute(sql`
+      INSERT INTO companies (name, issue_prefix)
+      VALUES ('Beta Corp', 'BET')
+      RETURNING id
+    `);
+    const otherCompanyId =
+      (otherRows.rows?.[0] as { id: string } | undefined)?.id ??
+      (otherRows[0] as { id: string }).id;
+
+    await svc.record({
+      clusterConnectionId: clusterId,
+      companyId: otherCompanyId,
+      namespaceName: "paperclip-beta-corp",
+    });
+
+    // Original binding should still be paperclip-acme-v2
+    const acme = await svc.getByClusterAndCompany(clusterId, companyId);
+    expect(acme?.namespaceName).toBe("paperclip-acme-v2");
+
+    // New binding should be paperclip-beta-corp
+    const beta = await svc.getByClusterAndCompany(clusterId, otherCompanyId);
+    expect(beta?.namespaceName).toBe("paperclip-beta-corp");
+  });
+});

--- a/server/src/services/cluster-namespace-bindings.test.ts
+++ b/server/src/services/cluster-namespace-bindings.test.ts
@@ -23,9 +23,7 @@ beforeAll(async () => {
     VALUES ('seed-cluster', 'in-cluster', '{"cilium":false,"storageClass":"standard","architectures":["amd64"]}'::jsonb, 'sys')
     RETURNING id
   `);
-  clusterId =
-    (clusterRows.rows?.[0] as { id: string } | undefined)?.id ??
-    (clusterRows[0] as { id: string }).id;
+  clusterId = (clusterRows[0] as { id: string }).id;
 
   // Seed a company
   const companyRows = await db.execute(sql`
@@ -33,9 +31,7 @@ beforeAll(async () => {
     VALUES ('Acme')
     RETURNING id
   `);
-  companyId =
-    (companyRows.rows?.[0] as { id: string } | undefined)?.id ??
-    (companyRows[0] as { id: string }).id;
+  companyId = (companyRows[0] as { id: string }).id;
 });
 
 afterAll(async () => {
@@ -74,6 +70,38 @@ describe("clusterNamespaceBindingsService", () => {
     expect(found?.namespaceName).toBe("paperclip-acme-v2");
   });
 
+  it("record() handles concurrent first-write without violating the unique constraint", async () => {
+    // Seed an isolated company so this test does not interact with the rows
+    // written by the earlier suite cases.
+    const conRows = await db.execute(sql`
+      INSERT INTO companies (name, issue_prefix)
+      VALUES ('Gamma Corp', 'GAM')
+      RETURNING id
+    `);
+    const conCompanyId = (conRows[0] as { id: string }).id;
+
+    const svc = clusterNamespaceBindingsService(db);
+    const N = 8;
+    // The pre-fix select-then-insert shape lost this race: two callers would
+    // both observe no row and one would hit the unique constraint as an
+    // unhandled error. With ON CONFLICT the upsert is unconditionally atomic.
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        svc.record({
+          clusterConnectionId: clusterId,
+          companyId: conCompanyId,
+          namespaceName: `paperclip-gamma-${i}`,
+        }),
+      ),
+    );
+
+    const found = await svc.getByClusterAndCompany(clusterId, conCompanyId);
+    expect(found).not.toBeNull();
+    // The winning name is whichever upsert committed last; we only need to
+    // assert that exactly one row exists and no exceptions were thrown.
+    expect(found?.namespaceName).toMatch(/^paperclip-gamma-\d$/);
+  });
+
   it("record() preserves other rows when called for a different company", async () => {
     const svc = clusterNamespaceBindingsService(db);
 
@@ -83,9 +111,7 @@ describe("clusterNamespaceBindingsService", () => {
       VALUES ('Beta Corp', 'BET')
       RETURNING id
     `);
-    const otherCompanyId =
-      (otherRows.rows?.[0] as { id: string } | undefined)?.id ??
-      (otherRows[0] as { id: string }).id;
+    const otherCompanyId = (otherRows[0] as { id: string }).id;
 
     await svc.record({
       clusterConnectionId: clusterId,

--- a/server/src/services/cluster-namespace-bindings.ts
+++ b/server/src/services/cluster-namespace-bindings.ts
@@ -1,0 +1,60 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { clusterNamespaceBindings } from "@paperclipai/db";
+
+export interface RecordBindingInput {
+  clusterConnectionId: string;
+  companyId: string;
+  namespaceName: string;
+}
+
+export interface ClusterNamespaceBindingsService {
+  record(input: RecordBindingInput): Promise<void>;
+  getByClusterAndCompany(
+    clusterConnectionId: string,
+    companyId: string,
+  ): Promise<{ id: string; namespaceName: string } | null>;
+}
+
+export function clusterNamespaceBindingsService(db: Db): ClusterNamespaceBindingsService {
+  return {
+    async record(input) {
+      const [existing] = await db
+        .select()
+        .from(clusterNamespaceBindings)
+        .where(
+          and(
+            eq(clusterNamespaceBindings.clusterConnectionId, input.clusterConnectionId),
+            eq(clusterNamespaceBindings.companyId, input.companyId),
+          ),
+        );
+
+      if (existing) {
+        await db
+          .update(clusterNamespaceBindings)
+          .set({ namespaceName: input.namespaceName, updatedAt: new Date() })
+          .where(eq(clusterNamespaceBindings.id, existing.id));
+        return;
+      }
+
+      await db.insert(clusterNamespaceBindings).values({
+        clusterConnectionId: input.clusterConnectionId,
+        companyId: input.companyId,
+        namespaceName: input.namespaceName,
+      });
+    },
+
+    async getByClusterAndCompany(clusterConnectionId, companyId) {
+      const [row] = await db
+        .select()
+        .from(clusterNamespaceBindings)
+        .where(
+          and(
+            eq(clusterNamespaceBindings.clusterConnectionId, clusterConnectionId),
+            eq(clusterNamespaceBindings.companyId, companyId),
+          ),
+        );
+      return row ? { id: row.id, namespaceName: row.namespaceName } : null;
+    },
+  };
+}

--- a/server/src/services/cluster-namespace-bindings.ts
+++ b/server/src/services/cluster-namespace-bindings.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { clusterNamespaceBindings } from "@paperclipai/db";
 
@@ -19,29 +19,25 @@ export interface ClusterNamespaceBindingsService {
 export function clusterNamespaceBindingsService(db: Db): ClusterNamespaceBindingsService {
   return {
     async record(input) {
-      const [existing] = await db
-        .select()
-        .from(clusterNamespaceBindings)
-        .where(
-          and(
-            eq(clusterNamespaceBindings.clusterConnectionId, input.clusterConnectionId),
-            eq(clusterNamespaceBindings.companyId, input.companyId),
-          ),
-        );
-
-      if (existing) {
-        await db
-          .update(clusterNamespaceBindings)
-          .set({ namespaceName: input.namespaceName, updatedAt: new Date() })
-          .where(eq(clusterNamespaceBindings.id, existing.id));
-        return;
-      }
-
-      await db.insert(clusterNamespaceBindings).values({
-        clusterConnectionId: input.clusterConnectionId,
-        companyId: input.companyId,
-        namespaceName: input.namespaceName,
-      });
+      // Atomic upsert keyed on the (cluster_connection_id, company_id) unique
+      // index. The previous select-then-insert had a TOCTOU race under
+      // concurrent provisioning: two callers could both observe no existing
+      // binding, both INSERT, and one would hit the unique constraint as an
+      // unhandled error.
+      await db
+        .insert(clusterNamespaceBindings)
+        .values({
+          clusterConnectionId: input.clusterConnectionId,
+          companyId: input.companyId,
+          namespaceName: input.namespaceName,
+        })
+        .onConflictDoUpdate({
+          target: [clusterNamespaceBindings.clusterConnectionId, clusterNamespaceBindings.companyId],
+          set: {
+            namespaceName: input.namespaceName,
+            updatedAt: sql`now()`,
+          },
+        });
     },
 
     async getByClusterAndCompany(clusterConnectionId, companyId) {

--- a/server/src/services/cluster-tenant-policies.test.ts
+++ b/server/src/services/cluster-tenant-policies.test.ts
@@ -73,6 +73,36 @@ describe("clusterTenantPoliciesService", () => {
     expect(fetched?.limitRange?.default?.cpu).toBe("2");
   });
 
+  it("upsert() handles concurrent first-write without a unique-constraint error", async () => {
+    // Seed an isolated company so this case doesn't interact with rows
+    // written by earlier suite cases.
+    const conRows = await db.execute(sql`
+      INSERT INTO companies (name, issue_prefix) VALUES ('Delta Corp', 'DLT') RETURNING id
+    `);
+    const conCompanyId = (conRows[0] as { id: string }).id;
+    const svc = clusterTenantPoliciesService(db);
+    const N = 8;
+    // Pre-fix shape lost this race: two callers both observed existing=null
+    // and both attempted INSERT, with the loser surfacing a unique-constraint
+    // error from cluster_tenant_policies_cluster_company_uq. The atomic
+    // ON CONFLICT shape eliminates that error path.
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        svc.upsert({
+          clusterConnectionId: clusterId,
+          companyId: conCompanyId,
+          quota: { requestsCpu: `${i}` },
+          limitRange: null,
+          additionalAllowFqdns: [],
+          imageOverrides: null,
+        }),
+      ),
+    );
+    const found = await svc.get(clusterId, conCompanyId);
+    expect(found).not.toBeNull();
+    expect(found?.quota?.requestsCpu).toMatch(/^\d$/);
+  });
+
   it("upsert() preserves httpProxyUrl when the caller doesn't pass one", async () => {
     const svc = clusterTenantPoliciesService(db);
     // Set a proxy URL via an explicit upsert.

--- a/server/src/services/cluster-tenant-policies.test.ts
+++ b/server/src/services/cluster-tenant-policies.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
     VALUES ('seed-cluster', 'in-cluster', '{"cilium":false,"storageClass":"standard","architectures":["amd64"]}'::jsonb, 'sys')
     RETURNING id
   `);
-  clusterId = (clusterRows.rows?.[0] as { id: string } | undefined)?.id ?? (clusterRows[0] as { id: string }).id;
+  clusterId = (clusterRows[0] as { id: string }).id;
 
   // companies has: id (uuid, defaultRandom), name (text notNull), and everything else defaults.
   const companyRows = await db.execute(sql`
@@ -27,7 +27,7 @@ beforeAll(async () => {
     VALUES ('Acme')
     RETURNING id
   `);
-  companyId = (companyRows.rows?.[0] as { id: string } | undefined)?.id ?? (companyRows[0] as { id: string }).id;
+  companyId = (companyRows[0] as { id: string }).id;
 });
 afterAll(async () => { await dbHandle.cleanup(); });
 

--- a/server/src/services/cluster-tenant-policies.test.ts
+++ b/server/src/services/cluster-tenant-policies.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { startEmbeddedPostgresTestDatabase, type EmbeddedPostgresTestDatabase, createDb } from "@paperclipai/db";
+import type { Db } from "@paperclipai/db";
+import { sql } from "drizzle-orm";
+import { clusterTenantPoliciesService } from "./cluster-tenant-policies.js";
+
+let dbHandle: EmbeddedPostgresTestDatabase;
+let db: Db;
+let clusterId: string;
+let companyId: string;
+
+beforeAll(async () => {
+  dbHandle = await startEmbeddedPostgresTestDatabase("paperclip-tenant-pol-test-");
+  db = createDb(dbHandle.connectionString);
+
+  // Seed a cluster connection and a company.
+  const clusterRows = await db.execute(sql`
+    INSERT INTO cluster_connections (label, kind, capabilities, created_by)
+    VALUES ('seed-cluster', 'in-cluster', '{"cilium":false,"storageClass":"standard","architectures":["amd64"]}'::jsonb, 'sys')
+    RETURNING id
+  `);
+  clusterId = (clusterRows.rows?.[0] as { id: string } | undefined)?.id ?? (clusterRows[0] as { id: string }).id;
+
+  // companies has: id (uuid, defaultRandom), name (text notNull), and everything else defaults.
+  const companyRows = await db.execute(sql`
+    INSERT INTO companies (name)
+    VALUES ('Acme')
+    RETURNING id
+  `);
+  companyId = (companyRows.rows?.[0] as { id: string } | undefined)?.id ?? (companyRows[0] as { id: string }).id;
+});
+afterAll(async () => { await dbHandle.cleanup(); });
+
+describe("clusterTenantPoliciesService", () => {
+  it("get() returns null when no policy exists", async () => {
+    const svc = clusterTenantPoliciesService(db);
+    const result = await svc.get(clusterId, companyId);
+    expect(result).toBeNull();
+  });
+
+  it("upsert() creates a row, then a second upsert updates it", async () => {
+    const svc = clusterTenantPoliciesService(db);
+    const created = await svc.upsert({
+      clusterConnectionId: clusterId,
+      companyId,
+      quota: { requestsCpu: "32" },
+      limitRange: null,
+      additionalAllowFqdns: ["api.acme.io"],
+      imageOverrides: null,
+    });
+    expect(created.quota?.requestsCpu).toBe("32");
+    expect(created.additionalAllowFqdns).toEqual(["api.acme.io"]);
+
+    const updated = await svc.upsert({
+      clusterConnectionId: clusterId,
+      companyId,
+      quota: { requestsCpu: "64", countJobs: 200 },
+      limitRange: { default: { cpu: "2" } },
+      additionalAllowFqdns: ["api.acme.io", "*.linear.app"],
+      imageOverrides: { claude_local: "ecr.acme.io/agent-runtime-claude:v1" },
+    });
+    expect(updated.quota?.requestsCpu).toBe("64");
+    expect(updated.quota?.countJobs).toBe(200);
+    expect(updated.additionalAllowFqdns).toEqual(["api.acme.io", "*.linear.app"]);
+    expect(updated.imageOverrides?.claude_local).toBe("ecr.acme.io/agent-runtime-claude:v1");
+  });
+
+  it("get() reads back what upsert wrote", async () => {
+    const svc = clusterTenantPoliciesService(db);
+    const fetched = await svc.get(clusterId, companyId);
+    expect(fetched).not.toBeNull();
+    expect(fetched?.additionalAllowFqdns).toEqual(["api.acme.io", "*.linear.app"]);
+    expect(fetched?.limitRange?.default?.cpu).toBe("2");
+  });
+});

--- a/server/src/services/cluster-tenant-policies.test.ts
+++ b/server/src/services/cluster-tenant-policies.test.ts
@@ -72,4 +72,33 @@ describe("clusterTenantPoliciesService", () => {
     expect(fetched?.additionalAllowFqdns).toEqual(["api.acme.io", "*.linear.app"]);
     expect(fetched?.limitRange?.default?.cpu).toBe("2");
   });
+
+  it("upsert() preserves httpProxyUrl when the caller doesn't pass one", async () => {
+    const svc = clusterTenantPoliciesService(db);
+    // Set a proxy URL via an explicit upsert.
+    await svc.upsert({
+      clusterConnectionId: clusterId, companyId,
+      quota: null, limitRange: null,
+      additionalAllowFqdns: [], imageOverrides: null,
+      httpProxyUrl: "http://proxy.acme.internal:3128",
+    });
+    expect((await svc.get(clusterId, companyId))?.httpProxyUrl).toBe("http://proxy.acme.internal:3128");
+
+    // Subsequent upsert without httpProxyUrl must NOT clear it.
+    await svc.upsert({
+      clusterConnectionId: clusterId, companyId,
+      quota: null, limitRange: null,
+      additionalAllowFqdns: ["api.example.com"], imageOverrides: null,
+    });
+    expect((await svc.get(clusterId, companyId))?.httpProxyUrl).toBe("http://proxy.acme.internal:3128");
+
+    // Explicit null clears it.
+    await svc.upsert({
+      clusterConnectionId: clusterId, companyId,
+      quota: null, limitRange: null,
+      additionalAllowFqdns: [], imageOverrides: null,
+      httpProxyUrl: null,
+    });
+    expect((await svc.get(clusterId, companyId))?.httpProxyUrl).toBeNull();
+  });
 });

--- a/server/src/services/cluster-tenant-policies.ts
+++ b/server/src/services/cluster-tenant-policies.ts
@@ -39,34 +39,41 @@ export function clusterTenantPoliciesService(db: Db): ClusterTenantPoliciesServi
     },
 
     async upsert(input) {
+      // We still read existing once to implement the preserve-on-omit
+      // semantics for httpProxyUrl. The read is racy w.r.t. another concurrent
+      // upsert, but the write below is unconditionally atomic via
+      // ON CONFLICT — no caller will surface a unique-constraint error from
+      // cluster_tenant_policies_cluster_company_uq. Race semantics under
+      // concurrent (omit, set, set, omit, …) call patterns: an explicit
+      // setter always overwrites an omitter's preserved value, which is the
+      // desired last-explicit-write-wins shape.
       const existing = await this.get(input.clusterConnectionId, input.companyId);
-      // Preserve httpProxyUrl when the caller didn't explicitly pass one (undefined).
-      // An explicit `null` clears it; an explicit string overwrites it.
       const httpProxyUrl =
         input.httpProxyUrl === undefined ? (existing?.httpProxyUrl ?? null) : input.httpProxyUrl;
+      const networkJson = { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl };
 
-      if (existing) {
-        const [updated] = await db.update(clusterTenantPolicies).set({
+      const [row] = await db
+        .insert(clusterTenantPolicies)
+        .values({
+          clusterConnectionId: input.clusterConnectionId,
+          companyId: input.companyId,
           quotaJson: input.quota,
           limitRangeJson: input.limitRange,
-          networkJson: { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl },
+          networkJson,
           imageOverridesJson: input.imageOverrides,
-          updatedAt: new Date(),
-        }).where(and(
-          eq(clusterTenantPolicies.clusterConnectionId, input.clusterConnectionId),
-          eq(clusterTenantPolicies.companyId, input.companyId),
-        )).returning();
-        return mapRow(updated);
-      }
-      const [created] = await db.insert(clusterTenantPolicies).values({
-        clusterConnectionId: input.clusterConnectionId,
-        companyId: input.companyId,
-        quotaJson: input.quota,
-        limitRangeJson: input.limitRange,
-        networkJson: { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl },
-        imageOverridesJson: input.imageOverrides,
-      }).returning();
-      return mapRow(created);
+        })
+        .onConflictDoUpdate({
+          target: [clusterTenantPolicies.clusterConnectionId, clusterTenantPolicies.companyId],
+          set: {
+            quotaJson: input.quota,
+            limitRangeJson: input.limitRange,
+            networkJson,
+            imageOverridesJson: input.imageOverrides,
+            updatedAt: new Date(),
+          },
+        })
+        .returning();
+      return mapRow(row);
     },
   };
 }

--- a/server/src/services/cluster-tenant-policies.ts
+++ b/server/src/services/cluster-tenant-policies.ts
@@ -1,0 +1,72 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { clusterTenantPolicies } from "@paperclipai/db";
+import type { TenantPolicy } from "@paperclipai/execution-target-kubernetes";
+
+export interface UpsertTenantPolicyInput {
+  clusterConnectionId: string;
+  companyId: string;
+  quota: TenantPolicy["quota"];
+  limitRange: TenantPolicy["limitRange"];
+  additionalAllowFqdns: string[];
+  imageOverrides: Record<string, string> | null;
+}
+
+export interface TenantPolicyRow extends TenantPolicy {
+  clusterConnectionId: string;
+  companyId: string;
+}
+
+export interface ClusterTenantPoliciesService {
+  get(clusterConnectionId: string, companyId: string): Promise<TenantPolicyRow | null>;
+  upsert(input: UpsertTenantPolicyInput): Promise<TenantPolicyRow>;
+}
+
+export function clusterTenantPoliciesService(db: Db): ClusterTenantPoliciesService {
+  return {
+    async get(clusterConnectionId, companyId) {
+      const [row] = await db.select().from(clusterTenantPolicies).where(and(
+        eq(clusterTenantPolicies.clusterConnectionId, clusterConnectionId),
+        eq(clusterTenantPolicies.companyId, companyId),
+      ));
+      return row ? mapRow(row) : null;
+    },
+
+    async upsert(input) {
+      const existing = await this.get(input.clusterConnectionId, input.companyId);
+      if (existing) {
+        const [updated] = await db.update(clusterTenantPolicies).set({
+          quotaJson: input.quota,
+          limitRangeJson: input.limitRange,
+          networkJson: { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl: null },
+          imageOverridesJson: input.imageOverrides,
+          updatedAt: new Date(),
+        }).where(and(
+          eq(clusterTenantPolicies.clusterConnectionId, input.clusterConnectionId),
+          eq(clusterTenantPolicies.companyId, input.companyId),
+        )).returning();
+        return mapRow(updated);
+      }
+      const [created] = await db.insert(clusterTenantPolicies).values({
+        clusterConnectionId: input.clusterConnectionId,
+        companyId: input.companyId,
+        quotaJson: input.quota,
+        limitRangeJson: input.limitRange,
+        networkJson: { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl: null },
+        imageOverridesJson: input.imageOverrides,
+      }).returning();
+      return mapRow(created);
+    },
+  };
+}
+
+function mapRow(r: typeof clusterTenantPolicies.$inferSelect): TenantPolicyRow {
+  return {
+    clusterConnectionId: r.clusterConnectionId,
+    companyId: r.companyId,
+    quota: r.quotaJson ?? null,
+    limitRange: r.limitRangeJson ?? null,
+    additionalAllowFqdns: r.networkJson?.additionalAllowFqdns ?? [],
+    imageOverrides: r.imageOverridesJson ?? null,
+  };
+}

--- a/server/src/services/cluster-tenant-policies.ts
+++ b/server/src/services/cluster-tenant-policies.ts
@@ -9,12 +9,18 @@ export interface UpsertTenantPolicyInput {
   quota: TenantPolicy["quota"];
   limitRange: TenantPolicy["limitRange"];
   additionalAllowFqdns: string[];
+  /**
+   * Egress HTTP proxy URL for the tenant. When omitted (undefined), any existing
+   * value is preserved on upsert; pass `null` explicitly to clear it.
+   */
+  httpProxyUrl?: string | null;
   imageOverrides: Record<string, string> | null;
 }
 
 export interface TenantPolicyRow extends TenantPolicy {
   clusterConnectionId: string;
   companyId: string;
+  httpProxyUrl: string | null;
 }
 
 export interface ClusterTenantPoliciesService {
@@ -34,11 +40,16 @@ export function clusterTenantPoliciesService(db: Db): ClusterTenantPoliciesServi
 
     async upsert(input) {
       const existing = await this.get(input.clusterConnectionId, input.companyId);
+      // Preserve httpProxyUrl when the caller didn't explicitly pass one (undefined).
+      // An explicit `null` clears it; an explicit string overwrites it.
+      const httpProxyUrl =
+        input.httpProxyUrl === undefined ? (existing?.httpProxyUrl ?? null) : input.httpProxyUrl;
+
       if (existing) {
         const [updated] = await db.update(clusterTenantPolicies).set({
           quotaJson: input.quota,
           limitRangeJson: input.limitRange,
-          networkJson: { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl: null },
+          networkJson: { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl },
           imageOverridesJson: input.imageOverrides,
           updatedAt: new Date(),
         }).where(and(
@@ -52,7 +63,7 @@ export function clusterTenantPoliciesService(db: Db): ClusterTenantPoliciesServi
         companyId: input.companyId,
         quotaJson: input.quota,
         limitRangeJson: input.limitRange,
-        networkJson: { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl: null },
+        networkJson: { additionalAllowFqdns: input.additionalAllowFqdns, httpProxyUrl },
         imageOverridesJson: input.imageOverrides,
       }).returning();
       return mapRow(created);
@@ -67,6 +78,7 @@ function mapRow(r: typeof clusterTenantPolicies.$inferSelect): TenantPolicyRow {
     quota: r.quotaJson ?? null,
     limitRange: r.limitRangeJson ?? null,
     additionalAllowFqdns: r.networkJson?.additionalAllowFqdns ?? [],
+    httpProxyUrl: r.networkJson?.httpProxyUrl ?? null,
     imageOverrides: r.imageOverridesJson ?? null,
   };
 }

--- a/server/vitest.integration.config.ts
+++ b/server/vitest.integration.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * Vitest config for slow integration tests that require external infrastructure
+ * (kind clusters, embedded postgres, etc.).  Run with:
+ *
+ *   pnpm -w exec vitest run --config server/vitest.integration.config.ts <pattern>
+ *
+ * Intentionally NOT included in the main vitest.config.ts to avoid slowing
+ * down the unit-test loop.
+ */
+export default defineConfig({
+  test: {
+    environment: "node",
+    // kind cluster creation is inherently sequential (Docker resource pressure).
+    fileParallelism: false,
+    testTimeout: 240_000,
+    hookTimeout: 240_000,
+    // No supertest setup needed for infrastructure integration tests.
+    setupFiles: [],
+    include: ["src/__tests__/**/*.integration.test.ts", "src/__tests__/k8s-*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, with `claude_local` / `codex_local` / etc. running on the user's machine today.
> - To host Paperclip in the cloud, agents need a hardened, multi-tenant execution surface — not the operator's laptop.
> - Kubernetes is the right substrate (industry-standard isolation primitives, k8s-native quotas/policies, broad operator familiarity), and the [design spec](docs/superpowers/specs/2026-05-08-paperclip-cloud-adapter-design.md) was approved with multi-tenancy as a property of the orchestrator, not bolted on.
> - The work splits into M1 (this PR — tenant provisioning), M2 (#5558, agent execution end-to-end), M3 (UI + production hardening).
> - This pull request lays the foundation: a new `kubernetes` execution-target kind, a platform-module-style `ExecutionTargetDriverRegistry`, a new `@paperclipai/execution-target-kubernetes` package with idempotent tenant-namespace provisioning (Namespace + RBAC + ResourceQuota + LimitRange + NetworkPolicy + Cilium variant + image-pull-secret), three new Drizzle tables, the `paperclip cluster …` CLI, and operator docs.
> - The benefit is a self-contained, reviewable shipping unit: existing `claude_local` runs unchanged on `local` targets; the kubernetes target is registered but explicitly rejects with `errorCode: "execution_target_not_yet_supported"` until M2.

## What Changed

- New package `@paperclipai/execution-target-kubernetes` with pure builders (Namespace, RBAC, Quota, LimitRange, default-deny + RFC1918/link-local/CGNAT/IPv6-ULA NetworkPolicy, Cilium FQDN variant via dynamic CRD client, ImagePullSecret) and an idempotent `ensureTenantNamespace` orchestrator using `@kubernetes/client-node` v0.21.
- New `kubernetes` kind on the `AdapterExecutionTarget` discriminated union; new `ExecutionTargetDriverRegistry` so future drivers register without touching `server/`.
- Three new Drizzle tables: `cluster_connections`, `cluster_namespace_bindings`, `cluster_tenant_policies` + service layer + `paperclip cluster` CLI.
- All seven existing local adapters extended to return a structured `execution_target_not_yet_supported` error when given a kubernetes target (contract-tested across all of them).
- Operator docs: quickstart, security model (PSS Restricted, NSA/CISA + CIS), multi-tenant onboarding, cluster RBAC.
- CI workflow `.github/workflows/k8s-integration.yml` boots a kind cluster and runs the integration suite.

## Verification

- 53 unit tests (golden snapshots for every k8s resource builder) + 3 kind-based integration tests (`ensure-tenant`, `ensure-tenant-idempotency`, `ensure-tenant-drift`, `pss-restricted`) all green.
- Strengthened the LimitRange integration assertion to confirm Container `default`/`defaultRequest`/`max` fields actually land on the cluster (Greptile flagged `_default` as a potential typo; the assertion proves the typed client's `attributeTypeMap` correctly renames `_default` → `default` on the wire).
- Live verification on a local kind cluster (author tested end-to-end during development).
- CLI smoke: `paperclip cluster ensure-tenant <companyId>` end-to-end against kind.
- Caught a real k8s API bug during integration — IPv6 `fd00::/8` nested inside an IPv4 `0.0.0.0/0` `except` returns 422 — and fixed in the NetworkPolicy builder.

## Risks

- `pnpm-lock.yaml` is in the diff. The `policy` job rejects this. Unfortunately PRs that introduce new workspace packages must update the lockfile or `verify` (`pnpm install --frozen-lockfile`) fails. **Maintainer action needed**: either land a `chore/refresh-lockfile` interim PR with the new entries first, or override `policy` for this PR. The lockfile diff is purely additive — entries for the new k8s-execution workspace package and its `@kubernetes/client-node` dep.
- M1 ships a `kubernetes` execution-target kind that is registered but does NOT execute agent runs. Operators who configure a kubernetes target receive a clear `execution_target_not_yet_supported` error until M2 (#5558) lands. This is intentional fail-fast behavior and contract-tested across every adapter.
- New external dependency `@kubernetes/client-node@^0.21` (~1MB) added to a single workspace package only.

## Model Used

Claude Opus 4.7 (1M context). Multi-stage workflow: brainstorming → spec → plan → subagent-driven implementation. Subagents used Sonnet for mechanical implementation tasks and Opus 4.7 for cross-cutting / debugging work. Light use of extended thinking on architectural decisions during brainstorming.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, no UI changes
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge