### PR TITLE
[HAT-1268] Canonicalize agent mention links at comment ingest

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -893,6 +893,7 @@ export {
   buildProjectMentionHref,
   buildSkillMentionHref,
   buildUserMentionHref,
+  canonicalizeAgentMentionLinks,
   extractAgentMentionIds,
   extractProjectMentionIds,
   extractSkillMentionIds,

--- a/packages/shared/src/project-mentions.test.ts
+++ b/packages/shared/src/project-mentions.test.ts
@@ -4,6 +4,7 @@ import {
   buildProjectMentionHref,
   buildSkillMentionHref,
   buildUserMentionHref,
+  canonicalizeAgentMentionLinks,
   extractAgentMentionIds,
   extractProjectMentionIds,
   extractSkillMentionIds,
@@ -48,5 +49,65 @@ describe("project-mentions", () => {
       slug: "release-changelog",
     });
     expect(extractSkillMentionIds(`[/release-changelog](${href})`)).toEqual(["skill-123"]);
+  });
+});
+
+describe("canonicalizeAgentMentionLinks", () => {
+  const STAMAT_ID = "4cc20438-8403-4f37-995a-b91d7f6734b8";
+  const OVERLORD_ID = "5772a3a1-4c7e-4da0-9e18-72b327db736c";
+  const agents = [
+    { id: STAMAT_ID, name: "Stamat" },
+    { id: OVERLORD_ID, name: "Overlord" },
+  ];
+
+  it("rewrites bad Stamat-CTO label with Overlord ID to canonical Stamat mention", () => {
+    const input = `[@Stamat-CTO](agent://${OVERLORD_ID})`;
+    expect(canonicalizeAgentMentionLinks(input, agents)).toBe(
+      `[@Stamat](agent://${STAMAT_ID})`,
+    );
+  });
+
+  it("leaves correct Overlord mention unchanged", () => {
+    const input = `[@Overlord](agent://${OVERLORD_ID})`;
+    expect(canonicalizeAgentMentionLinks(input, agents)).toBe(input);
+  });
+
+  it("does not rewrite when label has no matching agent", () => {
+    const input = `[@UnknownAgent](agent://${OVERLORD_ID})`;
+    expect(canonicalizeAgentMentionLinks(input, agents)).toBe(input);
+  });
+
+  it("leaves mention unchanged when label ID is already correct", () => {
+    const input = `[@Stamat-CTO](agent://${STAMAT_ID})`;
+    expect(canonicalizeAgentMentionLinks(input, agents)).toBe(input);
+  });
+
+  it("rewrites Name (Role) parenthesized suffix pattern", () => {
+    const input = `[@Stamat (CTO)](agent://${OVERLORD_ID})`;
+    expect(canonicalizeAgentMentionLinks(input, agents)).toBe(
+      `[@Stamat](agent://${STAMAT_ID})`,
+    );
+  });
+
+  it("does not rewrite when multiple agents share the same name prefix", () => {
+    const ambiguous = [
+      { id: "id-1", name: "Stamat" },
+      { id: "id-2", name: "Stamat" },
+    ];
+    const input = `[@Stamat-CTO](agent://${OVERLORD_ID})`;
+    expect(canonicalizeAgentMentionLinks(input, ambiguous)).toBe(input);
+  });
+
+  it("rewrites multiple mentions in one body independently", () => {
+    const body = `[@Stamat-CTO](agent://${OVERLORD_ID}) and [@Overlord](agent://${OVERLORD_ID})`;
+    const result = canonicalizeAgentMentionLinks(body, agents);
+    expect(result).toBe(
+      `[@Stamat](agent://${STAMAT_ID}) and [@Overlord](agent://${OVERLORD_ID})`,
+    );
+  });
+
+  it("returns body unchanged when agents list is empty", () => {
+    const input = `[@Stamat-CTO](agent://${OVERLORD_ID})`;
+    expect(canonicalizeAgentMentionLinks(input, [])).toBe(input);
   });
 });

--- a/packages/shared/src/project-mentions.ts
+++ b/packages/shared/src/project-mentions.ts
@@ -193,6 +193,57 @@ export function extractAgentMentionIds(markdown: string): string[] {
   return [...ids];
 }
 
+function resolveAgentByLabel(
+  label: string,
+  agents: ReadonlyArray<{ id: string; name: string }>,
+): { id: string; name: string } | null {
+  const lowerLabel = label.toLowerCase();
+
+  const exactMatches = agents.filter((a) => a.name.toLowerCase() === lowerLabel);
+  if (exactMatches.length === 1) return exactMatches[0];
+  if (exactMatches.length > 1) return null;
+
+  // "Name-Role" → try matching "Name"
+  const dashIdx = label.indexOf("-");
+  if (dashIdx > 0) {
+    const prefix = label.slice(0, dashIdx).toLowerCase();
+    const dashMatches = agents.filter((a) => a.name.toLowerCase() === prefix);
+    if (dashMatches.length === 1) return dashMatches[0];
+    if (dashMatches.length > 1) return null;
+  }
+
+  // "Name (Role)" → try matching "Name"
+  const parenIdx = label.indexOf(" (");
+  if (parenIdx > 0) {
+    const prefix = label.slice(0, parenIdx).toLowerCase();
+    const parenMatches = agents.filter((a) => a.name.toLowerCase() === prefix);
+    if (parenMatches.length === 1) return parenMatches[0];
+    if (parenMatches.length > 1) return null;
+  }
+
+  return null;
+}
+
+/**
+ * Rewrites agent mention links whose display label uniquely resolves to a different agent
+ * than the href id. Preserves mentions where the label is ambiguous or non-matching.
+ */
+export function canonicalizeAgentMentionLinks(
+  body: string,
+  agents: ReadonlyArray<{ id: string; name: string }>,
+): string {
+  if (!body || agents.length === 0) return body;
+  const re = /\[([^\]]*)\]\((agent:\/\/[^)\s]+)\)/g;
+  return body.replace(re, (full, labelRaw: string, href: string) => {
+    const parsed = parseAgentMentionHref(href);
+    if (!parsed) return full;
+    const label = labelRaw.startsWith("@") ? labelRaw.slice(1) : labelRaw;
+    const resolved = resolveAgentByLabel(label, agents);
+    if (!resolved || resolved.id === parsed.agentId) return full;
+    return `[@${resolved.name}](${buildAgentMentionHref(resolved.id)})`;
+  });
+}
+
 export function extractUserMentionIds(markdown: string): string[] {
   if (!markdown) return [];
   const ids = new Set<string>();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2392,7 +2392,8 @@ export function issueRoutes(
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
-      comment = await svc.addComment(id, commentBody, {
+      const canonicalCommentBody = await svc.canonicalizeCommentBody(issue.companyId, commentBody as string);
+      comment = await svc.addComment(id, canonicalCommentBody, {
         agentId: actor.agentId ?? undefined,
         userId: actor.actorType === "user" ? actor.actorId : undefined,
         runId: actor.runId,
@@ -3502,7 +3503,8 @@ export function issueRoutes(
       }
     }
 
-    const comment = await svc.addComment(id, req.body.body, {
+    const canonicalBody = await svc.canonicalizeCommentBody(currentIssue.companyId, req.body.body as string);
+    const comment = await svc.addComment(id, canonicalBody, {
       agentId: actor.agentId ?? undefined,
       userId: actor.actorType === "user" ? actor.actorId : undefined,
       runId: actor.runId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -33,7 +33,7 @@ import type {
   IssueProductivityReviewTrigger,
   IssueRelationIssueSummary,
 } from "@paperclipai/shared";
-import { clampIssueRequestDepth, extractAgentMentionIds, extractProjectMentionIds, isUuidLike } from "@paperclipai/shared";
+import { canonicalizeAgentMentionLinks, clampIssueRequestDepth, extractAgentMentionIds, extractProjectMentionIds, isUuidLike } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -3777,6 +3777,15 @@ export function issueService(db: Db) {
         }
       }
       return [...resolved];
+    },
+
+    canonicalizeCommentBody: async (companyId: string, body: string): Promise<string> => {
+      if (!body) return body;
+      const agentRows = await db
+        .select({ id: agents.id, name: agents.name })
+        .from(agents)
+        .where(and(eq(agents.companyId, companyId), ne(agents.status, "terminated")));
+      return canonicalizeAgentMentionLinks(body, agentRows);
     },
 
     findMentionedProjectIds: async (


### PR DESCRIPTION
## Summary

- Adds `canonicalizeAgentMentionLinks()` to `@paperclipai/shared`: for each `[@Label](agent://id)` in markdown, if the display label uniquely resolves to a different active agent (by exact name, or conservative `Name-Role` / `Name (Role)` suffix stripping), rewrites to the correct agent ID and canonical name. Ambiguous or non-matching labels are left unchanged.
- Adds `canonicalizeCommentBody()` to `issueService`: fetches non-terminated company agents and calls the pure helper.
- Applies canonicalization in `POST /issues/:id/comments` and `PATCH /issues/:id` before `svc.addComment()`, fixing both save and wakeup resolution.
- 8 new focused tests: bad-input rewrite, stable Overlord mention, ambiguous no-rewrite, correct-ID no-op, parens suffix, multi-match guard, multi-mention body, empty-agents guard.

Closes HAT-1268. Unblocks HAT-1267 and HAT-1269.

## Test plan

- [x] `pnpm vitest run packages/shared/src/project-mentions.test.ts` — 12/12 pass
- [x] `pnpm vitest run server/src/__tests__/normalize-agent-mention-token.test.ts` — 9/9 pass
- [x] TypeScript check clean