### PR TITLE
feat(claude-local): guaranteed post-run reporting via adapter hook (STAA-2549)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -62,6 +62,47 @@ import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
+async function reportRun(input: {
+  runId: string;
+  agentId: string;
+  agentName: string;
+  companyId: string;
+  status: "succeeded" | "failed";
+  summary: string;
+  startedAt: Date;
+  finishedAt: Date;
+  apiUrl: string;
+  apiKey: string;
+}): Promise<void> {
+  const { runId, agentId, agentName, companyId, status, summary, startedAt, finishedAt, apiUrl, apiKey } = input;
+  const payload = {
+    runId,
+    agentId,
+    agentName,
+    agentType: "claude_local",
+    companyId,
+    status,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    durationMs: finishedAt.getTime() - startedAt.getTime(),
+    resultSummary: summary.slice(0, 2000),
+    source: "heartbeat",
+  };
+  const response = await fetch(`${apiUrl}/v1/admin/agent-runs`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`agent-runs POST failed ${response.status}: ${text.slice(0, 200)}`);
+  }
+}
+
 interface ClaudeExecutionInput {
   runId: string;
   agent: AdapterExecutionContext["agent"];
@@ -402,6 +443,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     graceSec,
     extraArgs,
   } = runtimeConfig;
+  const runStartedAt = new Date();
+  const spUrl = (typeof env.STANDARD_POWER_API_URL === "string" ? env.STANDARD_POWER_API_URL : "").trim();
+  const spKey = (typeof env.STANDARD_POWER_API_KEY === "string" ? env.STANDARD_POWER_API_KEY : "").trim();
   let loggedEnv = initialLoggedEnv;
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
   const terminalResultCleanupGraceMs = Math.max(
@@ -909,6 +953,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   };
 
+  let adapterResult: AdapterExecutionResult | null = null;
   try {
     const initial = await runAttempt(sessionId ?? null);
     if (
@@ -923,10 +968,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
       );
       const retry = await runAttempt(null);
-      return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+      adapterResult = toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
+    } else {
+      adapterResult = toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
     }
-
-    return toAdapterResult(initial, { fallbackSessionId: runtimeSessionId || runtime.sessionId });
+    return adapterResult;
   } finally {
     if (paperclipBridge) {
       await paperclipBridge.stop();
@@ -937,6 +983,24 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] Restoring workspace changes from ${describeAdapterExecutionTarget(executionTarget)}.\n`,
       );
       await restoreRemoteWorkspace();
+    }
+    if (spUrl && spKey) {
+      const finishedAt = new Date();
+      const isSuccess = adapterResult != null && !adapterResult.errorCode && (adapterResult.exitCode ?? 0) === 0;
+      reportRun({
+        runId,
+        agentId: agent.id,
+        agentName: agent.name,
+        companyId: agent.companyId,
+        status: isSuccess ? "succeeded" : "failed",
+        summary: adapterResult?.summary ?? "",
+        startedAt: runStartedAt,
+        finishedAt,
+        apiUrl: spUrl,
+        apiKey: spKey,
+      }).catch((err: unknown) => {
+        onLog("stderr", `[paperclip] agent-runs report failed: ${err}\n`).catch(() => {});
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary

Moves agent-run reporting out of the agent prompt and into the adapter execute.ts as a guaranteed post-run hook. The hook fires in the `finally` block regardless of how the agent exits (early clean exit, timeout, error), posting to `STANDARD_POWER_API_URL/v1/admin/agent-runs` with run metadata.

- Adds `reportRun()` function that POSTs run metadata to the configured API endpoint
- Fires in `finally` block so it is guaranteed regardless of run outcome
- Reports `succeeded` or `failed` based on adapter result exit code and error state
- No-ops silently if `STANDARD_POWER_API_URL` or `STANDARD_POWER_API_KEY` are not set

## Test plan
- [ ] Trigger an agent run and verify a record appears in `agent_runs` table
- [ ] Confirm the hook fires on error/timeout runs as well as successful ones

Related: STAA-2549, STAA-2551