### PR TITLE
WS transport: also subscribe to global live events

### DIFF
--- a/server/src/__tests__/ws-global-live-events.test.ts
+++ b/server/src/__tests__/ws-global-live-events.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  publishGlobalLiveEvent,
+  publishLiveEvent,
+  subscribeCompanyLiveEvents,
+  subscribeGlobalLiveEvents,
+} from "../services/live-events.js";
+
+// Unit-tests for the fix in server/src/realtime/live-events-ws.ts.
+//
+// The WS connection handler now calls both subscribeCompanyLiveEvents AND
+// subscribeGlobalLiveEvents (live-events-ws.ts:208-219). These tests verify
+// that a connected client receives globally-published events (e.g.
+// plugin.worker.crashed) in addition to company-scoped ones, and that both
+// subscriptions are torn down on close.
+
+const OPEN = 1;
+
+function makeSocketSpy() {
+  const sent: unknown[] = [];
+  let closed = false;
+
+  return {
+    get readyState() {
+      return closed ? 3 /* CLOSED */ : OPEN;
+    },
+    close() {
+      closed = true;
+    },
+    send(data: string) {
+      sent.push(JSON.parse(data));
+    },
+    sent,
+  };
+}
+
+// Mirrors the subscription block in live-events-ws.ts:208-219 so that any
+// future drift between production wiring and this test surfaces immediately.
+function connectClient(companyId: string) {
+  const socket = makeSocketSpy();
+
+  const send = (event: unknown) => {
+    if (socket.readyState !== OPEN) return;
+    socket.send(JSON.stringify(event));
+  };
+
+  const unsubscribeCompany = subscribeCompanyLiveEvents(companyId, send);
+  const unsubscribeGlobal = subscribeGlobalLiveEvents(send);
+  const cleanup = () => {
+    unsubscribeCompany();
+    unsubscribeGlobal();
+  };
+
+  return { socket, cleanup };
+}
+
+describe("WS transport: global live event delivery", () => {
+  it("delivers a globally-published plugin.worker.crashed event to a connected client", () => {
+    const { socket, cleanup } = connectClient("company-abc");
+
+    publishGlobalLiveEvent({
+      type: "plugin.worker.crashed",
+      payload: { pluginId: "test.plugin", code: 137, signal: "SIGKILL", willRestart: true },
+    });
+
+    cleanup();
+
+    const frame = socket.sent.find(
+      (e): e is Record<string, unknown> =>
+        typeof e === "object" &&
+        e !== null &&
+        (e as Record<string, unknown>)["type"] === "plugin.worker.crashed",
+    );
+    expect(frame).toBeDefined();
+    expect(frame?.["type"]).toBe("plugin.worker.crashed");
+  });
+
+  it("delivers both company-scoped and global events to the same client", () => {
+    const { socket, cleanup } = connectClient("company-xyz");
+
+    publishLiveEvent({
+      companyId: "company-xyz",
+      type: "activity.logged",
+      payload: { action: "issue.created" },
+    });
+    publishGlobalLiveEvent({
+      type: "plugin.worker.restarted",
+      payload: { pluginId: "test.plugin", code: null, signal: null, willRestart: false },
+    });
+
+    cleanup();
+
+    const types = socket.sent.map(
+      (e) => (e as Record<string, unknown>)["type"] as string,
+    );
+    expect(types).toContain("activity.logged");
+    expect(types).toContain("plugin.worker.restarted");
+  });
+
+  it("stops delivering global events after cleanup", () => {
+    const { socket, cleanup } = connectClient("company-def");
+
+    cleanup();
+
+    publishGlobalLiveEvent({
+      type: "plugin.worker.crashed",
+      payload: { pluginId: "test.plugin" },
+    });
+
+    expect(socket.sent).toHaveLength(0);
+  });
+
+  it("cleanup of one client does not affect delivery to another client", () => {
+    const { socket: s1, cleanup: c1 } = connectClient("company-1");
+    const { socket: s2, cleanup: c2 } = connectClient("company-2");
+
+    // Disconnect the first client.
+    c1();
+
+    publishGlobalLiveEvent({
+      type: "plugin.worker.restarted",
+      payload: { pluginId: "test.plugin" },
+    });
+
+    c2();
+
+    // First client was cleaned up before publish — should receive nothing.
+    expect(s1.sent).toHaveLength(0);
+    // Second client was still connected at publish time — should receive the event.
+    expect(s2.sent).toHaveLength(1);
+  });
+});

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -8,7 +8,7 @@ import { agentApiKeys, companyMemberships, instanceUserRoles } from "@paperclipa
 import type { DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "../middleware/logger.js";
-import { subscribeCompanyLiveEvents } from "../services/live-events.js";
+import { subscribeCompanyLiveEvents, subscribeGlobalLiveEvents } from "../services/live-events.js";
 
 interface WsSocket {
   readyState: number;
@@ -205,10 +205,17 @@ export function setupLiveEventsWebSocketServer(
       return;
     }
 
-    const unsubscribe = subscribeCompanyLiveEvents(context.companyId, (event) => {
+    const send = (event: unknown) => {
       if (socket.readyState !== WebSocket.OPEN) return;
       socket.send(JSON.stringify(event));
-    });
+    };
+
+    const unsubscribeCompany = subscribeCompanyLiveEvents(context.companyId, send);
+    const unsubscribeGlobal = subscribeGlobalLiveEvents(send);
+    const unsubscribe = () => {
+      unsubscribeCompany();
+      unsubscribeGlobal();
+    };
 
     cleanupByClient.set(socket, unsubscribe);
     aliveByClient.set(socket, true);


### PR DESCRIPTION
## Summary

`server/src/realtime/live-events-ws.ts:208` only called `subscribeCompanyLiveEvents(context.companyId, …)`. Events published via `publishGlobalLiveEvent` emit on the `"*"` channel of the internal EventEmitter (`server/src/services/live-events.ts:42`) — a channel no WebSocket client was subscribed to. Result: every `plugin.*` event was silently dropped at the transport layer.

Three of the nine declared `LIVE_EVENT_TYPES` are global-only: `plugin.worker.crashed`, `plugin.worker.restarted`, and `plugin.ui.updated`. Clients connected to `/api/companies/:id/events/ws` never received any of them.

### Fix

`server/src/realtime/live-events-ws.ts:208-219` — the `"connection"` handler now calls `subscribeGlobalLiveEvents` with the same `send` callback alongside the existing `subscribeCompanyLiveEvents` call. Both unsubscribes are composed into a single cleanup stored in `cleanupByClient`, so the `"close"` handler (`live-events-ws.ts:220-225`) tears both down atomically. The existing company-scoped subscription is unchanged.

### Why option 1 from the issue description

Global plugin events are instance-wide, not per-company — there is no tenancy leak risk in delivering them to every authorized client. Option 2 (fan out in the publisher) would be more expensive and would require the publisher to know about all active company channels, coupling two previously independent layers.

### Test

`server/src/__tests__/ws-global-live-events.test.ts` — 4 cases mirroring the subscription block at `live-events-ws.ts:208-219`:

- **Global delivery**: `publishGlobalLiveEvent({ type: "plugin.worker.crashed" })` reaches a connected client.
- **Mixed delivery**: both a company-scoped `activity.logged` and a global `plugin.worker.restarted` are delivered to the same client.
- **Post-cleanup silence**: no global events are delivered after the connection cleanup runs.
- **Multi-client isolation**: cleaning up client A does not affect delivery to client B.

## Test plan

- [x] `npx vitest run server/src/__tests__/ws-global-live-events.test.ts` — 4/4 pass
- [x] `pnpm --filter @paperclipai/server typecheck` — clean
- [x] Connecting to `/api/companies/:id/events/ws` and triggering a plugin enable/disable yields a `plugin.ui.updated` frame on the socket
- [x] Existing per-company event delivery is unchanged