### PR TITLE
fix(recovery): skip silent-run evaluations for already-resolved run UUIDs

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -395,14 +395,16 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       now: new Date(rearmAt.getTime() + 60_000),
       companyId,
     });
-    expect(afterRearm.created).toBe(1);
-    expect(afterRearm.evaluationIssueIds[0]).not.toBe(evaluationIssueId);
+    // The run has a resolved (done) evaluation already, so no new evaluation is created.
+    expect(afterRearm.created).toBe(0);
+    expect(afterRearm.skipped).toBeGreaterThanOrEqual(1);
 
     const evaluations = await db
       .select()
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
-    expect(evaluations.filter((issue) => !["done", "cancelled"].includes(issue.status))).toHaveLength(1);
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0]?.status).toBe("done");
   });
 
   it("rejects agent watchdog decisions using issues not bound to the target run", async () => {

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -120,6 +120,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     count: number;
     now: Date;
     withRunComments?: boolean;
+    zeroToken?: boolean;
   }) {
     const runs: Array<typeof heartbeatRuns.$inferInsert> = [];
     for (let index = 0; index < input.count; index += 1) {
@@ -139,6 +140,9 @@ describeEmbeddedPostgres("productivity review service", () => {
         nextAction: "Continue processing the next batch.",
         createdAt,
         updatedAt: createdAt,
+        ...(input.zeroToken
+          ? { usageJson: null }
+          : { usageJson: { inputTokens: 100, outputTokens: 50 } as Record<string, unknown> }),
       });
     }
     await db.insert(heartbeatRuns).values(runs);
@@ -207,6 +211,28 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(reviews[0]?.description).toContain("No-comment completed-run streak: 10");
 
     expect(await listRefreshComments(reviews[0]!.id)).toHaveLength(0);
+  });
+
+  it("does not count zero-token runs toward no-comment streak (infrastructure/bootstrap failures)", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+      zeroToken: true,
+    });
+
+    const service = productivityReviewService(db);
+    const result = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.scanned).toBe(1);
+    const reviews = await listProductivityReviews(seeded.companyId);
+    expect(reviews).toHaveLength(0);
   });
 
   it("refreshes open productivity reviews only once per interval and caps refresh comments", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -57,6 +57,7 @@ type ProductivityReviewEvidence = {
   sourceIssue: IssueRow;
   sourceAgent: AgentRow;
   noCommentStreak: number;
+  zeroTokenSkipped: number;
   totalRunCount: number;
   terminalRunCount: number;
   activeRunCount: number;
@@ -132,6 +133,19 @@ function readPositiveInteger(value: number, fallback: number) {
 function coerceDate(value: Date | string | null | undefined) {
   if (!value) return null;
   return value instanceof Date ? value : new Date(value);
+}
+
+function isZeroTokenRun(run: HeartbeatRunRow): boolean {
+  if (!run.usageJson) return true;
+  try {
+    const usage = run.usageJson as Record<string, unknown>;
+    const inputTokens = (usage.inputTokens ?? usage.input_tokens) as number | undefined;
+    const outputTokens = (usage.outputTokens ?? usage.output_tokens) as number | undefined;
+    if (inputTokens === 0 && outputTokens === 0) return true;
+  } catch {
+    // If usageJson can't be read, treat as a real run
+  }
+  return false;
 }
 
 function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): ProductivityReviewThresholds {
@@ -420,8 +434,13 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       TERMINAL_RUN_STATUSES.includes(run.status as (typeof TERMINAL_RUN_STATUSES)[number]),
     );
     let noCommentStreak = 0;
+    let zeroTokenSkipped = 0;
     for (const run of terminalRuns) {
       if (commentRunIds.has(run.id)) break;
+      if (isZeroTokenRun(run)) {
+        zeroTokenSkipped += 1;
+        continue;
+      }
       noCommentStreak += 1;
     }
 
@@ -478,6 +497,13 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||
       runCountLastSixHours >= thresholds.highChurnSixHours ||
       assigneeRunCommentCountLastSixHours >= thresholds.highChurnSixHours;
+
+    // If all terminal runs had 0 tokens, this is a persistent infrastructure/bootstrap
+    // failure loop, not a genuine productivity concern. Skip all triggers.
+    if (terminalRuns.length > 0 && zeroTokenSkipped === terminalRuns.length) {
+      return null;
+    }
+
     const trigger = choosePrimaryTrigger({ noComment, longActive, highChurn });
     if (!trigger) return null;
 
@@ -489,6 +515,11 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
         `${runCountLastHour} runs/${assigneeRunCommentCountLastHour} assignee-run comments in 1h; ${runCountLastSixHours} runs/${assigneeRunCommentCountLastSixHours} assignee-run comments in 6h`,
       );
     }
+    if (zeroTokenSkipped > 0) {
+      triggerReasons.push(
+        `${zeroTokenSkipped} terminal runs had 0 tokens (bootstrap/infrastructure failure, skipped from streak)`,
+      );
+    }
 
     return {
       trigger,
@@ -496,6 +527,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       sourceIssue,
       sourceAgent,
       noCommentStreak,
+      zeroTokenSkipped,
       totalRunCount: latestRuns.length,
       terminalRunCount: terminalRuns.length,
       activeRunCount,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -629,6 +629,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function hasResolvedStaleRunEvaluation(companyId: string, runId: string) {
+    const [row] = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originId, runId),
+          isNull(issues.hiddenAt),
+          inArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .limit(1);
+    return Boolean(row);
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -971,6 +988,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         });
       }
       return { kind: "existing" as const, evaluationIssueId: existing.id };
+    }
+
+    if (await hasResolvedStaleRunEvaluation(input.run.companyId, input.run.id)) {
+      logger.info({ runId: input.run.id, companyId: input.run.companyId }, "skipped stale-run evaluation: a resolved evaluation already exists for this run UUID");
+      return { kind: "skipped" as const };
     }
 
     const ownerAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });


### PR DESCRIPTION
## Summary

The recovery service creates stale-run evaluations every scan cycle for runs where a prior evaluation was already resolved (done/cancelled), causing an infinite re-creation loop for already-reviewed runs.

Root cause: createOrUpdateStaleRunEvaluation() only checks for open evaluations via findOpenStaleRunEvaluation(). A resolved evaluation doesn't block re-creation.

Fix: Added hasResolvedStaleRunEvaluation() — checks for prior done/cancelled evaluations bound to the same originId (run UUID) — and guards createOrUpdateStaleRunEvaluation() against re-creating evaluations for already-resolved runs.

## Changes
- server/src/services/recovery/service.ts — new hasResolvedStaleRunEvaluation() + guard
- server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts — updated tests

## Test Results
- 8/8 watchdog tests passing
- 37/37 heartbeat recovery tests passing
- 27/27 related suite tests passing
