### PR TITLE
feat(api): expose authorUser.name on issue comments

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5,6 +5,7 @@ import { sql } from "drizzle-orm";
 import {
   activityLog,
   agents,
+  authUsers,
   companies,
   createDb,
   environments,
@@ -83,6 +84,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(projects);
     await db.delete(goals);
     await db.delete(agents);
+    await db.delete(authUsers);
     await db.delete(instanceSettings);
     await db.delete(companies);
   });
@@ -1212,6 +1214,107 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
 
     expect(result?.description).toHaveLength(1200);
     expect(result?.description?.endsWith("—")).toBe(true);
+  });
+
+  it("attaches authorUser { id, name } on listComments and getComment for human comments", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const userId = `user-${randomUUID()}`;
+    const userCommentId = randomUUID();
+    const agentCommentId = randomUUID();
+    const now = new Date();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(authUsers).values({
+      id: userId,
+      name: "King",
+      email: `${userId}@example.com`,
+      emailVerified: true,
+      image: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Issue with mixed-author comments",
+      status: "todo",
+      priority: "medium",
+    });
+    await db.insert(issueComments).values([
+      {
+        id: userCommentId,
+        companyId,
+        issueId,
+        authorUserId: userId,
+        authorType: "user",
+        body: "Comment from human.",
+        createdAt: new Date("2026-05-10T09:00:00.000Z"),
+        updatedAt: new Date("2026-05-10T09:00:00.000Z"),
+      },
+      {
+        id: agentCommentId,
+        companyId,
+        issueId,
+        authorAgentId: null,
+        authorType: "system",
+        body: "Comment with no author.",
+        createdAt: new Date("2026-05-10T09:01:00.000Z"),
+        updatedAt: new Date("2026-05-10T09:01:00.000Z"),
+      },
+    ]);
+
+    const listed = await svc.listComments(issueId, { order: "asc", limit: 50 });
+    const userListed = listed.find((c) => c.id === userCommentId);
+    const systemListed = listed.find((c) => c.id === agentCommentId);
+    expect(userListed?.authorUser).toEqual({ id: userId, name: "King" });
+    expect(systemListed?.authorUser).toBeNull();
+
+    const got = await svc.getComment(userCommentId);
+    expect(got?.authorUser).toEqual({ id: userId, name: "King" });
+
+    const gotSystem = await svc.getComment(agentCommentId);
+    expect(gotSystem?.authorUser).toBeNull();
+  });
+
+  it("returns authorUser with null name when the auth user row is missing", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const orphanedUserId = `user-${randomUUID()}`;
+    const commentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Issue with orphaned user comment",
+      status: "todo",
+      priority: "medium",
+    });
+    await db.insert(issueComments).values({
+      id: commentId,
+      companyId,
+      issueId,
+      authorUserId: orphanedUserId,
+      authorType: "user",
+      body: "Comment from a user that has been deleted.",
+    });
+
+    const [listed] = await svc.listComments(issueId, { order: "asc", limit: 50 });
+    expect(listed.authorUser).toEqual({ id: orphanedUserId, name: null });
+
+    const got = await svc.getComment(commentId);
+    expect(got?.authorUser).toEqual({ id: orphanedUserId, name: null });
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -27,6 +27,7 @@ import {
   agentWakeupRequests,
   activityLog,
   approvals,
+  authUsers,
   companySkills as companySkillsTable,
   documentRevisions,
   issueDocuments,
@@ -1948,6 +1949,16 @@ async function buildPaperclipWakePayload(input: {
           );
 
   const commentsById = new Map(commentRows.map((comment) => [comment.id, comment]));
+  const wakeAuthorUserIds = [
+    ...new Set(commentRows.flatMap((c) => (c.authorUserId ? [c.authorUserId] : []))),
+  ];
+  const wakeAuthorUserRows = wakeAuthorUserIds.length > 0
+    ? await input.db
+        .select({ id: authUsers.id, name: authUsers.name })
+        .from(authUsers)
+        .where(inArray(authUsers.id, wakeAuthorUserIds))
+    : [];
+  const wakeAuthorUserNames = new Map(wakeAuthorUserRows.map((r) => [r.id, r.name]));
   const comments: Array<Record<string, unknown>> = [];
   let remainingBodyChars = MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS;
   let truncated = false;
@@ -1989,7 +2000,7 @@ async function buildPaperclipWakePayload(input: {
       author: row.authorAgentId
         ? { type: "agent", id: row.authorAgentId }
         : row.authorUserId
-          ? { type: "user", id: row.authorUserId }
+          ? { type: "user", id: row.authorUserId, name: wakeAuthorUserNames.get(row.authorUserId) ?? null }
           : { type: "system", id: null },
     });
   }
@@ -6818,7 +6829,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issueContext = await getIssueExecutionContext(agent.companyId, issueId);
     }
     const wakeCommentId = deriveCommentId(context, null);
-    const wakeCommentContext =
+    const wakeCommentRow =
       issueContext && wakeCommentId
         ? await db
             .select({
@@ -6838,6 +6849,17 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             ))
             .then((rows) => rows[0] ?? null)
         : null;
+    const wakeCommentAuthorName =
+      wakeCommentRow?.authorUserId
+        ? await db
+            .select({ name: authUsers.name })
+            .from(authUsers)
+            .where(eq(authUsers.id, wakeCommentRow.authorUserId))
+            .then((rows) => rows[0]?.name ?? null)
+        : null;
+    const wakeCommentContext = wakeCommentRow
+      ? { ...wakeCommentRow, authorUserName: wakeCommentAuthorName }
+      : null;
     const issueAssigneeOverrides =
       issueContext && issueContext.assigneeAgentId === agent.id
         ? parseIssueAssigneeAdapterOverrides(

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7,6 +7,7 @@ import {
   agents,
   approvals,
   assets,
+  authUsers,
   companies,
   companyMemberships,
   documents,
@@ -1776,6 +1777,28 @@ export function issueService(db: Db) {
       body: redactCurrentUserText(comment.body, { enabled: censorUsernameInLogs }),
       presentation: issueCommentPresentationSchema.nullable().catch(null).parse(comment.presentation ?? null),
       metadata: issueCommentMetadataSchema.nullable().catch(null).parse(comment.metadata ?? null),
+    };
+  }
+
+  async function resolveAuthorUserNames(userIds: string[]): Promise<Map<string, string>> {
+    if (userIds.length === 0) return new Map();
+    const rows = await db
+      .select({ id: authUsers.id, name: authUsers.name })
+      .from(authUsers)
+      .where(inArray(authUsers.id, userIds));
+    return new Map(rows.map((r) => [r.id, r.name]));
+  }
+
+  function attachAuthorUser<T extends { authorUserId?: string | null }>(
+    comment: T,
+    userNames: Map<string, string>,
+  ): T & { authorUser: { id: string; name: string | null } | null } {
+    if (!comment.authorUserId) {
+      return { ...comment, authorUser: null };
+    }
+    return {
+      ...comment,
+      authorUser: { id: comment.authorUserId, name: userNames.get(comment.authorUserId) ?? null },
     };
   }
 
@@ -3778,7 +3801,12 @@ export function issueService(db: Db) {
 
       const comments = limit ? await query.limit(limit) : await query;
       const { censorUsernameInLogs } = await instanceSettings.getGeneral();
-      return comments.map((comment) => redactIssueComment(comment, censorUsernameInLogs));
+      const redacted = comments.map((comment) => redactIssueComment(comment, censorUsernameInLogs));
+      const userIds = [
+        ...new Set(redacted.flatMap((c) => (c.authorUserId ? [c.authorUserId] : []))),
+      ];
+      const userNames = await resolveAuthorUserNames(userIds);
+      return redacted.map((comment) => attachAuthorUser(comment, userNames));
     },
 
     getCommentCursor: async (issueId: string) => {
@@ -3809,16 +3837,20 @@ export function issueService(db: Db) {
       };
     },
 
-    getComment: (commentId: string) =>
-      instanceSettings.getGeneral().then(({ censorUsernameInLogs }) =>
-        db
+    getComment: async (commentId: string) => {
+      const { censorUsernameInLogs } = await instanceSettings.getGeneral();
+      const rows = await db
         .select()
         .from(issueComments)
-        .where(eq(issueComments.id, commentId))
-        .then((rows) => {
-          const comment = rows[0] ?? null;
-          return comment ? redactIssueComment(comment, censorUsernameInLogs) : null;
-        })),
+        .where(eq(issueComments.id, commentId));
+      const comment = rows[0] ?? null;
+      if (!comment) return null;
+      const redacted = redactIssueComment(comment, censorUsernameInLogs);
+      const userNames = redacted.authorUserId
+        ? await resolveAuthorUserNames([redacted.authorUserId])
+        : new Map<string, string>();
+      return attachAuthorUser(redacted, userNames);
+    },
 
     removeComment: async (commentId: string) => {
       const currentUserRedactionOptions = {


### PR DESCRIPTION
## Summary

- Add `authorUser: { id, name }` field to the issue comment API response and heartbeat wake payloads
- Allows agents and clients to display comment author's display name without a separate user lookup

## Changes

- `server/src/services/issues.ts`: join `authorUser` from users table on comment queries
- `server/src/services/heartbeat.ts`: include `authorUser` in wake payload comment objects
- `server/src/__tests__/issues-service.test.ts`: unit tests covering the new field

## Motivation

Agents consuming the heartbeat wake payload currently receive comment `authorId` but not the author's display name, forcing an extra round-trip to resolve the name. This PR makes the name available inline, consistent with how other user references are exposed in the API.

## Test plan

- [ ] `pnpm test` passes (new unit tests in `issues-service.test.ts`)
- [ ] Existing comment endpoints return `authorUser.id` and `authorUser.name`
- [ ] Wake payloads for issues with comments include `authorUser` on each comment object