### PR TITLE
fix(adapter-claude-local): stop mislabeling successful runs as claude_auth_required

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeTransientUpstreamError,
 } from "./parse.js";
@@ -119,5 +120,58 @@ describe("extractClaudeRetryNotBefore", () => {
     expect(
       extractClaudeRetryNotBefore({ errorMessage: "Overloaded. Try again later." }, new Date()),
     ).toBeNull();
+  });
+});
+
+describe("detectClaudeLoginRequired", () => {
+  it("does not flag a successful run whose agent output mentions auth keywords", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result:
+          "Published the docs page. The HTTP error reference now lists `401 Unauthorized` and `403 Forbidden` next to the recommended retry guidance.",
+      },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(false);
+  });
+
+  it("flags a real CLI auth failure on stderr", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: null,
+      stdout: "",
+      stderr: "Please log in. Run `claude login` first.",
+    });
+    expect(result.requiresLogin).toBe(true);
+  });
+
+  it("flags an error envelope whose result text describes the auth failure", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: {
+        subtype: "error",
+        is_error: true,
+        result: "authentication required: please run claude login",
+      },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(true);
+  });
+
+  it("flags a structured errors entry that names an auth failure even on a success envelope", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: {
+        subtype: "success",
+        is_error: false,
+        result: "All good — finished writing the post.",
+        errors: [{ message: "login required" }],
+      },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(true);
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -134,8 +134,19 @@ export function detectClaudeLoginRequired(input: {
   stdout: string;
   stderr: string;
 }): { requiresLogin: boolean; loginUrl: string | null } {
-  const resultText = asString(input.parsed?.result, "").trim();
-  const messages = [resultText, ...extractClaudeErrorMessages(input.parsed ?? {}), input.stdout, input.stderr]
+  const parsed = input.parsed;
+  // On a successful CLI envelope, `parsed.result` is the agent's own output
+  // and may legitimately contain words like "Unauthorized", "login required",
+  // or "authentication required" (HTTP error tables, doc snippets, code
+  // samples). Including it in the auth-required haystack mislabels healthy
+  // runs as `claude_auth_required`. Real CLI auth failures still surface
+  // through stdout/stderr and through the structured `errors` array.
+  const isSuccessEnvelope =
+    parsed != null &&
+    asString(parsed.subtype, "") === "success" &&
+    parsed.is_error !== true;
+  const resultText = isSuccessEnvelope ? "" : asString(parsed?.result, "").trim();
+  const messages = [resultText, ...extractClaudeErrorMessages(parsed ?? {}), input.stdout, input.stderr]
     .join("\n")
     .split(/\r?\n/)
     .map((line) => line.trim())


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agent runs are executed through per-provider adapters; `adapter-claude-local` shells out to the Claude CLI and parses its stream-JSON envelope
> - The adapter classifies failure causes from that envelope so the heartbeat / recovery path can decide whether to retry, escalate, or mark a run as needing human auth
> - The `claude_auth_required` classifier is implemented as a regex over a haystack of strings; today the haystack includes `parsed.result`, which on a successful CLI envelope is the agent's own final output
> - Any agent that publishes documentation, blog posts, or HTTP error tables containing words like "Unauthorized" or "login required" gets its successful run mislabeled as failed with `errorCode: claude_auth_required`
> - This pull request gates the parsed result out of that haystack when the envelope is a real success (`subtype === "success"`, `is_error !== true`)
> - The benefit is healthy runs stop being classified as auth failures purely because of the substring of the agent's content, while real CLI auth failures continue to be detected through stdout/stderr and the structured `errors` array

## What Changed

- `detectClaudeLoginRequired` in `packages/adapters/claude-local/src/server/parse.ts` now skips `parsed.result` when the parsed envelope is a successful CLI result (`subtype === "success"` and `is_error !== true`).
- Added four regression tests in `parse.test.ts`:
  - Successful run whose agent output contains `401 Unauthorized` → not flagged.
  - Real CLI auth failure on stderr (`Please log in. Run 'claude login' first.`) → flagged.
  - Error envelope whose `result` text describes the auth failure → flagged (existing behavior preserved).
  - Structured `errors: [{ message: "login required" }]` on a success envelope → flagged (structured signals still trusted).

## Verification

- `pnpm exec vitest run src/server/parse.test.ts` → 13 tests passing (9 pre-existing + 4 new).
- `pnpm --filter @paperclipai/adapter-claude-local typecheck` → no diagnostics.
- The fix is restricted to one function and one test file; no other adapter or service surface is touched.

## Risks

- **Low risk.** The change is strictly subtractive on the haystack: a string we used to scan is no longer scanned, and only when the CLI envelope itself indicates success. Real auth failures (which never produce a `subtype === "success"` / `is_error: false` envelope) continue to be detected through `stdout`, `stderr`, and the structured `errors` array.
- The structured `errors` array is still scanned even on success envelopes, so an adapter implementation that, against the schema, paired `subtype: "success"` with an auth error in `errors` would still classify correctly.

## Model Used

- Claude Opus 4.7 (claude-opus-4-7), 1M context window, extended thinking + tool use, via Claude Code CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (no UI)
- [ ] I have updated relevant documentation to reflect my changes — N/A (behavior is documented in test names + inline comment)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge