### PR TITLE
MAN-282: Add idempotency check for backlog-mirroring routine runs

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -771,6 +771,37 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(inboxIssues.map((issue) => issue.id)).toContain(previousIssue.id);
   });
 
+  it("coalesces mirror issues with the same GitHub reference even without a live heartbeat run", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    const previousRunId = randomUUID();
+    const mirrorTitle = "[ForgeOpsLLC/manholepro-lead-engine#123] Test mirror issue";
+
+    await db.update(routines).set({ title: mirrorTitle }).where(eq(routines.id, routine.id));
+
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: mirrorTitle,
+      description: routine.description,
+      status: "todo",
+      priority: routine.priority,
+      assigneeAgentId: null,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+
+    expect(run.status).toBe("coalesced");
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+
+    const allIssues = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+    expect(allIssues).toHaveLength(1);
+  });
+
   it("does not coalesce live routine runs with different resolved variables", async () => {
     const { companyId, agentId, projectId, svc } = await seedFixture();
     const variableRoutine = await svc.create(

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -871,6 +871,34 @@ export function routineService(
     );
   }
 
+  function extractGithubIssueRef(title: string): string | null {
+    const match = title.match(/\[[^\]\/]+\/[^\]\/]+#\d+\]/);
+    return match ? match[0] : null;
+  }
+
+  async function findExistingMirrorIssue(
+    companyId: string,
+    title: string,
+    executor: Db = db,
+  ) {
+    const ref = extractGithubIssueRef(title);
+    if (!ref) return null;
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          sql`${issues.title} LIKE ${`%${ref}%`}`,
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function findLiveExecutionIssue(
     routine: typeof routines.$inferSelect,
     executor: Db = db,
@@ -1188,6 +1216,34 @@ export function routineService(
           return updated ?? createdRun;
         }
 
+        const mirrorIssue = await findExistingMirrorIssue(input.routine.companyId, title, txDb);
+        if (mirrorIssue && input.routine.concurrencyPolicy !== "always_enqueue") {
+          const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+          if (manualRunnerUserId) {
+            await touchIssueForUserInbox(txDb, {
+              companyId: input.routine.companyId,
+              issueId: mirrorIssue.id,
+              userId: manualRunnerUserId,
+              touchedAt: triggeredAt,
+            });
+          }
+          const updated = await finalizeRun(createdRun.id, {
+            status,
+            linkedIssueId: mirrorIssue.id,
+            coalescedIntoRunId: mirrorIssue.originRunId,
+            completedAt: triggeredAt,
+          }, txDb);
+          await updateRoutineTouchedState({
+            routineId: input.routine.id,
+            triggerId: input.trigger?.id ?? null,
+            triggeredAt,
+            status,
+            issueId: mirrorIssue.id,
+            nextRunAt,
+          }, txDb);
+          return updated ?? createdRun;
+        }
+
         try {
           createdIssue = await issueSvc.create(input.routine.companyId, {
             projectId,
@@ -1225,7 +1281,34 @@ export function routineService(
             kind: issueOriginKind,
             id: issueOriginId,
           });
-          if (!existingIssue) throw error;
+          if (!existingIssue) {
+            const mirrorIssue = await findExistingMirrorIssue(input.routine.companyId, title, txDb);
+            if (!mirrorIssue) throw error;
+            const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
+            if (manualRunnerUserId) {
+              await touchIssueForUserInbox(txDb, {
+                companyId: input.routine.companyId,
+                issueId: mirrorIssue.id,
+                userId: manualRunnerUserId,
+                touchedAt: triggeredAt,
+              });
+            }
+            const updated = await finalizeRun(createdRun.id, {
+              status,
+              linkedIssueId: mirrorIssue.id,
+              coalescedIntoRunId: mirrorIssue.originRunId,
+              completedAt: triggeredAt,
+            }, txDb);
+            await updateRoutineTouchedState({
+              routineId: input.routine.id,
+              triggerId: input.trigger?.id ?? null,
+              triggeredAt,
+              status,
+              issueId: mirrorIssue.id,
+              nextRunAt,
+            }, txDb);
+            return updated ?? createdRun;
+          }
           const status = input.routine.concurrencyPolicy === "skip_if_active" ? "skipped" : "coalesced";
           if (manualRunnerUserId) {
             await touchIssueForUserInbox(txDb, {


### PR DESCRIPTION
## Summary

Fixes duplicate Paperclip→GitHub mirror issues by adding a title-based idempotency check before creating mirror issues from routine runs.

## Problem

When the backlog management agent mirrors GitHub issues into Paperclip, the mirroring step has no idempotency check, so each GitHub issue spawns 2-5 Paperclip copies (e.g. GitHub #544 → MAN-273, MAN-274, MAN-275, MAN-276).

## Solution

- `extractGithubIssueRef()` — parses `[Owner/Repo#NNN]` from title
- `findExistingMirrorIssue()` — queries open issues by title LIKE ref
- Coalesces new run against existing mirror when ref matches (both happy-path and unique-constraint fallback arms)

## Tests

Adds embedded-postgres test: `coalesces mirror issues with the same GitHub reference even without a live heartbeat run`

Closes #282