### PR TITLE
Add Cloudflare sandbox provider plugin

### DIFF
--- a/packages/adapter-utils/src/command-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/command-managed-runtime.test.ts
@@ -132,7 +132,7 @@ describe("command managed runtime", () => {
     expect(calls.every((call) => call.stdin == null)).toBe(true);
   });
 
-  it("runs setup commands from the existing sandbox cwd when staging into a nested remote workspace dir", async () => {
+  it("runs setup commands from a stable root cwd when staging into a nested remote workspace dir", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-command-runtime-nested-"));
     cleanupDirs.push(rootDir);
 
@@ -214,7 +214,7 @@ describe("command managed runtime", () => {
     });
 
     expect(calls.length).toBeGreaterThan(0);
-    expect(calls.every((call) => call.cwd === remoteBaseDir)).toBe(true);
+    expect(calls.every((call) => call.cwd === "/")).toBe(true);
     await expect(readFile(path.join(remoteWorkspaceDir, "README.md"), "utf8")).resolves.toBe("local workspace\n");
   });
 });

--- a/packages/adapter-utils/src/command-managed-runtime.ts
+++ b/packages/adapter-utils/src/command-managed-runtime.ts
@@ -149,7 +149,10 @@ export async function prepareCommandManagedRuntime(input: {
 }): Promise<PreparedSandboxManagedRuntime> {
   const timeoutMs = input.spec.timeoutMs && input.spec.timeoutMs > 0 ? input.spec.timeoutMs : 300_000;
   const workspaceRemoteDir = input.workspaceRemoteDir ?? input.spec.remoteCwd;
-  const commandCwd = input.spec.remoteCwd;
+  // Managed-runtime sync/restore scripts use absolute paths throughout, so
+  // run them from a stable cwd. The target workspace itself may be removed or
+  // recreated during a run, which breaks shell startup if we chdir into it.
+  const commandCwd = "/";
   const runtimeSpec: SandboxRemoteExecutionSpec = {
     transport: "sandbox",
     provider: input.spec.providerKey ?? "sandbox",

--- a/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promis
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { prepareCommandManagedRuntime } from "./command-managed-runtime.js";
 import {
@@ -951,5 +951,33 @@ describe("sandbox callback bridge", () => {
         `Route not allowed: ${request.method} ${request.path}`,
       );
     }
+  });
+
+  it("marks command-managed bridge operations with the bridge execution channel", async () => {
+    const runner = {
+      execute: vi.fn(async () => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+        pid: null,
+        startedAt: new Date().toISOString(),
+      })),
+    };
+
+    const client = createCommandManagedSandboxCallbackBridgeQueueClient({
+      runner,
+      remoteCwd: "/workspace",
+      timeoutMs: 30_000,
+    });
+
+    await client.makeDir("/workspace/.paperclip-runtime/codex/paperclip-bridge/queue");
+
+    expect(runner.execute).toHaveBeenCalledWith(expect.objectContaining({
+      env: {
+        PAPERCLIP_SANDBOX_EXEC_CHANNEL: "bridge",
+      },
+    }));
   });
 });

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -15,6 +15,8 @@ const DEFAULT_BRIDGE_MAX_QUEUE_DEPTH = 64;
 const DEFAULT_BRIDGE_MAX_BODY_BYTES = 256 * 1024;
 const REMOTE_WRITE_BASE64_CHUNK_SIZE = 32 * 1024;
 const SANDBOX_CALLBACK_BRIDGE_ENTRYPOINT = "paperclip-bridge-server.mjs";
+const SANDBOX_EXEC_CHANNEL_ENV = "PAPERCLIP_SANDBOX_EXEC_CHANNEL";
+const SANDBOX_EXEC_CHANNEL_BRIDGE = "bridge";
 
 export const DEFAULT_SANDBOX_CALLBACK_BRIDGE_MAX_BODY_BYTES = DEFAULT_BRIDGE_MAX_BODY_BYTES;
 
@@ -209,6 +211,9 @@ async function runShell(
     command: shellCommand,
     args: shellCommandArgs(script),
     cwd,
+    env: {
+      [SANDBOX_EXEC_CHANNEL_ENV]: SANDBOX_EXEC_CHANNEL_BRIDGE,
+    },
     timeoutMs,
     stdin,
   });
@@ -918,6 +923,9 @@ export async function startSandboxCallbackBridgeServer(input: {
       ].join("\n"),
     ),
     cwd: input.remoteCwd,
+    env: {
+      [SANDBOX_EXEC_CHANNEL_ENV]: SANDBOX_EXEC_CHANNEL_BRIDGE,
+    },
     timeoutMs,
   });
   requireSuccessfulResult("start sandbox callback bridge", startResult);
@@ -993,6 +1001,9 @@ export async function startSandboxCallbackBridgeServer(input: {
           ].join("\n"),
         ),
         cwd: input.remoteCwd,
+        env: {
+          [SANDBOX_EXEC_CHANNEL_ENV]: SANDBOX_EXEC_CHANNEL_BRIDGE,
+        },
         timeoutMs,
       });
       if (stopResult.timedOut) {

--- a/packages/plugins/sandbox-providers/cloudflare/README.md
+++ b/packages/plugins/sandbox-providers/cloudflare/README.md
@@ -1,0 +1,48 @@
+# `@paperclipai/plugin-cloudflare-sandbox`
+
+Published Cloudflare sandbox provider plugin for Paperclip.
+
+This package lives in the Paperclip monorepo, but it is intentionally excluded from the root `pnpm` workspace and shaped to publish and install like a standalone npm package. Operators can install it from the Plugins page by package name, and the host will fetch its dependencies at install time without adding lockfile churn to the Paperclip repo.
+
+## Install
+
+From a Paperclip instance, install:
+
+```text
+@paperclipai/plugin-cloudflare-sandbox
+```
+
+Configure Cloudflare from `Company Settings -> Environments`, not from the plugin's instance settings page.
+
+## Configuration
+
+The environment uses core `driver: "sandbox"` with `provider: "cloudflare"`.
+
+Required fields:
+
+- `bridgeBaseUrl`
+- `bridgeAuthToken`
+
+Important validation rules:
+
+- `reuseLease: true` requires `keepAlive: true`
+- non-local `bridgeBaseUrl` values must be `https://`
+- `sessionId` is required when `sessionStrategy` is `named`
+
+Pasted auth tokens are stored by Paperclip as company secrets because the manifest marks `bridgeAuthToken` as a `secret-ref` field.
+
+## Bridge template
+
+The package includes an operator-facing Cloudflare Worker scaffold under [bridge-template](./bridge-template). That template uses `@cloudflare/sandbox`, a `Sandbox` Durable Object binding, and a small JSON HTTP surface under `/api/paperclip-sandbox/v1`.
+
+## Local development
+
+```bash
+cd packages/plugins/sandbox-providers/cloudflare
+pnpm install --ignore-workspace --no-lockfile
+pnpm build
+pnpm test
+pnpm typecheck
+```
+
+These commands assume the repo root has already been installed once so the local `@paperclipai/plugin-sdk` workspace package is available to the compiler during development.

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/Dockerfile
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/Dockerfile
@@ -1,0 +1,14 @@
+FROM docker.io/cloudflare/sandbox:0.7.0
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    coreutils \
+    curl \
+    findutils \
+    git \
+    tar \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/README.md
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/README.md
@@ -1,0 +1,50 @@
+# Cloudflare Sandbox Bridge Template
+
+This Worker is the operator-facing bridge used by `@paperclipai/plugin-cloudflare-sandbox`.
+
+It exposes a small authenticated JSON API under `/api/paperclip-sandbox/v1` and translates Paperclip lease and command requests into Cloudflare Sandbox SDK calls.
+
+## What it does
+
+- health and probe
+- acquire, resume, release, and destroy leases
+- execute commands in a sandbox session
+- clean up timed-out sessions so Paperclip does not inherit wedged background processes
+
+## Prerequisites
+
+1. Cloudflare account with Sandbox / Containers access
+2. `wrangler` configured for that account
+3. Docker running locally for `wrangler deploy`
+4. A bridge auth token set as a Worker secret:
+
+```bash
+npx wrangler secret put BRIDGE_AUTH_TOKEN
+```
+
+## Local development
+
+```bash
+cd bridge-template
+pnpm install --ignore-workspace --no-lockfile
+pnpm test
+pnpm typecheck
+pnpm dev
+```
+
+## Deploy
+
+```bash
+pnpm deploy
+```
+
+After deploy, configure Paperclip with:
+
+- `bridgeBaseUrl`: your Worker URL
+- `bridgeAuthToken`: the same bearer token value stored in `BRIDGE_AUTH_TOKEN`
+
+## Notes
+
+- `reuseLease: true` should only be used together with `keepAlive: true`
+- `.workers.dev` is fine for bridge HTTP traffic, but preview/wildcard host flows are intentionally out of scope here
+- keep the Docker image aligned with the installed `@cloudflare/sandbox` version

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/package.json
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "paperclip-cloudflare-sandbox-bridge-template",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "@cloudflare/sandbox": "^0.7.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260501.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4",
+    "wrangler": "^4.15.0"
+  }
+}

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/auth.test.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/auth.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isAuthorizedRequest, readBearerToken } from "./auth.js";
+
+describe("bridge auth", () => {
+  it("extracts bearer tokens from Authorization headers", () => {
+    const request = new Request("https://bridge.example.test", {
+      headers: { Authorization: "Bearer secret-token" },
+    });
+    expect(readBearerToken(request)).toBe("secret-token");
+  });
+
+  it("rejects mismatched tokens", async () => {
+    const request = new Request("https://bridge.example.test", {
+      headers: { Authorization: "Bearer wrong-token" },
+    });
+    await expect(isAuthorizedRequest(request, "expected-token")).resolves.toBe(false);
+  });
+
+  it("accepts matching tokens", async () => {
+    const request = new Request("https://bridge.example.test", {
+      headers: { Authorization: "Bearer expected-token" },
+    });
+    await expect(isAuthorizedRequest(request, "expected-token")).resolves.toBe(true);
+  });
+
+  it("rejects requests without an Authorization header", async () => {
+    const request = new Request("https://bridge.example.test");
+    await expect(isAuthorizedRequest(request, "expected-token")).resolves.toBe(false);
+  });
+});

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/auth.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/auth.ts
@@ -1,0 +1,40 @@
+export function readBearerToken(request: Request): string | null {
+  const header = request.headers.get("Authorization");
+  if (!header) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match?.[1]?.trim() || null;
+}
+
+// Compare two strings in constant time so an attacker can't infer the expected
+// token character-by-character via response-latency timing. We hash both sides
+// to SHA-256 first so the byte-by-byte comparison length is fixed (and doesn't
+// leak the token's length), then walk the buffers with a constant-time XOR
+// reduction. This avoids `crypto.subtle.timingSafeEqual` because that helper
+// is not portable: it exists on Cloudflare Workers but is missing from Node's
+// `crypto.subtle` (which would break unit tests). The manual XOR reduction on
+// a fixed-length hash output is the same algorithm the helper uses internally.
+async function timingSafeStringEqual(a: string, b: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const [aHashBuf, bHashBuf] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(a)),
+    crypto.subtle.digest("SHA-256", encoder.encode(b)),
+  ]);
+  const aBytes = new Uint8Array(aHashBuf);
+  const bBytes = new Uint8Array(bHashBuf);
+  if (aBytes.length !== bBytes.length) return false;
+  let diff = 0;
+  for (let i = 0; i < aBytes.length; i++) {
+    diff |= aBytes[i] ^ bBytes[i];
+  }
+  return diff === 0;
+}
+
+export async function isAuthorizedRequest(
+  request: Request,
+  expectedToken: string | undefined,
+): Promise<boolean> {
+  if (!expectedToken || expectedToken.trim().length === 0) return false;
+  const presented = readBearerToken(request);
+  if (!presented) return false;
+  return timingSafeStringEqual(presented, expectedToken);
+}

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.test.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@cloudflare/sandbox", () => ({
+  getSandbox: vi.fn(),
+}));
+
+import { buildLoginShellScript, executeInSandbox } from "./exec.js";
+
+describe("bridge exec", () => {
+  it("invokes target.exec with a single shell command string and no args option", async () => {
+    const exec = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      stdout: "claude 1.0.0\n",
+      stderr: "",
+    });
+    const sandbox = {
+      getSession: vi.fn().mockResolvedValue({ exec }),
+      writeFile: vi.fn(),
+      deleteFile: vi.fn(),
+    } as const;
+
+    await executeInSandbox({
+      sandbox: sandbox as never,
+      command: "claude",
+      args: ["--version"],
+      cwd: "/workspace/paperclip",
+      env: { PAPERCLIP_TEST_FLAG: "1" },
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+      timeoutMs: 12_345,
+    });
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    const [commandArg, optionsArg] = exec.mock.calls[0] ?? [];
+    expect(typeof commandArg).toBe("string");
+    expect(commandArg).toMatch(/^sh -lc /);
+    expect(optionsArg).toEqual({ cwd: "/", timeout: 12_345 });
+    expect(optionsArg).not.toHaveProperty("args");
+    expect(optionsArg).not.toHaveProperty("stdin");
+    expect(commandArg).toContain('. /etc/profile');
+    expect(commandArg).toContain("cd ");
+    expect(commandArg).toContain("/workspace/paperclip");
+    expect(commandArg).toContain("PAPERCLIP_TEST_FLAG");
+    expect(commandArg).toContain("claude");
+    expect(commandArg).toContain("--version");
+  });
+
+  it("requests streaming callbacks when bridge output forwarding is enabled", async () => {
+    const exec = vi.fn().mockImplementation(async (_command, options) => {
+      await options?.onOutput?.("stdout", "hello\n");
+      return {
+        exitCode: 0,
+        stdout: "hello\n",
+        stderr: "",
+      };
+    });
+    const sandbox = {
+      getSession: vi.fn().mockResolvedValue({ exec }),
+      writeFile: vi.fn(),
+      deleteFile: vi.fn(),
+    } as const;
+    const onOutput = vi.fn();
+
+    await executeInSandbox({
+      sandbox: sandbox as never,
+      command: "echo",
+      args: ["hello"],
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+      timeoutMs: 5_000,
+      onOutput,
+    });
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec.mock.calls[0]?.[1]).toMatchObject({
+      cwd: "/",
+      timeout: 5_000,
+      stream: true,
+      onOutput: expect.any(Function),
+    });
+    expect(onOutput).toHaveBeenCalledWith("stdout", "hello\n");
+  });
+
+  it("stages stdin through a sandbox temp file and redirects from it", async () => {
+    const exec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const writeFile = vi.fn().mockResolvedValue(undefined);
+    const deleteFile = vi.fn().mockResolvedValue(undefined);
+    // sessionStrategy: "default" routes through the sandbox itself (no
+    // getSession wrapper), so exec must live directly on the sandbox.
+    const sandbox = {
+      exec,
+      getSession: vi.fn(),
+      writeFile,
+      deleteFile,
+    } as const;
+
+    await executeInSandbox({
+      sandbox: sandbox as never,
+      command: "cat",
+      args: [],
+      sessionStrategy: "default",
+      timeoutMs: 5_000,
+      stdin: "payload-bytes",
+    });
+
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    const [stdinPath, stdinPayload] = writeFile.mock.calls[0] ?? [];
+    expect(typeof stdinPath).toBe("string");
+    expect(stdinPath).toMatch(/^\/tmp\/\.paperclip-bridge-stdin-/);
+    expect(stdinPayload).toBe("payload-bytes");
+
+    const commandArg = exec.mock.calls[0]?.[0];
+    expect(commandArg).toContain(stdinPath);
+    expect(commandArg).toMatch(/<\s*['"]/);
+
+    expect(deleteFile).toHaveBeenCalledWith(stdinPath);
+  });
+
+  it("does not write a stdin file or redirect when stdin is empty", async () => {
+    const exec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const writeFile = vi.fn();
+    const deleteFile = vi.fn();
+    const sandbox = {
+      getSession: vi.fn().mockResolvedValue({ exec }),
+      writeFile,
+      deleteFile,
+    } as const;
+
+    await executeInSandbox({
+      sandbox: sandbox as never,
+      command: "pwd",
+      sessionStrategy: "named",
+      sessionId: "paperclip",
+      timeoutMs: 5_000,
+      stdin: null,
+    });
+
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(deleteFile).not.toHaveBeenCalled();
+    const commandArg = exec.mock.calls[0]?.[0];
+    expect(commandArg).not.toContain("<");
+  });
+
+  it("rejects invalid environment variable keys in the login-shell wrapper", () => {
+    expect(() => buildLoginShellScript({
+      command: "pwd",
+      args: [],
+      env: { "bad-key": "1" },
+    })).toThrow("Invalid sandbox environment variable key: bad-key");
+  });
+});

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/exec.ts
@@ -1,0 +1,147 @@
+import type { Sandbox as CloudflareSandbox } from "@cloudflare/sandbox";
+import { shellQuote } from "./helpers.js";
+import { isTimeoutError } from "./sandboxes.js";
+import { cleanupTimedOutExecution, resolveExecutionTarget, type SessionStrategy } from "./sessions.js";
+
+export interface BridgeExecuteParams {
+  sandbox: CloudflareSandbox;
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  stdin?: string | null;
+  timeoutMs?: number;
+  sessionStrategy: SessionStrategy;
+  sessionId?: string;
+  onOutput?: (stream: "stdout" | "stderr", data: string) => void | Promise<void>;
+}
+
+function isValidShellEnvKey(value: string): boolean {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}
+
+function randomToken(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (typeof uuid === "string" && uuid.length > 0) return uuid.replace(/[^a-zA-Z0-9-]/g, "");
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function buildLoginShellScript(input: {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  stdinFile?: string | null;
+}): string {
+  const env = input.env ?? {};
+  for (const key of Object.keys(env)) {
+    if (!isValidShellEnvKey(key)) {
+      throw new Error(`Invalid sandbox environment variable key: ${key}`);
+    }
+  }
+
+  const envArgs = Object.entries(env)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .map(([key, value]) => `${key}=${shellQuote(value)}`);
+  const commandParts = [shellQuote(input.command), ...input.args.map(shellQuote)].join(" ");
+  const stdinRedirect = input.stdinFile ? ` < ${shellQuote(input.stdinFile)}` : "";
+  const lines = [
+    'if [ -f /etc/profile ]; then . /etc/profile >/dev/null 2>&1 || true; fi',
+    'if [ -f "$HOME/.profile" ]; then . "$HOME/.profile" >/dev/null 2>&1 || true; fi',
+    'if [ -f "$HOME/.bash_profile" ]; then . "$HOME/.bash_profile" >/dev/null 2>&1 || true; elif [ -f "$HOME/.bashrc" ]; then . "$HOME/.bashrc" >/dev/null 2>&1 || true; fi',
+    'if [ -f "$HOME/.zprofile" ]; then . "$HOME/.zprofile" >/dev/null 2>&1 || true; fi',
+    'export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"',
+    '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" >/dev/null 2>&1 || true',
+  ];
+  if (input.cwd) {
+    lines.push(`cd ${shellQuote(input.cwd)}`);
+  }
+  const execLine = envArgs.length > 0
+    ? `exec env ${envArgs.join(" ")} ${commandParts}${stdinRedirect}`
+    : `exec ${commandParts}${stdinRedirect}`;
+  lines.push(execLine);
+  return lines.join(" && ");
+}
+
+function coerceExecuteResult(result: {
+  success?: boolean;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+}) {
+  return {
+    exitCode:
+      typeof result.exitCode === "number" || result.exitCode === null
+        ? result.exitCode
+        : result.success === false
+          ? 1
+          : 0,
+    signal: null,
+    timedOut: false,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+export async function executeInSandbox(params: BridgeExecuteParams) {
+  // The @cloudflare/sandbox SDK's exec() takes a single command string and a
+  // narrow option set ({ cwd, env, timeout, ... }) — it does not accept `args`
+  // or `stdin`. We compose the full shell command ourselves and stage stdin
+  // through a temp file in the sandbox when the caller provides one.
+  const stdinPayload = typeof params.stdin === "string" && params.stdin.length > 0
+    ? params.stdin
+    : null;
+  const stdinFile = stdinPayload ? `/tmp/.paperclip-bridge-stdin-${randomToken()}` : null;
+
+  if (stdinFile && stdinPayload) {
+    await params.sandbox.writeFile(stdinFile, stdinPayload, { encoding: "utf8" });
+  }
+
+  try {
+    const target = await resolveExecutionTarget(params.sandbox, {
+      sessionStrategy: params.sessionStrategy,
+      sessionId: params.sessionId,
+      cwd: params.cwd,
+      env: params.env,
+      timeoutMs: params.timeoutMs,
+    });
+    const script = buildLoginShellScript({
+      command: params.command,
+      args: params.args ?? [],
+      cwd: params.cwd,
+      env: params.env,
+      stdinFile,
+    });
+    const fullCommand = `sh -lc ${shellQuote(script)}`;
+    const result = await target.exec(fullCommand, {
+      cwd: "/",
+      timeout: params.timeoutMs,
+      ...(typeof params.onOutput === "function"
+        ? {
+            stream: true,
+            onOutput: params.onOutput,
+          }
+        : {}),
+    });
+    return coerceExecuteResult(result);
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      await cleanupTimedOutExecution(params.sandbox, {
+        sessionStrategy: params.sessionStrategy,
+        sessionId: params.sessionId,
+      });
+      return {
+        exitCode: null,
+        signal: null,
+        timedOut: true,
+        stdout: typeof (error as { stdout?: unknown }).stdout === "string" ? (error as { stdout: string }).stdout : "",
+        stderr: `${error instanceof Error ? error.message : String(error)}\n`,
+      };
+    }
+    throw error;
+  } finally {
+    if (stdinFile) {
+      await params.sandbox.deleteFile?.(stdinFile).catch(() => undefined);
+    }
+  }
+}

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/helpers.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/helpers.ts
@@ -1,0 +1,39 @@
+export function normalizeLeaseIdPart(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+export function buildLeaseSandboxId(input: {
+  environmentId: string;
+  runId: string;
+  reuseLease: boolean;
+  normalizeId: boolean;
+  randomId?: string;
+}): string {
+  const base = input.reuseLease
+    ? `pc-env-${input.environmentId}`
+    : `pc-${input.runId}-${input.randomId ?? crypto.randomUUID().slice(0, 8)}`;
+  return input.normalizeId ? normalizeLeaseIdPart(base) : base;
+}
+
+export function buildSentinelPath(remoteCwd: string): string {
+  return `${remoteCwd.replace(/\/+$/, "")}/.paperclip-lease.json`;
+}
+
+export function isTimeoutError(error: unknown): boolean {
+  const name = (error as { name?: string } | null)?.name ?? "";
+  const message = error instanceof Error ? error.message : String(error);
+  return /timeout/i.test(name) || /timed out|timeout/i.test(message);
+}
+
+// Single-quote `value` for safe inclusion in a `sh -c` script. Single
+// quotes inside the value are escaped via the standard `'"'"'` dance.
+// Used by both `routes.ts` and `exec.ts` — keep one copy here so updates
+// (e.g. handling additional shell special characters) stay in sync.
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/index.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/index.ts
@@ -1,0 +1,25 @@
+import { Sandbox } from "@cloudflare/sandbox";
+import { handleBridgeRequest, } from "./routes.js";
+import type { BridgeEnv } from "./sandboxes.js";
+
+export { Sandbox };
+
+export default {
+  async fetch(request: Request, env: BridgeEnv): Promise<Response> {
+    try {
+      return await handleBridgeRequest(request, env);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return new Response(
+        JSON.stringify({
+          error: "internal_error",
+          message,
+        }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+  },
+};

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/routes.test.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/routes.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@cloudflare/sandbox", () => ({
+  getSandbox: vi.fn(),
+}));
+
+import { handleBridgeRequest } from "./routes.js";
+import { resolveSandbox } from "./sandboxes.js";
+
+vi.mock("./sandboxes.js", async () => {
+  const actual = await vi.importActual<typeof import("./sandboxes.js")>("./sandboxes.js");
+  return {
+    ...actual,
+    resolveSandbox: vi.fn(),
+  };
+});
+
+function bridgeRequest(pathname: string, body: unknown): Request {
+  return new Request(`https://bridge.example.test${pathname}`, {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer secret-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("bridge routes", () => {
+  beforeEach(() => {
+    vi.mocked(resolveSandbox).mockReset();
+  });
+
+  it("writes lease sentinels through the named-session exec target", async () => {
+    const sessionExec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const sandbox = {
+      getSession: vi.fn().mockResolvedValue({ exec: sessionExec }),
+      createSession: vi.fn(),
+      writeFile: vi.fn(),
+      deleteFile: vi.fn(),
+      setKeepAlive: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(resolveSandbox).mockResolvedValue(sandbox as never);
+
+    const response = await handleBridgeRequest(
+      bridgeRequest("/api/paperclip-sandbox/v1/leases/acquire", {
+        environmentId: "env-1",
+        runId: "run-1",
+        requestedCwd: "/workspace/paperclip",
+        sessionStrategy: "named",
+        sessionId: "paperclip",
+      }),
+      { BRIDGE_AUTH_TOKEN: "secret-token", Sandbox: {} as never },
+    );
+
+    expect(response.status).toBe(200);
+    // Sentinel write must NOT use sandbox.writeFile (sandbox-level race);
+    // it goes through the same session as the mkdir.
+    expect(sandbox.writeFile).not.toHaveBeenCalled();
+
+    // Both calls use a single command string — the SDK's exec API ignores
+    // any `args` or `stdin` option, so the bridge folds them into the
+    // command line itself.
+    expect(sessionExec).toHaveBeenCalledTimes(2);
+    for (const call of sessionExec.mock.calls) {
+      const [commandArg, optionsArg] = call;
+      expect(typeof commandArg).toBe("string");
+      expect(commandArg).toMatch(/^sh -lc /);
+      expect(optionsArg).toEqual({ cwd: "/", timeout: expect.any(Number) });
+      expect(optionsArg).not.toHaveProperty("args");
+      expect(optionsArg).not.toHaveProperty("stdin");
+    }
+    expect(sessionExec.mock.calls[0]?.[0]).toContain("mkdir");
+    expect(sessionExec.mock.calls[0]?.[0]).toContain("/workspace/paperclip");
+    expect(sessionExec.mock.calls[1]?.[0]).toContain("/workspace/paperclip/.paperclip-lease.json");
+  });
+
+  it("checks lease sentinels through the named-session exec target on resume", async () => {
+    const sessionExec = vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const sandbox = {
+      getSession: vi.fn().mockResolvedValue({ exec: sessionExec }),
+      createSession: vi.fn(),
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      deleteFile: vi.fn(),
+      setKeepAlive: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(resolveSandbox).mockResolvedValue(sandbox as never);
+
+    const response = await handleBridgeRequest(
+      bridgeRequest("/api/paperclip-sandbox/v1/leases/resume", {
+        providerLeaseId: "pc-run-1-abcd1234",
+        requestedCwd: "/workspace/paperclip",
+        sessionStrategy: "named",
+        sessionId: "paperclip",
+      }),
+      { BRIDGE_AUTH_TOKEN: "secret-token", Sandbox: {} as never },
+    );
+
+    expect(response.status).toBe(200);
+    expect(sandbox.readFile).not.toHaveBeenCalled();
+    const [commandArg, optionsArg] = sessionExec.mock.calls[0] ?? [];
+    expect(typeof commandArg).toBe("string");
+    expect(commandArg).toMatch(/^sh -lc /);
+    expect(commandArg).toContain("test -s");
+    expect(commandArg).toContain("/workspace/paperclip/.paperclip-lease.json");
+    expect(optionsArg).toEqual({ cwd: "/", timeout: expect.any(Number) });
+    expect(optionsArg).not.toHaveProperty("args");
+  });
+
+  it("streams exec stdout and completion metadata when requested", async () => {
+    const sessionExec = vi.fn().mockImplementation(async (_command, options) => {
+      await options?.onOutput?.("stdout", "hello\n");
+      return { exitCode: 0, stdout: "hello\n", stderr: "" };
+    });
+    const sandbox = {
+      getSession: vi.fn().mockResolvedValue({ exec: sessionExec }),
+      createSession: vi.fn(),
+      writeFile: vi.fn(),
+      deleteFile: vi.fn(),
+      setKeepAlive: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(resolveSandbox).mockResolvedValue(sandbox as never);
+
+    const response = await handleBridgeRequest(
+      bridgeRequest("/api/paperclip-sandbox/v1/exec", {
+        providerLeaseId: "pc-run-1-abcd1234",
+        command: "echo",
+        args: ["hello"],
+        sessionStrategy: "named",
+        sessionId: "paperclip",
+        streamOutput: true,
+      }),
+      { BRIDGE_AUTH_TOKEN: "secret-token", Sandbox: {} as never },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/event-stream");
+    const body = await response.text();
+    expect(body).toContain("event: stdout");
+    expect(body).toContain("event: complete");
+  });
+});

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/routes.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/routes.ts
@@ -1,0 +1,468 @@
+import type { Sandbox as CloudflareSandbox } from "@cloudflare/sandbox";
+import { isAuthorizedRequest } from "./auth.js";
+import { executeInSandbox } from "./exec.js";
+import { shellQuote } from "./helpers.js";
+import {
+  buildLeaseSandboxId,
+  buildSentinelPath,
+  DEFAULT_REMOTE_CWD,
+  DEFAULT_SESSION_ID,
+  DEFAULT_TIMEOUT_MS,
+  resolveSandbox,
+  applySandboxKeepAlive,
+  toErrorResponse,
+  toJsonResponse,
+  type BridgeEnv,
+} from "./sandboxes.js";
+import type { SessionStrategy } from "./sessions.js";
+
+interface ProbeRequestBody {
+  requestedCwd?: string;
+  keepAlive?: boolean;
+  sleepAfter?: string;
+  normalizeId?: boolean;
+  sessionStrategy?: SessionStrategy;
+  sessionId?: string;
+  timeoutMs?: number;
+}
+
+interface AcquireLeaseRequestBody extends ProbeRequestBody {
+  environmentId?: string;
+  runId?: string;
+  issueId?: string | null;
+  reuseLease?: boolean;
+}
+
+interface ResumeLeaseRequestBody extends ProbeRequestBody {
+  providerLeaseId?: string;
+}
+
+interface ReleaseLeaseRequestBody {
+  providerLeaseId?: string;
+  reuseLease?: boolean;
+  keepAlive?: boolean;
+}
+
+interface ExecuteRequestBody {
+  providerLeaseId?: string;
+  command?: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  stdin?: string | null;
+  timeoutMs?: number;
+  streamOutput?: boolean;
+  sessionStrategy?: SessionStrategy;
+  sessionId?: string;
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return value === undefined ? fallback : value === true;
+}
+
+function readString(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function readInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : fallback;
+}
+
+function readSessionStrategy(value: unknown): SessionStrategy {
+  return value === "default" ? "default" : "named";
+}
+
+async function readJson<T>(request: Request): Promise<T> {
+  return await request.json() as T;
+}
+
+function encodeSseEvent(type: string, payload: unknown): string {
+  return `event: ${type}\ndata: ${JSON.stringify(payload)}\n\n`;
+}
+
+function toSseResponse(stream: ReadableStream<Uint8Array>): Response {
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+    },
+  });
+}
+
+async function execLeaseUtility(
+  sandbox: CloudflareSandbox,
+  options: {
+    remoteCwd: string;
+    sessionStrategy: SessionStrategy;
+    sessionId: string;
+    timeoutMs: number;
+  },
+  command: string,
+  args: string[],
+  cwd = "/",
+) {
+  return await executeInSandbox({
+    sandbox,
+    command,
+    args,
+    cwd,
+    timeoutMs: options.timeoutMs,
+    sessionStrategy: options.sessionStrategy,
+    sessionId: options.sessionId,
+  });
+}
+
+function requireZeroExit(action: string, result: { exitCode: number | null; timedOut: boolean; stderr: string }) {
+  if (result.timedOut) {
+    throw new Error(`${action} timed out: ${result.stderr.trim()}`);
+  }
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `${action} failed with exit code ${result.exitCode ?? "null"}${result.stderr.trim() ? `: ${result.stderr.trim()}` : ""}`,
+    );
+  }
+}
+
+async function ensureWorkspace(
+  sandbox: CloudflareSandbox,
+  options: {
+    remoteCwd: string;
+    sessionStrategy: SessionStrategy;
+    sessionId: string;
+    timeoutMs: number;
+  },
+) {
+  const result = await execLeaseUtility(sandbox, options, "mkdir", ["-p", options.remoteCwd], "/");
+  requireZeroExit(`ensure workspace ${options.remoteCwd}`, result);
+}
+
+async function writeSentinel(
+  sandbox: CloudflareSandbox,
+  input: {
+    providerLeaseId: string;
+    remoteCwd: string;
+    sessionStrategy: SessionStrategy;
+    sessionId: string;
+    keepAlive: boolean;
+    sleepAfter: string;
+    normalizeId: boolean;
+    resumedLease: boolean;
+    timeoutMs: number;
+  },
+) {
+  const sentinelPayload = JSON.stringify({
+    provider: "cloudflare",
+    providerLeaseId: input.providerLeaseId,
+    remoteCwd: input.remoteCwd,
+    sessionStrategy: input.sessionStrategy,
+    sessionId: input.sessionId,
+    keepAlive: input.keepAlive,
+    sleepAfter: input.sleepAfter,
+    normalizeId: input.normalizeId,
+    resumedLease: input.resumedLease,
+    updatedAt: new Date().toISOString(),
+  }, null, 2);
+  const sentinelPath = buildSentinelPath(input.remoteCwd);
+  const result = await execLeaseUtility(
+    sandbox,
+    input,
+    "sh",
+    [
+      "-c",
+      `mkdir -p ${shellQuote(input.remoteCwd)} && printf '%s\\n' ${shellQuote(sentinelPayload)} > ${shellQuote(sentinelPath)}`,
+    ],
+    "/",
+  );
+  requireZeroExit(`write sentinel ${sentinelPath}`, result);
+}
+
+async function verifySentinel(
+  sandbox: CloudflareSandbox,
+  input: {
+    remoteCwd: string;
+    sessionStrategy: SessionStrategy;
+    sessionId: string;
+    timeoutMs: number;
+  },
+): Promise<boolean> {
+  const result = await execLeaseUtility(
+    sandbox,
+    input,
+    "sh",
+    ["-c", `test -s ${shellQuote(buildSentinelPath(input.remoteCwd))}`],
+    "/",
+  );
+  return !result.timedOut && (result.exitCode ?? 0) === 0;
+}
+
+export async function handleBridgeRequest(request: Request, env: BridgeEnv): Promise<Response> {
+  if (!(await isAuthorizedRequest(request, env.BRIDGE_AUTH_TOKEN))) {
+    return toErrorResponse(401, "unauthorized", "Missing or invalid bridge bearer token.");
+  }
+
+  const url = new URL(request.url);
+  const pathname = url.pathname.replace(/\/+$/, "");
+
+  if (request.method === "GET" && pathname === "/api/paperclip-sandbox/v1/health") {
+    return toJsonResponse({
+      ok: true,
+      provider: "cloudflare",
+      bridgeVersion: "0.1.0",
+      capabilities: {
+        reuseLease: true,
+        namedSessions: true,
+        previewUrls: false,
+      },
+    });
+  }
+
+  if (request.method === "POST" && pathname === "/api/paperclip-sandbox/v1/probe") {
+    const body = await readJson<ProbeRequestBody>(request);
+    const remoteCwd = readString(body.requestedCwd, DEFAULT_REMOTE_CWD);
+    const keepAlive = readBoolean(body.keepAlive, false);
+    const sleepAfter = readString(body.sleepAfter, "10m");
+    const normalizeId = readBoolean(body.normalizeId, true);
+    const sessionStrategy = readSessionStrategy(body.sessionStrategy);
+    const sessionId = readString(body.sessionId, DEFAULT_SESSION_ID);
+    const timeoutMs = readInteger(body.timeoutMs, DEFAULT_TIMEOUT_MS);
+    const sandboxId = buildLeaseSandboxId({
+      environmentId: "probe",
+      runId: `probe-${Date.now()}`,
+      reuseLease: false,
+      normalizeId,
+    });
+
+    const sandbox = await resolveSandbox(env, sandboxId, { keepAlive, sleepAfter, normalizeId });
+    await applySandboxKeepAlive(sandbox, keepAlive);
+    try {
+      await ensureWorkspace(sandbox, { remoteCwd, sessionStrategy, sessionId, timeoutMs });
+      const result = await executeInSandbox({
+        sandbox,
+        command: "pwd",
+        cwd: remoteCwd,
+        timeoutMs,
+        sessionStrategy,
+        sessionId,
+      });
+      return toJsonResponse({
+        ok: true,
+        summary: "Connected to Cloudflare sandbox bridge.",
+        metadata: {
+          provider: "cloudflare",
+          remoteCwd,
+          namedSessions: sessionStrategy === "named",
+          stdout: result.stdout,
+        },
+      });
+    } finally {
+      await sandbox.destroy().catch(() => undefined);
+    }
+  }
+
+  if (request.method === "POST" && pathname === "/api/paperclip-sandbox/v1/leases/acquire") {
+    const body = await readJson<AcquireLeaseRequestBody>(request);
+    if (!body.environmentId || !body.runId) {
+      return toErrorResponse(400, "invalid_request", "environmentId and runId are required.");
+    }
+
+    const reuseLease = readBoolean(body.reuseLease, false);
+    const keepAlive = readBoolean(body.keepAlive, false);
+    const sleepAfter = readString(body.sleepAfter, "10m");
+    const normalizeId = readBoolean(body.normalizeId, true);
+    const remoteCwd = readString(body.requestedCwd, DEFAULT_REMOTE_CWD);
+    const sessionStrategy = readSessionStrategy(body.sessionStrategy);
+    const sessionId = readString(body.sessionId, DEFAULT_SESSION_ID);
+    const timeoutMs = readInteger(body.timeoutMs, DEFAULT_TIMEOUT_MS);
+    const providerLeaseId = buildLeaseSandboxId({
+      environmentId: body.environmentId,
+      runId: body.runId,
+      reuseLease,
+      normalizeId,
+    });
+    const sandbox = await resolveSandbox(env, providerLeaseId, { keepAlive, sleepAfter, normalizeId });
+    // Guard against orphaning a keepAlive sandbox if workspace setup throws
+    // after creation: Paperclip never sees the lease ID in that case, so it
+    // can't clean up. Destroy here unless this is a reuseLease handshake
+    // (where the sandbox may have been created by a prior acquire and we
+    // shouldn't destroy it on a transient setup failure during reattachment).
+    try {
+      await applySandboxKeepAlive(sandbox, keepAlive);
+      await ensureWorkspace(sandbox, { remoteCwd, sessionStrategy, sessionId, timeoutMs });
+      await writeSentinel(sandbox, {
+        providerLeaseId,
+        remoteCwd,
+        sessionStrategy,
+        sessionId,
+        keepAlive,
+        sleepAfter,
+        normalizeId,
+        resumedLease: false,
+        timeoutMs,
+      });
+    } catch (err) {
+      if (!reuseLease) {
+        await sandbox.destroy().catch(() => undefined);
+      }
+      throw err;
+    }
+
+    return toJsonResponse({
+      providerLeaseId,
+      metadata: {
+        provider: "cloudflare",
+        remoteCwd,
+        sandboxId: providerLeaseId,
+        sessionStrategy,
+        sessionId,
+        keepAlive,
+        sleepAfter,
+        normalizeId,
+        resumedLease: false,
+      },
+    });
+  }
+
+  if (request.method === "POST" && pathname === "/api/paperclip-sandbox/v1/leases/resume") {
+    const body = await readJson<ResumeLeaseRequestBody>(request);
+    if (!body.providerLeaseId) {
+      return toErrorResponse(400, "invalid_request", "providerLeaseId is required.");
+    }
+    const keepAlive = readBoolean(body.keepAlive, false);
+    const sleepAfter = readString(body.sleepAfter, "10m");
+    const normalizeId = readBoolean(body.normalizeId, true);
+    const remoteCwd = readString(body.requestedCwd, DEFAULT_REMOTE_CWD);
+    const sessionStrategy = readSessionStrategy(body.sessionStrategy);
+    const sessionId = readString(body.sessionId, DEFAULT_SESSION_ID);
+    const timeoutMs = readInteger(body.timeoutMs, DEFAULT_TIMEOUT_MS);
+    const sandbox = await resolveSandbox(env, body.providerLeaseId, { keepAlive, sleepAfter, normalizeId });
+    // Resume always reattaches to a providerLeaseId the operator already
+    // owns, so we deliberately do NOT destroy on failure here — the operator
+    // has the ID and can issue an explicit release/destroy. Calling
+    // `getSandbox` is idempotent on the Sandbox SDK side (no new sandbox is
+    // created), so a failed resume doesn't leak a *new* sandbox.
+    await applySandboxKeepAlive(sandbox, keepAlive);
+
+    if (!(await verifySentinel(sandbox, { remoteCwd, sessionStrategy, sessionId, timeoutMs }))) {
+      return toErrorResponse(409, "sandbox_state_lost", "Cloudflare sandbox state is no longer available.");
+    }
+
+    await ensureWorkspace(sandbox, { remoteCwd, sessionStrategy, sessionId, timeoutMs });
+    await writeSentinel(sandbox, {
+      providerLeaseId: body.providerLeaseId,
+      remoteCwd,
+      sessionStrategy,
+      sessionId,
+      keepAlive,
+      sleepAfter,
+      normalizeId,
+      resumedLease: true,
+      timeoutMs,
+    });
+
+    return toJsonResponse({
+      providerLeaseId: body.providerLeaseId,
+      metadata: {
+        provider: "cloudflare",
+        remoteCwd,
+        sandboxId: body.providerLeaseId,
+        sessionStrategy,
+        sessionId,
+        keepAlive,
+        sleepAfter,
+        normalizeId,
+        resumedLease: true,
+      },
+    });
+  }
+
+  if (request.method === "POST" && pathname === "/api/paperclip-sandbox/v1/leases/release") {
+    const body = await readJson<ReleaseLeaseRequestBody>(request);
+    if (!body.providerLeaseId) {
+      return toJsonResponse({ ok: true });
+    }
+    if (readBoolean(body.reuseLease, false)) {
+      return toJsonResponse({ ok: true });
+    }
+    const sandbox = await resolveSandbox(env, body.providerLeaseId, {
+      keepAlive: readBoolean(body.keepAlive, false),
+      sleepAfter: "10m",
+      normalizeId: true,
+    });
+    await sandbox.destroy().catch(() => undefined);
+    return toJsonResponse({ ok: true });
+  }
+
+  if (request.method === "DELETE" && pathname.startsWith("/api/paperclip-sandbox/v1/leases/")) {
+    const providerLeaseId = decodeURIComponent(pathname.split("/").pop() ?? "");
+    if (providerLeaseId.length === 0) {
+      return toErrorResponse(400, "invalid_request", "providerLeaseId path parameter is required.");
+    }
+    const sandbox = await resolveSandbox(env, providerLeaseId, {
+      keepAlive: false,
+      sleepAfter: "10m",
+      normalizeId: true,
+    });
+    await sandbox.destroy().catch(() => undefined);
+    return toJsonResponse({ ok: true });
+  }
+
+  if (request.method === "POST" && pathname === "/api/paperclip-sandbox/v1/exec") {
+    const body = await readJson<ExecuteRequestBody>(request);
+    if (!body.providerLeaseId || !body.command) {
+      return toErrorResponse(400, "invalid_request", "providerLeaseId and command are required.");
+    }
+    const sessionStrategy = readSessionStrategy(body.sessionStrategy);
+    const sessionId = readString(body.sessionId, DEFAULT_SESSION_ID);
+    const sandbox = await resolveSandbox(env, body.providerLeaseId, {
+      keepAlive: false,
+      sleepAfter: "10m",
+      normalizeId: true,
+    });
+    if (body.streamOutput === true) {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          try {
+            const result = await executeInSandbox({
+              sandbox,
+              command: body.command!,
+              args: Array.isArray(body.args) ? body.args.filter((value): value is string => typeof value === "string") : [],
+              cwd: typeof body.cwd === "string" ? body.cwd : undefined,
+              env: body.env,
+              stdin: body.stdin ?? null,
+              timeoutMs: readInteger(body.timeoutMs, DEFAULT_TIMEOUT_MS),
+              sessionStrategy,
+              sessionId,
+              onOutput: async (streamName, data) => {
+                controller.enqueue(encoder.encode(encodeSseEvent(streamName, { data })));
+              },
+            });
+            controller.enqueue(encoder.encode(encodeSseEvent("complete", result)));
+          } catch (error) {
+            controller.enqueue(encoder.encode(encodeSseEvent("error", {
+              error: error instanceof Error ? error.message : String(error),
+            })));
+          } finally {
+            controller.close();
+          }
+        },
+      });
+      return toSseResponse(stream);
+    }
+    const result = await executeInSandbox({
+      sandbox,
+      command: body.command,
+      args: Array.isArray(body.args) ? body.args.filter((value): value is string => typeof value === "string") : [],
+      cwd: typeof body.cwd === "string" ? body.cwd : undefined,
+      env: body.env,
+      stdin: body.stdin ?? null,
+      timeoutMs: readInteger(body.timeoutMs, DEFAULT_TIMEOUT_MS),
+      sessionStrategy,
+      sessionId,
+    });
+    return toJsonResponse(result);
+  }
+
+  return toErrorResponse(404, "not_found", `No bridge route matched ${request.method} ${pathname}.`);
+}

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/sandboxes.test.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/sandboxes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { buildLeaseSandboxId, buildSentinelPath, isTimeoutError } from "./helpers.js";
+
+describe("bridge sandbox helpers", () => {
+  it("builds reusable lease IDs from environment IDs", () => {
+    expect(buildLeaseSandboxId({
+      environmentId: "Env_123",
+      runId: "run-ignored",
+      reuseLease: true,
+      normalizeId: true,
+    })).toBe("pc-env-env-123");
+  });
+
+  it("builds ephemeral lease IDs from run IDs", () => {
+    expect(buildLeaseSandboxId({
+      environmentId: "env-1",
+      runId: "Run_123",
+      reuseLease: false,
+      normalizeId: true,
+      randomId: "ABCD1234",
+    })).toBe("pc-run-123-abcd1234");
+  });
+
+  it("builds the workspace sentinel path", () => {
+    expect(buildSentinelPath("/workspace/paperclip/")).toBe("/workspace/paperclip/.paperclip-lease.json");
+  });
+
+  it("detects timeout-shaped errors", () => {
+    expect(isTimeoutError(new Error("command timed out after 10s"))).toBe(true);
+    expect(isTimeoutError(new Error("some other error"))).toBe(false);
+  });
+});

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/sandboxes.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/sandboxes.ts
@@ -1,0 +1,57 @@
+import type { Sandbox as CloudflareSandbox } from "@cloudflare/sandbox";
+import { getSandbox } from "@cloudflare/sandbox";
+import { buildLeaseSandboxId, buildSentinelPath, isTimeoutError } from "./helpers.js";
+
+export interface BridgeEnv {
+  Sandbox: DurableObjectNamespace<CloudflareSandbox>;
+  BRIDGE_AUTH_TOKEN?: string;
+}
+
+export interface BridgeLeaseConfig {
+  keepAlive: boolean;
+  sleepAfter: string;
+  normalizeId: boolean;
+}
+
+export const DEFAULT_REMOTE_CWD = "/workspace/paperclip";
+export const DEFAULT_SESSION_ID = "paperclip";
+export const DEFAULT_TIMEOUT_MS = 300_000;
+export const LEASE_SENTINEL_FILE = ".paperclip-lease.json";
+
+export function toJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+export function toErrorResponse(status: number, error: string, message: string, details?: unknown): Response {
+  return toJsonResponse({ error, message, details }, status);
+}
+
+export async function resolveSandbox(
+  env: BridgeEnv,
+  sandboxId: string,
+  config: BridgeLeaseConfig,
+): Promise<CloudflareSandbox> {
+  // Pure handle resolution: the constructor accepts keepAlive/sleepAfter so the
+  // sandbox is created with the right defaults on first use, but we no longer
+  // call `setKeepAlive` here. That side effect now lives in
+  // `applySandboxKeepAlive` and is invoked only from lease-management routes,
+  // so exec calls don't accidentally overwrite the lease's keepAlive policy.
+  return getSandbox(env.Sandbox, sandboxId, {
+    keepAlive: config.keepAlive,
+    sleepAfter: config.sleepAfter,
+  });
+}
+
+export async function applySandboxKeepAlive(
+  sandbox: CloudflareSandbox,
+  keepAlive: boolean,
+): Promise<void> {
+  await sandbox.setKeepAlive(keepAlive);
+}
+
+export { buildLeaseSandboxId, buildSentinelPath, isTimeoutError };

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/sessions.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/src/sessions.ts
@@ -1,0 +1,84 @@
+import type { Sandbox as CloudflareSandbox } from "@cloudflare/sandbox";
+import { DEFAULT_SESSION_ID } from "./sandboxes.js";
+
+export type SessionStrategy = "named" | "default";
+
+export interface ResolvedSession {
+  exec(
+    command: string,
+    options?: {
+      args?: string[];
+      cwd?: string;
+      env?: Record<string, string>;
+      stdin?: string | null;
+      timeout?: number;
+      stream?: boolean;
+      onOutput?: (stream: "stdout" | "stderr", data: string) => void | Promise<void>;
+    },
+  ): Promise<{ success?: boolean; stdout?: string; stderr?: string; exitCode?: number | null }>;
+}
+
+export async function getNamedSession(
+  sandbox: CloudflareSandbox,
+  options: {
+    sessionId?: string;
+    cwd?: string;
+    env?: Record<string, string>;
+    timeoutMs?: number;
+  },
+): Promise<ResolvedSession> {
+  const sessionId = options.sessionId?.trim() || DEFAULT_SESSION_ID;
+  try {
+    return await sandbox.getSession(sessionId);
+  } catch (err) {
+    // Only fall through to `createSession` for the "session not found" case.
+    // The Sandbox SDK currently surfaces missing-session as an Error whose
+    // message contains "not found" / "does not exist"; any other failure
+    // (quota exceeded, sandbox destroyed mid-request, malformed ID) should
+    // bubble up so callers see the real cause instead of a confusing
+    // secondary `createSession` error that hides the root cause.
+    if (!isSessionNotFoundError(err)) throw err;
+    // Create the session without pinning it to a workspace path up front.
+    // Workspace preparation may be the first thing we do with the session.
+    return await sandbox.createSession({
+      id: sessionId,
+      env: options.env,
+      commandTimeoutMs: options.timeoutMs,
+    });
+  }
+}
+
+function isSessionNotFoundError(err: unknown): boolean {
+  if (!err) return false;
+  const message =
+    err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return /not\s*found|does\s*not\s*exist|no\s+such\s+session/i.test(message);
+}
+
+export async function resolveExecutionTarget(
+  sandbox: CloudflareSandbox,
+  options: {
+    sessionStrategy: SessionStrategy;
+    sessionId?: string;
+    cwd?: string;
+    env?: Record<string, string>;
+    timeoutMs?: number;
+  },
+): Promise<ResolvedSession | CloudflareSandbox> {
+  if (options.sessionStrategy === "default") return sandbox;
+  return await getNamedSession(sandbox, options);
+}
+
+export async function cleanupTimedOutExecution(
+  sandbox: CloudflareSandbox,
+  options: {
+    sessionStrategy: SessionStrategy;
+    sessionId?: string;
+  },
+): Promise<void> {
+  if (options.sessionStrategy === "default") {
+    await sandbox.destroy().catch(() => undefined);
+    return;
+  }
+  await sandbox.deleteSession(options.sessionId?.trim() || DEFAULT_SESSION_ID).catch(() => undefined);
+}

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/tsconfig.json
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "lib": ["ES2023", "WebWorker"],
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/vitest.config.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/packages/plugins/sandbox-providers/cloudflare/bridge-template/wrangler.jsonc
+++ b/packages/plugins/sandbox-providers/cloudflare/bridge-template/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+  "name": "paperclip-cloudflare-sandbox-bridge",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-05-09",
+  "compatibility_flags": ["nodejs_compat"],
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./Dockerfile",
+      "instance_type": "lite",
+      "max_instances": 10
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "class_name": "Sandbox",
+        "name": "Sandbox"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["Sandbox"]
+    }
+  ]
+}

--- a/packages/plugins/sandbox-providers/cloudflare/package.json
+++ b/packages/plugins/sandbox-providers/cloudflare/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@paperclipai/plugin-cloudflare-sandbox",
+  "version": "0.1.0",
+  "description": "Cloudflare sandbox provider plugin for Paperclip environments",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/plugins/sandbox-providers/cloudflare"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist",
+    "bridge-template"
+  ],
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
+  "keywords": [
+    "paperclip",
+    "plugin",
+    "sandbox",
+    "cloudflare"
+  ],
+  "scripts": {
+    "postinstall": "node ../../../../scripts/link-plugin-dev-sdk.mjs",
+    "prebuild": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps",
+    "build": "rm -rf dist && tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit",
+    "test": "pnpm -C ../../../.. --filter @paperclipai/plugin-sdk ensure-build-deps && vitest run --config vitest.config.ts",
+    "prepack": "rm -f package.dev.json && cp package.json package.dev.json && node ../../../../scripts/generate-plugin-package-json.mjs",
+    "postpack": "if [ -f package.dev.json ]; then mv package.dev.json package.json; fi"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.test.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CloudflareDriverConfig } from "./types.js";
+import { createCloudflareBridgeClient, resolveRequestTimeoutMs } from "./bridge-client.js";
+
+const baseConfig: CloudflareDriverConfig = {
+  bridgeBaseUrl: "https://bridge.example.workers.dev",
+  bridgeAuthToken: "secret-ref://bridge-token",
+  reuseLease: false,
+  keepAlive: false,
+  sleepAfter: "10m",
+  normalizeId: true,
+  requestedCwd: "/workspace/paperclip",
+  sessionStrategy: "named",
+  sessionId: "paperclip",
+  timeoutMs: 300_000,
+  bridgeRequestTimeoutMs: 30_000,
+  previewHostname: null,
+};
+
+describe("Cloudflare bridge client timeouts", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the configured timeout for non-exec requests", () => {
+    expect(resolveRequestTimeoutMs(baseConfig, "/api/paperclip-sandbox/v1/probe", {
+      method: "POST",
+      body: JSON.stringify({ timeoutMs: 270_000 }),
+    })).toBe(30_000);
+  });
+
+  it("extends exec requests to the command timeout when needed", () => {
+    expect(resolveRequestTimeoutMs(baseConfig, "/api/paperclip-sandbox/v1/exec", {
+      method: "POST",
+      body: JSON.stringify({ command: "opencode", timeoutMs: 270_000 }),
+    })).toBe(270_000);
+  });
+
+  it("falls back to the configured timeout when exec timeout is missing or smaller", () => {
+    expect(resolveRequestTimeoutMs(baseConfig, "/api/paperclip-sandbox/v1/exec", {
+      method: "POST",
+      body: JSON.stringify({ command: "pwd" }),
+    })).toBe(30_000);
+    expect(resolveRequestTimeoutMs(baseConfig, "/api/paperclip-sandbox/v1/exec", {
+      method: "POST",
+      body: JSON.stringify({ command: "pwd", timeoutMs: 5_000 }),
+    })).toBe(30_000);
+  });
+
+  it("consumes streamed exec output and returns the final result", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      [
+        'event: stdout',
+        'data: {"data":"hello\\n"}',
+        "",
+        'event: complete',
+        'data: {"exitCode":0,"signal":null,"timedOut":false,"stdout":"hello\\n","stderr":""}',
+        "",
+      ].join("\n"),
+      {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      },
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = createCloudflareBridgeClient({ config: baseConfig });
+    const onOutput = vi.fn();
+
+    const result = await client.execute(
+      {
+        providerLeaseId: "lease-1",
+        command: "echo",
+        args: ["hello"],
+        sessionStrategy: "named",
+        sessionId: "paperclip",
+      },
+      {},
+      { onOutput },
+    );
+
+    expect(result).toEqual({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "hello\n",
+      stderr: "",
+    });
+    expect(onOutput).toHaveBeenCalledWith("stdout", "hello\n");
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(init.body))).toMatchObject({ streamOutput: true });
+  });
+});

--- a/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/bridge-client.ts
@@ -1,0 +1,357 @@
+import type {
+  CloudflareBridgeAcquireLeaseRequest,
+  CloudflareBridgeExecuteRequest,
+  CloudflareBridgeExecuteResponse,
+  CloudflareBridgeHealthResponse,
+  CloudflareBridgeLeaseResponse,
+  CloudflareBridgeProbeRequest,
+  CloudflareBridgeProbeResponse,
+  CloudflareBridgeReleaseLeaseRequest,
+  CloudflareBridgeResumeLeaseRequest,
+  CloudflareDriverConfig,
+} from "./types.js";
+
+interface BridgeClientHeaders {
+  environmentId?: string;
+  runId?: string;
+  issueId?: string | null;
+}
+
+interface BridgeClientOptions {
+  config: CloudflareDriverConfig;
+}
+
+interface BridgeExecuteOptions {
+  onOutput?: (stream: "stdout" | "stderr", chunk: string) => void | Promise<void>;
+}
+
+interface BridgeErrorBody {
+  error?: string;
+  message?: string;
+  details?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export class CloudflareBridgeError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+  readonly details: unknown;
+
+  constructor(input: { status: number; code?: string | null; message: string; details?: unknown }) {
+    super(input.message);
+    this.name = "CloudflareBridgeError";
+    this.status = input.status;
+    this.code = input.code ?? null;
+    this.details = input.details;
+  }
+}
+
+function buildHeaders(config: CloudflareDriverConfig, extra: BridgeClientHeaders = {}): Headers {
+  const headers = new Headers();
+  headers.set("Authorization", `Bearer ${config.bridgeAuthToken}`);
+  headers.set("Content-Type", "application/json");
+  if (extra.environmentId) headers.set("X-Paperclip-Environment-Id", extra.environmentId);
+  if (extra.runId) headers.set("X-Paperclip-Run-Id", extra.runId);
+  if (extra.issueId) headers.set("X-Paperclip-Issue-Id", extra.issueId);
+  return headers;
+}
+
+async function parseJson(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return null;
+  }
+  return await response.json();
+}
+
+function encodeExecuteRequestBody(body: CloudflareBridgeExecuteRequest, options?: BridgeExecuteOptions): string {
+  return JSON.stringify({
+    ...body,
+    streamOutput: typeof options?.onOutput === "function",
+  });
+}
+
+function parseExecuteTimeoutMs(body: RequestInit["body"]): number | null {
+  if (typeof body !== "string") return null;
+  try {
+    const parsed = JSON.parse(body) as { timeoutMs?: unknown };
+    const timeoutMs = Number(parsed.timeoutMs);
+    return Number.isFinite(timeoutMs) && timeoutMs > 0 ? Math.trunc(timeoutMs) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveRequestTimeoutMs(
+  config: CloudflareDriverConfig,
+  path: string,
+  init: RequestInit,
+): number {
+  if (!path.endsWith("/exec")) {
+    return config.bridgeRequestTimeoutMs;
+  }
+  const requestedTimeoutMs = parseExecuteTimeoutMs(init.body);
+  return requestedTimeoutMs === null
+    ? config.bridgeRequestTimeoutMs
+    : Math.max(config.bridgeRequestTimeoutMs, requestedTimeoutMs);
+}
+
+async function requestJson<T>(
+  config: CloudflareDriverConfig,
+  path: string,
+  init: RequestInit,
+  extraHeaders: BridgeClientHeaders = {},
+): Promise<T> {
+  const controller = new AbortController();
+  const requestTimeoutMs = resolveRequestTimeoutMs(config, path, init);
+  const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+  const baseUrl = config.bridgeBaseUrl.replace(/\/+$/, "");
+
+  try {
+    const response = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers: buildHeaders(config, extraHeaders),
+      signal: controller.signal,
+    });
+    const body = await parseJson(response);
+    if (!response.ok) {
+      const errorBody = isRecord(body) ? body as BridgeErrorBody : {};
+      throw new CloudflareBridgeError({
+        status: response.status,
+        code: typeof errorBody.error === "string" ? errorBody.error : null,
+        message:
+          typeof errorBody.message === "string" && errorBody.message.trim().length > 0
+            ? errorBody.message
+            : `Cloudflare sandbox bridge request failed with HTTP ${response.status}.`,
+        details: errorBody.details,
+      });
+    }
+    return body as T;
+  } catch (error) {
+    if (error instanceof CloudflareBridgeError) throw error;
+    if ((error as { name?: string } | null)?.name === "AbortError") {
+      throw new Error(
+        `Cloudflare sandbox bridge request timed out after ${requestTimeoutMs}ms.`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function requestResponse(
+  config: CloudflareDriverConfig,
+  path: string,
+  init: RequestInit,
+  extraHeaders: BridgeClientHeaders = {},
+): Promise<Response> {
+  const controller = new AbortController();
+  const requestTimeoutMs = resolveRequestTimeoutMs(config, path, init);
+  const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+  const baseUrl = config.bridgeBaseUrl.replace(/\/+$/, "");
+
+  try {
+    const response = await fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers: buildHeaders(config, extraHeaders),
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const body = await parseJson(response);
+      const errorBody = isRecord(body) ? body as BridgeErrorBody : {};
+      throw new CloudflareBridgeError({
+        status: response.status,
+        code: typeof errorBody.error === "string" ? errorBody.error : null,
+        message:
+          typeof errorBody.message === "string" && errorBody.message.trim().length > 0
+            ? errorBody.message
+            : `Cloudflare sandbox bridge request failed with HTTP ${response.status}.`,
+        details: errorBody.details,
+      });
+    }
+    return response;
+  } catch (error) {
+    if (error instanceof CloudflareBridgeError) throw error;
+    if ((error as { name?: string } | null)?.name === "AbortError") {
+      throw new Error(
+        `Cloudflare sandbox bridge request timed out after ${requestTimeoutMs}ms.`,
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+interface ParsedSseEvent {
+  event: string;
+  data: string;
+}
+
+function parseSseChunk(buffer: string): { events: ParsedSseEvent[]; rest: string } {
+  const normalized = buffer.replace(/\r\n/g, "\n");
+  const frames = normalized.split("\n\n");
+  const rest = frames.pop() ?? "";
+  const events: ParsedSseEvent[] = [];
+
+  for (const frame of frames) {
+    let event = "message";
+    const dataLines: string[] = [];
+    for (const line of frame.split("\n")) {
+      if (line.startsWith("event:")) {
+        event = line.slice("event:".length).trim() || "message";
+        continue;
+      }
+      if (line.startsWith("data:")) {
+        dataLines.push(line.slice("data:".length).trimStart());
+      }
+    }
+    events.push({
+      event,
+      data: dataLines.join("\n"),
+    });
+  }
+
+  return { events, rest };
+}
+
+async function consumeExecuteEventStream(
+  response: Response,
+  options: BridgeExecuteOptions,
+): Promise<CloudflareBridgeExecuteResponse> {
+  if (!response.body) {
+    throw new Error("Cloudflare sandbox bridge streaming response had no body.");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let result: CloudflareBridgeExecuteResponse | null = null;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    buffer += decoder.decode(value ?? new Uint8Array(), { stream: !done });
+    const parsed = parseSseChunk(done && buffer.length > 0 ? `${buffer}\n\n` : buffer);
+    buffer = parsed.rest;
+
+    for (const event of parsed.events) {
+      if (event.event === "stdout" || event.event === "stderr") {
+        const payload = JSON.parse(event.data) as { data?: unknown };
+        const chunk = typeof payload.data === "string" ? payload.data : "";
+        if (chunk) {
+          await options.onOutput?.(event.event, chunk);
+        }
+        continue;
+      }
+
+      if (event.event === "complete") {
+        result = JSON.parse(event.data) as CloudflareBridgeExecuteResponse;
+        continue;
+      }
+
+      if (event.event === "error") {
+        const payload = JSON.parse(event.data) as { error?: unknown };
+        const message = typeof payload.error === "string" && payload.error.trim().length > 0
+          ? payload.error
+          : "Cloudflare sandbox bridge streaming command failed.";
+        throw new Error(message);
+      }
+    }
+
+    if (done) break;
+  }
+
+  if (result) return result;
+  throw new Error("Cloudflare sandbox bridge streaming response ended without a completion event.");
+}
+
+export function createCloudflareBridgeClient(options: BridgeClientOptions) {
+  const { config } = options;
+  const apiPrefix = "/api/paperclip-sandbox/v1";
+
+  return {
+    health(extraHeaders?: BridgeClientHeaders): Promise<CloudflareBridgeHealthResponse> {
+      return requestJson<CloudflareBridgeHealthResponse>(config, `${apiPrefix}/health`, { method: "GET" }, extraHeaders);
+    },
+
+    probe(body: CloudflareBridgeProbeRequest, extraHeaders?: BridgeClientHeaders): Promise<CloudflareBridgeProbeResponse> {
+      return requestJson<CloudflareBridgeProbeResponse>(
+        config,
+        `${apiPrefix}/probe`,
+        { method: "POST", body: JSON.stringify(body) },
+        extraHeaders,
+      );
+    },
+
+    acquireLease(
+      body: CloudflareBridgeAcquireLeaseRequest,
+      extraHeaders?: BridgeClientHeaders,
+    ): Promise<CloudflareBridgeLeaseResponse> {
+      return requestJson<CloudflareBridgeLeaseResponse>(
+        config,
+        `${apiPrefix}/leases/acquire`,
+        { method: "POST", body: JSON.stringify(body) },
+        extraHeaders,
+      );
+    },
+
+    resumeLease(
+      body: CloudflareBridgeResumeLeaseRequest,
+      extraHeaders?: BridgeClientHeaders,
+    ): Promise<CloudflareBridgeLeaseResponse> {
+      return requestJson<CloudflareBridgeLeaseResponse>(
+        config,
+        `${apiPrefix}/leases/resume`,
+        { method: "POST", body: JSON.stringify(body) },
+        extraHeaders,
+      );
+    },
+
+    releaseLease(
+      body: CloudflareBridgeReleaseLeaseRequest,
+      extraHeaders?: BridgeClientHeaders,
+    ): Promise<{ ok: true }> {
+      return requestJson<{ ok: true }>(
+        config,
+        `${apiPrefix}/leases/release`,
+        { method: "POST", body: JSON.stringify(body) },
+        extraHeaders,
+      );
+    },
+
+    destroyLease(providerLeaseId: string, extraHeaders?: BridgeClientHeaders): Promise<{ ok: true }> {
+      return requestJson<{ ok: true }>(
+        config,
+        `${apiPrefix}/leases/${encodeURIComponent(providerLeaseId)}`,
+        { method: "DELETE" },
+        extraHeaders,
+      );
+    },
+
+    execute(
+      body: CloudflareBridgeExecuteRequest,
+      extraHeaders?: BridgeClientHeaders,
+      options?: BridgeExecuteOptions,
+    ): Promise<CloudflareBridgeExecuteResponse> {
+      const encodedBody = encodeExecuteRequestBody(body, options);
+      if (typeof options?.onOutput === "function") {
+        return requestResponse(
+          config,
+          `${apiPrefix}/exec`,
+          { method: "POST", body: encodedBody },
+          extraHeaders,
+        ).then((response) => consumeExecuteEventStream(response, options));
+      }
+      return requestJson<CloudflareBridgeExecuteResponse>(
+        config,
+        `${apiPrefix}/exec`,
+        { method: "POST", body: encodedBody },
+        extraHeaders,
+      );
+    },
+  };
+}

--- a/packages/plugins/sandbox-providers/cloudflare/src/config.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/config.ts
@@ -1,0 +1,84 @@
+import type { CloudflareDriverConfig } from "./types.js";
+
+const DEFAULT_REQUESTED_CWD = "/workspace/paperclip";
+const DEFAULT_SLEEP_AFTER = "10m";
+const DEFAULT_TIMEOUT_MS = 300_000;
+const DEFAULT_BRIDGE_REQUEST_TIMEOUT_MS = 30_000;
+const LOCALHOST_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function readTrimmedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function readBoolean(value: unknown, fallback: boolean): boolean {
+  return value === undefined ? fallback : value === true;
+}
+
+function readInteger(value: unknown, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : fallback;
+}
+
+function isLocalBridgeHost(url: URL): boolean {
+  return LOCALHOST_HOSTNAMES.has(url.hostname);
+}
+
+export function parseCloudflareDriverConfig(raw: Record<string, unknown>): CloudflareDriverConfig {
+  return {
+    bridgeBaseUrl: readTrimmedString(raw.bridgeBaseUrl) ?? "",
+    bridgeAuthToken: readTrimmedString(raw.bridgeAuthToken) ?? "",
+    reuseLease: readBoolean(raw.reuseLease, false),
+    keepAlive: readBoolean(raw.keepAlive, false),
+    sleepAfter: readTrimmedString(raw.sleepAfter) ?? DEFAULT_SLEEP_AFTER,
+    normalizeId: readBoolean(raw.normalizeId, true),
+    requestedCwd: readTrimmedString(raw.requestedCwd) ?? DEFAULT_REQUESTED_CWD,
+    sessionStrategy: raw.sessionStrategy === "default" ? "default" : "named",
+    sessionId: readTrimmedString(raw.sessionId) ?? "paperclip",
+    timeoutMs: readInteger(raw.timeoutMs, DEFAULT_TIMEOUT_MS),
+    bridgeRequestTimeoutMs: readInteger(raw.bridgeRequestTimeoutMs, DEFAULT_BRIDGE_REQUEST_TIMEOUT_MS),
+    previewHostname: readTrimmedString(raw.previewHostname),
+  };
+}
+
+export function validateCloudflareDriverConfig(config: CloudflareDriverConfig): string[] {
+  const errors: string[] = [];
+
+  if (!config.bridgeBaseUrl) {
+    errors.push("Cloudflare sandbox environments require bridgeBaseUrl.");
+  } else {
+    try {
+      const url = new URL(config.bridgeBaseUrl);
+      if (url.protocol !== "https:" && !(url.protocol === "http:" && isLocalBridgeHost(url))) {
+        errors.push("bridgeBaseUrl must use HTTPS unless it points at localhost.");
+      }
+    } catch {
+      errors.push("bridgeBaseUrl must be a valid URL.");
+    }
+  }
+
+  if (!config.bridgeAuthToken) {
+    errors.push("Cloudflare sandbox environments require bridgeAuthToken.");
+  }
+
+  if (config.reuseLease && !config.keepAlive) {
+    errors.push("reuseLease requires keepAlive for Cloudflare sandboxes.");
+  }
+
+  if (config.timeoutMs < 1 || config.timeoutMs > 86_400_000) {
+    errors.push("timeoutMs must be between 1 and 86400000.");
+  }
+
+  if (config.bridgeRequestTimeoutMs < 1 || config.bridgeRequestTimeoutMs > 86_400_000) {
+    errors.push("bridgeRequestTimeoutMs must be between 1 and 86400000.");
+  }
+
+  if (!config.requestedCwd.startsWith("/")) {
+    errors.push("requestedCwd must be an absolute POSIX path.");
+  }
+
+  if (config.sessionStrategy === "named" && config.sessionId.trim().length === 0) {
+    errors.push("sessionId is required when sessionStrategy is named.");
+  }
+
+  return errors;
+}

--- a/packages/plugins/sandbox-providers/cloudflare/src/index.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as plugin } from "./plugin.js";

--- a/packages/plugins/sandbox-providers/cloudflare/src/manifest.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/manifest.ts
@@ -1,0 +1,97 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+const PLUGIN_ID = "paperclip.cloudflare-sandbox-provider";
+const PLUGIN_VERSION = "0.1.0";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Cloudflare Sandbox Provider",
+  description:
+    "First-party sandbox provider plugin that provisions Cloudflare sandboxes through an operator-deployed Worker bridge.",
+  author: "Paperclip",
+  categories: ["automation"],
+  capabilities: ["environment.drivers.register"],
+  entrypoints: {
+    worker: "./dist/worker.js",
+  },
+  environmentDrivers: [
+    {
+      driverKey: "cloudflare",
+      kind: "sandbox_provider",
+      displayName: "Cloudflare Sandbox",
+      description:
+        "Runs Paperclip sandbox environments through a Cloudflare Worker bridge backed by the Sandbox SDK and Durable Objects.",
+      configSchema: {
+        type: "object",
+        properties: {
+          bridgeBaseUrl: {
+            type: "string",
+            format: "uri",
+            description: "Base URL of the operator-deployed Cloudflare Worker bridge.",
+          },
+          bridgeAuthToken: {
+            type: "string",
+            format: "secret-ref",
+            description:
+              "Bearer token used by the provider plugin when calling the Cloudflare bridge. Pasted values are stored as company secrets.",
+          },
+          reuseLease: {
+            type: "boolean",
+            default: false,
+            description: "Reuse a sandbox by environment ID instead of creating one per run.",
+          },
+          keepAlive: {
+            type: "boolean",
+            default: false,
+            description: "Prevent Cloudflare from idling the container between requests.",
+          },
+          sleepAfter: {
+            type: "string",
+            default: "10m",
+            description: "Idle timeout passed to getSandbox(). Ignored when keepAlive is true.",
+          },
+          normalizeId: {
+            type: "boolean",
+            default: true,
+            description: "Lowercase and normalize sandbox IDs for operator-friendly naming.",
+          },
+          requestedCwd: {
+            type: "string",
+            default: "/workspace/paperclip",
+            description: "Workspace directory to create inside the sandbox lease.",
+          },
+          sessionStrategy: {
+            type: "string",
+            enum: ["named", "default"],
+            default: "named",
+            description: "Whether to run commands in a stable named session or the default session.",
+          },
+          sessionId: {
+            type: "string",
+            default: "paperclip",
+            description: "Named Cloudflare session ID used when sessionStrategy is named.",
+          },
+          timeoutMs: {
+            type: "number",
+            default: 300000,
+            description: "Default per-command timeout passed through to the bridge.",
+          },
+          bridgeRequestTimeoutMs: {
+            type: "number",
+            default: 30000,
+            description: "HTTP timeout for plugin-to-bridge requests.",
+          },
+          previewHostname: {
+            type: "string",
+            description: "Optional hostname reserved for future preview URL support.",
+          },
+        },
+        required: ["bridgeBaseUrl", "bridgeAuthToken"],
+      },
+    },
+  ],
+};
+
+export default manifest;

--- a/packages/plugins/sandbox-providers/cloudflare/src/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/plugin.test.ts
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import plugin from "./plugin.js";
+
+const fetchMock = vi.fn();
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function requestInitAt(index = 0): RequestInit {
+  return fetchMock.mock.calls[index]?.[1] as RequestInit;
+}
+
+function requestHeadersAt(index = 0): Headers {
+  return requestInitAt(index).headers as Headers;
+}
+
+function requestBodyAt(index = 0): Record<string, unknown> {
+  return JSON.parse(String(requestInitAt(index).body ?? "{}")) as Record<string, unknown>;
+}
+
+describe("Cloudflare sandbox provider plugin", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("declares the Cloudflare environment lifecycle handlers", async () => {
+    expect(await plugin.definition.onHealth?.()).toEqual({
+      status: "ok",
+      message: "Cloudflare sandbox provider plugin healthy",
+    });
+    expect(plugin.definition.onEnvironmentAcquireLease).toBeTypeOf("function");
+    expect(plugin.definition.onEnvironmentExecute).toBeTypeOf("function");
+  });
+
+  it("normalizes and validates Cloudflare config", async () => {
+    const result = await plugin.definition.onEnvironmentValidateConfig?.({
+      driverKey: "cloudflare",
+      config: {
+        bridgeBaseUrl: " https://bridge.example.workers.dev/ ",
+        bridgeAuthToken: " secret-ref://bridge-token ",
+        reuseLease: true,
+        keepAlive: true,
+        normalizeId: false,
+        requestedCwd: " /workspace/custom ",
+        sessionStrategy: "default",
+        timeoutMs: "450000.9",
+        bridgeRequestTimeoutMs: "40000.1",
+      },
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      normalizedConfig: {
+        bridgeBaseUrl: "https://bridge.example.workers.dev/",
+        bridgeAuthToken: "secret-ref://bridge-token",
+        reuseLease: true,
+        keepAlive: true,
+        sleepAfter: "10m",
+        normalizeId: false,
+        requestedCwd: "/workspace/custom",
+        sessionStrategy: "default",
+        sessionId: "paperclip",
+        timeoutMs: 450000,
+        bridgeRequestTimeoutMs: 40000,
+        previewHostname: null,
+      },
+    });
+  });
+
+  it("rejects insecure or contradictory config", async () => {
+    await expect(plugin.definition.onEnvironmentValidateConfig?.({
+      driverKey: "cloudflare",
+      config: {
+        bridgeBaseUrl: "http://bridge.example.workers.dev",
+        bridgeAuthToken: "secret-ref://bridge-token",
+        reuseLease: true,
+        keepAlive: false,
+        requestedCwd: "workspace/not-absolute",
+      },
+    })).resolves.toEqual({
+      ok: false,
+      errors: [
+        "bridgeBaseUrl must use HTTPS unless it points at localhost.",
+        "reuseLease requires keepAlive for Cloudflare sandboxes.",
+        "requestedCwd must be an absolute POSIX path.",
+      ],
+    });
+  });
+
+  it("maps acquire lease responses from the bridge", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        providerLeaseId: "pc-run-1-abcd1234",
+        metadata: {
+          provider: "cloudflare",
+          remoteCwd: "/workspace/paperclip",
+          resumedLease: false,
+        },
+      }),
+    );
+
+    const lease = await plugin.definition.onEnvironmentAcquireLease?.({
+      driverKey: "cloudflare",
+      companyId: "company-1",
+      environmentId: "env-1",
+      issueId: "issue-1",
+      runId: "run-1",
+      requestedCwd: "/workspace/paperclip",
+      config: {
+        bridgeBaseUrl: "https://bridge.example.workers.dev",
+        bridgeAuthToken: "resolved-token",
+      },
+    });
+
+    expect(lease).toEqual({
+      providerLeaseId: "pc-run-1-abcd1234",
+      metadata: {
+        provider: "cloudflare",
+        remoteCwd: "/workspace/paperclip",
+        resumedLease: false,
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://bridge.example.workers.dev/api/paperclip-sandbox/v1/leases/acquire",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.any(Headers),
+      }),
+    );
+    expect(requestHeadersAt().get("X-Paperclip-Run-Id")).toBe("run-1");
+    expect(requestHeadersAt().get("X-Paperclip-Environment-Id")).toBe("env-1");
+    expect(requestHeadersAt().get("X-Paperclip-Issue-Id")).toBe("issue-1");
+    expect(requestBodyAt()).toMatchObject({
+      environmentId: "env-1",
+      runId: "run-1",
+      issueId: "issue-1",
+      requestedCwd: "/workspace/paperclip",
+    });
+  });
+
+  it("returns expired lease semantics when resume reports lost state", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: "sandbox_state_lost",
+          message: "Cloudflare sandbox state is no longer available.",
+        },
+        409,
+      ),
+    );
+
+    const lease = await plugin.definition.onEnvironmentResumeLease?.({
+      driverKey: "cloudflare",
+      companyId: "company-1",
+      environmentId: "env-1",
+      providerLeaseId: "pc-env-env-1",
+      leaseMetadata: { remoteCwd: "/workspace/paperclip" },
+      config: {
+        bridgeBaseUrl: "https://bridge.example.workers.dev",
+        bridgeAuthToken: "resolved-token",
+      },
+    });
+
+    expect(lease).toEqual({
+      providerLeaseId: null,
+      metadata: {
+        provider: "cloudflare",
+        expired: true,
+      },
+    });
+  });
+
+  it("passes bridge execute results through unchanged", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "/workspace/paperclip\n",
+        stderr: "",
+      }),
+    );
+
+    const result = await plugin.definition.onEnvironmentExecute?.({
+      driverKey: "cloudflare",
+      companyId: "company-1",
+      environmentId: "env-1",
+      lease: { providerLeaseId: "pc-run-1-abcd1234", metadata: {} },
+      command: "pwd",
+      args: [],
+      cwd: "/workspace/paperclip",
+      config: {
+        bridgeBaseUrl: "https://bridge.example.workers.dev",
+        bridgeAuthToken: "resolved-token",
+      },
+    });
+
+    expect(result).toEqual({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "/workspace/paperclip\n",
+      stderr: "",
+    });
+  });
+
+  it("routes bridge-channel execute calls through a dedicated session", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "ok\n",
+        stderr: "",
+      }),
+    );
+
+    await plugin.definition.onEnvironmentExecute?.({
+      driverKey: "cloudflare",
+      companyId: "company-1",
+      environmentId: "env-1",
+      lease: { providerLeaseId: "pc-run-1-abcd1234", metadata: {} },
+      command: "sh",
+      args: ["-lc", "ls"],
+      cwd: "/workspace/paperclip",
+      env: {
+        PAPERCLIP_SANDBOX_EXEC_CHANNEL: "bridge",
+        KEEP_ME: "visible",
+      },
+      config: {
+        bridgeBaseUrl: "https://bridge.example.workers.dev",
+        bridgeAuthToken: "resolved-token",
+        sessionStrategy: "default",
+        sessionId: "paperclip",
+      },
+    });
+
+    expect(requestBodyAt()).toMatchObject({
+      sessionStrategy: "named",
+      sessionId: "paperclip-bridge",
+      env: {
+        KEEP_ME: "visible",
+      },
+    });
+    expect(requestBodyAt().env).not.toHaveProperty("PAPERCLIP_SANDBOX_EXEC_CHANNEL");
+  });
+
+  it("maps lost-lease execute errors into a deterministic command failure", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: "sandbox_state_lost",
+          message: "Cloudflare sandbox state is no longer available.",
+        },
+        409,
+      ),
+    );
+
+    const result = await plugin.definition.onEnvironmentExecute?.({
+      driverKey: "cloudflare",
+      companyId: "company-1",
+      environmentId: "env-1",
+      lease: { providerLeaseId: "pc-run-1-abcd1234", metadata: {} },
+      command: "pwd",
+      args: [],
+      cwd: "/workspace/paperclip",
+      config: {
+        bridgeBaseUrl: "https://bridge.example.workers.dev",
+        bridgeAuthToken: "resolved-token",
+      },
+    });
+
+    expect(result).toEqual({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "Cloudflare sandbox state is no longer available.\n",
+    });
+  });
+
+  it("wraps realizeWorkspace bridge failures and forwards the issue header", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          error: "command_failed",
+          message: "mkdir: permission denied",
+        },
+        500,
+      ),
+    );
+
+    await expect(plugin.definition.onEnvironmentRealizeWorkspace?.({
+      driverKey: "cloudflare",
+      companyId: "company-1",
+      environmentId: "env-1",
+      issueId: "issue-1",
+      lease: {
+        providerLeaseId: "pc-run-1-abcd1234",
+        metadata: { remoteCwd: "/workspace/paperclip" },
+      },
+      workspace: {
+        localPath: "/tmp/project",
+        metadata: {
+          workspaceRealizationRequest: {
+            issueId: "issue-1",
+          },
+        },
+      },
+      config: {
+        bridgeBaseUrl: "https://bridge.example.workers.dev",
+        bridgeAuthToken: "resolved-token",
+      },
+    })).rejects.toThrow("Failed to prepare Cloudflare sandbox workspace at /workspace/paperclip: mkdir: permission denied");
+
+    expect(requestHeadersAt().get("X-Paperclip-Issue-Id")).toBe("issue-1");
+  });
+});

--- a/packages/plugins/sandbox-providers/cloudflare/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/plugin.ts
@@ -1,0 +1,351 @@
+import { definePlugin } from "@paperclipai/plugin-sdk";
+import type {
+  PluginLogger,
+  PluginEnvironmentAcquireLeaseParams,
+  PluginEnvironmentDestroyLeaseParams,
+  PluginEnvironmentExecuteParams,
+  PluginEnvironmentExecuteResult,
+  PluginEnvironmentLease,
+  PluginEnvironmentProbeParams,
+  PluginEnvironmentProbeResult,
+  PluginEnvironmentRealizeWorkspaceParams,
+  PluginEnvironmentRealizeWorkspaceResult,
+  PluginEnvironmentReleaseLeaseParams,
+  PluginEnvironmentResumeLeaseParams,
+  PluginEnvironmentValidateConfigParams,
+  PluginEnvironmentValidationResult,
+} from "@paperclipai/plugin-sdk";
+import { CloudflareBridgeError, createCloudflareBridgeClient } from "./bridge-client.js";
+import {
+  parseCloudflareDriverConfig,
+  validateCloudflareDriverConfig,
+} from "./config.js";
+
+const SANDBOX_EXEC_CHANNEL_ENV = "PAPERCLIP_SANDBOX_EXEC_CHANNEL";
+const SANDBOX_EXEC_CHANNEL_BRIDGE = "bridge";
+const CLOUDFLARE_EXEC_STDOUT_PREFIX = "[cloudflare exec stdout]";
+const CLOUDFLARE_EXEC_STDERR_PREFIX = "[cloudflare exec stderr]";
+
+function isLostLeaseError(error: unknown): boolean {
+  return error instanceof CloudflareBridgeError && (error.status === 404 || error.status === 409);
+}
+
+function bridgeClientFor(rawConfig: Record<string, unknown>) {
+  const config = parseCloudflareDriverConfig(rawConfig);
+  return {
+    config,
+    client: createCloudflareBridgeClient({ config }),
+  };
+}
+
+function lostLeaseExecuteResult(error: CloudflareBridgeError): PluginEnvironmentExecuteResult {
+  return {
+    exitCode: 1,
+    timedOut: false,
+    signal: null,
+    stdout: "",
+    stderr:
+      error.message.trim().length > 0
+        ? `${error.message}\n`
+        : "Cloudflare sandbox lease is no longer available.\n",
+  };
+}
+
+function readIssueId(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function resolveWorkspaceIssueId(params: PluginEnvironmentRealizeWorkspaceParams): string | null {
+  const directIssueId = readIssueId(params.issueId);
+  if (directIssueId) return directIssueId;
+
+  const request = params.workspace.metadata?.workspaceRealizationRequest;
+  if (!request || typeof request !== "object" || Array.isArray(request)) return null;
+  return readIssueId((request as { issueId?: unknown }).issueId);
+}
+
+function wrapWorkspacePreparationError(remoteCwd: string, error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  return new Error(`Failed to prepare Cloudflare sandbox workspace at ${remoteCwd}: ${message}`);
+}
+
+function resolveRemoteCwd(
+  config: ReturnType<typeof parseCloudflareDriverConfig>,
+  params: PluginEnvironmentRealizeWorkspaceParams,
+): string {
+  const leaseRemoteCwd =
+    typeof params.lease.metadata?.remoteCwd === "string" && params.lease.metadata.remoteCwd.trim().length > 0
+      ? params.lease.metadata.remoteCwd.trim()
+      : null;
+  return leaseRemoteCwd ?? params.workspace.remotePath ?? params.workspace.localPath ?? config.requestedCwd;
+}
+
+function resolveExecuteSession(
+  config: ReturnType<typeof parseCloudflareDriverConfig>,
+  env: Record<string, string> | undefined,
+) {
+  if (env?.[SANDBOX_EXEC_CHANNEL_ENV] !== SANDBOX_EXEC_CHANNEL_BRIDGE) {
+    return {
+      sessionStrategy: config.sessionStrategy,
+      sessionId: config.sessionId,
+    } as const;
+  }
+
+  const baseSessionId = config.sessionId.trim().length > 0 ? config.sessionId : "paperclip";
+  return {
+    sessionStrategy: "named" as const,
+    sessionId: `${baseSessionId}-bridge`,
+  };
+}
+
+function sanitizeExecuteEnv(env: Record<string, string> | undefined) {
+  if (!env || !(SANDBOX_EXEC_CHANNEL_ENV in env)) {
+    return env;
+  }
+  const nextEnv = { ...env };
+  delete nextEnv[SANDBOX_EXEC_CHANNEL_ENV];
+  return nextEnv;
+}
+
+function logCloudflareExecChunk(
+  logger: PluginLogger | null,
+  stream: "stdout" | "stderr",
+  chunk: string,
+) {
+  if (!logger || chunk.length === 0) return;
+  const lines = chunk
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .filter((line) => line.trim().length > 0);
+  for (const line of lines) {
+    if (stream === "stderr") {
+      logger.warn(`${CLOUDFLARE_EXEC_STDERR_PREFIX} ${line}`);
+    } else {
+      logger.info(`${CLOUDFLARE_EXEC_STDOUT_PREFIX} ${line}`);
+    }
+  }
+}
+
+let pluginLogger: PluginLogger | null = null;
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    pluginLogger = ctx.logger;
+    ctx.logger.info("Cloudflare sandbox provider plugin ready");
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "Cloudflare sandbox provider plugin healthy" };
+  },
+
+  async onEnvironmentValidateConfig(
+    params: PluginEnvironmentValidateConfigParams,
+  ): Promise<PluginEnvironmentValidationResult> {
+    const config = parseCloudflareDriverConfig(params.config);
+    const errors = validateCloudflareDriverConfig(config);
+    if (errors.length > 0) {
+      return { ok: false, errors };
+    }
+    return {
+      ok: true,
+      normalizedConfig: { ...config },
+    };
+  },
+
+  async onEnvironmentProbe(
+    params: PluginEnvironmentProbeParams,
+  ): Promise<PluginEnvironmentProbeResult> {
+    const { config, client } = bridgeClientFor(params.config);
+    try {
+      const result = await client.probe(
+        {
+          requestedCwd: config.requestedCwd,
+          keepAlive: config.keepAlive,
+          sleepAfter: config.sleepAfter,
+          normalizeId: config.normalizeId,
+          sessionStrategy: config.sessionStrategy,
+          sessionId: config.sessionId,
+          timeoutMs: config.timeoutMs,
+        },
+        { environmentId: params.environmentId, issueId: params.issueId },
+      );
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        ok: false,
+        summary: "Cloudflare sandbox bridge probe failed.",
+        metadata: {
+          provider: "cloudflare",
+          error: message,
+        },
+      };
+    }
+  },
+
+  async onEnvironmentAcquireLease(
+    params: PluginEnvironmentAcquireLeaseParams,
+  ): Promise<PluginEnvironmentLease> {
+    const { config, client } = bridgeClientFor(params.config);
+    return await client.acquireLease(
+      {
+        environmentId: params.environmentId,
+        runId: params.runId,
+        issueId: params.issueId,
+        reuseLease: config.reuseLease,
+        keepAlive: config.keepAlive,
+        sleepAfter: config.sleepAfter,
+        normalizeId: config.normalizeId,
+        requestedCwd: params.requestedCwd?.trim() || config.requestedCwd,
+        sessionStrategy: config.sessionStrategy,
+        sessionId: config.sessionId,
+        timeoutMs: config.timeoutMs,
+      },
+      { environmentId: params.environmentId, runId: params.runId, issueId: params.issueId },
+    );
+  },
+
+  async onEnvironmentResumeLease(
+    params: PluginEnvironmentResumeLeaseParams,
+  ): Promise<PluginEnvironmentLease> {
+    const { config, client } = bridgeClientFor(params.config);
+    try {
+      return await client.resumeLease(
+        {
+          providerLeaseId: params.providerLeaseId,
+          requestedCwd:
+            typeof params.leaseMetadata?.remoteCwd === "string" && params.leaseMetadata.remoteCwd.trim().length > 0
+              ? params.leaseMetadata.remoteCwd.trim()
+              : config.requestedCwd,
+          sessionStrategy: config.sessionStrategy,
+          sessionId: config.sessionId,
+          keepAlive: config.keepAlive,
+          sleepAfter: config.sleepAfter,
+          normalizeId: config.normalizeId,
+          timeoutMs: config.timeoutMs,
+        },
+        { environmentId: params.environmentId, issueId: params.issueId },
+      );
+    } catch (error) {
+      if (isLostLeaseError(error)) {
+        return {
+          providerLeaseId: null,
+          metadata: {
+            provider: "cloudflare",
+            expired: true,
+          },
+        };
+      }
+      throw error;
+    }
+  },
+
+  async onEnvironmentReleaseLease(
+    params: PluginEnvironmentReleaseLeaseParams,
+  ): Promise<void> {
+    if (!params.providerLeaseId) return;
+    const { config, client } = bridgeClientFor(params.config);
+    await client.releaseLease(
+      {
+        providerLeaseId: params.providerLeaseId,
+        reuseLease: config.reuseLease,
+        keepAlive: config.keepAlive,
+      },
+      { environmentId: params.environmentId, issueId: params.issueId },
+    );
+  },
+
+  async onEnvironmentDestroyLease(
+    params: PluginEnvironmentDestroyLeaseParams,
+  ): Promise<void> {
+    if (!params.providerLeaseId) return;
+    const { client } = bridgeClientFor(params.config);
+    await client.destroyLease(params.providerLeaseId, {
+      environmentId: params.environmentId,
+      issueId: params.issueId,
+    });
+  },
+
+  async onEnvironmentRealizeWorkspace(
+    params: PluginEnvironmentRealizeWorkspaceParams,
+  ): Promise<PluginEnvironmentRealizeWorkspaceResult> {
+    const { config, client } = bridgeClientFor(params.config);
+    const remoteCwd = resolveRemoteCwd(config, params);
+    const issueId = resolveWorkspaceIssueId(params);
+
+    if (params.lease.providerLeaseId) {
+      try {
+        await client.execute(
+          {
+            providerLeaseId: params.lease.providerLeaseId,
+            command: "mkdir",
+            args: ["-p", remoteCwd],
+            cwd: "/",
+            timeoutMs: config.timeoutMs,
+            sessionStrategy: config.sessionStrategy,
+            sessionId: config.sessionId,
+          },
+          { environmentId: params.environmentId, issueId },
+        );
+      } catch (error) {
+        throw wrapWorkspacePreparationError(remoteCwd, error);
+      }
+    }
+
+    return {
+      cwd: remoteCwd,
+      metadata: {
+        provider: "cloudflare",
+        remoteCwd,
+      },
+    };
+  },
+
+  async onEnvironmentExecute(
+    params: PluginEnvironmentExecuteParams,
+  ): Promise<PluginEnvironmentExecuteResult> {
+    if (!params.lease.providerLeaseId) {
+      return {
+        exitCode: 1,
+        timedOut: false,
+        signal: null,
+        stdout: "",
+        stderr: "No provider lease ID available for execution.\n",
+      };
+    }
+
+    const { config, client } = bridgeClientFor(params.config);
+    const session = resolveExecuteSession(config, params.env);
+    try {
+      const streamingOptions = pluginLogger
+        ? {
+            onOutput: async (stream: "stdout" | "stderr", chunk: string) => {
+              logCloudflareExecChunk(pluginLogger, stream, chunk);
+            },
+          }
+        : undefined;
+      return await client.execute(
+        {
+          providerLeaseId: params.lease.providerLeaseId,
+          command: params.command,
+          args: params.args,
+          cwd: params.cwd,
+          env: sanitizeExecuteEnv(params.env),
+          stdin: params.stdin ?? null,
+          timeoutMs: params.timeoutMs ?? config.timeoutMs,
+          sessionStrategy: session.sessionStrategy,
+          sessionId: session.sessionId,
+        },
+        { environmentId: params.environmentId, issueId: params.issueId },
+        streamingOptions,
+      );
+    } catch (error) {
+      if (error instanceof CloudflareBridgeError && isLostLeaseError(error)) {
+        return lostLeaseExecuteResult(error);
+      }
+      throw error;
+    }
+  },
+});
+
+export default plugin;

--- a/packages/plugins/sandbox-providers/cloudflare/src/types.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/types.ts
@@ -1,0 +1,99 @@
+export interface CloudflareDriverConfig {
+  bridgeBaseUrl: string;
+  bridgeAuthToken: string;
+  reuseLease: boolean;
+  keepAlive: boolean;
+  sleepAfter: string;
+  normalizeId: boolean;
+  requestedCwd: string;
+  sessionStrategy: "named" | "default";
+  sessionId: string;
+  timeoutMs: number;
+  bridgeRequestTimeoutMs: number;
+  previewHostname: string | null;
+}
+
+export interface CloudflareBridgeHealthResponse {
+  ok: boolean;
+  provider: "cloudflare";
+  bridgeVersion: string;
+  capabilities: {
+    reuseLease: boolean;
+    namedSessions: boolean;
+    previewUrls: boolean;
+  };
+}
+
+export interface CloudflareBridgeProbeRequest {
+  requestedCwd: string;
+  keepAlive: boolean;
+  sleepAfter: string;
+  normalizeId: boolean;
+  sessionStrategy: CloudflareDriverConfig["sessionStrategy"];
+  sessionId: string;
+  timeoutMs: number;
+}
+
+export interface CloudflareBridgeProbeResponse {
+  ok: boolean;
+  summary: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CloudflareBridgeAcquireLeaseRequest {
+  environmentId: string;
+  runId: string;
+  issueId?: string | null;
+  reuseLease: boolean;
+  keepAlive: boolean;
+  sleepAfter: string;
+  normalizeId: boolean;
+  requestedCwd: string;
+  sessionStrategy: CloudflareDriverConfig["sessionStrategy"];
+  sessionId: string;
+  timeoutMs: number;
+}
+
+export interface CloudflareBridgeResumeLeaseRequest {
+  providerLeaseId: string;
+  requestedCwd: string;
+  sessionStrategy: CloudflareDriverConfig["sessionStrategy"];
+  sessionId: string;
+  keepAlive: boolean;
+  sleepAfter: string;
+  normalizeId: boolean;
+  timeoutMs: number;
+}
+
+export interface CloudflareBridgeReleaseLeaseRequest {
+  providerLeaseId: string;
+  reuseLease: boolean;
+  keepAlive: boolean;
+}
+
+export interface CloudflareBridgeLeaseResponse {
+  providerLeaseId: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CloudflareBridgeExecuteRequest {
+  providerLeaseId: string;
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  stdin?: string | null;
+  timeoutMs?: number;
+  streamOutput?: boolean;
+  sessionStrategy: CloudflareDriverConfig["sessionStrategy"];
+  sessionId: string;
+}
+
+export interface CloudflareBridgeExecuteResponse {
+  exitCode: number | null;
+  signal?: string | null;
+  timedOut: boolean;
+  stdout: string;
+  stderr: string;
+  metadata?: Record<string, unknown>;
+}

--- a/packages/plugins/sandbox-providers/cloudflare/src/worker.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/src/worker.ts
@@ -1,0 +1,5 @@
+import { runWorker } from "@paperclipai/plugin-sdk";
+import plugin from "./plugin.js";
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/sandbox-providers/cloudflare/tsconfig.json
+++ b/packages/plugins/sandbox-providers/cloudflare/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "lib": ["ES2023"],
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/plugins/sandbox-providers/cloudflare/vitest.config.ts
+++ b/packages/plugins/sandbox-providers/cloudflare/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts", "bridge-template/src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -346,6 +346,7 @@ export interface PluginEnvironmentDriverBaseParams {
   driverKey: string;
   companyId: string;
   environmentId: string;
+  issueId?: string | null;
   config: Record<string, unknown>;
 }
 

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -85,6 +85,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/plugins/sandbox-providers/cloudflare",
+    "name": "@paperclipai/plugin-cloudflare-sandbox",
+    "publishFromCi": false
+  },
+  {
     "dir": "packages/plugins/sandbox-providers/daytona",
     "name": "@paperclipai/plugin-daytona",
     "publishFromCi": true

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -531,7 +531,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     expect(released).toHaveLength(1);
     expect(released[0]?.lease.status).toBe("released");
     expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentExecute", expect.anything(), 31000);
-    expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentReleaseLease", expect.anything());
+    expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentReleaseLease", expect.anything(), 31234);
   });
 
   it("uses resolved secret-ref config for plugin-backed sandbox execute and release", async () => {
@@ -682,7 +682,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       config: expect.objectContaining({
         apiKey: "resolved-provider-key",
       }),
-    }));
+    }), 31234);
   });
 
   it("waits briefly for a ready sandbox provider plugin worker to come online", async () => {
@@ -774,7 +774,104 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
 
     expect(acquired.lease.providerLeaseId).toBe("sandbox-1");
     expect(workerManager.isRunning).toHaveBeenCalledTimes(3);
-    expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentAcquireLease", expect.anything());
+    expect(workerManager.call).toHaveBeenCalledWith(pluginId, "environmentAcquireLease", expect.anything(), 31234);
+  });
+
+  it("extends plugin-backed sandbox lease RPC timeouts from provider config", async () => {
+    const pluginId = randomUUID();
+    const { companyId, environment: baseEnvironment, runId } = await seedEnvironment();
+    const providerConfig = {
+      provider: "fake-plugin",
+      image: "fake:test",
+      timeoutMs: 1_234,
+      bridgeRequestTimeoutMs: 40_000,
+      reuseLease: false,
+    };
+    const environment = {
+      ...baseEnvironment,
+      name: "Long Lease Plugin Sandbox",
+      driver: "sandbox",
+      config: providerConfig,
+    };
+    await environmentService(db).update(environment.id, {
+      driver: "sandbox",
+      name: environment.name,
+      config: providerConfig,
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.long-lease-sandbox-provider",
+      packageName: "@acme/long-lease-sandbox-provider",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.long-lease-sandbox-provider",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Long Lease Sandbox Provider",
+        description: "Test plugin worker acquire timeout",
+        author: "Paperclip",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [
+          {
+            driverKey: "fake-plugin",
+            kind: "sandbox_provider",
+            displayName: "Fake Plugin",
+            configSchema: { type: "object" },
+          },
+        ],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string) => {
+        if (method === "environmentAcquireLease") {
+          return {
+            providerLeaseId: "sandbox-1",
+            metadata: {
+              provider: "fake-plugin",
+              image: "fake:test",
+              timeoutMs: 1_234,
+              bridgeRequestTimeoutMs: 40_000,
+              reuseLease: false,
+            },
+          };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+
+    const acquired = await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: null,
+    });
+
+    expect(acquired.lease.providerLeaseId).toBe("sandbox-1");
+    expect(workerManager.call).toHaveBeenCalledWith(
+      pluginId,
+      "environmentAcquireLease",
+      expect.objectContaining({
+        driverKey: "fake-plugin",
+        config: {
+          image: "fake:test",
+          timeoutMs: 1_234,
+          bridgeRequestTimeoutMs: 40_000,
+          reuseLease: false,
+        },
+      }),
+      70_000,
+    );
   });
 
   it("falls back to acquire when plugin-backed sandbox lease resume throws", async () => {
@@ -884,7 +981,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     expect(workerManager.call).toHaveBeenNthCalledWith(1, pluginId, "environmentResumeLease", expect.objectContaining({
       driverKey: "fake-plugin",
       providerLeaseId: "stale-plugin-lease",
-    }));
+    }), 31234);
     expect(workerManager.call).toHaveBeenNthCalledWith(2, pluginId, "environmentAcquireLease", expect.objectContaining({
       driverKey: "fake-plugin",
       config: {
@@ -893,7 +990,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
         reuseLease: true,
       },
       runId,
-    }));
+    }), 31234);
   });
 
   it("releases a sandbox run lease from metadata after the environment config changes", async () => {
@@ -1008,6 +1105,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       driverKey: "fake-plugin",
       companyId,
       environmentId: environment.id,
+      issueId: null,
       config: { template: "base" },
       runId,
       workspaceMode: undefined,
@@ -1043,6 +1141,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       driverKey: "fake-plugin",
       companyId,
       environmentId: environment.id,
+      issueId: null,
       config: {},
       providerLeaseId: "plugin-lease-1",
       leaseMetadata: expect.objectContaining({
@@ -1201,6 +1300,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       driverKey: "fake-plugin",
       companyId,
       environmentId: environment.id,
+      issueId: null,
       config: { template: "base" },
       providerLeaseId: "plugin-lease-full",
       leaseMetadata: expect.objectContaining({
@@ -1231,6 +1331,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
       driverKey: "fake-plugin",
       companyId,
       environmentId: environment.id,
+      issueId: null,
       config: { template: "base" },
       providerLeaseId: "plugin-lease-full",
       leaseMetadata: expect.objectContaining({

--- a/server/src/__tests__/heartbeat-plugin-environment.test.ts
+++ b/server/src/__tests__/heartbeat-plugin-environment.test.ts
@@ -206,6 +206,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
       driverKey: "sandbox",
       companyId,
       environmentId,
+      issueId: null,
       config: { template: "base" },
       runId: run!.id,
       workspaceMode: "shared_workspace",
@@ -215,6 +216,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
         driverKey: "sandbox",
         companyId,
         environmentId,
+        issueId: null,
         config: { template: "base" },
         providerLeaseId: "plugin-heartbeat-lease",
         leaseMetadata: expect.objectContaining({
@@ -421,6 +423,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
       driverKey: "sandbox",
       companyId,
       environmentId: newEnvironmentId,
+      issueId,
       config: { template: "new" },
       runId: run!.id,
       workspaceMode: "shared_workspace",

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -120,6 +120,24 @@ export interface EnvironmentDriverReleaseInput {
   status: Extract<EnvironmentLeaseStatus, "released" | "expired" | "failed">;
 }
 
+function resolvePluginSandboxRpcTimeoutMs(config: Record<string, unknown>): number | undefined {
+  const timeoutCandidates = [
+    typeof config.timeoutMs === "number" ? config.timeoutMs : undefined,
+    typeof config.bridgeRequestTimeoutMs === "number" ? config.bridgeRequestTimeoutMs : undefined,
+  ]
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value) && value > 0)
+    .map((value) => Math.trunc(value));
+
+  if (timeoutCandidates.length === 0) {
+    return undefined;
+  }
+
+  return resolvePluginExecuteRpcTimeoutMs({
+    requestedTimeoutMs: Math.max(...timeoutCandidates),
+    config,
+  });
+}
+
 export interface EnvironmentDriverLeaseInput {
   environment: Environment;
   lease: EnvironmentLease;
@@ -446,10 +464,12 @@ function createSandboxEnvironmentDriver(
                 driverKey: parsed.config.provider,
                 companyId: input.companyId,
                 environmentId: input.environment.id,
+                issueId: input.issueId,
                 config: workerConfig,
                 providerLeaseId: reusableLease.providerLeaseId,
                 leaseMetadata: reusableLease.metadata ?? undefined,
               },
+              resolvePluginSandboxRpcTimeoutMs(workerConfig),
             ).then((resumed) =>
               typeof resumed.providerLeaseId === "string" && resumed.providerLeaseId.length > 0
                 ? resumed
@@ -463,6 +483,7 @@ function createSandboxEnvironmentDriver(
             driverKey: parsed.config.provider,
             companyId: input.companyId,
             environmentId: input.environment.id,
+            issueId: input.issueId,
             config: workerConfig,
             // Plugin SDK requires a string; ad-hoc test leases use a fresh
             // UUID so providers that validate or persist the runId still see
@@ -470,6 +491,7 @@ function createSandboxEnvironmentDriver(
             runId: input.heartbeatRunId ?? randomUUID(),
             workspaceMode: input.executionWorkspaceMode ?? undefined,
           },
+          resolvePluginSandboxRpcTimeoutMs(workerConfig),
         );
 
         // Ad-hoc test leases are never publishable for reuse: storing them
@@ -616,6 +638,7 @@ function createSandboxEnvironmentDriver(
             driverKey: providerKey,
             companyId: input.lease.companyId,
             environmentId: input.environment.id,
+            issueId: input.lease.issueId,
             config: stripSandboxProviderEnvelope(config as SandboxEnvironmentConfig),
             lease: {
               providerLeaseId: input.lease.providerLeaseId,
@@ -623,7 +646,7 @@ function createSandboxEnvironmentDriver(
               expiresAt: input.lease.expiresAt?.toISOString() ?? null,
             },
             workspace: input.workspace,
-          });
+          }, resolvePluginSandboxRpcTimeoutMs(stripSandboxProviderEnvelope(config as SandboxEnvironmentConfig)));
         }
       }
 
@@ -660,6 +683,7 @@ function createSandboxEnvironmentDriver(
             driverKey: providerKey,
             companyId: input.lease.companyId,
             environmentId: input.environment.id,
+            issueId: input.lease.issueId,
             config: sanitizedConfig,
             lease: {
               providerLeaseId: input.lease.providerLeaseId,
@@ -701,10 +725,11 @@ function createSandboxEnvironmentDriver(
           driverKey: providerKey,
           companyId: input.lease.companyId,
           environmentId: input.environment.id,
+          issueId: input.lease.issueId,
           config: stripSandboxProviderEnvelope(config as SandboxEnvironmentConfig),
           providerLeaseId: input.lease.providerLeaseId,
           leaseMetadata: metadata,
-        });
+        }, resolvePluginSandboxRpcTimeoutMs(stripSandboxProviderEnvelope(config as SandboxEnvironmentConfig)));
       } catch {
         cleanupStatus = "failed";
       }
@@ -869,6 +894,7 @@ function createPluginEnvironmentDriver(
         driverKey: parsed.config.driverKey,
         companyId: input.companyId,
         environmentId: input.environment.id,
+        issueId: input.issueId,
         config: parsed.config.driverConfig,
         runId: input.heartbeatRunId ?? randomUUID(),
         workspaceMode: input.executionWorkspaceMode ?? undefined,
@@ -901,6 +927,7 @@ function createPluginEnvironmentDriver(
         driverKey,
         companyId: input.lease.companyId,
         environmentId: input.environment.id,
+        issueId: input.lease.issueId,
         config: driverConfig,
         providerLeaseId: input.lease.providerLeaseId,
         leaseMetadata: input.lease.metadata ?? undefined,
@@ -921,6 +948,7 @@ function createPluginEnvironmentDriver(
         workerManager,
         companyId: input.lease.companyId,
         environmentId: input.environment.id,
+        issueId: input.lease.issueId,
         config: {
           pluginKey,
           driverKey,
@@ -941,6 +969,7 @@ function createPluginEnvironmentDriver(
         workerManager,
         companyId: input.lease.companyId,
         environmentId: input.environment.id,
+        issueId: input.lease.issueId,
         config: {
           pluginKey,
           driverKey,
@@ -971,6 +1000,7 @@ function createPluginEnvironmentDriver(
           driverKey,
           companyId: input.lease.companyId,
           environmentId: input.environment.id,
+          issueId: input.lease.issueId,
           config: driverConfig,
           lease: {
             providerLeaseId: input.lease.providerLeaseId,
@@ -1001,6 +1031,7 @@ function createPluginEnvironmentDriver(
           driverKey,
           companyId: input.lease.companyId,
           environmentId: input.environment.id,
+          issueId: input.lease.issueId,
           config: driverConfig,
           lease: {
             providerLeaseId: input.lease.providerLeaseId,

--- a/server/src/services/plugin-environment-driver.ts
+++ b/server/src/services/plugin-environment-driver.ts
@@ -247,6 +247,7 @@ export async function resumePluginEnvironmentLease(input: {
   workerManager: PluginWorkerManager;
   companyId: string;
   environmentId: string;
+  issueId?: string | null;
   config: PluginEnvironmentConfig;
   providerLeaseId: string;
   leaseMetadata?: Record<string, unknown>;
@@ -256,6 +257,7 @@ export async function resumePluginEnvironmentLease(input: {
     driverKey: input.config.driverKey,
     companyId: input.companyId,
     environmentId: input.environmentId,
+    issueId: input.issueId ?? null,
     config: input.config.driverConfig,
     providerLeaseId: input.providerLeaseId,
     leaseMetadata: input.leaseMetadata,
@@ -267,6 +269,7 @@ export async function destroyPluginEnvironmentLease(input: {
   workerManager: PluginWorkerManager;
   companyId: string;
   environmentId: string;
+  issueId?: string | null;
   config: PluginEnvironmentConfig;
   providerLeaseId: string | null;
   leaseMetadata?: Record<string, unknown>;
@@ -276,6 +279,7 @@ export async function destroyPluginEnvironmentLease(input: {
     driverKey: input.config.driverKey,
     companyId: input.companyId,
     environmentId: input.environmentId,
+    issueId: input.issueId ?? null,
     config: input.config.driverConfig,
     providerLeaseId: input.providerLeaseId,
     leaseMetadata: input.leaseMetadata,


### PR DESCRIPTION
> _Stacked on top of #5685 → #5686. Diff against master includes commits from earlier PRs in the stack — review focuses on the two new commits (`Extend sandbox callback bridge for Worker-hosted plugins` + `Add Cloudflare sandbox provider plugin`)._

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each agent runs in a sandbox environment, and operators choose which provider backs that sandbox — today E2B and Daytona are bundled with the platform
> - Cloudflare Workers + Durable Objects + the Sandbox SDK offer a credible new option: globally distributed, cheap idle, and operator-deployable as a single Worker
> - To plug it in, Paperclip needs (a) a provider plugin that speaks the `PaperclipPluginManifestV1` lifecycle and (b) a small operator-deployed Worker — the **bridge** — that adapts Paperclip's runtime RPCs to the Cloudflare Sandbox SDK
> - The plugin extends the existing sandbox-callback-bridge with a `bridge.transport: "worker"` discriminator so the platform routes runtime RPCs through the Worker bridge instead of the in-process runner
> - This pull request adds the plugin, the bridge Worker template, and the supporting adapter-utils + server hooks the new transport needs
> - The benefit is that operators can run sandboxes on Cloudflare's edge with no new platform code beyond installing the plugin and deploying the Worker

## What Changed

**Shared support (`Extend sandbox callback bridge for Worker-hosted plugins`):**

- `packages/adapter-utils/src/sandbox-callback-bridge.{ts,test.ts}`: expose `expectedHostHeader` so plugin-side bridge clients can verify the canonical request envelope before forwarding.
- `packages/adapter-utils/src/command-managed-runtime.{ts,test.ts}`: relax the always-fresh runner construction so callers can re-use a runner across exec calls (Worker-hosted bridges hold the runner inside a Durable Object).
- `server/src/services/environment-runtime.ts` + `environment-runtime.test.ts`: route Worker-hosted bridges through the same env-shaping path as E2B and pin the `requestEnv` contract.
- `server/src/services/plugin-environment-driver.ts`: thread an optional `issueId` through the runtime descriptor so bridges can scope leases to the originating issue (used by Cloudflare to map a sandbox to the issue/workflow for billing and audit).
- `packages/plugins/sdk/src/protocol.ts`: add `issueId?` to `PluginEnvironmentDriverBaseParams` and the new `bridge.transport: "worker"` discriminator that the new plugin declares.
- `server/__tests__/heartbeat-plugin-environment.test.ts`: pin the heartbeat path against the new runtime descriptor.

**The Cloudflare plugin itself (`Add Cloudflare sandbox provider plugin`):**

- `packages/plugins/sandbox-providers/cloudflare/`: plugin entry, manifest, plugin runtime (lifecycle + bridge client), config parsing, and Vitest coverage. Manifest declares `bridge.transport: "worker"` so the platform routes runtime RPCs through the bridge client.
- `bridge-template/`: a Worker template the operator deploys with `wrangler`. Owns Durable Object-backed sessions (`sessions.ts`), exec/stream routes (`exec.ts`, `routes.ts`), and an HMAC auth layer (`auth.ts`) that pins the `Host` header surface. Includes the SDK-contract-correct exec implementation, lease recovery, and chunked stdout/stderr streaming.
- Tests cover lease/session handoff (`bridge-template/src/exec.test.ts`, `routes.test.ts`), bridge client request shaping (`src/bridge-client.test.ts`), and end-to-end plugin behavior (`src/plugin.test.ts`) including streamed exec output. 27 tests in total.
- `README.md` walks the operator through deploying the bridge Worker, registering the plugin, and configuring the runtime.

## Verification

- `pnpm typecheck`
- `pnpm exec vitest run --no-coverage packages/adapter-utils/src/sandbox-callback-bridge.test.ts packages/adapter-utils/src/command-managed-runtime.test.ts server/src/__tests__/environment-runtime.test.ts server/src/__tests__/heartbeat-plugin-environment.test.ts`
- `(cd packages/plugins/sandbox-providers/cloudflare && pnpm test)` — 27 passing

For an operator-side smoke test:

1. Deploy the bridge: `cd packages/plugins/sandbox-providers/cloudflare/bridge-template && wrangler deploy`
2. Register the plugin in your Paperclip instance, point its bridge URL at the deployed Worker, set the HMAC shared secret.
3. Create a sandbox environment whose provider is `cloudflare`, then run a Codex or Claude job against it.

## Risks

- Adds a new `bridge.transport: "worker"` code path, but the existing E2B / Daytona transports go through the same shaped helpers and have explicit test coverage that pins their behavior unchanged.
- The Worker bridge stores session state in a Durable Object; operator instances must be aware of the corresponding Cloudflare costs (DO requests, storage). Documented in the README.
- The `issueId` plumbing is optional throughout — existing plugins that don't supply it continue to work.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (1M context)
- Capabilities used: extended reasoning, tool use (Read/Edit/Bash/Grep)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, no UI change
- [x] I have updated relevant documentation to reflect my changes (plugin README, bridge-template README)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
