### PR TITLE
feat(adapter-claude-local): add @paperclipai/mcp-server workspace dependency

### DIFF
--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "workspace:*",
+    "@paperclipai/mcp-server": "workspace:*",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
+      '@paperclipai/mcp-server':
+        specifier: workspace:*
+        version: link:../../mcp-server
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1


### PR DESCRIPTION
## Summary

Add `@paperclipai/mcp-server` as a workspace dependency to `@paperclipai/adapter-claude-local` so the native plugin MCP injection code can resolve the package at runtime.

**Context:** Child of PRO-3849 — Memory plugin MCP injection proper fix.

**Root cause:** The adapter's plugin MCP injection code is silently inactive because `@paperclipai/mcp-server` was not listed as a dependency, causing the runtime resolver to fail silently.

## Changes

- `packages/adapters/claude-local/package.json` — adds `"@paperclipai/mcp-server": "workspace:*"` to `dependencies`
- `pnpm-lock.yaml` — updated to reflect the new workspace link

## Verification

- Build: `pnpm --filter @paperclipai/adapter-claude-local build` — completed cleanly on mst001
- Workspace link: `packages/adapters/claude-local/node_modules/@paperclipai/mcp-server` — confirmed present after `pnpm install`
- Dist: `dist/index.js` and `dist/index.d.ts` confirmed present in `packages/adapters/claude-local/dist/`

## Hard constraints respected

- `@paperclipai/mcp-server` added to `dependencies` (not `devDependencies`)
- Build ran on mst001, not the Paperclip VM (GV-2026-003 compliant)

Closes PRO-3854.