### PR TITLE
feat(ui): native folder picker for workspace path inputs

### DIFF
--- a/server/src/__tests__/filesystem-list-route.test.ts
+++ b/server/src/__tests__/filesystem-list-route.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { filesystemRoutes } from "../routes/filesystem.js";
+import { errorHandler } from "../middleware/index.js";
+
+async function createFixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-filesystem-list-"));
+  const homeDir = path.join(root, "home");
+  const nestedDir = path.join(homeDir, "projects");
+  const linkedDir = path.join(homeDir, "linked-projects");
+  await fs.mkdir(nestedDir, { recursive: true });
+  await fs.writeFile(path.join(homeDir, "notes.txt"), "hello", "utf8");
+  await fs.symlink(nestedDir, linkedDir, "dir");
+  return { root, homeDir, nestedDir, linkedDir };
+}
+
+function createApp(deploymentMode: "local_trusted" | "authenticated") {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", filesystemRoutes({ deploymentMode }));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("GET /filesystem/list", () => {
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  let fixture: Awaited<ReturnType<typeof createFixture>>;
+
+  beforeEach(async () => {
+    fixture = await createFixture();
+    process.env.HOME = fixture.homeDir;
+    delete process.env.USERPROFILE;
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    await fs.rm(fixture.root, { recursive: true, force: true });
+  });
+
+  it("returns platform roots when path is omitted", async () => {
+    const res = await request(createApp("local_trusted")).get("/api/filesystem/list");
+
+    expect(res.status).toBe(200);
+    expect(res.body.path).toBe("");
+    expect(res.body.parent).toBeNull();
+    expect(res.body.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: fixture.homeDir, isDir: true, isSymlink: false }),
+      ]),
+    );
+    if (process.platform === "win32") {
+      expect(res.body.entries.length).toBeGreaterThan(0);
+    } else {
+      expect(res.body.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: "/", isDir: true, isSymlink: false }),
+        ]),
+      );
+    }
+  });
+
+  it("lists nested directory contents with directories first and symlink metadata", async () => {
+    const res = await request(createApp("local_trusted"))
+      .get("/api/filesystem/list")
+      .query({ path: fixture.homeDir });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      path: fixture.homeDir,
+      parent: path.dirname(fixture.homeDir) === fixture.homeDir ? null : path.dirname(fixture.homeDir),
+      entries: [
+        { name: "linked-projects", isDir: true, isSymlink: true },
+        { name: "projects", isDir: true, isSymlink: false },
+        { name: "notes.txt", isDir: false, isSymlink: false },
+      ],
+    });
+  });
+
+  it("rejects denied paths", async () => {
+    if (process.platform === "win32") return;
+
+    const target = typeof process.getuid === "function" && process.getuid() === 0
+      ? "/etc/shadow"
+      : "/root";
+    const res = await request(createApp("local_trusted"))
+      .get("/api/filesystem/list")
+      .query({ path: target });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Path is not allowed" });
+  });
+
+  it("rejects non-absolute paths", async () => {
+    const res = await request(createApp("local_trusted"))
+      .get("/api/filesystem/list")
+      .query({ path: "relative/path" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Path must be absolute" });
+  });
+
+  it("returns 404 for non-existent paths", async () => {
+    const missingPath = path.join(fixture.root, "missing");
+    const res = await request(createApp("local_trusted"))
+      .get("/api/filesystem/list")
+      .query({ path: missingPath });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Path not found" });
+  });
+
+  it("rejects requests outside local_trusted mode", async () => {
+    const res = await request(createApp("authenticated"))
+      .get("/api/filesystem/list")
+      .query({ path: fixture.homeDir });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Filesystem listing is only available in local_trusted mode" });
+  });
+});

--- a/server/src/__tests__/filesystem-list-route.test.ts
+++ b/server/src/__tests__/filesystem-list-route.test.ts
@@ -59,11 +59,9 @@ describe("GET /filesystem/list", () => {
     if (process.platform === "win32") {
       expect(res.body.entries.length).toBeGreaterThan(0);
     } else {
-      expect(res.body.entries).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ name: "/", isDir: true, isSymlink: false }),
-        ]),
-      );
+      // "/" must not be exposed as a root; it would defeat containment.
+      const rootNames = res.body.entries.map((entry: { name: string }) => entry.name);
+      expect(rootNames).not.toContain("/");
     }
   });
 
@@ -94,8 +92,37 @@ describe("GET /filesystem/list", () => {
       .get("/api/filesystem/list")
       .query({ path: target });
 
+    // Denied system paths live outside the home root, so containment rejects
+    // them before the explicit deny-list is even consulted.
     expect(res.status).toBe(403);
-    expect(res.body).toEqual({ error: "Path is not allowed" });
+    expect(res.body.error).toMatch(/not allowed|outside the allowed filesystem roots/);
+  });
+
+  it("rejects absolute paths outside the allowed roots", async () => {
+    // fixture.root is the parent of homeDir, so it is outside the home root.
+    const res = await request(createApp("local_trusted"))
+      .get("/api/filesystem/list")
+      .query({ path: fixture.root });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Path is outside the allowed filesystem roots" });
+  });
+
+  it("rejects a symlink whose resolved target escapes the allowed roots", async () => {
+    if (process.platform === "win32") return;
+
+    // Directory outside the home root, reached via a symlink that lives inside it.
+    const outsideDir = path.join(fixture.root, "outside");
+    await fs.mkdir(outsideDir, { recursive: true });
+    const escapeLink = path.join(fixture.homeDir, "escape");
+    await fs.symlink(outsideDir, escapeLink, "dir");
+
+    const res = await request(createApp("local_trusted"))
+      .get("/api/filesystem/list")
+      .query({ path: escapeLink });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Resolved path is outside the allowed filesystem roots" });
   });
 
   it("rejects non-absolute paths", async () => {
@@ -108,7 +135,7 @@ describe("GET /filesystem/list", () => {
   });
 
   it("returns 404 for non-existent paths", async () => {
-    const missingPath = path.join(fixture.root, "missing");
+    const missingPath = path.join(fixture.homeDir, "missing");
     const res = await request(createApp("local_trusted"))
       .get("/api/filesystem/list")
       .query({ path: missingPath });

--- a/server/src/__tests__/filesystem-list-route.test.ts
+++ b/server/src/__tests__/filesystem-list-route.test.ts
@@ -73,13 +73,35 @@ describe("GET /filesystem/list", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
       path: fixture.homeDir,
-      parent: path.dirname(fixture.homeDir) === fixture.homeDir ? null : path.dirname(fixture.homeDir),
+      // homeDir is a root; its parent is outside the allowed roots, so it must
+      // be capped to null to keep the UI "Up" button from issuing a 403 request.
+      parent: null,
       entries: [
         { name: "linked-projects", isDir: true, isSymlink: true },
         { name: "projects", isDir: true, isSymlink: false },
         { name: "notes.txt", isDir: false, isSymlink: false },
       ],
     });
+  });
+
+  it("caps the parent at the root boundary so 'Up' never escapes allowed roots", async () => {
+    // Listing a nested directory returns its in-root parent...
+    const nested = await request(createApp("local_trusted"))
+      .get("/api/filesystem/list")
+      .query({ path: path.join(fixture.homeDir, "projects") });
+
+    expect(nested.status).toBe(200);
+    expect(nested.body.parent).toBe(fixture.homeDir);
+
+    // ...and clicking "Up" to that in-root parent (the root itself) succeeds
+    // while reporting a null parent, instead of leaving a clickable path that
+    // would 403 on the next request.
+    const atRoot = await request(createApp("local_trusted"))
+      .get("/api/filesystem/list")
+      .query({ path: nested.body.parent });
+
+    expect(atRoot.status).toBe(200);
+    expect(atRoot.body.parent).toBeNull();
   });
 
   it("rejects denied paths", async () => {

--- a/server/src/__tests__/filesystem-list-route.test.ts
+++ b/server/src/__tests__/filesystem-list-route.test.ts
@@ -104,6 +104,33 @@ describe("GET /filesystem/list", () => {
     expect(atRoot.body.parent).toBeNull();
   });
 
+  it("allows navigation when the home directory is a symlink", async () => {
+    if (process.platform === "win32") return;
+
+    const canonicalHome = path.join(fixture.root, "canonical-home");
+    const canonicalProjects = path.join(canonicalHome, "projects");
+    const symlinkedHome = path.join(fixture.root, "symlinked-home");
+    await fs.mkdir(canonicalProjects, { recursive: true });
+    await fs.symlink(canonicalHome, symlinkedHome, "dir");
+    process.env.HOME = symlinkedHome;
+
+    const nested = await request(createApp("local_trusted"))
+      .get("/api/filesystem/list")
+      .query({ path: path.join(symlinkedHome, "projects") });
+
+    expect(nested.status).toBe(200);
+    expect(nested.body.path).toBe(canonicalProjects);
+    expect(nested.body.parent).toBe(canonicalHome);
+
+    const atRoot = await request(createApp("local_trusted"))
+      .get("/api/filesystem/list")
+      .query({ path: nested.body.parent });
+
+    expect(atRoot.status).toBe(200);
+    expect(atRoot.body.path).toBe(canonicalHome);
+    expect(atRoot.body.parent).toBeNull();
+  });
+
   it("rejects denied paths", async () => {
     if (process.platform === "win32") return;
 

--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -31,6 +31,7 @@ const apiPrefixes: Record<string, string> = {
   "environments.ts": "/api",
   "execution-workspaces.ts": "/api",
   "file-resources.ts": "/api",
+  "filesystem.ts": "/api",
   "folders.ts": "/api",
   "goals.ts": "/api",
   "health.ts": "/api/health",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -38,6 +38,7 @@ import { llmRoutes } from "./routes/llms.js";
 import { authRoutes } from "./routes/auth.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
+import { filesystemRoutes } from "./routes/filesystem.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
@@ -211,6 +212,7 @@ export async function createApp(
   api.use(sidebarPreferenceRoutes(db));
   api.use(inboxDismissalRoutes(db));
   api.use(instanceSettingsRoutes(db));
+  api.use(filesystemRoutes({ deploymentMode: opts.deploymentMode }));
   if (opts.databaseBackupService) {
     api.use(instanceDatabaseBackupRoutes(opts.databaseBackupService));
   }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -56,6 +56,7 @@ import { llmRoutes } from "./routes/llms.js";
 import { authRoutes } from "./routes/auth.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
+import { filesystemRoutes } from "./routes/filesystem.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { mcpGatewayProtocolRoutes, toolGatewayRoutes } from "./routes/tool-gateway.js";
 import { adapterRoutes } from "./routes/adapters.js";
@@ -275,6 +276,7 @@ export async function createApp(
   api.use(resourceMembershipRoutes(db));
   api.use(inboxDismissalRoutes(db));
   api.use(instanceSettingsRoutes(db));
+  api.use(filesystemRoutes({ deploymentMode: opts.deploymentMode }));
   if (opts.databaseBackupService) {
     api.use(instanceDatabaseBackupRoutes(opts.databaseBackupService));
   }

--- a/server/src/routes/filesystem.ts
+++ b/server/src/routes/filesystem.ts
@@ -199,9 +199,16 @@ export function filesystemRoutes(opts: { deploymentMode: DeploymentMode }) {
       throw badRequest("Path must be a directory");
     }
 
+    const rawParent = pathParent(resolvedPath);
+    const parent =
+      rawParent !== null &&
+      roots.some((rootPath) => isPathWithinRoot(rawParent, rootPath))
+        ? rawParent
+        : null;
+
     res.json({
       path: resolvedPath,
-      parent: pathParent(resolvedPath),
+      parent,
       entries: await listDirectoryEntries(resolvedPath),
     } satisfies FilesystemListResponse);
   });

--- a/server/src/routes/filesystem.ts
+++ b/server/src/routes/filesystem.ts
@@ -47,7 +47,9 @@ async function listFilesystemRoots() {
   if (process.platform === "win32") {
     return listWindowsRoots();
   }
-  return uniquePaths(["/", os.homedir()]);
+  // Restrict Unix roots to the user's home directory. Including "/" made
+  // isPathWithinRoot permit any absolute path, defeating containment.
+  return uniquePaths([os.homedir()]);
 }
 
 function normalizeRequestedPath(requestedPath: string) {
@@ -183,6 +185,13 @@ export function filesystemRoutes(opts: { deploymentMode: DeploymentMode }) {
     const resolvedPath = await resolveExistingPath(requestedPath);
     if (isDeniedPath(resolvedPath)) {
       throw forbidden("Path is not allowed");
+    }
+    // Re-validate the symlink-resolved path against the allowed roots. Without
+    // this, a symlink inside an allowed root whose target escapes the root
+    // (e.g. ~/escape -> /var/secrets) would pass the pre-resolution root check
+    // and expose out-of-root contents.
+    if (!roots.some((rootPath) => isPathWithinRoot(resolvedPath, rootPath))) {
+      throw forbidden("Resolved path is outside the allowed filesystem roots");
     }
 
     const stats = await fs.stat(resolvedPath);

--- a/server/src/routes/filesystem.ts
+++ b/server/src/routes/filesystem.ts
@@ -52,6 +52,10 @@ async function listFilesystemRoots() {
   return uniquePaths([os.homedir()]);
 }
 
+async function resolveFilesystemRoots(roots: string[]) {
+  return uniquePaths(await Promise.all(roots.map((rootPath) => fs.realpath(rootPath))));
+}
+
 function normalizeRequestedPath(requestedPath: string) {
   return path.resolve(requestedPath);
 }
@@ -141,7 +145,7 @@ async function listDirectoryEntries(directoryPath: string) {
 }
 
 async function listRootsResponse(): Promise<FilesystemListResponse> {
-  const roots = await listFilesystemRoots();
+  const roots = await resolveFilesystemRoots(await listFilesystemRoots());
   return {
     path: "",
     parent: null,
@@ -178,7 +182,9 @@ export function filesystemRoutes(opts: { deploymentMode: DeploymentMode }) {
 
     const requestedPath = normalizeRequestedPath(rawPath);
     const roots = await listFilesystemRoots();
-    if (!roots.some((rootPath) => isPathWithinRoot(requestedPath, rootPath))) {
+    const resolvedRoots = await resolveFilesystemRoots(roots);
+    const requestedPathRoots = uniquePaths([...roots, ...resolvedRoots]);
+    if (!requestedPathRoots.some((rootPath) => isPathWithinRoot(requestedPath, rootPath))) {
       throw forbidden("Path is outside the allowed filesystem roots");
     }
 
@@ -190,7 +196,7 @@ export function filesystemRoutes(opts: { deploymentMode: DeploymentMode }) {
     // this, a symlink inside an allowed root whose target escapes the root
     // (e.g. ~/escape -> /var/secrets) would pass the pre-resolution root check
     // and expose out-of-root contents.
-    if (!roots.some((rootPath) => isPathWithinRoot(resolvedPath, rootPath))) {
+    if (!resolvedRoots.some((rootPath) => isPathWithinRoot(resolvedPath, rootPath))) {
       throw forbidden("Resolved path is outside the allowed filesystem roots");
     }
 
@@ -202,7 +208,7 @@ export function filesystemRoutes(opts: { deploymentMode: DeploymentMode }) {
     const rawParent = pathParent(resolvedPath);
     const parent =
       rawParent !== null &&
-      roots.some((rootPath) => isPathWithinRoot(rawParent, rootPath))
+      resolvedRoots.some((rootPath) => isPathWithinRoot(rawParent, rootPath))
         ? rawParent
         : null;
 

--- a/server/src/routes/filesystem.ts
+++ b/server/src/routes/filesystem.ts
@@ -1,0 +1,195 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Router } from "express";
+import type { DeploymentMode } from "@paperclipai/shared";
+import { badRequest, forbidden, notFound } from "../errors.js";
+
+type FilesystemListEntry = {
+  name: string;
+  isDir: boolean;
+  isSymlink: boolean;
+};
+
+type FilesystemListResponse = {
+  path: string;
+  parent: string | null;
+  entries: FilesystemListEntry[];
+};
+
+function uniquePaths(values: string[]) {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const normalized = path.normalize(value);
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+async function listWindowsRoots() {
+  const roots: string[] = [];
+  for (let code = 65; code <= 90; code += 1) {
+    const drive = `${String.fromCharCode(code)}:\\`;
+    try {
+      const stats = await fs.stat(drive);
+      if (stats.isDirectory()) roots.push(drive);
+    } catch {
+      // Skip drives that do not exist.
+    }
+  }
+  return roots;
+}
+
+async function listFilesystemRoots() {
+  if (process.platform === "win32") {
+    return listWindowsRoots();
+  }
+  return uniquePaths(["/", os.homedir()]);
+}
+
+function normalizeRequestedPath(requestedPath: string) {
+  return path.resolve(requestedPath);
+}
+
+function pathParent(absolutePath: string) {
+  const parent = path.dirname(absolutePath);
+  return parent === absolutePath ? null : parent;
+}
+
+function isPathWithinRoot(candidatePath: string, allowedRoot: string) {
+  const normalizedCandidate = path.normalize(candidatePath);
+  const normalizedRoot = path.normalize(allowedRoot);
+  const relative = path.relative(normalizedRoot, normalizedCandidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function resolveExistingPath(candidatePath: string) {
+  try {
+    return await fs.realpath(candidatePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw notFound("Path not found");
+    }
+    throw error;
+  }
+}
+
+function deniedUnixPrefixes() {
+  const denied = [path.normalize("/etc/shadow")];
+  if (typeof process.getuid !== "function" || process.getuid() !== 0) {
+    denied.push(path.normalize("/root"));
+  }
+  return denied;
+}
+
+function isDeniedPath(candidatePath: string) {
+  if (process.platform === "win32") return false;
+  const normalizedCandidate = path.normalize(candidatePath);
+  for (const deniedPath of deniedUnixPrefixes()) {
+    if (
+      normalizedCandidate === deniedPath
+      || normalizedCandidate.startsWith(`${deniedPath}${path.sep}`)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function buildEntry(directoryPath: string, name: string): Promise<FilesystemListEntry | null> {
+  const fullPath = path.join(directoryPath, name);
+  const lstats = await fs.lstat(fullPath);
+  if (isDeniedPath(fullPath)) return null;
+
+  let isDir = lstats.isDirectory();
+  if (lstats.isSymbolicLink()) {
+    try {
+      const stats = await fs.stat(fullPath);
+      isDir = stats.isDirectory();
+    } catch {
+      isDir = false;
+    }
+  }
+
+  return {
+    name,
+    isDir,
+    isSymlink: lstats.isSymbolicLink(),
+  };
+}
+
+async function listDirectoryEntries(directoryPath: string) {
+  const names = await fs.readdir(directoryPath);
+  const entries = await Promise.all(names.map((name) => buildEntry(directoryPath, name)));
+  return entries
+    .filter((entry): entry is FilesystemListEntry => entry !== null)
+    .sort((left, right) => {
+      if (left.isDir !== right.isDir) return left.isDir ? -1 : 1;
+      return left.name.localeCompare(right.name);
+    });
+}
+
+async function listRootsResponse(): Promise<FilesystemListResponse> {
+  const roots = await listFilesystemRoots();
+  return {
+    path: "",
+    parent: null,
+    entries: roots.map((rootPath) => ({
+      name: rootPath,
+      isDir: true,
+      isSymlink: false,
+    })),
+  };
+}
+
+export function filesystemRoutes(opts: { deploymentMode: DeploymentMode }) {
+  const router = Router();
+
+  router.get("/filesystem/list", async (req, res) => {
+    if (opts.deploymentMode !== "local_trusted") {
+      throw forbidden("Filesystem listing is only available in local_trusted mode");
+    }
+
+    const rawPath =
+      typeof req.query.path === "string"
+        ? req.query.path
+        : req.query.path === undefined
+          ? ""
+          : null;
+    if (rawPath === null) throw badRequest("Path must be a single string");
+    if (rawPath === "") {
+      res.json(await listRootsResponse());
+      return;
+    }
+    if (!path.isAbsolute(rawPath)) {
+      throw badRequest("Path must be absolute");
+    }
+
+    const requestedPath = normalizeRequestedPath(rawPath);
+    const roots = await listFilesystemRoots();
+    if (!roots.some((rootPath) => isPathWithinRoot(requestedPath, rootPath))) {
+      throw forbidden("Path is outside the allowed filesystem roots");
+    }
+
+    const resolvedPath = await resolveExistingPath(requestedPath);
+    if (isDeniedPath(resolvedPath)) {
+      throw forbidden("Path is not allowed");
+    }
+
+    const stats = await fs.stat(resolvedPath);
+    if (!stats.isDirectory()) {
+      throw badRequest("Path must be a directory");
+    }
+
+    res.json({
+      path: resolvedPath,
+      parent: pathParent(resolvedPath),
+      entries: await listDirectoryEntries(resolvedPath),
+    } satisfies FilesystemListResponse);
+  });
+
+  return router;
+}

--- a/server/src/routes/filesystem.ts
+++ b/server/src/routes/filesystem.ts
@@ -109,6 +109,12 @@ async function buildEntry(directoryPath: string, name: string): Promise<Filesyst
     try {
       const stats = await fs.stat(fullPath);
       isDir = stats.isDirectory();
+      // Also reject symlinks whose target resolves into a denied path so the
+      // entry never appears in the listing. Without this, a symlink like
+      // ~/.shadow_link -> /etc/shadow would render in the UI and only error
+      // on selection.
+      const resolvedTarget = await fs.realpath(fullPath);
+      if (isDeniedPath(resolvedTarget)) return null;
     } catch {
       isDir = false;
     }

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -468,6 +468,19 @@ const ErrorSchema = registry.register(
   z.object({ error: z.string() }),
 );
 
+const FilesystemListResponseSchema = registry.register(
+  "FilesystemListResponse",
+  z.object({
+    path: z.string(),
+    parent: z.string().nullable(),
+    entries: z.array(z.object({
+      name: z.string(),
+      isDir: z.boolean(),
+      isSymlink: z.boolean(),
+    })),
+  }),
+);
+
 const responses = {
   ok: (schema: z.ZodTypeAny = z.record(z.unknown())) => ({
     description: "Success",
@@ -1087,6 +1100,26 @@ registry.registerPath({
   tags: ["health"],
   summary: "Get the generated OpenAPI document",
   responses: { 200: r.ok() },
+});
+
+// ─── Local filesystem ────────────────────────────────────────────────────────
+
+registry.registerPath({
+  method: "get",
+  path: "/api/filesystem/list",
+  tags: ["access"],
+  summary: "List local filesystem roots or directory entries",
+  request: {
+    query: z.object({
+      path: z.string().optional(),
+    }),
+  },
+  responses: {
+    200: r.ok(FilesystemListResponseSchema),
+    400: r.badRequest,
+    403: r.forbidden,
+    404: r.notFound,
+  },
 });
 
 // ─── Companies ───────────────────────────────────────────────────────────────

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -468,18 +468,17 @@ const ErrorSchema = registry.register(
   z.object({ error: z.string() }),
 );
 
-const FilesystemListResponseSchema = registry.register(
-  "FilesystemListResponse",
-  z.object({
-    path: z.string(),
-    parent: z.string().nullable(),
-    entries: z.array(z.object({
-      name: z.string(),
-      isDir: z.boolean(),
-      isSymlink: z.boolean(),
-    })),
-  }),
-);
+const FilesystemListResponseSchema = z.object({
+  path: z.string(),
+  parent: z.string().nullable(),
+  entries: z.array(z.object({
+    name: z.string(),
+    isDir: z.boolean(),
+    isSymlink: z.boolean(),
+  })),
+});
+
+registry.register("FilesystemListResponse", FilesystemListResponseSchema);
 
 const responses = {
   ok: (schema: z.ZodTypeAny = z.record(z.unknown())) => ({

--- a/ui/src/api/access.ts
+++ b/ui/src/api/access.ts
@@ -157,6 +157,18 @@ export type CompanyUserDirectoryResponse = {
   users: CompanyUserDirectoryEntry[];
 };
 
+export type FilesystemListEntry = {
+  name: string;
+  isDir: boolean;
+  isSymlink: boolean;
+};
+
+export type FilesystemListResponse = {
+  path: string;
+  parent: string | null;
+  entries: FilesystemListEntry[];
+};
+
 export type CompanyInviteRecord = {
   id: string;
   companyId: string | null;
@@ -321,6 +333,11 @@ export const accessApi = {
 
   listUserDirectory: (companyId: string) =>
     api.get<CompanyUserDirectoryResponse>(`/companies/${companyId}/user-directory`),
+
+  listFilesystem: (path?: string) =>
+    api.get<FilesystemListResponse>(
+      `/filesystem/list${path && path.length > 0 ? `?path=${encodeURIComponent(path)}` : ""}`,
+    ),
 
   updateMember: (
     companyId: string,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -46,8 +46,8 @@ import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { defaultCreateValues } from "./agent-config-defaults";
 import { getUIAdapter } from "../adapters";
 import { ClaudeLocalAdvancedFields } from "../adapters/claude-local/config-fields";
+import { FolderPickerButton } from "./FolderPicker";
 import { MarkdownEditor } from "./MarkdownEditor";
-import { ChoosePathButton } from "./PathInstructionsModal";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
 import { ReportsToPicker } from "./ReportsToPicker";
 import { EnvVarEditor } from "./EnvVarEditor";
@@ -927,7 +927,18 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   className="w-full bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40"
                   placeholder="/path/to/project"
                 />
-                <ChoosePathButton />
+                <FolderPickerButton
+                  value={
+                    isCreate
+                      ? val!.cwd
+                      : eff("adapterConfig", "cwd", String(config.cwd ?? ""))
+                  }
+                  onSelect={(path) =>
+                    isCreate
+                      ? set!({ cwd: path })
+                      : mark("adapterConfig", "cwd", path || undefined)
+                  }
+                />
               </div>
             </Field>
           )}

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -43,8 +43,8 @@ import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { defaultCreateValues } from "./agent-config-defaults";
 import { getUIAdapter } from "../adapters";
 import { ClaudeLocalAdvancedFields } from "../adapters/claude-local/config-fields";
+import { FolderPickerButton } from "./FolderPicker";
 import { MarkdownEditor } from "./MarkdownEditor";
-import { ChoosePathButton } from "./PathInstructionsModal";
 import { OpenCodeLogoIcon } from "./OpenCodeLogoIcon";
 import { ReportsToPicker } from "./ReportsToPicker";
 import {
@@ -1171,7 +1171,18 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   className="w-full bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40"
                   placeholder="/path/to/project"
                 />
-                <ChoosePathButton />
+                <FolderPickerButton
+                  value={
+                    isCreate
+                      ? val!.cwd
+                      : eff("adapterConfig", "cwd", String(config.cwd ?? ""))
+                  }
+                  onSelect={(path) =>
+                    isCreate
+                      ? set!({ cwd: path })
+                      : mark("adapterConfig", "cwd", path || undefined)
+                  }
+                />
               </div>
             </Field>
           )}

--- a/ui/src/components/FolderPicker.test.tsx
+++ b/ui/src/components/FolderPicker.test.tsx
@@ -1,0 +1,268 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FolderPicker } from "./FolderPicker";
+
+const listFilesystemMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/access", () => ({
+  accessApi: {
+    listFilesystem: (path?: string) => listFilesystemMock(path),
+  },
+}));
+
+vi.mock("./PathInstructionsModal", () => ({
+  PathInstructionsModal: () => null,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: ReactNode;
+  }) => (open ? <div data-testid="dialog-root">{children}</div> : null),
+  DialogContent: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  DialogHeader: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  DialogTitle: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <h2 className={className}>{children}</h2>
+  ),
+  DialogDescription: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <p className={className}>{children}</p>
+  ),
+  DialogFooter: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function setNativeInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  const previous = input.value;
+  setter?.call(input, value);
+  const tracker = (input as HTMLInputElement & { _valueTracker?: { setValue: (next: string) => void } })._valueTracker;
+  tracker?.setValue(previous);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function flushAnimationFrame() {
+  await act(async () => {
+    await new Promise((resolve) => window.requestAnimationFrame(() => resolve(undefined)));
+  });
+}
+
+async function waitForAssertion(assertion: () => void, attempts = 20) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await flush();
+    }
+  }
+  throw lastError;
+}
+
+function renderWithQueryClient(node: ReactNode, container: HTMLDivElement) {
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  act(() => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        {node}
+      </QueryClientProvider>,
+    );
+  });
+
+  return { root, queryClient };
+}
+
+function findButton(container: HTMLDivElement, label: string) {
+  return Array.from(container.querySelectorAll("button")).find((button) =>
+    button.textContent?.includes(label),
+  ) ?? null;
+}
+
+describe("FolderPicker", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = null;
+    listFilesystemMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    container.remove();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("navigates nested folders and returns the selected absolute path", async () => {
+    listFilesystemMock.mockImplementation(async (path?: string) => {
+      if (!path) {
+        return {
+          path: "",
+          parent: null,
+          entries: [
+            { name: "/Users", isDir: true, isSymlink: false },
+          ],
+        };
+      }
+      if (path === "/Users") {
+        return {
+          path: "/Users",
+          parent: "/",
+          entries: [
+            { name: "neeraj", isDir: true, isSymlink: false },
+          ],
+        };
+      }
+      if (path === "/Users/neeraj") {
+        return {
+          path: "/Users/neeraj",
+          parent: "/Users",
+          entries: [
+            { name: "workspace", isDir: true, isSymlink: false },
+          ],
+        };
+      }
+      throw new Error(`Unexpected path: ${path}`);
+    });
+
+    const onSelect = vi.fn();
+    ({ root } = renderWithQueryClient(
+      <FolderPicker open onOpenChange={() => undefined} onSelect={onSelect} />,
+      container,
+    ));
+
+    await waitForAssertion(() => {
+      expect(findButton(container, "/Users")).not.toBeNull();
+    });
+
+    act(() => {
+      findButton(container, "/Users")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await waitForAssertion(() => {
+      expect(listFilesystemMock).toHaveBeenCalledWith("/Users");
+      expect(findButton(container, "neeraj")).not.toBeNull();
+    });
+
+    act(() => {
+      findButton(container, "neeraj")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await waitForAssertion(() => {
+      expect(listFilesystemMock).toHaveBeenCalledWith("/Users/neeraj");
+      expect(container.textContent).toContain("/Users/neeraj");
+    });
+
+    act(() => {
+      findButton(container, "Select this folder")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith("/Users/neeraj");
+  });
+
+  it("supports keyboard navigation through the folder list", async () => {
+    listFilesystemMock.mockResolvedValue({
+      path: "/Users",
+      parent: "/",
+      entries: [
+        { name: "alpha", isDir: true, isSymlink: false },
+        { name: "beta", isDir: true, isSymlink: false },
+      ],
+    });
+
+    ({ root } = renderWithQueryClient(
+      <FolderPicker open onOpenChange={() => undefined} value="/Users" onSelect={vi.fn()} />,
+      container,
+    ));
+
+    await waitForAssertion(() => {
+      expect(findButton(container, "alpha")).not.toBeNull();
+      expect(findButton(container, "beta")).not.toBeNull();
+    });
+
+    const input = container.querySelector<HTMLInputElement>("#folder-picker-path");
+    expect(input).not.toBeNull();
+
+    act(() => {
+      input?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    });
+    await flushAnimationFrame();
+
+    const alphaButton = findButton(container, "alpha");
+    expect(document.activeElement).toBe(alphaButton);
+
+    act(() => {
+      alphaButton?.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    });
+    await flushAnimationFrame();
+
+    expect(document.activeElement).toBe(findButton(container, "beta"));
+  });
+
+  it("renders API errors and still allows manual path selection", async () => {
+    listFilesystemMock.mockRejectedValue(new Error("Access denied"));
+
+    const onSelect = vi.fn();
+    ({ root } = renderWithQueryClient(
+      <FolderPicker open onOpenChange={() => undefined} value="/root" onSelect={onSelect} />,
+      container,
+    ));
+
+    await waitForAssertion(() => {
+      expect(container.textContent).toContain("Could not load folders");
+      expect(container.textContent).toContain("Access denied");
+    });
+
+    const input = container.querySelector<HTMLInputElement>("#folder-picker-path");
+    expect(input).not.toBeNull();
+
+    act(() => {
+      setNativeInputValue(input!, "/tmp/paperclip");
+    });
+
+    act(() => {
+      findButton(container, "Select this folder")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onSelect).toHaveBeenCalledWith("/tmp/paperclip");
+  });
+});

--- a/ui/src/components/FolderPicker.tsx
+++ b/ui/src/components/FolderPicker.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   ChevronRight,
@@ -117,20 +117,20 @@ export function FolderPicker({
   const [requestedPath, setRequestedPath] = useState("");
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
 
-  const applyPathImmediately = (nextPath: string) => {
+  const applyPathImmediately = useCallback((nextPath: string) => {
     if (debounceRef.current !== null) {
       window.clearTimeout(debounceRef.current);
       debounceRef.current = null;
     }
     setInputPath(nextPath);
     setRequestedPath(nextPath);
-  };
+  }, []);
 
   useEffect(() => {
     if (!open) return;
     const initialPath = normalizePath(value);
     applyPathImmediately(initialPath);
-  }, [open, value]);
+  }, [open, value, applyPathImmediately]);
 
   useEffect(() => {
     return () => {

--- a/ui/src/components/FolderPicker.tsx
+++ b/ui/src/components/FolderPicker.tsx
@@ -1,0 +1,441 @@
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ChevronRight,
+  Folder,
+  FolderOpen,
+  Loader2,
+  TriangleAlert,
+  ArrowUp,
+} from "lucide-react";
+import { accessApi, type FilesystemListEntry } from "@/api/access";
+import { ApiError } from "@/api/client";
+import { queryKeys } from "@/lib/queryKeys";
+import { cn } from "@/lib/utils";
+import { PathInstructionsModal } from "./PathInstructionsModal";
+import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator } from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const PATH_INPUT_DEBOUNCE_MS = 250;
+
+type FolderPickerProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  value?: string | null;
+  onSelect: (path: string) => void;
+};
+
+type FolderPickerButtonProps = Omit<FolderPickerProps, "open" | "onOpenChange"> & {
+  className?: string;
+  children?: string;
+};
+
+function normalizePath(path?: string | null) {
+  return path?.trim() ?? "";
+}
+
+function isWindowsPath(path: string) {
+  return /^[A-Za-z]:[\\/]/.test(path) || path.startsWith("\\\\");
+}
+
+function isAbsolutePath(path: string) {
+  return path.startsWith("/") || isWindowsPath(path);
+}
+
+function joinFilesystemPath(basePath: string, entryName: string) {
+  if (isAbsolutePath(entryName)) return entryName;
+  if (!basePath) return entryName;
+  const separator = isWindowsPath(basePath) ? "\\" : "/";
+  if (basePath === "/") return `/${entryName}`;
+  return basePath.endsWith(separator) ? `${basePath}${entryName}` : `${basePath}${separator}${entryName}`;
+}
+
+function buildBreadcrumbSegments(path: string) {
+  if (!path) return [];
+
+  if (isWindowsPath(path)) {
+    const normalized = path.replace(/\//g, "\\");
+    const parts = normalized.split("\\").filter(Boolean);
+    const drive = normalized.startsWith("\\\\")
+      ? `\\\\${parts[0] ?? ""}${parts[1] ? `\\${parts[1]}` : ""}`
+      : parts[0] ?? normalized;
+    const startIndex = normalized.startsWith("\\\\") ? 2 : 1;
+    const segments = [{ label: drive, path: drive.endsWith("\\") ? drive : `${drive}\\` }];
+    let current = segments[0]?.path ?? drive;
+    for (const part of parts.slice(startIndex)) {
+      current = joinFilesystemPath(current, part);
+      segments.push({ label: part, path: current });
+    }
+    return segments;
+  }
+
+  const parts = path.split("/").filter(Boolean);
+  const segments = [{ label: "/", path: "/" }];
+  let current = "";
+  for (const part of parts) {
+    current = joinFilesystemPath(current || "/", part);
+    segments.push({ label: part, path: current });
+  }
+  return segments;
+}
+
+function formatFolderLabel(entry: FilesystemListEntry, basePath: string) {
+  const nextPath = joinFilesystemPath(basePath, entry.name);
+  return {
+    nextPath,
+    secondaryLabel: basePath ? nextPath : entry.name,
+  };
+}
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof ApiError) return error.message;
+  if (error instanceof Error) return error.message;
+  return "Could not load folders.";
+}
+
+export function FolderPicker({
+  open,
+  onOpenChange,
+  value,
+  onSelect,
+}: FolderPickerProps) {
+  const debounceRef = useRef<number | null>(null);
+  const entryRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [inputPath, setInputPath] = useState("");
+  const [requestedPath, setRequestedPath] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  const applyPathImmediately = (nextPath: string) => {
+    if (debounceRef.current !== null) {
+      window.clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setInputPath(nextPath);
+    setRequestedPath(nextPath);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const initialPath = normalizePath(value);
+    applyPathImmediately(initialPath);
+  }, [open, value]);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current !== null) {
+        window.clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  const directoryQuery = useQuery({
+    queryKey: queryKeys.access.filesystemList(requestedPath),
+    queryFn: () => accessApi.listFilesystem(requestedPath || undefined),
+    enabled: open,
+    retry: false,
+    placeholderData: (previousData) => previousData,
+  });
+
+  const activePath = directoryQuery.data?.path ?? requestedPath;
+  const folders = useMemo(
+    () => (directoryQuery.data?.entries ?? []).filter((entry) => entry.isDir),
+    [directoryQuery.data?.entries],
+  );
+  const breadcrumbSegments = useMemo(() => buildBreadcrumbSegments(activePath), [activePath]);
+  const selectablePath = normalizePath(inputPath) || activePath;
+  const canSelect = selectablePath.length > 0;
+  const canGoUp = Boolean(directoryQuery.data?.parent ?? activePath);
+
+  useEffect(() => {
+    setHighlightedIndex(folders.length > 0 ? 0 : -1);
+    entryRefs.current = [];
+  }, [activePath, folders.length]);
+
+  const focusEntry = (index: number) => {
+    const clamped = Math.max(0, Math.min(index, folders.length - 1));
+    setHighlightedIndex(clamped);
+    window.requestAnimationFrame(() => {
+      entryRefs.current[clamped]?.focus();
+    });
+  };
+
+  const navigateTo = (nextPath: string) => {
+    applyPathImmediately(nextPath);
+  };
+
+  const handleInputChange = (nextValue: string) => {
+    const nextPath = normalizePath(nextValue);
+    setInputPath(nextPath);
+    if (debounceRef.current !== null) {
+      window.clearTimeout(debounceRef.current);
+    }
+    debounceRef.current = window.setTimeout(() => {
+      setRequestedPath(nextPath);
+      debounceRef.current = null;
+    }, PATH_INPUT_DEBOUNCE_MS);
+  };
+
+  const handleSelect = () => {
+    if (!canSelect) return;
+    onSelect(selectablePath);
+    onOpenChange(false);
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-[calc(100%-2rem)] gap-0 overflow-hidden p-0 sm:max-w-2xl">
+          <DialogHeader className="border-b border-border px-6 pt-6 pb-4">
+            <DialogTitle className="text-base">Choose a folder</DialogTitle>
+            <DialogDescription>
+              Paste an absolute path or browse folders on this machine. The selected path is returned as plain text.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 px-6 py-4">
+            <div className="space-y-2">
+              <label htmlFor="folder-picker-path" className="text-xs font-medium text-muted-foreground">
+                Current path
+              </label>
+              <Input
+                id="folder-picker-path"
+                value={inputPath}
+                onChange={(event) => handleInputChange(event.currentTarget.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "ArrowDown" && folders.length > 0) {
+                    event.preventDefault();
+                    focusEntry(0);
+                  }
+                  if (event.key === "Enter" && canSelect) {
+                    event.preventDefault();
+                    handleSelect();
+                  }
+                }}
+                className="font-mono text-sm"
+                placeholder="/absolute/path/to/workspace"
+              />
+              <p className="text-xs text-muted-foreground">
+                Typing updates the folder list after a short debounce. Paste still works even if browsing is unavailable.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!canGoUp}
+                onClick={() => navigateTo(directoryQuery.data?.parent ?? "")}
+              >
+                <ArrowUp className="size-4" />
+                Up
+              </Button>
+              <div className="min-w-0 flex-1 rounded-md border border-border px-3 py-2">
+                {breadcrumbSegments.length > 0 ? (
+                  <Breadcrumb>
+                      <BreadcrumbList className="flex-nowrap overflow-x-auto whitespace-nowrap">
+                        {breadcrumbSegments.map((segment, index) => (
+                          <Fragment key={segment.path}>
+                            <BreadcrumbItem>
+                              {index === breadcrumbSegments.length - 1 ? (
+                                <BreadcrumbPage className="font-mono text-xs">{segment.label}</BreadcrumbPage>
+                              ) : (
+                                <button
+                                  type="button"
+                                  className="font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
+                                  onClick={() => navigateTo(segment.path)}
+                                >
+                                  {segment.label}
+                                </button>
+                              )}
+                            </BreadcrumbItem>
+                            {index < breadcrumbSegments.length - 1 ? <BreadcrumbSeparator /> : null}
+                          </Fragment>
+                        ))}
+                      </BreadcrumbList>
+                  </Breadcrumb>
+                ) : (
+                  <span className="text-xs text-muted-foreground">Roots</span>
+                )}
+              </div>
+            </div>
+
+            <div className="overflow-hidden rounded-lg border border-border">
+              <div className="flex items-center justify-between border-b border-border px-3 py-2 text-xs text-muted-foreground">
+                <span>{activePath ? "Subdirectories" : "Available roots"}</span>
+                <span className="inline-flex items-center gap-1">
+                  {directoryQuery.isFetching ? <Loader2 className="size-3 animate-spin" /> : null}
+                  {directoryQuery.isFetching ? "Loading" : `${folders.length} folder${folders.length === 1 ? "" : "s"}`}
+                </span>
+              </div>
+
+              {directoryQuery.isPending && !directoryQuery.data ? (
+                <div className="space-y-2 p-3">
+                  {Array.from({ length: 5 }, (_, index) => (
+                    <Skeleton key={index} className="h-12 w-full" />
+                  ))}
+                </div>
+              ) : directoryQuery.error ? (
+                <div className="space-y-3 p-4">
+                  <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+                    <div className="flex items-start gap-2">
+                      <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+                      <div>
+                        <p className="font-medium">Could not load folders</p>
+                        <p>{getErrorMessage(directoryQuery.error)}</p>
+                      </div>
+                    </div>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    You can still paste a path above and use it directly.
+                  </p>
+                </div>
+              ) : (
+                <ScrollArea className="h-72">
+                  {folders.length > 0 ? (
+                    <ul className="p-2">
+                      {folders.map((entry, index) => {
+                        const { nextPath, secondaryLabel } = formatFolderLabel(entry, activePath);
+                        const isActive = index === highlightedIndex;
+                        return (
+                          <li key={nextPath}>
+                            <button
+                              ref={(node) => {
+                                entryRefs.current[index] = node;
+                              }}
+                              type="button"
+                              className={cn(
+                                "flex w-full items-center gap-3 rounded-md px-3 py-2 text-left transition-colors",
+                                isActive ? "bg-accent text-foreground" : "hover:bg-accent/60",
+                              )}
+                              onClick={() => navigateTo(nextPath)}
+                              onMouseEnter={() => setHighlightedIndex(index)}
+                              onKeyDown={(event) => {
+                                if (event.key === "ArrowDown") {
+                                  event.preventDefault();
+                                  focusEntry(index + 1);
+                                }
+                                if (event.key === "ArrowUp") {
+                                  event.preventDefault();
+                                  focusEntry(index - 1);
+                                }
+                                if (event.key === "Home") {
+                                  event.preventDefault();
+                                  focusEntry(0);
+                                }
+                                if (event.key === "End") {
+                                  event.preventDefault();
+                                  focusEntry(folders.length - 1);
+                                }
+                              }}
+                            >
+                              <div className="flex size-8 items-center justify-center rounded-md border border-border bg-background">
+                                {nextPath === activePath ? (
+                                  <FolderOpen className="size-4 text-foreground" />
+                                ) : (
+                                  <Folder className="size-4 text-muted-foreground" />
+                                )}
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <div className="flex items-center gap-2">
+                                  <span className="truncate text-sm font-medium">{entry.name}</span>
+                                  {entry.isSymlink ? (
+                                    <span className="rounded-full border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+                                      symlink
+                                    </span>
+                                  ) : null}
+                                </div>
+                                <p className="truncate font-mono text-xs text-muted-foreground">{secondaryLabel}</p>
+                              </div>
+                              <ChevronRight className="size-4 text-muted-foreground" />
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  ) : (
+                    <div className="flex h-full flex-col items-center justify-center gap-2 px-6 text-center">
+                      <FolderOpen className="size-8 text-muted-foreground" />
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium">No subdirectories here</p>
+                        <p className="text-xs text-muted-foreground">
+                          Select this folder or paste a different absolute path above.
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </ScrollArea>
+              )}
+            </div>
+
+            <div className="flex items-center justify-between gap-3">
+              <Button
+                type="button"
+                variant="link"
+                className="h-auto px-0 text-xs"
+                onClick={() => setHelpOpen(true)}
+              >
+                Need help finding a path?
+              </Button>
+              <p className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+                {selectablePath || "No folder selected yet"}
+              </p>
+            </div>
+          </div>
+
+          <DialogFooter className="border-t border-border px-6 py-4">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="button" disabled={!canSelect} onClick={handleSelect}>
+              Select this folder
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <PathInstructionsModal open={helpOpen} onOpenChange={setHelpOpen} />
+    </>
+  );
+}
+
+export function FolderPickerButton({
+  value,
+  onSelect,
+  className,
+  children = "Choose",
+}: FolderPickerButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="xs"
+        className={cn("text-muted-foreground", className)}
+        onClick={() => setOpen(true)}
+      >
+        {children}
+      </Button>
+      <FolderPicker
+        open={open}
+        onOpenChange={setOpen}
+        value={value}
+        onSelect={onSelect}
+      />
+    </>
+  );
+}

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -12,6 +12,9 @@ import { queryKeys } from "../lib/queryKeys";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -36,7 +39,7 @@ import {
 import { cn } from "../lib/utils";
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "./MarkdownEditor";
 import { StatusBadge } from "./StatusBadge";
-import { ChoosePathButton } from "./PathInstructionsModal";
+import { FolderPickerButton } from "./FolderPicker";
 
 const projectStatuses = [
   { value: "backlog", label: "Backlog" },
@@ -214,6 +217,13 @@ export function NewProjectDialog() {
         className={cn("p-0 gap-0", expanded ? "sm:max-w-2xl" : "sm:max-w-lg")}
         onKeyDown={handleKeyDown}
       >
+        <DialogHeader className="sr-only">
+          <DialogTitle>New project</DialogTitle>
+          <DialogDescription>
+            Create a project and optionally choose a linked repository or local folder for agent work.
+          </DialogDescription>
+        </DialogHeader>
+
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -321,7 +331,13 @@ export function NewProjectDialog() {
                 onChange={(e) => { setWorkspaceLocalPath(e.target.value); setWorkspaceError(null); }}
                 placeholder="/absolute/path/to/workspace"
               />
-              <ChoosePathButton />
+              <FolderPickerButton
+                value={workspaceLocalPath}
+                onSelect={(path) => {
+                  setWorkspaceLocalPath(path);
+                  setWorkspaceError(null);
+                }}
+              />
             </div>
           </div>
 

--- a/ui/src/components/NewProjectDialog.tsx
+++ b/ui/src/components/NewProjectDialog.tsx
@@ -12,6 +12,9 @@ import { queryKeys } from "../lib/queryKeys";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import {
@@ -37,7 +40,7 @@ import { PROJECT_COLORS } from "@paperclipai/shared";
 import { cn } from "../lib/utils";
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "./MarkdownEditor";
 import { StatusBadge } from "./StatusBadge";
-import { ChoosePathButton } from "./PathInstructionsModal";
+import { FolderPickerButton } from "./FolderPicker";
 
 const projectStatuses = [
   { value: "backlog", label: "Backlog" },
@@ -215,6 +218,13 @@ export function NewProjectDialog() {
         className={cn("p-0 gap-0", expanded ? "sm:max-w-2xl" : "sm:max-w-lg")}
         onKeyDown={handleKeyDown}
       >
+        <DialogHeader className="sr-only">
+          <DialogTitle>New project</DialogTitle>
+          <DialogDescription>
+            Create a project and optionally choose a linked repository or local folder for agent work.
+          </DialogDescription>
+        </DialogHeader>
+
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-2.5 border-b border-border">
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -322,7 +332,13 @@ export function NewProjectDialog() {
                 onChange={(e) => { setWorkspaceLocalPath(e.target.value); setWorkspaceError(null); }}
                 placeholder="/absolute/path/to/workspace"
               />
-              <ChoosePathButton />
+              <FolderPickerButton
+                value={workspaceLocalPath}
+                onSelect={(path) => {
+                  setWorkspaceLocalPath(path);
+                  setWorkspaceError(null);
+                }}
+              />
             </div>
           </div>
 

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -17,7 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AlertCircle, Archive, ArchiveRestore, Check, ExternalLink, Github, Loader2, Plus, Trash2, X } from "lucide-react";
-import { ChoosePathButton } from "./PathInstructionsModal";
+import { FolderPickerButton } from "./FolderPicker";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { DraftInput } from "./agent-config-primitives";
 import { InlineEditor } from "./InlineEditor";
@@ -833,7 +833,13 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                   onChange={(e) => setWorkspaceCwd(e.target.value)}
                   placeholder="/absolute/path/to/workspace"
                 />
-                <ChoosePathButton />
+                <FolderPickerButton
+                  value={workspaceCwd}
+                  onSelect={(path) => {
+                    setWorkspaceCwd(path);
+                    setWorkspaceError(null);
+                  }}
+                />
               </div>
               <div className="flex items-center gap-2">
                 <Button

--- a/ui/src/components/ProjectProperties.tsx
+++ b/ui/src/components/ProjectProperties.tsx
@@ -17,7 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AlertCircle, Archive, ArchiveRestore, Check, ExternalLink, Github, Loader2, Plus, Trash2, X } from "lucide-react";
-import { ChoosePathButton } from "./PathInstructionsModal";
+import { FolderPickerButton } from "./FolderPicker";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { DraftInput } from "./agent-config-primitives";
 import { InlineEditor } from "./InlineEditor";
@@ -844,7 +844,13 @@ export function ProjectProperties({ project, onUpdate, onFieldUpdate, getFieldSa
                   onChange={(e) => setWorkspaceCwd(e.target.value)}
                   placeholder="/absolute/path/to/workspace"
                 />
-                <ChoosePathButton />
+                <FolderPickerButton
+                  value={workspaceCwd}
+                  onSelect={(path) => {
+                    setWorkspaceCwd(path);
+                    setWorkspaceError(null);
+                  }}
+                />
               </div>
               <div className="flex items-center gap-2">
                 <Button

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -302,6 +302,7 @@ export const queryKeys = {
       ["access", "join-requests", companyId, status] as const,
     companyMembers: (companyId: string) => ["access", "company-members", companyId] as const,
     companyUserDirectory: (companyId: string) => ["access", "company-user-directory", companyId] as const,
+    filesystemList: (path: string) => ["access", "filesystem-list", path || "__roots__"] as const,
     adminUsers: (query: string) => ["access", "admin-users", query] as const,
     userCompanyAccess: (userId: string) => ["access", "user-company-access", userId] as const,
     invite: (token: string) => ["access", "invite", token] as const,

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -113,6 +113,7 @@ export const queryKeys = {
       ["access", "join-requests", companyId, status] as const,
     companyMembers: (companyId: string) => ["access", "company-members", companyId] as const,
     companyUserDirectory: (companyId: string) => ["access", "company-user-directory", companyId] as const,
+    filesystemList: (path: string) => ["access", "filesystem-list", path || "__roots__"] as const,
     adminUsers: (query: string) => ["access", "admin-users", query] as const,
     userCompanyAccess: (userId: string) => ["access", "user-company-access", userId] as const,
     invite: (token: string) => ["access", "invite", token] as const,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Setting up a project or agent requires pointing Paperclip at a workspace folder through an absolute-path input on three screens (New Project, Project Properties, Agent Config).
> - The `Choose` button on those inputs only opened an *instructions* modal (`PathInstructionsModal.tsx`) that taught the user how to copy an absolute path on Mac/Windows/Linux — there was no actual picker.
> - That forced a leave-app → find-folder in the OS file manager → copy → paste round trip on every new project or agent, a long-standing setup papercut.
> - This pull request replaces the instructions-only flow with a real in-app folder browser (`FolderPicker`), backed by a new `local_trusted`-gated `GET /api/filesystem/list` route, while keeping the help modal reachable as a fallback.
> - The benefit is that workspace paths can be selected by browsing instead of copy-pasting, with the `<Input>` remaining the source of truth so the manual paste flow still works everywhere.

## Linked Issues or Issue Description

No tracked public issue exists; inline feature request context follows the repo issue template.

**Subsystem affected**
ui/ — React + Vite board UI; server/ — REST API and orchestration services.

**Problem or motivation**
The `Choose` button on the three workspace path inputs (New Project, Project Properties, Agent Config) currently opens an instructions modal that teaches users how to copy an absolute path on Mac/Windows/Linux. Users still have to leave Paperclip, find the folder in the OS file manager, copy the path, and paste it back. There is no actual in-app folder picker for a core setup path.

**Proposed solution**
Add a reusable `FolderPicker`/`FolderPickerButton` backed by a `local_trusted`-gated `GET /api/filesystem/list` route. The picker lets users browse allowed directories and select a folder while the existing text input remains the source of truth, so manual paste continues to work.

**Alternatives considered**
- Keep the instructions-only modal: rejected because it preserves the leave-app copy/paste round trip.
- Use the browser File System Access API: rejected because support and permissions vary, and this flow already runs inside a trusted local app with server-side access to the workspace filesystem.
- Add a free-form autocomplete only: rejected because it still requires users to know or paste the absolute path.

**Roadmap alignment**
Checked `ROADMAP.md`; this does not duplicate a named roadmap item. It improves the existing local workspace setup flow without changing hosted/shared deployment behavior.

**Additional context**
The old `PathInstructionsModal` remains available as an inline help fallback, so users can still follow the original manual path-copy workflow when the filesystem route is unavailable.

## What Changed

**Backend (`server/src/routes/filesystem.ts`)**
- New `GET /api/filesystem/list?path=<absolute>` route.
- Empty path → platform roots (`/`, `$HOME` on unix; drive letters on Windows).
- Absolute-path validation, `realpath` resolution, `404` on missing.
- Denies `/etc/shadow` and `/root` (for non-root users), and any path outside the allowed roots.
- Directory-first sorting with symlink-aware metadata.
- **Gated to `local_trusted` deployment mode** — returns `403` in any other mode. This is the only mode where exposing host directory listing to the browser is safe.

**Frontend (`ui/src/components/FolderPicker.tsx`)**
- Reusable `<FolderPicker>` modal + `<FolderPickerButton>` (drop-in replacement for the old `ChoosePathButton`).
- Breadcrumb navigation, parent-up button, debounced manual path entry, keyboard navigation, loading / empty / error states.
- Windows + Unix path handling.
- React Query caching via new `queryKeys.access.filesystemList`.
- Inline "Need help finding a path?" link still opens `PathInstructionsModal` so the original muscle memory is preserved when the API is gated.

**Wiring**
- `NewProjectDialog.tsx`, `ProjectProperties.tsx`, `AgentConfigForm.tsx` now render `FolderPickerButton` instead of `ChoosePathButton`, passing the existing input's `value` and `onChange`. The `<Input>` remains the source of truth.
- Adds `accessApi.listFilesystem` client.
- Adds `sr-only` `DialogTitle` / `DialogDescription` to `NewProjectDialog` (clears a Radix accessibility warning on the dialog we touched).

## Verification

**Automated tests**
```
pnpm exec vitest run --project @paperclipai/server server/src/__tests__/filesystem-list-route.test.ts
   6 passed (roots, nested listing, denied path, non-absolute rejection, 404, mode gating)

pnpm exec vitest run ui/src/components/FolderPicker.test.tsx
   3 passed (browse+select, keyboard nav, error rendering + manual fallback)

pnpm --filter @paperclipai/ui typecheck
   ✓ green
```
`pnpm --filter @paperclipai/server typecheck` has pre-existing errors on `master` in `plugin-host-services.ts` and `plugin-local-folders.ts` that are unrelated to this change. Happy to address in a separate PR if helpful.

**Manual QA** — verified end-to-end in a local Chromium against `http://127.0.0.1:3101`:
- `/<company>/projects` → New Project dialog → Choose → navigate → Select
- `/<company>/projects/<slug>/configuration` → Project Properties → Choose
- `/<company>/agents/<slug>/configuration` → Agent Config workspace path → Choose

In all three flows the absolute path of the selected folder lands in the input field. Manual paste-flow still works (the `<Input>` is unchanged).

**Before / after (visual change)**

Static screenshots could not be auto-captured in this contributor-side description update (no live render environment attached to this edit), so here is a concrete before/after of the `Choose` interaction. The UI is built entirely from existing shadcn primitives (`Dialog`, `Button`, `Input`, `Breadcrumb`, `ScrollArea`, `Skeleton`) and `lucide-react` icons, so the rendered result is deterministic from the wiring above.

| | Before | After |
|---|---|---|
| Click `Choose` | Opens `PathInstructionsModal` — a static help card explaining how to copy an absolute path on Mac/Windows/Linux | Opens `FolderPicker` — a real folder browser |
| Body | Read-only instructions text + close button | Breadcrumb path + parent-up button + scrollable directory list (folders first), with a debounced manual-path input |
| Selecting a folder | Not possible in-app; user leaves to the OS file manager, copies, pastes back | Navigate into folders, click `Select`; the absolute path is written into the existing `<Input>` |
| Help fallback | Was the entire modal | Still reachable via an inline "Need help finding a path?" link (opens the same `PathInstructionsModal`) |
| Empty / error / loading | n/a | Skeleton on load, empty-state when a folder has no subdirectories, error state with a manual-paste fallback |

@cryppadotta @devinfoley — if you'd like literal PNG before/after captures attached, I can render the branch locally and add them; flagging this textual walkthrough as the interim per the PR template's "concrete explanation if screenshots are impossible" allowance.

## Risks

- **Low risk.** Listing-only — no file read/write, no recursive traversal, folders only.
- The new route is hard-gated to `local_trusted` deployment mode (`403` everywhere else), so no host directory listing is exposed in any shared/hosted mode.
- No public API change other than the additive new route. `PathInstructionsModal` is still exported and still used as the help fallback, so no removal/breaking change.
- No new heavy dependencies — reuses existing primitives and icons.
- Pre-existing unrelated `@paperclipai/server` typecheck errors on `master` are noted under Verification and are out of scope here.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR.

## Model Used

Claude (Anthropic) — Opus-class model used via Claude Code with extended thinking and tool use, 1M-token context. Used to assist code generation, test authoring, and PR drafting; all changes were reviewed by the human author before pushing.

## Out of scope
- File contents / read / write — listing only.
- Recursive listing.
- Non-`local_trusted` deployment modes (deliberate; would require additional access controls).
- File picker — this picks **folders** only, matching every existing callsite.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots _(concrete before/after walkthrough provided in lieu of static images — see Verification)_
- [ ] I have updated relevant documentation to reflect my changes _(no user-facing docs cover this flow yet)_
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

