### PR TITLE
feat(access): grant joins:approve to CEO agents by default (GRA-10)

### DIFF
--- a/packages/db/src/migrations/0084_grant_joins_approve_to_ceo_agents.sql
+++ b/packages/db/src/migrations/0084_grant_joins_approve_to_ceo_agents.sql
@@ -1,0 +1,27 @@
+-- Backfill `joins:approve` for existing CEO agents.
+-- New CEO agents get this seeded by the server at creation time
+-- (see server/src/routes/agents.ts applyDefaultAgentRoleGrants).
+-- This migration covers CEO agents created before that change shipped.
+
+INSERT INTO "principal_permission_grants" (
+  "company_id",
+  "principal_type",
+  "principal_id",
+  "permission_key",
+  "scope",
+  "granted_by_user_id",
+  "created_at",
+  "updated_at"
+)
+SELECT
+  "agents"."company_id",
+  'agent',
+  "agents"."id"::text,
+  'joins:approve',
+  NULL,
+  NULL,
+  now(),
+  now()
+FROM "agents"
+WHERE "agents"."role" = 'ceo'
+ON CONFLICT ("company_id", "principal_type", "principal_id", "permission_key") DO NOTHING;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1778074536410,
       "tag": "0083_company_secret_provider_configs",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1778421032000,
+      "tag": "0084_grant_joins_approve_to_ceo_agents",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -860,6 +860,70 @@ describe.sequential("agent permission routes", () => {
     );
   }, 15_000);
 
+  it("grants joins:approve in addition to tasks:assign when board creates a CEO agent", async () => {
+    mockAgentService.create.mockResolvedValue({ ...baseAgent, role: "ceo" });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "CEO",
+        role: "ceo",
+        adapterType: "process",
+        adapterConfig: {},
+      }));
+
+    expect([200, 201]).toContain(res.status);
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "tasks:assign",
+      true,
+      "board-user",
+    );
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "joins:approve",
+      true,
+      "board-user",
+    );
+  }, 15_000);
+
+  it("does not grant joins:approve to non-CEO agents on creation", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Builder",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {},
+      }));
+
+    expect([200, 201]).toContain(res.status);
+    const joinsApproveCalls = mockAccessService.setPrincipalPermission.mock.calls.filter(
+      (call) => call[3] === "joins:approve",
+    );
+    expect(joinsApproveCalls).toEqual([]);
+  }, 15_000);
+
   it("rejects unsupported query parameters on the agent list route", async () => {
     const app = await createApp({
       type: "board",
@@ -1371,6 +1435,62 @@ describe.sequential("agent permission routes", () => {
     );
     expect(res.body.access.canAssignTasks).toBe(true);
     expect(res.body.access.taskAssignSource).toBe("agent_creator");
+  });
+
+  it("grants joins:approve when CEO permissions are updated", async () => {
+    mockAgentService.updatePermissions.mockResolvedValue({
+      ...baseAgent,
+      role: "ceo",
+      permissions: { canCreateAgents: true },
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .patch(`/api/agents/${agentId}/permissions`)
+      .send({ canCreateAgents: true, canAssignTasks: false }));
+
+    expect(res.status).toBe(200);
+    expect(mockAccessService.setPrincipalPermission).toHaveBeenCalledWith(
+      companyId,
+      "agent",
+      agentId,
+      "joins:approve",
+      true,
+      "board-user",
+    );
+  });
+
+  it("does not grant joins:approve when non-CEO permissions are updated", async () => {
+    mockAgentService.updatePermissions.mockResolvedValue({
+      ...baseAgent,
+      role: "engineer",
+      permissions: { canCreateAgents: true },
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .patch(`/api/agents/${agentId}/permissions`)
+      .send({ canCreateAgents: true, canAssignTasks: false }));
+
+    expect(res.status).toBe(200);
+    const joinsApproveCalls = mockAccessService.setPrincipalPermission.mock.calls.filter(
+      (call) => call[3] === "joins:approve",
+    );
+    expect(joinsApproveCalls).toEqual([]);
   });
 
   it("exposes a dedicated agent route for the inbox mine view", async () => {

--- a/server/src/__tests__/join-request-approve-ceo-route.test.ts
+++ b/server/src/__tests__/join-request-approve-ceo-route.test.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  companyMemberships,
+  createDb,
+  invites,
+  joinRequests,
+  principalPermissionGrants,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { accessRoutes } from "../routes/access.js";
+import { errorHandler } from "../middleware/index.js";
+
+vi.mock("../services/hire-hook.js", () => ({
+  notifyHireApproved: vi.fn(async () => undefined),
+}));
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping CEO joins:approve route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("POST /companies/:companyId/join-requests/:requestId/{approve,reject} (CEO agent)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId!: string;
+  let ceoAgentId!: string;
+  let inviteId!: string;
+  let joinRequestId!: string;
+  let placeholderAgentId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-join-approve-ceo-route-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  beforeEach(async () => {
+    companyId = randomUUID();
+    ceoAgentId = randomUUID();
+    inviteId = randomUUID();
+    joinRequestId = randomUUID();
+    placeholderAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: ceoAgentId,
+        companyId,
+        name: "CEO",
+        role: "ceo",
+      },
+      {
+        id: placeholderAgentId,
+        companyId,
+        name: "Joiner",
+        role: "engineer",
+      },
+    ]);
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "agent",
+      principalId: ceoAgentId,
+      status: "active",
+      membershipRole: "member",
+    });
+    await db.insert(invites).values({
+      id: inviteId,
+      companyId,
+      inviteType: "company_join",
+      tokenHash: `token-${inviteId}`,
+      allowedJoinTypes: "agent",
+      defaultsPayload: null,
+      expiresAt: new Date(Date.now() + 86_400_000),
+    });
+    await db.insert(joinRequests).values({
+      id: joinRequestId,
+      inviteId,
+      companyId,
+      requestType: "agent",
+      status: "pending_approval",
+      requestIp: "127.0.0.1",
+      createdAgentId: placeholderAgentId,
+      agentName: "Joiner",
+    });
+  });
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(joinRequests);
+    await db.delete(invites);
+    await db.delete(principalPermissionGrants);
+    await db.delete(companyMemberships);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp() {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "agent",
+        agentId: ceoAgentId,
+        companyId,
+        companyIds: [companyId],
+        source: "agent_key",
+      };
+      next();
+    });
+    app.use(
+      "/api",
+      accessRoutes(db, {
+        deploymentMode: "local_trusted",
+        deploymentExposure: "private",
+        bindHost: "127.0.0.1",
+        allowedHostnames: [],
+      }),
+    );
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function grantJoinsApprove() {
+    await db.insert(principalPermissionGrants).values({
+      companyId,
+      principalType: "agent",
+      principalId: ceoAgentId,
+      permissionKey: "joins:approve",
+      scope: null,
+      grantedByUserId: null,
+    });
+  }
+
+  it("denies the CEO agent without a joins:approve grant", async () => {
+    const res = await request(createApp()).post(
+      `/api/companies/${companyId}/join-requests/${joinRequestId}/approve`,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("approves the join request when the CEO agent has a joins:approve grant", async () => {
+    await grantJoinsApprove();
+
+    const res = await request(createApp()).post(
+      `/api/companies/${companyId}/join-requests/${joinRequestId}/approve`,
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("approved");
+  });
+
+  it("rejects the join request when the CEO agent has a joins:approve grant", async () => {
+    await grantJoinsApprove();
+
+    const res = await request(createApp()).post(
+      `/api/companies/${companyId}/join-requests/${joinRequestId}/reject`,
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.status).toBe("rejected");
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -524,9 +524,10 @@ export function agentRoutes(
     };
   }
 
-  async function applyDefaultAgentTaskAssignGrant(
+  async function applyDefaultAgentRoleGrants(
     companyId: string,
     agentId: string,
+    agentRole: string,
     grantedByUserId: string | null,
   ) {
     await access.ensureMembership(companyId, "agent", agentId, "member", "active");
@@ -538,6 +539,16 @@ export function agentRoutes(
       true,
       grantedByUserId,
     );
+    if (agentRole === "ceo") {
+      await access.setPrincipalPermission(
+        companyId,
+        "agent",
+        agentId,
+        "joins:approve",
+        true,
+        grantedByUserId,
+      );
+    }
   }
 
   async function assertCanCreateAgentsForCompany(req: Request, companyId: string) {
@@ -2098,9 +2109,10 @@ export function agentRoutes(
       trackAgentCreated(telemetryClient, { agentRole: agent.role, agentId: agent.id });
     }
 
-    await applyDefaultAgentTaskAssignGrant(
+    await applyDefaultAgentRoleGrants(
       companyId,
       agent.id,
+      agent.role,
       actor.actorType === "user" ? actor.actorId : null,
     );
 
@@ -2219,9 +2231,10 @@ export function agentRoutes(
       trackAgentCreated(telemetryClient, { agentRole: agent.role, agentId: agent.id });
     }
 
-    await applyDefaultAgentTaskAssignGrant(
+    await applyDefaultAgentRoleGrants(
       companyId,
       agent.id,
+      agent.role,
       req.actor.type === "board" ? (req.actor.userId ?? null) : null,
     );
 
@@ -2272,6 +2285,7 @@ export function agentRoutes(
 
     const effectiveCanAssignTasks =
       agent.role === "ceo" || Boolean(agent.permissions?.canCreateAgents) || req.body.canAssignTasks;
+    const effectiveCanApproveJoins = agent.role === "ceo";
     await access.ensureMembership(agent.companyId, "agent", agent.id, "member", "active");
     await access.setPrincipalPermission(
       agent.companyId,
@@ -2281,6 +2295,16 @@ export function agentRoutes(
       effectiveCanAssignTasks,
       req.actor.type === "board" ? (req.actor.userId ?? null) : null,
     );
+    if (effectiveCanApproveJoins) {
+      await access.setPrincipalPermission(
+        agent.companyId,
+        "agent",
+        agent.id,
+        "joins:approve",
+        true,
+        req.actor.type === "board" ? (req.actor.userId ?? null) : null,
+      );
+    }
 
     const actor = getActorInfo(req);
     await logActivity(db, {
@@ -2295,6 +2319,7 @@ export function agentRoutes(
       details: {
         canCreateAgents: agent.permissions?.canCreateAgents ?? false,
         canAssignTasks: effectiveCanAssignTasks,
+        canApproveJoins: effectiveCanApproveJoins,
       },
     });
 


### PR DESCRIPTION
## Summary

CEO agents could not approve pending join requests directly because `joins:approve` was only handed to human `owner`/`admin` roles. The fallback worked only via the local-implicit board path, which is a dev-only crutch.

This PR seeds `joins:approve` at CEO agent creation, re-applies it on CEO permission updates, and backfills existing CEO agents in already-running companies.

## Changes

- **`server/src/routes/agents.ts`** — Renamed `applyDefaultAgentTaskAssignGrant` to `applyDefaultAgentRoleGrants`. New CEO agents now get `joins:approve` in addition to the existing `tasks:assign`. Updated both creation paths to pass `agent.role`.
- **`server/src/routes/agents.ts`** (permissions update handler) — When CEO permissions are saved, also set `joins:approve = true`. Activity log gets a `canApproveJoins` field. Mirrors the existing `effectiveCanAssignTasks` pattern.
- **`packages/db/src/migrations/0084_grant_joins_approve_to_ceo_agents.sql`** — Idempotent backfill: insert a `joins:approve` grant for every existing agent with `role='ceo'` that doesn't already have one. Uses the existing unique index `(company_id, principal_type, principal_id, permission_key)` for `ON CONFLICT DO NOTHING`.
- Tests covering all three behaviors plus a full embedded-postgres route test that exercises `POST /companies/:companyId/join-requests/:requestId/approve` with a CEO agent bearer.

## Why option A (auto-grant), not option B (silent role bypass)

Option B would have been less code but would mask the permission model — `/api/agents/me → access.grants` would not show `joins:approve` even though the CEO agent could use it. Option A keeps the grant model honest.

## Acceptance criteria mapping

| AC | Addressed by |
|----|--------------|
| 1. CEO agent can call approve/reject with bearer | Helper rename + permissions handler + migration |
| 2. Visible in `/api/agents/me → access.grants` | Uses `setPrincipalPermission` (same read path) |
| 3. Existing CEO agents backfilled | Migration `0084_*.sql` |
| 4. Doesn't leak `joins:approve` to every agent | No change to `agentJoinGrantsFromDefaults` |
| 5. Tests | `join-request-approve-ceo-route.test.ts` (3 tests, embedded postgres, CEO agent bearer) + 4 new unit tests in `agent-permissions-routes.test.ts` |

## Out of scope (flagged for follow-up)

- There are two definitions of `agentJoinGrantsFromDefaults` — `services/invite-grants.ts:40` (canonical, exported, tested) and `routes/access.ts:2041` (the one actually wired in). Identical bodies today. Worth a cleanup ticket.
- We may eventually want `users:invite` and/or `agents:create` (currently a CEO bypass via `canCreateAgents`) reified as grants for symmetry with human `owner`/`admin` roles. Not addressed here.

## Test plan

- [x] `agent-permissions-routes.test.ts` — 47 tests pass (including the 4 new ones for CEO grants and the negative-path non-CEO assertions)
- [x] `join-request-approve-ceo-route.test.ts` — 3 tests pass (embedded postgres; verifies 403 without grant, 200 with grant on both `/approve` and `/reject`)
- [x] Full agent/access scope (11 files, 99 tests) passes
- [x] Migration numbering check passes (`packages/db/src/check-migration-numbering.ts`)
- [x] Migration applies cleanly (verified by the embedded-postgres route test, which runs all migrations on setup)

The 34 failures from the broader server test run all relate to plugin-SDK build artifacts not being present in this fresh worktree (`@paperclipai/plugin-sdk` dist/), the `workspace-runtime` test spawning `pnpm` directly (which is only on PATH via `corepack`), and a flaky heartbeat timing test — none touch this change.

Closes GRA-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)