### PR TITLE
fix: redact credentials in run logs

### DIFF
--- a/server/src/__tests__/heartbeat-run-log.test.ts
+++ b/server/src/__tests__/heartbeat-run-log.test.ts
@@ -21,4 +21,23 @@ describe("compactRunLogChunk", () => {
     expect(compacted).toContain("[paperclip truncated run log chunk:");
     expect(compacted.endsWith("tail")).toBe(true);
   });
+
+  it("redacts credentials before run log chunks are stored or streamed", () => {
+    const chunk = [
+      "Authorization: Bearer live-bearer-token-value",
+      "export PAPERCLIP_API_KEY='quoted-paperclip-key'",
+      "curl https://example.test/api?token=url-token-value",
+      "paperclipai login --api-key cli-secret-value",
+      '{"token":"json-token-value"}',
+    ].join("\n");
+
+    const compacted = compactRunLogChunk(chunk);
+
+    expect(compacted).toContain("***REDACTED***");
+    expect(compacted).not.toContain("live-bearer-token-value");
+    expect(compacted).not.toContain("quoted-paperclip-key");
+    expect(compacted).not.toContain("url-token-value");
+    expect(compacted).not.toContain("cli-secret-value");
+    expect(compacted).not.toContain("json-token-value");
+  });
 });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -70,7 +70,11 @@ describe("redaction", () => {
     const input = [
       "Authorization: Bearer live-bearer-token-value",
       `payload {"apiKey":"json-secret-value"}`,
+      `payload {"token":"json-token-value"}`,
       `escaped {\\"apiKey\\":\\"escaped-json-secret\\"}`,
+      `export OPPM_API_KEY='quoted-secret-value'`,
+      `curl https://example.test/hook?access_token=url-token-value&safe=1`,
+      `paperclipai login --api-key cli-secret-value`,
       `GITHUB_TOKEN=${githubToken}`,
       `session=${jwt}`,
     ].join("\n");
@@ -80,7 +84,11 @@ describe("redaction", () => {
     expect(result).toContain(REDACTED_EVENT_VALUE);
     expect(result).not.toContain("live-bearer-token-value");
     expect(result).not.toContain("json-secret-value");
+    expect(result).not.toContain("json-token-value");
     expect(result).not.toContain("escaped-json-secret");
+    expect(result).not.toContain("quoted-secret-value");
+    expect(result).not.toContain("url-token-value");
+    expect(result).not.toContain("cli-secret-value");
     expect(result).not.toContain(githubToken);
     expect(result).not.toContain(jwt);
   });

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1,7 +1,7 @@
 import { redactCommandText } from "@paperclipai/adapter-utils";
 
 const SECRET_PAYLOAD_KEY_RE =
-  /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
+  /(api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|\btoken\b|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
 const COMMAND_PAYLOAD_KEY_RE =
   /(^command$|^cmd$|command[-_]?line|resolved[-_]?command|PAPERCLIP_RESOLVED_COMMAND)/i;
 const COMMAND_ARGS_PAYLOAD_KEY_RE = /^(commandArgs|command_?args|argv)$/i;
@@ -9,9 +9,11 @@ const JWT_VALUE_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-
 const CLI_SECRET_FLAG_RE =
   /^-{1,2}(?:api[-_]?key|(?:access[-_]?|auth[-_]?)?token|token|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)$/i;
 const JSON_SECRET_FIELD_TEXT_RE =
-  /((?:"|')?(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)(?:"|')?\s*:\s*(?:"|'))[^"'`\r\n]+((?:"|'))/gi;
+  /((?:"|')?(?:api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)(?:"|')?\s*:\s*(?:"|'))[^"'`\r\n]+((?:"|'))/gi;
 const ESCAPED_JSON_SECRET_FIELD_TEXT_RE =
-  /((?:\\")?(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)(?:\\")?\s*:\s*(?:\\"))[^\\\r\n]+((?:\\"))/gi;
+  /((?:\\")?(?:api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)(?:\\")?\s*:\s*(?:\\"))[^\\\r\n]+((?:\\"))/gi;
+const ENV_SECRET_ASSIGNMENT_TEXT_RE =
+  /(\b(?:export\s+)?[A-Za-z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|AUTHORIZATION|JWT|CREDENTIAL)[A-Za-z0-9_]*\s*=\s*)(?:"[^"\r\n]*"|'[^'\r\n]*'|`[^`\r\n]*`|[^\s"'`]+)/gi;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -97,7 +99,8 @@ export function redactSensitiveText(input: string): string {
   return redactCommandText(
     input
       .replace(JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
-      .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`),
+      .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
+      .replace(ENV_SECRET_ASSIGNMENT_TEXT_RE, `$1${REDACTED_EVENT_VALUE}`),
     REDACTED_EVENT_VALUE,
   );
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -941,7 +941,7 @@ function redactInlineBase64ImageData(chunk: string) {
 }
 
 export function compactRunLogChunk(chunk: string, maxChars = MAX_PERSISTED_LOG_CHUNK_CHARS) {
-  const normalized = redactInlineBase64ImageData(chunk);
+  const normalized = redactSensitiveText(redactInlineBase64ImageData(chunk));
   if (normalized.length <= maxChars) return normalized;
 
   const headChars = Math.max(0, Math.floor(maxChars * 0.6));

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import { notFound } from "../errors.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { redactSensitiveText } from "../redaction.js";
 
 export type RunLogStoreType = "local_file";
 
@@ -112,7 +113,7 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
       const line = JSON.stringify({
         ts: event.ts,
         stream: event.stream,
-        chunk: event.chunk,
+        chunk: redactSensitiveText(event.chunk),
       });
       const persisted = `${line}\n`;
       await fs.appendFile(absPath, persisted, "utf8");


### PR DESCRIPTION
## Summary
- Redact sensitive text before heartbeat log chunks are streamed, excerpted, or stored
- Redact again at the run-log store append boundary as a storage-layer backstop
- Extend redaction coverage for quoted env assignments, token JSON fields, URL query credentials, and CLI secret flags

Linked issue: MUR-162

## Tests
- pnpm --filter @paperclipai/server exec vitest run src/__tests__/redaction.test.ts src/__tests__/heartbeat-run-log.test.ts