### PR TITLE
fix(skills): include references/ tree when import source is the skill dir itself

### DIFF
--- a/server/src/__tests__/company-skills.test.ts
+++ b/server/src/__tests__/company-skills.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeGitHubSkillDirectory,
   parseSkillImportSourceInput,
   readLocalSkillImportFromDirectory,
+  readLocalSkillImports,
 } from "../services/company-skills.js";
 
 const cleanupDirs = new Set<string>();
@@ -184,6 +185,46 @@ describe("project workspace skill discovery", () => {
         },
       ],
     });
+  });
+});
+
+describe("readLocalSkillImports — directory source", () => {
+  it("includes references/ tree when source points directly at the skill dir (SKILL.md at root)", async () => {
+    // Regression: dirname('SKILL.md') === '.' caused entry.startsWith('./') to never match,
+    // silently dropping every file except SKILL.md itself.
+    const skillDir = await makeTempDir("paperclip-at-root-import-");
+    await writeSkillDir(skillDir, "At Root Skill");
+    await fs.mkdir(path.join(skillDir, "references"), { recursive: true });
+    await fs.writeFile(path.join(skillDir, "references", "guide.md"), "# Guide\n", "utf8");
+    await fs.writeFile(path.join(skillDir, "references", "checklist.md"), "# Checklist\n", "utf8");
+
+    const [imported] = await readLocalSkillImports(
+      "44444444-4444-4444-4444-444444444444",
+      skillDir,
+    );
+
+    expect(imported).toBeDefined();
+    expect(new Set(imported.fileInventory.map((entry) => entry.path))).toEqual(
+      new Set(["SKILL.md", "references/guide.md", "references/checklist.md"]),
+    );
+  });
+
+  it("includes references/ tree when source is a parent dir containing the skill subdir (wrapper-dir case)", async () => {
+    const parentDir = await makeTempDir("paperclip-wrapper-dir-import-");
+    const skillSubDir = path.join(parentDir, "my-skill");
+    await writeSkillDir(skillSubDir, "Wrapped Skill");
+    await fs.mkdir(path.join(skillSubDir, "references"), { recursive: true });
+    await fs.writeFile(path.join(skillSubDir, "references", "overview.md"), "# Overview\n", "utf8");
+
+    const [imported] = await readLocalSkillImports(
+      "44444444-4444-4444-4444-444444444444",
+      parentDir,
+    );
+
+    expect(imported).toBeDefined();
+    expect(new Set(imported.fileInventory.map((entry) => entry.path))).toEqual(
+      new Set(["SKILL.md", "references/overview.md"]),
+    );
   });
 });
 

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -973,7 +973,7 @@ export async function discoverProjectWorkspaceSkillDirectories(target: ProjectSk
     .sort((left, right) => left.skillDir.localeCompare(right.skillDir));
 }
 
-async function readLocalSkillImports(companyId: string, sourcePath: string): Promise<ImportedSkill[]> {
+export async function readLocalSkillImports(companyId: string, sourcePath: string): Promise<ImportedSkill[]> {
   const resolvedPath = path.resolve(sourcePath);
   const stat = await fs.stat(resolvedPath).catch(() => null);
   if (!stat) {
@@ -1027,10 +1027,11 @@ async function readLocalSkillImports(companyId: string, sourcePath: string): Pro
   const imports: ImportedSkill[] = [];
   for (const skillPath of skillPaths) {
     const skillDir = path.posix.dirname(skillPath);
+    const isAtRoot = skillDir === ".";
     const inventory = allFiles
-      .filter((entry) => entry === skillPath || entry.startsWith(`${skillDir}/`))
+      .filter((entry) => isAtRoot || entry === skillPath || entry.startsWith(`${skillDir}/`))
       .map((entry) => {
-        const relative = entry === skillPath ? "SKILL.md" : entry.slice(skillDir.length + 1);
+        const relative = entry === skillPath ? "SKILL.md" : (isAtRoot ? entry : entry.slice(skillDir.length + 1));
         return {
           path: normalizePortablePath(relative),
           kind: classifyInventoryKind(relative),


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and loads company skills to extend their capabilities
> - Skills can have companion files under `references/`, `scripts/`, and `assets/` — essential for multi-file skill bundles
> - `POST /api/companies/{id}/skills/import` accepts a `source` path that can be a parent dir (containing skill subdirs) or the skill dir itself (SKILL.md at root)
> - `readLocalSkillImports` builds a per-skill inventory by filtering `allFiles` with `entry.startsWith(`${skillDir}/`)`, where `skillDir = path.posix.dirname(skillPath)`
> - When `source` points directly at the skill dir, `skillPath === 'SKILL.md'`, so `skillDir === '.'` and `entry.startsWith('./')` never matches — walker output has no `./` prefix
> - The same bug also corrupts the `relative` path via `entry.slice(skillDir.length + 1)` = `entry.slice(2)` (e.g., `'references/foo.md'` → `'ferences/foo.md'`)
> - This PR guards the at-root case with `isAtRoot = skillDir === "."`: include all walked entries and use `entry` as the relative path directly, matching the surface the wrapper-dir case already produces

## What Changed

- `server/src/services/company-skills.ts` — `readLocalSkillImports`: added `isAtRoot` guard; filter and map now include all walked files when SKILL.md is at root
- `server/src/services/company-skills.ts` — exported `readLocalSkillImports` (was unexported) to enable direct unit testing
- `server/src/__tests__/company-skills.test.ts` — added `readLocalSkillImports — directory source` describe block with two regression tests:
  - **at-root case**: source = skill dir directly, asserts SKILL.md + references/ both inventoried
  - **wrapper-dir case**: source = parent dir, asserts existing behavior unchanged

## Verification

```
cd server && npx vitest run src/__tests__/company-skills.test.ts
```

Result:
```
 ✓ src/__tests__/company-skills.test.ts (14 tests) 17ms

 Test Files  1 passed (1)
      Tests  14 passed (14)
   Duration  939ms
```

All 14 tests pass (12 pre-existing + 2 new regression tests).

## Risks

- Low risk. The fix is scoped to two lines in a single function. The `isAtRoot` guard only activates when `path.posix.dirname(skillPath) === "."` — i.e., exactly the broken case. All other paths (wrapper-dir, single-file SKILL.md, GitHub URL imports) are unaffected.
- Exporting `readLocalSkillImports` widens the module surface slightly. The function was already called from two internal call sites; the export just enables direct testing.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context window: 200K tokens
- Capabilities: tool use, code execution, file editing

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — backend only)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge