### PR TITLE
fix(plugins): pass DB UUID to registerPluginTools so tools/execute works after reinstall

### DIFF
--- a/server/src/__tests__/plugin-tool-registry-reinstall.test.ts
+++ b/server/src/__tests__/plugin-tool-registry-reinstall.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression tests for JEN-27: plugin tools/execute 502 after reinstall.
+ *
+ * Root cause: activatePlugin called registerPluginTools(pluginKey, manifest)
+ * without the DB UUID. The tool registry stored pluginDbId = pluginKey.
+ * workerManager.isRunning(pluginKey) always returned false because the workers
+ * map is keyed by DB UUID, not pluginKey. Result: 502 on every tools/execute call.
+ *
+ * Fix: registerPluginTools now accepts an optional pluginDbId parameter.
+ * activatePlugin passes the DB UUID so isRunning checks resolve correctly.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { createPluginToolRegistry } from "../services/plugin-tool-registry.js";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+
+const PLUGIN_KEY = "acme.test-plugin";
+const PLUGIN_DB_UUID = "00000000-0000-0000-0000-000000000001";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_KEY,
+  apiVersion: 1,
+  version: "1.0.0",
+  displayName: "Test Plugin",
+  description: "Used for JEN-27 regression",
+  author: "test",
+  categories: ["automation"],
+  capabilities: [],
+  entrypoints: { worker: "dist/worker.js" },
+  tools: [
+    {
+      name: "do-thing",
+      displayName: "Do Thing",
+      description: "Does a thing",
+      parametersSchema: { type: "object", properties: {}, required: [], additionalProperties: false },
+    },
+  ],
+};
+
+const runContext = {
+  agentId: "agent-1",
+  runId: "run-1",
+  companyId: "co-1",
+  projectId: "proj-1",
+};
+
+describe("plugin-tool-registry reinstall regression (JEN-27)", () => {
+  it("registers tools with DB UUID so isRunning resolves correctly", async () => {
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === PLUGIN_DB_UUID),
+      call: vi.fn().mockResolvedValue({ result: "ok" }),
+    } as unknown as PluginWorkerManager;
+
+    const registry = createPluginToolRegistry(workerManager);
+
+    // Simulate what activatePlugin does AFTER the fix: pass pluginDbId
+    registry.registerPlugin(PLUGIN_KEY, manifest, PLUGIN_DB_UUID);
+
+    const result = await registry.executeTool(
+      `${PLUGIN_KEY}:do-thing`,
+      {},
+      runContext,
+    );
+
+    expect(workerManager.isRunning).toHaveBeenCalledWith(PLUGIN_DB_UUID);
+    expect(result).toMatchObject({ pluginId: PLUGIN_KEY, toolName: "do-thing", result: { result: "ok" } });
+  });
+
+  it("fails with worker-not-running when pluginDbId is omitted (regression guard)", async () => {
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === PLUGIN_DB_UUID),
+      call: vi.fn(),
+    } as unknown as PluginWorkerManager;
+
+    const registry = createPluginToolRegistry(workerManager);
+
+    // Simulate the OLD (buggy) behavior: no pluginDbId passed → falls back to pluginKey
+    registry.registerPlugin(PLUGIN_KEY, manifest);
+
+    await expect(
+      registry.executeTool(`${PLUGIN_KEY}:do-thing`, {}, runContext),
+    ).rejects.toThrow(/not running/);
+
+    // isRunning was called with the pluginKey (not UUID), which returned false
+    expect(workerManager.isRunning).toHaveBeenCalledWith(PLUGIN_KEY);
+    expect(workerManager.call).not.toHaveBeenCalled();
+  });
+
+  it("re-registration on reinstall uses the new UUID and tool calls succeed", async () => {
+    const UUID_BEFORE = "00000000-0000-0000-0000-000000000001";
+    const UUID_AFTER = "00000000-0000-0000-0000-000000000002";
+
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === UUID_AFTER),
+      call: vi.fn().mockResolvedValue({ result: "reinstall-ok" }),
+    } as unknown as PluginWorkerManager;
+
+    const registry = createPluginToolRegistry(workerManager);
+
+    // First install with UUID_BEFORE
+    registry.registerPlugin(PLUGIN_KEY, manifest, UUID_BEFORE);
+
+    // Uninstall / unregister
+    registry.unregisterPlugin(PLUGIN_KEY);
+
+    // Reinstall with UUID_AFTER (e.g. hard-delete + fresh install creates new UUID)
+    registry.registerPlugin(PLUGIN_KEY, manifest, UUID_AFTER);
+
+    const result = await registry.executeTool(
+      `${PLUGIN_KEY}:do-thing`,
+      {},
+      runContext,
+    );
+
+    expect(workerManager.isRunning).toHaveBeenCalledWith(UUID_AFTER);
+    expect(result).toMatchObject({ result: { result: "reinstall-ok" } });
+  });
+});

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1678,11 +1678,12 @@ export function pluginLoader(
       // 3. Unregister agent tools
       toolDispatcher.unregisterPluginTools(pluginKey);
 
-      // 4. Stop the worker process
+      // 4. Stop the worker process.
+      // Call stopWorker unconditionally: the manager handles the "not found"
+      // case gracefully, and a worker in crashed/starting/stopping state also
+      // needs its handle removed so a subsequent startWorker call succeeds.
       try {
-        if (workerManager.isRunning(pluginId)) {
-          await workerManager.stopWorker(pluginId);
-        }
+        await workerManager.stopWorker(pluginId);
       } catch (err) {
         log.warn(
           { pluginId, err: err instanceof Error ? err.message : String(err) },
@@ -1904,7 +1905,8 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        // Pass pluginId (DB UUID) so tools resolve correctly in isRunning() checks.
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,16 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's unique identifier (pluginKey string)
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - The plugin's database UUID, used for worker routing.
+   *   When omitted, falls back to `pluginId`. Always supply this to ensure
+   *   `workerManager.isRunning(pluginDbId)` resolves correctly.
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId?: string,
   ): void;
 
   /**
@@ -429,8 +433,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId?: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents via plugin workers communicating over JSON-RPC
> - The plugin tool dispatcher routes `tools/execute` calls through `plugin-tool-registry`, which stores a `pluginDbId` per tool for `workerManager.isRunning()` lookups
> - `workerManager.isRunning(id)` checks the in-memory `workers` map, which is keyed by **DB UUID**
> - `activatePlugin` called `registerPluginTools(pluginKey, manifest)` without passing the DB UUID — so tools were stored with `pluginDbId = pluginKey` (the string key like `"acme.foo"`)
> - `isRunning("acme.foo")` always returned `false` because the workers map has no such entry — only the UUID key — producing a 502 on every `tools/execute` call after reinstall
> - A second issue: `unloadSingle` only called `stopWorker` when `isRunning` was true, leaving crashed/starting/stopping worker handles in the map; `startWorker` would throw "already registered" on the next activate
> - This PR fixes both: pass the DB UUID to `registerPluginTools`, and call `stopWorker` unconditionally in `unloadSingle`

## What Changed

- `server/src/services/plugin-tool-dispatcher.ts`: Add optional `pluginDbId` parameter to `registerPluginTools` interface and implementation; forward it to `registry.registerPlugin`
- `server/src/services/plugin-loader.ts` (`activatePlugin`): Pass `pluginId` (DB UUID) as third argument to `registerPluginTools` so tools store the correct lookup key
- `server/src/services/plugin-loader.ts` (`unloadSingle`): Replace `if (isRunning) stopWorker` with unconditional `stopWorker` call; the manager already handles "not found" gracefully, and crashed/starting handles must also be evicted
- `server/src/__tests__/plugin-tool-registry-reinstall.test.ts`: New regression tests — with UUID → execute succeeds; without UUID → execute throws "not running"; unregister + re-register with new UUID → execute succeeds (hard-delete + reinstall path)

## Verification

```sh
cd server
pnpm exec vitest run src/__tests__/plugin-tool-registry-reinstall.test.ts  # 3 new tests pass
pnpm exec vitest run src/__tests__/plugin-worker-manager.test.ts src/__tests__/plugin-scoped-api-routes.test.ts src/__tests__/plugin-routes-authz.test.ts src/__tests__/plugin-database.test.ts src/__tests__/heartbeat-plugin-environment.test.ts src/__tests__/environment-runtime.test.ts  # 62 existing tests pass
pnpm exec tsc --noEmit  # clean
```

## Risks

- `registerPluginTools` gains an optional third parameter — all existing callers that omit it continue to work (falls back to `pluginId`). The only call that changes behaviour is in `activatePlugin` which now passes the UUID it already has in scope.
- Unconditional `stopWorker` in `unloadSingle` is safe: `stopWorker` logs a warning and returns immediately when no handle exists; `stopInternal` returns immediately when process is already gone (null childProcess after crash).
- Low risk overall: changes are additive to the public interface and fix a consistent failure mode.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6
- Tool use: yes (file reads, bash, edit)
- Context: 200k

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge