### PR TITLE
fix(BLU-6939): concurrency_policy covers open issues without a live heartbeat

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -218,7 +218,12 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(allRoutines.map((entry) => entry.id)).toEqual(expect.arrayContaining([routine.id, otherRoutine.id]));
   });
 
-  it("creates a fresh execution issue when the previous routine issue is open but idle", async () => {
+  it("coalesces against the previous routine issue when it is open but idle (BLU-6939)", async () => {
+    // coalesce_if_active must consider any open routine_execution issue, not
+    // just ones that currently have a live heartbeat. Routines that gate on
+    // HITL approval commonly leave the prior issue parked in `todo`/`blocked`
+    // between heartbeats; before this fix every subsequent fire created a
+    // new duplicate issue and the policy was silently bypassed.
     const { companyId, issueSvc, routine, svc } = await seedFixture();
     const previousRunId = randomUUID();
     const previousIssue = await issueSvc.create(companyId, {
@@ -245,12 +250,17 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       completedAt: new Date("2026-03-20T12:00:00.000Z"),
     });
 
+    // getDetail still reflects the live-heartbeat semantic for the UI
+    // `activeIssue` field — no live run here, so it is null. The concurrency
+    // policy uses the broader open-issue check, so the run below still
+    // coalesces.
     const detailBefore = await svc.getDetail(routine.id);
     expect(detailBefore?.activeIssue).toBeNull();
 
     const run = await svc.runRoutine(routine.id, { source: "manual" });
-    expect(run.status).toBe("issue_created");
-    expect(run.linkedIssueId).not.toBe(previousIssue.id);
+    expect(run.status).toBe("coalesced");
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+    expect(run.coalescedIntoRunId).toBe(previousRunId);
 
     const routineIssues = await db
       .select({
@@ -260,9 +270,52 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       .from(issues)
       .where(eq(issues.originId, routine.id));
 
-    expect(routineIssues).toHaveLength(2);
-    expect(routineIssues.map((issue) => issue.id)).toContain(previousIssue.id);
-    expect(routineIssues.map((issue) => issue.id)).toContain(run.linkedIssueId);
+    expect(routineIssues).toHaveLength(1);
+    expect(routineIssues[0]?.id).toBe(previousIssue.id);
+  });
+
+  it("skips when the previous routine issue is open but idle under skip_if_active (BLU-6939)", async () => {
+    const { companyId, issueSvc, routine, svc } = await seedFixture();
+    await db
+      .update(routines)
+      .set({ concurrencyPolicy: "skip_if_active" })
+      .where(eq(routines.id, routine.id));
+
+    const previousRunId = randomUUID();
+    const previousIssue = await issueSvc.create(companyId, {
+      projectId: routine.projectId,
+      title: routine.title,
+      description: routine.description,
+      status: "blocked",
+      priority: routine.priority,
+      assigneeAgentId: routine.assigneeAgentId,
+      originKind: "routine_execution",
+      originId: routine.id,
+      originRunId: previousRunId,
+    });
+
+    await db.insert(routineRuns).values({
+      id: previousRunId,
+      companyId,
+      routineId: routine.id,
+      triggerId: null,
+      source: "manual",
+      status: "issue_created",
+      triggeredAt: new Date("2026-03-20T12:00:00.000Z"),
+      linkedIssueId: previousIssue.id,
+      completedAt: new Date("2026-03-20T12:00:00.000Z"),
+    });
+
+    const run = await svc.runRoutine(routine.id, { source: "manual" });
+    expect(run.status).toBe("skipped");
+    expect(run.linkedIssueId).toBe(previousIssue.id);
+
+    const routineIssues = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.originId, routine.id));
+    expect(routineIssues).toHaveLength(1);
+    expect(routineIssues[0]?.id).toBe(previousIssue.id);
   });
 
   it("creates draft routines without a project or default assignee", async () => {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -937,6 +937,38 @@ export function routineService(
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  // Like findLiveExecutionIssue, but matches any open routine-execution issue
+  // regardless of whether a heartbeat run is currently live. Used to enforce
+  // concurrency_policy semantics (skip_if_active / coalesce_if_active) — those
+  // policies must catch open issues that are between heartbeats, e.g. parked
+  // in `blocked` waiting for HITL approval (BLU-6939).
+  async function findOpenExecutionIssue(
+    routine: typeof routines.$inferSelect,
+    executor: Db = db,
+    dispatchFingerprint?: string | null,
+    origin?: { kind: string; id: string | null },
+  ) {
+    const fingerprintCondition = routineExecutionFingerprintCondition(dispatchFingerprint);
+    const originKind = origin?.kind ?? "routine_execution";
+    const originId = origin?.id ?? routine.id;
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, originKind),
+          eq(issues.originId, originId),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+          ...(fingerprintCondition ? [fingerprintCondition] : []),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -1192,7 +1224,12 @@ export function routineService(
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
-        const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
+        // Concurrency policy must consider any open routine_execution issue,
+        // not just ones with a currently-live heartbeat. Routines that gate on
+        // HITL approval can leave the prior execution issue parked in `blocked`
+        // between heartbeats; the policy is meant to coalesce/skip against
+        // those too. See BLU-6939.
+        const activeIssue = await findOpenExecutionIssue(input.routine, txDb, dispatchFingerprint, {
           kind: issueOriginKind,
           id: issueOriginId,
         });
@@ -1256,7 +1293,10 @@ export function routineService(
             throw error;
           }
 
-          const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
+          // Same broader semantics as the pre-insert check above — match any
+          // open routine_execution issue, including ones with no live heartbeat
+          // (BLU-6939).
+          const existingIssue = await findOpenExecutionIssue(input.routine, txDb, dispatchFingerprint, {
             kind: issueOriginKind,
             id: issueOriginId,
           });


### PR DESCRIPTION
## Summary

Routine `concurrency_policy` (`skip_if_active` / `coalesce_if_active`) was silently bypassed for any routine whose execution issue persists in `blocked` / `in_progress` between heartbeats — because the policy check inner-joined `heartbeatRuns` and required a live run.

Production evidence (2026-05-10 audit):

- **Social Media Posting** (`coalesce_if_active`, fires 3×/day): 23 open execution tickets in 10 days for a single HITL-gated routine.
- **Inbound Lead Qualification** (`skip_if_active`, fires 3×/business day): 10 open execution tickets in 9 days under the same fingerprint.

## Fix

Option A from the ticket: split the helper into two functions with distinct semantics, route each call site to the appropriate one.

- `findLiveExecutionIssue` (existing) — *issues with a currently-running heartbeat*. Unchanged. Still used for the UI `activeIssue` field on the routine detail response (line 1530).
- `findOpenExecutionIssue` (new) — *any open routine_execution issue regardless of heartbeat liveness*. Used at the two policy-enforcement sites in `dispatchRoutineRun`:
  - pre-insert concurrency check (routines.ts:1232)
  - post-insert conflict-recovery path triggered by `issues_open_routine_execution_uq` (routines.ts:1299)

## Tests

- The regression at line 221 (`creates a fresh execution issue when the previous routine issue is open but idle`) was literally codifying the buggy behavior. Flipped to assert `coalesced` against the open-idle issue + only one routine issue exists after. Renamed accordingly.
- Added a parallel test for `skip_if_active` per the ticket's acceptance criterion 2.

\`\`\`
✓ server/src/__tests__/routines-service.test.ts (33 tests)        5.8s
✓ server/src/__tests__/routines-e2e.test.ts (4 tests)            10.0s
✓ server/src/__tests__/routines-routes.test.ts (13 tests)         1.2s
✓ server/src/__tests__/plugin-managed-routines.test.ts (3 tests)  3.6s
✓ server/src/__tests__/routine-run-telemetry.test.ts (1 test)     3.0s
pnpm tsc --noEmit  ✓ clean
\`\`\`

## Out of scope (deliberate, per ticket)

- The partial unique index \`issues_open_routine_execution_uq\` still gates on \`execution_run_id IS NOT NULL\`. Tightening that predicate is belt-and-suspenders for a rare cross-tx race; ticket lists it as "may want to" and the JS check above is the primary correctness fix. Leaving as a follow-up.
- UI \`activeIssue\` field semantics. The renamed-test comment makes the dual-meaning explicit (UI shows live-heartbeat only; policy uses broader open-issue check). Any UI display improvement is separate scope.

## Test plan

- [x] New BLU-6939 regression tests pass (coalesce + skip for open-idle previous issue).
- [x] Existing `coalesces only when the existing routine issue has a live execution run` continues to pass — live-heartbeat path is unchanged.
- [x] Existing `does not coalesce live routine runs with different resolved variables` continues to pass — fingerprint discrimination is preserved (same WHERE filter shape).
- [x] E2E + telemetry + routes + plugin-managed all green.
- [ ] Once merged, confirm Social Media Posting routine stops creating duplicate execution issues (currently mitigated via prompt-side consolidation per the 2026-05-10 ops audit).

## Notes

- This is Super Dev's first PR against the Paperclip control-plane repo. Routing direction was given by Head of Product on the ticket; a board-approval request for permanent scope expansion is still open (\`2361bb2f-adb1-471e-8727-b36008ece26b\`) and not blocking this fix.
- 100% surgical: 2 files changed, +101/-8 lines. No refactoring of adjacent code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)