### PR TITLE
fix(openclaw-gateway): add disablePaperclipMetadata config flag

### DIFF
--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -37,6 +37,7 @@ Request behavior fields:
 - autoPairOnFirstConnect (boolean, optional): on first "pairing required", attempt device.pair.list/device.pair.approve via shared auth, then retry once (default true)
 - paperclipApiUrl (string, optional): absolute Paperclip base URL advertised in wake text
 - claimedApiKeyPath (string, optional): path to the claimed API key JSON file read by the agent at wake time (default ~/.openclaw/workspace/paperclip-claimed-api-key.json)
+- disablePaperclipMetadata (boolean, optional): suppress the standard \`paperclip\` metadata block on outbound agent params for gateways with strict schema validation that reject unknown top-level fields; wake context is still delivered via env vars and the appended wake text in \`message\` (default false)
 
 Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1105,6 +1105,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const scopes = normalizeScopes(ctx.config.scopes);
   const deviceFamily = nonEmpty(ctx.config.deviceFamily);
   const disableDeviceAuth = parseBoolean(ctx.config.disableDeviceAuth, false);
+  const disablePaperclipMetadata = parseBoolean(ctx.config.disablePaperclipMetadata, false);
 
   const wakePayload = buildWakePayload(ctx);
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
@@ -1130,7 +1131,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const templateMessage = nonEmpty(payloadTemplate.message) ?? nonEmpty(payloadTemplate.text);
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
-  const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
+  const paperclipPayload = disablePaperclipMetadata
+    ? null
+    : buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
 
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
@@ -1139,7 +1142,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  if (disablePaperclipMetadata) {
+    delete agentParams.paperclip;
+  } else if (paperclipPayload) {
+    agentParams.paperclip = paperclipPayload;
+  }
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies and dispatches work to remote agent runtimes through gateway adapters.
> - The `openclaw_gateway` adapter attaches a top-level `paperclip` metadata block on every dispatch (run id, wake context, workspace hints) so the receiving agent has structured context.
> - Some OpenClaw gateway builds with strict schema validation (e.g. 2026.5.7) reject any unknown top-level field and refuse the dispatch with `unexpected property 'paperclip'`. The adapter then can't deliver work to that gateway at all.
> - Wake context is already delivered to the agent via env vars and the appended wake text in `message`, so the structured `paperclip` block is helpful but not strictly required for those gateways to function.
> - This pull request adds an opt-in `disablePaperclipMetadata` adapter config flag. When true, the adapter skips building the standard paperclip payload and removes any `paperclip` key seeded from `payloadTemplate`, allowing dispatch to strict-schema gateways without losing run/wake context.
> - The benefit is that operators of strict-schema OpenClaw deployments can configure the adapter to interoperate with their gateway without changes in OpenClaw itself, while default behavior remains unchanged for gateways that accept the metadata.

## What Changed

- Add `disablePaperclipMetadata` (boolean, default `false`) to `openclaw_gateway` adapter config, read in `packages/adapters/openclaw-gateway/src/server/execute.ts` with the same `parseBoolean(ctx.config.X, false)` helper already used for `disableDeviceAuth`.
- When the flag is true, skip `buildStandardPaperclipPayload(...)` and explicitly `delete agentParams.paperclip` so a `paperclip` key seeded from `payloadTemplate` is also stripped.
- Document the new field in `packages/adapters/openclaw-gateway/src/index.ts` `agentConfigurationDoc` under "Request behavior fields".

## Verification

- Code review of the diff: the new flag uses the same access pattern as `disableDeviceAuth`, so typing and runtime semantics for reading config are unchanged.
- Default branch (`disablePaperclipMetadata` unset / false): control flow falls into the existing branches — `buildStandardPaperclipPayload` runs and `agentParams.paperclip` is assigned the resulting payload, so there is no behavior change for current users.
- Manual smoke test from the originating incident: a hot patch of the published runtime dist (`@paperclipai/adapter-openclaw-gateway` 2026.428.0) carrying the same logic restored OpenClaw dispatch end-to-end against an OpenClaw gateway running build 2026.5.7. Wake context (env vars + appended wake text) was preserved and OpenClaw resumed picking up tasks.
- I do not have a pnpm workspace install configured on this machine; relying on CI for the full typecheck/test matrix on push.

## Risks

- Low risk. Single opt-in boolean defaulting to `false`; existing gateways that accept the `paperclip` metadata are unaffected.
- The flag intentionally also strips `paperclip` from `payloadTemplate` when enabled, so an operator can't accidentally re-introduce the rejected field via template — this is the desired semantics for strict-schema gateways.
- No changes to wake env vars, session keying, device auth, or the `message`/`wakeText` flow.

## Model Used

- Provider/model: Anthropic Claude — `claude-opus-4-7` (Opus 4.7) via Claude Code CLI
- Capabilities used: tool use (read/edit/grep/bash); no extended thinking mode for this PR
- The original commit was authored under the same model and toolchain.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (the OpenClaw integration is shipped in the roadmap; this is an interop fix, not core feature work)
- [ ] I have run tests locally and they pass — workspace install not configured locally; relying on CI
- [ ] I have added or updated tests where applicable — there are no existing automated tests for `agentParams` payload assembly in this adapter; happy to add a unit test (e.g. asserting `agentParams.paperclip` is omitted when the flag is set) if maintainers prefer
- [x] N/A — no UI change, so no before/after screenshots
- [x] I have updated relevant documentation to reflect my changes (`agentConfigurationDoc`)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
