### PR TITLE
adapters: render promptTemplate before wake payload

### DIFF
--- a/docs/adapters/codex-local.md
+++ b/docs/adapters/codex-local.md
@@ -23,6 +23,18 @@ The `codex_local` adapter runs OpenAI's Codex CLI locally. It supports session p
 | `fastMode` | boolean | No | Enables Codex Fast mode. Currently supported on `gpt-5.4` only and burns credits faster |
 | `dangerouslyBypassApprovalsAndSandbox` | boolean | No | Skip safety checks (dev only) |
 
+## Prompt Composition (Caching)
+
+For non-resumed runs, Paperclip assembles the Codex prompt in this order:
+
+1. `instructionsFilePath` contents (if configured and readable)
+2. `bootstrapPromptTemplate` (first run only)
+3. `promptTemplate`
+4. Wake payload (or resume delta, when applicable)
+5. Session handoff note (if provided)
+
+This ordering is intentional: models that support prefix prompt caching can reuse the stable `promptTemplate` portion even when the wake payload changes each heartbeat, improving `cached_input_tokens`.
+
 ## Session Persistence
 
 Codex uses `previous_response_id` for session continuity. The adapter serializes and restores this across heartbeats, allowing the agent to maintain conversation context.

--- a/docs/adapters/codex-local.md
+++ b/docs/adapters/codex-local.md
@@ -35,6 +35,8 @@ For non-resumed runs, Paperclip assembles the Codex prompt in this order:
 
 This ordering is intentional: models that support prefix prompt caching can reuse the stable `promptTemplate` portion even when the wake payload changes each heartbeat, improving `cached_input_tokens`.
 
+To verify the cache impact, compare two consecutive non-resumed heartbeats with different wake payloads and compute `cachedInputTokens / inputTokens` from the run token usage. The ratio should increase when more stable prompt text is moved into the cacheable prefix.
+
 ## Session Persistence
 
 Codex uses `previous_response_id` for session continuity. The adapter serializes and restores this across heartbeats, allowing the agent to maintain conversation context.

--- a/docs/adapters/gemini-local.md
+++ b/docs/adapters/gemini-local.md
@@ -35,6 +35,8 @@ For non-resumed runs, Paperclip assembles the Gemini `--prompt` value in this or
 
 This ordering is intentional: models that support prefix prompt caching can reuse the stable `promptTemplate` portion even when the wake payload changes each heartbeat, improving `cached_input_tokens`.
 
+To verify the cache impact, compare two consecutive non-resumed heartbeats with different wake payloads and compute `cachedInputTokens / inputTokens` from the run token usage. The ratio should increase when more stable prompt text is moved into the cacheable prefix.
+
 ## Session Persistence
 
 The adapter persists Gemini session IDs between heartbeats. On the next wake, it resumes the existing conversation with `--resume` so the agent retains context.

--- a/docs/adapters/gemini-local.md
+++ b/docs/adapters/gemini-local.md
@@ -23,6 +23,18 @@ The `gemini_local` adapter runs Google's Gemini CLI locally. It supports session
 | `graceSec` | number | No | Grace period before force-kill |
 | `yolo` | boolean | No | Pass `--approval-mode yolo` for unattended operation |
 
+## Prompt Composition (Caching)
+
+For non-resumed runs, Paperclip assembles the Gemini `--prompt` value in this order:
+
+1. `instructionsFilePath` contents (if configured and readable)
+2. `bootstrapPromptTemplate` (first run only)
+3. `promptTemplate`
+4. Wake payload (or resume delta, when applicable)
+5. Runtime notes (Paperclip env + API access hints)
+
+This ordering is intentional: models that support prefix prompt caching can reuse the stable `promptTemplate` portion even when the wake payload changes each heartbeat, improving `cached_input_tokens`.
+
 ## Session Persistence
 
 The adapter persists Gemini session IDs between heartbeats. On the next wake, it resumes the existing conversation with `--resume` so the agent retains context.

--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -916,10 +916,10 @@ async function buildPrompt(ctx: AdapterExecutionContext, resumedSession: boolean
   const prompt = joinPromptSections([
     promptInstructionsPrefix,
     renderedBootstrapPrompt,
+    renderedPrompt,
     wakePrompt,
     sessionHandoffNote,
     taskContextNote,
-    renderedPrompt,
   ]);
 
   return {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -634,10 +634,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const taskContextNote = asString(context.paperclipTaskMarkdown, "").trim();
   const prompt = joinPromptSections([
     renderedBootstrapPrompt,
+    renderedPrompt,
     wakePrompt,
     sessionHandoffNote,
     taskContextNote,
-    renderedPrompt,
   ]);
   const promptMetrics = {
     promptChars: prompt.length,

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -651,10 +651,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const prompt = joinPromptSections([
     promptInstructionsPrefix,
     renderedBootstrapPrompt,
+    renderedPrompt,
     wakePrompt,
     codexFallbackHandoffNote,
     sessionHandoffNote,
-    renderedPrompt,
   ]);
   const promptMetrics = {
     promptChars: prompt.length,

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -555,10 +555,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
+    renderedPrompt,
     wakePrompt,
     sessionHandoffNote,
     paperclipEnvNote,
-    renderedPrompt,
   ]);
   const promptMetrics = {
     promptChars: prompt.length,

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -472,11 +472,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
+    renderedPrompt,
     wakePrompt,
     sessionHandoffNote,
     paperclipEnvNote,
     apiAccessNote,
-    renderedPrompt,
   ]);
   const promptMetrics = {
     promptChars: prompt.length,

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -521,9 +521,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const prompt = joinPromptSections([
       instructionsPrefix,
       renderedBootstrapPrompt,
+      renderedPrompt,
       wakePrompt,
       sessionHandoffNote,
-      renderedPrompt,
     ]);
     const promptMetrics = {
       promptChars: prompt.length,

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -580,9 +580,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const userPrompt = joinPromptSections([
     renderedBootstrapPrompt,
+    renderedHeartbeatPrompt,
     wakePrompt,
     sessionHandoffNote,
-    renderedHeartbeatPrompt,
   ]);
   const promptMetrics = {
     systemPromptChars: renderedSystemPromptExtension.length,

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -481,6 +481,9 @@ describe("codex execute", () => {
       expect(capture.prompt).toContain("## Paperclip Wake Payload");
       expect(capture.prompt).toContain("Treat this wake payload as the highest-priority change for the current heartbeat.");
       expect(capture.prompt).toContain("Do not switch to another issue until you have handled this wake.");
+      expect(capture.prompt.indexOf("Follow the paperclip heartbeat.")).toBeLessThan(
+        capture.prompt.indexOf("## Paperclip Wake Payload"),
+      );
       expect(capture.prompt).toContain(
         "acknowledge the latest comment and explain how it changes your next action.",
       );

--- a/server/src/__tests__/gemini-local-execute.test.ts
+++ b/server/src/__tests__/gemini-local-execute.test.ts
@@ -156,6 +156,102 @@ describe("gemini execute", () => {
     }
   });
 
+  it("renders promptTemplate before the wake payload for prompt cache friendliness", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-wake-prompt-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "gemini");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeGeminiCommand(commandPath);
+
+    const previousHome = process.env.HOME;
+    process.env.HOME = root;
+
+    try {
+      const result = await execute({
+        runId: "run-wake",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Gemini Coder",
+          adapterType: "gemini_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: commandPath,
+          cwd: workspace,
+          model: "gemini-2.5-pro",
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Follow the paperclip heartbeat.",
+        },
+        context: {
+          issueId: "issue-1",
+          taskId: "issue-1",
+          wakeReason: "issue_commented",
+          wakeCommentId: "comment-2",
+          paperclipWake: {
+            reason: "issue_commented",
+            issue: {
+              id: "issue-1",
+              identifier: "PAP-874",
+              title: "chat-speed issues",
+              status: "in_progress",
+              priority: "medium",
+            },
+            commentIds: ["comment-2"],
+            latestCommentId: "comment-2",
+            comments: [
+              {
+                id: "comment-2",
+                issueId: "issue-1",
+                body: "Second comment",
+                bodyTruncated: false,
+                createdAt: "2026-03-28T14:35:10.000Z",
+                author: { type: "user", id: "user-1" },
+              },
+            ],
+            commentWindow: {
+              requestedCount: 1,
+              includedCount: 1,
+              missingCount: 0,
+            },
+            truncated: false,
+            fallbackFetchNeeded: false,
+          },
+        },
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.errorMessage).toBeNull();
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      const promptFlagIndex = capture.argv.indexOf("--prompt");
+      const promptArg = promptFlagIndex >= 0 ? capture.argv[promptFlagIndex + 1] : "";
+      expect(promptArg).toContain("Follow the paperclip heartbeat.");
+      expect(promptArg).toContain("## Paperclip Wake Payload");
+      expect(promptArg.indexOf("Follow the paperclip heartbeat.")).toBeLessThan(
+        promptArg.indexOf("## Paperclip Wake Payload"),
+      );
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("always passes --approval-mode yolo", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-yolo-"));
     const workspace = path.join(root, "workspace");


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies through short, repeatable heartbeats.
> - Local CLI adapters (Codex/Claude/Gemini/Cursor/OpenCode/Pi/ACPX) build a per-run prompt by joining multiple sections.
> - The wake payload is highly dynamic per heartbeat (issue state, comments, run metadata).
> - The adapter-level `promptTemplate` is relatively stable per agent.
> - Today the local adapters append `promptTemplate` after the wake payload, pushing stable tokens into the non-cacheable suffix for prefix-caching providers.
> - This PR moves `promptTemplate` earlier in the assembled prompt so the stable prefix is larger and caching hit-rate can improve.

## What Changed

- Reordered prompt assembly so rendered `promptTemplate` appears before the rendered Paperclip wake prompt across local adapters (`codex_local`, `claude_local`, `gemini_local`, `cursor`, `opencode_local`, `pi_local`, `acpx_local`).

## Verification

- `pnpm -r --filter @paperclipai/adapter-claude-local --filter @paperclipai/adapter-gemini-local --filter @paperclipai/adapter-cursor-local --filter @paperclipai/adapter-pi-local typecheck`
- `pnpm exec vitest packages/adapters/codex-local/src/server/execute.remote.test.ts packages/adapters/opencode-local/src/server/execute.remote.test.ts packages/adapters/acpx-local/src/server/execute.test.ts packages/adapters/claude-local/src/server/execute.remote.test.ts packages/adapters/gemini-local/src/server/execute.remote.test.ts packages/adapters/cursor-local/src/server/execute.test.ts packages/adapters/pi-local/src/server/execute.remote.test.ts`

## Risks

- Low risk: prompt content is unchanged, but section order changes.
- If an operator-authored `promptTemplate` text references the wake payload as being "above", it may now be "below" in the combined prompt for fresh sessions.

## Model Used

- OpenAI GPT-5.2 (`gpt-5.2`) with Codex CLI tool use; reasoning effort `xhigh`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
