### PR TITLE
feat(adapter-claude-local): add plugin MCP injection mechanism (PRO-3915)

### DIFF
--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@paperclipai/adapter-utils": "workspace:*",
+    "@paperclipai/mcp-server": "workspace:*",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -67,7 +68,8 @@ const require = createRequire(import.meta.url);
 function resolvePluginMcpStdioPath(): string | null {
   try {
     const pkgJsonPath = require.resolve("@paperclipai/mcp-server/package.json");
-    return path.join(path.dirname(pkgJsonPath), "dist", "plugin-stdio.js");
+    const resolvedPath = path.join(path.dirname(pkgJsonPath), "dist", "plugin-stdio.js");
+    return existsSync(resolvedPath) ? resolvedPath : null;
   } catch {
     return null;
   }
@@ -683,7 +685,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         },
       },
     };
-    await fs.writeFile(pluginMcpConfigPath, JSON.stringify(mcpConfig, null, 2), "utf-8");
+    await fs.writeFile(pluginMcpConfigPath, JSON.stringify(mcpConfig, null, 2), { encoding: "utf-8", mode: 0o600 });
     await onLog(
       "stdout",
       `[paperclip] Plugin tool MCP config written to ${pluginMcpConfigPath}\n`,

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
@@ -61,6 +62,16 @@ import { prepareClaudePromptBundle } from "./prompt-cache.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+function resolvePluginMcpStdioPath(): string | null {
+  try {
+    const pkgJsonPath = require.resolve("@paperclipai/mcp-server/package.json");
+    return path.join(path.dirname(pkgJsonPath), "dist", "plugin-stdio.js");
+  } catch {
+    return null;
+  }
+}
 
 interface ClaudeExecutionInput {
   runId: string;
@@ -134,6 +145,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const workspaceBranch = asString(workspaceContext.branchName, "") || null;
   const workspaceWorktreePath = asString(workspaceContext.worktreePath, "") || null;
   const agentHome = asString(workspaceContext.agentHome, "") || null;
+  const workspaceProjectId = asString(workspaceContext.projectId, "") || null;
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
         (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
@@ -367,6 +379,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceBranch = asString(workspaceContext.branchName, "") || null;
   const workspaceWorktreePath = asString(workspaceContext.worktreePath, "") || null;
   const agentHome = asString(workspaceContext.agentHome, "") || null;
+  const workspaceProjectId = asString(workspaceContext.projectId, "") || null;
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
         (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
@@ -648,6 +661,35 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     heartbeatPromptChars: renderedPrompt.length,
   };
 
+  const pluginMcpStdioPath = !executionTargetIsRemote ? resolvePluginMcpStdioPath() : null;
+  const pluginMcpConfigPath =
+    pluginMcpStdioPath !== null && workspaceProjectId !== null
+      ? `/tmp/paperclip-plugin-mcp-${runId}.json`
+      : null;
+  if (pluginMcpConfigPath !== null && pluginMcpStdioPath !== null && workspaceProjectId !== null) {
+    const mcpConfig = {
+      mcpServers: {
+        "paperclip-plugins": {
+          command: "node",
+          args: [pluginMcpStdioPath],
+          env: {
+            PAPERCLIP_API_URL: env.PAPERCLIP_API_URL ?? "",
+            PAPERCLIP_API_KEY: env.PAPERCLIP_API_KEY ?? "",
+            PAPERCLIP_AGENT_ID: env.PAPERCLIP_AGENT_ID ?? "",
+            PAPERCLIP_RUN_ID: runId,
+            PAPERCLIP_COMPANY_ID: env.PAPERCLIP_COMPANY_ID ?? "",
+            PAPERCLIP_PROJECT_ID: workspaceProjectId,
+          },
+        },
+      },
+    };
+    await fs.writeFile(pluginMcpConfigPath, JSON.stringify(mcpConfig, null, 2), "utf-8");
+    await onLog(
+      "stdout",
+      `[paperclip] Plugin tool MCP config written to ${pluginMcpConfigPath}\n`,
+    );
+  }
+
   const buildClaudeArgs = (
     resumeSessionId: string | null,
     attemptInstructionsFilePath: string | undefined,
@@ -672,6 +714,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
     args.push("--add-dir", effectivePromptBundleAddDir);
     if (extraArgs.length > 0) args.push(...extraArgs);
+    if (pluginMcpConfigPath !== null) {
+      args.push("--mcp-config", pluginMcpConfigPath);
+    }
     return args;
   };
 
@@ -928,6 +973,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
   } finally {
+    if (pluginMcpConfigPath !== null) {
+      await fs.unlink(pluginMcpConfigPath).catch(() => {});
+    }
     if (paperclipBridge) {
       await paperclipBridge.stop();
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
+      '@paperclipai/mcp-server':
+        specifier: workspace:*
+        version: link:../../mcp-server
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1


### PR DESCRIPTION
Summary: Implements plugin MCP stdio injection in claude-local adapter so plugin tools (memory_store, memory_get, etc.) are available to local agent sessions.

Root issue: PRO-3849. Implementation issue: PRO-3915.

Changes:
- packages/adapters/claude-local/package.json: add @paperclipai/mcp-server workspace:* dep (absorbs PR #5587)
- packages/adapters/claude-local/src/server/execute.ts:
  - resolvePluginMcpStdioPath(): resolves dist/plugin-stdio.js from @paperclipai/mcp-server; returns null if not installed
  - Writes /tmp/paperclip-plugin-mcp-{runId}.json before each local run with a project workspace; passes --mcp-config to Claude CLI
  - Temp file deleted in finally block (self-cleaning)
  - --mcp-config injected programmatically, NOT in adapter extraArgs

Guards (injection skipped when): remote execution target, package not installed/built, no project workspace.

TypeScript typecheck passes (tsc --noEmit). Supersedes PR #5587 dep addition.

Next step: PRO-3855 — DevOps build @paperclipai/mcp-server dist and deploy.