### PR TITLE
Prevent misconfigured Paperclip worker launches

### DIFF
--- a/server/src/__tests__/worker-preflight.test.ts
+++ b/server/src/__tests__/worker-preflight.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  isPaperclipWorkerPreflightRequired,
+  runPaperclipWorkerPreflight,
+  WorkerPreflightError,
+} from "../services/worker-preflight.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("worker preflight routing", () => {
+  it("requires preflight for the Paperclip OpenCode wrapper", () => {
+    expect(
+      isPaperclipWorkerPreflightRequired({
+        adapterType: "opencode_local",
+        config: { command: "/Users/davidai/.local/bin/paperclip-opencode-worker" },
+        env: {},
+      }),
+    ).toBe(true);
+  });
+
+  it("requires preflight for the Paperclip OpenClaude wrapper", () => {
+    expect(
+      isPaperclipWorkerPreflightRequired({
+        adapterType: "claude_local",
+        config: { command: "/Users/davidai/.local/bin/paperclip-openclaude-worker" },
+        env: {},
+      }),
+    ).toBe(true);
+  });
+
+  it("does not gate normal local CLI adapters", () => {
+    expect(
+      isPaperclipWorkerPreflightRequired({
+        adapterType: "opencode_local",
+        config: { command: "opencode" },
+        env: {},
+      }),
+    ).toBe(false);
+    expect(
+      isPaperclipWorkerPreflightRequired({
+        adapterType: "claude_local",
+        config: { command: "claude" },
+        env: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("allows an emergency environment disable", () => {
+    expect(
+      isPaperclipWorkerPreflightRequired({
+        adapterType: "opencode_local",
+        config: { command: "/Users/davidai/.local/bin/paperclip-opencode-worker" },
+        env: { PAPERCLIP_WORKER_PREFLIGHT_ENABLED: "false" },
+      }),
+    ).toBe(false);
+  });
+
+  it("can be forced for a specific adapter config", () => {
+    expect(
+      isPaperclipWorkerPreflightRequired({
+        adapterType: "opencode_local",
+        config: { command: "opencode", paperclipWorkerPreflight: true },
+        env: {},
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("worker preflight execution", () => {
+  it("runs the doctor and logs a pass summary", async () => {
+    const doctor = await writeDoctor("printf '23 ok, 0 warn, 0 fail\\n'");
+    const logs: string[] = [];
+
+    await runPaperclipWorkerPreflight({
+      adapterType: "opencode_local",
+      config: { command: "/Users/davidai/.local/bin/paperclip-opencode-worker" },
+      env: { PAPERCLIP_WORKER_DOCTOR_BIN: doctor },
+      onLog: async (_stream, chunk) => {
+        logs.push(chunk);
+      },
+    });
+
+    expect(logs.join("")).toContain("Worker preflight passed: 23 ok, 0 warn, 0 fail");
+  });
+
+  it("throws a dedicated preflight error when the doctor fails", async () => {
+    const doctor = await writeDoctor("printf '22 ok, 0 warn, 1 fail\\n'; exit 7");
+
+    await expect(
+      runPaperclipWorkerPreflight({
+        adapterType: "claude_local",
+        config: { command: "/Users/davidai/.local/bin/paperclip-openclaude-worker" },
+        env: { PAPERCLIP_WORKER_DOCTOR_BIN: doctor },
+        onLog: async () => undefined,
+      }),
+    ).rejects.toBeInstanceOf(WorkerPreflightError);
+  });
+});
+
+async function writeDoctor(body: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-worker-doctor-"));
+  tempDirs.push(dir);
+  const file = path.join(dir, "paperclip-worker-doctor");
+  await fs.writeFile(file, `#!/usr/bin/env bash\nset -euo pipefail\n${body}\n`);
+  await fs.chmod(file, 0o700);
+  return file;
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -81,6 +81,11 @@ import {
 } from "./run-liveness.js";
 import { logActivity, publishPluginDomainEvent, type LogActivityInput } from "./activity-log.js";
 import {
+  runPaperclipWorkerPreflight,
+  WorkerPreflightError,
+  WORKER_PREFLIGHT_ERROR_CODE,
+} from "./worker-preflight.js";
+import {
   buildWorkspaceReadyComment,
   cleanupExecutionWorkspaceArtifacts,
   ensureRuntimeServicesForRun,
@@ -7578,6 +7583,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           (entry): entry is [string, string] => typeof entry[0] === "string" && typeof entry[1] === "string",
         ),
       );
+      await runPaperclipWorkerPreflight({
+        adapterType: agent.adapterType,
+        config: resolvedConfig,
+        env: adapterEnv,
+        onLog,
+      });
       const runtimeServices = await ensureRuntimeServicesForRun({
         db,
         runId: run.id,
@@ -7957,7 +7968,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         err instanceof Error ? err.message : "Unknown adapter failure",
         await getCurrentUserRedactionOptions(),
       );
-      logger.error({ err, runId }, "heartbeat execution failed");
+      const errorCode = err instanceof WorkerPreflightError
+        ? WORKER_PREFLIGHT_ERROR_CODE
+        : "adapter_failed";
+      logger.error({ err, runId, errorCode }, "heartbeat execution failed");
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {
@@ -7977,10 +7991,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       const failedRun = await setRunStatus(run.id, "failed", {
         error: message,
-        errorCode: "adapter_failed",
+        errorCode,
         finishedAt: new Date(),
         resultJson: mergeRunStopMetadataForAgent(agent, "failed", {
-          errorCode: "adapter_failed",
+          errorCode,
           errorMessage: message,
         }),
         stdoutExcerpt,

--- a/server/src/services/worker-preflight.ts
+++ b/server/src/services/worker-preflight.ts
@@ -1,0 +1,164 @@
+import { execFile } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_PREFLIGHT_TIMEOUT_MS = 60_000;
+const MAX_PREFLIGHT_LOG_BYTES = 12 * 1024;
+const ANSI_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+
+export const WORKER_PREFLIGHT_ERROR_CODE = "worker_preflight_failed";
+
+type WorkerPreflightEnv = NodeJS.ProcessEnv;
+
+export class WorkerPreflightError extends Error {
+  readonly errorCode = WORKER_PREFLIGHT_ERROR_CODE;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "WorkerPreflightError";
+  }
+}
+
+export function isPaperclipWorkerPreflightRequired(input: {
+  adapterType: string | null | undefined;
+  config: Record<string, unknown>;
+  env?: WorkerPreflightEnv;
+}) {
+  const env = input.env ?? process.env;
+  if (isFalseLike(env.PAPERCLIP_WORKER_PREFLIGHT_ENABLED)) return false;
+  if (isTrueLike(env.PAPERCLIP_WORKER_PREFLIGHT_FORCE)) return true;
+  if (isTrueLike(input.config.paperclipWorkerPreflight)) return true;
+
+  const command = readCommand(input.config);
+  const commandName = command ? path.basename(firstShellToken(command)) : null;
+  if (!commandName) return false;
+
+  if (input.adapterType === "opencode_local") {
+    return commandName === "paperclip-opencode-worker";
+  }
+  if (input.adapterType === "claude_local") {
+    return commandName === "paperclip-openclaude-worker";
+  }
+  return false;
+}
+
+export async function runPaperclipWorkerPreflight(input: {
+  adapterType: string;
+  config: Record<string, unknown>;
+  env?: WorkerPreflightEnv;
+  onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+}) {
+  const env = { ...process.env, ...(input.env ?? {}) };
+  if (!isPaperclipWorkerPreflightRequired({ ...input, env })) return;
+
+  const homeDir = os.homedir();
+  const doctorCommand = readString(input.config.workerDoctorCommand) ??
+    readString(env.PAPERCLIP_WORKER_DOCTOR_BIN) ??
+    path.join(homeDir, ".local/bin/paperclip-worker-doctor");
+  const proofPath = path.join(homeDir, ".paperclip/proof/model-policy/latest.md");
+  const timeoutMs = normalizeTimeoutMs(env.PAPERCLIP_WORKER_PREFLIGHT_TIMEOUT_MS);
+  const label = describePreflightTarget(input.adapterType, input.config);
+
+  await input.onLog("stderr", `[paperclip] Running worker preflight for ${label}.\n`);
+
+  try {
+    const result = await execFileAsync(doctorCommand, ["--quick"], {
+      cwd: homeDir,
+      env,
+      timeout: timeoutMs,
+      maxBuffer: 256 * 1024,
+    });
+    const summary = summarizeDoctorOutput(`${result.stdout}\n${result.stderr}`) ?? "paperclip-worker-doctor --quick";
+    await input.onLog("stderr", `[paperclip] Worker preflight passed: ${summary}. Proof: ${proofPath}\n`);
+  } catch (err) {
+    const failure = normalizeExecFailure(err);
+    const output = truncateForLog(`${failure.stdout}\n${failure.stderr}`.trim());
+    const summary = summarizeDoctorOutput(output) ?? failure.reason ?? "doctor failed";
+    const outputBlock = output ? `\n${output}\n` : "\n";
+    await input.onLog("stderr", `[paperclip] Worker preflight failed for ${label}: ${summary}.${outputBlock}`);
+    throw new WorkerPreflightError(
+      `Worker preflight failed for ${label}: ${summary}. Run ${doctorCommand} --quick and inspect ${proofPath}.`,
+      { cause: err },
+    );
+  }
+}
+
+function readCommand(config: Record<string, unknown>) {
+  return readString(config.command);
+}
+
+function readString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function firstShellToken(value: string) {
+  return value.trim().split(/\s+/)[0] ?? "";
+}
+
+function isFalseLike(value: unknown) {
+  return typeof value === "string" && ["0", "false", "no", "off"].includes(value.trim().toLowerCase());
+}
+
+function isTrueLike(value: unknown) {
+  if (value === true) return true;
+  if (value === 1) return true;
+  return typeof value === "string" && ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+function normalizeTimeoutMs(value: unknown) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_PREFLIGHT_TIMEOUT_MS;
+  return Math.max(1_000, Math.min(Math.floor(parsed), 5 * 60_000));
+}
+
+function describePreflightTarget(adapterType: string, config: Record<string, unknown>) {
+  const command = readCommand(config);
+  return command ? `${adapterType} (${path.basename(firstShellToken(command))})` : adapterType;
+}
+
+function stripAnsi(value: string) {
+  return value.replace(ANSI_PATTERN, "");
+}
+
+function truncateForLog(value: string) {
+  const clean = stripAnsi(value).trim();
+  if (Buffer.byteLength(clean, "utf8") <= MAX_PREFLIGHT_LOG_BYTES) return clean;
+  return `...${Buffer.from(clean).subarray(-MAX_PREFLIGHT_LOG_BYTES).toString("utf8")}`;
+}
+
+function summarizeDoctorOutput(value: string) {
+  const cleanLines = stripAnsi(value)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return (
+    cleanLines.find((line) => /^\d+\s+ok,\s+\d+\s+warn,\s+\d+\s+fail$/i.test(line)) ??
+    cleanLines.find((line) => /\bfail\b/i.test(line)) ??
+    cleanLines.find((line) => /\bwarn\b/i.test(line)) ??
+    null
+  );
+}
+
+function normalizeExecFailure(err: unknown) {
+  const candidate = err as {
+    code?: string | number | null;
+    signal?: string | null;
+    killed?: boolean;
+    stdout?: string | Buffer;
+    stderr?: string | Buffer;
+    message?: string;
+  };
+  const stdout = candidate?.stdout ? String(candidate.stdout) : "";
+  const stderr = candidate?.stderr ? String(candidate.stderr) : "";
+  const reason = candidate?.killed
+    ? "doctor timed out"
+    : candidate?.code != null
+      ? `doctor exited with ${candidate.code}`
+      : candidate?.signal
+        ? `doctor stopped by ${candidate.signal}`
+        : candidate?.message;
+  return { stdout, stderr, reason };
+}


### PR DESCRIPTION
## Summary
- add a Paperclip worker preflight helper that runs `paperclip-worker-doctor --quick` before launching the Paperclip OpenCode/OpenClaude wrapper commands
- fail heartbeat runs with `worker_preflight_failed` when the worker model policy, key files, or fallback routing are broken
- keep normal local adapters untouched unless preflight is explicitly forced

## Verification
- `pnpm exec vitest run server/src/__tests__/worker-preflight.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `/Users/davidai/.local/bin/paperclip-worker-doctor --quick`
- live local Paperclip health endpoint returned `status: ok` after the change was prepared

## Notes
- This PR branch is based on current upstream `master` and contains only the worker-preflight slice.
- The live local service tree remains dirty and was not used as the PR source.