### PR TITLE
feat(routines): add skip_if_open concurrency policy

### DIFF
--- a/docs/api/routines.md
+++ b/docs/api/routines.md
@@ -61,7 +61,10 @@ Fields:
 |-------|-----------|
 | `coalesce_if_active` (default) | Incoming run is immediately finalised as `coalesced` and linked to the active run — no new issue is created |
 | `skip_if_active` | Incoming run is immediately finalised as `skipped` and linked to the active run — no new issue is created |
+| `skip_if_open` | Incoming run is immediately finalised as `skipped` and linked to any previous run issue still in a non-terminal status (`todo`, `in_progress`, `in_review`, `blocked`). Use this when an unpicked-up `todo` should still suppress duplicates. |
 | `always_enqueue` | Always create a new run regardless of active runs |
+
+`skip_if_active` only suppresses duplicates while the previous run has a live heartbeat (queued or running). `skip_if_open` is stricter: it suppresses duplicates as long as the previous run issue is in any non-terminal status, even if its heartbeat run has ended.
 
 **Catch-up policies:**
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -187,7 +187,12 @@ export type ProjectStatus = (typeof PROJECT_STATUSES)[number];
 export const ROUTINE_STATUSES = ["active", "paused", "archived"] as const;
 export type RoutineStatus = (typeof ROUTINE_STATUSES)[number];
 
-export const ROUTINE_CONCURRENCY_POLICIES = ["coalesce_if_active", "always_enqueue", "skip_if_active"] as const;
+export const ROUTINE_CONCURRENCY_POLICIES = [
+  "coalesce_if_active",
+  "always_enqueue",
+  "skip_if_active",
+  "skip_if_open",
+] as const;
 export type RoutineConcurrencyPolicy = (typeof ROUTINE_CONCURRENCY_POLICIES)[number];
 
 export const ROUTINE_CATCH_UP_POLICIES = ["skip_missed", "enqueue_missed_with_cap"] as const;

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -221,6 +221,89 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(routineIssues.map((issue) => issue.id)).toContain(run.linkedIssueId);
   });
 
+  it("skips a new run when skip_if_open and a previous run issue is open but idle", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    await db
+      .update(routines)
+      .set({ concurrencyPolicy: "skip_if_open" })
+      .where(eq(routines.id, routine.id));
+
+    const previousRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "todo",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+      completedAt: new Date("2026-03-20T12:00:00.000Z"),
+    });
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("skipped");
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+    expect(run.coalescedIntoRunId).toBe(previousRunId);
+
+    const routineIssues = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+
+    expect(routineIssues).toHaveLength(1);
+    expect(routineIssues[0]?.id).toBe(previousIssue.id);
+  });
+
+  it("ignores terminal previous run issues under skip_if_open", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    await db
+      .update(routines)
+      .set({ concurrencyPolicy: "skip_if_open" })
+      .where(eq(routines.id, routine.id));
+
+    const previousRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "done",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+      completedAt: new Date("2026-03-20T12:00:00.000Z"),
+    });
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("issue_created");
+    expect(run.linkedIssueId).not.toBe(previousIssue.id);
+  });
+
   it("creates draft routines without a project or default assignee", async () => {
     const { companyId, svc } = await seedFixture();
 

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -656,6 +656,27 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  // Returns any non-terminal routine_execution issue for this routine, regardless of
+  // whether it is currently bound to a live heartbeat run. Used by `skip_if_open` so
+  // a stale `todo` run that was never picked up still suppresses duplicate creation.
+  async function findOpenExecutionIssue(routine: typeof routines.$inferSelect, executor: Db = db) {
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, "routine_execution"),
+          eq(issues.originId, routine.id),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -791,13 +812,18 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
-        const activeIssue = await findLiveExecutionIssue(input.routine, txDb);
-        if (activeIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
-          const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+        const policy = input.routine.concurrencyPolicy;
+        // `skip_if_open` widens the dedup window: any non-terminal run issue blocks
+        // re-firing, even one stuck in `todo` whose heartbeat run is no longer live.
+        const existingIssue = policy === "skip_if_open"
+          ? await findOpenExecutionIssue(input.routine, txDb)
+          : await findLiveExecutionIssue(input.routine, txDb);
+        if (existingIssue && policy !== "always_enqueue") {
+          const status = policy === "skip_if_active" || policy === "skip_if_open" ? "skipped" : "coalesced";
           const updated = await finalizeRun(createdRun.id, {
             status,
-            linkedIssueId: activeIssue.id,
-            coalescedIntoRunId: activeIssue.originRunId,
+            linkedIssueId: existingIssue.id,
+            coalescedIntoRunId: existingIssue.originRunId,
             completedAt: triggeredAt,
           }, txDb);
           await updateRoutineTouchedState({
@@ -805,7 +831,7 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
             triggerId: input.trigger?.id ?? null,
             triggeredAt,
             status,
-            issueId: activeIssue.id,
+            issueId: existingIssue.id,
             nextRunAt,
           }, txDb);
           return updated ?? createdRun;
@@ -840,9 +866,12 @@ export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeup
             throw error;
           }
 
-          const existingIssue = await findLiveExecutionIssue(input.routine, txDb);
+          const policy = input.routine.concurrencyPolicy;
+          const existingIssue = policy === "skip_if_open"
+            ? await findOpenExecutionIssue(input.routine, txDb)
+            : await findLiveExecutionIssue(input.routine, txDb);
           if (!existingIssue) throw error;
-          const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+          const status = policy === "skip_if_active" || policy === "skip_if_open" ? "skipped" : "coalesced";
           const updated = await finalizeRun(createdRun.id, {
             status,
             linkedIssueId: existingIssue.id,

--- a/skills/paperclip/references/routines.md
+++ b/skills/paperclip/references/routines.md
@@ -64,7 +64,10 @@ Controls what happens when a trigger fires while the previous run issue is still
 |--------|-----------|
 | `coalesce_if_active` **(default)** | New run is marked `coalesced` and linked to the existing active run — no new issue created |
 | `skip_if_active` | New run is marked `skipped` and linked to the existing active run — no new issue created |
+| `skip_if_open` | New run is marked `skipped` and linked to any previous run issue still in a non-terminal status (`todo`, `in_progress`, `in_review`, `blocked`). Use this when an unpicked-up `todo` issue should still suppress duplicates. |
 | `always_enqueue` | Always create a new issue regardless of active runs |
+
+`skip_if_active` only suppresses duplicates when the previous run has a live heartbeat run (queued or running). `skip_if_open` is stricter: it also suppresses duplicates when the previous run issue exists in any non-terminal state but has no live heartbeat (e.g. a `todo` that was never picked up).
 
 ---
 

--- a/ui/src/pages/RoutineDetail.tsx
+++ b/ui/src/pages/RoutineDetail.tsx
@@ -57,7 +57,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import type { RoutineTrigger, RoutineVariable } from "@paperclipai/shared";
 
-const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active"];
+const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active", "skip_if_open"];
 const catchUpPolicies = ["skip_missed", "enqueue_missed_with_cap"];
 const triggerKinds = ["schedule", "webhook"];
 const signingModes = ["bearer", "hmac_sha256", "github_hmac", "none"];
@@ -66,6 +66,7 @@ const concurrencyPolicyDescriptions: Record<string, string> = {
   coalesce_if_active: "Keep one follow-up run queued while an active run is still working.",
   always_enqueue: "Queue every trigger occurrence, even if several runs stack up.",
   skip_if_active: "Drop overlapping trigger occurrences while the routine is already active.",
+  skip_if_open: "Drop overlapping trigger occurrences while any previous run issue is still open.",
 };
 const catchUpPolicyDescriptions: Record<string, string> = {
   skip_missed: "Ignore schedule windows that were missed while the routine or scheduler was paused.",

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -50,12 +50,13 @@ import {
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import type { RoutineListItem, RoutineVariable } from "@paperclipai/shared";
 
-const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active"];
+const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active", "skip_if_open"];
 const catchUpPolicies = ["skip_missed", "enqueue_missed_with_cap"];
 const concurrencyPolicyDescriptions: Record<string, string> = {
   coalesce_if_active: "If a run is already active, keep just one follow-up run queued.",
   always_enqueue: "Queue every trigger occurrence, even if the routine is already running.",
   skip_if_active: "Drop new trigger occurrences while a run is still active.",
+  skip_if_open: "Drop new trigger occurrences while any previous run issue is still open (todo, in progress, in review, or blocked).",
 };
 const catchUpPolicyDescriptions: Record<string, string> = {
   skip_missed: "Ignore windows that were missed while the scheduler or routine was paused.",


### PR DESCRIPTION
## Summary

Adds a new `skip_if_open` concurrency policy for routines that suppresses duplicate run issues even when a previous run is parked in any non-terminal status (`backlog`, `todo`, `in_progress`, `in_review`, `blocked`).

The existing `skip_if_active` / `coalesce_if_active` policies only catch duplicates while a heartbeat run is queued or running, so successive fires can stack up `todo` tickets when the agent never gets to them. `skip_if_open` widens the dedup window to any open routine_execution issue regardless of heartbeat run state.

## Changes

- Add `skip_if_open` to `ROUTINE_CONCURRENCY_POLICIES`
- Add `findOpenExecutionIssue` helper that ignores heartbeat liveness
- Wire policy into both the pre-create check and the unique-constraint recovery path; map to `skipped` when triggered
- Surface in Routines + RoutineDetail UI dropdowns with descriptions
- Update `docs/api/routines.md` and `skills/paperclip/references/routines.md`
- Tests: `skip_if_open` suppresses duplicate against an idle `todo`, and ignores terminal previous issues

## Acceptance criteria (UPG-598)

- [x] New `skip_if_open` policy available on routines
- [x] With this policy, a routine will not create a new issue if any previous run issue is in a non-terminal status
- [x] Existing policies unchanged

## Test plan

- [x] Server unit tests: `routines-service.test.ts`, `routines-routes.test.ts`
- [x] UI tests: `Routines.test.tsx`
- [x] Full suite: 51 tests pass
- [x] Typecheck clean

Tracks UPG-598. Context: UPG-597 (Option B of routine dedup fix).