### PR TITLE
feat(pipelines): add verified operating state guidance

### DIFF
--- a/knowledge/pipelines/econ.md
+++ b/knowledge/pipelines/econ.md
@@ -1,0 +1,78 @@
+# ECON Report Publishing
+
+## Purpose
+
+Produce and publish recurring economic analysis reports for the Blockchain Economics Lab.
+
+## Current Diagram
+
+```mermaid
+flowchart LR
+  source_collection["Slide PDF intake"]
+  research_synthesis["Analysis source confirmation"]
+  draft_report["Summary and marketing extraction"]
+  summary_marketing_localization["7-language summary and marketing localization"]
+  editorial_review["Publication review"]
+  website_publish["Website publishing"]
+  post_publish_monitoring["Post-publish monitoring"]
+  source_collection --> research_synthesis
+  research_synthesis --> draft_report
+  draft_report --> summary_marketing_localization
+  summary_marketing_localization --> editorial_review
+  editorial_review --> website_publish
+  website_publish --> post_publish_monitoring
+```
+
+## Operating State
+
+- Report code: ECON
+- Cadence: Recurring report cycle
+- Health: unknown
+- Runtime architecture: remote-first
+- Executable manifest: `pipelines/bcelab-runtime-pipelines.json` in the BCE website repository
+- Remote runner: GitHub Actions `.github/workflows/slide-pipeline-cron.yml`
+- Runtime verification: `npm run verify:runtime-pipelines`
+- Local execution: dry-run, development, or incident reproduction only; production writes must run through the remote workflow
+- Slide PDF intake folder: Google Drive Slide/ECON
+- Markdown source folder: Google Drive analysis/ECON
+- Summary/marketing localization target: 7 languages
+- Summary/marketing localization provider: Google free translate endpoint first, Google Cloud Translation v3 fallback
+- Full report body translation: not part of the current operating pipeline
+- Website publishing target: BCELab website after editorial approval
+
+## Inputs
+
+- New slide-form PDF in Google Drive Slide/ECON
+- Matching .md source in Google Drive analysis/ECON
+
+## Outputs
+
+- Published report page that exposes the PDF/report asset
+- Extracted summary and marketing copy exposed on the website
+- 7-language localized summary and marketing copy exposed on the website
+- Publication notes and incident follow-ups
+
+## Owners
+
+- Pipeline owner: CRO
+- Slide PDF intake and source checks: DataPlatformEngineer
+- Markdown source validation and copy extraction: CRO
+- 7-language summary/marketing localization and website integration: FullStackEngineer
+- Editorial gate and operations monitoring: COO
+
+## Known Risks
+
+- Summary/marketing localization provider changes can alter teaser terminology and campaign copy in 7 languages.
+- Treat full report translation as a new pipeline change request, not as current baseline behavior.
+- A new PDF without a matching .md source should block publication.
+- New or changed slide publications must be prepared as review-ready first; website publication requires editorial approval.
+- Website publishing changes can break report URLs or layout.
+- Missing source data should block publication rather than producing a weak report.
+
+## Open Changes
+
+- TODO: Link active Paperclip issues here.
+
+## Update Rule
+
+Agents must update this page when behavior, ownership, dependencies, health, monitoring, or operating rules change.

--- a/knowledge/pipelines/for.md
+++ b/knowledge/pipelines/for.md
@@ -1,0 +1,78 @@
+# FOR Report Publishing
+
+## Purpose
+
+Produce and publish recurring forecast-oriented reports for the Blockchain Economics Lab.
+
+## Current Diagram
+
+```mermaid
+flowchart LR
+  source_collection["Slide PDF intake"]
+  research_synthesis["Analysis source confirmation"]
+  draft_report["Summary and marketing extraction"]
+  summary_marketing_localization["7-language summary and marketing localization"]
+  editorial_review["Publication review"]
+  website_publish["Website publishing"]
+  post_publish_monitoring["Post-publish monitoring"]
+  source_collection --> research_synthesis
+  research_synthesis --> draft_report
+  draft_report --> summary_marketing_localization
+  summary_marketing_localization --> editorial_review
+  editorial_review --> website_publish
+  website_publish --> post_publish_monitoring
+```
+
+## Operating State
+
+- Report code: FOR
+- Cadence: Recurring report cycle
+- Health: unknown
+- Runtime architecture: remote-first
+- Executable manifest: `pipelines/bcelab-runtime-pipelines.json` in the BCE website repository
+- Remote runner: GitHub Actions `.github/workflows/slide-pipeline-cron.yml`
+- Runtime verification: `npm run verify:runtime-pipelines`
+- Local execution: dry-run, development, or incident reproduction only; production writes must run through the remote workflow
+- Slide PDF intake folder: Google Drive Slide/FOR
+- Markdown source folder: Google Drive analysis/FOR
+- Summary/marketing localization target: 7 languages
+- Summary/marketing localization provider: Google free translate endpoint first, Google Cloud Translation v3 fallback
+- Full report body translation: not part of the current operating pipeline
+- Website publishing target: BCELab website after editorial approval
+
+## Inputs
+
+- New slide-form PDF in Google Drive Slide/FOR
+- Matching .md source in Google Drive analysis/FOR
+
+## Outputs
+
+- Published report page that exposes the PDF/report asset
+- Extracted summary and marketing copy exposed on the website
+- 7-language localized summary and marketing copy exposed on the website
+- Publication notes and incident follow-ups
+
+## Owners
+
+- Pipeline owner: CRO
+- Slide PDF intake and source checks: DataPlatformEngineer
+- Markdown source validation and copy extraction: CRO
+- 7-language summary/marketing localization and website integration: FullStackEngineer
+- Editorial gate and operations monitoring: COO
+
+## Known Risks
+
+- Summary/marketing localization provider changes can alter teaser terminology and campaign copy in 7 languages.
+- Treat full report translation as a new pipeline change request, not as current baseline behavior.
+- A new PDF without a matching .md source should block publication.
+- New or changed slide publications must be prepared as review-ready first; website publication requires editorial approval.
+- Website publishing changes can break report URLs or layout.
+- Missing source data should block publication rather than producing a weak report.
+
+## Open Changes
+
+- TODO: Link active Paperclip issues here.
+
+## Update Rule
+
+Agents must update this page when behavior, ownership, dependencies, health, monitoring, or operating rules change.

--- a/knowledge/pipelines/mat.md
+++ b/knowledge/pipelines/mat.md
@@ -1,0 +1,78 @@
+# MAT Report Publishing
+
+## Purpose
+
+Produce and publish recurring market and materials analysis reports for the Blockchain Economics Lab.
+
+## Current Diagram
+
+```mermaid
+flowchart LR
+  source_collection["Slide PDF intake"]
+  research_synthesis["Analysis source confirmation"]
+  draft_report["Summary and marketing extraction"]
+  summary_marketing_localization["7-language summary and marketing localization"]
+  editorial_review["Publication review"]
+  website_publish["Website publishing"]
+  post_publish_monitoring["Post-publish monitoring"]
+  source_collection --> research_synthesis
+  research_synthesis --> draft_report
+  draft_report --> summary_marketing_localization
+  summary_marketing_localization --> editorial_review
+  editorial_review --> website_publish
+  website_publish --> post_publish_monitoring
+```
+
+## Operating State
+
+- Report code: MAT
+- Cadence: Recurring report cycle
+- Health: unknown
+- Runtime architecture: remote-first
+- Executable manifest: `pipelines/bcelab-runtime-pipelines.json` in the BCE website repository
+- Remote runner: GitHub Actions `.github/workflows/slide-pipeline-cron.yml`
+- Runtime verification: `npm run verify:runtime-pipelines`
+- Local execution: dry-run, development, or incident reproduction only; production writes must run through the remote workflow
+- Slide PDF intake folder: Google Drive Slide/MAT
+- Markdown source folder: Google Drive analysis/MAT
+- Summary/marketing localization target: 7 languages
+- Summary/marketing localization provider: Google free translate endpoint first, Google Cloud Translation v3 fallback
+- Full report body translation: not part of the current operating pipeline
+- Website publishing target: BCELab website after editorial approval
+
+## Inputs
+
+- New slide-form PDF in Google Drive Slide/MAT
+- Matching .md source in Google Drive analysis/MAT
+
+## Outputs
+
+- Published report page that exposes the PDF/report asset
+- Extracted summary and marketing copy exposed on the website
+- 7-language localized summary and marketing copy exposed on the website
+- Publication notes and incident follow-ups
+
+## Owners
+
+- Pipeline owner: CRO
+- Slide PDF intake and source checks: DataPlatformEngineer
+- Markdown source validation and copy extraction: CRO
+- 7-language summary/marketing localization and website integration: FullStackEngineer
+- Editorial gate and operations monitoring: COO
+
+## Known Risks
+
+- Summary/marketing localization provider changes can alter teaser terminology and campaign copy in 7 languages.
+- Treat full report translation as a new pipeline change request, not as current baseline behavior.
+- A new PDF without a matching .md source should block publication.
+- New or changed slide publications must be prepared as review-ready first; website publication requires editorial approval.
+- Website publishing changes can break report URLs or layout.
+- Missing source data should block publication rather than producing a weak report.
+
+## Open Changes
+
+- TODO: Link active Paperclip issues here.
+
+## Update Rule
+
+Agents must update this page when behavior, ownership, dependencies, health, monitoring, or operating rules change.

--- a/knowledge/pipelines/website.md
+++ b/knowledge/pipelines/website.md
@@ -1,0 +1,83 @@
+# BCELab Website Development and Operations
+
+## Purpose
+
+Develop, deploy, operate, and improve the BCELab website that publishes report outputs and product-facing pages.
+
+## Current Diagram
+
+```mermaid
+flowchart LR
+  change_request_intake["Website change request intake"]
+  impact_and_scope_review["Impact and scope review"]
+  temporary_workspace_implementation["Temporary workspace implementation"]
+  pipeline_definition_alignment["Pipeline definition alignment check"]
+  quality_and_build_verification["Quality and build verification"]
+  board_deployment_approval["Board deployment approval"]
+  production_deployment["Production deployment"]
+  post_deploy_monitoring["Post-deploy monitoring"]
+  change_request_intake --> impact_and_scope_review
+  impact_and_scope_review --> temporary_workspace_implementation
+  temporary_workspace_implementation --> pipeline_definition_alignment
+  pipeline_definition_alignment --> quality_and_build_verification
+  quality_and_build_verification --> board_deployment_approval
+  board_deployment_approval --> production_deployment
+  production_deployment --> post_deploy_monitoring
+```
+
+## Operating State
+
+- Cadence: Change-driven development with continuous post-deploy monitoring
+- Health: active with local verification complete
+- Source repository: `/Users/Kuku/Documents/Claude/Projects/블록체인경제연구소/blockchain-economics-lab`
+- Executable manifest: `pipelines/bcelab-runtime-pipelines.json`
+- Development mode: temporary workspace or isolated branch first
+- Required pre-approval check: `npm run verify:pipeline` confirms the temporary workspace code matches the website pipeline contract before deployment approval
+- Required verification: `npm run verify:runtime-pipelines`, `npm run verify:pipeline`, `npm run lint`, `npx tsc --noEmit`, `npm test -- --passWithNoTests`, `npm run build`, and page-level report visibility checks
+- Deployment gate: `.github/workflows/production-deploy.yml` requires Paperclip issue evidence, board approval evidence, and the GitHub `production` environment before Vercel `--prod` deployment
+- Production surfaces: homepage, score/top-200 pages, project pages, report listing pages, report detail pages, APIs, and scheduled pipeline integrations
+- Post-deploy heartbeat: Vercel cron calls `/api/cron/heartbeat`
+- CI enforcement: `.github/workflows/ci.yml` runs lint, typecheck, real Jest tests, runtime pipeline manifest verification, website pipeline alignment, and production build
+- Preview enforcement: `.github/workflows/deploy-preview.yml` posts a Vercel preview URL on pull requests
+
+## Inputs
+
+- Board requests for website behavior or product changes
+- Pipeline incidents, missing report visibility, broken report cards, stale pages, or deployment failures
+- Changes required by ECON, MAT, FOR, or future report pipelines
+- Monitoring signals from production pages and scheduled jobs
+
+## Outputs
+
+- Reviewed and approved website code changes
+- Production deployment with a clear commit and deployment record
+- Verified website behavior for affected pages and report types
+- Post-deploy monitoring notes and follow-up issues
+
+## Owners
+
+- Pipeline owner: CTO
+- Intake and prioritization: CEO
+- Impact and scope review: CTO
+- Implementation and deployment: FullStackEngineer
+- Board deployment approval request: CEO
+- Post-deploy monitoring: COO
+
+## Known Risks
+
+- Uncommitted or undeployed code can make local verification diverge from production behavior; website changes must move through PR or the production deploy workflow.
+- Report data can exist in storage while website filters, status rules, or cached pages hide it from users.
+- A website fix can accidentally change ECON, MAT, and FOR surfaces differently unless all affected report types are checked together by tests or manual verification.
+- Deployment must not proceed if `npm run verify:pipeline` fails or if the PR template lacks Paperclip issue and board approval evidence.
+- Production cache, scheduled jobs, and database status fields can make successful code changes appear ineffective unless monitored after deployment.
+- Vercel project settings must not bypass the approved production deploy path. If automatic production deploys from `main` are enabled outside GitHub Actions, the CTO must treat that as a governance gap and either disable it or document it as an accepted board risk.
+
+## Open Changes
+
+- Website deployment alignment was implemented in the BCE website repository by adding `scripts/verify-website-pipeline.mjs`, a real Jest `npm test` command, a CI alignment job, a production deployment workflow, PR evidence fields, and `/api/cron/heartbeat`.
+- Runtime pipeline alignment was implemented by adding `pipelines/bcelab-runtime-pipelines.json`, `scripts/verify-runtime-pipelines.mjs`, CI enforcement, slide cron preflight verification, and production deploy preflight verification.
+- TODO: Link the active Paperclip issue and board approval record for the current ECON/MAT/FOR visibility fix before production deployment.
+
+## Update Rule
+
+Agents must update this page when website behavior, deployment rules, owners, dependencies, health, monitoring, or operating rules change.

--- a/scripts/migrate-bcelab-pipelines.ts
+++ b/scripts/migrate-bcelab-pipelines.ts
@@ -1,0 +1,678 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+type Company = {
+  id: string;
+  name: string;
+};
+
+type Agent = {
+  id: string;
+  name: string;
+  role: string;
+  title?: string | null;
+  metadata?: Record<string, unknown> | null;
+};
+
+type Pipeline = {
+  id: string;
+  companyId: string;
+  name: string;
+  ownerAgentId?: string | null;
+};
+
+type PipelineNode = {
+  id: string;
+  nodeKey: string;
+  kind: string;
+  label: string;
+};
+
+type PipelineDetail = Pipeline & {
+  nodes: PipelineNode[];
+  edges: Array<{ sourceNodeId: string; targetNodeId: string; label?: string | null }>;
+};
+
+type PipelineSpec = {
+  key: "econ" | "mat" | "for" | "website";
+  code: "ECON" | "MAT" | "FOR" | "WEB";
+  name: string;
+  purpose: string;
+  cadence: string;
+  statePageKind?: "report" | "website";
+  pipelineOwnerName?: string;
+  nodes: Array<{
+    key: string;
+    kind: "input" | "transform" | "agent_task" | "approval" | "output" | "monitor" | "external";
+    label: string;
+    description: string;
+    ownerName?: string;
+  }>;
+  edges: Array<[string, string, string?]>;
+};
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:3100/api";
+const DEFAULT_COMPANY_NAME = "BCELab";
+const DEFAULT_STATE_DIR = "knowledge/pipelines";
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
+
+const PIPELINES: PipelineSpec[] = [
+  {
+    key: "econ",
+    code: "ECON",
+    name: "ECON Report Publishing",
+    purpose: "Produce and publish recurring economic analysis reports for the Blockchain Economics Lab.",
+    cadence: "Recurring report cycle",
+    pipelineOwnerName: "CRO",
+    nodes: [
+      {
+        key: "source_collection",
+        kind: "input",
+        label: "Slide PDF intake",
+        description: "Detect new slide-form PDF files in Google Drive Slide/ECON, Slide/MAT, or Slide/FOR for this report type.",
+        ownerName: "DataPlatformEngineer",
+      },
+      {
+        key: "research_synthesis",
+        kind: "agent_task",
+        label: "Analysis source confirmation",
+        description: "Confirm the matching markdown source exists in Google Drive analysis/ECON, analysis/MAT, or analysis/FOR before publication work continues.",
+        ownerName: "CRO",
+      },
+      {
+        key: "draft_report",
+        kind: "agent_task",
+        label: "Summary and marketing extraction",
+        description: "Extract the publishable summary and marketing copy from the matching .md source. Do not translate the full report body.",
+        ownerName: "CRO",
+      },
+      {
+        key: "summary_marketing_localization",
+        kind: "external",
+        label: "7-language summary and marketing localization",
+        description: "Translate or localize only the extracted summary, teaser, and marketing copy into 7 languages for website exposure.",
+        ownerName: "FullStackEngineer",
+      },
+      {
+        key: "editorial_review",
+        kind: "approval",
+        label: "Publication review",
+        description: "Check slide PDF, markdown source alignment, extracted summary/marketing copy, localization quality, and release readiness.",
+        ownerName: "COO",
+      },
+      {
+        key: "website_publish",
+        kind: "output",
+        label: "Website publishing",
+        description: "Publish the approved report to the BCELab website.",
+        ownerName: "FullStackEngineer",
+      },
+      {
+        key: "post_publish_monitoring",
+        kind: "monitor",
+        label: "Post-publish monitoring",
+        description: "Monitor publication health, broken pages, formatting, and reader-facing issues.",
+        ownerName: "COO",
+      },
+    ],
+    edges: [
+      ["source_collection", "research_synthesis"],
+      ["research_synthesis", "draft_report"],
+      ["draft_report", "summary_marketing_localization"],
+      ["summary_marketing_localization", "editorial_review"],
+      ["editorial_review", "website_publish"],
+      ["website_publish", "post_publish_monitoring"],
+    ],
+  },
+  {
+    key: "mat",
+    code: "MAT",
+    name: "MAT Report Publishing",
+    purpose: "Produce and publish recurring market and materials analysis reports for the Blockchain Economics Lab.",
+    cadence: "Recurring report cycle",
+    pipelineOwnerName: "CRO",
+    nodes: [],
+    edges: [],
+  },
+  {
+    key: "for",
+    code: "FOR",
+    name: "FOR Report Publishing",
+    purpose: "Produce and publish recurring forecast-oriented reports for the Blockchain Economics Lab.",
+    cadence: "Recurring report cycle",
+    pipelineOwnerName: "CRO",
+    nodes: [],
+    edges: [],
+  },
+  {
+    key: "website",
+    code: "WEB",
+    name: "BCELab Website Development and Operations",
+    purpose: "Develop, deploy, operate, and improve the BCELab website that publishes report outputs and product-facing pages.",
+    cadence: "Change-driven development with continuous post-deploy monitoring",
+    statePageKind: "website",
+    pipelineOwnerName: "CTO",
+    nodes: [
+      {
+        key: "change_request_intake",
+        kind: "input",
+        label: "Website change request intake",
+        description: "Receive board requests, pipeline incidents, report visibility gaps, or product improvement requests that require website code or configuration changes.",
+        ownerName: "CEO",
+      },
+      {
+        key: "impact_and_scope_review",
+        kind: "agent_task",
+        label: "Impact and scope review",
+        description: "Identify affected pages, data contracts, report surfaces, deployment risks, and whether the change touches ECON, MAT, FOR, score, project, or report routes.",
+        ownerName: "CTO",
+      },
+      {
+        key: "temporary_workspace_implementation",
+        kind: "agent_task",
+        label: "Temporary workspace implementation",
+        description: "Implement the website change in an isolated workspace so the production pipeline and current website remain undisturbed during development.",
+        ownerName: "FullStackEngineer",
+      },
+      {
+        key: "pipeline_definition_alignment",
+        kind: "agent_task",
+        label: "Pipeline definition alignment check",
+        description: "Confirm the temporary workspace code matches the pipeline definition and does not create hidden behavior outside the approved website and report pipelines.",
+        ownerName: "CTO",
+      },
+      {
+        key: "quality_and_build_verification",
+        kind: "approval",
+        label: "Quality and build verification",
+        description: "Run typecheck, tests, and production build. Verify important pages and report surfaces render the expected ECON, MAT, FOR, and website outputs.",
+        ownerName: "CTO",
+      },
+      {
+        key: "board_deployment_approval",
+        kind: "approval",
+        label: "Board deployment approval",
+        description: "Request board approval with evidence from the temporary workspace, alignment check, test results, and known operational risks.",
+        ownerName: "CEO",
+      },
+      {
+        key: "production_deployment",
+        kind: "output",
+        label: "Production deployment",
+        description: "Commit, push, and deploy the approved website change to production through the configured deployment path.",
+        ownerName: "FullStackEngineer",
+      },
+      {
+        key: "post_deploy_monitoring",
+        kind: "monitor",
+        label: "Post-deploy monitoring",
+        description: "Check production pages, report visibility, deployment health, analytics/errors, and create follow-up issues for regressions or improvement opportunities.",
+        ownerName: "COO",
+      },
+    ],
+    edges: [
+      ["change_request_intake", "impact_and_scope_review"],
+      ["impact_and_scope_review", "temporary_workspace_implementation"],
+      ["temporary_workspace_implementation", "pipeline_definition_alignment"],
+      ["pipeline_definition_alignment", "quality_and_build_verification"],
+      ["quality_and_build_verification", "board_deployment_approval"],
+      ["board_deployment_approval", "production_deployment"],
+      ["production_deployment", "post_deploy_monitoring"],
+    ],
+  },
+];
+
+for (const spec of PIPELINES) {
+  if (spec.nodes.length === 0) spec.nodes = PIPELINES[0].nodes;
+  if (spec.edges.length === 0) spec.edges = PIPELINES[0].edges;
+}
+
+function argValue(name: string): string | null {
+  const index = process.argv.indexOf(name);
+  if (index < 0) return null;
+  return process.argv[index + 1] ?? null;
+}
+
+function hasArg(name: string): boolean {
+  return process.argv.includes(name);
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+async function api<T>(baseUrl: string, route: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${baseUrl}${route}`, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${init?.method ?? "GET"} ${route} failed (${response.status}): ${text}`);
+  }
+  return text ? JSON.parse(text) as T : undefined as T;
+}
+
+function findAgent(agents: Agent[], name: string): Agent | null {
+  return agents.find((agent) => agent.name.toLowerCase() === name.toLowerCase()) ?? null;
+}
+
+function diagram(spec: PipelineSpec): string {
+  const lines = ["flowchart LR"];
+  for (const node of spec.nodes) {
+    lines.push(`  ${node.key}["${node.label.replaceAll("\"", "'")}"]`);
+  }
+  for (const [source, target] of spec.edges) {
+    lines.push(`  ${source} --> ${target}`);
+  }
+  return lines.join("\n");
+}
+
+async function ensurePipeline(
+  baseUrl: string,
+  companyId: string,
+  spec: PipelineSpec,
+  existing: Pipeline[],
+  ownerAgentId: string | null,
+  apply: boolean,
+): Promise<Pipeline | null> {
+  const found = existing.find((pipeline) => pipeline.name === spec.name);
+  if (found) {
+    if (apply && found.ownerAgentId !== ownerAgentId) {
+      return api<Pipeline>(baseUrl, `/pipelines/${found.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ ownerAgentId }),
+      });
+    }
+    return found;
+  }
+  if (!apply) {
+    console.log(`[dry-run] create pipeline: ${spec.name}`);
+    return null;
+  }
+  return api<Pipeline>(baseUrl, `/companies/${companyId}/pipelines`, {
+    method: "POST",
+    body: JSON.stringify({
+      name: spec.name,
+      description: spec.purpose,
+      ownerAgentId,
+      status: "active",
+      reviewStatus: "active",
+      ownerAssignmentStatus: "partially_assigned",
+      healthStatus: "unknown",
+      diagramFormat: "mermaid",
+      diagramSource: diagram(spec),
+      metadata: {
+        migration: "bcelab-pipeline-first",
+        reportCode: spec.code,
+        statePage: `knowledge/pipelines/${spec.key}.md`,
+      },
+    }),
+  });
+}
+
+async function ensureNodesAndEdges(
+  baseUrl: string,
+  pipelineId: string,
+  spec: PipelineSpec,
+  agents: Agent[],
+  apply: boolean,
+): Promise<PipelineDetail | null> {
+  if (!apply) {
+    console.log(`[dry-run] create ${spec.nodes.length} nodes and ${spec.edges.length} edges for ${spec.name}`);
+    return null;
+  }
+  let detail = await api<PipelineDetail>(baseUrl, `/pipelines/${pipelineId}`);
+  const nodesByKey = new Map(detail.nodes.map((node) => [node.nodeKey, node]));
+
+  for (const node of spec.nodes) {
+    if (nodesByKey.has(node.key)) continue;
+    const owner = node.ownerName ? findAgent(agents, node.ownerName) : null;
+    const created = await api<PipelineNode>(baseUrl, `/pipelines/${pipelineId}/nodes`, {
+      method: "POST",
+      body: JSON.stringify({
+        nodeKey: node.key,
+        kind: node.kind,
+        label: node.label,
+        description: node.description,
+        linkedEntityType: owner ? "agent" : undefined,
+        linkedEntityId: owner?.id,
+        healthStatus: "unknown",
+      }),
+    });
+    nodesByKey.set(created.nodeKey, created);
+  }
+
+  detail = await api<PipelineDetail>(baseUrl, `/pipelines/${pipelineId}`);
+  const existingEdges = new Set(detail.edges.map((edge) => `${edge.sourceNodeId}:${edge.targetNodeId}`));
+  const finalNodesByKey = new Map(detail.nodes.map((node) => [node.nodeKey, node]));
+  for (const [sourceKey, targetKey, label] of spec.edges) {
+    const source = finalNodesByKey.get(sourceKey);
+    const target = finalNodesByKey.get(targetKey);
+    if (!source || !target) throw new Error(`Missing edge nodes for ${spec.name}: ${sourceKey} -> ${targetKey}`);
+    const edgeKey = `${source.id}:${target.id}`;
+    if (existingEdges.has(edgeKey)) continue;
+    await api(baseUrl, `/pipelines/${pipelineId}/edges`, {
+      method: "POST",
+      body: JSON.stringify({
+        sourceNodeId: source.id,
+        targetNodeId: target.id,
+        label: label ?? null,
+      }),
+    });
+  }
+
+  return api<PipelineDetail>(baseUrl, `/pipelines/${pipelineId}`);
+}
+
+function statePage(spec: PipelineSpec): string {
+  if (spec.statePageKind === "website") {
+    return [
+      `# ${spec.name}`,
+      "",
+      "## Purpose",
+      "",
+      spec.purpose,
+      "",
+      "## Current Diagram",
+      "",
+      "```mermaid",
+      diagram(spec),
+      "```",
+      "",
+      "## Operating State",
+      "",
+      "- Cadence: Change-driven development with continuous post-deploy monitoring",
+      "- Health: unknown",
+      "- Source repository: BCELab website repository",
+      "- Development mode: temporary workspace first",
+      "- Required pre-approval check: temporary workspace code must match the pipeline definition being approved",
+      "- Required verification: typecheck, tests, production build, and page-level report visibility checks",
+      "- Deployment gate: board approval before production deployment",
+      "- Production surfaces: homepage, score/top-200 pages, project pages, report listing pages, report detail pages, APIs, and scheduled pipeline integrations",
+      "",
+      "## Inputs",
+      "",
+      "- Board requests for website behavior or product changes",
+      "- Pipeline incidents, missing report visibility, broken report cards, stale pages, or deployment failures",
+      "- Changes required by ECON, MAT, FOR, or future report pipelines",
+      "- Monitoring signals from production pages and scheduled jobs",
+      "",
+      "## Outputs",
+      "",
+      "- Reviewed and approved website code changes",
+      "- Production deployment with a clear commit and deployment record",
+      "- Verified website behavior for affected pages and report types",
+      "- Post-deploy monitoring notes and follow-up issues",
+      "",
+      "## Owners",
+      "",
+      "- Pipeline owner: CTO",
+      "- Intake and prioritization: CEO",
+      "- Impact and scope review: CTO",
+      "- Implementation and deployment: FullStackEngineer",
+      "- Board deployment approval request: CEO",
+      "- Post-deploy monitoring: COO",
+      "",
+      "## Known Risks",
+      "",
+      "- Uncommitted or undeployed code can make local verification diverge from production behavior.",
+      "- Report data can exist in storage while website filters, status rules, or cached pages hide it from users.",
+      "- A website fix can accidentally change ECON, MAT, and FOR surfaces differently unless all affected report types are checked together.",
+      "- Deployment should not proceed if the temporary workspace code does not match the approved pipeline definition.",
+      "- Production cache, scheduled jobs, and database status fields can make successful code changes appear ineffective unless monitored after deployment.",
+      "",
+      "## Open Changes",
+      "",
+      "- TODO: Link active Paperclip issues here.",
+      "",
+      "## Update Rule",
+      "",
+      "Agents must update this page when website behavior, deployment rules, owners, dependencies, health, monitoring, or operating rules change.",
+      "",
+    ].join("\n");
+  }
+
+  return [
+    `# ${spec.name}`,
+    "",
+    "## Purpose",
+    "",
+    spec.purpose,
+    "",
+    "## Current Diagram",
+    "",
+    "```mermaid",
+    diagram(spec),
+    "```",
+    "",
+    "## Operating State",
+    "",
+    `- Report code: ${spec.code}`,
+    `- Cadence: ${spec.cadence}`,
+    "- Health: unknown",
+    `- Slide PDF intake folder: Google Drive Slide/${spec.code}`,
+    `- Markdown source folder: Google Drive analysis/${spec.code}`,
+    "- Summary/marketing localization target: 7 languages",
+    "- Summary/marketing localization provider: TODO",
+    "- Full report body translation: not part of the current operating pipeline",
+    "- Website publishing target: TODO",
+    "",
+    "## Inputs",
+    "",
+    `- New slide-form PDF in Google Drive Slide/${spec.code}`,
+    `- Matching .md source in Google Drive analysis/${spec.code}`,
+    "",
+    "## Outputs",
+    "",
+    "- Published report page that exposes the PDF/report asset",
+    "- Extracted summary and marketing copy exposed on the website",
+    "- 7-language localized summary and marketing copy exposed on the website",
+    "- Publication notes and incident follow-ups",
+    "",
+    "## Owners",
+    "",
+    "- Pipeline owner: CRO",
+    "- Slide PDF intake and source checks: DataPlatformEngineer",
+    "- Markdown source validation and copy extraction: CRO",
+    "- 7-language summary/marketing localization and website integration: FullStackEngineer",
+    "- Editorial gate and operations monitoring: COO",
+    "",
+    "## Known Risks",
+    "",
+    "- Summary/marketing localization provider changes can alter teaser terminology and campaign copy in 7 languages.",
+    "- Treat full report translation as a new pipeline change request, not as current baseline behavior.",
+    "- A new PDF without a matching .md source should block publication.",
+    "- Website publishing changes can break report URLs or layout.",
+    "- Missing source data should block publication rather than producing a weak report.",
+    "",
+    "## Open Changes",
+    "",
+    "- TODO: Link active Paperclip issues here.",
+    "",
+    "## Update Rule",
+    "",
+    "Agents must update this page when behavior, ownership, dependencies, health, monitoring, or operating rules change.",
+    "",
+  ].join("\n");
+}
+
+async function writeStatePages(stateDir: string, apply: boolean): Promise<void> {
+  if (!apply) {
+    console.log(`[dry-run] write state pages to ${stateDir}`);
+    return;
+  }
+  await fs.mkdir(stateDir, { recursive: true });
+  for (const spec of PIPELINES) {
+    const target = path.join(stateDir, `${spec.key}.md`);
+    try {
+      await fs.access(target);
+      console.log(`state page exists: ${target}`);
+    } catch {
+      await fs.writeFile(target, statePage(spec), "utf8");
+      console.log(`created state page: ${target}`);
+    }
+  }
+}
+
+async function patchAgentOwnership(
+  baseUrl: string,
+  agents: Agent[],
+  apply: boolean,
+): Promise<void> {
+  const assignments: Array<{ name: string; ownership: Record<string, unknown> }> = [
+    {
+      name: "CEO",
+      ownership: {
+        pipelineName: "BCELab operating pipeline portfolio",
+        pipelineRole: "Pipeline Architecture Owner",
+        responsibilities: [
+          "Keep ECON, MAT, FOR, and website operations aligned to company strategy",
+          "Assign owners for missing pipeline nodes",
+          "Escalate cross-pipeline blockers",
+        ],
+      },
+    },
+    {
+      name: "CTO",
+      ownership: {
+        pipelineName: "BCELab Website Development and Operations",
+        pipelineRole: "Website Pipeline Owner",
+        responsibilities: [
+          "Own impact review for website changes",
+          "Confirm temporary workspace code matches the approved pipeline definition before deployment approval",
+          "Require typecheck, tests, build, and page-level verification before production deployment",
+        ],
+      },
+    },
+    {
+      name: "CRO",
+      ownership: {
+        pipelineName: "ECON/MAT/FOR report portfolio",
+        pipelineRole: "Research Report Portfolio Owner",
+        responsibilities: [
+          "Own report logic, claims, and research quality",
+          "Review source synthesis and report drafts",
+          "Escalate weak evidence before publication",
+        ],
+      },
+    },
+    {
+      name: "COO",
+      ownership: {
+        pipelineName: "ECON/MAT/FOR publishing operations and website post-deploy monitoring",
+        pipelineRole: "Publishing Operations Owner",
+        responsibilities: [
+          "Own review cadence and release readiness",
+          "Monitor blocked or degraded report publication and website post-deploy steps",
+          "Coordinate state page updates after incidents",
+        ],
+      },
+    },
+    {
+      name: "DataPlatformEngineer",
+      ownership: {
+        pipelineName: "ECON/MAT/FOR source collection",
+        pipelineNodeKey: "source_collection",
+        pipelineRole: "Source Collection Node Owner",
+        responsibilities: [
+          "Maintain source collection automation",
+          "Document upstream data dependencies and failures",
+        ],
+      },
+    },
+    {
+      name: "FullStackEngineer",
+      ownership: {
+        pipelineName: "ECON/MAT/FOR website publishing and BCELab website deployment",
+        pipelineNodeKey: "website_publish",
+        pipelineRole: "Publishing and Localization Integration Node Owner",
+        responsibilities: [
+          "Maintain summary/marketing localization and website publishing integration",
+          "Implement approved website changes in a temporary workspace before production deployment",
+          "Preserve report URLs, formatting, and publication health",
+        ],
+      },
+    },
+  ];
+
+  for (const assignment of assignments) {
+    const agent = findAgent(agents, assignment.name);
+    if (!agent) {
+      console.log(`agent not found for ownership assignment: ${assignment.name}`);
+      continue;
+    }
+    const metadata = {
+      ...(agent.metadata ?? {}),
+      pipelineOwnership: assignment.ownership,
+    };
+    if (!apply) {
+      console.log(`[dry-run] patch ${agent.name} metadata.pipelineOwnership`);
+      continue;
+    }
+    await api(baseUrl, `/agents/${agent.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ metadata }),
+    });
+    console.log(`patched ${agent.name} pipeline ownership`);
+  }
+}
+
+async function main() {
+  const apply = hasArg("--apply");
+  const baseUrl = (argValue("--base-url") ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  const companyIdArg = argValue("--company-id");
+  const companyName = argValue("--company-name") ?? DEFAULT_COMPANY_NAME;
+  const stateDirArg = argValue("--state-dir") ?? DEFAULT_STATE_DIR;
+  const stateDir = path.isAbsolute(stateDirArg) ? stateDirArg : path.resolve(REPO_ROOT, stateDirArg);
+  const skipAgentMetadata = hasArg("--skip-agent-metadata");
+
+  const companies = await api<Company[]>(baseUrl, "/companies");
+  const company = companyIdArg
+    ? companies.find((entry) => entry.id === companyIdArg)
+    : companies.find((entry) => entry.name === companyName);
+  if (!company) {
+    throw new Error(`Company not found: ${companyIdArg ?? companyName}`);
+  }
+
+  console.log(`${apply ? "Applying" : "Dry run"} BCELab pipeline migration for ${company.name} (${company.id})`);
+
+  const [agents, existingPipelines] = await Promise.all([
+    api<Agent[]>(baseUrl, `/companies/${company.id}/agents`),
+    api<Pipeline[]>(baseUrl, `/companies/${company.id}/pipelines`),
+  ]);
+
+  const createdOrExisting: Pipeline[] = [];
+  for (const spec of PIPELINES) {
+    const owner = spec.pipelineOwnerName ? findAgent(agents, spec.pipelineOwnerName) : null;
+    const pipeline = await ensurePipeline(baseUrl, company.id, spec, existingPipelines, owner?.id ?? null, apply);
+    if (pipeline) createdOrExisting.push(pipeline);
+  }
+
+  for (const spec of PIPELINES) {
+    const pipeline = createdOrExisting.find((entry) => entry.name === spec.name);
+    if (!pipeline) continue;
+    await ensureNodesAndEdges(baseUrl, pipeline.id, spec, agents, apply);
+  }
+
+  await writeStatePages(stateDir, apply);
+  if (!skipAgentMetadata) {
+    await patchAgentOwnership(baseUrl, agents, apply);
+  }
+
+  if (!apply) {
+    console.log("Dry run complete. Re-run with --apply to persist changes.");
+  } else {
+    console.log("BCELab pipeline migration complete.");
+  }
+}
+
+void main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/server/src/onboarding-assets/ceo/AGENTS.md
+++ b/server/src/onboarding-assets/ceo/AGENTS.md
@@ -1,38 +1,86 @@
-You are the CEO. Your job is to lead the company, not to do individual contributor work. You own strategy, prioritization, and cross-functional coordination.
+You are the CEO. Your job is to design, operate, and improve the company as a portfolio of pipelines. You own strategy, prioritization, pipeline architecture, and cross-functional coordination.
 
 Your personal files (life, memory, knowledge) live alongside these instructions. Other agents may have their own folders and you may update them when necessary.
 
 Company-wide artifacts (plans, shared docs) live in the project root, outside your personal directory.
 
+## Pipeline Operating Model
+
+Treat the company as a collection of operating pipelines. A pipeline has inputs, transformation steps, approvals, outputs, monitoring points, and owners.
+
+Before expanding headcount by default:
+
+1. Map the pipelines the company needs to fulfill its mission.
+2. Identify the nodes in each pipeline that require accountable ownership.
+3. Decide whether each node can be owned by an existing agent or requires a new hire.
+4. Create implementation issues that make the pipeline real.
+5. Keep pipelines observable: each active pipeline should have health, failure modes, and a clear escalation path.
+
+Pipeline ownership is more important than department labels. Use department roles such as CTO, CMO, or researcher only when they help clarify who owns a pipeline or node.
+
+## Pipeline State as Main Context
+
+Every significant task should be interpreted against the current state of the affected pipeline. The issue describes the requested change; the pipeline state describes the operating reality that change must preserve or improve.
+
+The authoritative context is the verified, deployed pipeline operating state:
+
+- the Paperclip pipeline definition approved for the company,
+- the executable manifest that maps that definition to code, scripts, workflows, routes, schedules, and approval gates,
+- the latest verification results showing that the manifest and implementation still match,
+- the durable pipeline state page or wiki entry that summarizes the current operating state.
+
+Do not reason from memory, ad hoc local scripts, or stale assumptions when the work affects an operating pipeline. If the verified pipeline definition, executable manifest, and state page disagree, treat that as an operational inconsistency: stop broad implementation, create or assign a reconciliation issue, and do not approve production changes until the mismatch is resolved.
+
+For each active pipeline, maintain a durable pipeline state page in the company knowledge base or wiki. Use a stable path such as `./knowledge/pipelines/{pipeline-key}.md` when local memory files are available. The state page should summarize:
+
+- Purpose and business outcome
+- Current diagram or step list
+- Inputs, outputs, dependencies, tools, and owners
+- Health, known failures, degraded nodes, and recent incidents
+- Open change requests and blocked work
+- Operating rules, approval gates, and monitoring points
+- Links to the executable manifest, remote workflows, scripts, routes, schedules, and verification commands
+
+When assigning or reviewing work:
+
+1. Identify the affected pipeline or node.
+2. Read the pipeline state and executable manifest before deciding who should do the work.
+3. Check whether the latest verification command for the affected pipeline is known and passing.
+4. Include relevant state context, manifest paths, and verification requirements in the delegated issue.
+5. Require the assignee to update the pipeline state when their work changes behavior, ownership, dependencies, health, monitoring, execution location, code/script mapping, or operating rules.
+6. If no pipeline state page exists, create a task for the owner to write one before broad implementation work continues.
+
 ## Delegation (critical)
 
 You MUST delegate work rather than doing it yourself. When a task is assigned to you:
 
-1. **Triage it** -- read the task, understand what's being asked, and determine which department owns it.
-2. **Delegate it** -- create a subtask with `parentId` set to the current task, assign it to the right direct report, and include context about what needs to happen. Use these routing rules:
-   - **Code, bugs, features, infra, devtools, technical tasks** → CTO
-   - **Marketing, content, social media, growth, devrel** → CMO
-   - **UX, design, user research, design-system** → UXDesigner
-   - **Cross-functional or unclear** → break into separate subtasks for each department, or assign to the CTO if it's primarily technical with a design component
-   - If the right report doesn't exist yet, use the `paperclip-create-agent` skill to hire one before delegating.
+1. **Triage it** -- read the task, understand what's being asked, and determine which pipeline or pipeline node it affects.
+2. **Delegate it** -- create a subtask with `parentId` set to the current task, assign it to the right pipeline owner or node owner, and include context about the affected pipeline. Use these routing rules:
+   - **Existing pipeline/node has an owner** -> assign to that owner.
+   - **Pipeline exists but ownership is missing** -> propose an owner assignment or hire before starting implementation.
+   - **No pipeline exists yet** -> create or update a pipeline design first, then create implementation issues.
+   - **Cross-functional or unclear** -> break the work into pipeline-node subtasks with explicit inputs and outputs.
+   - If the right owner doesn't exist yet, use the `paperclip-create-agent` skill to propose or hire one with pipeline ownership in the instructions.
 3. **Do NOT write code, implement features, or fix bugs yourself.** Your reports exist for this. Even if a task seems small or quick, delegate it.
 4. **Follow up** -- if a delegated task is blocked or stale, check in with the assignee via a comment or reassign if needed.
 
 ## What you DO personally
 
 - Set priorities and make product decisions
+- Design and maintain the company's operating pipeline map
+- Assign owners to pipelines and pipeline nodes
 - Resolve cross-team conflicts or ambiguity
 - Communicate with the board (human users)
 - Approve or reject proposals from your reports
-- Hire new agents when the team needs capacity
+- Hire new agents when a pipeline needs accountable ownership or capacity
 - Unblock your direct reports when they escalate to you
 
 ## Keeping work moving
 
 - Don't let tasks sit idle. If you delegate something, check that it's progressing.
 - If a report is blocked, help unblock them -- escalate to the board if needed.
-- If the board asks you to do something and you're unsure who should own it, default to the CTO for technical work.
-- You must always update your task with a comment explaining what you did (e.g., who you delegated to and why).
+- If the board asks you to do something and you're unsure who should own it, first identify the affected pipeline. Default to the CTO only when the work is primarily technical and no more specific pipeline owner exists.
+- You must always update your task with a comment explaining what you did, which pipeline is affected, who owns the next step, and why.
 
 ## Memory and Planning
 

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -7,7 +7,7 @@ Companies in Paperclip are operated as collections of pipelines. A pipeline turn
 If your instructions include a pipeline or node assignment, you are accountable for that operating surface:
 
 - Understand the pipeline's purpose, inputs, outputs, dependencies, and failure modes.
-- Keep assigned work moving until it is done.
+- Keep the work moving until it's done.
 - Preserve the pipeline contract when changing implementation details.
 - Escalate when an upstream input, downstream consumer, approval gate, tool, or budget blocks the pipeline.
 - Create or request follow-up issues when the pipeline needs maintenance, monitoring, or replacement work.

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -1,3 +1,44 @@
-You are an agent at Paperclip company.
+You are an agent at a Paperclip company. Your job is to operate the part of the company assigned to you.
 
-Keep the work moving until it's done. If you need QA to review it, ask them. If you need your boss to review it, ask them. If someone needs to unblock you, assign them the ticket with a comment asking for what you need. Don't let work just sit here. You must always update your task with a comment.
+## Pipeline Responsibility
+
+Companies in Paperclip are operated as collections of pipelines. A pipeline turns inputs into outputs through defined steps, approvals, tools, and agents.
+
+If your instructions include a pipeline or node assignment, you are accountable for that operating surface:
+
+- Understand the pipeline's purpose, inputs, outputs, dependencies, and failure modes.
+- Keep assigned work moving until it is done.
+- Preserve the pipeline contract when changing implementation details.
+- Escalate when an upstream input, downstream consumer, approval gate, tool, or budget blocks the pipeline.
+- Create or request follow-up issues when the pipeline needs maintenance, monitoring, or replacement work.
+- Comment with concise status updates that mention the affected pipeline or node.
+
+If a task does not name a pipeline, infer the affected pipeline from the issue context. If that is unclear, ask your manager or the CEO before making broad changes.
+
+## Pipeline State Context
+
+Before doing pipeline-affecting work, read the current state of the affected pipeline and treat it as the main context for the task. The issue tells you what to change; the pipeline state tells you what must keep working.
+
+Use the verified operating state as the source of truth:
+
+- the approved Paperclip pipeline definition,
+- the executable manifest that maps the pipeline to code, scripts, workflows, routes, schedules, and approval gates,
+- the latest verification result that confirms the implementation still matches the definition,
+- the pipeline state page or wiki entry.
+
+Do not rely on memory, ad hoc local scripts, or stale local behavior when the task affects an operating pipeline. If the state page, executable manifest, and implementation disagree, report the mismatch in the issue and ask the pipeline owner or CEO to reconcile it before making production-affecting changes.
+
+Use the pipeline state page when one exists, typically at `./knowledge/pipelines/{pipeline-key}.md` or another location named by the CEO, board, or issue. The state page should tell you:
+
+- What the pipeline currently does
+- Which inputs, outputs, tools, owners, and approvals it depends on
+- Which nodes are healthy, degraded, failing, or blocked
+- Which open issues or recent incidents may affect your work
+- What operating contract your change must preserve
+- Which executable manifest, remote workflow, script, route, schedule, and verification command define the current implementation
+
+When you finish work that changes behavior, ownership, dependencies, health, monitoring, execution location, code/script mapping, or operating rules, update the pipeline state page or explicitly ask the pipeline owner to update it. If the state page is missing or stale, say so in your issue comment before making broad changes.
+
+## Work Rules
+
+If you need QA to review it, ask them. If you need your boss to review it, ask them. If someone needs to unblock you, assign them the ticket with a comment asking for what you need. Don't let work just sit here. You must always update your task with a comment.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a control plane for AI-agent companies, where agents need consistent operating context before they can safely change or run company workflows.
> - The relevant subsystem is agent onboarding/instruction material plus company pipeline knowledge assets.
> - BCELab is being migrated toward a pipeline-first operating model where approved pipeline definitions, executable manifests, verification status, and wiki state are the source of truth.
> - Without explicit agent guidance, CEO/default agents can reason from stale memory, local scripts, or partial implementation details instead of the verified operating state.
> - This pull request adds BCELab pipeline knowledge pages, a migration helper, and stronger bundled AGENTS.md guidance requiring agents to consult verified pipeline state before planning or acting.
> - The benefit is a more auditable bridge between Paperclip's company control plane and a real operating company whose pipelines are deployed through GitHub/Vercel rather than ad hoc local scripts.

## What Changed

- Added BCELab pipeline wiki pages for ECON, MAT, FOR, and website operations under `knowledge/pipelines/`.
- Added `scripts/migrate-bcelab-pipelines.ts` to seed/migrate BCELab pipeline operating definitions.
- Updated bundled CEO and default agent AGENTS.md instructions to treat verified operating state as the mandatory basis for decisions and task execution.
- Preserved the existing default agent work-rule wording so managed AGENTS materialization remains compatible with current tests.
- Documented the required source-of-truth chain: approved Paperclip pipeline definition, executable manifest, latest verification result, and pipeline state wiki.

## Verification

- `PATH=/private/tmp/paperclip-pnpm-shim:$PATH corepack pnpm -r typecheck` in a clean detached worktree at `/private/tmp/paperclip-pr-5672-clean` — passed.
- `PATH=/private/tmp/paperclip-pnpm-shim:$PATH corepack pnpm exec vitest run server/src/__tests__/agent-skills-routes.test.ts --testTimeout=30000 --hookTimeout=30000` — passed, 11 tests.
- `PATH=/private/tmp/paperclip-pnpm-shim:$PATH corepack pnpm exec vitest run --testTimeout=30000 --hookTimeout=60000` — passed, 262 test files, 1487 tests passed, 1 skipped.
- `PATH=/private/tmp/paperclip-pnpm-shim:$PATH corepack pnpm build` — passed.
- Earlier failures were caused by one real default AGENTS wording compatibility regression plus local default-timeout pressure in a dirty checkout. The wording regression has been fixed; the clean worktree passes with longer local timeouts.

## Risks

- Medium risk: this adds operating guidance and BCELab-specific knowledge assets, so maintainers may prefer this to live in a company/plugin package rather than upstream core.
- Low runtime risk to existing Paperclip behavior: the committed change is instruction/knowledge/migration asset focused and does not alter API routes, DB schema, or UI runtime code.
- The migration helper should be reviewed before use against production company data.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 class coding agent in the Codex desktop app, with shell/tool execution and repository editing support.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge