### PR TITLE
feat(server): export issue-scoped heartbeat runs to Langfuse

### DIFF
--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -52,3 +52,17 @@ These are set automatically by the server when invoking agents:
 |----------|-------------|
 | `ANTHROPIC_API_KEY` | Anthropic API key (for Claude Local adapter) |
 | `OPENAI_API_KEY` | OpenAI API key (for Codex Local adapter) |
+
+## Langfuse Export (Optional)
+
+When enabled, Paperclip exports **issue-scoped heartbeat runs** to Langfuse via `POST /api/public/ingestion`.
+Exports are metadata-only (no prompts, run logs, file paths, issue bodies, or env vars).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PAPERCLIP_LANGFUSE_ENABLED` | (disabled) | Enable Paperclip → Langfuse export (`1/true/yes/on`) |
+| `LANGFUSE_HOST` | (unset) | Langfuse base URL (e.g. `http://127.0.0.1:3001`) |
+| `LANGFUSE_PUBLIC_KEY` | (unset) | Langfuse public key (Basic Auth username) |
+| `LANGFUSE_SECRET_KEY` | (unset) | Langfuse secret key (Basic Auth password) |
+| `PAPERCLIP_LANGFUSE_TIMEOUT_MS` | `3000` | Ingestion request timeout in milliseconds |
+| `PAPERCLIP_LANGFUSE_ENVIRONMENT` | `local` | Langfuse `environment` field for traces |

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -65,4 +65,4 @@ Exports are metadata-only (no prompts, run logs, file paths, issue bodies, or en
 | `LANGFUSE_PUBLIC_KEY` | (unset) | Langfuse public key (Basic Auth username) |
 | `LANGFUSE_SECRET_KEY` | (unset) | Langfuse secret key (Basic Auth password) |
 | `PAPERCLIP_LANGFUSE_TIMEOUT_MS` | `3000` | Ingestion request timeout in milliseconds |
-| `PAPERCLIP_LANGFUSE_ENVIRONMENT` | `local` | Langfuse `environment` field for traces |
+| `PAPERCLIP_LANGFUSE_ENVIRONMENT` | `local` | Langfuse `environment` field for traces (normalized to lowercase `a-z0-9-_`, max 40 chars; values starting with `langfuse` fall back to `local`) |

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -144,7 +144,7 @@ import {
 import { recoveryService } from "./recovery/service.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
-import { maybeExportHeartbeatRunToLangfuse } from "./langfuse-export.js";
+import { isLangfuseEnabled, maybeExportHeartbeatRunToLangfuse } from "./langfuse-export.js";
 import {
   redactCurrentUserText,
   redactCurrentUserValue,
@@ -7860,7 +7860,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }, normalizedUsage);
 
         let promptVersion = agent.updatedAt ? agent.updatedAt.toISOString() : null;
-        if (process.env.PAPERCLIP_LANGFUSE_ENABLED === "1") {
+        if (issueRef && isLangfuseEnabled()) {
           try {
             const latestRevision = await db
               .select({ id: agentConfigRevisions.id })

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -22,6 +22,7 @@ import {
 } from "@paperclipai/shared";
 import {
   agents,
+  agentConfigRevisions,
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
@@ -143,6 +144,7 @@ import {
 import { recoveryService } from "./recovery/service.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
+import { maybeExportHeartbeatRunToLangfuse } from "./langfuse-export.js";
 import {
   redactCurrentUserText,
   redactCurrentUserValue,
@@ -7856,6 +7858,46 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         await updateRuntimeState(agent, finalizedRun, adapterResult, {
           legacySessionId: nextSessionState.legacySessionId,
         }, normalizedUsage);
+
+        let promptVersion = agent.updatedAt ? agent.updatedAt.toISOString() : null;
+        if (process.env.PAPERCLIP_LANGFUSE_ENABLED === "1") {
+          try {
+            const latestRevision = await db
+              .select({ id: agentConfigRevisions.id })
+              .from(agentConfigRevisions)
+              .where(and(eq(agentConfigRevisions.companyId, agent.companyId), eq(agentConfigRevisions.agentId, agent.id)))
+              .orderBy(desc(agentConfigRevisions.createdAt))
+              .limit(1)
+              .then((rows) => rows[0] ?? null);
+            promptVersion = latestRevision?.id ?? promptVersion;
+          } catch {
+            // best effort only
+          }
+        }
+
+        const langfuseUsage = normalizedUsage ?? rawUsage;
+        void maybeExportHeartbeatRunToLangfuse({
+          companyId: agent.companyId,
+          run: finalizedRun,
+          agent: { id: agent.id, name: agent.name, adapterType: agent.adapterType },
+          issue: issueRef ? { id: issueRef.id, identifier: issueRef.identifier, title: issueRef.title } : null,
+          adapterResult: {
+            provider: adapterResult.provider ?? null,
+            model: adapterResult.model ?? null,
+            billingType: adapterResult.billingType ?? null,
+            costUsd: adapterResult.costUsd ?? null,
+            exitCode: adapterResult.exitCode ?? null,
+          },
+          usage: langfuseUsage
+            ? {
+              inputTokens: langfuseUsage.inputTokens,
+              outputTokens: langfuseUsage.outputTokens,
+              cachedInputTokens: langfuseUsage.cachedInputTokens,
+            }
+            : null,
+          promptVersion,
+        });
+
         if (taskKey) {
           if (adapterResult.clearSession || (!nextSessionState.params && !nextSessionState.displayId)) {
             await clearTaskSessions(agent.companyId, agent.id, {

--- a/server/src/services/langfuse-export.test.ts
+++ b/server/src/services/langfuse-export.test.ts
@@ -66,6 +66,7 @@ describe("langfuse export", () => {
     process.env.LANGFUSE_HOST = "http://127.0.0.1:3001/";
     process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
     process.env.LANGFUSE_SECRET_KEY = "sk-test";
+    process.env.PAPERCLIP_LANGFUSE_ENVIRONMENT = "Production";
 
     await maybeExportHeartbeatRunToLangfuse({
       companyId: "company-1",
@@ -102,6 +103,7 @@ describe("langfuse export", () => {
     expect(trace.id).toBe("run-1");
     expect(trace.sessionId).toBe("issue-1");
     expect(trace.name).toBe("paperclip.heartbeat_run");
+    expect(trace.environment).toBe("production");
 
     const generation = body.batch.find((event: { type: string }) => event.type === "generation-create")?.body;
     expect(generation.traceId).toBe("run-1");

--- a/server/src/services/langfuse-export.test.ts
+++ b/server/src/services/langfuse-export.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { maybeExportHeartbeatRunToLangfuse } from "./langfuse-export.js";
+
+describe("langfuse export", () => {
+  let envSnapshot: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    envSnapshot = { ...process.env };
+  });
+
+  afterEach(() => {
+    for (const key of Object.keys(process.env)) {
+      if (!(key in envSnapshot)) {
+        delete process.env[key];
+      }
+    }
+    Object.assign(process.env, envSnapshot);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("no-ops when disabled", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo, _init?: RequestInit) =>
+      ({ ok: true, status: 200, statusText: "OK" } as Response)
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    process.env.LANGFUSE_HOST = "http://127.0.0.1:3001";
+    process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
+    process.env.LANGFUSE_SECRET_KEY = "sk-test";
+
+    await maybeExportHeartbeatRunToLangfuse({
+      run: { id: "run-1" },
+      issue: { id: "issue-1" },
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when run is not issue-scoped", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo, _init?: RequestInit) =>
+      ({ ok: true, status: 200, statusText: "OK" } as Response)
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    process.env.PAPERCLIP_LANGFUSE_ENABLED = "1";
+    process.env.LANGFUSE_HOST = "http://127.0.0.1:3001";
+    process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
+    process.env.LANGFUSE_SECRET_KEY = "sk-test";
+
+    await maybeExportHeartbeatRunToLangfuse({
+      run: { id: "run-1" },
+      issue: null,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts a minimal trace payload when configured", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo, _init?: RequestInit) =>
+      ({ ok: true, status: 200, statusText: "OK" } as Response)
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    process.env.PAPERCLIP_LANGFUSE_ENABLED = "true";
+    process.env.LANGFUSE_HOST = "http://127.0.0.1:3001/";
+    process.env.LANGFUSE_PUBLIC_KEY = "pk-test";
+    process.env.LANGFUSE_SECRET_KEY = "sk-test";
+
+    await maybeExportHeartbeatRunToLangfuse({
+      companyId: "company-1",
+      run: {
+        id: "run-1",
+        status: "succeeded",
+        startedAt: "2026-05-10T10:00:00.000Z",
+        finishedAt: "2026-05-10T10:01:00.000Z",
+      },
+      agent: { id: "agent-1", name: "Odin", adapterType: "codex_local" },
+      issue: { id: "issue-1", identifier: "ARG-206", title: "Upstream Langfuse export" },
+      adapterResult: { provider: "openai", model: "gpt-5.2", billingType: "api", costUsd: 0.25, exitCode: 0 },
+      usage: { inputTokens: 10, outputTokens: 5, cachedInputTokens: 2 },
+      promptVersion: "rev-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0] ?? [undefined, undefined];
+    expect(url).toBe("http://127.0.0.1:3001/api/public/ingestion");
+    expect(options?.method).toBe("POST");
+    expect((options?.headers as Record<string, string> | undefined)?.authorization).toBe(
+      `Basic ${Buffer.from("pk-test:sk-test", "utf8").toString("base64")}`,
+    );
+
+    const body = JSON.parse(String(options?.body));
+    expect(body.batch).toHaveLength(3);
+    expect(body.batch.map((event: { type: string }) => event.type)).toEqual([
+      "trace-create",
+      "generation-create",
+      "score-create",
+    ]);
+
+    const trace = body.batch.find((event: { type: string }) => event.type === "trace-create")?.body;
+    expect(trace.id).toBe("run-1");
+    expect(trace.sessionId).toBe("issue-1");
+    expect(trace.name).toBe("paperclip.heartbeat_run");
+
+    const generation = body.batch.find((event: { type: string }) => event.type === "generation-create")?.body;
+    expect(generation.traceId).toBe("run-1");
+    expect(generation.name).toBe("paperclip.run");
+    expect(generation.costDetails.total).toBe(0.25);
+
+    const score = body.batch.find((event: { type: string }) => event.type === "score-create")?.body;
+    expect(score.traceId).toBe("run-1");
+    expect(score.name).toBe("paperclip.outcome");
+    expect(score.value).toBe(1);
+    expect(score.observationId).toBe(generation.id);
+  });
+});

--- a/server/src/services/langfuse-export.ts
+++ b/server/src/services/langfuse-export.ts
@@ -47,6 +47,20 @@ function safeShortString(value: unknown, maxChars: number) {
   return `${trimmed.slice(0, Math.max(0, maxChars - 1))}…`;
 }
 
+function normalizeLangfuseEnvironment(value: unknown) {
+  const raw = safeShortString(value, 40);
+  if (!raw) return "local";
+
+  const normalized = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  if (!normalized) return "local";
+  if (normalized.startsWith("langfuse")) return "local";
+  return normalized;
+}
+
 function deriveUuidV4(seed: string) {
   const hash = createHash("sha256").update(seed).digest();
   const bytes = Buffer.from(hash.subarray(0, 16));
@@ -160,7 +174,7 @@ export async function maybeExportHeartbeatRunToLangfuse(input: LangfuseHeartbeat
       name: DEFAULT_TRACE_NAME,
       userId: typeof agentId === "string" ? agentId : null,
       sessionId: issueId,
-      environment: safeShortString(process.env.PAPERCLIP_LANGFUSE_ENVIRONMENT, 40) ?? "local",
+      environment: normalizeLangfuseEnvironment(process.env.PAPERCLIP_LANGFUSE_ENVIRONMENT),
       version: safeShortString(input?.promptVersion, 120) ?? null,
       tags: ["paperclip", "heartbeat", ...(adapterType ? [adapterType] : []), ...(issueIdentifier ? [issueIdentifier] : [])],
       metadata: {

--- a/server/src/services/langfuse-export.ts
+++ b/server/src/services/langfuse-export.ts
@@ -11,6 +11,10 @@ function parseBooleanEnv(value: unknown) {
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
+export function isLangfuseEnabled() {
+  return parseBooleanEnv(process.env.PAPERCLIP_LANGFUSE_ENABLED);
+}
+
 function normalizeHost(value: unknown) {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
@@ -125,7 +129,7 @@ export type LangfuseHeartbeatRunExportInput = {
 
 export async function maybeExportHeartbeatRunToLangfuse(input: LangfuseHeartbeatRunExportInput) {
   try {
-    const enabled = parseBooleanEnv(process.env.PAPERCLIP_LANGFUSE_ENABLED);
+    const enabled = isLangfuseEnabled();
     if (!enabled) return;
 
     const host =
@@ -157,6 +161,7 @@ export async function maybeExportHeartbeatRunToLangfuse(input: LangfuseHeartbeat
     const generationId = deriveUuidV4(`${runId}:generation:v1`);
     const traceEventId = deriveUuidV4(`${runId}:trace-create:v1`);
     const generationEventId = deriveUuidV4(`${runId}:generation-create:v1`);
+    const scoreId = deriveUuidV4(`${runId}:score:v1`);
     const scoreEventId = deriveUuidV4(`${runId}:score-create:v1`);
 
     const provider = safeShortString(input?.adapterResult?.provider, 80);
@@ -221,7 +226,7 @@ export async function maybeExportHeartbeatRunToLangfuse(input: LangfuseHeartbeat
     };
 
     const scoreBody = {
-      id: scoreEventId,
+      id: scoreId,
       traceId: runId,
       observationId: generationId,
       name: "paperclip.outcome",

--- a/server/src/services/langfuse-export.ts
+++ b/server/src/services/langfuse-export.ts
@@ -1,0 +1,259 @@
+import { createHash } from "node:crypto";
+import { logger } from "../middleware/logger.js";
+import type { UsageSummary } from "../adapters/index.js";
+
+const DEFAULT_TIMEOUT_MS = 3000;
+const DEFAULT_TRACE_NAME = "paperclip.heartbeat_run";
+
+function parseBooleanEnv(value: unknown) {
+  if (typeof value !== "string") return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function normalizeHost(value: unknown) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    // tolerate scheme-less inputs like "localhost:3000"
+    try {
+      const url = new URL(`http://${trimmed}`);
+      return url.toString().replace(/\/$/, "");
+    } catch {
+      return null;
+    }
+  }
+}
+
+function toIsoString(value: unknown) {
+  if (!value) return new Date().toISOString();
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function safeShortString(value: unknown, maxChars: number) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (trimmed.length <= maxChars) return trimmed;
+  return `${trimmed.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function deriveUuidV4(seed: string) {
+  const hash = createHash("sha256").update(seed).digest();
+  const bytes = Buffer.from(hash.subarray(0, 16));
+  // RFC 4122 version 4 + variant 1
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function buildAuthHeader(publicKey: string, secretKey: string) {
+  const token = Buffer.from(`${publicKey}:${secretKey}`, "utf8").toString("base64");
+  return `Basic ${token}`;
+}
+
+function parseTimeoutMs(value: unknown) {
+  if (typeof value !== "string") return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeNumber(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export type LangfuseHeartbeatRunExportInput = {
+  companyId?: string | null;
+  run?: {
+    id?: string | null;
+    agentId?: string | null;
+    status?: string | null;
+    startedAt?: Date | string | null;
+    createdAt?: Date | string | null;
+    finishedAt?: Date | string | null;
+    updatedAt?: Date | string | null;
+  } | null;
+  agent?: {
+    id?: string | null;
+    name?: string | null;
+    adapterType?: string | null;
+  } | null;
+  issue?: {
+    id?: string | null;
+    identifier?: string | null;
+    title?: string | null;
+  } | null;
+  adapterResult?: {
+    provider?: string | null;
+    model?: string | null;
+    billingType?: string | null;
+    costUsd?: number | string | null;
+    exitCode?: number | null;
+  } | null;
+  usage?: UsageSummary | null;
+  promptVersion?: string | null;
+};
+
+export async function maybeExportHeartbeatRunToLangfuse(input: LangfuseHeartbeatRunExportInput) {
+  try {
+    const enabled = parseBooleanEnv(process.env.PAPERCLIP_LANGFUSE_ENABLED);
+    if (!enabled) return;
+
+    const host =
+      normalizeHost(process.env.LANGFUSE_HOST) ??
+      normalizeHost(process.env.LANGFUSE_BASE_URL) ??
+      normalizeHost(process.env.LANGFUSE_URL);
+    const publicKey = typeof process.env.LANGFUSE_PUBLIC_KEY === "string" ? process.env.LANGFUSE_PUBLIC_KEY.trim() : "";
+    const secretKey = typeof process.env.LANGFUSE_SECRET_KEY === "string" ? process.env.LANGFUSE_SECRET_KEY.trim() : "";
+    if (!host || !publicKey || !secretKey) return;
+
+    const runId = input?.run?.id;
+    if (typeof runId !== "string" || !runId) return;
+
+    const issueId = input?.issue?.id ?? null;
+    // Keep this exporter low-risk: only export issue-scoped runs.
+    if (typeof issueId !== "string" || !issueId) return;
+
+    const agentId = input?.agent?.id ?? input?.run?.agentId ?? null;
+    const agentName = safeShortString(input?.agent?.name, 120);
+    const adapterType = safeShortString(input?.agent?.adapterType, 80);
+    const issueIdentifier = safeShortString(input?.issue?.identifier, 40);
+    const issueTitle = safeShortString(input?.issue?.title, 200);
+    const status = safeShortString(input?.run?.status, 40);
+
+    const startTime = toIsoString(input?.run?.startedAt ?? input?.run?.createdAt);
+    const endTime = toIsoString(input?.run?.finishedAt ?? input?.run?.updatedAt);
+    const now = new Date().toISOString();
+
+    const generationId = deriveUuidV4(`${runId}:generation:v1`);
+    const traceEventId = deriveUuidV4(`${runId}:trace-create:v1`);
+    const generationEventId = deriveUuidV4(`${runId}:generation-create:v1`);
+    const scoreEventId = deriveUuidV4(`${runId}:score-create:v1`);
+
+    const provider = safeShortString(input?.adapterResult?.provider, 80);
+    const model = safeShortString(input?.adapterResult?.model, 120);
+    const billingType = safeShortString(input?.adapterResult?.billingType, 40);
+
+    const inputTokens = normalizeNumber(input?.usage?.inputTokens) ?? 0;
+    const cachedInputTokens = normalizeNumber(input?.usage?.cachedInputTokens) ?? 0;
+    const outputTokens = normalizeNumber(input?.usage?.outputTokens) ?? 0;
+    const costUsd = normalizeNumber(input?.adapterResult?.costUsd) ?? null;
+
+    const traceBody = {
+      id: runId,
+      timestamp: startTime,
+      name: DEFAULT_TRACE_NAME,
+      userId: typeof agentId === "string" ? agentId : null,
+      sessionId: issueId,
+      environment: safeShortString(process.env.PAPERCLIP_LANGFUSE_ENVIRONMENT, 40) ?? "local",
+      version: safeShortString(input?.promptVersion, 120) ?? null,
+      tags: ["paperclip", "heartbeat", ...(adapterType ? [adapterType] : []), ...(issueIdentifier ? [issueIdentifier] : [])],
+      metadata: {
+        paperclip: {
+          companyId: input?.companyId ?? null,
+          runId,
+          status,
+          agentId,
+          agentName,
+          adapterType,
+          issueId,
+          issueIdentifier,
+          issueTitle,
+        },
+      },
+    };
+
+    const usageDetails = {
+      input: inputTokens,
+      output: outputTokens,
+      cache_read_input_tokens: cachedInputTokens,
+    };
+
+    const generationBody = {
+      traceId: runId,
+      id: generationId,
+      name: "paperclip.run",
+      startTime,
+      endTime,
+      model: model ?? null,
+      version: safeShortString(input?.promptVersion, 120) ?? null,
+      promptName: agentName ? `paperclip.agent:${agentName}` : null,
+      usageDetails,
+      // Langfuse ingestion currently drops generation observations when costDetails is null/omitted.
+      // Prefer a safe default so token usage always shows up in the UI.
+      costDetails: { total: costUsd ?? 0 },
+      metadata: {
+        paperclip: {
+          provider,
+          billingType,
+          ...(typeof input?.adapterResult?.exitCode === "number" ? { exitCode: input.adapterResult.exitCode } : {}),
+        },
+      },
+    };
+
+    const scoreBody = {
+      id: scoreEventId,
+      traceId: runId,
+      observationId: generationId,
+      name: "paperclip.outcome",
+      value: status === "succeeded" ? 1 : 0,
+      comment: status ? `paperclip run status: ${status}` : null,
+      metadata: {
+        paperclip: {
+          status,
+        },
+      },
+    };
+
+    const payload = {
+      batch: [
+        { id: traceEventId, timestamp: now, type: "trace-create", body: traceBody },
+        { id: generationEventId, timestamp: now, type: "generation-create", body: generationBody },
+        { id: scoreEventId, timestamp: now, type: "score-create", body: scoreBody },
+      ],
+    };
+
+    const endpoint = `${host}/api/public/ingestion`;
+    const timeoutMs = parseTimeoutMs(process.env.PAPERCLIP_LANGFUSE_TIMEOUT_MS) ?? DEFAULT_TIMEOUT_MS;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          authorization: buildAuthHeader(publicKey, secretKey),
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        logger.warn(
+          { status: response.status, statusText: response.statusText, runId, issueId },
+          "langfuse export failed",
+        );
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch (err) {
+    logger.warn({ err }, "langfuse export crashed");
+  }
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates agent heartbeats and persists run status/usage/cost
> - Operators need optional observability hooks beyond anonymous product telemetry
> - We validated a Langfuse export flow in a local-only dist patch (ARG-185)
> - That patch lived only in compiled `dist/` output and would be overwritten on upgrade
> - This PR moves the exporter into `@paperclipai/server` source under `server/src/services/`
> - To keep risk low, export is opt-in, best-effort, and restricted to issue-scoped runs
> - Exported payload is metadata-only (no prompts, run logs, file paths, issue bodies, or env vars)
> - A small unit test locks the payload shape and gating behavior, and docs are updated for config

## What Changed

- Added `server/src/services/langfuse-export.ts` to export issue-scoped heartbeat runs to Langfuse ingestion (metadata-only, opt-in)
- Wired the exporter into `server/src/services/heartbeat.ts` after `finalizedRun` is persisted
- Added `server/src/services/langfuse-export.test.ts` to cover enablement + issue-scope gating + payload basics
- Documented Langfuse env vars in `docs/deploy/environment-variables.md`

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/services/langfuse-export.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

Manual (optional):
- Set `PAPERCLIP_LANGFUSE_ENABLED=1`, `LANGFUSE_HOST`, `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`
- Complete an issue-scoped heartbeat run and confirm a `paperclip.heartbeat_run` trace appears in Langfuse

## Risks

- When enabled, run metadata (runId/issueId/agentId/adapterType/status + token usage/cost) is exported to the configured Langfuse instance
- Langfuse ingestion API/schema changes could cause exports to fail (logged as warn; exporter is best-effort)
- Minor runtime overhead (single HTTP POST with timeout; no blocking on success)

> Checked `ROADMAP.md` — no overlapping planned core work found for this narrow, opt-in exporter.

## Model Used

- OpenAI `gpt-5.2` (Codex CLI; tool use enabled)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
