### PR TITLE
Fix MIL-525 heartbeat-context parity and workspace binding reuse

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -325,6 +325,20 @@ Operators should prefer `snooze` for known time-bounded quiet periods. `continue
 
 The board can record watchdog decisions. The assigned owner of the watchdog evaluation issue can also record them. Other agents cannot.
 
+### Operator note: `running` with `activeRunId = null`
+
+During stale-run cleanup, snapshot surfaces (for example issue-tree hold member snapshots) can briefly reflect stale run metadata while the canonical run row has already been removed or transitioned. Treat this as a reconciliation artifact, not proof that a run is still safely recoverable.
+
+Operator guidance:
+
+- trust canonical run state from heartbeat runs and run events over historical snapshots
+- if no active run row exists, treat the issue as not actively executing and continue normal recovery flow (requeue, explicit recovery issue, or unblock path)
+- do not assume a snapshot `running` status is authoritative when `activeRunId` is null
+
+Implementation guardrail:
+
+- issue-tree hold member responses normalize run metadata so `activeRunStatus` is null whenever `activeRunId` is null, preventing `running + null` from surfacing as a durable API state
+
 ## 11. Auto-Recover vs Explicit Recovery vs Human Escalation
 
 Paperclip uses three different recovery outcomes, depending on how much it can safely infer.

--- a/docs/api/issues.md
+++ b/docs/api/issues.md
@@ -83,6 +83,11 @@ Atomically claims the task and transitions to `in_progress`. Returns `409 Confli
 
 Idempotent if you already own the task.
 
+Checkout responses include both `executionWorkspaceId` and `currentExecutionWorkspace`:
+- `currentExecutionWorkspace` is non-null only when the linked execution workspace is currently realizable/resolvable.
+- `currentExecutionWorkspace` is `null` when no workspace is linked or lookup fails.
+- When non-null, `POST /api/issues/{issueId}/checkout` and `GET /api/issues/{issueId}/heartbeat-context` should expose the same workspace identity/details (for example `id` and `cwd`) for the same issue state.
+
 **Re-claiming after a crashed run:** If your previous run crashed while holding a task in `in_progress`, the new run must include `"in_progress"` in `expectedStatuses` to re-claim it:
 
 ```

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -658,6 +658,7 @@ export {
   createIssueSchema,
   createChildIssueSchema,
   createIssueLabelSchema,
+  ISSUE_EXECUTION_WORKSPACE_PREFERENCES,
   updateIssueSchema,
   issueExecutionPolicySchema,
   issueExecutionStateSchema,

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -321,6 +321,7 @@ export interface Issue {
   labelIds?: string[];
   labels?: IssueLabel[];
   blockedBy?: IssueRelationIssueSummary[];
+  blockedByIssueIds?: string[];
   blocks?: IssueRelationIssueSummary[];
   blockerAttention?: IssueBlockerAttention;
   productivityReview?: IssueProductivityReview | null;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -148,6 +148,7 @@ export {
 } from "./project.js";
 
 export {
+  ISSUE_EXECUTION_WORKSPACE_PREFERENCES,
   createIssueSchema,
   createChildIssueSchema,
   createIssueLabelSchema,

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -49,9 +49,11 @@ describe("issue validators", () => {
   it("normalizes escaped line breaks in issue comment bodies", () => {
     const parsed = addIssueCommentSchema.parse({
       body: "Progress update\\r\\n\\r\\nNext action.",
+      intervention: true,
     });
 
     expect(parsed.body).toBe("Progress update\n\nNext action.");
+    expect(parsed.intervention).toBe(true);
   });
 
   it("normalizes escaped line breaks in generated task drafts", () => {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -235,6 +235,7 @@ export type CheckoutIssue = z.infer<typeof checkoutIssueSchema>;
 
 export const addIssueCommentSchema = z.object({
   body: multilineTextSchema.pipe(z.string().min(1)),
+  intervention: z.boolean().optional(),
   reopen: z.boolean().optional(),
   resume: z.boolean().optional(),
   interrupt: z.boolean().optional(),

--- a/scripts/provision-worktree.sh
+++ b/scripts/provision-worktree.sh
@@ -31,49 +31,98 @@ source_env_path="$(dirname "$source_config_path")/.env"
 
 mkdir -p "$paperclip_dir"
 
+resolve_pnpm_command() {
+  hash -r >/dev/null 2>&1 || true
+  local pnpm_path
+  pnpm_path="$(command -v pnpm 2>/dev/null || true)"
+  if [[ -z "$pnpm_path" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$pnpm_path"
+}
+
 run_isolated_worktree_init() {
   local base_cli_runner="$base_cwd/cli/node_modules/tsx/dist/cli.mjs"
   local base_cli_entry="$base_cwd/cli/src/index.ts"
+  local migration_bundle_missing_exit_code=86
+
+  run_worktree_init_command() {
+    set +e
+    "$@"
+    local exit_code=$?
+    set -e
+    return "$exit_code"
+  }
+
+  run_worktree_init_with_dist_migration_fallback() {
+    local stdout_path stderr_path
+    stdout_path="$(mktemp)"
+    stderr_path="$(mktemp)"
+
+    set +e
+    "$@" >"$stdout_path" 2>"$stderr_path"
+    local exit_code=$?
+    set -e
+    cat "$stdout_path"
+    cat "$stderr_path" >&2
+    if [[ "$exit_code" -eq 0 ]]; then
+      rm -f "$stdout_path" "$stderr_path"
+      return 0
+    fi
+    if grep -q "ENOENT: no such file or directory, scandir .*dist/migrations" "$stdout_path" "$stderr_path"; then
+      rm -f "$stdout_path" "$stderr_path"
+      return "$migration_bundle_missing_exit_code"
+    fi
+
+    rm -f "$stdout_path" "$stderr_path"
+    return "$exit_code"
+  }
 
   if [[ -f "$base_cli_runner" && -f "$base_cli_entry" ]]; then
     (
       cd "$worktree_cwd"
-      node "$base_cli_runner" "$base_cli_entry" worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
+      run_worktree_init_command run_worktree_init_with_dist_migration_fallback node "$base_cli_runner" "$base_cli_entry" worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
     )
-    return 0
+    local exit_code=$?
+    if [[ "$exit_code" -eq 0 ]]; then
+      return 0
+    fi
+    if [[ "$exit_code" -eq "$migration_bundle_missing_exit_code" ]]; then
+      return "$migration_bundle_missing_exit_code"
+    fi
+    return "$exit_code"
   fi
 
-  if command -v pnpm >/dev/null 2>&1 && pnpm paperclipai --help >/dev/null 2>&1; then
+  local pnpm_cmd
+  pnpm_cmd="$(resolve_pnpm_command || true)"
+  if [[ -n "$pnpm_cmd" ]] && "$pnpm_cmd" paperclipai --help >/dev/null 2>&1; then
     (
       cd "$worktree_cwd"
-      pnpm paperclipai worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
+      run_worktree_init_command run_worktree_init_with_dist_migration_fallback "$pnpm_cmd" paperclipai worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
     )
-    return 0
-  fi
-
-  if command -v paperclipai >/dev/null 2>&1; then
-    (
-      cd "$worktree_cwd"
-      paperclipai worktree init --force --seed-mode minimal --name "$worktree_name" --from-config "$source_config_path"
-    )
-    return 0
+    local exit_code=$?
+    if [[ "$exit_code" -eq 0 ]]; then
+      return 0
+    fi
+    if [[ "$exit_code" -eq "$migration_bundle_missing_exit_code" ]]; then
+      return "$migration_bundle_missing_exit_code"
+    fi
+    return "$exit_code"
   fi
 
   return 127
 }
 
 paperclipai_command_available() {
-  if command -v pnpm >/dev/null 2>&1 && pnpm paperclipai --help >/dev/null 2>&1; then
+  local pnpm_cmd
+  pnpm_cmd="$(resolve_pnpm_command || true)"
+  if [[ -n "$pnpm_cmd" ]] && "$pnpm_cmd" paperclipai --help >/dev/null 2>&1; then
     return 0
   fi
 
   local base_cli_tsx_path="$base_cwd/cli/node_modules/tsx/dist/cli.mjs"
   local base_cli_entry_path="$base_cwd/cli/src/index.ts"
   if command -v node >/dev/null 2>&1 && [[ -f "$base_cli_tsx_path" ]] && [[ -f "$base_cli_entry_path" ]]; then
-    return 0
-  fi
-
-  if command -v paperclipai >/dev/null 2>&1; then
     return 0
   fi
 
@@ -336,7 +385,18 @@ if [[ -e "$worktree_config_path" && -e "$worktree_env_path" ]]; then
   echo "Reusing existing isolated Paperclip worktree config at $worktree_config_path" >&2
 else
   if paperclipai_command_available; then
+    set +e
     run_isolated_worktree_init
+    init_exit_code=$?
+    set -e
+    if [[ "$init_exit_code" -eq 0 ]]; then
+      :
+    elif [[ "$init_exit_code" -eq 86 ]]; then
+      echo "paperclipai worktree init could not locate dist migrations; writing isolated fallback config without DB seeding." >&2
+      write_fallback_worktree_config
+    else
+      exit "$init_exit_code"
+    fi
   else
     echo "paperclipai CLI not available in this workspace; writing isolated fallback config without DB seeding." >&2
     write_fallback_worktree_config

--- a/server/src/__tests__/agent-inbox-lite-routes.test.ts
+++ b/server/src/__tests__/agent-inbox-lite-routes.test.ts
@@ -1,0 +1,127 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+  listDependencyReadiness: vi.fn(),
+}));
+
+const mockIssueTreeControlService = vi.hoisted(() => ({
+  getActivePauseHoldGate: vi.fn(),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    agentService: () => ({}),
+    agentInstructionsService: () => ({}),
+    accessService: () => ({}),
+    approvalService: () => ({}),
+    companySkillService: () => ({ listRuntimeSkillEntries: vi.fn() }),
+    budgetService: () => ({}),
+    heartbeatService: () => ({}),
+    issueApprovalService: () => ({}),
+    issueService: () => mockIssueService,
+    issueTreeControlService: () => mockIssueTreeControlService,
+    logActivity: vi.fn(),
+    secretService: () => ({}),
+    syncInstructionsBundleConfigFromFilePath: vi.fn((_agent, config) => config),
+    workspaceOperationService: () => ({}),
+    ISSUE_LIST_DEFAULT_LIMIT: 100,
+  }));
+
+  vi.doMock("../services/instance-settings.js", () => ({
+    instanceSettingsService: () => ({
+      get: vi.fn(async () => ({
+        id: "instance-settings-1",
+        general: { censorUsernameInLogs: false, feedbackDataSharingPreference: "prompt" },
+      })),
+    }),
+  }));
+
+  vi.doMock("../adapters/index.js", () => ({
+    detectAdapterModel: vi.fn(),
+    findActiveServerAdapter: vi.fn(),
+    findServerAdapter: vi.fn(),
+    listAdapterModelProfiles: vi.fn(),
+    listAdapterModels: vi.fn(),
+    refreshAdapterModels: vi.fn(),
+    requireServerAdapter: vi.fn(),
+  }));
+}
+
+async function createApp() {
+  const [{ agentRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: "agent-1",
+      companyId: "company-1",
+      source: "agent_key",
+      runId: "run-1",
+    };
+    next();
+  });
+  app.use("/api", agentRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("agent inbox-lite route parity", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/agents.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+  });
+
+  it("marks dependencyReady false when checkout is blocked by active pause hold", async () => {
+    mockIssueService.list.mockResolvedValue([
+      {
+        id: "issue-1",
+        identifier: "PAP-1",
+        title: "Blocked lane",
+        status: "blocked",
+        priority: "high",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt: new Date("2026-05-04T10:00:00.000Z").toISOString(),
+        activeRun: null,
+      },
+    ]);
+    mockIssueService.listDependencyReadiness.mockResolvedValue(new Map([["issue-1", {
+      isDependencyReady: true,
+      unresolvedBlockerCount: 0,
+      unresolvedBlockerIssueIds: [],
+    }]]));
+    mockIssueTreeControlService.getActivePauseHoldGate.mockResolvedValue({
+      holdId: "hold-1",
+      rootIssueId: "root-1",
+      mode: "subtree",
+    });
+
+    const res = await request(await createApp()).get("/api/agents/me/inbox-lite");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      expect.objectContaining({
+        id: "issue-1",
+        dependencyReady: false,
+        checkoutBlocked: true,
+        checkoutBlockReason: "active_subtree_pause_hold",
+        activePauseHold: {
+          holdId: "hold-1",
+          rootIssueId: "root-1",
+          mode: "subtree",
+        },
+      }),
+    ]);
+  });
+});

--- a/server/src/__tests__/environment-selection-route-guards.test.ts
+++ b/server/src/__tests__/environment-selection-route-guards.test.ts
@@ -28,6 +28,10 @@ const mockEnvironmentService = vi.hoisted(() => ({
   getById: vi.fn(),
 }));
 
+const mockExecutionWorkspaceService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
 const mockCompanyService = vi.hoisted(() => ({
   getById: vi.fn(),
 }));
@@ -67,7 +71,7 @@ vi.mock("../services/index.js", () => ({
   agentService: () => ({
     getById: vi.fn(),
   }),
-  executionWorkspaceService: () => ({}),
+  executionWorkspaceService: () => mockExecutionWorkspaceService,
   goalService: () => ({
     getById: vi.fn(),
     getDefaultCompanyGoal: vi.fn(),
@@ -169,6 +173,8 @@ describe.sequential("execution environment route guards", () => {
       attachmentMaxBytes: 10 * 1024 * 1024,
     });
     mockEnvironmentService.getById.mockReset();
+    mockExecutionWorkspaceService.getById.mockReset();
+    mockExecutionWorkspaceService.getById.mockResolvedValue(null);
     mockIssueReferenceService.deleteDocumentSource.mockClear();
     mockIssueReferenceService.diffIssueReferenceSummary.mockClear();
     mockIssueReferenceService.emptySummary.mockClear();
@@ -382,5 +388,43 @@ describe.sequential("execution environment route guards", () => {
 
     expect(res.status).not.toBe(422);
     expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("forwards execution workspace fields on issue update", async () => {
+    const executionWorkspaceId = "22222222-2222-4222-8222-222222222222";
+    mockIssueService.getById.mockResolvedValue({
+      id: "issue-1",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      createdByUserId: null,
+      identifier: "PAPA-999",
+      executionPolicy: null,
+      executionState: null,
+    });
+    mockIssueService.update.mockResolvedValue({
+      id: "issue-1",
+      companyId: "company-1",
+      status: "todo",
+      identifier: "PAPA-999",
+    });
+    const app = createIssueApp();
+
+    const res = await request(app)
+      .patch("/api/issues/issue-1")
+      .send({
+        executionWorkspaceId,
+        executionWorkspacePreference: "reuse_existing",
+      });
+
+    expect(res.status).not.toBe(422);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "issue-1",
+      expect.objectContaining({
+        executionWorkspaceId,
+        executionWorkspacePreference: "reuse_existing",
+      }),
+    );
   });
 });

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq, sql } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -797,6 +797,333 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
         interaction: true,
       },
     });
+  });
+
+  it("suppresses replayed blocked-relay comments when the blocker fingerprint is unchanged", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const blockerId = randomUUID();
+    const blockedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        title: "Blocker",
+        status: "todo",
+        priority: "high",
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked issue",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+    const firstCommentId = randomUUID();
+    await db.insert(issueComments).values({
+      id: firstCommentId,
+      companyId,
+      issueId: blockedIssueId,
+      authorUserId: "board-user",
+      body: "First blocked follow-up",
+    });
+
+    const firstRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId: blockedIssueId, commentId: firstCommentId },
+      requestedByActorType: "user",
+      requestedByActorId: "board-user",
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        commentId: firstCommentId,
+        wakeCommentId: firstCommentId,
+        wakeReason: "issue_commented",
+      },
+    });
+    expect(firstRun).not.toBeNull();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, firstRun!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const secondCommentId = randomUUID();
+    await db.insert(issueComments).values({
+      id: secondCommentId,
+      companyId,
+      issueId: blockedIssueId,
+      authorUserId: "board-user",
+      body: "Second blocked follow-up",
+    });
+
+    const secondRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId: blockedIssueId, commentId: secondCommentId },
+      requestedByActorType: "user",
+      requestedByActorId: "board-user",
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        commentId: secondCommentId,
+        wakeCommentId: secondCommentId,
+        wakeReason: "issue_commented",
+      },
+    });
+    expect(secondRun).not.toBeNull();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, secondRun!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const relayComments = await db
+      .select({
+        id: issueComments.id,
+        createdByRunId: issueComments.createdByRunId,
+      })
+      .from(issueComments)
+      .where(and(eq(issueComments.companyId, companyId), eq(issueComments.issueId, blockedIssueId)))
+      .orderBy(asc(issueComments.createdAt), asc(issueComments.id));
+    const runRelayComments = relayComments.filter((comment) => comment.createdByRunId != null);
+    expect(runRelayComments).toHaveLength(1);
+    expect(runRelayComments[0]?.createdByRunId).toBe(firstRun!.id);
+
+    const [firstPersistedRun, secondPersistedRun] = await Promise.all([
+      db
+        .select({ resultJson: heartbeatRuns.resultJson })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, firstRun!.id))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ resultJson: heartbeatRuns.resultJson })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, secondRun!.id))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    const firstResult = firstPersistedRun?.resultJson as Record<string, unknown> | null;
+    const secondResult = secondPersistedRun?.resultJson as Record<string, unknown> | null;
+
+    expect(firstResult?.blockedRelayCommentDeduped).toBe(false);
+    expect(typeof firstResult?.blockedRelayStateFingerprint).toBe("string");
+    expect(secondResult?.blockedRelayCommentDeduped).toBe(true);
+    expect(secondResult?.blockedRelayStateFingerprint).toBe(firstResult?.blockedRelayStateFingerprint);
+  });
+
+  it("emits blocked-relay comments again when the blocker fingerprint changes", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const blockerAssigneeId = randomUUID();
+    const blockerId = randomUUID();
+    const blockedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: agentId,
+        companyId,
+        name: "CodexCoder",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {
+          heartbeat: {
+            wakeOnDemand: true,
+            maxConcurrentRuns: 1,
+          },
+        },
+        permissions: {},
+      },
+      {
+        id: blockerAssigneeId,
+        companyId,
+        name: "BlockerOwner",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        title: "Blocker",
+        status: "todo",
+        priority: "high",
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked issue",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+    const firstCommentId = randomUUID();
+    await db.insert(issueComments).values({
+      id: firstCommentId,
+      companyId,
+      issueId: blockedIssueId,
+      authorUserId: "board-user",
+      body: "First blocked follow-up",
+    });
+
+    const firstRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId: blockedIssueId, commentId: firstCommentId },
+      requestedByActorType: "user",
+      requestedByActorId: "board-user",
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        commentId: firstCommentId,
+        wakeCommentId: firstCommentId,
+        wakeReason: "issue_commented",
+      },
+    });
+    expect(firstRun).not.toBeNull();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, firstRun!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const bumpedMonitorAt = new Date(Date.now() + 60_000);
+    await db
+      .update(issues)
+      .set({
+        assigneeAgentId: blockerAssigneeId,
+        status: "in_progress",
+        monitorNextCheckAt: bumpedMonitorAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(issues.id, blockerId));
+
+    const secondCommentId = randomUUID();
+    await db.insert(issueComments).values({
+      id: secondCommentId,
+      companyId,
+      issueId: blockedIssueId,
+      authorUserId: "board-user",
+      body: "Second blocked follow-up",
+    });
+
+    const secondRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId: blockedIssueId, commentId: secondCommentId },
+      requestedByActorType: "user",
+      requestedByActorId: "board-user",
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        commentId: secondCommentId,
+        wakeCommentId: secondCommentId,
+        wakeReason: "issue_commented",
+      },
+    });
+    expect(secondRun).not.toBeNull();
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, secondRun!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const relayComments = await db
+      .select({
+        id: issueComments.id,
+        createdByRunId: issueComments.createdByRunId,
+      })
+      .from(issueComments)
+      .where(and(eq(issueComments.companyId, companyId), eq(issueComments.issueId, blockedIssueId)))
+      .orderBy(asc(issueComments.createdAt), asc(issueComments.id));
+    const runRelayComments = relayComments.filter((comment) => comment.createdByRunId != null);
+    expect(runRelayComments).toHaveLength(2);
+    expect(runRelayComments[0]?.createdByRunId).toBe(firstRun!.id);
+    expect(runRelayComments[1]?.createdByRunId).toBe(secondRun!.id);
+
+    const [firstPersistedRun, secondPersistedRun] = await Promise.all([
+      db
+        .select({ resultJson: heartbeatRuns.resultJson })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, firstRun!.id))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ resultJson: heartbeatRuns.resultJson })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, secondRun!.id))
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    const firstResult = firstPersistedRun?.resultJson as Record<string, unknown> | null;
+    const secondResult = secondPersistedRun?.resultJson as Record<string, unknown> | null;
+
+    expect(firstResult?.blockedRelayCommentDeduped).toBe(false);
+    expect(secondResult?.blockedRelayCommentDeduped).toBe(false);
+    expect(firstResult?.blockedRelayStateFingerprint).not.toBe(secondResult?.blockedRelayStateFingerprint);
   });
 
   it("allows comment interaction wakes when a legacy hold has a full_pause note", async () => {

--- a/server/src/__tests__/heartbeat-workspace-binding.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-binding.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { ExecutionWorkspace } from "@paperclipai/shared";
+import { shouldPreserveEquivalentSharedWorkspaceBinding } from "../services/heartbeat.ts";
+
+function makeWorkspace(overrides: Partial<ExecutionWorkspace>): ExecutionWorkspace {
+  const now = new Date("2026-05-10T00:00:00.000Z");
+  return {
+    id: overrides.id ?? "workspace-1",
+    companyId: overrides.companyId ?? "company-1",
+    projectId: overrides.projectId ?? "project-1",
+    projectWorkspaceId: overrides.projectWorkspaceId ?? "project-workspace-1",
+    sourceIssueId: overrides.sourceIssueId ?? null,
+    mode: overrides.mode ?? "shared_workspace",
+    strategyType: overrides.strategyType ?? "project_primary",
+    name: overrides.name ?? "Workspace",
+    status: overrides.status ?? "idle",
+    cwd: overrides.cwd ?? "/repo/server",
+    repoUrl: overrides.repoUrl ?? null,
+    baseRef: overrides.baseRef ?? null,
+    branchName: overrides.branchName ?? null,
+    providerType: overrides.providerType ?? "local_fs",
+    providerRef: overrides.providerRef ?? "/repo/server",
+    derivedFromExecutionWorkspaceId: overrides.derivedFromExecutionWorkspaceId ?? null,
+    lastUsedAt: overrides.lastUsedAt ?? now,
+    openedAt: overrides.openedAt ?? now,
+    closedAt: overrides.closedAt ?? null,
+    cleanupEligibleAt: overrides.cleanupEligibleAt ?? null,
+    cleanupReason: overrides.cleanupReason ?? null,
+    config: overrides.config ?? null,
+    metadata: overrides.metadata ?? null,
+    runtimeServices: overrides.runtimeServices,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  };
+}
+
+describe("shouldPreserveEquivalentSharedWorkspaceBinding", () => {
+  it("keeps an explicit reuse_existing binding when heartbeat materializes an equivalent shared workspace row", () => {
+    const existing = makeWorkspace({
+      id: "workspace-a",
+      cwd: "/Users/mstatev/dev/paperclip/server/",
+      providerRef: "/Users/mstatev/dev/paperclip/server/",
+    });
+    const persisted = makeWorkspace({
+      id: "workspace-b",
+      cwd: "/Users/mstatev/dev/paperclip/server",
+      providerRef: "/Users/mstatev/dev/paperclip/server",
+    });
+
+    expect(shouldPreserveEquivalentSharedWorkspaceBinding({
+      issueExecutionWorkspacePreference: "reuse_existing",
+      existingExecutionWorkspace: existing,
+      persistedExecutionWorkspace: persisted,
+    })).toBe(true);
+  });
+
+  it("does not preserve when the realized workspace is materially different", () => {
+    const existing = makeWorkspace({
+      id: "workspace-a",
+      projectWorkspaceId: "project-workspace-1",
+      cwd: "/Users/mstatev/dev/paperclip/server",
+      providerRef: "/Users/mstatev/dev/paperclip/server",
+    });
+    const persisted = makeWorkspace({
+      id: "workspace-b",
+      projectWorkspaceId: "project-workspace-2",
+      cwd: "/Users/mstatev/dev/paperclip/other",
+      providerRef: "/Users/mstatev/dev/paperclip/other",
+    });
+
+    expect(shouldPreserveEquivalentSharedWorkspaceBinding({
+      issueExecutionWorkspacePreference: "reuse_existing",
+      existingExecutionWorkspace: existing,
+      persistedExecutionWorkspace: persisted,
+    })).toBe(false);
+  });
+});

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -14,6 +14,7 @@ import {
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
   resolveRuntimeSessionParamsForWorkspace,
+  shouldPersistIssueWorkspaceReuse,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForWake,
   type ResolvedWorkspaceForRun,
@@ -253,6 +254,30 @@ describe("buildRealizedExecutionWorkspaceFromPersisted", () => {
     expect(result.worktreePath).toBe("/tmp/reused-worktree");
     expect(result.branchName).toBe("PAP-880-thumbs-capture-for-evals-feature");
     expect(result.source).toBe("task_session");
+  });
+});
+
+describe("shouldPersistIssueWorkspaceReuse", () => {
+  it("persists reuse for task-session workspaces even when persisted mode is shared", () => {
+    expect(shouldPersistIssueWorkspaceReuse({
+      existingPreference: null,
+      persistedWorkspaceMode: "shared_workspace",
+      realizedWorkspaceSource: "task_session",
+    })).toBe(true);
+  });
+
+  it("persists reuse for adapter-managed execution workspaces", () => {
+    expect(shouldPersistIssueWorkspaceReuse({
+      existingPreference: null,
+      persistedWorkspaceMode: "adapter_managed",
+    })).toBe(true);
+  });
+
+  it("does not force reuse for shared execution workspaces without an explicit preference", () => {
+    expect(shouldPersistIssueWorkspaceReuse({
+      existingPreference: null,
+      persistedWorkspaceMode: "shared_workspace",
+    })).toBe(false);
   });
 });
 

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -238,6 +238,7 @@ describe("issue activity event routes", () => {
       .send({ blockedByIssueIds: ["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"] });
 
     expect(res.status).toBe(200);
+    expect(res.body.blockedByIssueIds).toEqual(["bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"]);
     await vi.waitFor(() => {
       expect(mockLogActivity).toHaveBeenCalledWith(
         expect.anything(),

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -453,6 +453,140 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
+  it("allows peer agents with task-assignment authority to post explicit intervention comments on another agent's active checkout", async () => {
+    mockAccessService.hasPermission.mockImplementation(async (
+      _companyId: string,
+      _principalType: string,
+      principalId: string,
+      permissionKey: string,
+    ) => principalId === peerAgentId && permissionKey === "tasks:assign");
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Intervention packet", intervention: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Intervention packet",
+      expect.objectContaining({
+        agentId: peerAgentId,
+      }),
+    );
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+  });
+
+  it("allows explicit intervention comments on another agent's non-active issue while keeping ordinary peer comments denied", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "done", assigneeAgentId: ownerAgentId }));
+    mockAccessService.hasPermission.mockImplementation(async (
+      _companyId: string,
+      _principalType: string,
+      principalId: string,
+      permissionKey: string,
+    ) => principalId === peerAgentId && permissionKey === "tasks:assign");
+
+    const allowed = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Outcome callback", intervention: true });
+
+    expect(allowed.status, JSON.stringify(allowed.body)).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Outcome callback",
+      expect.objectContaining({
+        agentId: peerAgentId,
+      }),
+    );
+
+    mockIssueService.addComment.mockClear();
+
+    const denied = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "ordinary comment" });
+
+    expect(denied.status, JSON.stringify(denied.body)).toBe(403);
+    expect(denied.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("keeps denying non-comment peer mutations even when the actor can assign tasks", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }));
+    mockAccessService.hasPermission.mockImplementation(async (
+      _companyId: string,
+      _principalType: string,
+      principalId: string,
+      permissionKey: string,
+    ) => principalId === peerAgentId && permissionKey === "tasks:assign");
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Still blocked" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it.each(["todo", "blocked"] as const)(
+    "allows peer agent to patch execution workspace fields on %s issues",
+    async (status) => {
+      let mutableIssue = makeIssue({
+        status,
+        assigneeAgentId: ownerAgentId,
+        executionWorkspaceId: null,
+        executionWorkspacePreference: null,
+        executionWorkspaceSettings: null,
+      });
+      mockIssueService.getById.mockImplementation(async () => mutableIssue);
+      mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+        mutableIssue = {
+          ...mutableIssue,
+          ...patch,
+        };
+        return mutableIssue;
+      });
+
+      const res = await request(await createApp(peerActor()))
+        .patch(`/api/issues/${issueId}`)
+        .send({
+          executionWorkspaceId: "6f87120d-8d67-4f0e-88aa-b6ccdb9251e4",
+          executionWorkspacePreference: "reuse_existing",
+          executionWorkspaceSettings: { mode: "isolated_workspace" },
+        });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(mockIssueService.update).toHaveBeenCalledWith(
+        issueId,
+        expect.objectContaining({
+          executionWorkspaceId: "6f87120d-8d67-4f0e-88aa-b6ccdb9251e4",
+          executionWorkspacePreference: "reuse_existing",
+          executionWorkspaceSettings: { mode: "isolated_workspace" },
+        }),
+      );
+      expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+      expect(res.body).toMatchObject({
+        executionWorkspaceId: "6f87120d-8d67-4f0e-88aa-b6ccdb9251e4",
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceSettings: { mode: "isolated_workspace" },
+      });
+    },
+  );
+
+  it("keeps rejecting mixed peer-agent patches that include execution workspace fields plus non-workspace fields", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        executionWorkspacePreference: "reuse_existing",
+        title: "Not allowed",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: null }));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({

--- a/server/src/__tests__/issue-comment-churn-routes.test.ts
+++ b/server/src/__tests__/issue-comment-churn-routes.test.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agentWakeupRequests,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue comment churn route tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+describeEmbeddedPostgres("issue comment churn routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-comment-churn-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(agentWakeupRequests);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(actor: Express.Request["actor"]) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = actor;
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedIssue() {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const ownerAgentId = randomUUID();
+    const ownerRunIds = [randomUUID(), randomUUID(), randomUUID(), randomUUID()];
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: ownerAgentId,
+        companyId,
+        name: "OwnerAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values(
+      ownerRunIds.map((runId) => ({
+        id: runId,
+        companyId,
+        agentId: ownerAgentId,
+        status: "running",
+        invocationSource: "manual",
+        startedAt: new Date(),
+      })),
+    );
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Comment churn route issue",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: null,
+    });
+
+    return { companyId, issueId, ownerAgentId, ownerRunIds };
+  }
+
+  function agentActor(companyId: string, agentId: string, runId: string): Express.Request["actor"] {
+    return {
+      type: "agent",
+      agentId,
+      companyId,
+      runId,
+      source: "agent_jwt",
+    };
+  }
+
+  function boardActor(companyId: string, userId: string): Express.Request["actor"] {
+    return {
+      type: "board",
+      userId,
+      companyIds: [companyId],
+      memberships: [{ companyId, membershipRole: "admin", status: "active" }],
+      isInstanceAdmin: false,
+      source: "session",
+    };
+  }
+
+  it("rejects the fourth rapid same-agent comment even when run ids change", async () => {
+    const { companyId, issueId, ownerAgentId, ownerRunIds } = await seedIssue();
+
+    for (let index = 0; index < 3; index += 1) {
+      const res = await request(
+        createApp(agentActor(companyId, ownerAgentId, ownerRunIds[index])),
+      )
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: `comment ${index + 1}` });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(201);
+    }
+
+    const fourth = await request(createApp(agentActor(companyId, ownerAgentId, ownerRunIds[3])))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "comment 4" });
+
+    expect(fourth.status, JSON.stringify(fourth.body)).toBe(409);
+    expect(fourth.body.error).toContain("Issue comment churn guardrail triggered");
+  });
+
+  it("allows a different actor to comment during the same churn window", async () => {
+    const { companyId, issueId, ownerAgentId, ownerRunIds } = await seedIssue();
+
+    for (let index = 0; index < 3; index += 1) {
+      const res = await request(
+        createApp(agentActor(companyId, ownerAgentId, ownerRunIds[index])),
+      )
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: `comment ${index + 1}` });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(201);
+    }
+
+    const peer = await request(createApp(boardActor(companyId, "board-user-2")))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "allowed from different actor" });
+
+    expect(peer.status, JSON.stringify(peer.body)).toBe(201);
+    expect(peer.body.body).toBe("allowed from different actor");
+  });
+});

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -65,6 +65,9 @@ const mockIssueThreadInteractionService = vi.hoisted(() => ({
 const mockIssueTreeControlService = vi.hoisted(() => ({
   getActivePauseHoldGate: vi.fn(async () => null),
 }));
+const mockExecutionWorkspaceService = vi.hoisted(() => ({
+  getById: vi.fn(async () => null),
+}));
 
 vi.mock("@paperclipai/shared/telemetry", () => ({
   trackAgentTaskCompleted: vi.fn(),
@@ -107,6 +110,10 @@ vi.mock("../services/routines.js", () => ({
   routineService: () => mockRoutineService,
 }));
 
+vi.mock("../services/execution-workspaces.js", () => ({
+  executionWorkspaceService: () => mockExecutionWorkspaceService,
+}));
+
 vi.mock("../services/index.js", () => ({
   companyService: () => ({
     getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
@@ -114,7 +121,7 @@ vi.mock("../services/index.js", () => ({
   accessService: () => mockAccessService,
   agentService: () => mockAgentService,
   documentService: () => ({}),
-  executionWorkspaceService: () => ({}),
+  executionWorkspaceService: () => mockExecutionWorkspaceService,
   feedbackService: () => mockFeedbackService,
   goalService: () => ({}),
   heartbeatService: () => mockHeartbeatService,
@@ -189,6 +196,9 @@ function makeIssue(status: "todo" | "done" | "blocked" | "cancelled" | "in_progr
     createdByUserId: "local-board",
     identifier: "PAP-580",
     title: "Comment reopen default",
+    executionWorkspaceId: "66666666-6666-4666-8666-666666666666",
+    executionWorkspacePreference: "reuse_existing",
+    executionWorkspaceSettings: { mode: "isolated_workspace" },
   };
 }
 
@@ -234,6 +244,7 @@ describe.sequential("issue comment reopen routes", () => {
     mockInstanceSettingsService.listCompanyIds.mockReset();
     mockRoutineService.syncRunStatusForIssue.mockReset();
     mockIssueTreeControlService.getActivePauseHoldGate.mockReset();
+    mockExecutionWorkspaceService.getById.mockReset();
     mockTxInsertValues.mockReset();
     mockTxInsert.mockReset();
     mockDb.transaction.mockReset();
@@ -262,6 +273,7 @@ describe.sequential("issue comment reopen routes", () => {
     mockInstanceSettingsService.listCompanyIds.mockResolvedValue(["company-1"]);
     mockRoutineService.syncRunStatusForIssue.mockResolvedValue(undefined);
     mockIssueTreeControlService.getActivePauseHoldGate.mockResolvedValue(null);
+    mockExecutionWorkspaceService.getById.mockResolvedValue(null);
     mockIssueService.addComment.mockResolvedValue({
       id: "comment-1",
       issueId: "11111111-1111-4111-8111-111111111111",
@@ -467,7 +479,12 @@ describe.sequential("issue comment reopen routes", () => {
     expect(res.status).toBe(201);
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      {
+        status: "todo",
+        executionWorkspaceId: "66666666-6666-4666-8666-666666666666",
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceSettings: { mode: "isolated_workspace" },
+      },
     );
     await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       "22222222-2222-4222-8222-222222222222",
@@ -524,7 +541,12 @@ describe.sequential("issue comment reopen routes", () => {
     expect(res.status).toBe(201);
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      {
+        status: "todo",
+        executionWorkspaceId: "66666666-6666-4666-8666-666666666666",
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceSettings: { mode: "isolated_workspace" },
+      },
     );
     await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       "22222222-2222-4222-8222-222222222222",
@@ -835,7 +857,12 @@ describe.sequential("issue comment reopen routes", () => {
     expect(res.status).toBe(201);
     expect(mockIssueService.update).toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      {
+        status: "todo",
+        executionWorkspaceId: "66666666-6666-4666-8666-666666666666",
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceSettings: { mode: "isolated_workspace" },
+      },
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),

--- a/server/src/__tests__/issue-tree-control-service.test.ts
+++ b/server/src/__tests__/issue-tree-control-service.test.ts
@@ -215,6 +215,64 @@ describeEmbeddedPostgres("issueTreeControlService", () => {
     expect(released.members).toHaveLength(1);
   });
 
+  it("normalizes hold members when stale-run cleanup nulls activeRunId", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const rootIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Runner",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "running",
+      contextSnapshot: { issueId: rootIssueId },
+    });
+    await db.insert(issues).values({
+      id: rootIssueId,
+      companyId,
+      title: "Root",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionRunId: runId,
+    });
+
+    const svc = issueTreeControlService(db);
+    const created = await svc.createHold(companyId, rootIssueId, {
+      mode: "pause",
+      actor: { actorType: "system", actorId: "system" },
+    });
+
+    await db.delete(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+
+    const hold = await svc.getHold(companyId, created.hold.id);
+    expect(hold).not.toBeNull();
+    expect(hold?.members).toHaveLength(1);
+    expect(hold?.members?.[0]).toMatchObject({
+      activeRunId: null,
+      activeRunStatus: null,
+    });
+  });
+
   it("cancels non-terminal issue statuses and restores from the cancel snapshot", async () => {
     const companyId = randomUUID();
     const rootIssueId = randomUUID();

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -343,6 +343,11 @@ describe.sequential("issue goal context routes", () => {
 
     expect(res.status).toBe(200);
     expect(mockExecutionWorkspaceService.getById).toHaveBeenCalledWith("55555555-5555-4555-8555-555555555555");
+    expect(res.body.issue.executionWorkspaceId).toBe("55555555-5555-4555-8555-555555555555");
+    expect(res.body.issue.currentExecutionWorkspace).toEqual(expect.objectContaining({
+      id: "55555555-5555-4555-8555-555555555555",
+      mode: "isolated_workspace",
+    }));
     expect(res.body.currentExecutionWorkspace).toEqual(expect.objectContaining({
       id: "55555555-5555-4555-8555-555555555555",
       mode: "isolated_workspace",

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -6,6 +6,8 @@ import { issueRoutes } from "../routes/issues.js";
 
 const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
+  update: vi.fn(),
+  checkout: vi.fn(),
   getAncestors: vi.fn(),
   getRelationSummaries: vi.fn(),
   findMentionedProjectIds: vi.fn(),
@@ -227,10 +229,20 @@ describe.sequential("issue goal context routes", () => {
   });
 
   it("surfaces the project goal from GET /issues/:id when the issue has no direct goal", async () => {
+    mockIssueService.getCommentCursor.mockResolvedValue({
+      totalComments: 2,
+      latestCommentId: "comment-2",
+      latestCommentAt: "2026-05-04T21:15:17.065Z",
+    });
     const res = await request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111");
 
     expect(res.status).toBe(200);
     expect(res.body.goalId).toBe(projectGoal.id);
+    expect(res.body.commentCursor).toEqual({
+      totalComments: 2,
+      latestCommentId: "comment-2",
+      latestCommentAt: "2026-05-04T21:15:17.065Z",
+    });
     expect(res.body.goal).toEqual(
       expect.objectContaining({
         id: projectGoal.id,
@@ -313,6 +325,30 @@ describe.sequential("issue goal context routes", () => {
         identifier: "PAP-580",
       }),
     ]);
+    expect(res.body.issue.blockedByIssueIds).toEqual(["55555555-5555-4555-8555-555555555555"]);
+  });
+
+  it("keeps relation-derived blockedByIssueIds on GET /issues/:id even when document payload includes null", async () => {
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [
+        {
+          id: "55555555-5555-4555-8555-555555555555",
+          identifier: "PAP-580",
+          title: "Finish wakeup plumbing",
+          status: "done",
+          priority: "medium",
+          assigneeAgentId: null,
+          assigneeUserId: null,
+        },
+      ],
+      blocks: [],
+    });
+    mockDocumentsService.getIssueDocumentPayload.mockResolvedValue({ blockedByIssueIds: null });
+
+    const res = await request(createApp()).get("/api/issues/11111111-1111-4111-8111-111111111111");
+
+    expect(res.status).toBe(200);
+    expect(res.body.blockedByIssueIds).toEqual(["55555555-5555-4555-8555-555555555555"]);
   });
 
   it("surfaces the current execution workspace from GET /issues/:id/heartbeat-context", async () => {
@@ -358,5 +394,249 @@ describe.sequential("issue goal context routes", () => {
         }),
       ],
     }));
+  });
+
+  it("keeps checkout and heartbeat-context currentExecutionWorkspace fields in parity for the same issue", async () => {
+    const workspaceId = "66666666-6666-4666-8666-666666666666";
+    let mutableIssue = {
+      ...legacyProjectLinkedIssue,
+      executionWorkspaceId: null as string | null,
+    };
+
+    mockIssueService.getById.mockImplementation(async () => mutableIssue);
+    mockIssueService.checkout.mockImplementation(async () => {
+      mutableIssue = {
+        ...mutableIssue,
+        status: "in_progress",
+        executionWorkspaceId: workspaceId,
+      };
+      return mutableIssue;
+    });
+    mockExecutionWorkspaceService.getById.mockImplementation(async (id: string) =>
+      id === workspaceId
+        ? {
+            id: workspaceId,
+            name: "PAP-581 workspace",
+            mode: "isolated_workspace",
+            status: "active",
+            cwd: "/tmp/pap-581",
+            runtimeServices: [],
+          }
+        : null,
+    );
+
+    const checkoutRes = await request(createApp())
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/checkout")
+      .send({
+        agentId: "33333333-3333-4333-8333-333333333333",
+        expectedStatuses: ["todo", "backlog", "blocked"],
+      });
+
+    expect(checkoutRes.status).toBe(200);
+    expect(checkoutRes.body.executionWorkspaceId).toBe(workspaceId);
+    expect(checkoutRes.body.currentExecutionWorkspace).toEqual(
+      expect.objectContaining({
+        id: workspaceId,
+        cwd: "/tmp/pap-581",
+      }),
+    );
+
+    const contextRes = await request(createApp()).get(
+      "/api/issues/11111111-1111-4111-8111-111111111111/heartbeat-context",
+    );
+
+    expect(contextRes.status).toBe(200);
+    expect(contextRes.body.issue.executionWorkspaceId).toBe(workspaceId);
+    expect(contextRes.body.issue.currentExecutionWorkspace).toEqual(
+      expect.objectContaining({
+        id: workspaceId,
+        cwd: "/tmp/pap-581",
+      }),
+    );
+    expect(contextRes.body.currentExecutionWorkspace).toEqual(
+      expect.objectContaining({
+        id: workspaceId,
+        cwd: "/tmp/pap-581",
+      }),
+    );
+    expect(contextRes.body.issue.currentExecutionWorkspace).toEqual(checkoutRes.body.currentExecutionWorkspace);
+  });
+
+  it("keeps heartbeat-context executionWorkspaceId populated when workspace lookup is null", async () => {
+    const workspaceId = "77777777-7777-4777-8777-777777777777";
+    const issueWithWorkspace = {
+      ...legacyProjectLinkedIssue,
+      status: "in_progress",
+      executionWorkspaceId: workspaceId,
+    };
+
+    mockIssueService.getById.mockResolvedValue(issueWithWorkspace);
+    mockExecutionWorkspaceService.getById.mockResolvedValue(null);
+
+    const contextRes = await request(createApp()).get(
+      "/api/issues/11111111-1111-4111-8111-111111111111/heartbeat-context",
+    );
+
+    expect(contextRes.status).toBe(200);
+    expect(contextRes.body.issue.executionWorkspaceId).toBe(workspaceId);
+    expect(contextRes.body.issue.currentExecutionWorkspace).toBeNull();
+    expect(contextRes.body.currentExecutionWorkspace).toBeNull();
+  });
+
+  it("preserves direct PATCH execution workspace fields through the issue route", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const nextExecutionWorkspaceId = "88888888-8888-4888-8888-888888888888";
+    let mutableIssue = {
+      ...legacyProjectLinkedIssue,
+      executionWorkspaceId: null as string | null,
+      executionWorkspacePreference: null as string | null,
+      executionWorkspaceSettings: null as Record<string, unknown> | null,
+    };
+
+    mockIssueService.getById.mockImplementation(async () => mutableIssue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+      mutableIssue = {
+        ...mutableIssue,
+        ...patch,
+      };
+      return mutableIssue;
+    });
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        executionWorkspaceId: nextExecutionWorkspaceId,
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceSettings: { mode: "isolated_workspace" },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        executionWorkspaceId: nextExecutionWorkspaceId,
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceSettings: { mode: "isolated_workspace" },
+      }),
+    );
+    expect(res.body.executionWorkspaceId).toBe(nextExecutionWorkspaceId);
+    expect(res.body.executionWorkspacePreference).toBe("reuse_existing");
+    expect(res.body.executionWorkspaceSettings).toEqual({ mode: "isolated_workspace" });
+  });
+
+  it("accepts and persists agent_default as executionWorkspacePreference on direct PATCH", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    let mutableIssue = {
+      ...legacyProjectLinkedIssue,
+      executionWorkspaceId: null as string | null,
+      executionWorkspacePreference: null as string | null,
+      executionWorkspaceSettings: null as Record<string, unknown> | null,
+    };
+
+    mockIssueService.getById.mockImplementation(async () => mutableIssue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+      mutableIssue = {
+        ...mutableIssue,
+        ...patch,
+      };
+      return mutableIssue;
+    });
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        executionWorkspacePreference: "agent_default",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        executionWorkspacePreference: "agent_default",
+      }),
+    );
+    expect(res.body.executionWorkspacePreference).toBe("agent_default");
+  });
+
+  it("retries with a workspace-only patch when direct PATCH response returns stale workspace linkage", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const nextExecutionWorkspaceId = "99999999-9999-4999-8999-999999999999";
+    const nextPreference = "reuse_existing";
+    let mutableIssue = {
+      ...legacyProjectLinkedIssue,
+      executionWorkspaceId: "55555555-5555-4555-8555-555555555555",
+      executionWorkspacePreference: null as string | null,
+      executionWorkspaceSettings: null as Record<string, unknown> | null,
+    };
+    let updateCallCount = 0;
+
+    mockIssueService.getById.mockImplementation(async () => mutableIssue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+      updateCallCount += 1;
+      if (updateCallCount === 1) {
+        // Simulate the stale response observed in runtime: PATCH returns 200
+        // but workspace linkage fields are unchanged.
+        return mutableIssue;
+      }
+      mutableIssue = {
+        ...mutableIssue,
+        ...patch,
+      };
+      return mutableIssue;
+    });
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        executionWorkspaceId: nextExecutionWorkspaceId,
+        executionWorkspacePreference: nextPreference,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledTimes(2);
+    expect(mockIssueService.update).toHaveBeenNthCalledWith(
+      2,
+      issueId,
+      expect.objectContaining({
+        executionWorkspaceId: nextExecutionWorkspaceId,
+        executionWorkspacePreference: nextPreference,
+      }),
+    );
+    expect(res.body.executionWorkspaceId).toBe(nextExecutionWorkspaceId);
+    expect(res.body.executionWorkspacePreference).toBe(nextPreference);
+  });
+
+  it("returns explicit policy override reason when workspace linkage remains stale after retry", async () => {
+    const issueId = "11111111-1111-4111-8111-111111111111";
+    const nextExecutionWorkspaceId = "99999999-9999-4999-8999-999999999999";
+    const nextPreference = "reuse_existing";
+    const staleIssue = {
+      ...legacyProjectLinkedIssue,
+      executionWorkspaceId: "55555555-5555-4555-8555-555555555555",
+      executionWorkspacePreference: "agent_default" as string | null,
+      executionWorkspaceSettings: null as Record<string, unknown> | null,
+    };
+
+    mockIssueService.getById.mockImplementation(async () => staleIssue);
+    mockIssueService.update.mockImplementation(async () => staleIssue);
+
+    const res = await request(createApp())
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        executionWorkspaceId: nextExecutionWorkspaceId,
+        executionWorkspacePreference: nextPreference,
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body).toMatchObject({
+      error: "Execution workspace selection was overridden by policy",
+      details: {
+        reason: "execution_workspace_policy_override",
+        requestedExecutionWorkspaceId: nextExecutionWorkspaceId,
+        requestedExecutionWorkspacePreference: nextPreference,
+        persistedExecutionWorkspaceId: staleIssue.executionWorkspaceId,
+        persistedExecutionWorkspacePreference: staleIssue.executionWorkspacePreference,
+      },
+    });
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -77,6 +77,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     await db.delete(issueRelations);
     await db.delete(issueInboxArchives);
     await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
     await db.delete(issues);
     await db.delete(executionWorkspaces);
     await db.delete(projectWorkspaces);
@@ -102,7 +103,6 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
       requireBoardApprovalForNewAgents: false,
     });
-
     await db.insert(agents).values([
       {
         id: agentId,
@@ -219,7 +219,6 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
       issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
       requireBoardApprovalForNewAgents: false,
     });
-
     await db.insert(agents).values({
       id: agentId,
       companyId,
@@ -952,6 +951,151 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     });
 
     expect(comments.map((comment) => comment.id)).toEqual([firstCommentId]);
+  });
+
+  it("blocks high-frequency comments from the same actor on one issue", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "GuardrailAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Guardrail issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await svc.addComment(issueId, "first", { agentId });
+    await svc.addComment(issueId, "second", { agentId });
+    await svc.addComment(issueId, "third", { agentId });
+
+    await expect(
+      svc.addComment(issueId, "fourth", { agentId }),
+    ).rejects.toThrow("Issue comment churn guardrail triggered");
+  });
+
+  it("blocks high-frequency comments from the same actor even when run id changes", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "RunChangingGuardrailAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Guardrail run id scope issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const runIds = [randomUUID(), randomUUID(), randomUUID(), randomUUID()];
+    await db.insert(heartbeatRuns).values(
+      runIds.map((runId) => ({
+        id: runId,
+        companyId,
+        agentId,
+        status: "running",
+        invocationSource: "manual",
+      })),
+    );
+
+    await svc.addComment(issueId, "first", { agentId, runId: runIds[0] });
+    await svc.addComment(issueId, "second", { agentId, runId: runIds[1] });
+    await svc.addComment(issueId, "third", { agentId, runId: runIds[2] });
+
+    await expect(
+      svc.addComment(issueId, "fourth", { agentId, runId: runIds[3] }),
+    ).rejects.toThrow("Issue comment churn guardrail triggered");
+  });
+
+  it("does not block comments from a different actor", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const firstAgentId = randomUUID();
+    const secondAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: firstAgentId,
+        companyId,
+        name: "FirstGuardrailAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: secondAgentId,
+        companyId,
+        name: "SecondGuardrailAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Guardrail actor scope issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await svc.addComment(issueId, "first", { agentId: firstAgentId });
+    await svc.addComment(issueId, "second", { agentId: firstAgentId });
+    await svc.addComment(issueId, "third", { agentId: firstAgentId });
+
+    await expect(
+      svc.addComment(issueId, "allowed from different actor", { agentId: secondAgentId }),
+    ).resolves.toBeTruthy();
   });
 
   it("includes blockedBy summaries on list rows in one batched pass", async () => {
@@ -2564,6 +2708,146 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
         serviceStates: null,
       },
     });
+  });
+
+  it("persists executionWorkspaceId and executionWorkspacePreference on issue update", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const firstExecutionWorkspaceId = randomUUID();
+    const secondExecutionWorkspaceId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspace project",
+      status: "in_progress",
+    });
+
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary workspace",
+    });
+
+    await db.insert(executionWorkspaces).values([
+      {
+        id: firstExecutionWorkspaceId,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        name: "First workspace",
+        status: "active",
+        providerType: "git_worktree",
+      },
+      {
+        id: secondExecutionWorkspaceId,
+        companyId,
+        projectId,
+        projectWorkspaceId,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        name: "Second workspace",
+        status: "active",
+        providerType: "git_worktree",
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      title: "Workspace reassignment issue",
+      status: "in_progress",
+      priority: "medium",
+      executionWorkspaceId: firstExecutionWorkspaceId,
+      executionWorkspacePreference: null,
+    });
+
+    const updated = await svc.update(issueId, {
+      executionWorkspaceId: secondExecutionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+    });
+
+    expect(updated?.executionWorkspaceId).toBe(secondExecutionWorkspaceId);
+    expect(updated?.executionWorkspacePreference).toBe("reuse_existing");
+  });
+
+  it("persists executionWorkspaceId and executionWorkspacePreference on update when isolated workspaces are disabled", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspace project",
+      status: "in_progress",
+    });
+
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary workspace",
+    });
+
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Update workspace",
+      status: "active",
+      providerType: "git_worktree",
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      title: "Workspace preference write",
+      status: "todo",
+      priority: "medium",
+      executionWorkspaceId: null,
+      executionWorkspacePreference: null,
+    });
+
+    const updated = await svc.update(issueId, {
+      executionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      executionWorkspaceSettings: { mode: "isolated_workspace" },
+    });
+
+    expect(updated?.executionWorkspaceId).toBe(executionWorkspaceId);
+    expect(updated?.executionWorkspacePreference).toBe("reuse_existing");
+    expect(updated?.executionWorkspaceSettings).toBeNull();
   });
 });
 

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -120,6 +120,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     count: number;
     now: Date;
     withRunComments?: boolean;
+    resultJson?: Record<string, unknown>;
   }) {
     const runs: Array<typeof heartbeatRuns.$inferInsert> = [];
     for (let index = 0; index < input.count; index += 1) {
@@ -135,6 +136,7 @@ describeEmbeddedPostgres("productivity review service", () => {
         startedAt: createdAt,
         finishedAt: new Date(createdAt.getTime() + 30_000),
         contextSnapshot: { issueId: input.issueId, taskId: input.issueId },
+        resultJson: input.resultJson ?? null,
         livenessState: "advanced",
         nextAction: "Continue processing the next batch.",
         createdAt,
@@ -406,6 +408,77 @@ describeEmbeddedPostgres("productivity review service", () => {
         authorAgentId: seeded.managerId,
         createdByRunId: run.id,
         body: `Manager note ${index}`,
+        createdAt: run.createdAt as Date,
+        updatedAt: run.createdAt as Date,
+      })),
+    );
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("excludes deduplicated blocked-relay runs and comments from high-churn thresholds", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    const runs = await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 10,
+      now,
+      resultJson: { blockedRelayCommentDeduped: true },
+    });
+    await db.insert(issueComments).values(
+      runs.map((run, index) => ({
+        companyId: seeded.companyId,
+        issueId: seeded.issueId,
+        authorAgentId: seeded.coderId,
+        createdByRunId: run.id,
+        body: `Blocked relay ${index}`,
+        createdAt: run.createdAt as Date,
+        updatedAt: run.createdAt as Date,
+      })),
+    );
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("does not let deduplicated runs push high-churn counts over threshold", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    const countedRuns = await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 9,
+      now,
+    });
+    const dedupedRuns = await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 1,
+      now,
+      resultJson: { blockedRelayCommentDeduped: true },
+    });
+    await db.insert(issueComments).values(
+      [...countedRuns, ...dedupedRuns].map((run, index) => ({
+        companyId: seeded.companyId,
+        issueId: seeded.issueId,
+        authorAgentId: seeded.coderId,
+        createdByRunId: run.id,
+        body: `Mixed churn ${index}`,
         createdAt: run.createdAt as Date,
         updatedAt: run.createdAt as Date,
       })),

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -1305,7 +1305,7 @@ describe("realizeExecutionWorkspace", () => {
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
-  });
+  }, 30_000);
 
   it(
     "provisions worktree-local pnpm node_modules instead of reusing base-repo links",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -42,6 +42,7 @@ import {
   ISSUE_LIST_DEFAULT_LIMIT,
   issueApprovalService,
   issueService,
+  issueTreeControlService,
   logActivity,
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
@@ -164,6 +165,9 @@ export function agentRoutes(
   });
   const recovery = recoveryService(db, { enqueueWakeup: heartbeat.wakeup });
   const issueApprovalsSvc = issueApprovalService(db);
+  const issueTreeControl = typeof issueTreeControlService === "function"
+    ? issueTreeControlService(db)
+    : { getActivePauseHoldGate: async () => null };
   const secretsSvc = secretService(db);
   const instructions = agentInstructionsService();
   const companySkills = companySkillService(db);
@@ -1565,23 +1569,53 @@ export function agentRoutes(
       req.actor.companyId,
       rows.map((issue) => issue.id),
     );
+    const pauseHoldGates = await Promise.all(
+      rows.map((issue) => issueTreeControl.getActivePauseHoldGate(req.actor.companyId!, issue.id)),
+    );
+    const pauseHoldGateByIssueId = new Map(
+      rows.map((issue, index) => [issue.id, pauseHoldGates[index]] as const),
+    );
 
     res.json(
-      rows.map((issue) => ({
-        id: issue.id,
-        identifier: issue.identifier,
-        title: issue.title,
-        status: issue.status,
-        priority: issue.priority,
-        projectId: issue.projectId,
-        goalId: issue.goalId,
-        parentId: issue.parentId,
-        updatedAt: issue.updatedAt,
-        activeRun: issue.activeRun,
-        dependencyReady: dependencyReadiness.get(issue.id)?.isDependencyReady ?? true,
-        unresolvedBlockerCount: dependencyReadiness.get(issue.id)?.unresolvedBlockerCount ?? 0,
-        unresolvedBlockerIssueIds: dependencyReadiness.get(issue.id)?.unresolvedBlockerIssueIds ?? [],
-      })),
+      rows.map((issue) => {
+        const readiness = dependencyReadiness.get(issue.id);
+        const unresolvedBlockerCount = readiness?.unresolvedBlockerCount ?? 0;
+        const unresolvedBlockerIssueIds = readiness?.unresolvedBlockerIssueIds ?? [];
+        const activePauseHold = pauseHoldGateByIssueId.get(issue.id) ?? null;
+        const checkoutBlockedByPauseHold = Boolean(activePauseHold);
+        const checkoutBlockedByUnresolvedBlockers = unresolvedBlockerCount > 0;
+        const checkoutBlocked = checkoutBlockedByPauseHold || checkoutBlockedByUnresolvedBlockers;
+        const checkoutBlockReason = checkoutBlockedByPauseHold
+          ? "active_subtree_pause_hold"
+          : checkoutBlockedByUnresolvedBlockers
+            ? "unresolved_blockers"
+            : null;
+        return {
+          id: issue.id,
+          identifier: issue.identifier,
+          title: issue.title,
+          status: issue.status,
+          priority: issue.priority,
+          projectId: issue.projectId,
+          goalId: issue.goalId,
+          parentId: issue.parentId,
+          updatedAt: issue.updatedAt,
+          activeRun: issue.activeRun,
+          // Keep legacy field for existing consumers while enforcing checkout parity.
+          dependencyReady: !checkoutBlocked,
+          unresolvedBlockerCount,
+          unresolvedBlockerIssueIds,
+          checkoutBlocked,
+          checkoutBlockReason,
+          activePauseHold: activePauseHold
+            ? {
+              holdId: activePauseHold.holdId,
+              rootIssueId: activePauseHold.rootIssueId,
+              mode: activePauseHold.mode,
+            }
+            : null,
+        };
+      }),
     );
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -28,6 +28,7 @@ import {
   updateIssueWorkProductSchema,
   upsertIssueDocumentSchema,
   updateIssueSchema,
+  ISSUE_EXECUTION_WORKSPACE_PREFERENCES,
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
   type ExecutionWorkspace,
@@ -87,8 +88,31 @@ import {
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
+const issueExecutionWorkspacePreferencesRouteSchema = z.enum(ISSUE_EXECUTION_WORKSPACE_PREFERENCES);
+const issueExecutionWorkspaceSettingsRouteSchema = z
+  .object({
+    mode: issueExecutionWorkspacePreferencesRouteSchema.optional(),
+    environmentId: z.string().uuid().optional().nullable(),
+    workspaceStrategy: z
+      .object({
+        type: z.enum(["project_primary", "git_worktree", "adapter_managed", "cloud_sandbox"]).optional(),
+        baseRef: z.string().optional().nullable(),
+        branchTemplate: z.string().optional().nullable(),
+        worktreeParentDir: z.string().optional().nullable(),
+        provisionCommand: z.string().optional().nullable(),
+        teardownCommand: z.string().optional().nullable(),
+      })
+      .strict()
+      .optional()
+      .nullable(),
+    workspaceRuntime: z.record(z.unknown()).optional().nullable(),
+  })
+  .strict();
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
+  executionWorkspaceId: z.string().uuid().optional().nullable(),
+  executionWorkspacePreference: issueExecutionWorkspacePreferencesRouteSchema.optional().nullable(),
+  executionWorkspaceSettings: issueExecutionWorkspaceSettingsRouteSchema.optional().nullable(),
 });
 
 type ParsedExecutionState = NonNullable<ReturnType<typeof parseIssueExecutionState>>;
@@ -148,6 +172,19 @@ function summarizeIssueRelationForActivity(relation: {
     identifier: relation.identifier,
     title: relation.title,
   };
+}
+
+function relationIds(relations: { id: string }[]): string[] {
+  return relations.map((relation) => relation.id);
+}
+
+function normalizeBlockedByIssueIdsFromRelations(
+  blockedBy: Array<{ id?: string | null }> | undefined,
+): string[] | null {
+  if (!Array.isArray(blockedBy)) return null;
+  return blockedBy
+    .map((relation) => relation.id)
+    .filter((id): id is string => typeof id === "string");
 }
 
 function summarizeIssueReferenceActivityDetails(input:
@@ -647,6 +684,29 @@ export function issueRoutes(
     res: Response,
     issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
   ) {
+    const isCrossAssigneeInterventionComment = (() => {
+      if (req.method !== "POST") return false;
+      if (!/^\/issues\/[^/]+\/comments$/.test(req.path)) return false;
+      if (!req.body || typeof req.body !== "object") return false;
+      return (req.body as { intervention?: unknown }).intervention === true;
+    })();
+
+    const isExecutionWorkspaceOnlyPatch = (() => {
+      if (req.method !== "PATCH") return false;
+      if (!req.body || typeof req.body !== "object") return false;
+
+      const allowedKeys = new Set([
+        "executionWorkspaceId",
+        "executionWorkspacePreference",
+        "executionWorkspaceSettings",
+      ]);
+      const keys = Object.entries(req.body as Record<string, unknown>)
+        .filter(([, value]) => value !== undefined && value !== null)
+        .map(([key]) => key);
+      if (keys.length === 0) return false;
+      return keys.every((key) => allowedKeys.has(key));
+    })();
+
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
     if (!actorAgentId) {
@@ -658,6 +718,15 @@ export function issueRoutes(
     }
     if (issue.assigneeAgentId !== actorAgentId) {
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
+        return true;
+      }
+      if (
+        isCrossAssigneeInterventionComment &&
+        (await access.hasPermission(issue.companyId, "agent", actorAgentId, "tasks:assign"))
+      ) {
+        return true;
+      }
+      if (issue.status !== "in_progress" && isExecutionWorkspaceOnlyPatch) {
         return true;
       }
       if (issue.status === "in_progress") {
@@ -1142,6 +1211,7 @@ export function issueRoutes(
         goalId: goal?.id ?? issue.goalId,
         parentId: issue.parentId,
         blockedBy: relations.blockedBy,
+        blockedByIssueIds: relationIds(relations.blockedBy),
         blocks: relations.blocks,
         assigneeAgentId: issue.assigneeAgentId,
         assigneeUserId: issue.assigneeUserId,
@@ -1214,6 +1284,7 @@ export function issueRoutes(
       { project, goal },
       ancestors,
       mentionedProjectIds,
+      commentCursor,
       documentPayload,
       relations,
       blockerAttention,
@@ -1223,6 +1294,7 @@ export function issueRoutes(
       resolveIssueProjectAndGoal(issue),
       svc.getAncestors(issue.id),
       svc.findMentionedProjectIds(issue.id, { includeCommentBodies: false }),
+      svc.getCommentCursor(issue.id),
       documentsSvc.getIssueDocumentPayload(issue),
       svc.getRelationSummaries(issue.id),
       svc.listBlockerAttention(issue.companyId, [issue]).then((map) => map.get(issue.id) ?? null),
@@ -1236,6 +1308,7 @@ export function issueRoutes(
       ? await executionWorkspacesSvc.getById(issue.executionWorkspaceId)
       : null;
     const workProducts = await workProductsSvc.listForIssue(issue.id);
+    const blockedByIssueIds = relationIds(relations.blockedBy);
     res.json({
       ...issue,
       goalId: goal?.id ?? issue.goalId,
@@ -1246,7 +1319,9 @@ export function issueRoutes(
       blocks: relations.blocks,
       relatedWork: referenceSummary,
       referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
+      commentCursor,
       ...documentPayload,
+      blockedByIssueIds,
       project: project ?? null,
       goal: goal ?? null,
       mentionedProjects,
@@ -2217,6 +2292,17 @@ export function issueRoutes(
       };
     }
     Object.assign(updateFields, transition.patch);
+    // Preserve explicit workspace patch intent even if transition patching adds
+    // undefined placeholders for these fields.
+    if (Object.prototype.hasOwnProperty.call(req.body, "executionWorkspaceId")) {
+      updateFields.executionWorkspaceId = req.body.executionWorkspaceId;
+    }
+    if (Object.prototype.hasOwnProperty.call(req.body, "executionWorkspacePreference")) {
+      updateFields.executionWorkspacePreference = req.body.executionWorkspacePreference;
+    }
+    if (Object.prototype.hasOwnProperty.call(req.body, "executionWorkspaceSettings")) {
+      updateFields.executionWorkspaceSettings = req.body.executionWorkspaceSettings;
+    }
     if (reviewRequest !== undefined && transition.patch.executionState === undefined) {
       const existingExecutionState = parseIssueExecutionState(existing.executionState);
       if (!existingExecutionState || existingExecutionState.status !== "pending") {
@@ -2252,6 +2338,16 @@ export function issueRoutes(
         await assertCanAssignTasks(req, existing.companyId);
       }
     }
+
+    const requestedExecutionWorkspaceId = Object.prototype.hasOwnProperty.call(req.body, "executionWorkspaceId")
+      ? (req.body.executionWorkspaceId as string | null)
+      : undefined;
+    const requestedExecutionWorkspacePreference = Object.prototype.hasOwnProperty.call(req.body, "executionWorkspacePreference")
+      ? (req.body.executionWorkspacePreference as string | null)
+      : undefined;
+    const requestedExecutionWorkspaceSettings = Object.prototype.hasOwnProperty.call(req.body, "executionWorkspaceSettings")
+      ? (req.body.executionWorkspaceSettings as Record<string, unknown> | null)
+      : undefined;
 
     let issue;
     try {
@@ -2314,6 +2410,80 @@ export function issueRoutes(
       }
       throw err;
     }
+    if (
+      issue &&
+      (requestedExecutionWorkspaceId !== undefined || requestedExecutionWorkspacePreference !== undefined) &&
+      (
+        (requestedExecutionWorkspaceId !== undefined && issue.executionWorkspaceId !== requestedExecutionWorkspaceId) ||
+        (
+          requestedExecutionWorkspacePreference !== undefined &&
+          issue.executionWorkspacePreference !== requestedExecutionWorkspacePreference
+        )
+      )
+    ) {
+      // Guardrail for direct PATCH contract: if the broader issue mutation path
+      // returns stale execution-workspace linkage fields, retry a workspace-only
+      // persistence patch and use that response.
+      const workspaceOnlyPatch: {
+        executionWorkspaceId?: string | null;
+        executionWorkspacePreference?: string | null;
+        executionWorkspaceSettings?: Record<string, unknown> | null;
+        actorAgentId?: string | null;
+        actorUserId?: string | null;
+      } = {
+        actorAgentId: actor.agentId ?? null,
+        actorUserId: actor.actorType === "user" ? actor.actorId : null,
+      };
+      if (requestedExecutionWorkspaceId !== undefined) {
+        workspaceOnlyPatch.executionWorkspaceId = requestedExecutionWorkspaceId;
+      }
+      if (requestedExecutionWorkspacePreference !== undefined) {
+        workspaceOnlyPatch.executionWorkspacePreference = requestedExecutionWorkspacePreference;
+      }
+      if (requestedExecutionWorkspaceSettings !== undefined) {
+        workspaceOnlyPatch.executionWorkspaceSettings = requestedExecutionWorkspaceSettings;
+      }
+      const persistedWorkspacePatch = await svc.update(id, workspaceOnlyPatch);
+      if (persistedWorkspacePatch) {
+        issue = persistedWorkspacePatch;
+      }
+    }
+
+    if (issue && (requestedExecutionWorkspaceId !== undefined || requestedExecutionWorkspacePreference !== undefined)) {
+      // Re-read persisted state before returning 200 so direct PATCH cannot
+      // silently succeed with stale workspace linkage values.
+      const persistedIssue = await svc.getById(id);
+      if (!persistedIssue) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+      issue = persistedIssue;
+    }
+
+    if (
+      issue &&
+      (requestedExecutionWorkspaceId !== undefined || requestedExecutionWorkspacePreference !== undefined) &&
+      (
+        (requestedExecutionWorkspaceId !== undefined && issue.executionWorkspaceId !== requestedExecutionWorkspaceId) ||
+        (
+          requestedExecutionWorkspacePreference !== undefined &&
+          issue.executionWorkspacePreference !== requestedExecutionWorkspacePreference
+        )
+      )
+    ) {
+      res.status(409).json({
+        error: "Execution workspace selection was overridden by policy",
+        details: {
+          reason: "execution_workspace_policy_override",
+          requestedExecutionWorkspaceId: requestedExecutionWorkspaceId ?? null,
+          requestedExecutionWorkspacePreference: requestedExecutionWorkspacePreference ?? null,
+          persistedExecutionWorkspaceId: issue.executionWorkspaceId ?? null,
+          persistedExecutionWorkspacePreference: issue.executionWorkspacePreference ?? null,
+        },
+      });
+      return;
+    }
+
     if (!issue) {
       res.status(404).json({ error: "Issue not found" });
       return;
@@ -2374,6 +2544,7 @@ export function issueRoutes(
       issueResponse = {
         ...issue,
         blockedBy: updatedRelations.blockedBy,
+        blockedByIssueIds: relationIds(updatedRelations.blockedBy),
         blocks: updatedRelations.blocks,
       };
     }
@@ -2866,7 +3037,14 @@ export function issueRoutes(
       }
     })();
 
-    res.json({ ...issueResponse, comment });
+    const responseBlockedByIssueIds = normalizeBlockedByIssueIdsFromRelations(
+      (issueResponse as { blockedBy?: Array<{ id?: string | null }> }).blockedBy,
+    );
+    res.json({
+      ...issueResponse,
+      ...(responseBlockedByIssueIds ? { blockedByIssueIds: responseBlockedByIssueIds } : {}),
+      comment,
+    });
   });
 
   router.delete("/issues/:id", async (req, res) => {
@@ -2945,6 +3123,9 @@ export function issueRoutes(
     const checkoutRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !checkoutRunId) return;
     const updated = await svc.checkout(id, req.body.agentId, req.body.expectedStatuses, checkoutRunId);
+    const currentExecutionWorkspace = updated.executionWorkspaceId
+      ? await executionWorkspacesSvc.getById(updated.executionWorkspaceId)
+      : null;
     const actor = getActorInfo(req);
 
     await logActivity(db, {
@@ -2980,7 +3161,10 @@ export function issueRoutes(
         .catch((err) => logger.warn({ err, issueId: issue.id }, "failed to wake assignee on issue checkout"));
     }
 
-    res.json(updated);
+    res.json({
+      ...updated,
+      currentExecutionWorkspace,
+    });
   });
 
   router.post("/issues/:id/release", async (req, res) => {
@@ -3627,7 +3811,12 @@ export function issueRoutes(
     const commentReferenceSummaryBefore = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
 
     if (effectiveMoveToTodoRequested && (isClosed || (isBlocked && !hasUnresolvedFirstClassBlockers))) {
-      const reopenedIssue = await svc.update(id, { status: "todo" });
+      const reopenedIssue = await svc.update(id, {
+        status: "todo",
+        executionWorkspaceId: issue.executionWorkspaceId ?? null,
+        executionWorkspacePreference: issue.executionWorkspacePreference ?? null,
+        executionWorkspaceSettings: issue.executionWorkspaceSettings ?? null,
+      });
       if (!reopenedIssue) {
         res.status(404).json({ error: "Issue not found" });
         return;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1126,6 +1126,7 @@ export function issueRoutes(
         documentsSvc.getIssueDocumentByKey(issue.id, ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY),
         currentExecutionWorkspacePromise,
       ]);
+    const resolvedExecutionWorkspaceId = issue.executionWorkspaceId ?? currentExecutionWorkspace?.id ?? null;
 
     res.json({
       issue: {
@@ -1144,6 +1145,8 @@ export function issueRoutes(
         blocks: relations.blocks,
         assigneeAgentId: issue.assigneeAgentId,
         assigneeUserId: issue.assigneeUserId,
+        executionWorkspaceId: resolvedExecutionWorkspaceId,
+        currentExecutionWorkspace,
         originKind: issue.originKind,
         originId: issue.originId,
         updatedAt: issue.updatedAt,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -164,6 +164,7 @@ const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
 const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+const BLOCKED_RELAY_COMMENT_DEDUP_WINDOW_MS = 60 * 60 * 1000;
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -967,6 +968,48 @@ export function prioritizeProjectWorkspaceCandidatesForRun<T extends ProjectWork
   const preferredIndex = rows.findIndex((row) => row.id === preferredWorkspaceId);
   if (preferredIndex <= 0) return rows;
   return [rows[preferredIndex]!, ...rows.slice(0, preferredIndex), ...rows.slice(preferredIndex + 1)];
+}
+
+export function shouldPersistIssueWorkspaceReuse(input: {
+  existingPreference: string | null | undefined;
+  persistedWorkspaceMode: ExecutionWorkspace["mode"];
+  realizedWorkspaceSource?: RealizedExecutionWorkspace["source"] | null;
+}): boolean {
+  if (input.existingPreference === "reuse_existing") return true;
+  if (input.realizedWorkspaceSource === "task_session") return true;
+  return input.persistedWorkspaceMode !== "shared_workspace";
+}
+
+function normalizeWorkspacePathKey(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  return normalized.replace(/[\\/]+$/, "");
+}
+
+export function shouldPreserveEquivalentSharedWorkspaceBinding(input: {
+  issueExecutionWorkspacePreference: string | null | undefined;
+  existingExecutionWorkspace: ExecutionWorkspace | null | undefined;
+  persistedExecutionWorkspace: ExecutionWorkspace | null | undefined;
+}): boolean {
+  if (input.issueExecutionWorkspacePreference !== "reuse_existing") return false;
+  const existing = input.existingExecutionWorkspace;
+  const persisted = input.persistedExecutionWorkspace;
+  if (!existing || !persisted) return false;
+  if (existing.id === persisted.id) return false;
+  if (existing.mode !== "shared_workspace" || persisted.mode !== "shared_workspace") return false;
+  if (existing.projectId !== persisted.projectId) return false;
+  if ((existing.projectWorkspaceId ?? null) !== (persisted.projectWorkspaceId ?? null)) return false;
+  if (existing.strategyType !== persisted.strategyType) return false;
+  if ((existing.providerType ?? null) !== (persisted.providerType ?? null)) return false;
+
+  const existingPath = normalizeWorkspacePathKey(existing.providerRef) ?? normalizeWorkspacePathKey(existing.cwd);
+  const persistedPath = normalizeWorkspacePathKey(persisted.providerRef) ?? normalizeWorkspacePathKey(persisted.cwd);
+  if (existingPath && persistedPath) {
+    return existingPath === persistedPath;
+  }
+
+  return normalizeWorkspacePathKey(existing.cwd) === normalizeWorkspacePathKey(persisted.cwd);
 }
 
 function readNonEmptyString(value: unknown): string | null {
@@ -3949,6 +3992,81 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
+  async function computeBlockedRelayStateFingerprint(companyId: string, issueId: string) {
+    const blockerRows = await db
+      .select({
+        blockerId: issueRelations.issueId,
+        blockerStatus: issues.status,
+        blockerAssigneeAgentId: issues.assigneeAgentId,
+        blockerMonitorNextCheckAt: issues.monitorNextCheckAt,
+      })
+      .from(issueRelations)
+      .innerJoin(
+        issues,
+        and(
+          eq(issues.companyId, issueRelations.companyId),
+          eq(issues.id, issueRelations.issueId),
+        ),
+      )
+      .where(
+        and(
+          eq(issueRelations.companyId, companyId),
+          eq(issueRelations.relatedIssueId, issueId),
+          eq(issueRelations.type, "blocks"),
+        ),
+      )
+      .orderBy(asc(issueRelations.issueId));
+
+    return JSON.stringify(
+      blockerRows.map((row) => ({
+        blockerId: row.blockerId,
+        blockerStatus: row.blockerStatus,
+        blockerAssigneeAgentId: row.blockerAssigneeAgentId,
+        blockerMonitorNextCheckAt: row.blockerMonitorNextCheckAt
+          ? row.blockerMonitorNextCheckAt.toISOString()
+          : null,
+      })),
+    );
+  }
+
+  async function shouldSuppressDedupedBlockedRelayComment(input: {
+    companyId: string;
+    issueId: string;
+    runId: string;
+    agentId: string;
+    comment: string;
+  }): Promise<{ suppress: boolean; fingerprint: string | null }> {
+    const issue = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(and(eq(issues.companyId, input.companyId), eq(issues.id, input.issueId)))
+      .then((rows) => rows[0] ?? null);
+    if (!issue || issue.status !== "blocked") return { suppress: false, fingerprint: null };
+
+    const fingerprint = await computeBlockedRelayStateFingerprint(input.companyId, input.issueId);
+    const cutoff = new Date(Date.now() - BLOCKED_RELAY_COMMENT_DEDUP_WINDOW_MS);
+    const previous = await db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .innerJoin(heartbeatRuns, eq(heartbeatRuns.id, issueComments.createdByRunId))
+      .where(
+        and(
+          eq(issueComments.companyId, input.companyId),
+          eq(issueComments.issueId, input.issueId),
+          eq(issueComments.authorAgentId, input.agentId),
+          gt(issueComments.createdAt, cutoff),
+          sql`${issueComments.createdByRunId} <> ${input.runId}`,
+          sql`${heartbeatRuns.resultJson} ->> 'blockedRelayStateFingerprint' = ${fingerprint}`,
+        ),
+      )
+      .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+
+    if (!previous) return { suppress: false, fingerprint };
+    return { suppress: true, fingerprint };
+  }
+
   async function refreshContinuationSummaryForRun(
     run: typeof heartbeatRuns.$inferSelect,
     agent: typeof agents.$inferSelect,
@@ -6549,12 +6667,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
     if (issueId && persistedExecutionWorkspace) {
       const nextIssueWorkspaceMode = issueExecutionWorkspaceModeForPersistedWorkspace(persistedExecutionWorkspace.mode);
-      const shouldSwitchIssueToExistingWorkspace =
-        issueRef?.executionWorkspacePreference === "reuse_existing" ||
-        requestedExecutionWorkspaceMode === "isolated_workspace" ||
-        requestedExecutionWorkspaceMode === "operator_branch";
+      const shouldSwitchIssueToExistingWorkspace = shouldPersistIssueWorkspaceReuse({
+        existingPreference: issueRef?.executionWorkspacePreference,
+        persistedWorkspaceMode: persistedExecutionWorkspace.mode,
+        realizedWorkspaceSource: executionWorkspace.source,
+      });
+      const shouldKeepExistingWorkspaceBinding = shouldPreserveEquivalentSharedWorkspaceBinding({
+        issueExecutionWorkspacePreference: issueRef?.executionWorkspacePreference,
+        existingExecutionWorkspace,
+        persistedExecutionWorkspace,
+      });
       const nextIssuePatch: Record<string, unknown> = {};
-      if (issueRef?.executionWorkspaceId !== persistedExecutionWorkspace.id) {
+      if (
+        !shouldKeepExistingWorkspaceBinding
+        && issueRef?.executionWorkspaceId !== persistedExecutionWorkspace.id
+      ) {
         nextIssuePatch.executionWorkspaceId = persistedExecutionWorkspace.id;
       }
       if (resolvedProjectWorkspaceId && issueRef?.projectWorkspaceId !== resolvedProjectWorkspaceId) {
@@ -7201,7 +7328,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             if (!existingRunComment) {
               const issueComment = buildHeartbeatRunIssueComment(persistedResultJson);
               if (issueComment) {
-                await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: livenessRun.id });
+                const dedup = await shouldSuppressDedupedBlockedRelayComment({
+                  companyId: livenessRun.companyId,
+                  issueId,
+                  runId: livenessRun.id,
+                  agentId: agent.id,
+                  comment: issueComment,
+                });
+                if (!dedup.suppress) {
+                  await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: livenessRun.id });
+                }
+                if (dedup.fingerprint || dedup.suppress) {
+                  const latestResultJson = parseObject(livenessRun.resultJson);
+                  await db
+                    .update(heartbeatRuns)
+                    .set({
+                      resultJson: {
+                        ...latestResultJson,
+                        blockedRelayStateFingerprint: dedup.fingerprint,
+                        blockedRelayCommentDeduped: dedup.suppress,
+                      },
+                      updatedAt: new Date(),
+                    })
+                    .where(eq(heartbeatRuns.id, livenessRun.id));
+                }
               }
             }
           } catch (err) {

--- a/server/src/services/issue-tree-control.ts
+++ b/server/src/services/issue-tree-control.ts
@@ -275,6 +275,8 @@ function toHold(row: HoldRow, members?: HoldMemberRow[]): IssueTreeHold {
 }
 
 function toHoldMember(row: HoldMemberRow): IssueTreeHoldMember {
+  const activeRunId = row.activeRunId;
+  const activeRunStatus = activeRunId ? row.activeRunStatus : null;
   return {
     id: row.id,
     companyId: row.companyId,
@@ -287,8 +289,8 @@ function toHoldMember(row: HoldMemberRow): IssueTreeHoldMember {
     issueStatus: coerceIssueStatus(row.issueStatus),
     assigneeAgentId: row.assigneeAgentId,
     assigneeUserId: row.assigneeUserId,
-    activeRunId: row.activeRunId,
-    activeRunStatus: row.activeRunStatus,
+    activeRunId,
+    activeRunStatus,
     skipped: row.skipped,
     skipReason: row.skipReason,
     createdAt: row.createdAt,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -64,6 +64,8 @@ const ISSUE_LIST_RELATED_QUERY_CHUNK_SIZE = 500;
 export const MAX_CHILD_ISSUES_CREATED_BY_HELPER = 25;
 const MAX_CHILD_COMPLETION_SUMMARIES = 20;
 const CHILD_COMPLETION_SUMMARY_BODY_MAX_CHARS = 500;
+const ISSUE_COMMENT_CHURN_WINDOW_MS = 30_000;
+const ISSUE_COMMENT_CHURN_MAX_PER_WINDOW = 3;
 function assertTransition(from: string, to: string) {
   if (from === to) return;
   if (!ALL_ISSUE_STATUSES.includes(to)) {
@@ -2677,8 +2679,6 @@ export function issueService(db: Db) {
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
-        delete issueData.executionWorkspaceId;
-        delete issueData.executionWorkspacePreference;
         delete issueData.executionWorkspaceSettings;
       }
       if (data.assigneeAgentId && data.assigneeUserId) {
@@ -2924,8 +2924,6 @@ export function issueService(db: Db) {
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
-        delete issueData.executionWorkspaceId;
-        delete issueData.executionWorkspacePreference;
         delete issueData.executionWorkspaceSettings;
       }
 
@@ -3729,6 +3727,27 @@ export function issueService(db: Db) {
         enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
       };
       const redactedBody = redactCurrentUserText(body, currentUserRedactionOptions);
+      const now = new Date();
+      const hasActorIdentity = Boolean(actor.agentId || actor.userId);
+      if (hasActorIdentity) {
+        const windowStartedAt = new Date(now.getTime() - ISSUE_COMMENT_CHURN_WINDOW_MS);
+        const sameActorConditions = [
+          eq(issueComments.issueId, issueId),
+          gt(issueComments.createdAt, windowStartedAt),
+        ];
+        if (actor.agentId) sameActorConditions.push(eq(issueComments.authorAgentId, actor.agentId));
+        else sameActorConditions.push(isNull(issueComments.authorAgentId));
+        if (actor.userId) sameActorConditions.push(eq(issueComments.authorUserId, actor.userId));
+        else sameActorConditions.push(isNull(issueComments.authorUserId));
+
+        const [recentCommentCounts] = await db
+          .select({ count: sql<number>`count(*)::int` })
+          .from(issueComments)
+          .where(and(...sameActorConditions));
+        if ((recentCommentCounts?.count ?? 0) >= ISSUE_COMMENT_CHURN_MAX_PER_WINDOW) {
+          throw conflict("Issue comment churn guardrail triggered: too many comments in 30 seconds");
+        }
+      }
       const [comment] = await db
         .insert(issueComments)
         .values({
@@ -3738,6 +3757,8 @@ export function issueService(db: Db) {
           authorUserId: actor.userId ?? null,
           createdByRunId: actor.runId ?? null,
           body: redactedBody,
+          createdAt: now,
+          updatedAt: now,
         })
         .returning();
 

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -100,6 +100,10 @@ function issueRunScopeSql(issueId: string) {
   )`;
 }
 
+function includeInChurnSql() {
+  return sql`coalesce(${heartbeatRuns.resultJson} ->> 'blockedRelayCommentDeduped', 'false') != 'true'`;
+}
+
 function msToHuman(ms: number | null) {
   if (ms === null) return "unknown";
   const minutes = Math.floor(ms / 60_000);
@@ -351,6 +355,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           eq(heartbeatRuns.companyId, companyId),
           eq(heartbeatRuns.agentId, agentId),
           issueRunScopeSql(issueId),
+          includeInChurnSql(),
           sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) >= ${since.toISOString()}::timestamptz`,
         ),
       )
@@ -370,6 +375,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           eq(heartbeatRuns.companyId, companyId),
           eq(heartbeatRuns.agentId, agentId),
           issueRunScopeSql(issueId),
+          includeInChurnSql(),
           since ? sql`${issueComments.createdAt} >= ${since.toISOString()}::timestamptz` : undefined,
         ),
       )
@@ -393,6 +399,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           eq(heartbeatRuns.companyId, sourceIssue.companyId),
           eq(heartbeatRuns.agentId, sourceAgent.id),
           issueRunScopeSql(sourceIssue.id),
+          includeInChurnSql(),
         ),
       )
       .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through company-scoped issues, checkouts, execution workspaces, and heartbeat runs.
> - MIL-525 sits in the server/shared control-plane layer where issue checkout, heartbeat context, and execution workspace persistence have to agree on the same contract.
> - The failing behavior was parity drift: agent inbox-lite and heartbeat-context omitted data needed to reason about blocked checkouts, and heartbeat persistence could overwrite an equivalent shared workspace binding.
> - That drift made maintainers and downstream agents see inconsistent readiness/workspace state, which is exactly the kind of control-plane inconsistency the V1 implementation contract should avoid.
> - The fix also needed defensive follow-through around comment churn and blocked-relay dedupe so the new wake/resume paths do not create noisy regressions while we expose richer issue state.
> - This pull request aligns the route/service/shared validator contract, preserves equivalent shared workspace bindings, and adds regression coverage across the affected issue and heartbeat paths.
> - The benefit is that MIL-525 can move through review on a maintainer-published branch with the parity bug fixed and the surrounding execution semantics documented and tested.

## What Changed

- preserved equivalent shared-workspace bindings during heartbeat persistence instead of rewriting the issue binding when the realized workspace points at the same local workspace
- exposed `blockedByIssueIds`, `commentCursor`, and execution-workspace patch handling through the issue routes/shared validators so heartbeat-context and issue reads return the parity data consumers need
- updated agent inbox-lite to report checkout blocking parity, including active subtree pause-hold details rather than only unresolved blocker counts
- allowed governed cross-assignee intervention comments and non-checkout execution-workspace-only patches where appropriate, while keeping normal active-checkout ownership protections intact
- added churn/dedupe guardrails for issue comments and blocked-relay heartbeat comments, plus regression coverage for workspace binding, heartbeat selection, issue routes, productivity review, and issue tree control paths
- documented the execution-semantics and issues API contract changes and refreshed worktree provisioning expectations

## Verification

- from repo root: `pnpm run preflight:workspace-links && pnpm exec vitest run packages/shared/src/validators/issue.test.ts server/src/__tests__/agent-inbox-lite-routes.test.ts server/src/__tests__/environment-selection-route-guards.test.ts server/src/__tests__/heartbeat-workspace-binding.test.ts server/src/__tests__/heartbeat-workspace-session.test.ts server/src/__tests__/issue-activity-events-routes.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/issues-goal-context-routes.test.ts server/src/__tests__/issues-service.test.ts server/src/__tests__/workspace-runtime.test.ts server/src/__tests__/heartbeat-dependency-scheduling.test.ts server/src/__tests__/issue-comment-churn-routes.test.ts server/src/__tests__/issue-tree-control-service.test.ts server/src/__tests__/productivity-review-service.test.ts`

## Risks

- Medium: this touches core issue mutation and heartbeat orchestration paths, so any missed parity assumption could affect agent checkout or wake behavior outside the MIL-525 flow
- The new comment churn guard could surface `409` conflicts in edge-case automation that intentionally posts many comments in a short burst; the existing tests cover the intended budget but not every caller pattern
- Execution workspace persistence now preserves equivalent shared bindings more aggressively, so the main regression risk is failing to rebind when two workspaces look equivalent but are not actually interchangeable

> Checked `ROADMAP.md`; this is bugfix/contract-parity work, not overlapping planned core feature work.
>
> Related issues: `MIL-525`, `MIL-677`

## Model Used

- OpenAI Codex, GPT-5-based coding agent in the Codex CLI environment with tool use and code execution enabled; exact internal model revision/context window is not exposed in the workspace session

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
