### PR TITLE
feat(productivity-review): label-based exemption for long-running issues

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -20,11 +20,13 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueLabels,
   issueRelations,
   issueTreeHoldMembers,
   issueTreeHolds,
   issueWorkProducts,
   issues,
+  labels,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -2441,6 +2443,36 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const wakes = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
     expect(wakes.some((row) => row.reason === "run_liveness_continuation")).toBe(false);
   });
+  it("skips stranded recovery on candidate issues tagged with a long-running exemption label", async () => {
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    const labelId = randomUUID();
+    await db.insert(labels).values({
+      id: labelId,
+      companyId,
+      name: "monthly-audit",
+      color: "#0bf",
+    });
+    await db.insert(issueLabels).values({ issueId, labelId, companyId });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    const recoveries = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveries).toHaveLength(0);
+  });
+
   it("blocks stranded in-progress work after the continuation retry was already used", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -8,7 +8,9 @@ import {
   createDb,
   heartbeatRuns,
   issueComments,
+  issueLabels,
   issues,
+  labels,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -358,6 +360,66 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(review?.description).toContain("Primary trigger: `long_active_duration`");
     expect(review?.priority).toBe("medium");
     expect(hold.held).toBe(false);
+  });
+
+  it.each([
+    ["long-running-by-design"],
+    ["monthly-audit"],
+  ])("skips long-active candidate issues tagged with the %s exemption label", async (labelName) => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    const labelId = randomUUID();
+    await db.insert(labels).values({
+      id: labelId,
+      companyId: seeded.companyId,
+      name: labelName,
+      color: "#888",
+    });
+    await db.insert(issueLabels).values({
+      issueId: seeded.issueId,
+      labelId,
+      companyId: seeded.companyId,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.scanned).toBe(0);
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("still scans candidate issues whose label does not match the exemption set", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    const labelId = randomUUID();
+    await db.insert(labels).values({
+      id: labelId,
+      companyId: seeded.companyId,
+      name: "important",
+      color: "#f00",
+    });
+    await db.insert(issueLabels).values({
+      issueId: seeded.issueId,
+      labelId,
+      companyId: seeded.companyId,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.created).toBe(1);
   });
 
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -7,7 +7,9 @@ import {
   costEvents,
   heartbeatRuns,
   issueComments,
+  issueLabels,
   issues,
+  labels,
   projects,
 } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
@@ -37,6 +39,25 @@ const MAX_CANDIDATE_ISSUES = 250;
 const MAX_RUNS_FOR_STREAK = 100;
 const MAX_PARENT_WALK_DEPTH = 25;
 export const PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX = "Productivity review evidence refreshed.";
+
+// Label names that exempt an issue from automatic scanners that would otherwise
+// fire on intentionally long-running issues (monthly audit logs, weekly soak
+// umbrellas, etc.). Applies to both `reconcileProductivityReviews` and the
+// stranded-issue recovery scanner in `services/recovery/service.ts`.
+export const LONG_RUNNING_EXEMPT_LABEL_NAMES = [
+  "long-running-by-design",
+  "monthly-audit",
+] as const;
+
+export function longRunningExemptLabelNotExistsClause() {
+  return sql`not exists (
+    select 1
+    from ${issueLabels}
+    inner join ${labels} on ${labels.id} = ${issueLabels.labelId}
+    where ${issueLabels.issueId} = ${issues.id}
+      and ${labels.name} in (${sql.join(LONG_RUNNING_EXEMPT_LABEL_NAMES.map((name) => sql`${name}`), sql`, `)})
+  )`;
+}
 
 type IssueRow = typeof issues.$inferSelect;
 type AgentRow = typeof agents.$inferSelect;
@@ -776,6 +797,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           inArray(issues.status, ["todo", "in_progress"]),
           sql`${issues.assigneeAgentId} is not null`,
           sql`${issues.originKind} <> ${PRODUCTIVITY_REVIEW_ORIGIN_KIND}`,
+          longRunningExemptLabelNotExistsClause(),
         ),
       )
       .orderBy(asc(issues.updatedAt), asc(issues.id))

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -31,6 +31,7 @@ import { budgetService } from "../budgets.js";
 import { instanceSettingsService } from "../instance-settings.js";
 import { issueTreeControlService } from "../issue-tree-control.js";
 import { issueService } from "../issues.js";
+import { longRunningExemptLabelNotExistsClause } from "../productivity-review.js";
 import { getRunLogStore } from "../run-log-store.js";
 import {
   DEFAULT_MAX_SUCCESSFUL_RUN_HANDOFF_ATTEMPTS,
@@ -1790,6 +1791,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           isNull(issues.assigneeUserId),
           inArray(issues.status, ["todo", "in_progress"]),
           sql`${issues.assigneeAgentId} is not null`,
+          longRunningExemptLabelNotExistsClause(),
         ),
       );
 


### PR DESCRIPTION
## Summary

Adds a label-based exemption for the productivity-review and stranded-issue-recovery scanners so issues that are **intentionally** long-running (monthly audit logs, weekly Ops/Delivery soak umbrellas, etc.) stop generating false-positive review and recovery cascade tickets.

- Issues tagged with **`long-running-by-design`** or **`monthly-audit`** are now skipped by both:
  - \`reconcileProductivityReviews\` in \`server/src/services/productivity-review.ts\` (\`long_active_duration\` / \`no_comment_streak\` / \`high_churn\` triggers)
  - \`reconcileStrandedAssignedIssues\` in \`server/src/services/recovery/service.ts\` (\`blocker_attention_open_recovery\` / \`stranded_issue_recovery\` path)
- Implemented as a shared SQL fragment (\`longRunningExemptLabelNotExistsClause\`) so the candidate-selection queries stay in lockstep. The exempt label set lives in a single exported constant (\`LONG_RUNNING_EXEMPT_LABEL_NAMES\`).
- Untagged issues are unchanged.

## Why

Productivity-review scanners assume \`> threshold\` time in \`in_progress\` is a signal of stalled work. For intentionally month- or week-scoped tracking issues (e.g. an EOS Slack audit log appended to every weekday for a calendar month, or a weekly Ops/Delivery rollup umbrella), the scanner fires every ~6h, generating ~10–15 false-positive review/recovery cascade tickets per umbrella per day. Each false positive consumes a heartbeat budget on the assigned agent.

Originating internal ticket: BLU-6155 (board-routed platform FR). Option 2 (label-based exemption) was selected for simplicity and generality — it doesn't require new schema fields or per-issue overrides.

## Implementation notes

- Reserved label names (\`long-running-by-design\`, \`monthly-audit\`) are configurable via the \`LONG_RUNNING_EXEMPT_LABEL_NAMES\` constant if you want to add more.
- The exemption is opt-in: nothing changes for any existing issue until somebody attaches one of the reserved labels.
- No DB migrations — uses existing \`labels\` / \`issue_labels\` tables.
- Same filter is added at both candidate-selection sites; the scanners' downstream logic is untouched.

## Test plan

- [x] \`pnpm --filter=@paperclipai/server exec vitest run src/__tests__/productivity-review-service.test.ts src/__tests__/heartbeat-process-recovery.test.ts\` — 59 passed (2 new productivity tests + 1 new recovery test + 56 existing).
- [x] \`pnpm exec tsc --noEmit\` (server package, after \`pnpm -r build\` for shared/db/plugin-sdk) — 0 errors in changed files.
- Manual: applied label \`monthly-audit\` to a long-soak fixture issue and re-ran reconciliation — scanner reports \`scanned: 0\`, no review created. Removing the label restores the normal trigger path.

Co-Authored-By: Cosmo Paperclip <cosmo@blueorange.digital>