### PR TITLE
fix(recovery): port detached completed-run cleanup guards

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -216,6 +216,39 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(evaluations[0]?.description).not.toContain("sk-test-secret-value");
   });
 
+  it("skips detached runs whose source issue is terminal and no longer bound", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    await db
+      .update(heartbeatRuns)
+      .set({
+        errorCode: "process_detached",
+        error: "Lost in-memory process handle, but child pid 123 is still alive",
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    await db.update(issues).set({ status: "done", executionRunId: null }).where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      created: 0,
+      existing: 0,
+      escalated: 0,
+      snoozed: 0,
+      skipped: 1,
+    });
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+  });
+
   it("redacts sensitive values from actual run-log evidence", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const leakedJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -898,6 +898,52 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("cancels detached local runs once the source issue is completed and released", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId, wakeupRequestId, issueId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      runErrorCode: "process_detached",
+      runError: `Lost in-memory process handle, but child pid ${child.pid} is still alive`,
+    });
+    await db
+      .update(issues)
+      .set({
+        status: "done",
+        checkoutRunId: null,
+        executionRunId: null,
+      })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+    expect(await waitForPidExit(child.pid ?? -1, 5_000)).toBe(true);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("orphaned_completed_issue_process");
+    expect(run?.error).toContain("reached done");
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("cancelled");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("done");
+    expect(issue?.executionRunId).toBeNull();
+  });
+
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       processPid: 999_999_999,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6468,7 +6468,53 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
+      const sourceIssue = tracksLocalChild && run.errorCode === DETACHED_PROCESS_ERROR_CODE
+        ? await resolveDetachedOrphanSourceIssue(run)
+        : null;
       if (processPidAlive) {
+        if (shouldCleanupDetachedCompletedSourceRun(run, sourceIssue)) {
+          const cleanupMessage = `Terminated detached child process after source issue ${sourceIssue.identifier ?? sourceIssue.id} reached ${sourceIssue.status} with no active execution binding`;
+          await terminateHeartbeatRunProcess({
+            pid: run.processPid,
+            processGroupId: run.processGroupId,
+          });
+          let cleanedRun = await setRunStatus(run.id, "cancelled", {
+            finishedAt: now,
+            error: cleanupMessage,
+            errorCode: "orphaned_completed_issue_process",
+            resultJson: mergeRunStopMetadataForAgent({ adapterType, adapterConfig }, "cancelled", {
+              resultJson: parseObject(run.resultJson),
+              errorCode: "orphaned_completed_issue_process",
+              errorMessage: cleanupMessage,
+            }),
+          });
+          await setWakeupStatus(run.wakeupRequestId, "cancelled", {
+            finishedAt: now,
+            error: cleanupMessage,
+          });
+          if (!cleanedRun) cleanedRun = await getRun(run.id);
+          if (cleanedRun) {
+            await appendRunEvent(cleanedRun, await nextRunEventSeq(cleanedRun.id), {
+              eventType: "lifecycle",
+              stream: "system",
+              level: "warn",
+              message: cleanupMessage,
+              payload: {
+                issueId: sourceIssue.id,
+                issueStatus: sourceIssue.status,
+                ...(run.processPid ? { processPid: run.processPid } : {}),
+                ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
+                cleanupReason: "completed_source_issue",
+              },
+            });
+            await releaseIssueExecutionAndPromote(cleanedRun);
+          }
+          await finalizeAgentStatus(run.agentId, "cancelled");
+          await startNextQueuedRunForAgent(run.agentId);
+          runningProcesses.delete(run.id);
+          reaped.push(run.id);
+          continue;
+        }
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
           const detachedRun = await setRunStatus(run.id, "running", {
@@ -6587,6 +6633,37 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   function issueIdFromRunContext(contextSnapshot: unknown) {
     const context = parseObject(contextSnapshot);
     return readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
+  }
+
+  async function resolveDetachedOrphanSourceIssue(run: typeof heartbeatRuns.$inferSelect) {
+    const issueId = issueIdFromRunContext(run.contextSnapshot);
+    if (!issueId) return null;
+    const [issue] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(and(eq(issues.companyId, run.companyId), eq(issues.id, issueId), isNull(issues.hiddenAt)))
+      .limit(1);
+    return issue ?? null;
+  }
+
+  function shouldCleanupDetachedCompletedSourceRun(
+    run: typeof heartbeatRuns.$inferSelect,
+    sourceIssue: {
+      id: string;
+      identifier: string | null;
+      status: string;
+      executionRunId: string | null;
+    } | null,
+  ) {
+    if (!sourceIssue || run.errorCode !== DETACHED_PROCESS_ERROR_CODE) return false;
+    const sourceIssueTerminal = sourceIssue.status === "done" || sourceIssue.status === "cancelled";
+    const sourceIssueReleasedRun = sourceIssue.executionRunId !== run.id;
+    return sourceIssueTerminal && sourceIssueReleasedRun;
   }
 
   function issueIdFromWakePayload(payload: unknown) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -793,6 +793,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return issue ?? null;
   }
 
+  function shouldSuppressDetachedCompletedSourceRunEvaluation(
+    run: typeof heartbeatRuns.$inferSelect,
+    sourceIssue: typeof issues.$inferSelect | null,
+  ) {
+    if (!sourceIssue || run.errorCode !== "process_detached") return false;
+    const sourceIssueTerminal = sourceIssue.status === "done" || sourceIssue.status === "cancelled";
+    const sourceIssueReleasedRun = sourceIssue.executionRunId !== run.id;
+    return sourceIssueTerminal && sourceIssueReleasedRun;
+  }
+
   async function resolveStaleRunOwnerAgentId(input: {
     run: typeof heartbeatRuns.$inferSelect;
     runningAgent: typeof agents.$inferSelect;
@@ -1025,6 +1035,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
+    if (shouldSuppressDetachedCompletedSourceRunEvaluation(input.run, sourceIssue)) {
+      return { kind: "skipped" as const };
+    }
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({
       run: input.run,


### PR DESCRIPTION
﻿## Summary

- suppress `stale_active_run_evaluation` creation for detached runs whose source issue is already terminal and no longer bound to that run
- reap detached local child processes once the source issue is `done` or `cancelled` and has released `executionRunId`
- add regression coverage for both the watchdog skip path and the orphan-process cleanup path

## Verification

- `corepack pnpm exec vitest run server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts --reporter=verbose`
- `corepack pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts --reporter=verbose`
