### PR TITLE
test(plugin-core): coverage for plugin-loader/dispatcher/validator/event-bus

### DIFF
--- a/server/src/__tests__/plugin-config-validator.test.ts
+++ b/server/src/__tests__/plugin-config-validator.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview MO-070 — TDD coverage for plugin-config-validator.
+ *
+ * Validates configJson against the plugin manifest's instanceConfigSchema.
+ * This is the API boundary that prevents bad config from reaching the worker
+ * at startup — the Vexion plugin manifests use ajv with `secret-ref` format.
+ *
+ * MO-070 Phase B — Bug class targeted: BUG-CORE-002 (config validation drift).
+ */
+
+import { describe, expect, it } from "vitest";
+import { validateInstanceConfig } from "../services/plugin-config-validator.js";
+
+describe("plugin-config-validator", () => {
+  it("PASSES an empty config against an empty schema", () => {
+    const result = validateInstanceConfig({}, { type: "object" } as any);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it("FAILS when a required property is missing", () => {
+    const schema = {
+      type: "object",
+      required: ["apiKey"],
+      properties: { apiKey: { type: "string" } },
+    } as any;
+
+    const result = validateInstanceConfig({}, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors?.length).toBeGreaterThan(0);
+  });
+
+  it("FAILS with structured field error on type mismatch", () => {
+    const schema = {
+      type: "object",
+      properties: { timeout: { type: "number" } },
+    } as any;
+
+    const result = validateInstanceConfig({ timeout: "thirty" }, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.[0]).toMatchObject({ field: expect.stringContaining("timeout") });
+  });
+
+  it("collects ALL errors when allErrors is enabled (not just first)", () => {
+    const schema = {
+      type: "object",
+      required: ["a", "b"],
+      properties: { a: { type: "string" }, b: { type: "string" } },
+    } as any;
+
+    const result = validateInstanceConfig({}, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("accepts the custom `secret-ref` format (validates as always-true)", () => {
+    const schema = {
+      type: "object",
+      properties: { apiKey: { type: "string", format: "secret-ref" } },
+    } as any;
+
+    // Any string passes secret-ref (UUID validation happens later at resolve time)
+    const result = validateInstanceConfig({ apiKey: "anything-here" }, schema);
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates standard ajv formats (uuid)", () => {
+    const schema = {
+      type: "object",
+      properties: { id: { type: "string", format: "uuid" } },
+    } as any;
+
+    expect(validateInstanceConfig({ id: "not-a-uuid" }, schema).valid).toBe(false);
+    expect(validateInstanceConfig({ id: "12345678-1234-1234-1234-123456789012" }, schema).valid).toBe(true);
+  });
+});

--- a/server/src/__tests__/plugin-database-validators.test.ts
+++ b/server/src/__tests__/plugin-database-validators.test.ts
@@ -1,0 +1,249 @@
+/**
+ * @fileoverview MO-070 — Extra TDD coverage for plugin-database SQL validators.
+ *
+ * Existing plugin-database.test.ts covers the embedded-Postgres integration
+ * paths. This file fills in the pure-function validator coverage that came
+ * up during MO-069 plugin-scaffold work (CREATE INDEX rule, AppleDouble file
+ * rejection, namespace derivation determinism, DDL keyword guards).
+ *
+ * MO-070 Phase B — Bug class targeted: BUG-CORE-003 (validator edge cases).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  derivePluginDatabaseNamespace,
+  validatePluginMigrationStatement,
+  validatePluginRuntimeQuery,
+  validatePluginRuntimeExecute,
+} from "../services/plugin-database.js";
+
+describe("derivePluginDatabaseNamespace", () => {
+  it("is deterministic — same input always produces same namespace", () => {
+    const ns1 = derivePluginDatabaseNamespace("vexion.council-chat");
+    const ns2 = derivePluginDatabaseNamespace("vexion.council-chat");
+    expect(ns1).toBe(ns2);
+  });
+
+  it("differs for different plugin keys", () => {
+    const a = derivePluginDatabaseNamespace("vexion.council-chat");
+    const b = derivePluginDatabaseNamespace("vexion.mem0-sync-poc");
+    expect(a).not.toBe(b);
+  });
+
+  it("produces a valid postgres identifier (a-z0-9_, ≤63 chars, starts with letter or _)", () => {
+    const ns = derivePluginDatabaseNamespace("vexion.council-chat");
+    expect(ns).toMatch(/^[a-z_][a-z0-9_]*$/);
+    expect(ns.length).toBeLessThanOrEqual(63);
+    expect(ns.startsWith("plugin_")).toBe(true);
+  });
+
+  it("normalizes case and dashes from the plugin key", () => {
+    const ns = derivePluginDatabaseNamespace("VEXION.Council-Chat");
+    expect(ns).toMatch(/^[a-z_][a-z0-9_]*$/);
+  });
+
+  it("uses namespaceSlug override when provided", () => {
+    const withSlug = derivePluginDatabaseNamespace("vexion.council-chat", "council");
+    expect(withSlug).toContain("council");
+  });
+
+  it("never produces empty slug — falls back to 'plugin'", () => {
+    // Edge case: a key consisting entirely of non-alphanumeric characters.
+    const ns = derivePluginDatabaseNamespace("---", "---");
+    expect(ns).toMatch(/^plugin_plugin_/);
+  });
+
+  it("truncates at 63 chars (postgres identifier limit)", () => {
+    const longKey = "x".repeat(200);
+    const ns = derivePluginDatabaseNamespace(longKey);
+    expect(ns.length).toBeLessThanOrEqual(63);
+  });
+});
+
+describe("validatePluginMigrationStatement — DDL guards", () => {
+  it("rejects DROP TABLE (destructive in Phase 1)", () => {
+    expect(() =>
+      validatePluginMigrationStatement(
+        "DROP TABLE plugin_test.rows",
+        "plugin_test",
+      ),
+    ).toThrow(/Destructive/i);
+  });
+
+  it("rejects TRUNCATE (destructive)", () => {
+    expect(() =>
+      validatePluginMigrationStatement(
+        "TRUNCATE TABLE plugin_test.rows",
+        "plugin_test",
+      ),
+    ).toThrow(/Destructive/i);
+  });
+
+  it("rejects CREATE EXTENSION (banned in plugin namespace)", () => {
+    expect(() =>
+      validatePluginMigrationStatement(
+        "CREATE EXTENSION IF NOT EXISTS uuid-ossp",
+        "plugin_test",
+      ),
+    ).toThrow(/disallowed/i);
+  });
+
+  it("rejects CREATE FUNCTION (banned)", () => {
+    expect(() =>
+      validatePluginMigrationStatement(
+        "CREATE FUNCTION plugin_test.my_fn() RETURNS void AS $$ $$ LANGUAGE sql",
+        "plugin_test",
+      ),
+    ).toThrow(/disallowed/i);
+  });
+
+  it("rejects CREATE TRIGGER (banned)", () => {
+    expect(() =>
+      validatePluginMigrationStatement(
+        "CREATE TRIGGER plugin_test.audit AFTER INSERT ON plugin_test.rows FOR EACH ROW EXECUTE PROCEDURE noop()",
+        "plugin_test",
+      ),
+    ).toThrow(/disallowed/i);
+  });
+
+  it("rejects GRANT and REVOKE", () => {
+    expect(() =>
+      validatePluginMigrationStatement(
+        "GRANT SELECT ON plugin_test.rows TO public",
+        "plugin_test",
+      ),
+    ).toThrow(/disallowed/i);
+    expect(() =>
+      validatePluginMigrationStatement(
+        "REVOKE INSERT ON plugin_test.rows FROM public",
+        "plugin_test",
+      ),
+    ).toThrow(/disallowed/i);
+  });
+
+  it("rejects qualified references to non-plugin schemas", () => {
+    expect(() =>
+      validatePluginMigrationStatement(
+        "ALTER TABLE other_schema.rows ADD COLUMN x int",
+        "plugin_test",
+      ),
+    ).toThrow(/outside namespace/i);
+  });
+
+  it("rejects unqualified statements (must use schema-qualified names)", () => {
+    expect(() =>
+      validatePluginMigrationStatement(
+        "CREATE TABLE rows (id uuid PRIMARY KEY)",
+        "plugin_test",
+      ),
+    ).toThrow(/fully qualified/i);
+  });
+
+  it("allows ALTER on a table inside the plugin namespace", () => {
+    expect(() =>
+      validatePluginMigrationStatement(
+        "ALTER TABLE plugin_test.rows ADD COLUMN created_at timestamptz NOT NULL DEFAULT now()",
+        "plugin_test",
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("validatePluginRuntimeQuery (SELECT only)", () => {
+  it("allows a SELECT against the plugin namespace", () => {
+    expect(() =>
+      validatePluginRuntimeQuery(
+        "SELECT * FROM plugin_test.rows WHERE id = $1",
+        "plugin_test",
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects INSERT in query() (mutation must use execute())", () => {
+    expect(() =>
+      validatePluginRuntimeQuery(
+        "INSERT INTO plugin_test.rows (id) VALUES ($1)",
+        "plugin_test",
+      ),
+    ).toThrow(/SELECT/i);
+  });
+
+  it("rejects multi-statement input", () => {
+    expect(() =>
+      validatePluginRuntimeQuery(
+        "SELECT 1; SELECT 2",
+        "plugin_test",
+      ),
+    ).toThrow(/exactly one statement/i);
+  });
+
+  it("rejects DDL keywords in query() (drop/alter/create/truncate)", () => {
+    expect(() =>
+      validatePluginRuntimeQuery(
+        "SELECT * FROM plugin_test.rows WHERE foo = 'create table x'",
+        "plugin_test",
+      ),
+    ).not.toThrow(); // string literal — should be OK after strip
+
+    expect(() =>
+      validatePluginRuntimeQuery(
+        "WITH cte AS (SELECT 1) DROP TABLE plugin_test.rows",
+        "plugin_test",
+      ),
+    ).toThrow();
+  });
+});
+
+describe("validatePluginRuntimeExecute (INSERT/UPDATE/DELETE only)", () => {
+  it("allows INSERT in plugin namespace", () => {
+    expect(() =>
+      validatePluginRuntimeExecute(
+        "INSERT INTO plugin_test.rows (id, name) VALUES ($1, $2)",
+        "plugin_test",
+      ),
+    ).not.toThrow();
+  });
+
+  it("allows UPDATE in plugin namespace", () => {
+    expect(() =>
+      validatePluginRuntimeExecute(
+        "UPDATE plugin_test.rows SET name = $1 WHERE id = $2",
+        "plugin_test",
+      ),
+    ).not.toThrow();
+  });
+
+  it("rejects SELECT in execute() (must use query())", () => {
+    expect(() =>
+      validatePluginRuntimeExecute(
+        "SELECT * FROM plugin_test.rows",
+        "plugin_test",
+      ),
+    ).toThrow(/INSERT, UPDATE, or DELETE/i);
+  });
+
+  it("rejects INSERT into a non-plugin schema", () => {
+    expect(() =>
+      validatePluginRuntimeExecute(
+        "INSERT INTO public.issues (id, title) VALUES ($1, $2)",
+        "plugin_test",
+      ),
+    ).toThrow(/must be inside plugin namespace/i);
+  });
+
+  it("rejects DDL keywords in execute()", () => {
+    expect(() =>
+      validatePluginRuntimeExecute(
+        "INSERT INTO plugin_test.rows (sql) VALUES ('create table x')",
+        "plugin_test",
+      ),
+    ).not.toThrow(); // string literal — stripped
+
+    expect(() =>
+      validatePluginRuntimeExecute(
+        "INSERT INTO plugin_test.rows SELECT * FROM plugin_test.other; CREATE INDEX",
+        "plugin_test",
+      ),
+    ).toThrow(/exactly one statement/i);
+  });
+});

--- a/server/src/__tests__/plugin-event-bus.test.ts
+++ b/server/src/__tests__/plugin-event-bus.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @fileoverview MO-070 — TDD coverage for plugin-event-bus.
+ *
+ * The event bus is load-bearing for plugin-to-plugin communication
+ * (PLUGIN_SPEC.md §16). Vexion plugins (council-chat, mem0-sync-poc)
+ * emit and subscribe through this bus.
+ *
+ * MO-070 Phase B — covers:
+ *   - Namespace auto-prefix on emit
+ *   - Namespace-spoofing guard (cannot emit "plugin.*" directly)
+ *   - Wildcard pattern matching (trailing .*)
+ *   - Filter pre-delivery
+ *   - Error isolation (one bad handler doesn't break delivery to others)
+ *   - Subscription scope isolation between plugins
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { createPluginEventBus } from "../services/plugin-event-bus.js";
+
+describe("plugin-event-bus — emit + auto-namespace", () => {
+  it("auto-prefixes plugin-emitted events with `plugin.<pluginId>.`", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+
+    bus.forPlugin("watcher").subscribe("plugin.acme.linear.sync-done", handler);
+    await bus.forPlugin("acme.linear").emit("sync-done", "c-1", { count: 5 });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0]![0]).toMatchObject({
+      eventType: "plugin.acme.linear.sync-done",
+      companyId: "c-1",
+      actorType: "plugin",
+      actorId: "acme.linear",
+    });
+  });
+
+  it("rejects empty event name (namespace-collision guard)", async () => {
+    const bus = createPluginEventBus();
+    await expect(bus.forPlugin("acme").emit("", "c-1", {})).rejects.toThrow(/non-empty event name/i);
+    await expect(bus.forPlugin("acme").emit("   ", "c-1", {})).rejects.toThrow(/non-empty event name/i);
+  });
+
+  it("rejects empty companyId", async () => {
+    const bus = createPluginEventBus();
+    await expect(bus.forPlugin("acme").emit("sync-done", "", {})).rejects.toThrow(/companyId/i);
+  });
+
+  it("rejects emit with 'plugin.' prefix (spoofing guard)", async () => {
+    // A plugin must not be able to emit events that look like they came from
+    // another plugin or the core. The bus auto-namespaces, so emitting
+    // `plugin.foo.bar` would double-prefix AND let a plugin spoof.
+    const bus = createPluginEventBus();
+    await expect(
+      bus.forPlugin("acme").emit("plugin.other.sync-done", "c-1", {}),
+    ).rejects.toThrow(/must not include the "plugin\."/i);
+  });
+});
+
+describe("plugin-event-bus — pattern matching", () => {
+  it("matches exact event types", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("watcher").subscribe("issue.created" as any, handler);
+
+    await bus.emit({
+      eventId: "e-1",
+      eventType: "issue.created",
+      occurredAt: "2026-01-01T00:00:00Z",
+      entityId: "iss-1",
+      entityType: "issue",
+      payload: {},
+    } as any);
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("matches trailing wildcard `plugin.foo.*`", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("watcher").subscribe("plugin.acme.linear.*", handler);
+
+    await bus.forPlugin("acme.linear").emit("sync-done", "c-1", {});
+    await bus.forPlugin("acme.linear").emit("error", "c-1", {});
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT match across plugin boundaries (acme.linear.* does not catch acme.github.*)", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("watcher").subscribe("plugin.acme.linear.*", handler);
+
+    await bus.forPlugin("acme.github").emit("sync-done", "c-1", {});
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("plugin-event-bus — filters", () => {
+  it("pre-filters by companyId — non-matching events do not reach handler", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("watcher").subscribe("issue.created" as any, { companyId: "c-1" }, handler);
+
+    await bus.emit({
+      eventId: "e-1",
+      eventType: "issue.created",
+      companyId: "c-2",  // different company
+      occurredAt: "2026-01-01T00:00:00Z",
+      entityId: "iss-1",
+      entityType: "issue",
+      payload: {},
+    } as any);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("filter requires handler arg — throws on missing", () => {
+    const bus = createPluginEventBus();
+    expect(() => {
+      bus.forPlugin("watcher").subscribe("issue.created" as any, { companyId: "c-1" } as any);
+    }).toThrow(/Handler function is required/i);
+  });
+});
+
+describe("plugin-event-bus — isolation + error handling", () => {
+  it("a failing handler does not block other plugins' handlers", async () => {
+    const bus = createPluginEventBus();
+    const goodHandler = vi.fn().mockResolvedValue(undefined);
+    const badHandler = vi.fn().mockRejectedValue(new Error("boom"));
+
+    bus.forPlugin("good").subscribe("issue.created" as any, goodHandler);
+    bus.forPlugin("bad").subscribe("issue.created" as any, badHandler);
+
+    const result = await bus.emit({
+      eventId: "e-1",
+      eventType: "issue.created",
+      occurredAt: "2026-01-01T00:00:00Z",
+      entityId: "iss-1",
+      entityType: "issue",
+      payload: {},
+    } as any);
+
+    expect(goodHandler).toHaveBeenCalledOnce();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.pluginId).toBe("bad");
+  });
+
+  it("a synchronously-throwing handler is caught and reported as a delivery error (not swallowed silently)", async () => {
+    const bus = createPluginEventBus();
+    const syncThrow = vi.fn(() => { throw new Error("sync boom"); }) as any;
+
+    bus.forPlugin("bad").subscribe("issue.created" as any, syncThrow);
+
+    const result = await bus.emit({
+      eventId: "e-1",
+      eventType: "issue.created",
+      occurredAt: "2026-01-01T00:00:00Z",
+      entityId: "iss-1",
+      entityType: "issue",
+      payload: {},
+    } as any);
+
+    expect(result.errors).toHaveLength(1);
+    expect((result.errors[0]?.error as Error).message).toBe("sync boom");
+  });
+
+  it("clearPlugin removes all subscriptions for that plugin only", async () => {
+    const bus = createPluginEventBus();
+    const handlerA = vi.fn().mockResolvedValue(undefined);
+    const handlerB = vi.fn().mockResolvedValue(undefined);
+
+    bus.forPlugin("a").subscribe("issue.created" as any, handlerA);
+    bus.forPlugin("b").subscribe("issue.created" as any, handlerB);
+    expect(bus.subscriptionCount()).toBe(2);
+
+    bus.clearPlugin("a");
+    expect(bus.subscriptionCount("a")).toBe(0);
+    expect(bus.subscriptionCount("b")).toBe(1);
+
+    await bus.emit({
+      eventId: "e-1",
+      eventType: "issue.created",
+      occurredAt: "2026-01-01T00:00:00Z",
+      entityId: "iss-1",
+      entityType: "issue",
+      payload: {},
+    } as any);
+
+    expect(handlerA).not.toHaveBeenCalled();
+    expect(handlerB).toHaveBeenCalledOnce();
+  });
+});

--- a/server/src/__tests__/plugin-tool-dispatcher.test.ts
+++ b/server/src/__tests__/plugin-tool-dispatcher.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @fileoverview MO-070 — TDD coverage for plugin-tool-dispatcher.
+ *
+ * Companion to plugin-tool-registry.test.ts. The dispatcher is the orchestration
+ * layer that ties together the registry, worker manager, and lifecycle events.
+ *
+ * BUG-CORE-001 lives here at line 433 of plugin-tool-dispatcher.ts:
+ *   `registerPluginTools(pluginId, manifest)` does NOT forward pluginDbId to
+ *   registry.registerPlugin — so when plugin-loader.ts line 1907 calls this
+ *   from the activation path, the dbId becomes the pluginKey and worker
+ *   lookup by UUID fails.
+ *
+ * Compare with handlePluginEnabled (line 289) → registerFromDb (line 246-269)
+ * which DOES pass plugin.id (the dbUuid).
+ *
+ * MO-070 Phase B — Bug class targeted: BUG-CORE-001 + drift between code paths.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import { createPluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
+
+function makeManifest(overrides: Partial<PaperclipPluginManifestV1> = {}): PaperclipPluginManifestV1 {
+  return {
+    apiVersion: "paperclip.dev/v1",
+    pluginKey: "test.example",
+    version: "0.1.0",
+    displayName: "Test Example",
+    author: "tester",
+    license: "MIT",
+    categories: ["productivity"],
+    capabilities: {},
+    entrypoints: {},
+    tools: [
+      {
+        name: "search",
+        displayName: "Search",
+        description: "Find things",
+        parametersSchema: { type: "object", properties: {} },
+      },
+    ],
+    ...overrides,
+  } as unknown as PaperclipPluginManifestV1;
+}
+
+describe("plugin-tool-dispatcher — registerPluginTools (BUG-CORE-001)", () => {
+  it("registers tools when called with just (pluginKey, manifest) — but stores wrong dbId", () => {
+    // Mirrors plugin-loader.ts line 1907: registerPluginTools(pluginKey, manifest).
+    // Tools register, but the registry stores dbId = pluginKey (BUG).
+    const dispatcher = createPluginToolDispatcher();
+    dispatcher.registerPluginTools("vexion.council-chat", makeManifest({
+      pluginKey: "vexion.council-chat",
+      tools: [{
+        name: "open-room", displayName: "Open Room", description: "x", parametersSchema: {},
+      }],
+    } as Partial<PaperclipPluginManifestV1>));
+
+    const tool = dispatcher.getTool("vexion.council-chat:open-room");
+    expect(tool).not.toBeNull();
+    // EXPECTED-WRONG: bug means pluginDbId === pluginKey (no UUID propagation)
+    expect(tool?.pluginDbId).toBe("vexion.council-chat");
+  });
+
+  it("unregisters all tools for a plugin", () => {
+    const dispatcher = createPluginToolDispatcher();
+    dispatcher.registerPluginTools("acme.linear", makeManifest({
+      tools: [
+        { name: "a", displayName: "a", description: "x", parametersSchema: {} },
+        { name: "b", displayName: "b", description: "x", parametersSchema: {} },
+      ],
+    } as Partial<PaperclipPluginManifestV1>));
+    expect(dispatcher.toolCount("acme.linear")).toBe(2);
+
+    dispatcher.unregisterPluginTools("acme.linear");
+    expect(dispatcher.toolCount("acme.linear")).toBe(0);
+  });
+
+  it("toolCount aggregates across plugins", () => {
+    const dispatcher = createPluginToolDispatcher();
+    dispatcher.registerPluginTools("acme.a", makeManifest({ pluginKey: "acme.a" }));
+    dispatcher.registerPluginTools("acme.b", makeManifest({
+      pluginKey: "acme.b",
+      tools: [
+        { name: "x", displayName: "x", description: "x", parametersSchema: {} },
+        { name: "y", displayName: "y", description: "y", parametersSchema: {} },
+      ],
+    } as Partial<PaperclipPluginManifestV1>));
+
+    expect(dispatcher.toolCount("acme.a")).toBe(1);
+    expect(dispatcher.toolCount("acme.b")).toBe(2);
+    expect(dispatcher.toolCount()).toBe(3);
+  });
+});
+
+describe("plugin-tool-dispatcher — listToolsForAgent", () => {
+  it("returns AgentToolDescriptor shape (name/displayName/description/parametersSchema/pluginId)", () => {
+    const dispatcher = createPluginToolDispatcher();
+    dispatcher.registerPluginTools("acme.linear", makeManifest({
+      pluginKey: "acme.linear",
+      tools: [{
+        name: "search",
+        displayName: "Search Linear",
+        description: "Find tickets",
+        parametersSchema: { type: "object" },
+      }],
+    } as Partial<PaperclipPluginManifestV1>));
+
+    const tools = dispatcher.listToolsForAgent();
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({
+      name: "acme.linear:search",
+      displayName: "Search Linear",
+      description: "Find tickets",
+    });
+    expect(tools[0]?.parametersSchema).toBeDefined();
+  });
+
+  it("filters by pluginId", () => {
+    const dispatcher = createPluginToolDispatcher();
+    dispatcher.registerPluginTools("acme.a", makeManifest({ pluginKey: "acme.a" }));
+    dispatcher.registerPluginTools("acme.b", makeManifest({
+      pluginKey: "acme.b",
+      tools: [{ name: "other", displayName: "other", description: "x", parametersSchema: {} }],
+    } as Partial<PaperclipPluginManifestV1>));
+
+    const onlyA = dispatcher.listToolsForAgent({ pluginId: "acme.a" });
+    expect(onlyA).toHaveLength(1);
+    expect(onlyA[0]?.name).toBe("acme.a:search");
+  });
+});
+
+describe("plugin-tool-dispatcher — executeTool", () => {
+  it("dispatches to worker via the configured workerManager", async () => {
+    const isRunning = vi.fn().mockReturnValue(true);
+    const call = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "result" }] });
+    const workerManager = { isRunning, call } as any;
+
+    const dispatcher = createPluginToolDispatcher({ workerManager });
+    // Use the lifecycle-event path's signature (with explicit dbId) — works correctly
+    dispatcher.getRegistry().registerPlugin(
+      "acme.linear",
+      makeManifest({ pluginKey: "acme.linear" }),
+      "uuid-1234",
+    );
+
+    const result = await dispatcher.executeTool("acme.linear:search", { q: "x" }, {
+      agentId: "a-1",
+      runId: "r-1",
+      companyId: "c-1",
+    } as any);
+
+    expect(call).toHaveBeenCalledWith("uuid-1234", "executeTool", expect.objectContaining({
+      toolName: "search",
+      parameters: { q: "x" },
+    }));
+    expect(result.pluginId).toBe("acme.linear");
+    expect(result.toolName).toBe("search");
+  });
+
+  it("propagates worker errors as tool execution errors (does not crash)", async () => {
+    const isRunning = vi.fn().mockReturnValue(true);
+    const call = vi.fn().mockRejectedValue(new Error("worker exploded"));
+    const workerManager = { isRunning, call } as any;
+
+    const dispatcher = createPluginToolDispatcher({ workerManager });
+    dispatcher.getRegistry().registerPlugin(
+      "acme.linear",
+      makeManifest({ pluginKey: "acme.linear" }),
+      "uuid-1234",
+    );
+
+    await expect(
+      dispatcher.executeTool("acme.linear:search", {}, {
+        agentId: "a-1", runId: "r-1", companyId: "c-1",
+      } as any),
+    ).rejects.toThrow(/worker exploded/);
+  });
+});

--- a/server/src/__tests__/plugin-tool-registry.test.ts
+++ b/server/src/__tests__/plugin-tool-registry.test.ts
@@ -1,0 +1,230 @@
+/**
+ * @fileoverview MO-070 — TDD coverage for plugin-tool-registry.
+ *
+ * Surfaced by Vexion MO-068 + MO-069 discovery: the tool registration path
+ * has two distinct code paths that must propagate the plugin DB UUID
+ * (`pluginDbId`) correctly to enable worker lookup via `workerManager.call(dbId, ...)`.
+ *
+ * - Path A (lifecycle event → registerFromDb): passes dbId correctly.
+ * - Path B (plugin-loader activation → toolDispatcher.registerPluginTools): drops dbId.
+ *
+ * This file pins down the registry-level contract; the dispatcher-level
+ * contract is covered in plugin-tool-dispatcher.test.ts.
+ *
+ * MO-070 Phase B — Bug class targeted: BUG-CORE-001 (dbId propagation).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import { createPluginToolRegistry } from "../services/plugin-tool-registry.js";
+
+function makeManifest(overrides: Partial<PaperclipPluginManifestV1> = {}): PaperclipPluginManifestV1 {
+  return {
+    apiVersion: "paperclip.dev/v1",
+    pluginKey: "test.example",
+    version: "0.1.0",
+    displayName: "Test Example",
+    author: "tester",
+    license: "MIT",
+    categories: ["productivity"],
+    capabilities: {},
+    entrypoints: {},
+    tools: [
+      {
+        name: "search",
+        displayName: "Search",
+        description: "Find things",
+        parametersSchema: { type: "object", properties: { q: { type: "string" } } },
+      },
+    ],
+    ...overrides,
+  } as unknown as PaperclipPluginManifestV1;
+}
+
+describe("plugin-tool-registry — registration", () => {
+  it("registers a tool under its namespaced name", () => {
+    const registry = createPluginToolRegistry();
+    registry.registerPlugin("acme.linear", makeManifest({ pluginKey: "acme.linear" }));
+
+    const tool = registry.getTool("acme.linear:search");
+    expect(tool).not.toBeNull();
+    expect(tool?.name).toBe("search");
+    expect(tool?.pluginId).toBe("acme.linear");
+  });
+
+  it("uses pluginId as dbId fallback when dbId is omitted (BUG-CORE-001 regression)", () => {
+    // This is the bug surfaced by MO-068+069. When activation passes only
+    // (pluginKey, manifest) the registry stores dbId = pluginKey. Worker lookup
+    // by DB UUID later FAILS. Test pins the current (broken) behavior so a fix
+    // PR must update this expectation.
+    const registry = createPluginToolRegistry();
+    registry.registerPlugin("acme.linear", makeManifest({ pluginKey: "acme.linear" }));
+
+    const tool = registry.getTool("acme.linear:search");
+    expect(tool?.pluginDbId).toBe("acme.linear"); // CURRENT BROKEN BEHAVIOR — pluginId used as dbId
+  });
+
+  it("stores explicit dbId separately from pluginId when both are given", () => {
+    const registry = createPluginToolRegistry();
+    const dbUuid = "e8cedbb3-e718-4cb1-bab9-3db2025e8dc4";
+    registry.registerPlugin("acme.linear", makeManifest({ pluginKey: "acme.linear" }), dbUuid);
+
+    const tool = registry.getTool("acme.linear:search");
+    expect(tool?.pluginId).toBe("acme.linear");
+    expect(tool?.pluginDbId).toBe(dbUuid);
+  });
+
+  it("is idempotent — re-registering replaces previous tools", () => {
+    const registry = createPluginToolRegistry();
+    registry.registerPlugin("acme.linear", makeManifest({
+      tools: [{ name: "v1", displayName: "v1", description: "old", parametersSchema: {} }],
+    } as Partial<PaperclipPluginManifestV1>));
+
+    registry.registerPlugin("acme.linear", makeManifest({
+      tools: [{ name: "v2", displayName: "v2", description: "new", parametersSchema: {} }],
+    } as Partial<PaperclipPluginManifestV1>));
+
+    expect(registry.getTool("acme.linear:v1")).toBeNull();
+    expect(registry.getTool("acme.linear:v2")).not.toBeNull();
+    expect(registry.toolCount("acme.linear")).toBe(1);
+  });
+
+  it("handles plugins that declare no tools without throwing", () => {
+    const registry = createPluginToolRegistry();
+    expect(() => registry.registerPlugin("acme.minimal", makeManifest({ tools: [] }))).not.toThrow();
+    expect(registry.toolCount("acme.minimal")).toBe(0);
+  });
+
+  it("isolates tools across plugins (no cross-pollution)", () => {
+    const registry = createPluginToolRegistry();
+    registry.registerPlugin("acme.a", makeManifest({ pluginKey: "acme.a" }));
+    registry.registerPlugin("acme.b", makeManifest({
+      pluginKey: "acme.b",
+      tools: [{ name: "other", displayName: "Other", description: "x", parametersSchema: {} }],
+    } as Partial<PaperclipPluginManifestV1>));
+
+    expect(registry.getToolByPlugin("acme.a", "search")).not.toBeNull();
+    expect(registry.getToolByPlugin("acme.a", "other")).toBeNull();
+    expect(registry.getToolByPlugin("acme.b", "other")).not.toBeNull();
+    expect(registry.getToolByPlugin("acme.b", "search")).toBeNull();
+  });
+});
+
+describe("plugin-tool-registry — namespaced names", () => {
+  it("buildNamespacedName uses ':' separator", () => {
+    const registry = createPluginToolRegistry();
+    expect(registry.buildNamespacedName("acme.linear", "search-issues")).toBe("acme.linear:search-issues");
+  });
+
+  it("parseNamespacedName splits on the LAST ':' (pluginId may contain dots, not colons)", () => {
+    const registry = createPluginToolRegistry();
+    const parsed = registry.parseNamespacedName("vexion.council-chat:open-room");
+    expect(parsed).toEqual({ pluginId: "vexion.council-chat", toolName: "open-room" });
+  });
+
+  it("parseNamespacedName returns null for malformed names", () => {
+    const registry = createPluginToolRegistry();
+    expect(registry.parseNamespacedName("no-colon")).toBeNull();
+    expect(registry.parseNamespacedName(":leading-colon")).toBeNull();
+    expect(registry.parseNamespacedName("trailing-colon:")).toBeNull();
+  });
+});
+
+describe("plugin-tool-registry — unregister", () => {
+  it("removes all tools for a plugin", () => {
+    const registry = createPluginToolRegistry();
+    registry.registerPlugin("acme.linear", makeManifest({
+      tools: [
+        { name: "a", displayName: "a", description: "x", parametersSchema: {} },
+        { name: "b", displayName: "b", description: "x", parametersSchema: {} },
+      ],
+    } as Partial<PaperclipPluginManifestV1>));
+    expect(registry.toolCount("acme.linear")).toBe(2);
+
+    registry.unregisterPlugin("acme.linear");
+    expect(registry.toolCount("acme.linear")).toBe(0);
+    expect(registry.getTool("acme.linear:a")).toBeNull();
+  });
+
+  it("unregister on unknown plugin is a no-op (doesn't throw)", () => {
+    const registry = createPluginToolRegistry();
+    expect(() => registry.unregisterPlugin("never.installed")).not.toThrow();
+  });
+});
+
+describe("plugin-tool-registry — executeTool", () => {
+  it("throws when tool name is malformed", async () => {
+    const registry = createPluginToolRegistry();
+    await expect(
+      registry.executeTool("not-namespaced", {}, {
+        agentId: "a-1",
+        runId: "r-1",
+        companyId: "c-1",
+      } as any),
+    ).rejects.toThrow(/Invalid tool name/i);
+  });
+
+  it("throws when tool is not registered", async () => {
+    const registry = createPluginToolRegistry();
+    await expect(
+      registry.executeTool("acme.unknown:tool", {}, {
+        agentId: "a-1",
+        runId: "r-1",
+        companyId: "c-1",
+      } as any),
+    ).rejects.toThrow(/not registered/i);
+  });
+
+  it("throws when no worker manager is configured", async () => {
+    const registry = createPluginToolRegistry();
+    registry.registerPlugin("acme.linear", makeManifest({ pluginKey: "acme.linear" }), "db-uuid-1");
+
+    await expect(
+      registry.executeTool("acme.linear:search", { q: "x" }, {
+        agentId: "a-1",
+        runId: "r-1",
+        companyId: "c-1",
+      } as any),
+    ).rejects.toThrow(/no worker manager/i);
+  });
+
+  it("looks up worker by pluginDbId, not pluginId — uses the DB UUID for routing", async () => {
+    // This is the load-bearing assertion: workerManager.isRunning + .call MUST
+    // be invoked with the DB UUID (not the pluginKey). MO-069 monkey-patch
+    // showed this is exactly where the lookup-by-key path fails.
+    const isRunning = vi.fn().mockReturnValue(true);
+    const call = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "ok" }] });
+    const workerManager = { isRunning, call } as any;
+
+    const registry = createPluginToolRegistry(workerManager);
+    const dbUuid = "e8cedbb3-e718-4cb1-bab9-3db2025e8dc4";
+    registry.registerPlugin("vexion.council-chat", makeManifest({ pluginKey: "vexion.council-chat" }), dbUuid);
+
+    await registry.executeTool("vexion.council-chat:search", { q: "x" }, {
+      agentId: "a-1",
+      runId: "r-1",
+      companyId: "c-1",
+    } as any);
+
+    expect(isRunning).toHaveBeenCalledWith(dbUuid);
+    expect(call).toHaveBeenCalledWith(dbUuid, "executeTool", expect.objectContaining({ toolName: "search" }));
+    // Strong assertion: dbId is NOT the pluginKey
+    expect(isRunning).not.toHaveBeenCalledWith("vexion.council-chat");
+  });
+
+  it("throws when worker is not running (worker-not-ready path)", async () => {
+    const isRunning = vi.fn().mockReturnValue(false);
+    const workerManager = { isRunning, call: vi.fn() } as any;
+
+    const registry = createPluginToolRegistry(workerManager);
+    registry.registerPlugin("acme.linear", makeManifest({ pluginKey: "acme.linear" }), "db-uuid-1");
+
+    await expect(
+      registry.executeTool("acme.linear:search", {}, {
+        agentId: "a-1",
+        runId: "r-1",
+        companyId: "c-1",
+      } as any),
+    ).rejects.toThrow(/worker.*not running/i);
+  });
+});


### PR DESCRIPTION
## Summary

Adds 66 regression tests under `server/src/__tests__/` for plugin-core seams. **No production code changed.** Reported as part of Vexion's TDD-ponta-a-ponta MO-070 discovery phase.

Targets the bug-prone areas surfaced when bringing up the Vexion council-chat plugin (predecessor PR #5671 fixed the `pluginDbId` propagation bug):

- `plugin-tool-registry.test.ts` (16 tests) — pin the dbId fallback behavior at the registry layer, namespaced-naming + parseName edge cases, isolation across plugins, `executeTool` worker-lookup-by-UUID assertion.
- `plugin-tool-dispatcher.test.ts` (7 tests) — registration paths, `listToolsForAgent`, `executeTool` error propagation. Documents the asymmetry between `registerPluginTools` (no dbId, drops it) and `registerFromDb` (passes plugin.id correctly).
- `plugin-event-bus.test.ts` (12 tests) — auto-namespace `plugin.<pluginId>.` prefix, namespace-spoofing guard, wildcard pattern matching, `EventFilter` pre-delivery, error isolation across plugins, `clearPlugin` scope.
- `plugin-config-validator.test.ts` (6 tests) — ajv + custom `secret-ref` format + uuid format.
- `plugin-database-validators.test.ts` (25 tests) — namespace derivation determinism, DDL guards (DROP/TRUNCATE/EXTENSION/FUNCTION/TRIGGER/GRANT/REVOKE), SELECT-only `ctx.db.query`, INSERT/UPDATE/DELETE-only `ctx.db.execute`, schema isolation.

## Run

```
cd server && pnpm vitest run src/__tests__/plugin-tool-registry.test.ts \
  src/__tests__/plugin-tool-dispatcher.test.ts \
  src/__tests__/plugin-event-bus.test.ts \
  src/__tests__/plugin-config-validator.test.ts \
  src/__tests__/plugin-database-validators.test.ts
```

Result: **66/66 PASS in 1.27s**. Full server suite (916 tests) also remains green.

## Test plan

- [x] All 66 new tests PASS
- [x] No production code changed
- [x] Existing 850-test baseline still PASS (server suite = 916 total after)
- [x] Naming + structure follows existing patterns (vitest, factory `makeManifest`, `vi.fn()` mocks)
- [ ] Maintainers ratify the BUG-CORE-001 test that pins the **broken** dispatcher behavior (`pluginDbId === pluginKey` when activation path is used). When a future PR fixes `plugin-tool-dispatcher.ts:433` to pass dbId, this single assertion needs to flip.

## Origin

Reported-by: Vexion (Ramon Nassar) — MO-070 TDD discovery phase, 2026-05-11.
Companion to PR #5671 (`pluginDbId` propagation fix, already merged).