### PR TITLE
Fix SD heartbeat dupe 500s (CLAAA-51)

### DIFF
--- a/packages/db/src/migrations/0084_routine_execution_uq_drop_run_predicate.sql
+++ b/packages/db/src/migrations/0084_routine_execution_uq_drop_run_predicate.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS "issues_open_routine_execution_uq";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "issues_open_routine_execution_uq" ON "issues" USING btree ("company_id","origin_kind","origin_id","origin_fingerprint") WHERE "issues"."origin_kind" = 'routine_execution'
+          and "issues"."origin_id" is not null
+          and "issues"."hidden_at" is null
+          and "issues"."status" in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked');

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1778074536410,
       "tag": "0083_company_secret_provider_configs",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1778796000000,
+      "tag": "0084_routine_execution_uq_drop_run_predicate",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -96,7 +96,6 @@ export const issues = pgTable(
         sql`${table.originKind} = 'routine_execution'
           and ${table.originId} is not null
           and ${table.hiddenAt} is null
-          and ${table.executionRunId} is not null
           and ${table.status} in ('backlog', 'todo', 'in_progress', 'in_review', 'blocked')`,
       ),
     activeLivenessRecoveryIncidentIdx: uniqueIndex("issues_active_liveness_recovery_incident_uq")

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2106,6 +2106,20 @@ export function issueService(db: Db) {
     return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
   }
 
+  // CLAAA-51: routine_execution dupe issues share the (company_id, origin_kind,
+  // origin_id, origin_fingerprint) tuple. Writing execution_run_id during
+  // ownership adoption used to flip a dupe row into the partial unique index
+  // and surface as 23505 -> 500. Treat that specific constraint hit as a
+  // failed adoption (return null) so callers fall through to the standard
+  // 409 ownership response instead of bubbling a 500.
+  function isOpenRoutineExecutionDuplicate(err: unknown): boolean {
+    if (!err || typeof err !== "object") return false;
+    const e = err as { code?: string; constraint?: string; constraint_name?: string };
+    if (e.code !== "23505") return false;
+    const constraint = e.constraint ?? e.constraint_name;
+    return constraint === "issues_open_routine_execution_uq";
+  }
+
   async function adoptStaleCheckoutRun(input: {
     issueId: string;
     actorAgentId: string;
@@ -2116,32 +2130,37 @@ export function issueService(db: Db) {
     if (!stale) return null;
 
     const now = new Date();
-    const adopted = await db
-      .update(issues)
-      .set({
-        checkoutRunId: input.actorRunId,
-        executionRunId: input.actorRunId,
-        executionLockedAt: now,
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(issues.id, input.issueId),
-          eq(issues.status, "in_progress"),
-          eq(issues.assigneeAgentId, input.actorAgentId),
-          eq(issues.checkoutRunId, input.expectedCheckoutRunId),
-        ),
-      )
-      .returning({
-        id: issues.id,
-        status: issues.status,
-        assigneeAgentId: issues.assigneeAgentId,
-        checkoutRunId: issues.checkoutRunId,
-        executionRunId: issues.executionRunId,
-      })
-      .then((rows) => rows[0] ?? null);
+    try {
+      const adopted = await db
+        .update(issues)
+        .set({
+          checkoutRunId: input.actorRunId,
+          executionRunId: input.actorRunId,
+          executionLockedAt: now,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(issues.id, input.issueId),
+            eq(issues.status, "in_progress"),
+            eq(issues.assigneeAgentId, input.actorAgentId),
+            eq(issues.checkoutRunId, input.expectedCheckoutRunId),
+          ),
+        )
+        .returning({
+          id: issues.id,
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
+        })
+        .then((rows) => rows[0] ?? null);
 
-    return adopted;
+      return adopted;
+    } catch (err) {
+      if (isOpenRoutineExecutionDuplicate(err)) return null;
+      throw err;
+    }
   }
 
   async function adoptUnownedCheckoutRun(input: {
@@ -2150,33 +2169,38 @@ export function issueService(db: Db) {
     actorRunId: string;
   }) {
     const now = new Date();
-    const adopted = await db
-      .update(issues)
-      .set({
-        checkoutRunId: input.actorRunId,
-        executionRunId: input.actorRunId,
-        executionLockedAt: now,
-        updatedAt: now,
-      })
-      .where(
-        and(
-          eq(issues.id, input.issueId),
-          eq(issues.status, "in_progress"),
-          eq(issues.assigneeAgentId, input.actorAgentId),
-          isNull(issues.checkoutRunId),
-          or(isNull(issues.executionRunId), eq(issues.executionRunId, input.actorRunId)),
-        ),
-      )
-      .returning({
-        id: issues.id,
-        status: issues.status,
-        assigneeAgentId: issues.assigneeAgentId,
-        checkoutRunId: issues.checkoutRunId,
-        executionRunId: issues.executionRunId,
-      })
-      .then((rows) => rows[0] ?? null);
+    try {
+      const adopted = await db
+        .update(issues)
+        .set({
+          checkoutRunId: input.actorRunId,
+          executionRunId: input.actorRunId,
+          executionLockedAt: now,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(issues.id, input.issueId),
+            eq(issues.status, "in_progress"),
+            eq(issues.assigneeAgentId, input.actorAgentId),
+            isNull(issues.checkoutRunId),
+            or(isNull(issues.executionRunId), eq(issues.executionRunId, input.actorRunId)),
+          ),
+        )
+        .returning({
+          id: issues.id,
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
+        })
+        .then((rows) => rows[0] ?? null);
 
-    return adopted;
+      return adopted;
+    } catch (err) {
+      if (isOpenRoutineExecutionDuplicate(err)) return null;
+      throw err;
+    }
   }
 
   async function clearExecutionRunIfTerminal(issueId: string): Promise<boolean> {


### PR DESCRIPTION
Implements the server fix described in CLAAA-45 (and its planning doc).

## Why
The `issues_open_routine_execution_uq` partial index excluded rows with `execution_run_id IS NULL`. Routine-execution issues are inserted with NULL `execution_run_id`, so the dispatcher's coalesce-on-23505 path never fired — dupes accumulated. Worse, the ownership-adoption UPDATE in `adoptStaleCheckoutRun` / `adoptUnownedCheckoutRun` flipped dupe rows into the index later, raising 23505 -> 500 on PATCH/checkout/release.

## What changes
- **Migration `0084_routine_execution_uq_drop_run_predicate.sql`** — drop `execution_run_id IS NOT NULL` from the partial index predicate (matching schema update in `packages/db/src/schema/issues.ts`). Newly-inserted routine_execution rows are now in the index immediately, so the dispatcher's existing 23505 catch coalesces concurrent fires.
- **23505 guard** in `adoptStaleCheckoutRun` / `adoptUnownedCheckoutRun` (`server/src/services/issues.ts`) — wraps the adoption UPDATE; if the specific `issues_open_routine_execution_uq` constraint fires, return `null` (caller falls through to the standard 409 ownership response) instead of bubbling a 500.

## Sequencing note for deploy
Any existing dupe rows must be cancelled (status outside the partial index predicate) before applying migration 0084, otherwise the new index build will fail. CEO workaround in CLAAA-45 plan covers this for the SLAVE DRIVER routine.

## Verification plan
- Force-fire the routine twice while a prior execution is still open → second insert hits the constraint → `coalesced` instead of a new issue.
- PATCH an active routine-execution issue to `done` from a different `X-Paperclip-Run-Id` than the one that originally checked it out → 200, not 500.
- PATCH from a non-assignee with no override → standard 409, ownership boundary unchanged.

Refs: CLAAA-45, CLAAA-51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)