### PR TITLE
fix: close safe execution workspaces on issue completion

### DIFF
--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -68,6 +68,15 @@ Updatable fields: `title`, `description`, `status`, `priority`, `assigneeAgentId
 
 For `PATCH /api/issues/{issueId}`, `assigneeAgentId` may be either the agent UUID or the agent shortname/urlKey within the same company.
 
+When an issue first transitions to `done` and still has a linked execution workspace, the response now includes `executionWorkspaceCloseout` with the server-side closeout result:
+
+- `archived`: the workspace session was archived and cleanup succeeded
+- `cleanup_failed` or `error`: Paperclip archived the session record but cleanup work reported a failure
+- `blocked`: the issue was marked `done`, but Paperclip left the workspace open because cleanup was unsafe
+- `already_archived`: the linked workspace was already archived
+
+`executionWorkspaceCloseout.blockingReasons` explains blocked automatic closeouts such as dirty worktrees, unmerged branches, or shared sessions that are still linked to other open issues.
+
 ## Checkout (Claim Task)
 
 ```

--- a/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
+++ b/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
@@ -45,12 +45,18 @@ Issues are attached to execution workspace behavior, not to automatic runtime ma
 - An issue may reuse an existing execution workspace when you choose reuse.
 - Multiple issues may intentionally share one execution workspace so they can work against the same branch and running runtime services.
 - Assigning or running an issue does not automatically start or stop workspace services for that workspace.
+- When an issue first transitions to `done`, Paperclip now attempts an automatic execution-workspace closeout if the issue is still linked to one.
+- Automatic issue-completion closeout only archives disposable isolated workspaces when the close-readiness checks are already satisfied and the workspace is clean and merged.
+- Shared project-primary sessions are archived without deleting the underlying project checkout, and Paperclip skips the automatic closeout while other linked issues are still open.
 
 ## Execution workspace lifecycle
 
-Execution workspaces are durable until a human closes them.
+Execution workspaces are durable by default, but Paperclip now has a safe automatic closeout path on issue completion.
 
-- The UI can archive an execution workspace.
+- The UI can still archive an execution workspace manually.
+- Marking an issue `done` triggers a server-side closeout attempt for its linked execution workspace.
+- Automatic closeout reuses the same cleanup logic as manual archival, including runtime shutdown, teardown commands, cleanup commands, and artifact removal when allowed.
+- If automatic closeout is unsafe, Paperclip leaves the issue `done`, keeps the workspace available, and returns an explicit blocked or failed closeout result instead of deleting anything implicitly.
 - Closing an execution workspace stops its runtime services and cleans up its workspace artifacts when allowed.
 - Shared workspaces that point at the project primary checkout are treated more conservatively during cleanup than disposable isolated workspaces.
 

--- a/server/src/__tests__/execution-workspaces-routes.test.ts
+++ b/server/src/__tests__/execution-workspaces-routes.test.ts
@@ -18,6 +18,7 @@ const mockWorkspaceOperationService = vi.hoisted(() => ({
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockCloseExecutionWorkspace = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
   executionWorkspaceService: () => mockExecutionWorkspaceService,
@@ -25,7 +26,11 @@ vi.mock("../services/index.js", () => ({
   workspaceOperationService: () => mockWorkspaceOperationService,
 }));
 
-function createApp() {
+vi.mock("../services/execution-workspace-closeout.js", () => ({
+  closeExecutionWorkspace: mockCloseExecutionWorkspace,
+}));
+
+function createApp(db: any = {} as any) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -38,7 +43,7 @@ function createApp() {
     };
     next();
   });
-  app.use("/api", executionWorkspaceRoutes({} as any));
+  app.use("/api", executionWorkspaceRoutes(db));
   app.use(errorHandler);
   return app;
 }
@@ -78,5 +83,87 @@ describe.sequential("execution workspace routes", () => {
       reuseEligible: true,
     });
     expect(mockExecutionWorkspaceService.list).not.toHaveBeenCalled();
+  });
+
+  it("keeps shared project-primary archival in archived status when cleanup preserves the project workspace path", async () => {
+    const existingWorkspace = {
+      id: "workspace-1",
+      companyId: "company-1",
+      projectId: null,
+      projectWorkspaceId: null,
+      sourceIssueId: "issue-1",
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Shared primary session",
+      status: "active",
+      cwd: "/tmp/project-primary",
+      repoUrl: null,
+      baseRef: null,
+      branchName: null,
+      providerType: "local_fs",
+      providerRef: null,
+      derivedFromExecutionWorkspaceId: null,
+      lastUsedAt: new Date("2026-04-19T20:00:00.000Z"),
+      openedAt: new Date("2026-04-19T20:00:00.000Z"),
+      closedAt: null,
+      cleanupEligibleAt: null,
+      cleanupReason: null,
+      config: null,
+      metadata: {
+        source: "project_primary",
+      },
+      runtimeServices: [],
+      createdAt: new Date("2026-04-19T20:00:00.000Z"),
+      updatedAt: new Date("2026-04-19T20:00:00.000Z"),
+    };
+    const closedAt = new Date("2026-04-19T21:00:00.000Z");
+    const cleanupWarning = "Refusing to remove path \"/tmp/project-primary\" because it contains the project workspace.";
+    mockExecutionWorkspaceService.getById.mockResolvedValue(existingWorkspace);
+    mockCloseExecutionWorkspace.mockResolvedValue({
+      outcome: "archived",
+      workspace: {
+        ...existingWorkspace,
+        status: "archived",
+        closedAt,
+        cleanupReason: cleanupWarning,
+      },
+      closeReadiness: {
+        workspaceId: existingWorkspace.id,
+        state: "ready_with_warnings",
+        blockingReasons: [],
+        warnings: [
+          "This shared workspace session points at project workspace infrastructure. Archiving it only removes the session record.",
+        ],
+        linkedIssues: [],
+        plannedActions: [],
+        isDestructiveCloseAllowed: true,
+        isSharedWorkspace: true,
+        isProjectPrimaryWorkspace: true,
+        git: null,
+        runtimeServices: [],
+      },
+      cleanupWarnings: [cleanupWarning],
+      blockingReasons: [],
+      failureReason: null,
+    });
+
+    const db = {} as any;
+    const res = await request(createApp(db))
+      .patch(`/api/execution-workspaces/${existingWorkspace.id}`)
+      .send({ status: "archived" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      id: existingWorkspace.id,
+      status: "archived",
+      cleanupReason: cleanupWarning,
+    });
+    expect(mockCloseExecutionWorkspace).toHaveBeenCalledWith(db, {
+      executionWorkspaceId: existingWorkspace.id,
+      mode: "manual",
+      patch: expect.objectContaining({
+        status: "archived",
+      }),
+    });
   });
 });

--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import {
   companies,
   createDb,
@@ -13,6 +13,8 @@ import {
   issues,
   projectWorkspaces,
   projects,
+  workspaceRuntimeServices,
+  workspaceOperations,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -23,6 +25,7 @@ import {
   mergeExecutionWorkspaceConfig,
   readExecutionWorkspaceConfig,
 } from "../services/execution-workspaces.ts";
+import { closeExecutionWorkspace } from "../services/execution-workspace-closeout.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -157,6 +160,8 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
 
   afterEach(async () => {
     await db.delete(issues);
+    await db.delete(workspaceOperations);
+    await db.delete(workspaceRuntimeServices);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
     await db.delete(projects);
@@ -444,4 +449,386 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       "git_branch_delete",
     ]));
   }, 20_000);
+
+  it("auto-closes a merged clean git worktree when an issue is completed", async () => {
+    const repoRoot = await createTempRepo();
+    tempDirs.add(repoRoot);
+    const worktreePath = path.join(path.dirname(repoRoot), `paperclip-worktree-${randomUUID()}`);
+    tempDirs.add(worktreePath);
+    const branchName = "paperclip-close-merged";
+
+    await runGit(repoRoot, ["branch", branchName]);
+    await runGit(repoRoot, ["worktree", "add", worktreePath, branchName]);
+    await fs.writeFile(path.join(worktreePath, "feature.txt"), "close me\n", "utf8");
+    await runGit(worktreePath, ["add", "feature.txt"]);
+    await runGit(worktreePath, ["commit", "-m", "Feature commit"]);
+    await runGit(repoRoot, ["merge", "--no-ff", branchName, "-m", "Merge feature branch"]);
+
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspaces",
+      status: "in_progress",
+      executionWorkspacePolicy: {
+        enabled: true,
+        workspaceStrategy: {
+          type: "git_worktree",
+        },
+      },
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "git_repo",
+      isPrimary: true,
+      cwd: repoRoot,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      title: "Completed issue",
+      status: "done",
+      priority: "medium",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      sourceIssueId: issueId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Feature workspace",
+      status: "active",
+      providerType: "git_worktree",
+      cwd: worktreePath,
+      providerRef: worktreePath,
+      branchName,
+      baseRef: "main",
+      metadata: {
+        createdByRuntime: true,
+      },
+    });
+    await db.update(issues).set({ executionWorkspaceId }).where(eq(issues.id, issueId));
+
+    const result = await closeExecutionWorkspace(db, {
+      executionWorkspaceId,
+      mode: "issue_completion",
+    });
+
+    expect(result?.outcome).toBe("archived");
+    expect(result?.workspace.status).toBe("archived");
+    await expect(fs.stat(worktreePath)).rejects.toThrow();
+    await expect(
+      execFileAsync("git", ["branch", "--list", branchName], { cwd: repoRoot }),
+    ).resolves.toMatchObject({ stdout: "" });
+  }, 20_000);
+
+  it("retains a dirty or unmerged git worktree and reports a blocked closeout result on issue completion", async () => {
+    const repoRoot = await createTempRepo();
+    tempDirs.add(repoRoot);
+    const worktreePath = path.join(path.dirname(repoRoot), `paperclip-worktree-${randomUUID()}`);
+    tempDirs.add(worktreePath);
+    const branchName = "paperclip-close-blocked";
+
+    await runGit(repoRoot, ["branch", branchName]);
+    await runGit(repoRoot, ["worktree", "add", worktreePath, branchName]);
+    await fs.writeFile(path.join(worktreePath, "feature.txt"), "not merged\n", "utf8");
+    await runGit(worktreePath, ["add", "feature.txt"]);
+    await runGit(worktreePath, ["commit", "-m", "Unmerged feature commit"]);
+    await fs.writeFile(path.join(worktreePath, "untracked.txt"), "still dirty\n", "utf8");
+
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspaces",
+      status: "in_progress",
+      executionWorkspacePolicy: {
+        enabled: true,
+        workspaceStrategy: {
+          type: "git_worktree",
+        },
+      },
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "git_repo",
+      isPrimary: true,
+      cwd: repoRoot,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      title: "Completed issue",
+      status: "done",
+      priority: "medium",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      sourceIssueId: issueId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Feature workspace",
+      status: "active",
+      providerType: "git_worktree",
+      cwd: worktreePath,
+      providerRef: worktreePath,
+      branchName,
+      baseRef: "main",
+      metadata: {
+        createdByRuntime: true,
+      },
+    });
+    await db.update(issues).set({ executionWorkspaceId }).where(eq(issues.id, issueId));
+
+    const result = await closeExecutionWorkspace(db, {
+      executionWorkspaceId,
+      mode: "issue_completion",
+    });
+
+    expect(result?.outcome).toBe("blocked");
+    expect(result?.workspace.status).toBe("active");
+    expect(result?.blockingReasons).toEqual(expect.arrayContaining([
+      "Automatic issue-completion closeout skipped because this workspace is not merged into main.",
+      "Automatic issue-completion closeout requires a clean workspace; found 1 untracked file.",
+    ]));
+    await expect(fs.stat(worktreePath)).resolves.toBeDefined();
+  }, 20_000);
+
+  it("archives a shared project-primary session without deleting the project workspace path", async () => {
+    const projectWorkspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-shared-closeout-"));
+    tempDirs.add(projectWorkspaceRoot);
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspaces",
+      status: "in_progress",
+      executionWorkspacePolicy: {
+        enabled: true,
+      },
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      isPrimary: true,
+      cwd: projectWorkspaceRoot,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      title: "Completed issue",
+      status: "done",
+      priority: "medium",
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      sourceIssueId: issueId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Shared workspace",
+      status: "active",
+      providerType: "local_fs",
+      cwd: projectWorkspaceRoot,
+      metadata: {
+        source: "project_primary",
+      },
+    });
+    await db.update(issues).set({ executionWorkspaceId }).where(eq(issues.id, issueId));
+
+    const result = await closeExecutionWorkspace(db, {
+      executionWorkspaceId,
+      mode: "issue_completion",
+    });
+    const issueRow = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+
+    expect(result?.outcome).toBe("archived");
+    expect(result?.workspace.status).toBe("archived");
+    expect(issueRow?.executionWorkspaceId).toBeNull();
+    await expect(fs.stat(projectWorkspaceRoot)).resolves.toBeDefined();
+  });
+
+  it("shows inherited shared project runtime services on shared execution workspaces without duplicating old history", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const olderServiceId = randomUUID();
+    const currentServiceId = randomUUID();
+    const reuseKey = `project_workspace:${projectWorkspaceId}:paperclip-dev`;
+    const startedAt = new Date("2026-04-04T17:00:00.000Z");
+    const stoppedAt = new Date("2026-04-04T17:05:00.000Z");
+    const runningAt = new Date("2026-04-04T17:10:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspaces",
+      status: "in_progress",
+      executionWorkspacePolicy: {
+        enabled: true,
+      },
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      isPrimary: true,
+      cwd: "/tmp/paperclip-primary",
+      metadata: {
+        runtimeConfig: {
+          desiredState: "running",
+          workspaceRuntime: {
+            services: [{ name: "paperclip-dev", command: "pnpm dev" }],
+          },
+        },
+      },
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "Shared workspace",
+      status: "active",
+      providerType: "local_fs",
+      cwd: "/tmp/paperclip-primary",
+    });
+    await db.insert(workspaceRuntimeServices).values([
+      {
+        id: olderServiceId,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        executionWorkspaceId: null,
+        issueId: null,
+        scopeType: "project_workspace",
+        scopeId: projectWorkspaceId,
+        serviceName: "paperclip-dev",
+        status: "stopped",
+        lifecycle: "shared",
+        reuseKey,
+        command: "pnpm dev",
+        cwd: "/tmp/paperclip-primary",
+        port: 49195,
+        url: "http://127.0.0.1:49195",
+        provider: "local_process",
+        providerRef: "11111",
+        ownerAgentId: null,
+        startedByRunId: null,
+        lastUsedAt: stoppedAt,
+        startedAt,
+        stoppedAt,
+        stopPolicy: { type: "manual" },
+        healthStatus: "unknown",
+        createdAt: startedAt,
+        updatedAt: stoppedAt,
+      },
+      {
+        id: currentServiceId,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        executionWorkspaceId: null,
+        issueId: null,
+        scopeType: "project_workspace",
+        scopeId: projectWorkspaceId,
+        serviceName: "paperclip-dev",
+        status: "running",
+        lifecycle: "shared",
+        reuseKey,
+        command: "pnpm dev",
+        cwd: "/tmp/paperclip-primary",
+        port: 49222,
+        url: "http://127.0.0.1:49222",
+        provider: "local_process",
+        providerRef: "22222",
+        ownerAgentId: null,
+        startedByRunId: null,
+        lastUsedAt: runningAt,
+        startedAt: runningAt,
+        stoppedAt: null,
+        stopPolicy: { type: "manual" },
+        healthStatus: "healthy",
+        createdAt: runningAt,
+        updatedAt: runningAt,
+      },
+    ]);
+
+    const workspace = await svc.getById(executionWorkspaceId);
+    const listed = await svc.list(companyId, { projectId });
+
+    expect(workspace?.runtimeServices).toHaveLength(1);
+    expect(workspace?.runtimeServices?.[0]).toMatchObject({
+      id: currentServiceId,
+      status: "running",
+      projectWorkspaceId,
+      executionWorkspaceId: null,
+      url: "http://127.0.0.1:49222",
+    });
+    expect(listed[0]?.runtimeServices).toHaveLength(1);
+    expect(listed[0]?.runtimeServices?.[0]?.id).toBe(currentServiceId);
+  });
 });

--- a/server/src/__tests__/issue-workspace-closeout-routes.test.ts
+++ b/server/src/__tests__/issue-workspace-closeout-routes.test.ts
@@ -1,0 +1,309 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCloseExecutionWorkspace = vi.hoisted(() => vi.fn());
+const mockIssueService = vi.hoisted(() => ({
+  getAncestors: vi.fn(async () => []),
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(async () => null),
+  getComment: vi.fn(async () => null),
+  getCommentCursor: vi.fn(async () => ({
+    totalComments: 0,
+    latestCommentId: null,
+    latestCommentAt: null,
+  })),
+  getRelationSummaries: vi.fn(async () => ({ blockedBy: [], blocks: [] })),
+  update: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(async () => []),
+  getWakeableParentAfterChildCompletion: vi.fn(async () => null),
+  findMentionedAgents: vi.fn(async () => []),
+}));
+
+const mockExecutionWorkspaceService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+function registerMocks() {
+  vi.doMock("../services/execution-workspace-closeout.js", () => ({
+    closeExecutionWorkspace: mockCloseExecutionWorkspace,
+  }));
+  vi.doMock("../services/execution-workspaces.js", () => ({
+    executionWorkspaceService: () => mockExecutionWorkspaceService,
+  }));
+
+  vi.doMock("../services/index.js", () => ({
+    companyService: () => ({
+      getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+    }),
+    accessService: () => ({
+      canUser: vi.fn(),
+      hasPermission: vi.fn(),
+    }),
+    agentService: () => ({
+      getById: vi.fn(async () => null),
+    }),
+    documentService: () => ({
+      getIssueDocumentPayload: vi.fn(async () => ({})),
+    }),
+    executionWorkspaceService: () => mockExecutionWorkspaceService,
+    feedbackService: () => ({}),
+    goalService: () => ({
+      getById: vi.fn(async () => null),
+      getDefaultCompanyGoal: vi.fn(async () => null),
+    }),
+    heartbeatService: () => ({
+      wakeup: vi.fn(async () => undefined),
+      reportRunActivity: vi.fn(async () => undefined),
+    }),
+    instanceSettingsService: () => ({
+      get: vi.fn(),
+      listCompanyIds: vi.fn(),
+    }),
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      syncIssue: vi.fn(async () => undefined),
+      syncComment: vi.fn(async () => undefined),
+      listIssueReferenceSummary: vi.fn(async () => ({
+        outbound: [],
+        inbound: [],
+      })),
+      diffIssueReferenceSummary: vi.fn(() => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      })),
+    }),
+    issueService: () => mockIssueService,
+    issueThreadInteractionService: () => ({
+      expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+      expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+      listForIssue: vi.fn(async () => []),
+    }),
+    logActivity: vi.fn(async () => undefined),
+    projectService: () => ({
+      getById: vi.fn(async () => null),
+      listByIds: vi.fn(async () => []),
+    }),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({
+      listForIssue: vi.fn(async () => []),
+    }),
+  }));
+}
+
+async function createApp() {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "issue-1",
+    companyId: "company-1",
+    identifier: "PAP-1201",
+    title: "Close workspace on done",
+    description: null,
+    status: "in_progress",
+    priority: "medium",
+    parentId: null,
+    assigneeAgentId: "agent-1",
+    assigneeUserId: null,
+    createdByAgentId: null,
+    createdByUserId: "local-board",
+    executionWorkspaceId: "workspace-1",
+    labels: [],
+    labelIds: [],
+    ...overrides,
+  };
+}
+
+function makeWorkspace(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "workspace-1",
+    companyId: "company-1",
+    projectId: "project-1",
+    projectWorkspaceId: "project-workspace-1",
+    sourceIssueId: "issue-1",
+    mode: "isolated_workspace",
+    strategyType: "git_worktree",
+    name: "Feature workspace",
+    status: "active",
+    cwd: "/tmp/paperclip-worktree",
+    repoUrl: null,
+    baseRef: "main",
+    branchName: "pap-1201-close-workspace",
+    providerType: "git_worktree",
+    providerRef: "/tmp/paperclip-worktree",
+    derivedFromExecutionWorkspaceId: null,
+    lastUsedAt: new Date("2026-04-25T15:00:00.000Z"),
+    openedAt: new Date("2026-04-25T15:00:00.000Z"),
+    closedAt: null,
+    cleanupEligibleAt: null,
+    cleanupReason: null,
+    config: null,
+    metadata: null,
+    runtimeServices: [],
+    createdAt: new Date("2026-04-25T15:00:00.000Z"),
+    updatedAt: new Date("2026-04-25T15:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("issue workspace closeout routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/execution-workspace-closeout.js");
+    vi.doUnmock("../services/execution-workspaces.js");
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerMocks();
+    vi.resetAllMocks();
+  });
+
+  it("returns an explicit blocked closeout result when automatic issue completion cleanup is unsafe", async () => {
+    const existingIssue = makeIssue();
+    const completedIssue = makeIssue({ status: "done" });
+    const openWorkspace = makeWorkspace();
+
+    mockIssueService.getById.mockResolvedValue(existingIssue);
+    mockIssueService.update.mockResolvedValue(completedIssue);
+    mockExecutionWorkspaceService.getById.mockResolvedValue(openWorkspace);
+    mockCloseExecutionWorkspace.mockResolvedValue({
+      outcome: "blocked",
+      workspace: openWorkspace,
+      closeReadiness: {
+        workspaceId: openWorkspace.id,
+        state: "ready_with_warnings",
+        blockingReasons: [],
+        warnings: ["This workspace is 1 commit ahead of main and is not merged."],
+        linkedIssues: [],
+        plannedActions: [{ kind: "git_worktree_remove" }],
+        isDestructiveCloseAllowed: true,
+        isSharedWorkspace: false,
+        isProjectPrimaryWorkspace: false,
+        git: {
+          workspacePath: openWorkspace.cwd,
+          branchName: openWorkspace.branchName,
+          baseRef: "main",
+          hasDirtyTrackedFiles: false,
+          hasUntrackedFiles: true,
+          dirtyEntryCount: 0,
+          untrackedEntryCount: 1,
+          aheadCount: 1,
+          behindCount: 0,
+          isMergedIntoBase: false,
+          createdByRuntime: true,
+          repoRoot: "/tmp/paperclip",
+        },
+        runtimeServices: [],
+      },
+      cleanupWarnings: [],
+      blockingReasons: [
+        "Automatic issue-completion closeout skipped because this workspace is not merged into main.",
+      ],
+      failureReason: null,
+    });
+
+    const res = await request(await createApp())
+      .patch("/api/issues/issue-1")
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("done");
+    expect(res.body.executionWorkspaceId).toBe("workspace-1");
+    expect(res.body.executionWorkspaceCloseout).toMatchObject({
+      outcome: "blocked",
+      blockingReasons: [
+        "Automatic issue-completion closeout skipped because this workspace is not merged into main.",
+      ],
+    });
+    expect(mockCloseExecutionWorkspace).toHaveBeenCalledWith(expect.anything(), {
+      executionWorkspaceId: "workspace-1",
+      mode: "issue_completion",
+    });
+  });
+
+  it("refreshes the issue response after shared session closeout detaches the workspace id", async () => {
+    const existingIssue = makeIssue();
+    const completedIssue = makeIssue({ status: "done" });
+    const detachedIssue = makeIssue({ status: "done", executionWorkspaceId: null });
+    const openWorkspace = makeWorkspace({
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      providerType: "local_fs",
+      providerRef: null,
+      cwd: "/tmp/project-primary",
+      branchName: null,
+      baseRef: null,
+    });
+    const archivedWorkspace = {
+      ...openWorkspace,
+      status: "archived",
+      closedAt: new Date("2026-04-25T15:30:00.000Z"),
+    };
+
+    mockIssueService.getById
+      .mockResolvedValueOnce(existingIssue)
+      .mockResolvedValueOnce(detachedIssue);
+    mockIssueService.update.mockResolvedValue(completedIssue);
+    mockExecutionWorkspaceService.getById.mockResolvedValue(openWorkspace);
+    mockCloseExecutionWorkspace.mockResolvedValue({
+      outcome: "archived",
+      workspace: archivedWorkspace,
+      closeReadiness: {
+        workspaceId: archivedWorkspace.id,
+        state: "ready",
+        blockingReasons: [],
+        warnings: [],
+        linkedIssues: [],
+        plannedActions: [{ kind: "archive_record" }],
+        isDestructiveCloseAllowed: true,
+        isSharedWorkspace: true,
+        isProjectPrimaryWorkspace: true,
+        git: null,
+        runtimeServices: [],
+      },
+      cleanupWarnings: [],
+      blockingReasons: [],
+      failureReason: null,
+    });
+
+    const res = await request(await createApp())
+      .patch("/api/issues/issue-1")
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("done");
+    expect(res.body.executionWorkspaceId).toBeNull();
+    expect(res.body.executionWorkspaceCloseout).toMatchObject({
+      outcome: "archived",
+      workspace: {
+        id: "workspace-1",
+        status: "archived",
+      },
+    });
+    expect(mockIssueService.getById).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -1,7 +1,7 @@
 import { and, eq } from "drizzle-orm";
 import { Router, type Request, type Response } from "express";
 import type { Db } from "@paperclipai/db";
-import { issues, projects, projectWorkspaces } from "@paperclipai/db";
+import { projects, projectWorkspaces } from "@paperclipai/db";
 import {
   findWorkspaceCommandDefinition,
   matchWorkspaceRuntimeServiceToCommand,
@@ -11,12 +11,11 @@ import {
 import type { WorkspaceRuntimeDesiredState, WorkspaceRuntimeServiceStateMap } from "@paperclipai/shared";
 import { validate } from "../middleware/validate.js";
 import { executionWorkspaceService, logActivity, workspaceOperationService } from "../services/index.js";
-import { mergeExecutionWorkspaceConfig, readExecutionWorkspaceConfig } from "../services/execution-workspaces.js";
+import { mergeExecutionWorkspaceConfig } from "../services/execution-workspaces.js";
 import { parseProjectExecutionWorkspacePolicy } from "../services/execution-workspace-policy.js";
 import { readProjectWorkspaceRuntimeConfig } from "../services/project-workspace-runtime-config.js";
 import {
   buildWorkspaceRuntimeDesiredStatePatch,
-  cleanupExecutionWorkspaceArtifacts,
   ensurePersistedExecutionWorkspaceAvailable,
   listConfiguredRuntimeServiceEntries,
   runWorkspaceJobForControl,
@@ -30,8 +29,8 @@ import {
 } from "./workspace-command-authz.js";
 import { assertCanManageExecutionWorkspaceRuntimeServices } from "./workspace-runtime-service-authz.js";
 import { appendWithCap } from "../adapters/utils.js";
-
 const WORKSPACE_CONTROL_OUTPUT_MAX_CHARS = 256 * 1024;
+import { closeExecutionWorkspace } from "../services/execution-workspace-closeout.js";
 
 export function executionWorkspaceRoutes(db: Db) {
   const router = Router();
@@ -476,114 +475,29 @@ export function executionWorkspaceRoutes(db: Db) {
     }
     let workspace = existing;
     let cleanupWarnings: string[] = [];
-    const configForCleanup = readExecutionWorkspaceConfig(
-      ((patch.metadata as Record<string, unknown> | null | undefined) ?? (existing.metadata as Record<string, unknown> | null)) ?? null,
-    );
 
     if (req.body.status === "archived" && existing.status !== "archived") {
-      const readiness = await svc.getCloseReadiness(existing.id);
-      if (!readiness) {
-        res.status(404).json({ error: "Execution workspace not found" });
-        return;
-      }
-
-      if (readiness.state === "blocked") {
-        res.status(409).json({
-          error: readiness.blockingReasons[0] ?? "Execution workspace cannot be closed right now",
-          closeReadiness: readiness,
-        });
-        return;
-      }
-
-      const closedAt = new Date();
-      const archivedWorkspace = await svc.update(id, {
-        ...patch,
-        status: "archived",
-        closedAt,
-        cleanupReason: null,
+      const closeResult = await closeExecutionWorkspace(db, {
+        executionWorkspaceId: existing.id,
+        mode: "manual",
+        patch,
       });
-      if (!archivedWorkspace) {
+      if (!closeResult) {
         res.status(404).json({ error: "Execution workspace not found" });
         return;
       }
-      workspace = archivedWorkspace;
-
-      if (existing.mode === "shared_workspace") {
-        await db
-          .update(issues)
-          .set({
-            executionWorkspaceId: null,
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(issues.companyId, existing.companyId),
-              eq(issues.executionWorkspaceId, existing.id),
-            ),
-          );
+      cleanupWarnings = closeResult.cleanupWarnings;
+      workspace = closeResult.workspace;
+      if (closeResult.outcome === "blocked") {
+        res.status(409).json({
+          error: closeResult.blockingReasons[0] ?? "Execution workspace cannot be closed right now",
+          closeReadiness: closeResult.closeReadiness,
+        });
+        return;
       }
-
-      try {
-        await stopRuntimeServicesForExecutionWorkspace({
-          db,
-          executionWorkspaceId: existing.id,
-          workspaceCwd: existing.cwd,
-        });
-        const projectWorkspace = existing.projectWorkspaceId
-          ? await db
-              .select({
-                cwd: projectWorkspaces.cwd,
-                cleanupCommand: projectWorkspaces.cleanupCommand,
-              })
-              .from(projectWorkspaces)
-            .where(
-                and(
-                  eq(projectWorkspaces.id, existing.projectWorkspaceId),
-                  eq(projectWorkspaces.companyId, existing.companyId),
-                ),
-              )
-              .then((rows) => rows[0] ?? null)
-          : null;
-        const projectPolicy = existing.projectId
-          ? await db
-              .select({
-                executionWorkspacePolicy: projects.executionWorkspacePolicy,
-              })
-              .from(projects)
-              .where(and(eq(projects.id, existing.projectId), eq(projects.companyId, existing.companyId)))
-              .then((rows) => parseProjectExecutionWorkspacePolicy(rows[0]?.executionWorkspacePolicy))
-          : null;
-        const cleanupResult = await cleanupExecutionWorkspaceArtifacts({
-          workspace: existing,
-          projectWorkspace,
-          teardownCommand: configForCleanup?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null,
-          cleanupCommand: configForCleanup?.cleanupCommand ?? null,
-          recorder: workspaceOperationsSvc.createRecorder({
-            companyId: existing.companyId,
-            executionWorkspaceId: existing.id,
-          }),
-        });
-        cleanupWarnings = cleanupResult.warnings;
-        const cleanupPatch: Record<string, unknown> = {
-          closedAt,
-          cleanupReason: cleanupWarnings.length > 0 ? cleanupWarnings.join(" | ") : null,
-        };
-        if (!cleanupResult.cleaned) {
-          cleanupPatch.status = "cleanup_failed";
-        }
-        if (cleanupResult.warnings.length > 0 || !cleanupResult.cleaned) {
-          workspace = (await svc.update(id, cleanupPatch)) ?? workspace;
-        }
-      } catch (error) {
-        const failureReason = error instanceof Error ? error.message : String(error);
-        workspace =
-          (await svc.update(id, {
-            status: "cleanup_failed",
-            closedAt,
-            cleanupReason: failureReason,
-          })) ?? workspace;
+      if (closeResult.outcome === "error") {
         res.status(500).json({
-          error: `Failed to archive execution workspace: ${failureReason}`,
+          error: `Failed to archive execution workspace: ${closeResult.failureReason ?? "Unknown cleanup error"}`,
         });
         return;
       }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -99,6 +99,7 @@ import {
 } from "../services/issue-execution-policy.js";
 import { parseIssueExecutionWorkspaceSettings } from "../services/execution-workspace-policy.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { closeExecutionWorkspace } from "../services/execution-workspace-closeout.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -2733,7 +2734,7 @@ export function issueRoutes(
       }
     }
 
-    let issue;
+    let issue: typeof existing | null = null;
     try {
       if (transition.decision && decisionId) {
         const decision = transition.decision;
@@ -2849,14 +2850,76 @@ export function issueRoutes(
       referencedIssueIdentifiers?: string[];
     } = issue;
     let updatedRelations: Awaited<ReturnType<typeof svc.getRelationSummaries>> | null = null;
-    if (issue && Array.isArray(req.body.blockedByIssueIds)) {
+    const withUpdatedRelations = (currentIssue: typeof existing) =>
+      updatedRelations
+        ? {
+            ...currentIssue,
+            blockedBy: updatedRelations.blockedBy,
+            blocks: updatedRelations.blocks,
+          }
+        : currentIssue;
+
+    if (Array.isArray(req.body.blockedByIssueIds)) {
       updatedRelations = await svc.getRelationSummaries(issue.id);
-      issueResponse = {
-        ...issue,
-        blockedBy: updatedRelations.blockedBy,
-        blocks: updatedRelations.blocks,
-      };
     }
+    issueResponse = withUpdatedRelations(issue);
+    let executionWorkspaceCloseout:
+      | {
+          outcome: string;
+          workspace: ExecutionWorkspace;
+          closeReadiness: unknown;
+          cleanupWarnings: string[];
+          blockingReasons: string[];
+          failureReason: string | null;
+        }
+      | null = null;
+
+    const becameDone = existing.status !== "done" && issue.status === "done";
+    if (becameDone && issue.executionWorkspaceId) {
+      const closeResult = await closeExecutionWorkspace(db, {
+        executionWorkspaceId: issue.executionWorkspaceId,
+        mode: "issue_completion",
+      });
+      if (closeResult) {
+        executionWorkspaceCloseout = {
+          outcome: closeResult.outcome,
+          workspace: closeResult.workspace,
+          closeReadiness: closeResult.closeReadiness,
+          cleanupWarnings: closeResult.cleanupWarnings,
+          blockingReasons: closeResult.blockingReasons,
+          failureReason: closeResult.failureReason,
+        };
+
+        await logActivity(db, {
+          companyId: issue.companyId,
+          actorType: actor.actorType,
+          actorId: actor.actorId,
+          agentId: actor.agentId,
+          runId: actor.runId,
+          action: closeResult.outcome === "blocked" ? "execution_workspace.closeout_blocked" : "execution_workspace.updated",
+          entityType: "execution_workspace",
+          entityId: closeResult.workspace.id,
+          details: {
+            issueId: issue.id,
+            identifier: issue.identifier,
+            source: "issue.done.auto_close",
+            outcome: closeResult.outcome,
+            cleanupWarnings: closeResult.cleanupWarnings,
+            blockingReasons: closeResult.blockingReasons,
+            failureReason: closeResult.failureReason,
+          },
+        });
+
+        if (closeResult.outcome !== "blocked" && closeResult.outcome !== "already_archived") {
+          const refreshedIssue = await svc.getById(issue.id);
+          if (refreshedIssue) {
+            issue = refreshedIssue;
+            issueResponse = withUpdatedRelations(issue);
+          }
+        }
+      }
+    }
+
     await routinesSvc.syncRunStatusForIssue(issue.id);
 
     if (actor.runId) {
@@ -3321,7 +3384,6 @@ export function issueRoutes(
         }
       }
 
-      const becameDone = existing.status !== "done" && issue.status === "done";
       if (becameDone) {
         const dependents = await svc.listWakeableBlockedDependents(issue.id);
         for (const dependent of dependents) {
@@ -3387,7 +3449,7 @@ export function issueRoutes(
       }
     })();
 
-    res.json({ ...issueResponse, comment });
+    res.json({ ...issueResponse, comment, executionWorkspaceCloseout });
   });
 
   router.delete("/issues/:id", async (req, res) => {

--- a/server/src/services/execution-workspace-closeout.ts
+++ b/server/src/services/execution-workspace-closeout.ts
@@ -1,0 +1,225 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { executionWorkspaces, issues, projectWorkspaces, projects } from "@paperclipai/db";
+import type { ExecutionWorkspace, ExecutionWorkspaceCloseReadiness } from "@paperclipai/shared";
+import { parseProjectExecutionWorkspacePolicy } from "./execution-workspace-policy.js";
+import { executionWorkspaceService, readExecutionWorkspaceConfig } from "./execution-workspaces.js";
+import { workspaceOperationService } from "./workspace-operations.js";
+import { cleanupExecutionWorkspaceArtifacts, stopRuntimeServicesForExecutionWorkspace } from "./workspace-runtime.js";
+
+export type ExecutionWorkspaceCloseMode = "manual" | "issue_completion";
+
+export type ExecutionWorkspaceCloseResult = {
+  outcome: "archived" | "cleanup_failed" | "blocked" | "error" | "already_archived";
+  workspace: ExecutionWorkspace;
+  closeReadiness: ExecutionWorkspaceCloseReadiness | null;
+  cleanupWarnings: string[];
+  blockingReasons: string[];
+  failureReason: string | null;
+};
+
+function linkedOpenIssues(readiness: ExecutionWorkspaceCloseReadiness) {
+  return (readiness.linkedIssues ?? []).filter((issue) => issue.isTerminal === false);
+}
+
+function gitDirtyMessage(label: "tracked" | "untracked", count: number) {
+  const fileLabel =
+    count === 1
+      ? label === "tracked" ? "modified tracked file" : "untracked file"
+      : label === "tracked" ? "modified tracked files" : "untracked files";
+  return `Automatic issue-completion closeout requires a clean workspace; found ${count} ${fileLabel}.`;
+}
+
+function autoCloseBlockingReasons(readiness: ExecutionWorkspaceCloseReadiness): string[] {
+  const reasons: string[] = [];
+  const plannedActionKinds = new Set((readiness.plannedActions ?? []).map((action) => action.kind));
+  const hasDestructiveWorkspaceRemoval =
+    plannedActionKinds.has("git_worktree_remove") || plannedActionKinds.has("remove_local_directory");
+
+  if (readiness.isSharedWorkspace && linkedOpenIssues(readiness).length > 0) {
+    reasons.push("Automatic issue-completion closeout skipped because this shared workspace session is still linked to open issues.");
+  }
+
+  if (!hasDestructiveWorkspaceRemoval || !readiness.git) {
+    return reasons;
+  }
+
+  if (readiness.git.hasDirtyTrackedFiles) {
+    reasons.push(gitDirtyMessage("tracked", readiness.git.dirtyEntryCount));
+  }
+  if (readiness.git.hasUntrackedFiles) {
+    reasons.push(gitDirtyMessage("untracked", readiness.git.untrackedEntryCount));
+  }
+
+  if (plannedActionKinds.has("git_worktree_remove")) {
+    if (readiness.git.isMergedIntoBase === false) {
+      reasons.push(
+        `Automatic issue-completion closeout skipped because this workspace is not merged into ${readiness.git.baseRef ?? "its base ref"}.`,
+      );
+    } else if (readiness.git.isMergedIntoBase !== true) {
+      reasons.push(
+        `Automatic issue-completion closeout skipped because Paperclip could not confirm this workspace is merged into ${readiness.git.baseRef ?? "its base ref"}.`,
+      );
+    }
+  }
+
+  return reasons;
+}
+
+export async function closeExecutionWorkspace(
+  db: Db,
+  input: {
+    executionWorkspaceId: string;
+    mode?: ExecutionWorkspaceCloseMode;
+    patch?: Partial<typeof executionWorkspaces.$inferInsert>;
+  },
+): Promise<ExecutionWorkspaceCloseResult | null> {
+  const svc = executionWorkspaceService(db);
+  const workspaceOperationsSvc = workspaceOperationService(db);
+  const mode = input.mode ?? "manual";
+
+  const existing = await svc.getById(input.executionWorkspaceId);
+  if (!existing) return null;
+
+  if (existing.status === "archived") {
+    return {
+      outcome: "already_archived",
+      workspace: existing,
+      closeReadiness: null,
+      cleanupWarnings: [],
+      blockingReasons: [],
+      failureReason: null,
+    };
+  }
+
+  const readiness = await svc.getCloseReadiness(existing.id);
+  if (!readiness) return null;
+  const effectiveConfig = input.patch?.metadata !== undefined
+    ? readExecutionWorkspaceConfig((input.patch.metadata as Record<string, unknown> | null | undefined) ?? null)
+    : existing.config;
+
+  const blockingReasons = [
+    ...(readiness.state === "blocked" ? readiness.blockingReasons : []),
+    ...(mode === "issue_completion" ? autoCloseBlockingReasons(readiness) : []),
+  ];
+  if (blockingReasons.length > 0) {
+    return {
+      outcome: "blocked",
+      workspace: existing,
+      closeReadiness: readiness,
+      cleanupWarnings: [],
+      blockingReasons,
+      failureReason: null,
+    };
+  }
+
+  const closedAt = new Date();
+  let workspace =
+    (await svc.update(existing.id, {
+      ...(input.patch ?? {}),
+      status: "archived",
+      closedAt,
+      cleanupReason: null,
+    })) ?? existing;
+
+  if (existing.mode === "shared_workspace") {
+    await db
+      .update(issues)
+      .set({
+        executionWorkspaceId: null,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(issues.companyId, existing.companyId),
+          eq(issues.executionWorkspaceId, existing.id),
+        ),
+      );
+  }
+
+  try {
+    await stopRuntimeServicesForExecutionWorkspace({
+      db,
+      executionWorkspaceId: existing.id,
+      workspaceCwd: existing.cwd,
+    });
+
+    const projectWorkspace = existing.projectWorkspaceId
+      ? await db
+          .select({
+            cwd: projectWorkspaces.cwd,
+            cleanupCommand: projectWorkspaces.cleanupCommand,
+          })
+          .from(projectWorkspaces)
+          .where(
+            and(
+              eq(projectWorkspaces.id, existing.projectWorkspaceId),
+              eq(projectWorkspaces.companyId, existing.companyId),
+            ),
+          )
+          .then((rows) => rows[0] ?? null)
+      : null;
+
+    const projectPolicy = existing.projectId
+      ? await db
+          .select({
+            executionWorkspacePolicy: projects.executionWorkspacePolicy,
+          })
+          .from(projects)
+          .where(and(eq(projects.id, existing.projectId), eq(projects.companyId, existing.companyId)))
+          .then((rows) => parseProjectExecutionWorkspacePolicy(rows[0]?.executionWorkspacePolicy))
+      : null;
+
+    const cleanupResult = await cleanupExecutionWorkspaceArtifacts({
+      workspace: existing,
+      projectWorkspace,
+      teardownCommand: effectiveConfig?.teardownCommand ?? projectPolicy?.workspaceStrategy?.teardownCommand ?? null,
+      cleanupCommand: effectiveConfig?.cleanupCommand ?? null,
+      recorder: workspaceOperationsSvc.createRecorder({
+        companyId: existing.companyId,
+        executionWorkspaceId: existing.id,
+      }),
+    });
+
+    const cleanupWarnings = cleanupResult.warnings;
+    const preserveProjectPrimaryWorkspace =
+      readiness.isSharedWorkspace &&
+      readiness.isProjectPrimaryWorkspace &&
+      existing.providerType === "local_fs";
+
+    if (cleanupWarnings.length > 0 || (!cleanupResult.cleaned && !preserveProjectPrimaryWorkspace)) {
+      workspace =
+        (await svc.update(existing.id, {
+          closedAt,
+          cleanupReason: cleanupWarnings.length > 0 ? cleanupWarnings.join(" | ") : null,
+          ...(!cleanupResult.cleaned && !preserveProjectPrimaryWorkspace ? { status: "cleanup_failed" as const } : {}),
+        })) ?? workspace;
+    }
+
+    return {
+      outcome: workspace.status === "cleanup_failed" ? "cleanup_failed" : "archived",
+      workspace,
+      closeReadiness: readiness,
+      cleanupWarnings,
+      blockingReasons: [],
+      failureReason: null,
+    };
+  } catch (error) {
+    const failureReason = error instanceof Error ? error.message : String(error);
+    workspace =
+      (await svc.update(existing.id, {
+        status: "cleanup_failed",
+        closedAt,
+        cleanupReason: failureReason,
+      })) ?? workspace;
+
+    return {
+      outcome: "error",
+      workspace,
+      closeReadiness: readiness,
+      cleanupWarnings: [],
+      blockingReasons: [],
+      failureReason,
+    };
+  }
+}


### PR DESCRIPTION
Canonical landing candidate for Paperclip issue MTT-706 / MTT-702.\n\nThis branch refreshes the previously reviewed closeout hook onto current origin/master.\n\nLanded candidate SHA: a09502eab6375b389b6418942d52b67982bf7e38\nSource handoff SHA: ee049ea4c10d4eb0fed47e685609583add8d2253\n\nVerification run from /Users/michaelettlinger/pp_old/.worktrees/mtt706-land:\n- pnpm install --frozen-lockfile\n- pnpm run preflight:workspace-links\n- pnpm exec vitest run server/src/__tests__/issue-workspace-closeout-routes.test.ts server/src/__tests__/execution-workspaces-routes.test.ts server/src/__tests__/execution-workspaces-service.test.ts (3 files, 15 tests passed)\n- pnpm --filter @paperclipai/server typecheck\n\nAttempted direct pushes to paperclipai/paperclip master over HTTPS and SSH both failed for etticat with permission denied, so this PR is the maintainer merge path.