### PR TITLE
Enable CI publish for plugin-daytona

### DIFF
--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -82,7 +82,7 @@
   {
     "dir": "packages/plugins/sandbox-providers/daytona",
     "name": "@paperclipai/plugin-daytona",
-    "publishFromCi": false
+    "publishFromCi": true
   },
   {
     "dir": "packages/plugins/sandbox-providers/e2b",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The release pipeline gates new public packages behind a bootstrap policy: `scripts/check-release-package-bootstrap.mjs` requires every package marked `publishFromCi: true` in `scripts/release-package-manifest.json` to already exist on npm
> - PR #5580 added the new Daytona sandbox provider plugin but had to land with `publishFromCi: false` because the package had never been published, so CI's release plan would have failed bootstrap validation otherwise
> - Now that `@paperclipai/plugin-daytona` has been bootstrap-published to npm by hand, the temporary `false` flag is the only thing keeping it out of the standard CI publish flow
> - This pull request flips the Daytona entry to `publishFromCi: true`, matching every other release-enabled package in the manifest
> - The benefit is that future tagged releases will publish the Daytona plugin automatically alongside the rest of the monorepo's public packages

## What Changed

- Single-line flip in `scripts/release-package-manifest.json`: `@paperclipai/plugin-daytona` is now `publishFromCi: true`

## Verification

- `node ./scripts/release-package-map.mjs check` → `Release package manifest OK: 19 enabled for CI publish, 0 disabled pending bootstrap` (was 18 + 1)
- `node ./scripts/check-release-package-bootstrap.mjs scripts/release-package-manifest.json` against `origin/master` → `Release bootstrap OK for changed manifests: @paperclipai/plugin-daytona`, confirming npm sees the bootstrap-published package
- No code changes; no tests required beyond the existing manifest validators

## Risks

- Low risk. Only effect is that the next release run will include `@paperclipai/plugin-daytona` in its publish set
- If the npm bootstrap was incomplete, CI's bootstrap check will fail loudly before any release tag goes out — same safety net the policy is designed to provide

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`), extended thinking, tool use enabled

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable (N/A — manifest-only flag flip, covered by existing validators)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — release config)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge