### PR TITLE
fix(adapter-utils): loopback-safe PAPERCLIP_API_URL in buildPaperclipEnv

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -890,6 +890,19 @@ export function buildInvocationEnvForLogs(
   return redactEnvForLogs(merged);
 }
 
+function isLoopbackBindHost(rawHost: string): boolean {
+  const host = rawHost.trim().toLowerCase();
+  return host === "127.0.0.1" || host === "localhost" || host === "::1";
+}
+
+function urlHostnameIsLoopback(url: string): boolean {
+  try {
+    return isLoopbackBindHost(new URL(url).hostname);
+  } catch {
+    return false;
+  }
+}
+
 export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
   const resolveHostForUrl = (rawHost: string): string => {
     const host = rawHost.trim();
@@ -901,14 +914,29 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     PAPERCLIP_AGENT_ID: agent.id,
     PAPERCLIP_COMPANY_ID: agent.companyId,
   };
+  const listenHostRaw = (process.env.PAPERCLIP_LISTEN_HOST ?? "").trim();
+  const hostEnvFallback = (process.env.HOST ?? "").trim();
+  const bindHostForLoopbackPolicy = listenHostRaw || hostEnvFallback;
   const runtimeHost = resolveHostForUrl(
-    process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
+    bindHostForLoopbackPolicy || "localhost",
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
-  const apiUrl =
-    process.env.PAPERCLIP_RUNTIME_API_URL ??
-    process.env.PAPERCLIP_API_URL ??
+  const runtimeApiUrl = process.env.PAPERCLIP_RUNTIME_API_URL?.trim();
+  const configuredApiUrl = process.env.PAPERCLIP_API_URL?.trim();
+
+  let apiUrl =
+    runtimeApiUrl ??
+    configuredApiUrl ??
     `http://${runtimeHost}:${runtimePort}`;
+
+  const serverBindsLoopback = isLoopbackBindHost(bindHostForLoopbackPolicy);
+  if (serverBindsLoopback) {
+    const preferredConfigured = runtimeApiUrl ?? configuredApiUrl;
+    if (preferredConfigured && !urlHostnameIsLoopback(preferredConfigured)) {
+      apiUrl = `http://${runtimeHost}:${runtimePort}`;
+    }
+  }
+
   vars.PAPERCLIP_API_URL = apiUrl;
   return vars;
 }

--- a/server/src/__tests__/paperclip-env.test.ts
+++ b/server/src/__tests__/paperclip-env.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 });
 
 describe("buildPaperclipEnv", () => {
-  it("prefers an explicit PAPERCLIP_RUNTIME_API_URL", () => {
+  it("uses loopback listen origin when bind is loopback and runtime URL is off-loopback", () => {
     process.env.PAPERCLIP_RUNTIME_API_URL = "http://203.0.113.42:3102";
     process.env.PAPERCLIP_API_URL = "http://localhost:4100";
     process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
@@ -37,7 +37,29 @@ describe("buildPaperclipEnv", () => {
 
     const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
 
+    expect(env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:3101");
+  });
+
+  it("prefers an explicit PAPERCLIP_RUNTIME_API_URL when bind is not loopback", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://203.0.113.42:3102";
+    process.env.PAPERCLIP_API_URL = "http://localhost:4100";
+    process.env.PAPERCLIP_LISTEN_HOST = "0.0.0.0";
+    process.env.PAPERCLIP_LISTEN_PORT = "3101";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
     expect(env.PAPERCLIP_API_URL).toBe("http://203.0.113.42:3102");
+  });
+
+  it("uses loopback listen origin for MagicDNS-style hostnames when bind is loopback", () => {
+    process.env.PAPERCLIP_RUNTIME_API_URL = "http://macbook.example.ts.net:4242";
+    delete process.env.PAPERCLIP_API_URL;
+    process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+    process.env.PAPERCLIP_LISTEN_PORT = "4242";
+
+    const env = buildPaperclipEnv({ id: "agent-1", companyId: "company-1" });
+
+    expect(env.PAPERCLIP_API_URL).toBe("http://127.0.0.1:4242");
   });
 
   it("falls back to PAPERCLIP_API_URL when no runtime URL is configured", () => {


### PR DESCRIPTION
## Summary
When the server binds on loopback (`PAPERCLIP_LISTEN_HOST` / `HOST` is `127.0.0.1`, `localhost`, or `::1`) but `PAPERCLIP_RUNTIME_API_URL` or `PAPERCLIP_API_URL` points at a non-loopback hostname (e.g. Tailscale MagicDNS), co-located adapters could not reliably reach the API. `buildPaperclipEnv` now prefers the listen origin (`http://<resolved-host>:<port>`) in that case.

## Test plan
- [x] `pnpm exec vitest run server/src/__tests__/paperclip-env.test.ts` (6 tests)
