### PR TITLE
fix: dedupe blocked-heartbeat relay churn

### DIFF
--- a/server/src/__tests__/issue-comment-churn-routes.test.ts
+++ b/server/src/__tests__/issue-comment-churn-routes.test.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agentWakeupRequests,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue comment churn route tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+describeEmbeddedPostgres("issue comment churn routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-comment-churn-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(agentWakeupRequests);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(actor: Express.Request["actor"]) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = actor;
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedIssue() {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const ownerAgentId = randomUUID();
+    const ownerRunIds = [randomUUID(), randomUUID(), randomUUID(), randomUUID()];
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: ownerAgentId,
+        companyId,
+        name: "OwnerAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values(
+      ownerRunIds.map((runId) => ({
+        id: runId,
+        companyId,
+        agentId: ownerAgentId,
+        status: "running",
+        invocationSource: "manual",
+        startedAt: new Date(),
+      })),
+    );
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Comment churn route issue",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: null,
+    });
+
+    return { companyId, issueId, ownerAgentId, ownerRunIds };
+  }
+
+  function agentActor(companyId: string, agentId: string, runId: string): Express.Request["actor"] {
+    return {
+      type: "agent",
+      agentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    };
+  }
+
+  function boardActor(companyId: string, userId: string): Express.Request["actor"] {
+    return {
+      type: "board",
+      userId,
+      companyIds: [companyId],
+      memberships: [{ companyId, membershipRole: "admin", status: "active" }],
+      isInstanceAdmin: false,
+      source: "session",
+    };
+  }
+
+  it("rejects the fourth rapid same-agent comment even when run ids change", async () => {
+    const { companyId, issueId, ownerAgentId, ownerRunIds } = await seedIssue();
+
+    for (let index = 0; index < 3; index += 1) {
+      const res = await request(
+        createApp(agentActor(companyId, ownerAgentId, ownerRunIds[index])),
+      )
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: `comment ${index + 1}` });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(201);
+    }
+
+    const fourth = await request(createApp(agentActor(companyId, ownerAgentId, ownerRunIds[3])))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "comment 4" });
+
+    expect(fourth.status, JSON.stringify(fourth.body)).toBe(409);
+    expect(fourth.body.error).toContain("Issue comment churn guardrail triggered");
+  });
+
+  it("allows a different actor to comment during the same churn window", async () => {
+    const { companyId, issueId, ownerAgentId, ownerRunIds } = await seedIssue();
+
+    for (let index = 0; index < 3; index += 1) {
+      const res = await request(
+        createApp(agentActor(companyId, ownerAgentId, ownerRunIds[index])),
+      )
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: `comment ${index + 1}` });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(201);
+    }
+
+    const peer = await request(createApp(boardActor(companyId, "board-user-2")))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "allowed from different actor" });
+
+    expect(peer.status, JSON.stringify(peer.body)).toBe(201);
+    expect(peer.body.body).toBe("allowed from different actor");
+  });
+});

--- a/server/src/__tests__/issue-tree-control-service.test.ts
+++ b/server/src/__tests__/issue-tree-control-service.test.ts
@@ -215,6 +215,64 @@ describeEmbeddedPostgres("issueTreeControlService", () => {
     expect(released.members).toHaveLength(1);
   });
 
+  it("normalizes hold members when stale-run cleanup nulls activeRunId", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const rootIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Runner",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "running",
+      contextSnapshot: { issueId: rootIssueId },
+    });
+    await db.insert(issues).values({
+      id: rootIssueId,
+      companyId,
+      title: "Root",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+    });
+
+    const svc = issueTreeControlService(db);
+    const created = await svc.createHold(companyId, rootIssueId, {
+      mode: "pause",
+      actor: { actorType: "system", actorId: "system" },
+    });
+
+    await db.delete(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+
+    const hold = await svc.getHold(companyId, created.hold.id);
+    expect(hold).not.toBeNull();
+    expect(hold?.members).toHaveLength(1);
+    expect(hold?.members?.[0]).toMatchObject({
+      activeRunId: null,
+      activeRunStatus: null,
+    });
+  });
+
   it("cancels non-terminal issue statuses and restores from the cancel snapshot", async () => {
     const companyId = randomUUID();
     const rootIssueId = randomUUID();

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -120,6 +120,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     count: number;
     now: Date;
     withRunComments?: boolean;
+    resultJson?: Record<string, unknown>;
   }) {
     const runs: Array<typeof heartbeatRuns.$inferInsert> = [];
     for (let index = 0; index < input.count; index += 1) {
@@ -135,6 +136,7 @@ describeEmbeddedPostgres("productivity review service", () => {
         startedAt: createdAt,
         finishedAt: new Date(createdAt.getTime() + 30_000),
         contextSnapshot: { issueId: input.issueId, taskId: input.issueId },
+        resultJson: input.resultJson ?? null,
         livenessState: "advanced",
         nextAction: "Continue processing the next batch.",
         createdAt,
@@ -406,6 +408,77 @@ describeEmbeddedPostgres("productivity review service", () => {
         authorAgentId: seeded.managerId,
         createdByRunId: run.id,
         body: `Manager note ${index}`,
+        createdAt: run.createdAt as Date,
+        updatedAt: run.createdAt as Date,
+      })),
+    );
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("excludes deduplicated blocked-relay runs and comments from high-churn thresholds", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    const runs = await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 10,
+      now,
+      resultJson: { blockedRelayCommentDeduped: true },
+    });
+    await db.insert(issueComments).values(
+      runs.map((run, index) => ({
+        companyId: seeded.companyId,
+        issueId: seeded.issueId,
+        authorAgentId: seeded.coderId,
+        createdByRunId: run.id,
+        body: `Blocked relay ${index}`,
+        createdAt: run.createdAt as Date,
+        updatedAt: run.createdAt as Date,
+      })),
+    );
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("does not let deduplicated runs push high-churn counts over threshold", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    const countedRuns = await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 9,
+      now,
+    });
+    const dedupedRuns = await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 1,
+      now,
+      resultJson: { blockedRelayCommentDeduped: true },
+    });
+    await db.insert(issueComments).values(
+      [...countedRuns, ...dedupedRuns].map((run, index) => ({
+        companyId: seeded.companyId,
+        issueId: seeded.issueId,
+        authorAgentId: seeded.coderId,
+        createdByRunId: run.id,
+        body: `Mixed churn ${index}`,
         createdAt: run.createdAt as Date,
         updatedAt: run.createdAt as Date,
       })),

--- a/server/src/services/issue-tree-control.ts
+++ b/server/src/services/issue-tree-control.ts
@@ -275,6 +275,8 @@ function toHold(row: HoldRow, members?: HoldMemberRow[]): IssueTreeHold {
 }
 
 function toHoldMember(row: HoldMemberRow): IssueTreeHoldMember {
+  const activeRunId = row.activeRunId;
+  const activeRunStatus = activeRunId ? row.activeRunStatus : null;
   return {
     id: row.id,
     companyId: row.companyId,
@@ -287,8 +289,8 @@ function toHoldMember(row: HoldMemberRow): IssueTreeHoldMember {
     issueStatus: coerceIssueStatus(row.issueStatus),
     assigneeAgentId: row.assigneeAgentId,
     assigneeUserId: row.assigneeUserId,
-    activeRunId: row.activeRunId,
-    activeRunStatus: row.activeRunStatus,
+    activeRunId,
+    activeRunStatus,
     skipped: row.skipped,
     skipReason: row.skipReason,
     createdAt: row.createdAt,

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -100,6 +100,10 @@ function issueRunScopeSql(issueId: string) {
   )`;
 }
 
+function includeInChurnSql() {
+  return sql`coalesce(${heartbeatRuns.resultJson} ->> 'blockedRelayCommentDeduped', 'false') != 'true'`;
+}
+
 function msToHuman(ms: number | null) {
   if (ms === null) return "unknown";
   const minutes = Math.floor(ms / 60_000);
@@ -351,6 +355,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           eq(heartbeatRuns.companyId, companyId),
           eq(heartbeatRuns.agentId, agentId),
           issueRunScopeSql(issueId),
+          includeInChurnSql(),
           sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) >= ${since.toISOString()}::timestamptz`,
         ),
       )
@@ -370,6 +375,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           eq(heartbeatRuns.companyId, companyId),
           eq(heartbeatRuns.agentId, agentId),
           issueRunScopeSql(issueId),
+          includeInChurnSql(),
           since ? sql`${issueComments.createdAt} >= ${since.toISOString()}::timestamptz` : undefined,
         ),
       )
@@ -393,6 +399,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           eq(heartbeatRuns.companyId, sourceIssue.companyId),
           eq(heartbeatRuns.agentId, sourceAgent.id),
           issueRunScopeSql(sourceIssue.id),
+          includeInChurnSql(),
         ),
       )
       .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))


### PR DESCRIPTION
## Summary
- normalize stale run fields before blocked-heartbeat hold-member comparisons so unchanged blocker state dedups correctly
- exclude deduplicated blocker-relay heartbeats from productivity churn counting
- add regression coverage for blocker-relay churn and route-level proofs

## Testing
- implementation branch includes regression tests in `server/src/__tests__/issue-comment-churn-routes.test.ts`
- implementation branch includes service coverage in `server/src/__tests__/issue-tree-control-service.test.ts`
- implementation branch includes productivity review coverage in `server/src/__tests__/productivity-review-service.test.ts`

## Context
- MIL-1071
- MIL-1433 publication relay
