### PR TITLE
fix: quarantine repeatedly timing out assigned issues

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1808,6 +1808,38 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it("does not stack assigned todo dispatches for the same agent during one recovery sweep", async () => {
+    const { companyId, agentId, issueId } = await seedAssignedTodoNoRunFixture();
+    const secondIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(issues).values({
+      id: secondIssueId,
+      companyId,
+      title: "Second assigned todo work without a heartbeat",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      assigneeUserId: null,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.assignmentDispatched).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toHaveLength(1);
+    expect([issueId, secondIssueId]).toContain(result.issueIds[0]);
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    if (runs[0]?.id) {
+      await waitForRunToSettle(heartbeat, runs[0].id);
+    }
+  });
+
   it("does not duplicate initial assigned todo dispatch when a queued wake already exists", async () => {
     const { companyId, agentId, issueId } = await seedAssignedTodoNoRunFixture();
     await db.insert(agentWakeupRequests).values({
@@ -1952,6 +1984,78 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     if (retryRun) {
       await waitForRunToSettle(heartbeat, retryRun.id);
     }
+  });
+
+  it("quarantines assigned in-progress work after repeated timeouts instead of requeueing it", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "timed_out",
+      runErrorCode: "timeout",
+      runError: "Timed out after 600s",
+    });
+    const now = Date.now();
+    const timeoutRunIds = [randomUUID(), randomUUID(), randomUUID()];
+    await db.insert(heartbeatRuns).values(timeoutRunIds.map((id, index) => ({
+      id,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "timed_out",
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+      startedAt: new Date(now - (index + 1) * 10 * 60 * 1000),
+      finishedAt: new Date(now - (index + 1) * 10 * 60 * 1000 + 5 * 60 * 1000),
+      createdAt: new Date(now - (index + 1) * 10 * 60 * 1000),
+      updatedAt: new Date(now - (index + 1) * 10 * 60 * 1000 + 5 * 60 * 1000),
+      errorCode: "timeout",
+      error: "Timed out after 600s",
+    })));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.timeoutQuarantined).toBe(1);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    const recovery = await waitForValue(async () =>
+      db.select().from(issues).where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, "stranded_issue_recovery"),
+          eq(issues.originId, issueId),
+        ),
+      ).then((rows) => rows[0] ?? null),
+    );
+    if (!recovery) throw new Error("Expected stranded issue recovery issue to be created");
+    expect(recovery).toMatchObject({
+      companyId,
+      parentId: issueId,
+      assigneeAgentId: agentId,
+      originKind: "stranded_issue_recovery",
+      originId: issueId,
+      priority: "medium",
+      assigneeAdapterOverrides: { modelProfile: "cheap" },
+    });
+    expect([runId, ...timeoutRunIds]).toContain(recovery.originRunId ?? runId);
+    await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([recovery.id]);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("Paperclip quarantined this assigned `in_progress` issue");
+    expect(comments[0]?.body).toContain(timeoutRunIds[0]);
+    expect(comments[0]?.body).toContain(`Recovery issue: [${recovery.identifier}]`);
+
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    const sourceIssueRuns = runs.filter((run) => (run.contextSnapshot as Record<string, unknown> | null)?.issueId === issueId);
+    expect(sourceIssueRuns).toHaveLength(4);
   });
 
   it.each([

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -64,6 +64,8 @@ const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
+const ASSIGNED_ISSUE_TIMEOUT_QUARANTINE_COUNT_DEFAULT = 3;
+const ASSIGNED_ISSUE_TIMEOUT_QUARANTINE_WINDOW_SEC_DEFAULT = 24 * 60 * 60;
 
 type RecoveryWakeupOptions = {
   source?: "timer" | "assignment" | "on_demand" | "automation";
@@ -95,6 +97,11 @@ type SuccessfulRunHandoffRecoveryEvidence = {
   missingDisposition: string;
   handoffAttempt: number;
   maxHandoffAttempts: number;
+};
+
+type AssignedIssueTimeoutQuarantinePolicy = {
+  count: number;
+  windowSec: number;
 };
 
 type WatchdogDecisionActor =
@@ -142,6 +149,31 @@ function didAutomaticRecoveryFail(
     UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
       latestRun.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
     );
+}
+
+function parseAssignedIssueTimeoutQuarantinePolicy(agent: typeof agents.$inferSelect): AssignedIssueTimeoutQuarantinePolicy {
+  const runtimeConfig = parseObject(agent.runtimeConfig);
+  const heartbeat = parseObject(runtimeConfig.heartbeat);
+  return {
+    count: Math.max(
+      0,
+      Math.floor(
+        asNumber(
+          heartbeat.assignedIssueTimeoutQuarantineCount,
+          ASSIGNED_ISSUE_TIMEOUT_QUARANTINE_COUNT_DEFAULT,
+        ),
+      ),
+    ),
+    windowSec: Math.max(
+      0,
+      Math.floor(
+        asNumber(
+          heartbeat.assignedIssueTimeoutQuarantineWindowSec,
+          ASSIGNED_ISSUE_TIMEOUT_QUARANTINE_WINDOW_SEC_DEFAULT,
+        ),
+      ),
+    ),
+  };
 }
 
 function successfulRunHandoffRecoveryEvidence(latestRun: LatestIssueRun): SuccessfulRunHandoffRecoveryEvidence | null {
@@ -466,6 +498,82 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       )
       .limit(1)
       .then((rows) => Boolean(rows[0]));
+  }
+
+  async function hasAgentExecutionPath(companyId: string, agentId: string) {
+    return db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.agentId, agentId),
+          inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  async function collectRecentIssueTimeouts(input: {
+    companyId: string;
+    agentId: string;
+    issueId: string;
+    policy: AssignedIssueTimeoutQuarantinePolicy;
+  }) {
+    if (input.policy.count <= 0 || input.policy.windowSec <= 0) return [];
+    const cutoff = new Date(Date.now() - input.policy.windowSec * 1000);
+    const evidenceLimit = input.policy.count + 5;
+    return db
+      .select({
+        id: heartbeatRuns.id,
+        finishedAt: heartbeatRuns.finishedAt,
+        errorCode: heartbeatRuns.errorCode,
+      })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, input.companyId),
+          eq(heartbeatRuns.agentId, input.agentId),
+          eq(heartbeatRuns.status, "timed_out"),
+          gt(heartbeatRuns.finishedAt, cutoff),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}`,
+        ),
+      )
+      .orderBy(desc(heartbeatRuns.finishedAt), desc(heartbeatRuns.createdAt))
+      .limit(evidenceLimit);
+  }
+
+  async function maybeQuarantineRepeatedTimeouts(input: {
+    issue: typeof issues.$inferSelect;
+    agent: typeof agents.$inferSelect;
+    previousStatus: "todo" | "in_progress";
+    latestRun: LatestIssueRun;
+  }) {
+    const policy = parseAssignedIssueTimeoutQuarantinePolicy(input.agent);
+    if (policy.count <= 0 || policy.windowSec <= 0) return null;
+    const recentTimeouts = await collectRecentIssueTimeouts({
+      companyId: input.issue.companyId,
+      agentId: input.agent.id,
+      issueId: input.issue.id,
+      policy,
+    });
+    if (recentTimeouts.length < policy.count) return null;
+
+    const failureSummary = summarizeRunFailureForIssueComment(input.latestRun);
+    const timeoutWindowHours = Math.round(policy.windowSec / 3600);
+    const evidence = recentTimeouts
+      .map((run) => run.finishedAt ? `${run.id} at ${new Date(run.finishedAt).toISOString()}` : run.id)
+      .join(", ");
+    return escalateStrandedAssignedIssue({
+      issue: input.issue,
+      previousStatus: input.previousStatus,
+      latestRun: input.latestRun,
+      comment:
+        `Paperclip quarantined this assigned \`${input.previousStatus}\` issue after ${recentTimeouts.length} timeout runs ` +
+        `within ${timeoutWindowHours}h, with no live execution path.${failureSummary ?? ""} ` +
+        `Recent timeout runs: ${evidence}. Moving it to \`blocked\` so it is visible for intervention.`,
+    });
   }
 
   async function enqueueStrandedIssueRecovery(input: {
@@ -1801,10 +1909,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulContinuationObserved: 0,
       orphanBlockersAssigned: 0,
       successfulRunHandoffEscalated: 0,
+      timeoutQuarantined: 0,
       escalated: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
+    const recoveredAgentIds = new Set<string>();
 
     for (const issue of candidates) {
       const agentId = issue.assigneeAgentId;
@@ -1830,6 +1940,25 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
+      const timeoutQuarantine = await maybeQuarantineRepeatedTimeouts({
+        issue,
+        agent,
+        previousStatus: issue.status as "todo" | "in_progress",
+        latestRun,
+      });
+      if (timeoutQuarantine) {
+        recoveredAgentIds.add(agentId);
+        result.timeoutQuarantined += 1;
+        result.escalated += 1;
+        result.issueIds.push(issue.id);
+        continue;
+      }
+
+      if (recoveredAgentIds.has(agentId) || await hasAgentExecutionPath(issue.companyId, agentId)) {
+        result.skipped += 1;
+        continue;
+      }
+
       if (isStrandedIssueRecoveryIssue(issue) && isUnsuccessfulTerminalIssueRun(latestRun)) {
         const updated = await escalateStrandedRecoveryIssueInPlace({
           issue,
@@ -1860,6 +1989,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           const queued = await enqueueInitialAssignedTodoDispatch(issue, agentId);
           if (queued) {
             result.assignmentDispatched += 1;
+            recoveredAgentIds.add(agentId);
             result.issueIds.push(issue.id);
           } else {
             result.skipped += 1;
@@ -1907,6 +2037,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         });
         if (queued) {
           result.dispatchRequeued += 1;
+          recoveredAgentIds.add(agentId);
           result.issueIds.push(issue.id);
         } else {
           result.skipped += 1;
@@ -1982,6 +2113,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         });
         if (queued) {
           result.continuationRequeued += 1;
+          recoveredAgentIds.add(agentId);
           result.issueIds.push(issue.id);
         } else {
           result.skipped += 1;
@@ -2023,6 +2155,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
       if (queued) {
         result.continuationRequeued += 1;
+        recoveredAgentIds.add(agentId);
         result.issueIds.push(issue.id);
       } else {
         result.skipped += 1;


### PR DESCRIPTION
## Summary
- prevent stranded assigned-issue recovery from stacking multiple queued runs for the same agent in one sweep
- quarantine assigned issues after repeated recent timeout runs by moving them to blocked with recovery evidence
- add heartbeat recovery tests for one-run-per-agent recovery dispatch and timeout quarantine

## Thinking Path
- Michael was repeatedly timing out the same assigned Paperclip issue, then the recovery sweep kept redispatching it instead of surfacing the failure for intervention.
- The same sweep could also enqueue multiple Michael runs for different assigned issues, which recreates the backlog/stale-lock behavior we are trying to avoid.
- The fix keeps the external-cron architecture intact and hardens Paperclip's own recovery path: one active recovery per agent per sweep, and repeated timeouts become a visible blocked issue with evidence instead of another queued retry.

## Risks
- Recovery throughput is intentionally more conservative: after one recovery wake is queued for an agent, later assigned issues for that agent wait for a later sweep.
- Timeout quarantine may block issues that could have succeeded on one more retry, but the threshold/window are runtime configurable and default to three timeouts in 24 hours.
- The quarantine path creates recovery work; this revision also marks the agent as recovered in-memory after quarantine so follow-up dispatches cannot stack in the same sweep.

## Verification
- pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts
- pnpm typecheck

## Operational Note
- Live SUP-1321 was moved to blocked with a timeout-evidence comment after repeated Michael timeouts.
- Queued duplicate Michael runs for SUP-1499 and SUP-1501 were cancelled operationally so the live system has only one active Michael run while this PR is reviewed.

## Model Used
- GPT-5 Codex