### PR TITLE
Wire plugin.worker.{crashed,restarted} to publishGlobalLiveEvent

### DIFF
--- a/server/src/__tests__/plugin-worker-live-events.test.ts
+++ b/server/src/__tests__/plugin-worker-live-events.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  publishGlobalLiveEvent,
+  subscribeGlobalLiveEvents,
+} from "../services/live-events.js";
+import {
+  createPluginWorkerManager,
+  type PluginWorkerManagerOptions,
+} from "../services/plugin-worker-manager.js";
+
+// Mirrors the bridge in server/src/app.ts so any drift between the production
+// wiring and this contract test will surface as a compile or assertion error.
+const bridge: NonNullable<PluginWorkerManagerOptions["onWorkerEvent"]> = (e) =>
+  publishGlobalLiveEvent({
+    type: e.type,
+    payload: {
+      pluginId: e.pluginId,
+      code: e.code ?? null,
+      signal: e.signal ?? null,
+      willRestart: e.willRestart ?? false,
+    },
+  });
+
+describe("plugin worker → global live event wiring", () => {
+  it("type-checks against the manager's onWorkerEvent option", () => {
+    const manager = createPluginWorkerManager({ onWorkerEvent: bridge });
+    expect(typeof manager.startWorker).toBe("function");
+  });
+
+  it("forwards plugin.worker.crashed with full payload to global subscribers", () => {
+    const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+    const unsub = subscribeGlobalLiveEvents((e) =>
+      events.push({ type: e.type, payload: e.payload as Record<string, unknown> }),
+    );
+
+    bridge({
+      type: "plugin.worker.crashed",
+      pluginId: "acme.test",
+      code: 137,
+      signal: "SIGKILL",
+      willRestart: true,
+    });
+
+    unsub();
+
+    const crashed = events.find((e) => e.type === "plugin.worker.crashed");
+    expect(crashed).toBeDefined();
+    expect(crashed?.payload).toEqual({
+      pluginId: "acme.test",
+      code: 137,
+      signal: "SIGKILL",
+      willRestart: true,
+    });
+  });
+
+  it("forwards plugin.worker.restarted and normalizes missing fields to null/false", () => {
+    const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+    const unsub = subscribeGlobalLiveEvents((e) =>
+      events.push({ type: e.type, payload: e.payload as Record<string, unknown> }),
+    );
+
+    bridge({ type: "plugin.worker.restarted", pluginId: "acme.test" });
+
+    unsub();
+
+    const restarted = events.find((e) => e.type === "plugin.worker.restarted");
+    expect(restarted).toBeDefined();
+    expect(restarted?.payload).toEqual({
+      pluginId: "acme.test",
+      code: null,
+      signal: null,
+      willRestart: false,
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -45,6 +45,7 @@ import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
 import { createPluginWorkerManager, type PluginWorkerManager } from "./services/plugin-worker-manager.js";
+import { publishGlobalLiveEvent } from "./services/live-events.js";
 import { createPluginJobScheduler } from "./services/plugin-job-scheduler.js";
 import { pluginJobStore } from "./services/plugin-job-store.js";
 import { createPluginToolDispatcher } from "./services/plugin-tool-dispatcher.js";
@@ -173,7 +174,20 @@ export async function createApp(
   app.use(llmRoutes(db));
 
   const hostServicesDisposers = new Map<string, () => void>();
-  const workerManager = opts.pluginWorkerManager ?? createPluginWorkerManager();
+  const workerManager =
+    opts.pluginWorkerManager ??
+    createPluginWorkerManager({
+      onWorkerEvent: (e) =>
+        publishGlobalLiveEvent({
+          type: e.type,
+          payload: {
+            pluginId: e.pluginId,
+            code: e.code ?? null,
+            signal: e.signal ?? null,
+            willRestart: e.willRestart ?? false,
+          },
+        }),
+    });
 
   // Mount API routes
   const api = Router();


### PR DESCRIPTION
## Summary

`LIVE_EVENT_TYPES` in `packages/shared/src/constants.ts` declares `plugin.worker.crashed` and `plugin.worker.restarted`, and `plugin-worker-manager.ts` already emits the runtime callback when crash/ready handlers fire (`plugin-worker-manager.ts:1252-1272`) — but `server/src/app.ts` was constructing the worker manager without the `onWorkerEvent` bridge (line 174, pre-patch), so these events never reached `publishGlobalLiveEvent` and never appeared on the WebSocket transport.

### Root cause

`server/src/app.ts:174` called `createPluginWorkerManager()` with no options, leaving the `onWorkerEvent` slot undefined. `publishGlobalLiveEvent` (`server/src/services/live-events.ts:37-44`) emits on the `"*"` channel; without the bridge, nothing translated manager crash/ready callbacks into that channel.

### Fix

`server/src/app.ts:174-189` — `createPluginWorkerManager()` now receives an `onWorkerEvent` bridge that maps the manager's `WorkerEvent` shape to a `publishGlobalLiveEvent({ type, payload })` call. `code`/`signal` normalize to `null`, `willRestart` to `false` when absent. The `opts.pluginWorkerManager ?? …` injection seam (used by existing tests that pass a fake manager) is preserved, so no existing tests are affected.

### Contract test

`server/src/__tests__/plugin-worker-live-events.test.ts` — 3 cases:

- **Drift detector**: `bridge` is typed directly against `PluginWorkerManagerOptions["onWorkerEvent"]` — any manager option signature change fails at compile time.
- **`plugin.worker.crashed`**: verifies full `{ pluginId, code, signal, willRestart }` payload reaches a `subscribeGlobalLiveEvents` listener (`server/src/services/live-events.ts:51-54`).
- **`plugin.worker.restarted`**: verifies missing fields normalize to `null`/`false`.

## Test plan

- [x] `npx vitest run server/src/__tests__/plugin-worker-live-events.test.ts` — 3/3 pass
- [x] `pnpm --filter @paperclipai/server typecheck` — clean
- [x] Manual verification: spinning up a plugin and SIGKILLing its worker produces `plugin.worker.crashed` events on the global stream