### PR TITLE
fix(server/recovery): skip stranded escalation when issue has unresolved blockers

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2052,6 +2052,115 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it("skips Klasse-2 escalation when the in_progress issue has unresolved blockers (continuation_needed path)", async () => {
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    const blockerIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Unresolved prerequisite blocker",
+      status: "in_progress",
+      priority: "medium",
+      issueNumber: 99,
+      identifier: `${issuePrefix}-99`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.blockerSkipped).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+  });
+
+  it("skips Klasse-2 escalation when the todo issue has unresolved blockers (assignment_recovery path)", async () => {
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+    });
+    const blockerIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Unresolved prerequisite blocker",
+      status: "todo",
+      priority: "medium",
+      issueNumber: 98,
+      identifier: `${issuePrefix}-98`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.blockerSkipped).toBe(1);
+    expect(result.skipped).toBe(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+  });
+
+  it("still escalates Klasse-2 after the blocker is resolved (positive control)", async () => {
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    const blockerIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Already-resolved blocker",
+      status: "done",
+      priority: "medium",
+      issueNumber: 97,
+      identifier: `${issuePrefix}-97`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.blockerSkipped).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+  });
+
   it("redacts error-code-only stranded recovery failures in issue copy", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2127,6 +2127,44 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.status).toBe("todo");
   });
 
+  it("skips Klasse-2 escalation when the productive-continuation issue has unresolved blockers (Site-B path)", async () => {
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      retryReason: "issue_continuation_needed",
+      runSource: "issue.productive_terminal_continuation_recovery",
+      livenessState: "advanced",
+    });
+    const blockerIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId,
+      title: "Unresolved prerequisite blocker",
+      status: "in_progress",
+      priority: "medium",
+      issueNumber: 96,
+      identifier: `${issuePrefix}-96`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.blockerSkipped).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
   it("still escalates Klasse-2 after the blocker is resolved (positive control)", async () => {
     const { companyId, issueId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1930,6 +1930,128 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain(`Recovery issue: [${recovery.identifier}]`);
   });
 
+  it("skips Klasse-2 escalation when the assignee commented on the issue inside the cooldown window", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      authorUserId: null,
+      body: "Heartbeat coordination comment within cooldown window.",
+      createdAt: new Date(Date.now() - 30_000),
+      updatedAt: new Date(Date.now() - 30_000),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.cooldownSkipped).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+  });
+
+  it("skips Klasse-2 escalation when the assignee finished a succeeded run on the issue inside the cooldown window", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "succeeded",
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_continuation_needed",
+      },
+      startedAt: new Date("2026-03-18T23:55:00.000Z"),
+      finishedAt: new Date(Date.now() - 60_000),
+      updatedAt: new Date(Date.now() - 60_000),
+      createdAt: new Date("2026-03-18T23:54:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+    expect(result.cooldownSkipped).toBe(1);
+    expect(result.skipped).toBe(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
+  it("escalates Klasse-2 when the assignee comment is older than the cooldown window", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      authorUserId: null,
+      body: "Heartbeat comment from before the cooldown window.",
+      createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+      updatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.cooldownSkipped).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+  });
+
+  it("escalates Klasse-2 immediately when STRANDED_RECOVERY_COOLDOWN_MS=0 disables the cooldown", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      authorUserId: null,
+      body: "Recent comment that would normally be inside the cooldown.",
+      createdAt: new Date(Date.now() - 10_000),
+      updatedAt: new Date(Date.now() - 10_000),
+    });
+    const previous = process.env.STRANDED_RECOVERY_COOLDOWN_MS;
+    process.env.STRANDED_RECOVERY_COOLDOWN_MS = "0";
+    try {
+      const heartbeat = heartbeatService(db);
+      const result = await heartbeat.reconcileStrandedAssignedIssues();
+      expect(result.escalated).toBe(1);
+      expect(result.cooldownSkipped).toBe(0);
+      expect(result.issueIds).toEqual([issueId]);
+    } finally {
+      if (previous === undefined) delete process.env.STRANDED_RECOVERY_COOLDOWN_MS;
+      else process.env.STRANDED_RECOVERY_COOLDOWN_MS = previous;
+    }
+  });
+
   it("redacts error-code-only stranded recovery failures in issue copy", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -16,6 +16,7 @@ import {
   heartbeatRunWatchdogDecisions,
   heartbeatRuns,
   issueApprovals,
+  issueComments,
   issueRelations,
   issueThreadInteractions,
   issues,
@@ -46,6 +47,17 @@ import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js"
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
+const DEFAULT_STRANDED_RECOVERY_COOLDOWN_MS = 600_000;
+const MIN_STRANDED_RECOVERY_COOLDOWN_MS = 60_000;
+
+function readStrandedRecoveryCooldownMs(): number {
+  const raw = process.env.STRANDED_RECOVERY_COOLDOWN_MS;
+  if (raw === undefined || raw.trim() === "") return DEFAULT_STRANDED_RECOVERY_COOLDOWN_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_STRANDED_RECOVERY_COOLDOWN_MS;
+  if (parsed === 0) return 0;
+  return Math.max(MIN_STRANDED_RECOVERY_COOLDOWN_MS, parsed);
+}
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
@@ -331,6 +343,46 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
       .limit(1)
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function wasAssigneeRecentlyActive(
+    companyId: string,
+    issueId: string,
+    agentId: string,
+    cooldownMs: number,
+  ) {
+    if (cooldownMs <= 0) return false;
+    const cutoff = new Date(Date.now() - cooldownMs);
+    const [recentComment, recentSucceededRun] = await Promise.all([
+      db
+        .select({ id: issueComments.id })
+        .from(issueComments)
+        .where(
+          and(
+            eq(issueComments.companyId, companyId),
+            eq(issueComments.issueId, issueId),
+            eq(issueComments.authorAgentId, agentId),
+            gt(issueComments.createdAt, cutoff),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, companyId),
+            eq(heartbeatRuns.agentId, agentId),
+            eq(heartbeatRuns.status, "succeeded"),
+            gt(heartbeatRuns.finishedAt, cutoff),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+    ]);
+    return Boolean(recentComment || recentSucceededRun);
   }
 
   async function hasActiveExecutionPath(companyId: string, issueId: string) {
@@ -1597,9 +1649,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulContinuationObserved: 0,
       orphanBlockersAssigned: 0,
       escalated: 0,
+      cooldownSkipped: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
+
+    const strandedRecoveryCooldownMs = readStrandedRecoveryCooldownMs();
 
     for (const issue of candidates) {
       const agentId = issue.assigneeAgentId;
@@ -1668,6 +1723,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (didAutomaticRecoveryFail(latestRun, "assignment_recovery")) {
+          if (
+            await wasAssigneeRecentlyActive(
+              issue.companyId,
+              issue.id,
+              agentId,
+              strandedRecoveryCooldownMs,
+            )
+          ) {
+            result.cooldownSkipped += 1;
+            result.skipped += 1;
+            continue;
+          }
           const failureSummary = summarizeRunFailureForIssueComment(latestRun);
           const updated = await escalateStrandedAssignedIssue({
             issue,
@@ -1723,6 +1790,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         }
 
         if (isRepeatedProductiveContinuationRecovery(successfulRun)) {
+          if (
+            await wasAssigneeRecentlyActive(
+              issue.companyId,
+              issue.id,
+              agentId,
+              strandedRecoveryCooldownMs,
+            )
+          ) {
+            result.cooldownSkipped += 1;
+            result.skipped += 1;
+            continue;
+          }
           const updated = await escalateStrandedAssignedIssue({
             issue,
             previousStatus: "in_progress",
@@ -1762,6 +1841,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
       if (didAutomaticRecoveryFail(latestRun, "issue_continuation_needed")) {
+        if (
+          await wasAssigneeRecentlyActive(
+            issue.companyId,
+            issue.id,
+            agentId,
+            strandedRecoveryCooldownMs,
+          )
+        ) {
+          result.cooldownSkipped += 1;
+          result.skipped += 1;
+          continue;
+        }
         const failureSummary = summarizeRunFailureForIssueComment(latestRun);
         const updated = await escalateStrandedAssignedIssue({
           issue,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1650,6 +1650,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       orphanBlockersAssigned: 0,
       escalated: 0,
       cooldownSkipped: 0,
+      blockerSkipped: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
@@ -1735,6 +1736,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             result.skipped += 1;
             continue;
           }
+          const blockerIds = await existingUnresolvedBlockerIssueIds(issue.companyId, issue.id);
+          if (blockerIds.length > 0) {
+            result.blockerSkipped += 1;
+            result.skipped += 1;
+            continue;
+          }
           const failureSummary = summarizeRunFailureForIssueComment(latestRun);
           const updated = await escalateStrandedAssignedIssue({
             issue,
@@ -1802,6 +1809,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             result.skipped += 1;
             continue;
           }
+          const blockerIds = await existingUnresolvedBlockerIssueIds(issue.companyId, issue.id);
+          if (blockerIds.length > 0) {
+            result.blockerSkipped += 1;
+            result.skipped += 1;
+            continue;
+          }
           const updated = await escalateStrandedAssignedIssue({
             issue,
             previousStatus: "in_progress",
@@ -1850,6 +1863,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           )
         ) {
           result.cooldownSkipped += 1;
+          result.skipped += 1;
+          continue;
+        }
+        const blockerIds = await existingUnresolvedBlockerIssueIds(issue.companyId, issue.id);
+        if (blockerIds.length > 0) {
+          result.blockerSkipped += 1;
           result.skipped += 1;
           continue;
         }


### PR DESCRIPTION
## Summary

Skip the stranded-issue auto-block when the issue is legitimately waiting on an unresolved blocker recorded in `issue_relations`.

The `reconcileStrandedAssignedIssues()` loop already guards against recent agent activity via the Phase-1 cooldown window (PR #5305, commit `db578ca` — `STRANDED_RECOVERY_COOLDOWN_MS` default 600s). But it has a second false-positive mode: when an issue legitimately waits on a dependency (`issueRelations.type = "blocks"`), the loop reads the missing `executionRunId` as "stranded" and fires the auto-block comment, reverting the issue to `blocked` even though it was working as intended.

This PR closes that gap by adding an `existingUnresolvedBlockerIssueIds()` pre-check at all three `escalateStrandedAssignedIssue()` call sites:

| Site | Branch | service.ts line |
|------|--------|-----------------|
| Site-A | `assignment_recovery` (`todo` path) | 1739 |
| Site-B | `isRepeatedProductiveContinuationRecovery` (in-progress retry) | 1810 |
| Site-C | `issue_continuation_needed` (in-progress fail) | 1872 |

The helper at `service.ts:1541` was already available — `escalateStrandedAssignedIssue` itself calls it on line 1582 to register the recovery issue as a blocker. We now also call it before deciding to escalate, so issues with active blockers are skipped instead.

A new `blockerSkipped` counter on the result object provides operational visibility analogous to the existing `cooldownSkipped`.

## Test plan

- [x] `pnpm --filter @paperclipai/server vitest run src/__tests__/heartbeat-process-recovery.test.ts` — 44/44 PASS (41 existing + 3 new)
- [x] New negative-path test: `continuation_needed` does not escalate when blocker exists
- [x] New negative-path test: `assignment_recovery` does not escalate when blocker exists
- [x] New positive-control test: still escalates after blocker resolves (`status=done`)
- [x] All three new tests verify `blockerSkipped` counter increments correctly

## Production incidents covered

Two reproduced false-positives in our PSY deployment within 48 hours:
- 2026-05-06 MA F4-T2 — auto-blocked despite `blockedByIssueIds` populated
- 2026-05-08 MA F4-T1 — auto-blocked 5 min after atomic wave-trigger

A third recurrence happened on the tracking issue for this very patch while it was being investigated.

## Footprint

- +19 LOC prod / +109 LOC tests
- No API surface change, no schema change, no new ENV flag
- Performance: +1 DB query per iteration only when the cooldown check passes (typically <5% of iterations)

## Companion to PR #5305

Strictly orthogonal to the Phase-1 cooldown fix:
- #5305 covers the *timing* axis (do not escalate while the agent was recently active).
- This PR covers the *state* axis (do not escalate while the issue is legitimately blocked).

Both can land independently.