### PR TITLE
Fix productivity review refresh flooding

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -203,6 +203,8 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews[0]?.assigneeAgentId).toBe(seeded.managerId);
     expect(reviews[0]?.originId).toBe(seeded.issueId);
     expect(reviews[0]?.originFingerprint).toBe(`productivity-review:${seeded.issueId}`);
+    expect(reviews[0]?.description).toMatch(/^Expected output: technical_audit/);
+    expect(reviews[0]?.description).toContain("## Owner Action");
     expect(reviews[0]?.description).toContain("Primary trigger: `no_comment_streak`");
     expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
 
@@ -251,7 +253,47 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(tooSoonRefresh.existing).toBe(1);
     expect(cappedRefresh.updated).toBe(0);
     expect(cappedRefresh.existing).toBe(1);
+    const [refreshedReview] = await listProductivityReviews(seeded.companyId);
+    expect(refreshedReview?.description).toContain(
+      `Generated at: ${new Date(firstRefreshAt.getTime() + 2 * DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS).toISOString()}`,
+    );
     expect(await listRefreshComments(review!.id)).toHaveLength(DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS);
+  });
+
+  it("cancels an open productivity review when the source issue resolves", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const resolvedAt = new Date("2026-04-28T12:10:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.status).toBe("todo");
+
+    await db
+      .update(issues)
+      .set({ status: "done", completedAt: resolvedAt, updatedAt: resolvedAt })
+      .where(eq(issues.id, seeded.issueId));
+
+    const result = await service.reconcileProductivityReviews({
+      now: resolvedAt,
+      companyId: seeded.companyId,
+    });
+    const [resolvedReview] = await listProductivityReviews(seeded.companyId);
+
+    expect(result.resolved).toBe(1);
+    expect(resolvedReview?.status).toBe("cancelled");
+    expect(resolvedReview?.cancelledAt?.toISOString()).toBe(resolvedAt.toISOString());
+    expect(resolvedReview?.description).toContain("Disposition: cancelled diagnostic review.");
+    expect(resolvedReview?.description).toContain("Source issue");
+    expect(await listRefreshComments(review!.id)).toHaveLength(0);
   });
 
   it("caps productivity review creation per source issue in the rolling creation window", async () => {

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
   agents,
@@ -251,11 +251,11 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(firstRefresh.updated).toBe(1);
     expect(tooSoonRefresh.updated).toBe(0);
     expect(tooSoonRefresh.existing).toBe(1);
-    expect(cappedRefresh.updated).toBe(0);
-    expect(cappedRefresh.existing).toBe(1);
+    expect(cappedRefresh.updated).toBe(1);
+    expect(cappedRefresh.existing).toBe(0);
     const [refreshedReview] = await listProductivityReviews(seeded.companyId);
     expect(refreshedReview?.description).toContain(
-      `Generated at: ${new Date(firstRefreshAt.getTime() + 2 * DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS).toISOString()}`,
+      `Generated at: ${new Date(firstRefreshAt.getTime() + 3 * DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS).toISOString()}`,
     );
     expect(await listRefreshComments(review!.id)).toHaveLength(DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS);
   });
@@ -272,10 +272,34 @@ describeEmbeddedPostgres("productivity review service", () => {
       now,
     });
 
-    const service = productivityReviewService(db);
+    const reviewRunId = randomUUID();
+    const cancelRun = vi.fn(async () => null);
+    const service = productivityReviewService(db, { cancelRun });
     await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.status).toBe("todo");
+    await db.insert(heartbeatRuns).values({
+      id: reviewRunId,
+      companyId: seeded.companyId,
+      agentId: seeded.managerId,
+      status: "running",
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      startedAt: resolvedAt,
+      contextSnapshot: { issueId: review!.id, taskId: review!.id },
+      createdAt: resolvedAt,
+      updatedAt: resolvedAt,
+    });
+    await db
+      .update(issues)
+      .set({
+        status: "in_progress",
+        executionRunId: reviewRunId,
+        checkoutRunId: reviewRunId,
+        executionLockedAt: resolvedAt,
+        updatedAt: resolvedAt,
+      })
+      .where(eq(issues.id, review!.id));
 
     await db
       .update(issues)
@@ -289,11 +313,42 @@ describeEmbeddedPostgres("productivity review service", () => {
     const [resolvedReview] = await listProductivityReviews(seeded.companyId);
 
     expect(result.resolved).toBe(1);
+    expect(cancelRun).toHaveBeenCalledWith(reviewRunId, "Cancelled because productivity review source issue is no longer actionable");
     expect(resolvedReview?.status).toBe("cancelled");
     expect(resolvedReview?.cancelledAt?.toISOString()).toBe(resolvedAt.toISOString());
     expect(resolvedReview?.description).toContain("Disposition: cancelled diagnostic review.");
     expect(resolvedReview?.description).toContain("Source issue");
     expect(await listRefreshComments(review!.id)).toHaveLength(0);
+  });
+
+  it("cancels an open productivity review when the source issue loses its agent owner", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const unassignedAt = new Date("2026-04-28T12:20:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    await db
+      .update(issues)
+      .set({ assigneeAgentId: null, updatedAt: unassignedAt })
+      .where(eq(issues.id, seeded.issueId));
+
+    const result = await service.reconcileProductivityReviews({
+      now: unassignedAt,
+      companyId: seeded.companyId,
+    });
+    const [resolvedReview] = await listProductivityReviews(seeded.companyId);
+
+    expect(result.resolved).toBe(1);
+    expect(resolvedReview?.status).toBe("cancelled");
+    expect(resolvedReview?.description).toContain("Source issue state: `in_progress`");
   });
 
   it("caps productivity review creation per source issue in the rolling creation window", async () => {

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -204,6 +204,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews[0]?.originId).toBe(seeded.issueId);
     expect(reviews[0]?.originFingerprint).toBe(`productivity-review:${seeded.issueId}`);
     expect(reviews[0]?.description).toMatch(/^Expected output: technical_audit/);
+    expect(reviews[0]?.description).toContain("## Owner Notes");
     expect(reviews[0]?.description).toContain("## Owner Action");
     expect(reviews[0]?.description).toContain("Primary trigger: `no_comment_streak`");
     expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
@@ -258,6 +259,43 @@ describeEmbeddedPostgres("productivity review service", () => {
       `Generated at: ${new Date(firstRefreshAt.getTime() + 3 * DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS).toISOString()}`,
     );
     expect(await listRefreshComments(review!.id)).toHaveLength(DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS);
+  });
+
+  it("refreshes evidence on schedule without discarding owner notes or using unrelated issue touches", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const [review] = await listProductivityReviews(seeded.companyId);
+    const ownerNote = "Manager note: preserve this diagnosis.";
+    await db
+      .update(issues)
+      .set({
+        description: `${review!.description}\n\n${ownerNote}`,
+        updatedAt: new Date(now.getTime() + 30 * 60 * 1000),
+      })
+      .where(eq(issues.id, review!.id));
+
+    const refreshAt = new Date(now.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS);
+    const refreshed = await service.reconcileProductivityReviews({
+      now: refreshAt,
+      companyId: seeded.companyId,
+    });
+    const [refreshedReview] = await listProductivityReviews(seeded.companyId);
+
+    expect(refreshed.updated).toBe(1);
+    expect(refreshedReview?.description).toContain(`Generated at: ${refreshAt.toISOString()}`);
+    expect(refreshedReview?.description).toContain("## Owner Notes");
+    expect(refreshedReview?.description).toContain(ownerNote);
+    expect(await listRefreshComments(review!.id)).toHaveLength(1);
   });
 
   it("cancels an open productivity review when the source issue resolves", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2176,7 +2176,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   };
   const budgets = budgetService(db, budgetHooks);
   const recovery = recoveryService(db, { enqueueWakeup });
-  const productivityReviews = productivityReviewService(db, { enqueueWakeup });
+  const productivityReviews = productivityReviewService(db, { enqueueWakeup, cancelRun: cancelRunInternal });
   let unsafeTextProjectionPromise: Promise<boolean> | null = null;
 
   async function releaseEnvironmentLeasesForRun(input: {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -88,6 +88,10 @@ type EnqueueWakeup = (
     contextSnapshot?: Record<string, unknown>;
   },
 ) => Promise<unknown | null>;
+type CancelRun = (runId: string, reason?: string) => Promise<unknown | null>;
+
+const PRODUCTIVITY_REVIEW_RESOLVED_CANCEL_REASON =
+  "Cancelled because productivity review source issue is no longer actionable";
 
 function productivityReviewFingerprint(sourceIssueId: string) {
   return `productivity-review:${sourceIssueId}`;
@@ -133,6 +137,14 @@ function readPositiveInteger(value: number, fallback: number) {
 function coerceDate(value: Date | string | null | undefined) {
   if (!value) return null;
   return value instanceof Date ? value : new Date(value);
+}
+
+function maxDate(...values: Array<Date | string | null | undefined>) {
+  const dates = values
+    .map(coerceDate)
+    .filter((value): value is Date => Boolean(value));
+  if (dates.length === 0) return null;
+  return dates.reduce((latest, value) => value.getTime() > latest.getTime() ? value : latest, dates[0]!);
 }
 
 function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): ProductivityReviewThresholds {
@@ -206,7 +218,7 @@ function isActionableSourceIssue(issue: IssueRow | null | undefined) {
   );
 }
 
-export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: EnqueueWakeup }) {
+export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: EnqueueWakeup; cancelRun?: CancelRun }) {
   const issuesSvc = issueService(db);
   const budgets = budgetService(db);
 
@@ -672,9 +684,8 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     const existing = await findOpenProductivityReview(evidence.sourceIssue.companyId, evidence.sourceIssue.id);
     if (existing) {
       const refreshState = await getRefreshCommentState(evidence.sourceIssue.companyId, existing.id);
-      const lastRefreshOrCreationAt = refreshState.latestCreatedAt ?? existing.createdAt;
+      const lastRefreshOrCreationAt = maxDate(refreshState.latestCreatedAt, existing.updatedAt, existing.createdAt) ?? existing.createdAt;
       if (
-        refreshState.count >= opts.thresholds.maxRefreshComments ||
         evidence.generatedAt.getTime() - lastRefreshOrCreationAt.getTime() < opts.thresholds.refreshIntervalMs
       ) {
         return { kind: "existing" as const, reviewIssueId: existing.id };
@@ -683,7 +694,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         .update(issues)
         .set({ description: buildReviewMarkdown(evidence, opts.prefix), updatedAt: evidence.generatedAt })
         .where(eq(issues.id, existing.id));
-      await addRefreshComment(existing.id, buildRefreshComment(evidence, opts.prefix), evidence.generatedAt);
+      const refreshCommentAdded = refreshState.count < opts.thresholds.maxRefreshComments;
+      if (refreshCommentAdded) {
+        await addRefreshComment(existing.id, buildRefreshComment(evidence, opts.prefix), evidence.generatedAt);
+      }
       await logActivity(db, {
         companyId: evidence.sourceIssue.companyId,
         actorType: "system",
@@ -699,6 +713,8 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           noCommentStreak: evidence.noCommentStreak,
           runCountLastHour: evidence.runCountLastHour,
           commentCountLastHour: evidence.commentCountLastHour,
+          refreshCommentAdded,
+          refreshCommentCount: refreshState.count + (refreshCommentAdded ? 1 : 0),
         },
       });
       return { kind: "updated" as const, reviewIssueId: existing.id };
@@ -825,6 +841,16 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       if (!prefix) {
         prefix = await getCompanyIssuePrefix(review.companyId);
         prefixCache.set(review.companyId, prefix);
+      }
+      if (review.executionRunId && deps?.cancelRun) {
+        try {
+          await deps.cancelRun(review.executionRunId, PRODUCTIVITY_REVIEW_RESOLVED_CANCEL_REASON);
+        } catch (err) {
+          logger.warn(
+            { err, reviewIssueId: review.id, runId: review.executionRunId },
+            "failed to cancel productivity review run for resolved source issue",
+          );
+        }
       }
       await db
         .update(issues)

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -825,15 +825,24 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       .limit(MAX_CANDIDATE_ISSUES);
     if (openReviews.length === 0) return 0;
 
+    const sourceIssueIds = [
+      ...new Set(openReviews.map((review) => review.originId).filter((id): id is string => Boolean(id))),
+    ];
+    const sourceIssues = sourceIssueIds.length > 0
+      ? await db
+        .select()
+        .from(issues)
+        .where(inArray(issues.id, sourceIssueIds))
+      : [];
+    const sourceIssueByKey = new Map(
+      sourceIssues.map((issue) => [`${issue.companyId}:${issue.id}`, issue]),
+    );
+
     const prefixCache = new Map<string, string>();
     let resolved = 0;
     for (const review of openReviews) {
       const sourceIssue = review.originId
-        ? await db
-          .select()
-          .from(issues)
-          .where(and(eq(issues.companyId, review.companyId), eq(issues.id, review.originId)))
-          .then((rows) => rows[0] ?? null)
+        ? sourceIssueByKey.get(`${review.companyId}:${review.originId}`) ?? null
         : null;
       if (isActionableSourceIssue(sourceIssue)) continue;
 

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -29,6 +29,7 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 3;
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+const ACTIONABLE_SOURCE_ISSUE_STATUSES = ["todo", "in_progress"] as const;
 const MAX_CANDIDATE_ISSUES = 250;
 const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
@@ -194,6 +195,15 @@ function formatTrigger(trigger: ProductivityReviewTrigger) {
   if (trigger === "no_comment_streak") return "No-comment streak";
   if (trigger === "high_churn") return "High churn";
   return "Long active duration";
+}
+
+function isActionableSourceIssue(issue: IssueRow | null | undefined) {
+  if (!issue || issue.hiddenAt) return false;
+  if (!issue.assigneeAgentId || issue.assigneeUserId) return false;
+  if (issue.originKind === PRODUCTIVITY_REVIEW_ORIGIN_KIND) return false;
+  return ACTIONABLE_SOURCE_ISSUE_STATUSES.includes(
+    issue.status as (typeof ACTIONABLE_SOURCE_ISSUE_STATUSES)[number],
+  );
 }
 
 export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: EnqueueWakeup }) {
@@ -567,6 +577,8 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       ? evidence.usageSamples.map((sample) => `- \`${sample.runId}\`: \`${JSON.stringify(sample.usageJson).slice(0, 500)}\``).join("\n")
       : "- no usage payloads on sampled runs";
     return [
+      "Expected output: technical_audit",
+      "",
       "Paperclip detected an unusual productivity/progression pattern on an assigned issue.",
       "",
       "## Source",
@@ -608,11 +620,35 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       "",
       usage,
       "",
-      "## Manager Decision",
+      "## Owner Action",
       "",
       "- Close as productive if this pattern is expected.",
       "- Continue with a snooze window if the current work should keep running without repeat review spam.",
       "- Request decomposition, reroute, block with an unblock owner, or stop/cancel the source work if the work is inefficient.",
+    ].join("\n");
+  }
+
+  function buildResolvedReviewMarkdown(input: {
+    review: IssueRow;
+    sourceIssue: IssueRow | null;
+    prefix: string;
+    resolvedAt: Date;
+  }) {
+    const existing = input.review.description?.trim() || "Expected output: technical_audit";
+    const source = input.sourceIssue
+      ? issueUiLink(input.sourceIssue, input.prefix)
+      : `\`${input.review.originId ?? "unknown"}\``;
+    const sourceStatus = input.sourceIssue?.status ?? "missing";
+    return [
+      existing,
+      "",
+      "## Disposition",
+      "",
+      "Disposition: cancelled diagnostic review.",
+      `- Source issue: ${source}`,
+      `- Source issue state: \`${sourceStatus}\``,
+      "- Reason: source issue is no longer in an actionable assigned execution state.",
+      `- Cancelled at: ${input.resolvedAt.toISOString()}`,
     ].join("\n");
   }
 
@@ -643,6 +679,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       ) {
         return { kind: "existing" as const, reviewIssueId: existing.id };
       }
+      await db
+        .update(issues)
+        .set({ description: buildReviewMarkdown(evidence, opts.prefix), updatedAt: evidence.generatedAt })
+        .where(eq(issues.id, existing.id));
       await addRefreshComment(existing.id, buildRefreshComment(evidence, opts.prefix), evidence.generatedAt);
       await logActivity(db, {
         companyId: evidence.sourceIssue.companyId,
@@ -753,6 +793,77 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     return { kind: "created" as const, reviewIssueId: review.id };
   }
 
+  async function cancelResolvedOpenReviews(opts: { now: Date; companyId?: string }) {
+    const openReviews = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          opts.companyId ? eq(issues.companyId, opts.companyId) : undefined,
+          eq(issues.originKind, PRODUCTIVITY_REVIEW_ORIGIN_KIND),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(asc(issues.updatedAt), asc(issues.id))
+      .limit(MAX_CANDIDATE_ISSUES);
+    if (openReviews.length === 0) return 0;
+
+    const prefixCache = new Map<string, string>();
+    let resolved = 0;
+    for (const review of openReviews) {
+      const sourceIssue = review.originId
+        ? await db
+          .select()
+          .from(issues)
+          .where(and(eq(issues.companyId, review.companyId), eq(issues.id, review.originId)))
+          .then((rows) => rows[0] ?? null)
+        : null;
+      if (isActionableSourceIssue(sourceIssue)) continue;
+
+      let prefix = prefixCache.get(review.companyId);
+      if (!prefix) {
+        prefix = await getCompanyIssuePrefix(review.companyId);
+        prefixCache.set(review.companyId, prefix);
+      }
+      await db
+        .update(issues)
+        .set({
+          status: "cancelled",
+          description: buildResolvedReviewMarkdown({
+            review,
+            sourceIssue,
+            prefix,
+            resolvedAt: opts.now,
+          }),
+          completedAt: null,
+          cancelledAt: opts.now,
+          checkoutRunId: null,
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: opts.now,
+        })
+        .where(eq(issues.id, review.id));
+      await logActivity(db, {
+        companyId: review.companyId,
+        actorType: "system",
+        actorId: "system",
+        action: "issue.productivity_review_resolved",
+        entityType: "issue",
+        entityId: review.id,
+        agentId: review.assigneeAgentId,
+        details: {
+          source: "productivity_review.reconcile",
+          sourceIssueId: review.originId,
+          sourceIssueStatus: sourceIssue?.status ?? null,
+        },
+      });
+      resolved += 1;
+    }
+    return resolved;
+  }
+
   async function reconcileProductivityReviews(opts?: {
     now?: Date;
     companyId?: string;
@@ -760,6 +871,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   }) {
     const now = opts?.now ?? new Date();
     const thresholds = buildThresholds(opts?.thresholds);
+    const resolved = await cancelResolvedOpenReviews({ now, companyId: opts?.companyId });
     const candidates = await db
       .select()
       .from(issues)
@@ -783,6 +895,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       existing: 0,
       snoozed: 0,
       creationCapped: 0,
+      resolved,
       skipped: 0,
       failed: 0,
       reviewIssueIds: [] as string[],

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -92,6 +92,14 @@ type CancelRun = (runId: string, reason?: string) => Promise<unknown | null>;
 
 const PRODUCTIVITY_REVIEW_RESOLVED_CANCEL_REASON =
   "Cancelled because productivity review source issue is no longer actionable";
+const PRODUCTIVITY_REVIEW_OWNER_NOTES_HEADING = "## Owner Notes";
+const PRODUCTIVITY_REVIEW_OWNER_NOTES_EMPTY = "- none recorded";
+const PRODUCTIVITY_REVIEW_OWNER_ACTION_HEADING = "## Owner Action";
+const PRODUCTIVITY_REVIEW_OWNER_ACTIONS = [
+  "- Close as productive if this pattern is expected.",
+  "- Continue with a snooze window if the current work should keep running without repeat review spam.",
+  "- Request decomposition, reroute, block with an unblock owner, or stop/cancel the source work if the work is inefficient.",
+] as const;
 
 function productivityReviewFingerprint(sourceIssueId: string) {
   return `productivity-review:${sourceIssueId}`;
@@ -145,6 +153,54 @@ function maxDate(...values: Array<Date | string | null | undefined>) {
     .filter((value): value is Date => Boolean(value));
   if (dates.length === 0) return null;
   return dates.reduce((latest, value) => value.getTime() > latest.getTime() ? value : latest, dates[0]!);
+}
+
+function readReviewGeneratedAt(description: string | null | undefined) {
+  const match = String(description ?? "").match(/(?:^|\n)- Generated at: ([^\r\n]+)/);
+  const generatedAt = coerceDate(match?.[1]?.trim());
+  return generatedAt && Number.isFinite(generatedAt.getTime()) ? generatedAt : null;
+}
+
+function readMarkdownSection(description: string | null | undefined, heading: string) {
+  const lines = String(description ?? "").split(/\r?\n/);
+  const startIndex = lines.findIndex((line) => line.trim() === heading);
+  if (startIndex === -1) return null;
+  let endIndex = lines.length;
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    if (lines[index]?.startsWith("## ")) {
+      endIndex = index;
+      break;
+    }
+  }
+  const section = lines.slice(startIndex + 1, endIndex).join("\n").trim();
+  return section.length > 0 ? section : null;
+}
+
+function normalizeOwnerNotes(value: string | null | undefined) {
+  const normalized = String(value ?? "")
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== PRODUCTIVITY_REVIEW_OWNER_NOTES_EMPTY)
+    .join("\n")
+    .trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function readPreservedOwnerNotes(description: string | null | undefined) {
+  const ownerNotes = normalizeOwnerNotes(readMarkdownSection(description, PRODUCTIVITY_REVIEW_OWNER_NOTES_HEADING));
+  if (ownerNotes) return ownerNotes;
+
+  const ownerActionSection = readMarkdownSection(description, PRODUCTIVITY_REVIEW_OWNER_ACTION_HEADING);
+  if (!ownerActionSection) return null;
+  const lines = ownerActionSection.split(/\r?\n/);
+  let index = 0;
+  for (const action of PRODUCTIVITY_REVIEW_OWNER_ACTIONS) {
+    while (index < lines.length && lines[index]?.trim() === "") index += 1;
+    if (lines[index]?.trim() !== action) {
+      return normalizeOwnerNotes(ownerActionSection);
+    }
+    index += 1;
+  }
+  return normalizeOwnerNotes(lines.slice(index).join("\n"));
 }
 
 function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): ProductivityReviewThresholds {
@@ -574,7 +630,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     return null;
   }
 
-  function buildReviewMarkdown(evidence: ProductivityReviewEvidence, prefix: string) {
+  function buildReviewMarkdown(evidence: ProductivityReviewEvidence, prefix: string, ownerNotes?: string | null) {
     const latestRuns = evidence.latestRuns.length > 0
       ? evidence.latestRuns.map((run) =>
         `- ${runUiLink(run, prefix)} \`${run.status}\` liveness \`${run.livenessState ?? "unknown"}\`, created ${run.createdAt.toISOString()}${run.nextAction ? `, next action: ${truncateInline(run.nextAction, 160)}` : ""}`,
@@ -632,11 +688,13 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       "",
       usage,
       "",
-      "## Owner Action",
+      PRODUCTIVITY_REVIEW_OWNER_NOTES_HEADING,
       "",
-      "- Close as productive if this pattern is expected.",
-      "- Continue with a snooze window if the current work should keep running without repeat review spam.",
-      "- Request decomposition, reroute, block with an unblock owner, or stop/cancel the source work if the work is inefficient.",
+      ownerNotes?.trim() || PRODUCTIVITY_REVIEW_OWNER_NOTES_EMPTY,
+      "",
+      PRODUCTIVITY_REVIEW_OWNER_ACTION_HEADING,
+      "",
+      ...PRODUCTIVITY_REVIEW_OWNER_ACTIONS,
     ].join("\n");
   }
 
@@ -684,7 +742,9 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     const existing = await findOpenProductivityReview(evidence.sourceIssue.companyId, evidence.sourceIssue.id);
     if (existing) {
       const refreshState = await getRefreshCommentState(evidence.sourceIssue.companyId, existing.id);
-      const lastRefreshOrCreationAt = maxDate(refreshState.latestCreatedAt, existing.updatedAt, existing.createdAt) ?? existing.createdAt;
+      const lastRefreshOrCreationAt =
+        maxDate(refreshState.latestCreatedAt, readReviewGeneratedAt(existing.description), existing.createdAt) ??
+        existing.createdAt;
       if (
         evidence.generatedAt.getTime() - lastRefreshOrCreationAt.getTime() < opts.thresholds.refreshIntervalMs
       ) {
@@ -692,7 +752,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       }
       await db
         .update(issues)
-        .set({ description: buildReviewMarkdown(evidence, opts.prefix), updatedAt: evidence.generatedAt })
+        .set({
+          description: buildReviewMarkdown(evidence, opts.prefix, readPreservedOwnerNotes(existing.description)),
+          updatedAt: evidence.generatedAt,
+        })
         .where(eq(issues.id, existing.id));
       const refreshCommentAdded = refreshState.count < opts.thresholds.maxRefreshComments;
       if (refreshCommentAdded) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The heartbeat control plane uses productivity reviews to flag stalled or noisy execution patterns.
> - AGE-20 showed that the review path could itself become noisy by repeatedly posting refresh comments.
> - Those auto-generated review issues also lacked a concrete expected output, which let diagnostic work drift into the normal execution backlog without a crisp contract.
> - The source-of-truth service is `productivityReviewService`, which owns review creation, refresh, snooze, and reconciliation.
> - This pull request keeps review evidence aggregated on the review issue, caps refresh comments, and cancels stale reviews when their source issue is no longer actionable.
> - The benefit is a quieter monitoring surface with a clear owner action and regression coverage for the AGE-20 failure mode.

## What Changed

- Added `Expected output: technical_audit` and an `Owner Action` section to generated productivity review descriptions.
- Updated repeated productivity-review refreshes to rewrite the review description on the refresh interval while only adding refresh comments up to the existing cap.
- Added stale-review reconciliation that cancels open productivity reviews when the source issue is missing, hidden, terminal, human-owned, unassigned, or itself a productivity review.
- Wired stale-review cancellation through heartbeat run cancellation when a review is actively checked out.
- Added regression tests for the generated output contract, capped refresh aggregation, source-resolution cancellation, and source-owner-loss cancellation.

## Verification

- `pnpm exec vitest run server/src/__tests__/productivity-review-service.test.ts` - 13 tests passed.
- `pnpm --filter @paperclipai/server typecheck` - exited 0.
- `git diff --check` - exited 0.
- Red state was observed before implementation for the new regression cases: expected output was missing, capped refreshes did not update description state, and source-resolution cancellation did not cancel active review runs.
- Not run locally: full `pnpm test:run`, `pnpm build`, Playwright e2e. Those are covered by PR CI and were outside the focused service-level blast radius for this heartbeat.

## Risks

- Low migration risk: this only changes service behavior and tests, with no schema or public API changes.
- Behavioral risk: stale productivity review issues now auto-cancel when their source issue is no longer actionable. That is intended for diagnostic reviews, but reviewers should confirm there is no workflow that expects old productivity reviews to remain open after source completion or unassignment.
- Active review cancellation now calls the same heartbeat cancellation path used by issue cancellation, so run-state side effects should match existing issue behavior.
- I checked `ROADMAP.md`; this is a focused bugfix/guardrail and does not duplicate planned core feature work.

## Model Used

- OpenAI Codex, GPT-5.5 tool-enabled coding session with shell and local workspace access.
- Read-only reviewer subagent: OpenAI gpt-5.4, used for a focused changeset critique before finalizing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable; no UI changes)
- [x] I have updated relevant documentation to reflect my changes (not applicable; internal service behavior is covered by tests and this PR description)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---
Replacement for closed PR #5121. GitHub could not reopen the original PR after the source fork was deleted, so this PR restores the same head branch and preserves the original context.