### PR TITLE
Fix: findMentionedAgents plain-text parser stops at first space — multi-word agent names never resolve

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3096,4 +3096,35 @@ describeEmbeddedPostgres("issueService.findMentionedAgents", () => {
     );
     expect(new Set(result)).toEqual(new Set([cooId, designId, banksAgentId]));
   });
+
+  it("resolves a mention followed by a hyphen (e.g. @COO-please)", async () => {
+    // Trailing-boundary set must include `-` so inline-hyphenated phrasing
+    // like `@COO-please` resolves to the COO agent rather than silently
+    // failing.
+    await seed();
+    const result = await svc.findMentionedAgents(companyId, "@COO-please review");
+    expect(new Set(result)).toEqual(new Set([cooId]));
+  });
+
+  it("resolves a mention followed by an em-dash (e.g. @COO—please)", async () => {
+    // Em-dash (U+2014) is a common punctuation form in human-typed comments;
+    // the trailing-boundary set must include it.
+    await seed();
+    const result = await svc.findMentionedAgents(companyId, "@COO—please review");
+    expect(new Set(result)).toEqual(new Set([cooId]));
+  });
+
+  it("short-circuits without a DB query when body contains only an email-shape @", async () => {
+    // The early-return guard uses `/\B@/` (the same anchor as the scan loop)
+    // so bodies whose only `@` sits inside an email address skip the agent
+    // SELECT entirely. We can't directly assert "no SELECT was issued"
+    // without a spy, but the empty result combined with the guard's
+    // structure is the contract.
+    await seed();
+    const result = await svc.findMentionedAgents(
+      companyId,
+      "Please ping support@example.com if you need help",
+    );
+    expect(result).toEqual([]);
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2916,3 +2916,184 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     expect(row).toEqual({ executionRunId: null, executionLockedAt: null });
   });
 });
+
+
+describeEmbeddedPostgres("issueService.findMentionedAgents", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  let companyId!: string;
+  let cooId!: string;
+  let designId!: string;
+  let pmId!: string;
+  let banksAgentId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-find-mentioned-agents-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  // Each test seeds a company plus agents that exercise the mention parser:
+  //  - single-token name (COO)
+  //  - multi-word name (Director of Design)
+  //  - multi-word name with punctuation (Director of Project/Team Management)
+  //  - generic short name (Banks) used for the markdown-link path.
+  const seed = async () => {
+    companyId = randomUUID();
+    cooId = randomUUID();
+    designId = randomUUID();
+    pmId = randomUUID();
+    banksAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: cooId,
+        companyId,
+        name: "COO",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: designId,
+        companyId,
+        name: "Director of Design",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: pmId,
+        companyId,
+        name: "Director of Project/Team Management",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: banksAgentId,
+        companyId,
+        name: "Banks",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+  };
+
+  it("resolves a single-token mention (regression)", async () => {
+    await seed();
+    const result = await svc.findMentionedAgents(companyId, "@COO please review");
+    expect(new Set(result)).toEqual(new Set([cooId]));
+  });
+
+  it("resolves a multi-word agent name", async () => {
+    await seed();
+    const result = await svc.findMentionedAgents(
+      companyId,
+      "@Director of Design please review",
+    );
+    expect(new Set(result)).toEqual(new Set([designId]));
+  });
+
+  it("resolves a multi-word name with slash and mixed-case capitalisation", async () => {
+    await seed();
+    const result = await svc.findMentionedAgents(
+      companyId,
+      "@Director of Project/Team Management please review",
+    );
+    expect(new Set(result)).toEqual(new Set([pmId]));
+  });
+
+  it("does not resolve mentions when the body has no @", async () => {
+    await seed();
+    const result = await svc.findMentionedAgents(companyId, "Ready for COO review");
+    expect(result).toEqual([]);
+  });
+
+  it("does not resolve email-like @ inside a domain", async () => {
+    await seed();
+    const result = await svc.findMentionedAgents(
+      companyId,
+      "Reach me at user@example.com please",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("fails closed on a bare ambiguous prefix that matches no agent name exactly", async () => {
+    await seed();
+    // No agent is exactly named "Director"; longest-match-wins means none of the
+    // multi-word "Director of …" agents match a bare "@Director" alone.
+    const result = await svc.findMentionedAgents(
+      companyId,
+      "@Director and others please respond",
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("resolves markdown-link mentions via extractAgentMentionIds (regression)", async () => {
+    await seed();
+    const result = await svc.findMentionedAgents(
+      companyId,
+      `Hi [@Banks](agent://${banksAgentId}) take a look`,
+    );
+    expect(new Set(result)).toEqual(new Set([banksAgentId]));
+  });
+
+  it("resolves both plain-text and markdown-link mentions in the same body", async () => {
+    await seed();
+    const result = await svc.findMentionedAgents(
+      companyId,
+      `@Director of Design ping; also [@Banks](agent://${banksAgentId}) please review`,
+    );
+    expect(new Set(result)).toEqual(new Set([designId, banksAgentId]));
+  });
+
+  it("matches multi-word agent names case-insensitively", async () => {
+    await seed();
+    const result = await svc.findMentionedAgents(
+      companyId,
+      "@director of design please review",
+    );
+    expect(new Set(result)).toEqual(new Set([designId]));
+  });
+
+  it("resolves multiple distinct mentions in one body", async () => {
+    await seed();
+    const result = await svc.findMentionedAgents(
+      companyId,
+      "@COO and @Director of Design and @Banks please review",
+    );
+    expect(new Set(result)).toEqual(new Set([cooId, designId, banksAgentId]));
+  });
+});

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4055,7 +4055,14 @@ export function issueService(db: Db) {
 
     findMentionedAgents: async (companyId: string, body: string) => {
       const explicitAgentMentionIds = extractAgentMentionIds(body);
-      if (!body.includes("@") && explicitAgentMentionIds.length === 0) return [];
+      // Skip the DB query when there is no plausible mention candidate. A
+      // bare `body.includes("@")` is too broad — bodies containing only an
+      // email address (e.g. `user@example.com`) would trigger a wasted
+      // SELECT on every comment-create. `/\B@/` is the same anchor the
+      // scan-loop below uses, so this short-circuit is exact: if no
+      // position matches `\B@`, the loop would have produced an empty set
+      // anyway.
+      if (explicitAgentMentionIds.length === 0 && !/\B@/.test(body)) return [];
 
       // Decode HTML entities up-front so UI-encoded bodies match agent names verbatim.
       const normalizedBody = normalizeAgentMentionToken(body);
@@ -4082,7 +4089,11 @@ export function issueService(db: Db) {
           const candidate = window.slice(0, agent.name.length);
           if (candidate.toLowerCase() === agent.name.toLowerCase()) {
             const nextChar = window[agent.name.length];
-            if (nextChar === undefined || /[\s,.!?;:()[\]]/.test(nextChar)) {
+            // Trailing boundary set includes hyphen-minus (`-`) and em-dash
+            // (U+2014) so inline-hyphenated phrasing like `@COO-please` and
+            // em-dash-suffixed mentions resolve correctly rather than
+            // silently failing.
+            if (nextChar === undefined || /[\s,.!?;:()[\]\-—]/.test(nextChar)) {
               resolved.add(agent.id);
               break;
             }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4054,22 +4054,39 @@ export function issueService(db: Db) {
       }),
 
     findMentionedAgents: async (companyId: string, body: string) => {
-      const re = /\B@([^\s@,!?.]+)/g;
-      const tokens = new Set<string>();
-      let m: RegExpExecArray | null;
-      while ((m = re.exec(body)) !== null) {
-        const normalized = normalizeAgentMentionToken(m[1]);
-        if (normalized) tokens.add(normalized.toLowerCase());
-      }
-
       const explicitAgentMentionIds = extractAgentMentionIds(body);
-      if (tokens.size === 0 && explicitAgentMentionIds.length === 0) return [];
+      if (!body.includes("@") && explicitAgentMentionIds.length === 0) return [];
+
+      // Decode HTML entities up-front so UI-encoded bodies match agent names verbatim.
+      const normalizedBody = normalizeAgentMentionToken(body);
+
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
+
       const resolved = new Set<string>(explicitAgentMentionIds);
-      for (const agent of rows) {
-        if (tokens.has(agent.name.toLowerCase())) {
-          resolved.add(agent.id);
+      if (rows.length === 0) return [...resolved];
+
+      // Longest-name first so multi-word agent names (e.g. "Director of Design")
+      // win over any shorter name that is a prefix of another.
+      const sortedAgents = rows
+        .slice()
+        .sort((a, b) => b.name.length - a.name.length);
+
+      const atRe = /\B@/g;
+      let atMatch: RegExpExecArray | null;
+      while ((atMatch = atRe.exec(normalizedBody)) !== null) {
+        const start = atMatch.index + 1;
+        const window = normalizedBody.slice(start);
+        for (const agent of sortedAgents) {
+          if (window.length < agent.name.length) continue;
+          const candidate = window.slice(0, agent.name.length);
+          if (candidate.toLowerCase() === agent.name.toLowerCase()) {
+            const nextChar = window[agent.name.length];
+            if (nextChar === undefined || /[\s,.!?;:()[\]]/.test(nextChar)) {
+              resolved.add(agent.id);
+              break;
+            }
+          }
         }
       }
       return [...resolved];


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; agents react to events including `@`-mentions in issue comments and descriptions.
> - The mention subsystem has two parallel resolution paths: the markdown-link path (`[@Name](agent://uuid)`) handled by `extractAgentMentionIds`, and a plain-text fallback in `findMentionedAgents` for human-typed or agent-typed prose without explicit markdown.
> - The plain-text fallback uses a regex that stops at the first whitespace, so any agent whose name contains a space (`Director of Design`, `Director of Project/Team Management`) cannot be auto-mentioned from plain-text comments — only the first word matches, and the partial token rarely resolves to any agent.
> - This silently breaks wake-on-mention for the dominant class of agent names in role-titled companies. Affected paths: `findMentionedAgents` return value, mention-driven `enqueueWakeup`, downstream consumers of mention-set output.
> - This PR rewrites `findMentionedAgents` to use a longest-prefix multi-word match against the company's agent list: agents are sorted longest-name-first, each `\B@` position is sliced, and the first agent whose full name matches case-insensitively with a valid trailing boundary character wins.
> - The benefit is that plain-text `@<multi-word-name>` mentions now resolve reliably across role-titled and multi-word agent populations, restoring the convention-based wake-on-mention behavior that markdown-link mentions already enjoy.

## What Changed

- `findMentionedAgents` in `server/src/services/issues.ts` rewritten from single-token regex to longest-prefix multi-word scan.
- Early-return guard tightened from `!body.includes("@")` to `!/\B@/.test(body)` — same anchor as the scan loop, so bodies whose only `@` sits inside an email address (`user@example.com`) skip the agent SELECT entirely.
- Trailing-boundary character set expanded to include hyphen (`-`) and em-dash (U+2014) so inline-hyphenated phrasing like `@COO-please` and em-dash-suffixed mentions resolve correctly.
- 13 unit tests added covering: single-token, multi-word, hyphen boundary, em-dash boundary, slash + mixed case, email-only-body short-circuit, ambiguous-prefix fail-closed, markdown-link path preserved, mixed plain-text + markdown, case-insensitive, multiple distinct mentions.

## Verification

```bash
pnpm --filter @paperclipai/server test -- issues-service.test.ts
```

All 13 tests in the `issueService.findMentionedAgents` describe block pass against an embedded Postgres instance.

Live-verified in production (FirstString HoldCo deployment, 2026-05-07 onward): post-fix, `@Director of Design` plain-text mentions reliably resolve to the correct UUID and wake the agent.

## Risks

Low risk. The change is additive on the resolution side — more mentions resolve than before; none stop resolving. The early-return guard tightening eliminates a class of wasted DB query but cannot change behavior — the inner scan loop is the exclusive source of agent resolution and is unchanged in semantics. The markdown-link path (`extractAgentMentionIds`) is untouched.

## Model Used

Claude (Anthropic) — Claude Opus 4.7 (1M context window) via Claude Code CLI. The change was authored as part of the local patch series for FirstString HoldCo, then prepared as this upstream PR. Greptile-review revisions in this PR also authored by the same model.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have added tests covering the changed behavior
- [x] I have verified the change against my local deployment
- [x] I have flagged risks
- [x] I have specified the AI model used
