### PR TITLE
fix: add emergency run JWT revocation denylist

### DIFF
--- a/doc/RUN-JWT-REVOCATION.md
+++ b/doc/RUN-JWT-REVOCATION.md
@@ -1,0 +1,17 @@
+# Emergency Run JWT Revocation
+
+Paperclip local adapter runs authenticate with short-lived run-scoped JWTs. If a run token is exposed, operators can deny that specific `run_id` without rotating the shared signing secret.
+
+## Deny Run IDs
+
+Set `PAPERCLIP_AGENT_JWT_DENIED_RUN_IDS` to the run IDs to deny. The value may be comma-separated, whitespace-separated, newline-separated, or a JSON array.
+
+```bash
+PAPERCLIP_AGENT_JWT_DENIED_RUN_IDS="576c63c1-6ddc-4daf-93b6-de30c3d34f32,c79d03a8-6929-499b-80fb-7b45ca48db5c,b42a052b-3ddc-4f2b-ba61-03bbe37f53f4"
+```
+
+After changing the setting, restart or redeploy the Paperclip server process. The denied run IDs are checked during local agent JWT verification before the request is accepted as an agent actor. Do not add bearer tokens, JWT signatures, API keys, or raw log excerpts to the setting.
+
+## Remove Run IDs
+
+Remove the run ID from `PAPERCLIP_AGENT_JWT_DENIED_RUN_IDS`, then restart or redeploy the Paperclip server process. Other valid agent JWTs continue to authenticate as long as their `run_id` is not listed and the token is otherwise valid.

--- a/server/src/__tests__/agent-auth-jwt.test.ts
+++ b/server/src/__tests__/agent-auth-jwt.test.ts
@@ -7,6 +7,7 @@ describe("agent local JWT", () => {
   const ttlEnv = "PAPERCLIP_AGENT_JWT_TTL_SECONDS";
   const issuerEnv = "PAPERCLIP_AGENT_JWT_ISSUER";
   const audienceEnv = "PAPERCLIP_AGENT_JWT_AUDIENCE";
+  const deniedRunIdsEnv = "PAPERCLIP_AGENT_JWT_DENIED_RUN_IDS";
 
   const originalEnv = {
     secret: process.env[secretEnv],
@@ -14,6 +15,7 @@ describe("agent local JWT", () => {
     ttl: process.env[ttlEnv],
     issuer: process.env[issuerEnv],
     audience: process.env[audienceEnv],
+    deniedRunIds: process.env[deniedRunIdsEnv],
   };
 
   beforeEach(() => {
@@ -22,6 +24,7 @@ describe("agent local JWT", () => {
     process.env[ttlEnv] = "3600";
     delete process.env[issuerEnv];
     delete process.env[audienceEnv];
+    delete process.env[deniedRunIdsEnv];
     vi.useFakeTimers();
   });
 
@@ -37,6 +40,8 @@ describe("agent local JWT", () => {
     else process.env[issuerEnv] = originalEnv.issuer;
     if (originalEnv.audience === undefined) delete process.env[audienceEnv];
     else process.env[audienceEnv] = originalEnv.audience;
+    if (originalEnv.deniedRunIds === undefined) delete process.env[deniedRunIdsEnv];
+    else process.env[deniedRunIdsEnv] = originalEnv.deniedRunIds;
   });
 
   it("creates and verifies a token", () => {
@@ -95,6 +100,43 @@ describe("agent local JWT", () => {
 
     process.env[issuerEnv] = "paperclip";
     process.env[audienceEnv] = "paperclip-api";
+    expect(verifyLocalAgentJwt(token!)).toBeNull();
+  });
+
+  it("rejects denied run ids while allowing other valid agent JWTs", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    process.env[deniedRunIdsEnv] = [
+      "576c63c1-6ddc-4daf-93b6-de30c3d34f32",
+      "c79d03a8-6929-499b-80fb-7b45ca48db5c",
+      "b42a052b-3ddc-4f2b-ba61-03bbe37f53f4",
+    ].join(",");
+
+    const deniedToken = createLocalAgentJwt(
+      "agent-1",
+      "company-1",
+      "codex_local",
+      "c79d03a8-6929-499b-80fb-7b45ca48db5c",
+    );
+    const allowedToken = createLocalAgentJwt(
+      "agent-1",
+      "company-1",
+      "codex_local",
+      "f1da3a6c-cfaa-4e66-9a6e-3e8277a3cf16",
+    );
+
+    expect(verifyLocalAgentJwt(deniedToken!)).toBeNull();
+    expect(verifyLocalAgentJwt(allowedToken!)).toMatchObject({
+      sub: "agent-1",
+      company_id: "company-1",
+      run_id: "f1da3a6c-cfaa-4e66-9a6e-3e8277a3cf16",
+    });
+  });
+
+  it("accepts a JSON-array denied run id setting", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    process.env[deniedRunIdsEnv] = JSON.stringify(["run-1"]);
+    const token = createLocalAgentJwt("agent-1", "company-1", "codex_local", "run-1");
+
     expect(verifyLocalAgentJwt(token!)).toBeNull();
   });
 });

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -18,6 +18,7 @@ export interface LocalAgentJwtClaims {
 }
 
 const JWT_ALGORITHM = "HS256";
+const DENIED_RUN_IDS_ENV = "PAPERCLIP_AGENT_JWT_DENIED_RUN_IDS";
 
 function parseNumber(value: string | undefined, fallback: number) {
   const parsed = Number(value);
@@ -63,6 +64,33 @@ function safeCompare(a: string, b: string) {
   const right = Buffer.from(b);
   if (left.length !== right.length) return false;
   return timingSafeEqual(left, right);
+}
+
+function parseDeniedRunIds(raw: string | undefined) {
+  const value = raw?.trim();
+  if (!value) return new Set<string>();
+
+  if (value.startsWith("[")) {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return new Set(
+          parsed
+            .filter((item): item is string => typeof item === "string")
+            .map((item) => item.trim())
+            .filter(Boolean),
+        );
+      }
+    } catch {
+      // Fall through to delimiter parsing for malformed values.
+    }
+  }
+
+  return new Set(value.split(/[\s,]+/).map((item) => item.trim()).filter(Boolean));
+}
+
+function isDeniedRunId(runId: string) {
+  return parseDeniedRunIds(process.env[DENIED_RUN_IDS_ENV]).has(runId);
 }
 
 export function createLocalAgentJwt(agentId: string, companyId: string, adapterType: string, runId: string) {
@@ -118,6 +146,7 @@ export function verifyLocalAgentJwt(token: string): LocalAgentJwtClaims | null {
   const iat = typeof claims.iat === "number" ? claims.iat : null;
   const exp = typeof claims.exp === "number" ? claims.exp : null;
   if (!sub || !companyId || !adapterType || !runId || !iat || !exp) return null;
+  if (isDeniedRunId(runId)) return null;
 
   const now = Math.floor(Date.now() / 1000);
   if (exp < now) return null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Local adapter runs authenticate back to the Paperclip API with run-scoped JWTs.
> - If an individual run token is exposed, rotating the shared signing secret invalidates every active run token, which is too broad for emergency containment.
> - The auth verifier already has the signed `run_id` claim before a request is accepted as an agent actor.
> - This pull request adds an operator-managed denied-run-id setting that rejects listed run JWTs during verification.
> - The benefit is a focused emergency revocation path that does not expose token values and does not require full signing-secret rotation for every incident.

## What Changed

- Added `PAPERCLIP_AGENT_JWT_DENIED_RUN_IDS` support in local agent JWT verification.
- Accept comma-separated, whitespace-separated, newline-separated, or JSON-array denied run ID values.
- Added tests proving a denied `run_id` is rejected while another valid local agent JWT still verifies.
- Documented the emergency add/remove operational path and restart/redeploy requirement in `doc/RUN-JWT-REVOCATION.md`.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-auth-jwt.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low risk: the denylist only applies when `PAPERCLIP_AGENT_JWT_DENIED_RUN_IDS` is set and only affects local agent JWT verification.
- Operators must restart or redeploy the Paperclip server after changing the runtime setting.
- This does not revoke board API keys or persistent agent API keys; it is intentionally scoped to run JWTs.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5.5, tool-enabled coding agent with terminal and git access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge