### PR TITLE
fix(recovery): short-circuit stranded-issue recovery on agent run cascade

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -271,7 +271,7 @@ export type RoutineRunStatus = (typeof ROUTINE_RUN_STATUSES)[number];
 export const ROUTINE_RUN_SOURCES = ["schedule", "manual", "api", "webhook"] as const;
 export type RoutineRunSource = (typeof ROUTINE_RUN_SOURCES)[number];
 
-export const PAUSE_REASONS = ["manual", "budget", "system"] as const;
+export const PAUSE_REASONS = ["manual", "budget", "system", "cascade"] as const;
 export type PauseReason = (typeof PAUSE_REASONS)[number];
 
 export const PROJECT_COLORS = [

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1547,4 +1547,85 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
   });
+
+  it("short-circuits stranded-issue recovery and pauses the agent when in a 3-failure cascade", async () => {
+    // Reproduce the 2026-05-09 runaway: a misconfigured Hermes adapter
+    // failed every heartbeat, generating a fresh "Recover stalled issue"
+    // per failure (156 issues in 10 min). This test locks the
+    // short-circuit: 3 consecutive failed runs in the cascade window must
+    // suppress further recovery-issue creation AND pause the agent with
+    // pauseReason: "cascade".
+    mockAdapterExecute.mockRejectedValueOnce(new Error("continuation recovery failed"));
+
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      agentStatus: "idle",
+      processPid: 999_999_999,
+      processLossRetryCount: 1,
+    });
+
+    // Seed three additional FAILED heartbeat runs for the same agent in
+    // the last 15 min — this is what flips the cascade detector.
+    const recentBase = new Date(Date.now() - 5 * 60 * 1000);
+    await db.insert(heartbeatRuns).values([
+      {
+        id: randomUUID(),
+        companyId,
+        agentId,
+        status: "failed",
+        startedAt: new Date(recentBase.getTime() + 60_000),
+        finishedAt: new Date(recentBase.getTime() + 90_000),
+        contextSnapshot: {},
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        agentId,
+        status: "failed",
+        startedAt: new Date(recentBase.getTime() + 2 * 60_000),
+        finishedAt: new Date(recentBase.getTime() + 2.5 * 60_000),
+        contextSnapshot: {},
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        agentId,
+        status: "failed",
+        startedAt: new Date(recentBase.getTime() + 3 * 60_000),
+        finishedAt: new Date(recentBase.getTime() + 3.5 * 60_000),
+        contextSnapshot: {},
+      },
+    ]);
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    // Block the issue gets blocked but NO recovery issue should be created.
+    const blockedIssue = await waitForValue(async () =>
+      db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => {
+        const issue = rows[0] ?? null;
+        return issue?.status === "blocked" ? issue : null;
+      })
+    );
+    expect(blockedIssue?.status).toBe("blocked");
+
+    // Critical: NO stranded_issue_recovery issue exists for this source.
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originId, issueId)));
+    expect(recoveryIssues).toHaveLength(0);
+
+    // Agent must be paused with the cascade reason.
+    const pausedAgent = await waitForValue(async () =>
+      db.select().from(agents).where(eq(agents.id, agentId)).then((rows) => {
+        const a = rows[0] ?? null;
+        return a?.pauseReason === "cascade" ? a : null;
+      })
+    );
+    expect(pausedAgent?.status).toBe("paused");
+    expect(pausedAgent?.pauseReason).toBe("cascade");
+    expect(pausedAgent?.pausedAt).not.toBeNull();
+  });
 });

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -28,7 +28,7 @@ type ScopeRecord = {
   companyId: string;
   name: string;
   paused: boolean;
-  pauseReason: "manual" | "budget" | "system" | null;
+  pauseReason: "manual" | "budget" | "system" | "cascade" | null;
 };
 
 type PolicyRow = typeof budgetPolicies.$inferSelect;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1246,6 +1246,38 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     ].join("\n");
   }
 
+  // Cascade detection / pause helpers — coupled with stranded-issue recovery.
+  // Three consecutive failed runs within the window means the agent is in a
+  // tight failure loop; creating more recovery issues for it just produces
+  // garbage. Threshold matches schema v0.3.3 §8 "run cascade" check.
+  const CASCADE_THRESHOLD = 3;
+  const CASCADE_WINDOW_MS = 15 * 60 * 1000;
+
+  async function detectAgentRunCascade(agentId: string): Promise<boolean> {
+    const since = new Date(Date.now() - CASCADE_WINDOW_MS);
+    const recent = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.agentId, agentId), gt(heartbeatRuns.startedAt, since)))
+      .orderBy(desc(heartbeatRuns.startedAt))
+      .limit(CASCADE_THRESHOLD);
+    if (recent.length < CASCADE_THRESHOLD) return false;
+    return recent.every((r) => r.status === "failed");
+  }
+
+  async function pauseAgentForCascade(agentId: string): Promise<void> {
+    const now = new Date();
+    await db
+      .update(agents)
+      .set({
+        status: "paused",
+        pauseReason: "cascade",
+        pausedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(agents.id, agentId));
+  }
+
   async function ensureStrandedIssueRecoveryIssue(input: {
     issue: typeof issues.$inferSelect;
     latestRun: LatestIssueRun;
@@ -1256,6 +1288,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
     const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
     if (!ownerAgentId) return null;
+
+    // Cascade short-circuit: if the recovery owner has been failing in a
+    // tight loop, creating another recovery issue just feeds the loop.
+    // Pause the agent and skip recovery instead. Caught 2026-05-09 when a
+    // misconfigured Hermes adapter generated 156 recovery issues in 10
+    // minutes — same agent failing every heartbeat, each failure spawning
+    // a fresh recovery issue assigned right back to it.
+    const cascading = await detectAgentRunCascade(ownerAgentId);
+    if (cascading) {
+      await pauseAgentForCascade(ownerAgentId);
+      logger.warn(
+        { agentId: ownerAgentId, sourceIssueId: input.issue.id },
+        "recovery.short_circuit_cascade",
+      );
+      return null;
+    }
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
     const recovery = await issuesSvc.create(input.issue.companyId, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip's stranded-issue recovery loop calls `ensureStrandedIssueRecoveryIssue` for every orphaned run it reaps
> - The recovery owner is the agent assigned to handle the blocked issue; if that agent itself is broken, recovery hands the new issue right back to the same broken agent
> - The recovery loop has no awareness of cascade state — it will keep creating recovery issues as long as orphaned runs keep arriving
> - On 2026-05-09 a misconfigured `hermes_local` adapter on a downstream Paperclip instance (Vellum, my production deployment) failed every heartbeat, producing 156 "Recover stalled issue VEL-N" issues in ~10 minutes before a human intervened
> - The recovery issues are FK-blocked from deletion (`heartbeat_runs.issue_id → issues.id`), so the corpus accumulates and cannot be cleaned up by deleting the agent
> - The fix is a cascade detector gated directly in `ensureStrandedIssueRecoveryIssue`: if the recovery owner has ≥3 consecutive failed runs in the last 15 minutes, skip recovery creation and pause the agent with `pauseReason: "cascade"` instead
> - Threshold and window match schema v0.3.3 §8 "run cascade" semantics already present in the codebase

## What Changed

**`server/src/services/recovery/service.ts`** (+48 lines)
- `detectAgentRunCascade(agentId)`: queries the last 3 `heartbeatRuns` rows for the agent within a 15-minute window; returns `true` if every row has `status: "failed"`
- `pauseAgentForCascade(agentId)`: sets `status: "paused"`, `pauseReason: "cascade"`, `pausedAt: now` on the agent row
- `ensureStrandedIssueRecoveryIssue()`: before issuing `issuesSvc.create`, runs cascade detection on the resolved recovery owner; on a cascade hit, calls `pauseAgentForCascade`, emits a `recovery.short_circuit_cascade` warning log, and returns `null` (skipping creation)

**`packages/shared/src/constants.ts`** (+1 / -1)
- Adds `"cascade"` to the `PAUSE_REASONS` tuple constant and `PauseReason` type

**`server/src/services/budgets.ts`** (+1 / -1)
- Adds `"cascade"` to the inline `pauseReason` union in `ScopeRecord` to keep the local type consistent with the shared constant

**`server/src/__tests__/heartbeat-process-recovery.test.ts`** (+81 lines)
- 1 new test: seeds an agent with a stranded issue, inserts 3 prior `failed` heartbeat runs within the 15-minute window, triggers `reapOrphanedRuns()`, asserts:
  - The original issue transitions to `blocked` (existing behavior preserved)
  - **Zero** recovery issues exist for that source issue (cascade short-circuit fired)
  - The agent is `paused` with `pauseReason: "cascade"` and a non-null `pausedAt`

No schema migration required: `pauseReason` is a `text` column with no Postgres enum constraint.

## Verification

```bash
pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts server/src/__tests__/recovery-classifiers.test.ts
```

Full recovery test suite: **24/24 passing** (21 in `heartbeat-process-recovery.test.ts` including the 1 new cascade test + 3 in `recovery-classifiers.test.ts`, all unchanged).

**Production validation (downstream Vellum deployment, post-patch):**

| Period | Heartbeat runs | Single-run failures | Cascades | Recovery issues spawned |
|---|---|---|---|---|
| Pre-patch (2026-05-09, ~10 min) | ~156 | 156 | 1 undetected | 156 |
| Post-patch (2026-05-09 – 2026-05-11, 9 runs) | 9 | 1 | 0 | 0 |

The single post-patch failure was a transient network timeout; the agent recovered on the next heartbeat and did not reach the cascade threshold.

Note on run-count: the post-patch row counts all heartbeat-emitting activity. Of those 9, ~5 exercised the live-adapter path the patch guards (Korean Lector ingest, AudioLDM HermesLector promotion, the Marginalia audit run, the Flash and Sonnet re-syntheses). The remaining ~4 were filesystem-only or pure API operations (Lapidary tombstone, Reviser substitution, hygiene PATCH) that could not have triggered cascade. The structural argument rests on the gating logic and the unit test, not on run count alone.

## Origin / Disclosure

This fix was motivated by a production incident on my downstream Paperclip deployment (Vellum, a multi-agent literature-review tool I'm building). The change is additive and behavior-neutral for agents that are not in a failure loop: `detectAgentRunCascade` exits early if fewer than 3 `heartbeatRuns` rows exist within the window, so first-time or infrequently failing agents are unaffected. I believe any long-lived Paperclip instance running agents that can enter persistent failure loops is exposed to the same runaway, which is why I'm upstreaming the fix rather than keeping it local.

I have not checked `ROADMAP.md` for a planned first-party solution to cascade detection — if one exists and this overlaps it, I'm happy to close this in favor of the roadmap item or rebase onto it.

## Risks

- **Additive only.** No existing code path is altered for agents not in cascade. The short-circuit is a new early-return before the `issuesSvc.create` call.
- **Threshold is hard-coded.** `CASCADE_THRESHOLD = 3` and `CASCADE_WINDOW_MS = 15 * 60 * 1000` are module-level constants, not operator-configurable. A follow-up could expose these as per-agent policy fields if operators want different sensitivity. For now the values match schema v0.3.3 §8.
- **Cascade pause requires manual resume.** Once paused with `pauseReason: "cascade"`, the agent does not auto-resume. An operator must inspect the adapter configuration and resume manually. This is intentional — a cascade almost always indicates a configuration problem that automated retry cannot resolve — but it may be surprising if operators are not watching the pause queue.
- **`heartbeat_runs` FK constraint.** The recovery issues generated before the fix cannot be deleted while their associated `heartbeat_runs` rows exist (`heartbeat_runs.issue_id → issues.id` FK). The patch prevents future accumulation but does not clean up the existing corpus. A follow-up migration (soft-delete or nullable FK) would be needed to address pre-existing runaway issues.

## Suggested Follow-up

The test suite covers cascade detection + pause + recovery-issue suppression. It does not cover the FK constraint that prevents `DELETE` on the accumulated recovery issues. If the maintainers want, a unit test that seeds recovery issues with FK-linked `heartbeat_runs` and asserts the DELETE fails (or succeeds after FK is made deferrable/nullable) would lock in that behavior explicitly. I did not include it here because it touches the schema and felt out of scope for a bug-fix PR.

## Model Used

- Anthropic Claude Opus 4.7 (1M context) via Claude Code, tool use and local test execution enabled

## Checklist

- [x] Thinking path traces from project context to this change
- [x] Model used specified above
- [x] Change is additive; does not overlap with any core recovery work I'm aware of
- [x] Tests run locally and pass (24/24 across the recovery test files)
- [x] New test added covering the cascade scenario
- [ ] N/A — backend only; no UI changes (`pauseReason: "cascade"` reuses existing display surface)
- [x] Risks documented above
- [x] Will address reviewer comments before merge