### PR TITLE
Reap zombie wakeup queue entries

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -898,6 +898,151 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("reaps non-terminal wakeup requests linked to terminal or missing heartbeat runs", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const finishedAt = new Date("2026-03-19T00:05:00.000Z");
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const cases = [
+      { wakeupStatus: "queued", runStatus: "succeeded", expectedStatus: "completed", runError: null },
+      { wakeupStatus: "claimed", runStatus: "failed", expectedStatus: "failed", runError: "adapter failed" },
+      { wakeupStatus: "deferred_issue_execution", runStatus: "cancelled", expectedStatus: "cancelled", runError: "cancelled by user" },
+      { wakeupStatus: "claimed", runStatus: "timed_out", expectedStatus: "timed_out", runError: "adapter timed out" },
+    ];
+    const expected = new Map<string, { status: string; error: string | null }>();
+
+    for (const row of cases) {
+      const wakeupRequestId = randomUUID();
+      const runId = randomUUID();
+      await db.insert(agentWakeupRequests).values({
+        id: wakeupRequestId,
+        companyId,
+        agentId,
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: {},
+        status: row.wakeupStatus,
+        runId,
+        claimedAt: row.wakeupStatus === "claimed" ? new Date("2026-03-19T00:00:00.000Z") : null,
+      });
+      await db.insert(heartbeatRuns).values({
+        id: runId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        triggerDetail: "system",
+        status: row.runStatus,
+        wakeupRequestId,
+        finishedAt,
+        error: row.runError,
+      });
+      expected.set(wakeupRequestId, {
+        status: row.expectedStatus,
+        error: row.expectedStatus === "completed" ? null : row.runError,
+      });
+    }
+
+    const missingRunWakeupId = randomUUID();
+    const missingRunId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: missingRunWakeupId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: {},
+      status: "queued",
+      runId: missingRunId,
+    });
+    expected.set(missingRunWakeupId, {
+      status: "failed",
+      error: `Wake request references missing heartbeat run ${missingRunId}`,
+    });
+
+    const liveWakeupId = randomUUID();
+    const liveRunId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: liveWakeupId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: {},
+      status: "queued",
+      runId: liveRunId,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: liveRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "queued",
+      wakeupRequestId: liveWakeupId,
+    });
+
+    const deferredWakeupId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: deferredWakeupId,
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_execution_deferred",
+      payload: { issueId: randomUUID() },
+      status: "deferred_issue_execution",
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(0);
+
+    const wakeups = await db
+      .select({
+        id: agentWakeupRequests.id,
+        status: agentWakeupRequests.status,
+        error: agentWakeupRequests.error,
+        finishedAt: agentWakeupRequests.finishedAt,
+      })
+      .from(agentWakeupRequests)
+      .where(inArray(agentWakeupRequests.id, [...expected.keys(), liveWakeupId, deferredWakeupId]));
+    const wakeupById = new Map(wakeups.map((row) => [row.id, row]));
+
+    for (const [wakeupRequestId, expectation] of expected) {
+      const wakeup = wakeupById.get(wakeupRequestId);
+      expect(wakeup?.status).toBe(expectation.status);
+      expect(wakeup?.error).toBe(expectation.error);
+      expect(wakeup?.finishedAt).toBeTruthy();
+    }
+
+    expect(wakeupById.get(liveWakeupId)?.status).toBe("queued");
+    expect(wakeupById.get(liveWakeupId)?.finishedAt).toBeNull();
+    expect(wakeupById.get(deferredWakeupId)?.status).toBe("deferred_issue_execution");
+    expect(wakeupById.get(deferredWakeupId)?.finishedAt).toBeNull();
+  });
+
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       processPid: 999_999_999,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -203,6 +203,7 @@ const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_r
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
+const WAKEUP_REQUEST_NON_TERMINAL_STATUSES = ["queued", "claimed", "deferred_issue_execution"] as const;
 export {
   ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS,
   ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
@@ -3794,6 +3795,81 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .where(eq(agentWakeupRequests.id, wakeupRequestId));
   }
 
+  function terminalWakeupStatusForRunStatus(runStatus: string | null) {
+    switch (runStatus) {
+      case "succeeded":
+        return "completed";
+      case "failed":
+      case "cancelled":
+      case "timed_out":
+        return runStatus;
+      default:
+        return "failed";
+    }
+  }
+
+  async function reapZombieWakeupRequests() {
+    const zombies = await db
+      .select({
+        wakeupRequestId: agentWakeupRequests.id,
+        wakeupRunId: agentWakeupRequests.runId,
+        wakeupError: agentWakeupRequests.error,
+        runStatus: heartbeatRuns.status,
+        runError: heartbeatRuns.error,
+        runFinishedAt: heartbeatRuns.finishedAt,
+      })
+      .from(agentWakeupRequests)
+      .leftJoin(heartbeatRuns, eq(agentWakeupRequests.runId, heartbeatRuns.id))
+      .where(
+        and(
+          inArray(agentWakeupRequests.status, [...WAKEUP_REQUEST_NON_TERMINAL_STATUSES]),
+          sql`${agentWakeupRequests.runId} is not null`,
+          or(
+            isNull(heartbeatRuns.id),
+            inArray(heartbeatRuns.status, [...HEARTBEAT_RUN_TERMINAL_STATUSES]),
+          ),
+        ),
+      );
+
+    const now = new Date();
+    const reaped: string[] = [];
+    for (const zombie of zombies) {
+      const targetStatus = terminalWakeupStatusForRunStatus(zombie.runStatus ?? null);
+      const missingRun = !zombie.runStatus;
+      const fallbackError = missingRun
+        ? `Wake request references missing heartbeat run ${zombie.wakeupRunId ?? ""}`.trim()
+        : targetStatus === "completed"
+          ? null
+          : `Linked heartbeat run ended with status ${zombie.runStatus}`;
+      const updated = await db
+        .update(agentWakeupRequests)
+        .set({
+          status: targetStatus,
+          finishedAt: zombie.runFinishedAt ?? now,
+          error: zombie.wakeupError ?? zombie.runError ?? fallbackError,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(agentWakeupRequests.id, zombie.wakeupRequestId),
+            inArray(agentWakeupRequests.status, [...WAKEUP_REQUEST_NON_TERMINAL_STATUSES]),
+          ),
+        )
+        .returning({ id: agentWakeupRequests.id })
+        .then((rows) => rows[0] ?? null);
+      if (updated) reaped.push(updated.id);
+    }
+
+    if (reaped.length > 0) {
+      logger.warn(
+        { reapedCount: reaped.length, wakeupRequestIds: reaped },
+        "reaped zombie wakeup requests",
+      );
+    }
+
+    return { reaped: reaped.length, wakeupRequestIds: reaped };
+  }
+
   async function addContinuationExhaustedCommentOnce(input: {
     run: typeof heartbeatRuns.$inferSelect;
     issueId: string;
@@ -6442,6 +6518,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
+    await reapZombieWakeupRequests();
 
     // Find all runs stuck in "running" state (queued runs are legitimately waiting; resumeQueuedRuns handles them)
     const activeRuns = await db


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Agent wakeups are persisted in `agent_wakeup_requests`, while executable work is represented by paired `heartbeat_runs` rows.
> - Existing heartbeat recovery reaped orphaned `running` heartbeat runs, but did not reconcile wakeup rows that stayed non-terminal after their paired run had already terminalized or disappeared.
> - Those zombie wakeup rows can keep Paperclip's wake queue and liveness/readiness views believing old work is still pending.
> - This pull request adds wakeup-row reconciliation to the existing startup/periodic heartbeat reaper path.
> - The benefit is that the visible wake queue converges automatically without manual database cleanup.

## What Changed

- Added a `WAKEUP_REQUEST_NON_TERMINAL_STATUSES` sweep inside `reapOrphanedRuns()`.
- Reconciled linked wakeup rows whose `run_id` points to terminal `heartbeat_runs` statuses into `completed`, `failed`, `cancelled`, or `timed_out`.
- Marked non-terminal wakeup rows that reference a missing `heartbeat_runs` row as `failed` with an explanatory error.
- Added an embedded Postgres regression test that proves terminal-linked and missing-run wakeups are reaped while live queued and deferred unlinked wakeups are left untouched.

## Verification

- `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t "reaps non-terminal wakeup requests linked to terminal or missing heartbeat runs"` -> 1 passed, 44 skipped.
- `pnpm --filter @paperclipai/server typecheck` -> exit 0.
- `pnpm build` -> exit 0. Vite emitted existing chunk-size/dynamic-import warnings during the UI build.

Full-file local note: `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` ran the new test successfully but ended with 42 passed / 3 failed due existing cleanup failures deleting `companies` while `document_revisions` rows still existed after unrelated heartbeat execution setup errors. The focused regression test above isolates this change and passes.

## Risks

- Low risk. The sweep only touches wakeup rows in non-terminal wakeup statuses with a non-null `run_id` when the linked heartbeat run is terminal or missing.
- Deferred wakeups with no `run_id` are intentionally left alone because they are valid while waiting for an active issue execution path to release.
- Missing-run wakeups are marked `failed`; if an external integrator manually writes wakeup rows before writing heartbeat runs outside a transaction, those rows should no longer remain non-terminal indefinitely.

## Model Used

- OpenAI Codex, GPT-5 coding agent as configured in this environment; tool-using CLI session. Exact context window and internal reasoning mode are not exposed to the agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
