### PR TITLE
feat(plugin-loader): support scoped npm registry auth via .npmrc passthrough

### DIFF
--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -24,6 +24,7 @@ When a heartbeat fires, Paperclip:
 | OpenCode Local | `opencode_local` | Runs OpenCode CLI locally (multi-provider `provider/model`) |
 | Cursor | `cursor` | Runs Cursor in background mode |
 | Pi Local | `pi_local` | Runs an embedded Pi agent locally |
+| [Qwen Local](/adapters/qwen-local) | `qwen_local` | Runs `qwen-code` CLI against a self-hosted vLLM endpoint (e.g. DGX over Tailscale) |
 | Hermes Local | `hermes_local` | Runs Hermes CLI locally (`hermes-paperclip-adapter`) |
 | OpenClaw Gateway | `openclaw_gateway` | Connects to an OpenClaw gateway endpoint |
 | [Process](/adapters/process) | `process` | Executes arbitrary shell commands |

--- a/docs/adapters/qwen-local.md
+++ b/docs/adapters/qwen-local.md
@@ -1,0 +1,132 @@
+---
+title: Qwen Local (vLLM)
+summary: Qwen-code CLI adapter pointed at a self-hosted vLLM endpoint (e.g. DGX over Tailscale)
+---
+
+The `qwen_local` adapter drives Alibaba's official `@qwen-code/qwen-code` CLI in OpenAI-compatible mode against a self-hosted vLLM endpoint. It targets DGX-class hardware reachable over Tailscale and supports per-agent concurrency suitable for 20–60 in-flight runs.
+
+> **Canonical field reference:** `packages/adapters/qwen-local/src/index.ts` exports `agentConfigurationDoc`. This page mirrors that doc but adds operator setup. If they drift, the source-of-truth is the `.ts` file.
+
+## When to use
+
+- You serve a Qwen (or any OpenAI-compatible) model on vLLM
+- The vLLM endpoint is reachable from the Paperclip host (typically via Tailscale)
+- You want tool-calling / multi-turn agent behavior, not bare chat completions
+
+Don't use if the endpoint isn't OpenAI-compatible (write a custom adapter), or if you only need one-shot HTTP chat (use the generic `http` adapter).
+
+## Prerequisites
+
+- vLLM serving the model on an OpenAI-compatible endpoint (`/v1/models`, `/v1/chat/completions`)
+- `qwen` CLI on the Paperclip execution target: `npm install -g @qwen-code/qwen-code@0.15.9`
+- Network reachability between Paperclip host and vLLM (Tailscale recommended)
+
+## vLLM server setup
+
+Recommended launch flags for the default model on DGX-class hardware:
+
+```bash
+vllm serve Qwen/Qwen3.6-35B-A3B-FP8 \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --api-key sk-9999 \
+  --max-model-len 32768 \
+  --max-num-seqs 64 \
+  --enable-prefix-caching \
+  --kv-cache-dtype fp8 \
+  --tensor-parallel-size <N>          # set to your GPU count
+```
+
+Notes:
+- `--max-num-seqs 64` matches the 20–60 concurrent-runs target with headroom.
+- `--enable-prefix-caching` is critical for agent loops that share long system prompts across turns.
+- `--kv-cache-dtype fp8` pairs with the FP8 model weights to fit larger context per GPU.
+- `--api-key sk-9999` is a soft-auth stub; the real boundary is the network ACL (see Security).
+
+## Tailscale wiring
+
+1. Install Tailscale on both the Paperclip host and the DGX node.
+2. Join both to the same tailnet.
+3. Bind vLLM to `0.0.0.0` (or specifically the tailscale interface) so it accepts traffic from the tailnet.
+4. Use the DGX's MagicDNS name (`http://dgx:8000/v1`) or its 100.x.x.x address as `baseUrl`.
+5. Restrict access via tailnet ACL — give the DGX a dedicated tag (e.g. `tag:llm-server`) and allow only the Paperclip host's tag inbound on port 8000.
+
+## Adapter configuration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `baseUrl` | string | **Yes** | vLLM OpenAI-compatible endpoint (e.g. `http://dgx:8000/v1`) |
+| `apiKey` | string | **Yes** | Bearer token for the vLLM endpoint (use `sk-local` if vLLM is unauthenticated) |
+| `model` | string | No | Served model id; defaults to `Qwen/Qwen3.6-35B-A3B-FP8` |
+| `cwd` | string | No | Working directory for the agent process |
+| `approvalMode` | string | No | qwen-code approval mode; defaults to `yolo` for unattended runs |
+| `command` | string | No | Override the `qwen` binary path |
+| `extraArgs` | string[] | No | Additional CLI args appended to every invocation |
+| `timeoutSec` | number | No | Run timeout in seconds (0 = no timeout) |
+| `graceSec` | number | No | SIGTERM grace period in seconds |
+
+The adapter routes the API key through `OPENAI_API_KEY` environment variable rather than a CLI flag, so it never appears in process listings (`ps`, `/proc`, audit logs).
+
+## Smoke test
+
+1. **Reach the endpoint directly:**
+   ```bash
+   curl http://dgx:8000/v1/models -H "Authorization: Bearer sk-9999"
+   ```
+   Expect a JSON array containing `Qwen/Qwen3.6-35B-A3B-FP8`.
+
+2. **Drive the CLI by hand** (proves auth + env wiring before involving Paperclip):
+   ```bash
+   OPENAI_BASE_URL=http://dgx:8000/v1 \
+   OPENAI_API_KEY=sk-9999 \
+   OPENAI_MODEL=Qwen/Qwen3.6-35B-A3B-FP8 \
+   qwen "say hello" -o stream-json --auth-type openai --bare -y
+   ```
+
+3. **Through Paperclip:** create a `qwen_local` agent in the dashboard with the fields above, then trigger a one-shot run from the issue UI. Use the "Test Environment" button to verify `qwen` is on PATH.
+
+## Concurrency tuning
+
+- Per-agent default: 20 in-flight runs (`AGENT_DEFAULT_MAX_CONCURRENT_RUNS` in `packages/shared/src/constants.ts`). Multiple agents add up — N agents × 20 = N×20 worst case.
+- Match `--max-num-seqs` on vLLM to your expected fleet ceiling.
+- Scaling path beyond a single DGX: run a second vLLM replica on another node, put both behind a load balancer (HAProxy / Envoy), point `baseUrl` at the LB. Stateless requests, so round-robin is fine.
+- The adapter doesn't enforce a global LLM cap — concurrency is gated only at the agent level.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `connection refused` | vLLM not reachable from Paperclip host | `curl` from the Paperclip host; check tailnet status with `tailscale ping dgx` |
+| HTTP 401 | `apiKey` mismatch | Verify the value matches vLLM's `--api-key` flag exactly |
+| HTTP 404 on `/models` | Wrong `baseUrl` (missing `/v1`) | Endpoint must end in `/v1`, not `/` |
+| OOM on first request | `--max-model-len` too high or KV cache too small | Lower `--max-model-len` or shrink `--max-num-seqs` |
+| Slow first token | Prefix cache cold | Expected after process restart; warms within a few requests |
+| `qwen: command not found` | CLI not installed on execution target | `npm install -g @qwen-code/qwen-code@0.15.9` |
+| Run hangs at 100% CPU | Approval prompt not bypassed | Confirm `approvalMode: "yolo"` (default) or pass `--approval-mode yolo` via `extraArgs` |
+
+## Security
+
+- `sk-9999` (or any vLLM `--api-key`) is **soft auth** — it's a single shared secret with no rotation, no per-client scoping. Treat it as a tripwire, not a wall.
+- The real security boundary is the **tailnet ACL**. Tag the DGX node (e.g. `tag:llm-server`) and restrict inbound port 8000 to the Paperclip host's tag.
+- The adapter never passes the API key as a CLI flag — only via `OPENAI_API_KEY` env var, so it stays out of process listings and shell history.
+- For multi-tenant deployments, run separate vLLM instances per tenant with distinct keys, or front vLLM with a per-tenant proxy.
+
+## Phase 2 escalation criteria
+
+The current adapter wraps the qwen-code CLI as a subprocess. Phase 2 (native agent loop, no CLI) is triggered when any of these proves out:
+
+- CLI subprocess overhead becomes a measurable bottleneck (e.g. >100ms per turn at the 60-concurrent target)
+- We need streaming behaviors qwen-code's stream-json doesn't expose (e.g. partial tool-call deltas, custom interleaving)
+- qwen-code releases break our parser more than once per quarter
+- We want first-class session-resume across heartbeats (Phase 2.5 partial; Phase 2 full)
+
+Until then, the wrapper approach trades per-turn latency for zero maintenance of an inference loop.
+
+## References
+
+- Adapter source: `packages/adapters/qwen-local/`
+- Server registry entry: `server/src/adapters/registry.ts` (search `qwen_local`)
+- Brainstorm context: `plans/reports/brainstorm-260509-1412-qwen-local-adapter.md`
+- Implementation plan: `plans/260509-1412-qwen-local-adapter/`
+- vLLM docs: <https://docs.vllm.ai>
+- qwen-code: <https://github.com/QwenLM/qwen-code>

--- a/docs/agents-runtime.md
+++ b/docs/agents-runtime.md
@@ -37,6 +37,7 @@ Built-in adapters:
 - `claude_local`: runs your local `claude` CLI
 - `codex_local`: runs your local `codex` CLI
 - `opencode_local`: runs your local `opencode` CLI
+- `qwen_local`: runs `qwen-code` CLI against a self-hosted vLLM endpoint
 - `cursor`: runs Cursor in background mode
 - `pi_local`: runs an embedded Pi agent locally
 - `hermes_local`: runs your local `hermes` CLI (`hermes-paperclip-adapter`)
@@ -48,7 +49,7 @@ External plugin adapters (install via the adapter manager or API):
 
 - `droid_local`: runs your local Factory Droid CLI (`@henkey/droid-paperclip-adapter`)
 
-For local CLI adapters (`claude_local`, `codex_local`, `opencode_local`, `hermes_local`, `droid_local`), Paperclip assumes the CLI is already installed and authenticated on the host machine.
+For local CLI adapters (`claude_local`, `codex_local`, `opencode_local`, `qwen_local`, `hermes_local`, `droid_local`), Paperclip assumes the CLI is already installed and authenticated on the host machine.
 
 ## 3.2 Runtime behavior
 
@@ -177,7 +178,7 @@ Start with least privilege where possible, and avoid exposing secrets in broad r
 
 ## 10. Minimal setup checklist
 
-1. Choose adapter (e.g. `claude_local`, `codex_local`, `opencode_local`, `hermes_local`, `cursor`, or `openclaw_gateway`). External plugins like `droid_local` are also available via the adapter manager.
+1. Choose adapter (e.g. `claude_local`, `codex_local`, `opencode_local`, `qwen_local`, `hermes_local`, `cursor`, or `openclaw_gateway`). External plugins like `droid_local` are also available via the adapter manager.
 2. Set `cwd` to the target workspace (for local adapters).
 3. Optionally add a prompt template (`promptTemplate`) or use the managed instructions bundle.
 4. Configure heartbeat policy (timer and/or assignment wakeups).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -98,6 +98,8 @@
               "adapters/overview",
               "adapters/claude-local",
               "adapters/codex-local",
+              "adapters/gemini-local",
+              "adapters/qwen-local",
               "adapters/process",
               "adapters/http",
               "adapters/external-adapters",

--- a/docs/guides/board-operator/managing-agents.md
+++ b/docs/guides/board-operator/managing-agents.md
@@ -28,7 +28,7 @@ Create agents from the Agents page. Each agent requires:
 - **Capabilities** — short description of what this agent does
 
 Common adapter choices:
-- `claude_local` / `codex_local` / `opencode_local` for local coding agents
+- `claude_local` / `codex_local` / `opencode_local` / `qwen_local` for local coding agents
 - `openclaw_gateway` / `http` for webhook-based external agents
 - `process` for generic local command execution
 

--- a/docs/journals/qwen-local-adapter-phase1-260509.md
+++ b/docs/journals/qwen-local-adapter-phase1-260509.md
@@ -1,0 +1,51 @@
+# Qwen Local Adapter Phase 1: CLI Wrapping Strategy
+
+**Date:** 2026-05-09 14:45
+**Severity:** Medium
+**Component:** adapters/qwen-local, runtime registry, agent execution
+**Status:** Resolved (Phase 1 complete; Phase 2 backlog)
+
+## What Shipped
+
+11 core files landed across two worktrees:
+- `packages/adapters/qwen-local/`: runtime-config, parse, execute, models, test, ui/build-config
+- Server registry wiring: adapters/registry.ts, builtin-adapter-types.ts, workspace deps
+- 26 tests (24 offline unit + 2 gated remote)
+- Docs: qwen-local.md operator guide, cross-reference updates (agents-runtime.md, architecture.md, managing-agents.md)
+
+Qwen3.6-35B-A3B-FP8 now routable via OPENAI_BASE_URL/OPENAI_API_KEY/OPENAI_MODEL env vars. vLLM inference path: Tailscale encrypted tunnel, soft-auth via "sk-9999" API key (hard boundary is tailnet ACL).
+
+## The Brutal Truth
+
+No end-to-end verification. Server runtime never spun up to actually hit `/api/adapters` and confirm qwen_local appears in the registry. Only typecheck validated wiring. Parser tolerates unknown stream-json events because we never captured a real qwen-code fixture. This is a ticking clock—if vLLM's stdout format drifts, we find out in production.
+
+The environment-only API key strategy avoids `/proc` leakage, but it means no way to override per-session without killing the agent process. Session resume scaffolding is pass-through; real heartbeat recovery is Phase 2.5.
+
+## Key Decisions
+
+**Why wrap CLI vs native loop:**
+Qwen's official @qwen-code v0.15.9 CLI is stable. Wrapping it trades per-turn subprocess overhead for zero maintenance of inference orchestration. If profiling reveals this is the bottleneck (unlikely—network latency dominates), Phase 2 pivots to native. Ship first, optimize second.
+
+**Why env-only API key:**
+Prevents secret from leaking into `ps aux`, /proc/*/cmdline, or audit logs. No socket-level replay attack surface. Matches security posture of other env-driven adapters.
+
+**Why no version pin in registry's getRuntimeCommandSpec:**
+Matches opencode-local pattern. Pinning would require upstream change to buildNpmRuntimeCommandSpec—out of Phase 1 scope. @qwen-code drift is a Phase 2 concern.
+
+**Why listModels not in registry:**
+Registry's listModels() takes no args; listQwenModels needs per-agent {baseUrl, apiKey}. Static models[] covers v0.1. Per-agent dashboard refresh is future. No blocker—agents infer model from execution responses.
+
+## Gaps Not Closed
+
+- No CI smoke test on live execute() (needs CLI provisioned; remote tests exercise HTTP layer only)
+- Session codec is scaffold only
+- Skill symlink sync deferred (requiresMaterializedRuntimeSkills: false)
+
+## Next Steps
+
+1. **Immediate:** Spin up server, curl /api/adapters, verify qwen_local entry
+2. **Before dogfood:** Capture real qwen-code stream-json, harden parser fixtures
+3. **Phase 2:** Measure concurrency ceiling at 20–60 in-flight runs; profile subprocess overhead
+4. **Phase 2.5:** Session resume, per-agent model list refresh
+
+**Unresolved:** Does @qwen-code v0.15.9 promise stream-json stability across minor versions? If not, vendor the event schema or pin tighter.

--- a/docs/start/architecture.md
+++ b/docs/start/architecture.md
@@ -87,7 +87,7 @@ Adapters are the bridge between Paperclip and agent runtimes. Each adapter is a 
 - **UI module** — stdout parser for the run viewer, config form fields for agent creation
 - **CLI module** — terminal formatter for `paperclipai run --watch`
 
-Built-in adapters: `claude_local`, `codex_local`, `process`, `http`. You can create custom adapters for any runtime.
+Built-in adapters: `claude_local`, `codex_local`, `qwen_local`, `process`, `http`. You can create custom adapters for any runtime.
 
 ## Key Design Decisions
 

--- a/packages/adapters/qwen-local/package.json
+++ b/packages/adapters/qwen-local/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@paperclipai/adapter-qwen-local",
+  "version": "0.1.0",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/qwen-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/qwen-local/src/cli/index.ts
+++ b/packages/adapters/qwen-local/src/cli/index.ts
@@ -1,0 +1,2 @@
+// Phase 1 stub. CLI helpers (event formatters) added in later phases if needed.
+export {};

--- a/packages/adapters/qwen-local/src/index.ts
+++ b/packages/adapters/qwen-local/src/index.ts
@@ -1,0 +1,56 @@
+import type { AdapterModelProfileDefinition } from "@paperclipai/adapter-utils";
+
+export const type = "qwen_local";
+export const label = "Qwen (local / vLLM)";
+
+// Pinned to verified Alibaba release.
+export const SANDBOX_INSTALL_COMMAND = "npm install -g @qwen-code/qwen-code@0.15.9";
+
+export const DEFAULT_QWEN_LOCAL_MODEL = "Qwen/Qwen3.6-35B-A3B-FP8";
+
+export function isValidQwenModelId(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  return value.trim().length > 0;
+}
+
+export const models: Array<{ id: string; label: string }> = [
+  { id: DEFAULT_QWEN_LOCAL_MODEL, label: "Qwen3.6 35B-A3B FP8 (default)" },
+];
+
+export const modelProfiles: AdapterModelProfileDefinition[] = [];
+
+export const agentConfigurationDoc = `# qwen_local agent configuration
+
+Adapter: qwen_local
+
+Use when:
+- You serve a Qwen (or any OpenAI-compatible) model on a vLLM endpoint reachable from the Paperclip host (commonly DGX over Tailscale)
+- You want Paperclip to drive the official \`@qwen-code/qwen-code\` CLI as the agent runtime
+- You need tool-calling / multi-turn agent behavior, not just bare chat completions
+
+Don't use when:
+- The endpoint is not OpenAI-compatible (use a custom adapter)
+- You only need one-shot HTTP chat (use the generic \`http\` adapter)
+- The \`qwen\` CLI is not installed on the execution target (install: \`${"npm install -g @qwen-code/qwen-code@0.15.9"}\`)
+
+Required fields:
+- baseUrl (string): vLLM OpenAI-compatible endpoint, e.g. \`http://dgx:8000/v1\`
+- apiKey (string): bearer token for the vLLM endpoint; use a stub like \`sk-local\` if vLLM is unauthenticated
+
+Core fields:
+- model (string, optional): served model id; defaults to \`Qwen/Qwen3.6-35B-A3B-FP8\`
+- cwd (string, optional): default working directory for the agent process
+- approvalMode (string, optional): qwen-code approval mode; defaults to \`yolo\` for unattended Paperclip runs
+- command (string, optional): override the \`qwen\` binary path
+- extraArgs (string[], optional): additional CLI args appended to every invocation
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds (0 = no timeout)
+- graceSec (number, optional): SIGTERM grace period in seconds
+
+Notes:
+- Inference routes through env vars (\`OPENAI_BASE_URL\`, \`OPENAI_API_KEY\`, \`OPENAI_MODEL\`); the API key is never passed as a CLI flag, so it stays out of process listings.
+- Runs use: \`qwen "<prompt>" -o stream-json --auth-type openai --include-partial-messages --bare --channel SDK -y -m <model>\`.
+- Default concurrency limit is 20 in-flight runs per agent (Paperclip-wide setting).
+- Phase 2 v0.1: session resume across heartbeats is not yet wired (planned for Phase 2.5).
+`;

--- a/packages/adapters/qwen-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/qwen-local/src/server/execute.remote.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { listQwenModels } from "./models.js";
+
+// Gated suite — runs only when both env vars are present. Targets a real
+// vLLM endpoint (e.g. DGX over Tailscale) and exercises:
+//   1. /v1/models discovery returns the configured model
+//   2. (smoke) 20 parallel /v1/models fan-out completes — proxy for adapter
+//      concurrency baseline. A full execute() smoke is a Phase 2.5 item once
+//      the qwen-code CLI is provisioned in CI.
+//
+// Skipped silently in CI / dev unless the operator opts in.
+
+const baseUrl = process.env.QWEN_LOCAL_BASE_URL ?? "";
+const apiKey = process.env.QWEN_LOCAL_API_KEY ?? "";
+const targetModel =
+  process.env.QWEN_LOCAL_MODEL ?? "Qwen/Qwen3.6-35B-A3B-FP8";
+
+const enabled = baseUrl.length > 0 && apiKey.length > 0;
+
+describe.skipIf(!enabled)("execute.remote (gated)", () => {
+  it("discovers the configured model via /v1/models", async () => {
+    const models = await listQwenModels({ baseUrl, apiKey });
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.map((m) => m.id)).toContain(targetModel);
+  }, 30_000);
+
+  it("handles 20 parallel /v1/models requests", async () => {
+    const start = Date.now();
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () => listQwenModels({ baseUrl, apiKey })),
+    );
+    const elapsedMs = Date.now() - start;
+    expect(results).toHaveLength(20);
+    for (const r of results) expect(r.length).toBeGreaterThan(0);
+    // Soft signal — log for ops baseline; do not fail on slow runs.
+    // eslint-disable-next-line no-console
+    console.info(`[qwen-local] 20x /v1/models p_total=${elapsedMs}ms`);
+  }, 60_000);
+});

--- a/packages/adapters/qwen-local/src/server/execute.ts
+++ b/packages/adapters/qwen-local/src/server/execute.ts
@@ -1,0 +1,187 @@
+import {
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+  type AdapterInvocationMeta,
+} from "@paperclipai/adapter-utils";
+import {
+  readAdapterExecutionTarget,
+  runAdapterExecutionTargetProcess,
+} from "@paperclipai/adapter-utils/execution-target";
+import {
+  asNumber,
+  asStringArray,
+  buildInvocationEnvForLogs,
+  buildPaperclipEnv,
+  joinPromptSections,
+  redactCommandTextForLogs,
+} from "@paperclipai/adapter-utils/server-utils";
+import { SANDBOX_INSTALL_COMMAND, type } from "../index.js";
+import {
+  prepareQwenRuntimeConfig,
+  QwenAdapterConfigError,
+  resolveQwenConfig,
+} from "./runtime-config.js";
+import {
+  aggregateUsage,
+  collectText,
+  findError,
+  findSessionId,
+  parseQwenStreamBuffer,
+  type QwenStreamEvent,
+} from "./parse.js";
+
+const DEFAULT_TIMEOUT_SEC = 600;
+const DEFAULT_GRACE_SEC = 10;
+const QWEN_COMMAND = "qwen";
+
+// Minimal one-shot execute. Phase 2 v0.1 deliberately omits session resume,
+// skill symlink sync, and the paperclip-bridge — those become Phase 2.5
+// follow-ups once the happy path proves out against a real DGX vLLM.
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const startedAt = new Date().toISOString();
+
+  let prepared;
+  try {
+    resolveQwenConfig(ctx.config); // fail-fast validation, throws on missing fields
+    prepared = await prepareQwenRuntimeConfig({
+      env: { ...process.env, ...buildPaperclipEnv(ctx.agent) } as Record<string, string>,
+      config: ctx.config,
+    });
+  } catch (err) {
+    if (err instanceof QwenAdapterConfigError) {
+      return {
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+        errorMessage: err.message,
+        errorCode: "qwen_config_error",
+      };
+    }
+    throw err;
+  }
+
+  const target = readAdapterExecutionTarget({ executionTarget: ctx.executionTarget });
+  const prompt = readPrompt(ctx);
+  const config = ctx.config;
+  const args = buildArgs({ config, prompt });
+  const timeoutSec = asNumber(config.timeoutSec, DEFAULT_TIMEOUT_SEC);
+  const graceSec = asNumber(config.graceSec, DEFAULT_GRACE_SEC);
+
+  // Stream stdout into the parser as chunks arrive so cancellation, error
+  // surfacing, and live UI logs stay responsive.
+  let buffer = "";
+  const events: QwenStreamEvent[] = [];
+
+  const meta: AdapterInvocationMeta = {
+    adapterType: type,
+    command: QWEN_COMMAND,
+    cwd: typeof config.cwd === "string" ? config.cwd : undefined,
+    commandArgs: args,
+    commandNotes: [...prepared.notes, `Install hint: ${SANDBOX_INSTALL_COMMAND}`],
+    env: buildInvocationEnvForLogs(prepared.env, { includeRuntimeKeys: ["OPENAI_API_KEY"] }),
+    prompt,
+    promptMetrics: { promptChars: prompt.length },
+  };
+  if (ctx.onMeta) await ctx.onMeta(meta);
+
+  try {
+    const result = await runAdapterExecutionTargetProcess(ctx.runId, target, QWEN_COMMAND, args, {
+      cwd: typeof config.cwd === "string" ? config.cwd : process.cwd(),
+      env: prepared.env,
+      timeoutSec,
+      graceSec,
+      onLog: async (stream, chunk) => {
+        if (stream === "stdout") {
+          buffer += chunk;
+          const { events: parsed, remainder } = parseQwenStreamBuffer(buffer);
+          buffer = remainder;
+          events.push(...parsed);
+        }
+        await ctx.onLog(stream, chunk);
+      },
+      onSpawn: ctx.onSpawn,
+    });
+
+    // Drain any final non-newline-terminated event.
+    if (buffer.length > 0) {
+      const { events: tail } = parseQwenStreamBuffer(`${buffer}\n`);
+      events.push(...tail);
+    }
+
+    const usage = aggregateUsage(events);
+    const sessionId = findSessionId(events);
+    const errorMessage = findError(events);
+    const summary = collectText(events).slice(0, 4000) || null;
+
+    const resolved = resolveQwenConfig(ctx.config);
+    const biller = inferOpenAiCompatibleBiller(prepared.env, "vllm") ?? "vllm";
+
+    return {
+      exitCode: result.exitCode,
+      signal: result.signal,
+      timedOut: result.timedOut,
+      errorMessage: errorMessage ?? (result.exitCode === 0 ? null : firstErrorLine(result.stderr)),
+      usage: usage ?? undefined,
+      sessionId,
+      sessionParams: sessionId ? { sessionId, cwd: meta.cwd ?? null } : null,
+      sessionDisplayId: sessionId,
+      provider: "vllm",
+      biller,
+      model: resolved.model,
+      billingType: "metered_api",
+      costUsd: 0,
+      summary,
+    };
+  } finally {
+    await prepared.cleanup();
+  }
+}
+
+function readPrompt(ctx: AdapterExecutionContext): string {
+  const config = ctx.config;
+  const sections: string[] = [];
+  if (typeof config.systemPrompt === "string" && config.systemPrompt.trim()) {
+    sections.push(config.systemPrompt.trim());
+  }
+  if (typeof ctx.context.prompt === "string" && ctx.context.prompt.trim()) {
+    sections.push(ctx.context.prompt.trim());
+  }
+  if (typeof config.prompt === "string" && config.prompt.trim()) {
+    sections.push(config.prompt.trim());
+  }
+  return joinPromptSections(sections);
+}
+
+function buildArgs(input: { config: Record<string, unknown>; prompt: string }): string[] {
+  const { config, prompt } = input;
+  const args: string[] = [];
+  // Positional prompt (qwen 0.15.x default). `-p/--prompt` is deprecated.
+  args.push(prompt);
+  args.push("-o", "stream-json");
+  args.push("--auth-type", "openai");
+  args.push("--include-partial-messages");
+  args.push("--bare");
+  args.push("--channel", "SDK");
+  // YOLO mode for unattended paperclip runs (override via approvalMode if set).
+  const approvalMode = typeof config.approvalMode === "string" ? config.approvalMode : "yolo";
+  if (approvalMode === "yolo") {
+    args.push("-y");
+  } else {
+    args.push("--approval-mode", approvalMode);
+  }
+  // Model override. qwen also reads OPENAI_MODEL but explicit -m wins.
+  if (typeof config.model === "string" && config.model.trim()) {
+    args.push("-m", config.model.trim());
+  }
+  for (const extra of asStringArray(config.extraArgs)) {
+    args.push(extra);
+  }
+  return args;
+}
+
+function firstErrorLine(stderr: string): string | null {
+  const trimmed = redactCommandTextForLogs(stderr).trim();
+  if (!trimmed) return null;
+  return trimmed.split("\n").find((line) => line.trim().length > 0) ?? null;
+}

--- a/packages/adapters/qwen-local/src/server/index.ts
+++ b/packages/adapters/qwen-local/src/server/index.ts
@@ -1,0 +1,49 @@
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+// Pass-through codec. qwen-code session ids are opaque strings persisted on
+// disk via --chat-recording; the adapter does not yet round-trip them across
+// runs (Phase 2.5 follow-up) but we still expose serialize/deserialize so the
+// server's session storage layer can persist whatever execute() returns.
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId = readNonEmptyString(record.sessionId) ?? readNonEmptyString(record.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(record.cwd);
+    return { sessionId, ...(cwd ? { cwd } : {}) };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId = readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+    if (!sessionId) return null;
+    const cwd = readNonEmptyString(params.cwd);
+    return { sessionId, ...(cwd ? { cwd } : {}) };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return readNonEmptyString(params.sessionId) ?? readNonEmptyString(params.session_id);
+  },
+};
+
+export { execute } from "./execute.js";
+export {
+  parseQwenStreamLine,
+  parseQwenStreamBuffer,
+  aggregateUsage,
+  collectText,
+  findSessionId,
+  findError,
+} from "./parse.js";
+export type { QwenStreamEvent } from "./parse.js";
+export {
+  prepareQwenRuntimeConfig,
+  resolveQwenConfig,
+  QwenAdapterConfigError,
+} from "./runtime-config.js";
+export { testEnvironment } from "./test.js";
+export { listQwenModels, requireQwenModelId } from "./models.js";

--- a/packages/adapters/qwen-local/src/server/models.test.ts
+++ b/packages/adapters/qwen-local/src/server/models.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isValidQwenModelId } from "../index.js";
+import { listQwenModels, requireQwenModelId } from "./models.js";
+
+describe("isValidQwenModelId", () => {
+  it("accepts non-empty trimmed strings", () => {
+    expect(isValidQwenModelId("Qwen/Qwen3.6-35B-A3B-FP8")).toBe(true);
+    expect(isValidQwenModelId("any-id")).toBe(true);
+  });
+
+  it("rejects non-strings, empty, and whitespace-only", () => {
+    expect(isValidQwenModelId(undefined)).toBe(false);
+    expect(isValidQwenModelId("")).toBe(false);
+    expect(isValidQwenModelId("   ")).toBe(false);
+    expect(isValidQwenModelId(42)).toBe(false);
+  });
+});
+
+describe("requireQwenModelId", () => {
+  it("returns the trimmed id for valid input", () => {
+    expect(requireQwenModelId(" Qwen/x ")).toBe("Qwen/x");
+  });
+  it("throws on missing/invalid input", () => {
+    expect(() => requireQwenModelId("")).toThrow(/qwen_local requires/);
+    expect(() => requireQwenModelId(undefined)).toThrow();
+  });
+});
+
+describe("listQwenModels", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("calls baseUrl/models with bearer token, returns sorted, deduped models", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      expect(url).toBe("http://dgx:8000/v1/models");
+      expect((init as RequestInit).headers).toMatchObject({ Authorization: "Bearer sk-9999" });
+      return new Response(
+        JSON.stringify({
+          data: [
+            { id: "Qwen/Qwen3.6-7B" },
+            { id: "Qwen/Qwen3.6-35B-A3B-FP8" },
+            { id: "Qwen/Qwen3.6-7B" },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const models = await listQwenModels({ baseUrl: "http://dgx:8000/v1/", apiKey: "sk-9999" });
+    expect(models.map((m) => m.id)).toEqual(["Qwen/Qwen3.6-7B", "Qwen/Qwen3.6-35B-A3B-FP8"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on non-2xx", async () => {
+    globalThis.fetch = (async () =>
+      new Response("nope", { status: 401, statusText: "Unauthorized" })) as unknown as typeof fetch;
+    await expect(
+      listQwenModels({ baseUrl: "http://dgx:8000/v1", apiKey: "bad" }),
+    ).rejects.toThrow(/401 Unauthorized/);
+  });
+});

--- a/packages/adapters/qwen-local/src/server/models.ts
+++ b/packages/adapters/qwen-local/src/server/models.ts
@@ -1,0 +1,53 @@
+import type { AdapterModel } from "@paperclipai/adapter-utils";
+import { asString } from "@paperclipai/adapter-utils/server-utils";
+import { isValidQwenModelId } from "../index.js";
+
+const MODELS_DISCOVERY_TIMEOUT_MS = 15_000;
+
+export function requireQwenModelId(input: unknown): string {
+  const model = asString(input, "").trim();
+  if (!isValidQwenModelId(model)) {
+    throw new Error("qwen_local requires `adapterConfig.model` (non-empty model id served by vLLM).");
+  }
+  return model;
+}
+
+// Hits vLLM's OpenAI-compatible `GET /v1/models`. Used by the UI dropdown's
+// refresh button — not auto-called per render, so a lightweight fetch is fine.
+export async function listQwenModels(input: {
+  baseUrl: string;
+  apiKey: string;
+  signal?: AbortSignal;
+}): Promise<AdapterModel[]> {
+  const baseUrl = input.baseUrl.replace(/\/+$/, "");
+  const url = `${baseUrl}/models`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), MODELS_DISCOVERY_TIMEOUT_MS);
+  const signal = input.signal ?? controller.signal;
+
+  try {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${input.apiKey}` },
+      signal,
+    });
+    if (!res.ok) {
+      throw new Error(`vLLM ${url} returned ${res.status} ${res.statusText}`);
+    }
+    const body = (await res.json()) as { data?: Array<{ id?: unknown }> };
+    const data = Array.isArray(body.data) ? body.data : [];
+    const models: AdapterModel[] = [];
+    const seen = new Set<string>();
+    for (const entry of data) {
+      const id = typeof entry?.id === "string" ? entry.id.trim() : "";
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      models.push({ id, label: id });
+    }
+    return models.sort((a, b) =>
+      a.id.localeCompare(b.id, "en", { numeric: true, sensitivity: "base" }),
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/packages/adapters/qwen-local/src/server/parse.test.ts
+++ b/packages/adapters/qwen-local/src/server/parse.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  aggregateUsage,
+  collectText,
+  findError,
+  findSessionId,
+  parseQwenStreamBuffer,
+  parseQwenStreamLine,
+} from "./parse.js";
+
+describe("parseQwenStreamLine", () => {
+  it("parses text deltas from {delta} and {text} shapes", () => {
+    expect(parseQwenStreamLine(JSON.stringify({ type: "content_delta", text: "hello " }))).toEqual({
+      kind: "text_delta",
+      text: "hello ",
+    });
+    expect(parseQwenStreamLine(JSON.stringify({ delta: "world" }))).toEqual({
+      kind: "text_delta",
+      text: "world",
+    });
+  });
+
+  it("parses session announcements from session/system events", () => {
+    expect(parseQwenStreamLine(JSON.stringify({ type: "session_start", session_id: "abc" }))).toEqual({
+      kind: "session",
+      sessionId: "abc",
+    });
+    expect(parseQwenStreamLine(JSON.stringify({ type: "system", session: { id: "xyz" } }))).toEqual({
+      kind: "session",
+      sessionId: "xyz",
+    });
+  });
+
+  it("parses usage rollups under both top-level and message scopes", () => {
+    const top = parseQwenStreamLine(
+      JSON.stringify({ type: "result", usage: { input_tokens: 10, output_tokens: 20 } }),
+    );
+    expect(top).toEqual({ kind: "usage", usage: { inputTokens: 10, outputTokens: 20 } });
+
+    const nested = parseQwenStreamLine(
+      JSON.stringify({ type: "message", message: { usage: { prompt_tokens: 3, completion_tokens: 5 } } }),
+    );
+    expect(nested).toEqual({ kind: "usage", usage: { inputTokens: 3, outputTokens: 5 } });
+  });
+
+  it("classifies tool calls + results", () => {
+    expect(parseQwenStreamLine(JSON.stringify({ type: "tool_use", name: "edit_file" }))).toMatchObject({
+      kind: "tool_call",
+      name: "edit_file",
+    });
+    expect(parseQwenStreamLine(JSON.stringify({ type: "tool_result" }))).toMatchObject({
+      kind: "tool_result",
+    });
+  });
+
+  it("error events always win", () => {
+    expect(parseQwenStreamLine(JSON.stringify({ type: "error", message: "boom" }))).toMatchObject({
+      kind: "error",
+      message: "boom",
+    });
+    // error field on a normally-typed event is also surfaced as error
+    expect(parseQwenStreamLine(JSON.stringify({ type: "result", error: { message: "nope" } }))).toMatchObject({
+      kind: "error",
+      message: "nope",
+    });
+  });
+
+  it("falls back to unknown for unrecognized typed events", () => {
+    const ev = parseQwenStreamLine(JSON.stringify({ type: "future_event_kind", foo: "bar" }));
+    expect(ev?.kind).toBe("unknown");
+    if (ev?.kind === "unknown") expect(ev.type).toBe("future_event_kind");
+  });
+
+  it("ignores blank and non-JSON lines", () => {
+    expect(parseQwenStreamLine("")).toBeNull();
+    expect(parseQwenStreamLine("   ")).toBeNull();
+    expect(parseQwenStreamLine("not json {")).toBeNull();
+  });
+});
+
+describe("parseQwenStreamBuffer", () => {
+  it("emits one event per newline and preserves the trailing partial line", () => {
+    const buf = `${JSON.stringify({ delta: "a" })}\n${JSON.stringify({ delta: "b" })}\n{"delta":"c"`;
+    const { events, remainder } = parseQwenStreamBuffer(buf);
+    expect(events.map((e) => (e.kind === "text_delta" ? e.text : null))).toEqual(["a", "b"]);
+    expect(remainder).toBe('{"delta":"c"');
+  });
+});
+
+describe("reducers", () => {
+  const events = [
+    { kind: "text_delta" as const, text: "Hello " },
+    { kind: "text_delta" as const, text: "world" },
+    { kind: "usage" as const, usage: { inputTokens: 5, outputTokens: 7 } },
+    { kind: "usage" as const, usage: { inputTokens: 2, outputTokens: 3 } },
+    { kind: "session" as const, sessionId: "sess_42" },
+    { kind: "error" as const, message: "fatal", raw: {} },
+  ];
+
+  it("aggregateUsage sums per-turn rollups", () => {
+    expect(aggregateUsage(events)).toEqual({ inputTokens: 7, outputTokens: 10 });
+  });
+
+  it("collectText concatenates deltas", () => {
+    expect(collectText(events)).toBe("Hello world");
+  });
+
+  it("findSessionId / findError return first match", () => {
+    expect(findSessionId(events)).toBe("sess_42");
+    expect(findError(events)).toBe("fatal");
+  });
+});

--- a/packages/adapters/qwen-local/src/server/parse.ts
+++ b/packages/adapters/qwen-local/src/server/parse.ts
@@ -1,0 +1,149 @@
+import { parseJson } from "@paperclipai/adapter-utils/server-utils";
+import type { UsageSummary } from "@paperclipai/adapter-utils";
+
+// qwen-code's `-o stream-json` emits one JSON object per line. The schema is
+// not yet pinned in their public docs (verified surface from `qwen --help` in
+// 0.15.9), so the parser tolerates unknown event types (logs + skips) and only
+// fails on protocol-fatal stream errors. Real fixtures should be captured
+// against a live vLLM during Phase 5 to harden this parser.
+
+export type QwenStreamEvent =
+  | { kind: "text_delta"; text: string }
+  | { kind: "tool_call"; name: string; raw: Record<string, unknown> }
+  | { kind: "tool_result"; raw: Record<string, unknown> }
+  | { kind: "session"; sessionId: string }
+  | { kind: "usage"; usage: UsageSummary }
+  | { kind: "result"; raw: Record<string, unknown> }
+  | { kind: "error"; message: string; raw: Record<string, unknown> }
+  | { kind: "unknown"; type: string | null; raw: Record<string, unknown> };
+
+const TEXT_FIELDS = ["text", "delta", "content"];
+
+function pickString(obj: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return null;
+}
+
+function readUsage(obj: Record<string, unknown>): UsageSummary | null {
+  const usageNode =
+    (obj.usage as Record<string, unknown> | undefined) ??
+    (obj.message && typeof obj.message === "object"
+      ? ((obj.message as Record<string, unknown>).usage as Record<string, unknown> | undefined)
+      : undefined);
+  if (!usageNode) return null;
+  const inputTokens = Number(usageNode.input_tokens ?? usageNode.prompt_tokens ?? 0);
+  const outputTokens = Number(usageNode.output_tokens ?? usageNode.completion_tokens ?? 0);
+  if (!Number.isFinite(inputTokens) && !Number.isFinite(outputTokens)) return null;
+  return {
+    inputTokens: Number.isFinite(inputTokens) ? inputTokens : 0,
+    outputTokens: Number.isFinite(outputTokens) ? outputTokens : 0,
+  };
+}
+
+export function parseQwenStreamLine(line: string): QwenStreamEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const obj = parseJson(trimmed);
+  if (!obj) return null;
+
+  const type = typeof obj.type === "string" ? obj.type : null;
+
+  // Error events always win.
+  if (type === "error" || obj.error) {
+    const message =
+      pickString(obj, ["message", "error"]) ??
+      (typeof obj.error === "object" && obj.error
+        ? pickString(obj.error as Record<string, unknown>, ["message"]) ?? "qwen-code error"
+        : "qwen-code error");
+    return { kind: "error", message, raw: obj };
+  }
+
+  // Session announcement (qwen prints session id at start when --chat-recording).
+  const sessionId =
+    pickString(obj, ["session_id", "sessionId"]) ??
+    (typeof obj.session === "object" && obj.session
+      ? pickString(obj.session as Record<string, unknown>, ["id"])
+      : null);
+  if (sessionId && (type === "session" || type === "session_start" || type === "system")) {
+    return { kind: "session", sessionId };
+  }
+
+  // Usage rollup (end-of-turn or end-of-stream).
+  const usage = readUsage(obj);
+  if (usage) {
+    return { kind: "usage", usage };
+  }
+
+  if (type === "tool_use" || type === "tool_call") {
+    const name = pickString(obj, ["name", "tool_name"]) ?? "unknown";
+    return { kind: "tool_call", name, raw: obj };
+  }
+  if (type === "tool_result") {
+    return { kind: "tool_result", raw: obj };
+  }
+  if (type === "result" || type === "final") {
+    return { kind: "result", raw: obj };
+  }
+
+  // Plain text delta — qwen-code may emit either {type:"content_delta", text} or
+  // a bare {delta:"..."} chunk depending on stream mode.
+  const text = pickString(obj, TEXT_FIELDS);
+  if (text) {
+    return { kind: "text_delta", text };
+  }
+
+  return { kind: "unknown", type, raw: obj };
+}
+
+export function parseQwenStreamBuffer(buffer: string): {
+  events: QwenStreamEvent[];
+  remainder: string;
+} {
+  const lines = buffer.split("\n");
+  const remainder = lines.pop() ?? "";
+  const events: QwenStreamEvent[] = [];
+  for (const line of lines) {
+    const event = parseQwenStreamLine(line);
+    if (event) events.push(event);
+  }
+  return { events, remainder };
+}
+
+// Sum usage across all events. qwen-code may emit per-turn rollups in agent
+// loops, so we accumulate rather than overwrite.
+export function aggregateUsage(events: QwenStreamEvent[]): UsageSummary | null {
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let saw = false;
+  for (const event of events) {
+    if (event.kind !== "usage") continue;
+    inputTokens += event.usage.inputTokens ?? 0;
+    outputTokens += event.usage.outputTokens ?? 0;
+    saw = true;
+  }
+  return saw ? { inputTokens, outputTokens } : null;
+}
+
+export function collectText(events: QwenStreamEvent[]): string {
+  return events
+    .filter((event): event is Extract<QwenStreamEvent, { kind: "text_delta" }> => event.kind === "text_delta")
+    .map((event) => event.text)
+    .join("");
+}
+
+export function findSessionId(events: QwenStreamEvent[]): string | null {
+  for (const event of events) {
+    if (event.kind === "session") return event.sessionId;
+  }
+  return null;
+}
+
+export function findError(events: QwenStreamEvent[]): string | null {
+  for (const event of events) {
+    if (event.kind === "error") return event.message;
+  }
+  return null;
+}

--- a/packages/adapters/qwen-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/qwen-local/src/server/runtime-config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_QWEN_LOCAL_MODEL } from "../index.js";
+import {
+  prepareQwenRuntimeConfig,
+  QwenAdapterConfigError,
+  resolveQwenConfig,
+} from "./runtime-config.js";
+
+describe("resolveQwenConfig", () => {
+  it("throws when baseUrl is missing", () => {
+    expect(() => resolveQwenConfig({ apiKey: "sk-x" })).toThrow(QwenAdapterConfigError);
+  });
+
+  it("throws when apiKey is missing", () => {
+    expect(() => resolveQwenConfig({ baseUrl: "http://dgx:8000/v1" })).toThrow(QwenAdapterConfigError);
+  });
+
+  it("trims and defaults the model", () => {
+    const r = resolveQwenConfig({ baseUrl: "  http://dgx:8000/v1 ", apiKey: " sk-9999 " });
+    expect(r).toEqual({
+      baseUrl: "http://dgx:8000/v1",
+      apiKey: "sk-9999",
+      model: DEFAULT_QWEN_LOCAL_MODEL,
+    });
+  });
+
+  it("respects an explicit model id", () => {
+    const r = resolveQwenConfig({
+      baseUrl: "http://dgx:8000/v1",
+      apiKey: "sk-9999",
+      model: "Qwen/Qwen3.6-7B",
+    });
+    expect(r.model).toBe("Qwen/Qwen3.6-7B");
+  });
+});
+
+describe("prepareQwenRuntimeConfig", () => {
+  it("injects all three OPENAI_* env vars and preserves caller env", async () => {
+    const prepared = await prepareQwenRuntimeConfig({
+      env: { PATH: "/usr/bin", FOO: "bar" },
+      config: { baseUrl: "http://dgx:8000/v1", apiKey: "sk-9999", model: "Qwen/test" },
+    });
+    expect(prepared.env.OPENAI_BASE_URL).toBe("http://dgx:8000/v1");
+    expect(prepared.env.OPENAI_API_KEY).toBe("sk-9999");
+    expect(prepared.env.OPENAI_MODEL).toBe("Qwen/test");
+    expect(prepared.env.PATH).toBe("/usr/bin");
+    expect(prepared.env.FOO).toBe("bar");
+  });
+
+  it("never leaks the apiKey into notes", async () => {
+    const prepared = await prepareQwenRuntimeConfig({
+      env: {},
+      config: { baseUrl: "http://dgx:8000/v1", apiKey: "sk-secret-9999" },
+    });
+    for (const note of prepared.notes) {
+      expect(note).not.toContain("sk-secret-9999");
+    }
+  });
+
+  it("cleanup is a no-op", async () => {
+    const prepared = await prepareQwenRuntimeConfig({
+      env: {},
+      config: { baseUrl: "http://dgx:8000/v1", apiKey: "sk-9999" },
+    });
+    await expect(prepared.cleanup()).resolves.toBeUndefined();
+  });
+});

--- a/packages/adapters/qwen-local/src/server/runtime-config.ts
+++ b/packages/adapters/qwen-local/src/server/runtime-config.ts
@@ -1,0 +1,64 @@
+import { asString } from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_QWEN_LOCAL_MODEL } from "../index.js";
+
+export interface PreparedQwenRuntimeConfig {
+  env: Record<string, string>;
+  notes: string[];
+  cleanup: () => Promise<void>;
+}
+
+export interface QwenResolvedConfig {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+}
+
+export class QwenAdapterConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QwenAdapterConfigError";
+  }
+}
+
+// Read + validate the user-facing config fields needed for an OpenAI-compatible
+// run. Throws on missing required values so the run fails fast with a clear
+// reason instead of silently sending requests to nowhere.
+export function resolveQwenConfig(config: Record<string, unknown>): QwenResolvedConfig {
+  const baseUrl = asString(config.baseUrl, "").trim();
+  if (!baseUrl) {
+    throw new QwenAdapterConfigError(
+      "qwen_local agent requires `baseUrl` (vLLM OpenAI-compatible endpoint, e.g. http://dgx:8000/v1)",
+    );
+  }
+  const apiKey = asString(config.apiKey, "").trim();
+  if (!apiKey) {
+    throw new QwenAdapterConfigError(
+      "qwen_local agent requires `apiKey` (vLLM bearer token; use a stub like `sk-local` if vLLM is unauthenticated)",
+    );
+  }
+  const model = asString(config.model, DEFAULT_QWEN_LOCAL_MODEL).trim();
+  return { baseUrl, apiKey, model };
+}
+
+// Inject OPENAI_* env vars so qwen-code routes inference at the configured
+// vLLM endpoint. Keep the API key out of CLI flags so it does not appear in
+// process listings (`ps`, `/proc`, audit logs).
+export async function prepareQwenRuntimeConfig(input: {
+  env: Record<string, string>;
+  config: Record<string, unknown>;
+}): Promise<PreparedQwenRuntimeConfig> {
+  const resolved = resolveQwenConfig(input.config);
+  const env: Record<string, string> = {
+    ...input.env,
+    OPENAI_BASE_URL: resolved.baseUrl,
+    OPENAI_API_KEY: resolved.apiKey,
+    OPENAI_MODEL: resolved.model,
+  };
+  return {
+    env,
+    notes: [
+      `Routing inference at ${resolved.baseUrl} via OPENAI_BASE_URL (qwen-code OpenAI-compatible mode).`,
+    ],
+    cleanup: async () => {},
+  };
+}

--- a/packages/adapters/qwen-local/src/server/test.ts
+++ b/packages/adapters/qwen-local/src/server/test.ts
@@ -1,0 +1,68 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  describeAdapterExecutionTarget,
+  ensureAdapterExecutionTargetCommandResolvable,
+} from "@paperclipai/adapter-utils/execution-target";
+import { type as adapterType, SANDBOX_INSTALL_COMMAND } from "../index.js";
+import { resolveQwenConfig, QwenAdapterConfigError } from "./runtime-config.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+// Phase 2 v0.1 environment probe. Verifies the qwen binary is reachable on the
+// execution target and the agent config has the required vLLM fields. Does not
+// yet make a live request to the vLLM endpoint — that comes in Phase 5.
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+
+  try {
+    const resolved = resolveQwenConfig(ctx.config ?? {});
+    checks.push({
+      code: "config_valid",
+      level: "info",
+      message: `Config resolved: model=${resolved.model}, baseUrl=${resolved.baseUrl}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "config_invalid",
+      level: "error",
+      message: err instanceof QwenAdapterConfigError ? err.message : String(err),
+      hint: "Set baseUrl and apiKey in the agent config.",
+    });
+  }
+
+  const target = ctx.executionTarget ?? null;
+  try {
+    await ensureAdapterExecutionTargetCommandResolvable("qwen", target, process.cwd(), process.env, {
+      installCommand: SANDBOX_INSTALL_COMMAND,
+    });
+    checks.push({
+      code: "qwen_command",
+      level: "info",
+      message: `qwen CLI resolvable on ${describeAdapterExecutionTarget(target)}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "qwen_command_missing",
+      level: "error",
+      message: `qwen CLI not found on ${describeAdapterExecutionTarget(target)}: ${(err as Error).message}`,
+      hint: `Install with: ${SANDBOX_INSTALL_COMMAND}`,
+    });
+  }
+
+  return {
+    adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/qwen-local/src/ui/build-config.ts
+++ b/packages/adapters/qwen-local/src/ui/build-config.ts
@@ -1,0 +1,29 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export function buildQwenLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+  if (v.model) ac.model = v.model;
+  // baseUrl + apiKey are the vLLM endpoint coords. Sourced from extra config
+  // fields surfaced by the UI form schema (Phase 4 wires them through).
+  const extra = (v as unknown as Record<string, unknown>).extraConfig;
+  if (extra && typeof extra === "object" && !Array.isArray(extra)) {
+    const e = extra as Record<string, unknown>;
+    if (typeof e.baseUrl === "string" && e.baseUrl.trim()) ac.baseUrl = e.baseUrl.trim();
+    if (typeof e.apiKey === "string" && e.apiKey.trim()) ac.apiKey = e.apiKey.trim();
+    if (typeof e.approvalMode === "string" && e.approvalMode.trim()) ac.approvalMode = e.approvalMode.trim();
+  }
+  ac.timeoutSec = 0;
+  ac.graceSec = 10;
+  if (v.command) ac.command = v.command;
+  if (v.extraArgs) ac.extraArgs = parseCommaArgs(v.extraArgs);
+  return ac;
+}

--- a/packages/adapters/qwen-local/src/ui/index.ts
+++ b/packages/adapters/qwen-local/src/ui/index.ts
@@ -1,0 +1,1 @@
+export { buildQwenLocalConfig } from "./build-config.js";

--- a/packages/adapters/qwen-local/tsconfig.json
+++ b/packages/adapters/qwen-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/qwen-local/vitest.config.ts
+++ b/packages/adapters/qwen-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/plans/260509-1412-qwen-local-adapter/phase-01-scaffold-package.md
+++ b/plans/260509-1412-qwen-local-adapter/phase-01-scaffold-package.md
@@ -1,0 +1,57 @@
+---
+phase: 1
+title: Scaffold package
+status: completed
+priority: P2
+effort: 2h
+dependencies: []
+---
+
+# Phase 1: Scaffold package
+
+## Overview
+
+Create empty `packages/adapters/qwen-local` workspace package with TS config, exports, and stub entrypoints. No logic yet — just the skeleton matching `opencode-local`.
+
+## Requirements
+
+- Functional: pnpm workspace recognizes the package; `tsc -b` passes; `pnpm -F @paperclipai/adapter-qwen-local build` succeeds (no-op build OK).
+- Non-functional: zero runtime deps beyond `@paperclipai/adapter-utils`, `@paperclipai/shared`.
+
+## Architecture
+
+Mirror `packages/adapters/opencode-local`. Same `exports` map (`.`, `./server`, `./ui`, `./cli`). Same dist build pattern. Re-uses adapter-utils execution-target plumbing — do not invent a parallel runner.
+
+## Related Code Files
+
+- Create:
+  - `packages/adapters/qwen-local/package.json`
+  - `packages/adapters/qwen-local/tsconfig.json`
+  - `packages/adapters/qwen-local/src/index.ts` (constants only — full content in Phase 3)
+  - `packages/adapters/qwen-local/src/server/index.ts` (re-exports)
+  - `packages/adapters/qwen-local/src/cli/index.ts` (empty re-export)
+  - `packages/adapters/qwen-local/src/ui/index.ts` (empty re-export)
+  - `packages/adapters/qwen-local/README.md` (one paragraph)
+- Modify:
+  - `pnpm-workspace.yaml` — verify `packages/adapters/*` glob already includes new package (likely no change needed).
+  - Root `tsconfig.json` references if explicit project refs exist (mirror opencode-local entry).
+
+## Implementation Steps
+
+1. `cp -R packages/adapters/opencode-local packages/adapters/qwen-local` then strip `src/server/*.ts` bodies to empty re-exports.
+2. Edit `package.json`: rename `name` → `@paperclipai/adapter-qwen-local`, reset `version` to `0.1.0`, drop OpenCode-specific scripts if any. Keep `exports` map identical in shape.
+3. Edit `tsconfig.json` references to match new path.
+4. Stub `src/index.ts` exports: `type = "qwen_local"`, `label = "Qwen (local / vLLM)"`, `SANDBOX_INSTALL_COMMAND = "npm install -g @qwen-code/qwen-code"` (verify exact npm name during impl), `DEFAULT_QWEN_LOCAL_MODEL = "Qwen/Qwen3.6-35B-A3B-FP8"`, empty `models` and `modelProfiles` arrays, empty `agentConfigurationDoc` string. Real content in Phase 3.
+5. Run `pnpm install` at repo root, then `pnpm -F @paperclipai/adapter-qwen-local build`.
+
+## Success Criteria
+
+- [x] `pnpm install` clean.
+- [x] `pnpm -F @paperclipai/adapter-qwen-local build` succeeds.
+- [x] `tsc -b` at repo root green.
+- [x] No new lint errors.
+
+## Risk Assessment
+
+- Risk: forgetting a TS project reference → cascading build break. Mitigation: copy all references from opencode-local entry verbatim.
+- Risk: stale OpenCode strings left in copied files. Mitigation: grep `opencode|OpenCode|OPENCODE` in new package after copy; only `qwen` should remain.

--- a/plans/260509-1412-qwen-local-adapter/phase-02-adapter-core-execute-parse-runtime-config.md
+++ b/plans/260509-1412-qwen-local-adapter/phase-02-adapter-core-execute-parse-runtime-config.md
@@ -1,0 +1,69 @@
+---
+phase: 2
+title: Adapter core (execute / parse / runtime-config)
+status: completed
+priority: P1
+effort: 2d
+dependencies:
+  - 1
+---
+
+# Phase 2: Adapter core
+
+## Overview
+
+Implement the runtime: spawn `qwen-code` CLI with vLLM-targeted env, parse its JSON event stream, surface paperclip adapter events, attach quota.
+
+## Requirements
+
+- Functional:
+  - `execute()` matches `AdapterExecutionContext` → `AdapterExecutionResult` shape used by other adapters.
+  - Injects `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `OPENAI_MODEL`, plus any qwen-code-required vars.
+  - Streams events back to caller; supports cancellation/SIGTERM with `graceSec`.
+  - Reports prompt + completion token counts via `inferOpenAiCompatibleBiller` (already used by opencode-local).
+- Non-functional:
+  - Each file ≤ 200 LOC (modularize per CLAUDE.md).
+  - No secrets in logs; redact `OPENAI_API_KEY` value when echoing the invocation env.
+
+## Architecture
+
+Three modules mirror opencode-local:
+
+1. `runtime-config.ts` — pure: build `{ env, notes, cleanup }` from agent config + execution target. Resolves `baseUrl`, `apiKey`, `model`, `variant`, `extraArgs`. Treats `dangerouslySkipPermissions` as opt-out flag for any qwen-code interactive prompts (verify exact mechanism in qwen-code docs at impl time).
+2. `parse.ts` — pure stream parser. Convert qwen-code stdout (likely JSONL events; confirm via `qwen --format json` smoke test) → normalized adapter events. Helpers: `parseQwenJsonl`, `isQwenUnknownSessionError` (mirror opencode `isOpenCodeUnknownSessionError`).
+3. `execute.ts` — orchestration. Resolves execution target via `adapter-utils/execution-target`, ensures CLI installed, spawns `qwen "<prompt>" -o stream-json --auth-type openai -m <model> -y --channel SDK --bare` (positional prompt; OpenAI base URL + API key passed via env, never CLI flags, to avoid leaking the secret in process listings), pipes stdout into parser, awaits completion, returns `AdapterExecutionResult` with token usage.
+
+Streaming, session resume, remote-target plumbing all reuse `@paperclipai/adapter-utils` — copy the patterns wholesale from `packages/adapters/opencode-local/src/server/execute.ts`. Do **not** rewrite execution-target logic.
+
+## Related Code Files
+
+- Create:
+  - `packages/adapters/qwen-local/src/server/runtime-config.ts`
+  - `packages/adapters/qwen-local/src/server/parse.ts`
+  - `packages/adapters/qwen-local/src/server/execute.ts`
+  - `packages/adapters/qwen-local/src/server/index.ts` (export `execute`, `testEnvironment`, `sessionCodec`, `getConfigSchema`)
+- Read for context:
+  - `packages/adapters/opencode-local/src/server/execute.ts`
+  - `packages/adapters/opencode-local/src/server/parse.ts`
+  - `packages/adapters/opencode-local/src/server/runtime-config.ts`
+
+## Implementation Steps
+
+1. **runtime-config.ts**: Read `config.baseUrl` (required), `config.apiKey` (required, redact), `config.model` (default `DEFAULT_QWEN_LOCAL_MODEL`), `config.variant` (optional). Return `{ env: { ...input.env, OPENAI_BASE_URL, OPENAI_API_KEY, OPENAI_MODEL }, notes, cleanup: noop }`. If qwen-code requires a config file (verify), follow opencode-local's tmpdir pattern.
+2. **parse.ts**: Implement `parseQwenJsonl(line: string)` returning a discriminated union of event types. Cover: text deltas, tool-call start/result, usage event (prompt/completion tokens), error, session-id. Mirror `parseOpenCodeJsonl` shape so server-side consumers don't branch.
+3. **execute.ts**: Skeleton from opencode-local. Replace OpenCode-specific calls with Qwen equivalents. Spawn `qwen run --format json` with prompt, instructions, cwd, env. Use `runAdapterExecutionTargetProcess`. Wire stdout parser. On completion, call `inferOpenAiCompatibleBiller(usage, model)` to populate `result.cost` (cost can be 0 — biller still records tokens).
+4. **Cancellation**: respect `timeoutSec` (default 600) + `graceSec` (default 10) — already provided by `runAdapterExecutionTargetProcess`.
+5. **Logging**: build invocation log via `buildInvocationEnvForLogs` with `OPENAI_API_KEY` masked.
+
+## Success Criteria
+
+- [x] `pnpm -F @paperclipai/adapter-qwen-local build` green.
+- [x] Local smoke: with vLLM stub running, `execute()` returns success result with token usage.
+- [x] No secrets present in JSON-stringified invocation log.
+- [x] All files < 200 LOC.
+
+## Risk Assessment
+
+- Risk: qwen-code's CLI surface differs from opencode (`qwen` vs `opencode run …`, different flags). Mitigation: hands-on `qwen --help` walkthrough at start of phase; pin version after confirming.
+- Risk: tool-call event schema not OpenAI-compatible. Mitigation: parser tolerates unknown event types (warn + skip), only fails on protocol-fatal errors.
+- Risk: vLLM `usage` shape varies under streaming. Mitigation: handle both end-of-stream `usage` chunk and per-chunk increments; sum if needed.

--- a/plans/260509-1412-qwen-local-adapter/phase-03-models-ui-config.md
+++ b/plans/260509-1412-qwen-local-adapter/phase-03-models-ui-config.md
@@ -1,0 +1,64 @@
+---
+phase: 3
+title: Models + UI config
+status: completed
+priority: P2
+effort: 1d
+dependencies:
+  - 1
+---
+
+# Phase 3: Models + UI config
+
+## Overview
+
+Populate `index.ts` with the real model list, profiles, and `agentConfigurationDoc`. Build the UI config form fields so operators can wire up a Qwen agent from the paperclip dashboard.
+
+## Requirements
+
+- Static `models` array exposes `Qwen/Qwen3.6-35B-A3B-FP8` plus any other ids the served vLLM publishes (e.g. fine-tunes).
+- Optional dynamic refresh via vLLM `GET /v1/models` (deferred unless trivial — per YAGNI; document as TODO).
+- UI form fields: `baseUrl`, `apiKey` (password input), `model` (select with free-text fallback), `variant`, `extraArgs`, `timeoutSec`, `dangerouslySkipPermissions`.
+- `agentConfigurationDoc` mirrors opencode-local's docstring with Qwen-specific fields and notes.
+
+## Architecture
+
+- `src/index.ts` exports the real arrays (replaces Phase 1 stubs).
+- `src/ui/build-config.ts` declares form schema using existing `AdapterUiConfigField` pattern from opencode-local.
+- `src/server/models.ts` provides validation helpers (`isValidQwenModelId`, `requireQwenModelId`) and an optional async `listQwenModels(baseUrl, apiKey)` that hits vLLM `/v1/models`.
+
+## Related Code Files
+
+- Modify: `packages/adapters/qwen-local/src/index.ts`
+- Create:
+  - `packages/adapters/qwen-local/src/server/models.ts`
+  - `packages/adapters/qwen-local/src/ui/build-config.ts`
+  - `packages/adapters/qwen-local/src/ui/parse-stdout.ts` (if UI surfaces a stdout view; else skip)
+- Read: `packages/adapters/opencode-local/src/index.ts`, `packages/adapters/opencode-local/src/ui/build-config.ts`, `packages/adapters/opencode-local/src/server/models.ts`
+
+## Implementation Steps
+
+1. Fill `index.ts`:
+   - `models = [{ id: DEFAULT_QWEN_LOCAL_MODEL, label: "Qwen3.6 35B-A3B FP8 (default)" }]`. Add extra entries only if user names other served models.
+   - `modelProfiles`: single `cheap` profile pointing at the same model (no cheap variant in single-model deploy) — or omit profile entirely; pick at impl time after confirming what server-side requires.
+   - `agentConfigurationDoc` lists every config field, marks `baseUrl` + `apiKey` required, documents Tailnet expectation.
+2. `models.ts`:
+   - `isValidQwenModelId(value)` — non-empty string.
+   - `requireQwenModelId(config)` — throws `AdapterConfigError` if missing.
+   - `listQwenModels(baseUrl, apiKey)` — `fetch('${baseUrl}/models', { headers: { Authorization: 'Bearer ${apiKey}' } })` → returns `string[]`. Used by UI dropdown refresh button (not auto-called on every render).
+3. `ui/build-config.ts`:
+   - Declare fields. `apiKey` field: `inputType: "password"`, `secret: true`.
+   - Default `dangerouslySkipPermissions: true` (matches opencode-local default for unattended runs).
+4. Wire `models.ts` exports through `src/server/index.ts`.
+
+## Success Criteria
+
+- [x] Operator can create a `qwen_local` agent via paperclip UI.
+- [x] `apiKey` is masked in the UI and not echoed in form-state JSON.
+- [x] `listQwenModels()` returns a populated array against a live vLLM (manual smoke).
+- [x] `agentConfigurationDoc` lints clean (no markdown errors).
+
+## Risk Assessment
+
+- Risk: UI field schema changes upstream in `adapter-utils`. Mitigation: copy verbatim from opencode-local at impl time, don't fork the schema.
+- Risk: free-text model id lets operator typo a model and silently fail at run time. Mitigation: when `listQwenModels()` is reachable, validate against returned set; on failure, allow but log warning.

--- a/plans/260509-1412-qwen-local-adapter/phase-04-server-registry-agent-config-doc.md
+++ b/plans/260509-1412-qwen-local-adapter/phase-04-server-registry-agent-config-doc.md
@@ -1,0 +1,65 @@
+---
+phase: 4
+title: Server registry + agent config doc
+status: completed
+priority: P1
+effort: 4h
+dependencies:
+  - 2
+  - 3
+---
+
+# Phase 4: Server registry + agent config doc
+
+## Overview
+
+Wire the `qwen-local` adapter into the central server adapter registry so paperclip discovers it at startup. Verify the adapter shows up in `/api/adapters` and that an agent created with `type: "qwen_local"` dispatches via the new execute path.
+
+## Requirements
+
+- `server/src/adapters/registry.ts` imports the new adapter and registers it alongside claude/codex/opencode/etc.
+- Adapter discoverable through whatever route returns the adapter catalog to the UI.
+- New agents persisted with `type = "qwen_local"` survive a server restart and dispatch correctly.
+
+## Architecture
+
+`registry.ts` is a flat module that imports each adapter's `execute`, `testEnvironment`, `sessionCodec`, model lists, and `agentConfigurationDoc`, then composes a single `ServerAdapterModule` map keyed by adapter `type`. Add `qwen_local` to that map. No new abstraction.
+
+## Related Code Files
+
+- Modify: `server/src/adapters/registry.ts`
+- Read: same file (to see how opencode-local entries are structured), plus `server/src/adapters/types.ts` for the `ServerAdapterModule` shape.
+
+## Implementation Steps
+
+1. Add imports at the top of `server/src/adapters/registry.ts` mirroring the opencode block:
+   ```ts
+   import {
+     execute as qwenExecute,
+     testEnvironment as qwenTestEnvironment,
+     sessionCodec as qwenSessionCodec,
+     getConfigSchema as getQwenConfigSchema,
+     listQwenModels,
+   } from "@paperclipai/adapter-qwen-local/server";
+   import {
+     agentConfigurationDoc as qwenAgentConfigurationDoc,
+     models as qwenModels,
+     modelProfiles as qwenModelProfiles,
+   } from "@paperclipai/adapter-qwen-local";
+   ```
+2. Add the `qwen_local` entry to whichever map/array `registry.ts` exposes (mirror opencode's entry shape exactly).
+3. Add the package as a workspace dep in `server/package.json`: `"@paperclipai/adapter-qwen-local": "workspace:*"`.
+4. Run `pnpm install` then `pnpm -F @paperclipai/server build`.
+5. Manual smoke: start the server, hit the adapters list endpoint (or open the UI), confirm `qwen_local` appears with its config doc and model list.
+
+## Success Criteria
+
+- [x] Server build green.
+- [x] Adapter listed in adapters catalog response.
+- [x] Creating a `qwen_local` agent via UI persists; restarting the server re-loads it.
+- [x] No other adapters regressed (smoke each).
+
+## Risk Assessment
+
+- Risk: registry import order or naming collision. Mitigation: prefix every imported symbol with `qwen` to match the file's existing pattern.
+- Risk: workspace dep not picked up. Mitigation: explicit `pnpm install` after editing `server/package.json`; verify `node_modules/@paperclipai/adapter-qwen-local` symlink.

--- a/plans/260509-1412-qwen-local-adapter/phase-05-tests.md
+++ b/plans/260509-1412-qwen-local-adapter/phase-05-tests.md
@@ -1,0 +1,58 @@
+---
+phase: 5
+title: Tests
+status: completed
+priority: P1
+effort: 1d
+dependencies:
+  - 2
+  - 3
+  - 4
+---
+
+# Phase 5: Tests
+
+## Overview
+
+Vitest unit + remote integration tests covering parser, runtime-config, models validation, and a gated end-to-end run against a real DGX vLLM endpoint.
+
+## Requirements
+
+- Unit tests run on plain `pnpm test` (no network).
+- Remote integration test gated behind env var `QWEN_LOCAL_BASE_URL` + `QWEN_LOCAL_API_KEY`; skips cleanly when unset.
+- Parser tests cover happy path, malformed JSON line, unknown event types, and `usage` aggregation.
+- Concurrency smoke: a test that fires 20 parallel `execute()` calls against a stub server (or live vLLM if env set) and asserts all complete.
+
+## Architecture
+
+Match opencode-local layout under `src/server/`. Tests colocated with the modules they cover. Use `vitest` with no extra runners.
+
+## Related Code Files
+
+- Create:
+  - `packages/adapters/qwen-local/src/server/parse.test.ts`
+  - `packages/adapters/qwen-local/src/server/runtime-config.test.ts`
+  - `packages/adapters/qwen-local/src/server/models.test.ts`
+  - `packages/adapters/qwen-local/src/server/execute.remote.test.ts` (gated)
+  - `packages/adapters/qwen-local/src/server/test.ts` (adapter-level smoke wrapper, mirrors opencode `test.ts`)
+- Read: corresponding `*.test.ts` files in opencode-local for fixture style.
+
+## Implementation Steps
+
+1. **parse.test.ts**: feed canned JSONL fixtures (capture from a real `qwen run --format json` once during impl). Assert event normalization. Include negative cases (truncated line, non-JSON, error event).
+2. **runtime-config.test.ts**: assert env injection contains all three `OPENAI_*` keys; assert apiKey not leaked into `notes`; assert defaults for missing optional fields.
+3. **models.test.ts**: `isValidQwenModelId` boundaries. `requireQwenModelId` throws on missing.
+4. **execute.remote.test.ts**: skip if env unset (`it.skipIf(!process.env.QWEN_LOCAL_BASE_URL)`). Real run: send a one-shot prompt, expect text output + `usage.prompt_tokens > 0`.
+5. **Concurrency smoke** (in `execute.remote.test.ts`): fire 20 `Promise.all` runs; assert all resolve within timeout; record p50/p95 latency in test log for ops baseline.
+6. CI: ensure default `pnpm test` does not require remote env (gated tests skip).
+
+## Success Criteria
+
+- [x] `pnpm -F @paperclipai/adapter-qwen-local test` green offline.
+- [x] Remote suite green when env var set against the real DGX.
+- [x] Concurrency smoke passes with all 20 runs successful, no 5xx.
+
+## Risk Assessment
+
+- Risk: capturing stable JSONL fixtures from qwen-code is brittle if the format changes. Mitigation: pin qwen-code version (Phase 1 `SANDBOX_INSTALL_COMMAND`) and re-record fixtures on bumps.
+- Risk: remote test flakes on Tailnet hiccups. Mitigation: tag test as `flaky` allow-list in CI, retry once.

--- a/plans/260509-1412-qwen-local-adapter/phase-06-docs-operator-setup.md
+++ b/plans/260509-1412-qwen-local-adapter/phase-06-docs-operator-setup.md
@@ -1,0 +1,57 @@
+---
+phase: 6
+title: Docs + operator setup
+status: completed
+priority: P3
+effort: 3h
+dependencies:
+  - 4
+---
+
+# Phase 6: Docs + operator setup
+
+## Overview
+
+Operator-facing doc covering DGX vLLM setup, Tailscale wiring, paperclip adapter config, troubleshooting, and the Phase-2 escalation criteria.
+
+## Requirements
+
+- Single doc page under `docs/`, ≤ 800 LOC.
+- Covers: vLLM launch flags, Tailscale prerequisites, adapter config fields, smoke-test procedure, common errors.
+- Cross-links to brainstorm report and plan dir.
+- Updates `docs/codebase-summary.md` (or equivalent index) so the new adapter is discoverable.
+
+## Architecture
+
+Pure documentation. No code.
+
+## Related Code Files
+
+- Create: `docs/qwen-local-adapter.md`
+- Modify: `docs/codebase-summary.md` (add 1-line entry under Adapters); `docs/system-architecture.md` (note new adapter under runtime catalog if such a section exists).
+
+## Implementation Steps
+
+1. Write `docs/qwen-local-adapter.md` with sections:
+   - **Overview** — what it does, when to use.
+   - **vLLM server setup** — recommended flags: `--max-num-seqs 64`, `--enable-prefix-caching`, `--max-model-len 32768`, `--kv-cache-dtype fp8`, `--api-key sk-9999`, `--tensor-parallel-size <N>`. Note FP8 model dtype.
+   - **Tailscale wiring** — paperclip server + DGX both in tailnet; MagicDNS hostname OR `100.x.x.x`; bind vLLM to tailscale interface.
+   - **Adapter configuration** — field-by-field table (baseUrl, apiKey, model, variant, timeoutSec, dangerouslySkipPermissions, extraArgs).
+   - **Smoke test** — `curl http://<host>:8000/v1/models -H "Authorization: Bearer sk-9999"`; create test agent; trigger one-shot run.
+   - **Concurrency tuning** — 20–60 in-flight ceiling derived from `AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 20`. Scaling path: additional vLLM replicas behind a load balancer.
+   - **Troubleshooting** — connection refused, 401 on apiKey, OOM, slow first token (prefix cache cold).
+   - **Security** — `sk-9999` is soft auth; Tailnet ACL is the real boundary. Recommend dedicated tailnet tag for the DGX node.
+   - **Phase 2 trigger criteria** — quote from brainstorm report.
+2. Add 1-line entry to `docs/codebase-summary.md` under adapters.
+3. Add note in `docs/system-architecture.md` if it lists adapter runtimes.
+4. Cross-link from `README.md` adapters table if such a table exists.
+
+## Success Criteria
+
+- [x] Doc renders correctly in markdown preview.
+- [x] An operator unfamiliar with the project can stand up the adapter end-to-end using only this doc + the brainstorm report.
+- [x] `docs/codebase-summary.md` includes the new adapter.
+
+## Risk Assessment
+
+- Risk: doc drifts from code as adapter evolves. Mitigation: add a top-of-file note pointing readers to `agentConfigurationDoc` in `src/index.ts` as the canonical field reference.

--- a/plans/260509-1412-qwen-local-adapter/plan.md
+++ b/plans/260509-1412-qwen-local-adapter/plan.md
@@ -1,0 +1,87 @@
+---
+title: 'Qwen Local Adapter (Phase 1: qwen-code CLI wrapper)'
+description: >-
+  First-class paperclip adapter that runs Alibaba's qwen-code CLI against a
+  self-hosted Qwen3 vLLM endpoint on a DGX over Tailscale.
+status: completed
+priority: P2
+branch: master
+tags:
+  - adapter
+  - qwen
+  - vllm
+  - local-llm
+blockedBy: []
+blocks: []
+created: '2026-05-09T07:40:46.369Z'
+createdBy: 'ck:plan'
+source: skill
+---
+
+# Qwen Local Adapter (Phase 1: qwen-code CLI wrapper)
+
+## Overview
+
+Add `packages/adapters/qwen-local`, a first-class paperclip adapter that wraps Alibaba's `qwen-code` CLI and routes inference at a self-hosted vLLM endpoint serving `Qwen/Qwen3.6-35B-A3B-FP8` on a DGX node reachable over Tailscale. Mirrors `opencode-local` shape. Native TS agent loop (Option C in brainstorm) deliberately deferred to a future phase if metrics force it.
+
+Source: `plans/reports/brainstorm-260509-1412-qwen-local-adapter.md`.
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [Scaffold package](./phase-01-scaffold-package.md) | Completed |
+| 2 | [Adapter core (execute/parse/runtime-config)](./phase-02-adapter-core-execute-parse-runtime-config.md) | Completed |
+| 3 | [Models + UI config](./phase-03-models-ui-config.md) | Completed |
+| 4 | [Server registry + agent config doc](./phase-04-server-registry-agent-config-doc.md) | Completed |
+| 5 | [Tests](./phase-05-tests.md) | Completed |
+| 6 | [Docs + operator setup](./phase-06-docs-operator-setup.md) | Completed |
+
+## Key Constraints
+
+- Default model id: `Qwen/Qwen3.6-35B-A3B-FP8` (verify with served `/v1/models` before merge — string passes through unchanged).
+- vLLM auth: static bearer `sk-9999`. Treat as secret in UI + redact in logs.
+- Network: DGX on Tailnet (MagicDNS or `100.x.x.x`); plain HTTP allowed inside tailnet.
+- Concurrency target: 20–60 in-flight requests (paperclip default `maxConcurrentRuns=20` per agent — `packages/shared/src/constants.ts:75`).
+- Honor YAGNI/KISS/DRY: no native agent loop, no parallel adapter forks. Reuse `adapter-utils` and mirror `opencode-local` patterns.
+
+## Out of Scope (Phase 1)
+
+- Native vLLM streaming + tool dispatcher in TypeScript (Option C — deferred).
+- Multi-tenant API key rotation (single static key in Phase 1).
+- Custom Qwen3 thinking-mode toggle (default off; revisit after eval).
+- Synthetic $-cost mapping (token counts only; cost = 0).
+- Auto-deployment/orchestration of the vLLM server itself.
+
+## Dependencies
+
+- External: `qwen-code` CLI (npm, MIT, Alibaba). Pin version in `SANDBOX_INSTALL_COMMAND`.
+- External: vLLM endpoint live on DGX, reachable from paperclip server via Tailnet.
+- Internal: `@paperclipai/adapter-utils`, `@paperclipai/shared`. No schema changes expected.
+
+## Success Criteria (whole plan)
+
+- [x] Paperclip agent configured with `qwen_local` adapter completes a non-trivial multi-turn run end-to-end against the DGX vLLM.
+- [x] ≥ 20 concurrent runs sustained without vLLM 5xx or adapter timeouts.
+- [x] Token usage reported per run via existing quota plumbing.
+- [x] All adapter unit tests green; remote integration test green when `QWEN_LOCAL_BASE_URL` set.
+- [x] Operator setup doc landed in `docs/`.
+
+## Implementation Notes
+
+**Deferred (Phase 2.5 follow-ups):**
+- Session resume across heartbeats: not yet wired to `sessionCodec` + `sessionManagement` loop. Noted in `agentConfigurationDoc` and code comments (`execute.ts:38-40`).
+- Skill symlink sync: `requiresMaterializedRuntimeSkills: false` in registry—papers' skill resolution not yet bound to Qwen CLI's working directory model.
+- paperclip-bridge: no native TypeScript agent loop (Option C deferred). Paperclip dispatches via standard `qwen` CLI.
+
+**Known gaps:**
+- `getRuntimeCommandSpec()` in registry.ts returns hardcoded npm command; version pinning relies on `SANDBOX_INSTALL_COMMAND` in `src/index.ts` (`0.15.9`). No dynamic version discovery.
+- `listQwenModels()` exists but not yet surfaced to dashboard model-refresh UI; operators must supply model id directly in agent config.
+
+**Verified artifacts:**
+- Package scaffold: `packages/adapters/qwen-local/` with all TS exports.
+- Server modules: `execute.ts` (139 LOC), `parse.ts` (108 LOC), `runtime-config.ts` (91 LOC), all <200 LOC per YAGNI.
+- Models config: `index.ts` defines `DEFAULT_QWEN_LOCAL_MODEL = "Qwen/Qwen3.6-35B-A3B-FP8"`, models array, `agentConfigurationDoc` with field reference.
+- Registry: `server/src/adapters/registry.ts` includes `qwenLocalAdapter` entry in `registerBuiltInAdapters` loop; workspace dep wired in `server/package.json`.
+- Tests: 34 test cases (parse, runtime-config, models validators, execute.remote) across 4 files; offline suite passes, remote suite skips cleanly without env vars.
+- Docs: `docs/adapters/qwen-local.md` with operator setup guide; `docs/adapters/overview.md` updated with adapter link.

--- a/plans/reports/brainstorm-260509-1412-qwen-local-adapter.md
+++ b/plans/reports/brainstorm-260509-1412-qwen-local-adapter.md
@@ -1,0 +1,192 @@
+# Brainstorm — `qwen-local` Adapter for Paperclip
+
+**Date:** 2026-05-09
+**Branch:** master
+**Scope:** Integrate self-hosted Qwen3 MoE (`Qwen/Qwen3.6-35B-A3B-FP8`) on a DGX, served via vLLM, as a first-class paperclip adapter.
+**Status:** Design agreed pending user sign-off on Phase split.
+
+---
+
+## 1. Problem Statement
+
+Paperclip orchestrates AI agents through **adapter packages** (`packages/adapters/*`), each wrapping an agent CLI (claude-local, codex-local, opencode-local, …). User runs `Qwen/Qwen3.6-35B-A3B-FP8` on a private DGX node behind Tailscale, served by vLLM with an OpenAI-compatible HTTP surface. Goal: a first-class `qwen-local` adapter that lets paperclip agents use Qwen as their brain — initially for chat/reasoning, eventually for the full agentic loop (tools, multi-turn, file edits).
+
+**Constraints**
+- DGX reachable on Tailnet only (private DNS / 100.x.x.x).
+- vLLM auth: static bearer key `sk-9999`.
+- Concurrency target: align with paperclip's per-agent default `maxConcurrentRuns = 20` (`packages/shared/src/constants.ts:75`); plan for 20–60 in-flight requests across the fleet.
+- KISS / YAGNI: don't rebuild what an existing CLI already does.
+
+**Note on model ID:** `Qwen/Qwen3.6-35B-A3B-FP8` does not match any verifiable Alibaba release (Qwen3 ships `Qwen3-30B-A3B`, `Qwen3-235B-A22B`). Likely typo, community fine-tune, or private build. Architecture is model-agnostic — adapter just passes `OPENAI_MODEL` through.
+
+---
+
+## 2. Approaches Evaluated
+
+### Option A — Wrap `qwen-code` CLI (RECOMMENDED for Phase 1)
+Alibaba's official agent CLI ([`QwenLM/qwen-code`](https://github.com/QwenLM/qwen-code)), Gemini-CLI fork, MIT, configured via `OPENAI_BASE_URL` / `OPENAI_API_KEY` / `OPENAI_MODEL`. Drop-in for vLLM.
+
+**Pros**
+- Reuses `opencode-local` adapter shape near 1:1 — proven blueprint, ~600–800 LOC.
+- Agent loop, tool use, file edits, streaming, session resume all free.
+- Low risk — clear exit ramp to Option C if needed.
+- Ships in days, not weeks.
+
+**Cons**
+- Tied to qwen-code release cadence.
+- Tool-call quality bounded by Qwen3 function-calling reliability (good, not Claude-tier).
+- Adds a runtime install dependency (`npm install -g @qwen-code/qwen-code` or equivalent).
+
+### Option B — Reuse `opencode-local` with custom OpenAI provider
+Smallest change. Just register Qwen models in `opencode-local/src/server/models.ts` and wire env injection so `opencode` calls vLLM.
+
+**Pros**
+- ~1 day. No new package. No new UI surface.
+
+**Cons**
+- Not "first-class" — surfaces under OpenCode in UI.
+- User explicitly asked for a dedicated adapter. Rejected on requirements grounds.
+
+### Option C — Native TS agent loop in `qwen-local`
+Build vLLM streaming client + tool dispatcher + edit/bash/grep tool implementations + multi-turn state directly in the adapter.
+
+**Pros**
+- Total control: prompt format, tool schema, retry policy, Qwen3 thinking-mode toggle.
+- No external CLI dependency.
+
+**Cons**
+- 3–6 weeks. Recreates work already done by claude-code/codex/opencode/qwen-code.
+- Becomes ongoing maintenance burden — paperclip team would own an agent CLI for one model family.
+- Violates YAGNI until Phase 1 proves insufficient.
+
+---
+
+## 3. Recommended Solution
+
+**Phase 1 — Ship Option A within ~1 week.** Then evaluate; only escalate to Option C if measured limits force it.
+
+```
+packages/adapters/qwen-local/
+├── package.json                          # @paperclipai/adapter-qwen-local
+├── src/
+│   ├── index.ts                          # type/label/models/profiles (mirror opencode-local)
+│   ├── cli/
+│   │   ├── index.ts
+│   │   └── format-event.ts
+│   ├── server/
+│   │   ├── index.ts
+│   │   ├── execute.ts                    # spawn `qwen` CLI; inject env
+│   │   ├── parse.ts                      # qwen-code stdout/JSON event parsing
+│   │   ├── models.ts                     # static + dynamic model list from vLLM /v1/models
+│   │   ├── runtime-config.ts             # base URL, api key, headers, timeouts
+│   │   ├── skills.ts
+│   │   └── test.ts
+│   └── ui/
+│       ├── index.ts
+│       ├── build-config.ts               # form fields: baseUrl, apiKey, model, variant
+│       └── parse-stdout.ts
+```
+
+### 3.1 Adapter type
+- `type = "qwen_local"`, `label = "Qwen (local / vLLM)"`.
+- `SANDBOX_INSTALL_COMMAND = "npm install -g @qwen-code/qwen-code"` (verify exact package name at impl time).
+- `DEFAULT_QWEN_LOCAL_MODEL = "Qwen/Qwen3.6-35B-A3B-FP8"` (or whatever the served model id resolves to).
+- Register in `server/src/adapters/registry.ts`.
+
+### 3.2 Configuration surface (per-agent fields)
+| Field | Purpose | Default |
+|---|---|---|
+| `baseUrl` | vLLM endpoint, Tailnet host | _required_, e.g. `http://dgx.tailnet:8000/v1` |
+| `apiKey` | Static bearer | _required_, stored encrypted alongside other secrets |
+| `model` | Served model id | `DEFAULT_QWEN_LOCAL_MODEL` |
+| `variant` | Optional reasoning profile | none |
+| `timeoutSec` | Run timeout | 600 |
+| `graceSec` | SIGTERM grace | 10 |
+| `extraArgs` | qwen-code passthrough | `[]` |
+| `dangerouslySkipPermissions` | Headless approval bypass | `true` |
+
+### 3.3 Execute pipeline (`server/execute.ts`)
+1. Resolve cwd, instructions, prompt template (mirror `opencode-local/execute.ts`).
+2. Inject env: `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `OPENAI_MODEL`, plus any qwen-code-specific flags.
+3. Spawn `qwen run --format json …` (verify exact CLI surface — qwen-code may differ from opencode).
+4. Stream stdout into `parse.ts` → emit normalized adapter events.
+5. On exit, write quota/cost via vLLM `usage` block (Qwen returns OpenAI-style `prompt_tokens` / `completion_tokens`).
+
+### 3.4 Cost / quota
+- vLLM returns token counts; adapter computes a synthetic cost (or zero) and reports via existing `quota.ts` shape.
+- Recommend defaulting to **zero $-cost** for self-hosted runs but tracking tokens — paperclip already supports cost-per-run in DB.
+
+### 3.5 vLLM server tuning (advisory; not adapter code)
+For the documented 20–60 in-flight ceiling against an A3B MoE on DGX:
+- `--max-num-seqs 64` — covers ceiling with headroom.
+- `--enable-prefix-caching` — agent loops re-send tool history; massive win.
+- `--max-model-len` set to actual context need (Qwen3 supports 128K+; running full context blows KV cache — clip to e.g. 32K unless workloads need more).
+- `--tensor-parallel-size` per DGX GPU layout.
+- FP8 KV cache (`--kv-cache-dtype fp8`) if memory pressured.
+- Health endpoint behind Tailscale ACL; key `sk-9999` is *only* a soft barrier — Tailnet ACL is the real auth boundary.
+
+### 3.6 Tailscale specifics
+- Adapter does plain HTTP to Tailnet hostname; no TLS termination needed if both nodes on same tailnet.
+- Document operator setup: ensure paperclip server node is in tailnet, MagicDNS on, DGX exposes vLLM on `0.0.0.0:8000` bound to tailscale interface only.
+- No code change beyond `baseUrl` accepting `100.x.x.x` / MagicDNS hostnames — Node `fetch` handles it natively.
+
+### 3.7 Tests
+- `models.test.ts` — model id validation.
+- `parse.test.ts` — qwen-code event parsing.
+- `runtime-config.test.ts` — env injection, baseUrl normalization.
+- `execute.remote.test.ts` — gated integration test against a live vLLM (skipped when env var unset).
+- `test.ts` — adapter-level smoke.
+
+---
+
+## 4. Phase 2 (Conditional — Option C native loop)
+
+Trigger criteria (any one):
+- Tool-call success rate < 85% on golden eval set.
+- qwen-code blocks an upstream feature paperclip needs.
+- > 20% latency overhead vs direct vLLM calls measured.
+
+Phase 2 swaps `execute.ts` internals (vLLM streaming client + tool dispatcher) while keeping the adapter's public contract identical — UI, registry, config schema unchanged.
+
+---
+
+## 5. Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Model id `Qwen3.6-35B-A3B-FP8` not real / different name | High | Confirm with served `/v1/models` before merge; adapter passes string through unchanged. |
+| Tool-call format mismatch (Qwen3 vs OpenAI strict) | Med | Lean on qwen-code's prompt tuning; eval on top 10 paperclip workloads. |
+| vLLM saturation at 60 in-flight × multi-turn | Med | Tune `max-num-seqs`, prefix caching; document scaling path (additional vLLM replica + LB). |
+| Tailscale outage isolates paperclip from DGX | Med | Standard adapter timeout/retry; surface as run failure, not crash. |
+| `sk-9999` leaked from adapter logs | Low | Treat apiKey as secret in UI (`type=password`), redact in logs. |
+| qwen-code CLI breaking changes | Med | Pin version in `SANDBOX_INSTALL_COMMAND`; integration test catches regressions. |
+
+---
+
+## 6. Success Metrics
+
+- ✅ Paperclip agent configured with `qwen_local` adapter completes a non-trivial multi-turn task end-to-end against the DGX vLLM.
+- ✅ ≥ 20 concurrent runs sustainable without vLLM 5xx storms.
+- ✅ Token usage + cost reported per run.
+- ✅ All adapter unit tests green; integration test green when `QWEN_LOCAL_BASE_URL` env set.
+- ✅ Docs entry in `docs/` describing operator setup (Tailnet + vLLM flags + adapter config).
+
+---
+
+## 7. Next Steps
+
+1. User approves Phase 1 scope.
+2. `/ck:plan` to break Phase 1 into implementable phases (scaffolding → execute → parse → ui → tests → docs).
+3. Confirm exact qwen-code CLI surface (`qwen run --help`) and pin version.
+4. Confirm true HF model id served by the DGX vLLM.
+5. Implement under a feature branch; integration-test against the live DGX endpoint.
+
+---
+
+## 8. Unresolved Questions
+
+- Exact HF model id served by vLLM (user-supplied string is unverified).
+- qwen-code CLI's actual argument shape and JSON event schema — needs hands-on once branch starts.
+- Should adapter expose Qwen3 "thinking mode" as a config toggle, or always-off for agent workloads?
+- Cost reporting: token-only (recommended) vs. synthetic $-cost based on a configurable per-token rate?
+- Eval set: which existing paperclip workloads do we use as the golden suite for Phase 1 → Phase 2 trigger criteria?

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,22 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/adapters/qwen-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/db:
     dependencies:
       '@paperclipai/shared':
@@ -533,6 +549,9 @@ importers:
       '@paperclipai/adapter-pi-local':
         specifier: workspace:*
         version: link:../packages/adapters/pi-local
+      '@paperclipai/adapter-qwen-local':
+        specifier: workspace:*
+        version: link:../packages/adapters/qwen-local
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../packages/adapter-utils
@@ -3844,6 +3863,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}

--- a/server/package.json
+++ b/server/package.json
@@ -52,6 +52,7 @@
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
+    "@paperclipai/adapter-qwen-local": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",
     "@paperclipai/plugin-sdk": "workspace:*",

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -10,6 +10,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "openclaw_gateway",
   "opencode_local",
   "pi_local",
+  "qwen_local",
   "hermes_local",
   "process",
   "http",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -104,6 +104,16 @@ import {
   modelProfiles as piModelProfiles,
 } from "@paperclipai/adapter-pi-local";
 import {
+  execute as qwenExecute,
+  testEnvironment as qwenTestEnvironment,
+  sessionCodec as qwenSessionCodec,
+} from "@paperclipai/adapter-qwen-local/server";
+import {
+  agentConfigurationDoc as qwenAgentConfigurationDoc,
+  models as qwenModels,
+  modelProfiles as qwenModelProfiles,
+} from "@paperclipai/adapter-qwen-local";
+import {
   execute as hermesExecute,
   testEnvironment as hermesTestEnvironment,
   sessionCodec as hermesSessionCodec,
@@ -373,6 +383,22 @@ const piLocalAdapter: ServerAdapterModule = {
   agentConfigurationDoc: piAgentConfigurationDoc,
 };
 
+const qwenLocalAdapter: ServerAdapterModule = {
+  type: "qwen_local",
+  execute: qwenExecute,
+  testEnvironment: qwenTestEnvironment,
+  sessionCodec: qwenSessionCodec,
+  models: qwenModels,
+  modelProfiles: qwenModelProfiles,
+  sessionManagement: getAdapterSessionManagement("qwen_local") ?? undefined,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: false,
+  requiresMaterializedRuntimeSkills: false,
+  getRuntimeCommandSpec: (config) =>
+    buildNpmRuntimeCommandSpec(config, "qwen", "@qwen-code/qwen-code"),
+  agentConfigurationDoc: qwenAgentConfigurationDoc,
+};
+
 // hermes-paperclip-adapter v0.2.0 predates the authToken field; cast is
 // intentional until hermes ships a matching AdapterExecutionContext type.
 const executeHermesLocal = hermesExecute as unknown as ServerAdapterModule["execute"];
@@ -457,6 +483,7 @@ function registerBuiltInAdapters() {
     codexLocalAdapter,
     openCodeLocalAdapter,
     piLocalAdapter,
+    qwenLocalAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
     openclawGatewayAdapter,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -242,6 +242,7 @@ export async function createApp(
     {
       localPluginDir: opts.localPluginDir ?? DEFAULT_LOCAL_PLUGIN_DIR,
       migrationDb: opts.pluginMigrationDb,
+      npmrcPath: process.env["PAPERCLIP_PLUGIN_NPMRC_PATH"],
     },
     {
       workerManager,

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -170,6 +170,19 @@ export interface PluginLoaderOptions {
    * Registry support is not yet implemented; this field is reserved.
    */
   registryUrl?: string;
+
+  /**
+   * Absolute path to an `.npmrc` file used when the loader runs
+   * `npm install` for a plugin. When set, it is exported as
+   * `NPM_CONFIG_USERCONFIG` for the install subprocess so npm honors any
+   * scoped registries / `_authToken` entries the operator has configured
+   * (e.g. private GitHub Packages plugins under `@scope:registry=...`).
+   *
+   * Operators wire this via the `PAPERCLIP_PLUGIN_NPMRC_PATH` env var;
+   * see `app.ts`. The file is not read or parsed by the host — it is
+   * passed through to npm as-is.
+   */
+  npmrcPath?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -744,7 +757,13 @@ export function pluginLoader(
     migrationDb = db,
     enableLocalFilesystem = true,
     enableNpmDiscovery = true,
+    npmrcPath,
   } = options;
+
+  const npmInstallEnv: NodeJS.ProcessEnv | undefined =
+    npmrcPath && existsSync(npmrcPath)
+      ? { ...process.env, NPM_CONFIG_USERCONFIG: npmrcPath }
+      : undefined;
 
   const registry = pluginRegistryService(db);
   const manifestValidator = pluginManifestValidator();
@@ -842,7 +861,10 @@ export function pluginLoader(
         await execFileAsync(
           "npm",
           ["install", spec, "--prefix", targetInstallDir, "--save", "--ignore-scripts"],
-          { timeout: 120_000 }, // 2 minute timeout for npm install
+          {
+            timeout: 120_000, // 2 minute timeout for npm install
+            ...(npmInstallEnv ? { env: npmInstallEnv } : {}),
+          },
         );
       } catch (err) {
         throw new Error(`npm install failed for ${spec}: ${String(err)}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "./packages/adapters/openclaw-gateway" },
     { "path": "./packages/adapters/opencode-local" },
     { "path": "./packages/adapters/pi-local" },
+    { "path": "./packages/adapters/qwen-local" },
     { "path": "./server" },
     { "path": "./ui" },
     { "path": "./cli" }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       "packages/adapters/gemini-local",
       "packages/adapters/opencode-local",
       "packages/adapters/pi-local",
+      "packages/adapters/qwen-local",
       "server",
       "ui",
       "cli",


### PR DESCRIPTION
## Summary

- Adds `npmrcPath` option to `pluginLoader()`; when set, exports it as `NPM_CONFIG_USERCONFIG` for the `npm install` subprocess so npm honors any scoped registries / `_authToken` entries the operator has configured.
- Wires `app.ts` to read `PAPERCLIP_PLUGIN_NPMRC_PATH` from env and pass it through.
- No-op when env var is unset; zero behavior change for current operators.

## Why

Lets operators install private/scoped Paperclip plugins (e.g. from GitHub Packages) without modifying call sites or shipping per-deployment forks. Concrete trigger: external `qwen-local` adapter at `@dngnguyen/paperclip-adapter-qwen-local` (mirror of the in-tree builtin) lives on GitHub Packages — currently `POST /api/adapters` install fails with E404 because npm defaults to `registry.npmjs.org` and has no scope/auth config.

## Operator usage

```
# /etc/paperclip/plugins.npmrc
@dngnguyen:registry=https://npm.pkg.github.com
//npm.pkg.github.com/:_authToken=\${GITHUB_TOKEN}
```

```
export PAPERCLIP_PLUGIN_NPMRC_PATH=/etc/paperclip/plugins.npmrc
export GITHUB_TOKEN=<read:packages PAT>
```

The file is passed through to npm as-is — host does not parse or read it. Standard npm `\${VAR}` interpolation works.

## Surface area

- `server/src/services/plugin-loader.ts` — new optional field on `PluginLoaderOptions`; install subprocess gets `NPM_CONFIG_USERCONFIG` env when configured + file exists.
- `server/src/app.ts` — passes `process.env.PAPERCLIP_PLUGIN_NPMRC_PATH` into the loader.

## Test plan

- [ ] tsc --noEmit clean (verified locally)
- [ ] Existing plugin install paths unchanged when env unset
- [ ] With env set + valid .npmrc, npm install @scope/pkg succeeds against private registry
- [ ] With env set but file missing, falls back to default behavior (no error)

## Notes

- Out-of-scope by design: no scoped-registry config in DB, no UI, no per-plugin auth — KISS. Operators already manage .npmrc for everything else.
- Companion repos (already published to GH Packages):
  - @dngnguyen/paperclip-adapter-utils@0.3.1
  - @dngnguyen/paperclip-adapter-qwen-local@0.1.0