### PR TITLE
fix(ui): list view quick filter must fetch issues from server

### DIFF
--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -714,12 +714,17 @@ export function IssuesList({
   // re-fetch issues per status from the server so that low-priority or older issues that
   // fall outside the default 500-item server cap are still surfaced. This mirrors the
   // per-status fetching pattern used by the board view.
+  // Skip per-status fetches when a remote search is active — `filtered` uses
+  // `searchedIssues` in that case and would discard these results.
   const listStatusFilterValues = useMemo(
     () =>
-      viewState.viewMode === "list" && !searchWithinLoadedIssues && viewState.statuses.length > 0
+      viewState.viewMode === "list"
+      && !searchWithinLoadedIssues
+      && normalizedIssueSearch.length === 0
+      && viewState.statuses.length > 0
         ? viewState.statuses
         : [],
-    [searchWithinLoadedIssues, viewState.statuses, viewState.viewMode],
+    [normalizedIssueSearch, searchWithinLoadedIssues, viewState.statuses, viewState.viewMode],
   );
   const listStatusIssueQueries = useQueries({
     queries: listStatusFilterValues.map((status) => ({
@@ -727,7 +732,6 @@ export function IssuesList({
         ...queryKeys.issues.list(selectedCompanyId ?? "__no-company__"),
         "list-status",
         status,
-        normalizedIssueSearch,
         projectId ?? "__all-projects__",
         searchFilters ?? {},
         ISSUE_LIST_STATUS_RESULT_LIMIT,
@@ -736,13 +740,16 @@ export function IssuesList({
       queryFn: () =>
         issuesApi.list(selectedCompanyId!, {
           ...searchFilters,
-          ...(normalizedIssueSearch.length > 0 ? { q: normalizedIssueSearch } : {}),
           projectId,
           status,
           limit: ISSUE_LIST_STATUS_RESULT_LIMIT,
           ...(enableRoutineVisibilityFilter ? { includeRoutineExecutions: true } : {}),
         }),
-      enabled: !!selectedCompanyId,
+      enabled:
+        !!selectedCompanyId
+        && viewState.viewMode === "list"
+        && !searchWithinLoadedIssues
+        && normalizedIssueSearch.length === 0,
       placeholderData: (previousData: Issue[] | undefined) => previousData,
     })),
   });

--- a/ui/src/components/IssuesList.tsx
+++ b/ui/src/components/IssuesList.tsx
@@ -71,6 +71,7 @@ import { ISSUE_STATUSES, type Issue, type IssueStatus, type Project } from "@pap
 const ISSUE_SEARCH_DEBOUNCE_MS = 250;
 const ISSUE_SEARCH_RESULT_LIMIT = 200;
 const ISSUE_BOARD_COLUMN_RESULT_LIMIT = 200;
+const ISSUE_LIST_STATUS_RESULT_LIMIT = 200;
 const INITIAL_ISSUE_ROW_RENDER_LIMIT = 100;
 const ISSUE_ROW_RENDER_BATCH_SIZE = 150;
 const ISSUE_SCROLL_LOAD_THRESHOLD_PX = 320;
@@ -709,6 +710,42 @@ export function IssuesList({
       placeholderData: (previousData: Issue[] | undefined) => previousData,
     })),
   });
+  // When the list view has an active status filter (e.g. the "Active" quick-filter preset),
+  // re-fetch issues per status from the server so that low-priority or older issues that
+  // fall outside the default 500-item server cap are still surfaced. This mirrors the
+  // per-status fetching pattern used by the board view.
+  const listStatusFilterValues = useMemo(
+    () =>
+      viewState.viewMode === "list" && !searchWithinLoadedIssues && viewState.statuses.length > 0
+        ? viewState.statuses
+        : [],
+    [searchWithinLoadedIssues, viewState.statuses, viewState.viewMode],
+  );
+  const listStatusIssueQueries = useQueries({
+    queries: listStatusFilterValues.map((status) => ({
+      queryKey: [
+        ...queryKeys.issues.list(selectedCompanyId ?? "__no-company__"),
+        "list-status",
+        status,
+        normalizedIssueSearch,
+        projectId ?? "__all-projects__",
+        searchFilters ?? {},
+        ISSUE_LIST_STATUS_RESULT_LIMIT,
+        enableRoutineVisibilityFilter ? "with-routine-executions" : "without-routine-executions",
+      ],
+      queryFn: () =>
+        issuesApi.list(selectedCompanyId!, {
+          ...searchFilters,
+          ...(normalizedIssueSearch.length > 0 ? { q: normalizedIssueSearch } : {}),
+          projectId,
+          status,
+          limit: ISSUE_LIST_STATUS_RESULT_LIMIT,
+          ...(enableRoutineVisibilityFilter ? { includeRoutineExecutions: true } : {}),
+        }),
+      enabled: !!selectedCompanyId,
+      placeholderData: (previousData: Issue[] | undefined) => previousData,
+    })),
+  });
   const { data: executionWorkspaces = [] } = useQuery({
     queryKey: selectedCompanyId
       ? queryKeys.executionWorkspaces.summaryList(selectedCompanyId)
@@ -924,10 +961,31 @@ export function IssuesList({
       boardIssueQueries.some((query) => (query.data?.length ?? 0) === ISSUE_BOARD_COLUMN_RESULT_LIMIT),
     [boardIssueQueries, searchWithinLoadedIssues, viewState.viewMode],
   );
+  const listStatusIssues = useMemo(() => {
+    if (listStatusFilterValues.length === 0) return null;
+    const merged = new Map<string, Issue>();
+    let isPending = false;
+    for (const query of listStatusIssueQueries) {
+      isPending ||= query.isPending;
+      for (const issue of query.data ?? []) {
+        merged.set(issue.id, issue);
+      }
+    }
+    if (merged.size > 0) return [...merged.values()];
+    return isPending ? null : [];
+  }, [listStatusFilterValues, listStatusIssueQueries]);
+  const listStatusLimitReached = useMemo(
+    () =>
+      listStatusFilterValues.length > 0 &&
+      listStatusIssueQueries.some((query) => (query.data?.length ?? 0) === ISSUE_LIST_STATUS_RESULT_LIMIT),
+    [listStatusFilterValues, listStatusIssueQueries],
+  );
 
   const filtered = useMemo(() => {
     const useRemoteSearch = normalizedIssueSearch.length > 0 && !searchWithinLoadedIssues;
-    const sourceIssues = boardIssues ?? (useRemoteSearch ? searchedIssues : issues);
+    const sourceIssues =
+      boardIssues
+      ?? (useRemoteSearch ? searchedIssues : (listStatusIssues ?? issues));
     const searchScopedIssues = normalizedIssueSearch.length > 0 && searchWithinLoadedIssues
       ? sourceIssues.filter((issue) => issueMatchesLocalSearch(issue, normalizedIssueSearch))
       : sourceIssues;
@@ -943,6 +1001,7 @@ export function IssuesList({
   }, [
     boardIssues,
     issues,
+    listStatusIssues,
     searchedIssues,
     searchWithinLoadedIssues,
     viewState,
@@ -1438,6 +1497,11 @@ export function IssuesList({
       {boardColumnLimitReached && (
         <p className="text-xs text-muted-foreground">
           Some board columns are showing up to {ISSUE_BOARD_COLUMN_RESULT_LIMIT} issues. Refine filters or search to reveal the rest.
+        </p>
+      )}
+      {listStatusLimitReached && (
+        <p className="text-xs text-muted-foreground">
+          Some statuses are showing up to {ISSUE_LIST_STATUS_RESULT_LIMIT} issues. Refine filters or search to reveal the rest.
         </p>
       )}
       {!isLoading && filtered.length === 0 && viewState.viewMode === "list" && (


### PR DESCRIPTION
## Summary

- The project list view's quick-filter presets (`Active`, `Backlog`, `Done`) only filtered the already-loaded `issues` prop on the client.
- Large projects exceed the default 500-item server cap, and the server's priority-first sort drops all low-priority issues past that cap — so the `Active` preset could no longer surface them, even when they matched.
- Mirror the board view's per-status fetching pattern in the list view: when a status filter is active, issue one server query per selected status (`limit: 200`) and merge before client-side filtering.
- Reuse the same UX as `boardColumnLimitReached` for an analogous `listStatusLimitReached` hint when any status query saturates its cap.

## Repro

1. Open any project with > 500 issues whose `low`-priority entries would sort past rank 500 (priority first, then `canonicalLastActivityAt DESC`).
2. Switch to **List** view, pick the **Active** quick filter.
3. Observe that low-priority `todo` / `in_progress` / `in_review` / `blocked` issues never appear despite matching the preset.

After this change the matching issues are fetched from the server per-status and rendered.

## Test plan

- [x] `pnpm typecheck` (ui)
- [x] `pnpm build` (ui)
- [ ] Manual: large project, list view, toggle Active / Backlog / Done — verify previously hidden issues now show, and switching back to **All** restores the original prop-driven list.
- [ ] Manual: confirm the `listStatusLimitReached` hint renders when any status query hits the 200-item cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)