### PR TITLE
fix(api): prevent update wiping secret bindings

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -85,6 +85,7 @@ const mockIssueService = vi.hoisted(() => ({
 const mockSecretService = vi.hoisted(() => ({
   normalizeAdapterConfigForPersistence: vi.fn(),
   resolveAdapterConfigForRuntime: vi.fn(),
+  syncEnvBindingsForTarget: vi.fn(),
 }));
 
 const mockAgentInstructionsService = vi.hoisted(() => ({
@@ -318,6 +319,7 @@ describe.sequential("agent permission routes", () => {
     mockIssueService.list.mockReset();
     mockSecretService.normalizeAdapterConfigForPersistence.mockReset();
     mockSecretService.resolveAdapterConfigForRuntime.mockReset();
+    mockSecretService.syncEnvBindingsForTarget.mockReset();
     mockAgentInstructionsService.materializeManagedBundle.mockReset();
     mockCompanySkillService.listRuntimeSkillEntries.mockReset();
     mockCompanySkillService.resolveRequestedSkillKeys.mockReset();
@@ -378,6 +380,7 @@ describe.sequential("agent permission routes", () => {
     );
     mockSecretService.normalizeAdapterConfigForPersistence.mockImplementation(async (_companyId, config) => config);
     mockSecretService.resolveAdapterConfigForRuntime.mockImplementation(async (_companyId, config) => ({ config }));
+    mockSecretService.syncEnvBindingsForTarget.mockResolvedValue([]);
     mockInstanceSettingsService.getGeneral.mockResolvedValue({
       censorUsernameInLogs: false,
     });
@@ -1432,5 +1435,63 @@ describe.sequential("agent permission routes", () => {
 
     expect(res.status).toBe(403);
     expect(mockHeartbeatService.cancelRun).not.toHaveBeenCalled();
+  });
+
+  it("does not call syncEnvBindingsForTarget when updated adapterConfig has no env", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: {
+        model: "claude-3-5-sonnet",
+        env: { TOKEN: { type: "secret_ref", secretId: "s1", version: "latest" } },
+      },
+    });
+    mockAgentService.update.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: { model: "gpt-4" },
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .patch(`/api/agents/${agentId}`)
+      .send({ adapterConfig: { model: "gpt-4" }, replaceAdapterConfig: true }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockSecretService.syncEnvBindingsForTarget).not.toHaveBeenCalled();
+  });
+
+  it("calls syncEnvBindingsForTarget when updated adapterConfig has env", async () => {
+    const secretId = "44444444-4444-4444-8444-444444444444";
+    const env = { TOKEN: { type: "secret_ref", secretId, version: "latest" } };
+    mockSecretService.normalizeAdapterConfigForPersistence.mockImplementation(async (_companyId, config) => config);
+    mockAgentService.update.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: { model: "claude-3-5-sonnet", env },
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .patch(`/api/agents/${agentId}`)
+      .send({ adapterConfig: { model: "claude-3-5-sonnet", env } }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockSecretService.syncEnvBindingsForTarget).toHaveBeenCalledWith(
+      companyId,
+      { targetType: "agent", targetId: agentId },
+      env,
+    );
   });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2675,11 +2675,13 @@ export function agentRoutes(
     }
     if (touchesAdapterConfiguration) {
       const agentEnv = asRecord(agent.adapterConfig)?.env;
-      await secretsSvc.syncEnvBindingsForTarget?.(
-        agent.companyId,
-        { targetType: "agent", targetId: agent.id },
-        agentEnv,
-      );
+      if (agentEnv) {
+        await secretsSvc.syncEnvBindingsForTarget?.(
+          agent.companyId,
+          { targetType: "agent", targetId: agent.id },
+          agentEnv,
+        );
+      }
     }
 
     await logActivity(db, {


### PR DESCRIPTION
## Summary

I had an agent delete bindings when it called the API. Paperclip code has it's own guards to prevent this but that is a client side protection which the agent did not follow. This adds a server-side guard consistent with other methods.

## Thinking Path

  > - Paperclip orchestrates AI agents for zero-human companies
  > - Agents store their runtime environment variables in `adapterConfig.env`, some of which are secret refs pointing to stored credentials
  > - The secrets subsystem tracks which secrets are bound to which agents via `companySecretBindings` — this table is the source of truth for what an agent is authorised to use at runtime
  > - `syncEnvBindingsForTarget` does a full DELETE of all `env.*` bindings for a target before re-inserting from the current env — calling it with `undefined` wipes all bindings and inserts nothing
  > - The agent create route correctly guarded this call with `if (agentEnv)`, but the update route did not — meaning any PATCH that touched `adapterConfig` but resulted in no `env` on the returned agent would
  silently clear all secret bindings
  > - This is exactly the kind of mistake an agent makes on itself: it patches its own config to change a model or a flag, sends a minimal `adapterConfig` that doesn't include `env` because it didn't know to
  preserve it, and its credentials are silently unbound with no error
  > - This pull request adds the missing guard on the update path, matching the create path, and adds route-level tests covering both the regression and the positive case

  ## What Changed

  - Added `if (agentEnv)` guard around `syncEnvBindingsForTarget` in the agent PATCH route (`server/src/routes/agents.ts`), matching the behaviour of the create route
  - Added `syncEnvBindingsForTarget` to the mock secret service in `agent-permissions-routes.test.ts`
  - Added regression test: verifies sync is not called when the updated `adapterConfig` has no `env` (would have failed before this fix)
  - Added positive test: verifies sync is still called with the correct env when `env` is present after update

  ## Verification

  - `npx vitest run src/__tests__/agent-permissions-routes.test.ts` — all 45 tests pass, including the two new ones
  - The regression test directly captures the broken behaviour: mock `agentService.update` returns an agent with no `env`, assert `syncEnvBindingsForTarget` was never called

  ## Risks

  Low risk. The guard matches what the create path already does. The only behavioural change is skipping the sync when `adapterConfig.env` is absent after an update — in that case the sync would have deleted all
  bindings and inserted nothing, so skipping it is strictly safer. No migrations required.

  ## Model Used

  - Claude (Anthropic), `claude-opus-4-7` via Claude Code CLI. Used with tool execution (Read, Edit, Bash, Explore subagents) and plan mode for design review before each edit pass.

  ## Checklist

  - [x] I have included a thinking path that traces from project context to this change
  - [x] I have specified the model used (with version and capability details)
  - [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
  - [x] I have run tests locally and they pass
  - [x] I have added or updated tests where applicable
  - [x] If this change affects the UI, I have included before/after screenshots
  - [x] I have updated relevant documentation to reflect my changes
  - [x] I have considered and documented any risks above
  - [x] I will address all Greptile and reviewer comments before requesting merge