### PR TITLE
Hide signup link when account creation is disabled

### DIFF
--- a/server/src/__tests__/health-dev-server-token.test.ts
+++ b/server/src/__tests__/health-dev-server-token.test.ts
@@ -84,6 +84,7 @@ describe("GET /health dev-server supervisor access", () => {
           deploymentMode: "authenticated",
           deploymentExposure: "private",
           authReady: true,
+          authDisableSignUp: false,
           companyDeletionEnabled: true,
         }),
       );
@@ -98,6 +99,9 @@ describe("GET /health dev-server supervisor access", () => {
         deploymentMode: "authenticated",
         bootstrapStatus: "ready",
         bootstrapInviteActive: false,
+        features: {
+          authDisableSignUp: false,
+        },
         devServer: {
           enabled: true,
           restartRequired: true,

--- a/server/src/__tests__/health-dev-server-token.test.ts
+++ b/server/src/__tests__/health-dev-server-token.test.ts
@@ -99,6 +99,9 @@ describe("GET /health dev-server supervisor access", () => {
         deploymentExposure: "private",
         bootstrapStatus: "ready",
         bootstrapInviteActive: false,
+        features: {
+          authDisableSignUp: false,
+        },
         devServer: {
           enabled: true,
           restartRequired: true,

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -87,6 +87,7 @@ describe("GET /health", () => {
         deploymentMode: "authenticated",
         deploymentExposure: "public",
         authReady: true,
+        authDisableSignUp: true,
         companyDeletionEnabled: false,
       }),
     );
@@ -99,6 +100,9 @@ describe("GET /health", () => {
       deploymentMode: "authenticated",
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
+      features: {
+        authDisableSignUp: true,
+      },
     });
   });
 
@@ -121,6 +125,7 @@ describe("GET /health", () => {
         deploymentMode: "authenticated",
         deploymentExposure: "public",
         authReady: true,
+        authDisableSignUp: false,
         companyDeletionEnabled: false,
       }),
     );
@@ -133,6 +138,9 @@ describe("GET /health", () => {
       deploymentMode: "authenticated",
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
+      features: {
+        authDisableSignUp: false,
+      },
     });
   });
 
@@ -159,6 +167,7 @@ describe("GET /health", () => {
         deploymentMode: "authenticated",
         deploymentExposure: "public",
         authReady: true,
+        authDisableSignUp: true,
         companyDeletionEnabled: false,
       }),
     );
@@ -175,6 +184,7 @@ describe("GET /health", () => {
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
       features: {
+        authDisableSignUp: true,
         companyDeletionEnabled: false,
       },
     });

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -280,6 +280,9 @@ describe("GET /health", () => {
       deploymentExposure: "public",
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
+      features: {
+        authDisableSignUp: false,
+      },
       databaseBackup: {
         enabled: true,
         status: "warning",
@@ -336,6 +339,9 @@ describe("GET /health", () => {
       deploymentExposure: "public",
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
+      features: {
+        authDisableSignUp: false,
+      },
     });
     expect(res.body.serverInfo).toBeUndefined();
   });
@@ -373,6 +379,9 @@ describe("GET /health", () => {
       deploymentExposure: "public",
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
+      features: {
+        authDisableSignUp: false,
+      },
     });
     expect(res.body.serverInfo).toBeUndefined();
   });
@@ -417,6 +426,7 @@ describe("GET /health", () => {
       bootstrapStatus: "ready",
       bootstrapInviteActive: false,
       features: {
+        authDisableSignUp: false,
         companyDeletionEnabled: false,
       },
       serverInfo: testServerInfo,

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -125,6 +125,7 @@ export async function createApp(
     allowedHostnames: string[];
     bindHost: string;
     authReady: boolean;
+    authDisableSignUp: boolean;
     companyDeletionEnabled: boolean;
     instanceId?: string;
     hostVersion?: string;
@@ -184,6 +185,7 @@ export async function createApp(
       deploymentMode: opts.deploymentMode,
       deploymentExposure: opts.deploymentExposure,
       authReady: opts.authReady,
+      authDisableSignUp: opts.authDisableSignUp,
       companyDeletionEnabled: opts.companyDeletionEnabled,
     }),
   );

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -149,6 +149,7 @@ export async function createApp(
     allowedHostnames: string[];
     bindHost: string;
     authReady: boolean;
+    authDisableSignUp?: boolean;
     companyDeletionEnabled: boolean;
     instanceId?: string;
     hostVersion?: string;
@@ -218,6 +219,7 @@ export async function createApp(
       deploymentMode: opts.deploymentMode,
       deploymentExposure: opts.deploymentExposure,
       authReady: opts.authReady,
+      authDisableSignUp: opts.authDisableSignUp,
       companyDeletionEnabled: opts.companyDeletionEnabled,
       databaseBackupHealth: opts.databaseBackupHealth,
     }),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -612,6 +612,7 @@ export async function startServer(): Promise<StartedServer> {
     allowedHostnames: config.allowedHostnames,
     bindHost: config.host,
     authReady,
+    authDisableSignUp: config.authDisableSignUp,
     companyDeletionEnabled: config.companyDeletionEnabled,
     pluginMigrationDb: pluginMigrationDb as any,
     betterAuthHandler,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -685,6 +685,7 @@ export async function startServer(): Promise<StartedServer> {
     allowedHostnames: config.allowedHostnames,
     bindHost: config.host,
     authReady,
+    authDisableSignUp: config.authDisableSignUp,
     companyDeletionEnabled: config.companyDeletionEnabled,
     pluginMigrationDb: pluginMigrationDb as any,
     betterAuthHandler,

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -34,11 +34,13 @@ export function healthRoutes(
     deploymentMode: DeploymentMode;
     deploymentExposure: DeploymentExposure;
     authReady: boolean;
+    authDisableSignUp: boolean;
     companyDeletionEnabled: boolean;
   } = {
     deploymentMode: "local_trusted",
     deploymentExposure: "private",
     authReady: true,
+    authDisableSignUp: false,
     companyDeletionEnabled: true,
   },
 ) {
@@ -125,6 +127,9 @@ export function healthRoutes(
         deploymentMode: opts.deploymentMode,
         bootstrapStatus,
         bootstrapInviteActive,
+        features: {
+          authDisableSignUp: opts.authDisableSignUp,
+        },
         ...(devServer ? { devServer } : {}),
       });
       return;
@@ -139,6 +144,7 @@ export function healthRoutes(
       bootstrapStatus,
       bootstrapInviteActive,
       features: {
+        authDisableSignUp: opts.authDisableSignUp,
         companyDeletionEnabled: opts.companyDeletionEnabled,
       },
       ...(devServer ? { devServer } : {}),

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -62,6 +62,7 @@ export function healthRoutes(
     deploymentMode: DeploymentMode;
     deploymentExposure: DeploymentExposure;
     authReady: boolean;
+    authDisableSignUp?: boolean;
     companyDeletionEnabled: boolean;
     serverInfo?: ServerInfoSnapshot;
     databaseBackupHealth?: InspectDatabaseBackupHealthOptions;
@@ -69,6 +70,7 @@ export function healthRoutes(
     deploymentMode: "local_trusted",
     deploymentExposure: "private",
     authReady: true,
+    authDisableSignUp: false,
     companyDeletionEnabled: true,
   },
 ) {
@@ -204,6 +206,9 @@ export function healthRoutes(
         deploymentExposure: opts.deploymentExposure,
         bootstrapStatus,
         bootstrapInviteActive,
+        features: {
+          authDisableSignUp: opts.authDisableSignUp ?? false,
+        },
         ...(redactedDatabaseBackup ? { databaseBackup: redactedDatabaseBackup } : {}),
         ...(redactedWarnings ? { warnings: redactedWarnings } : {}),
         ...(devServer ? { devServer } : {}),
@@ -220,6 +225,7 @@ export function healthRoutes(
       bootstrapStatus,
       bootstrapInviteActive,
       features: {
+        authDisableSignUp: opts.authDisableSignUp ?? false,
         companyDeletionEnabled: opts.companyDeletionEnabled,
       },
       serverInfo,

--- a/ui/src/api/health.ts
+++ b/ui/src/api/health.ts
@@ -21,6 +21,7 @@ export type HealthStatus = {
   bootstrapStatus?: "ready" | "bootstrap_pending";
   bootstrapInviteActive?: boolean;
   features?: {
+    authDisableSignUp?: boolean;
     companyDeletionEnabled?: boolean;
   };
   devServer?: DevServerHealthStatus;

--- a/ui/src/api/health.ts
+++ b/ui/src/api/health.ts
@@ -23,6 +23,7 @@ export type HealthStatus = {
   bootstrapStatus?: "ready" | "bootstrap_pending";
   bootstrapInviteActive?: boolean;
   features?: {
+    authDisableSignUp?: boolean;
     companyDeletionEnabled?: boolean;
   };
   serverInfo?: ServerInfoSnapshot;

--- a/ui/src/pages/Auth.test.tsx
+++ b/ui/src/pages/Auth.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthPage } from "./Auth";
+
+const mockAuthApi = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  signInEmail: vi.fn(),
+  signUpEmail: vi.fn(),
+}));
+
+const mockHealthApi = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock("../api/auth", () => ({
+  authApi: mockAuthApi,
+}));
+
+vi.mock("../api/health", () => ({
+  healthApi: mockHealthApi,
+}));
+
+vi.mock("@/lib/router", () => ({
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [new URLSearchParams()],
+}));
+
+vi.mock("../components/AsciiArtAnimation", () => ({
+  AsciiArtAnimation: () => <div>ASCII art</div>,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+async function renderAuthPage(container: HTMLElement) {
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <AuthPage />
+      </QueryClientProvider>,
+    );
+  });
+  await flushReact();
+  await flushReact();
+
+  return root;
+}
+
+describe("AuthPage", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    mockAuthApi.getSession.mockResolvedValue(null);
+    mockHealthApi.get.mockResolvedValue({
+      status: "ok",
+      features: {
+        authDisableSignUp: false,
+      },
+    });
+  });
+
+  afterEach(() => {
+    container.remove();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("shows the create-account path when sign-up is enabled", async () => {
+    const root = await renderAuthPage(container);
+
+    expect(container.textContent).toContain("Need an account?");
+    expect(container.textContent).toContain("Create one");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("hides the create-account path when sign-up is disabled", async () => {
+    mockHealthApi.get.mockResolvedValue({
+      status: "ok",
+      features: {
+        authDisableSignUp: true,
+      },
+    });
+
+    const root = await renderAuthPage(container);
+
+    expect(container.textContent).toContain("Sign in to Paperclip");
+    expect(container.textContent).not.toContain("Need an account?");
+    expect(container.textContent).not.toContain("Create one");
+    expect(container.textContent).not.toContain("Create your Paperclip account");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/pages/Auth.test.tsx
+++ b/ui/src/pages/Auth.test.tsx
@@ -10,12 +10,19 @@ import { AuthPage } from "./Auth";
 const getSessionMock = vi.hoisted(() => vi.fn());
 const signInEmailMock = vi.hoisted(() => vi.fn());
 const signUpEmailMock = vi.hoisted(() => vi.fn());
+const healthGetMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../api/auth", () => ({
   authApi: {
     getSession: () => getSessionMock(),
     signInEmail: (input: unknown) => signInEmailMock(input),
     signUpEmail: (input: unknown) => signUpEmailMock(input),
+  },
+}));
+
+vi.mock("../api/health", () => ({
+  healthApi: {
+    get: () => healthGetMock(),
   },
 }));
 
@@ -85,6 +92,12 @@ describe("AuthPage", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     getSessionMock.mockResolvedValue(null);
+    healthGetMock.mockResolvedValue({
+      status: "ok",
+      features: {
+        authDisableSignUp: false,
+      },
+    });
     signInEmailMock.mockResolvedValue(undefined);
     signUpEmailMock.mockResolvedValue(undefined);
   });
@@ -165,6 +178,25 @@ describe("AuthPage", () => {
     expect(nameInput.getAttribute("autocomplete")).toBe("name");
     expect(nameInput.required).toBe(true);
     expect(passwordInput.getAttribute("autocomplete")).toBe("new-password");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("hides the sign-up affordance when account creation is disabled", async () => {
+    healthGetMock.mockResolvedValueOnce({
+      status: "ok",
+      features: {
+        authDisableSignUp: true,
+      },
+    });
+
+    const root = await mount();
+
+    expect(container.textContent).not.toContain("Need an account?");
+    expect(container.textContent).not.toContain("Create one");
+    expect(container.textContent).toContain("Sign in to Paperclip");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearchParams } from "@/lib/router";
 import { authApi } from "../api/auth";
+import { healthApi } from "../api/health";
 import { queryKeys } from "../lib/queryKeys";
 import { getRememberedInvitePath } from "../lib/invite-memory";
 import { Button } from "@/components/ui/button";
@@ -29,6 +30,19 @@ export function AuthPage() {
     queryFn: () => authApi.getSession(),
     retry: false,
   });
+  const { data: health, isLoading: isHealthLoading } = useQuery({
+    queryKey: queryKeys.health,
+    queryFn: () => healthApi.get(),
+    retry: false,
+  });
+  const signUpDisabled = health?.features?.authDisableSignUp === true;
+
+  useEffect(() => {
+    if (signUpDisabled && mode === "sign_up") {
+      setMode("sign_in");
+      setError(null);
+    }
+  }, [signUpDisabled, mode]);
 
   useEffect(() => {
     if (session) {
@@ -41,6 +55,9 @@ export function AuthPage() {
       if (mode === "sign_in") {
         await authApi.signInEmail({ email: email.trim(), password });
         return;
+      }
+      if (signUpDisabled) {
+        throw new Error("Account creation is disabled for this instance.");
       }
       await authApi.signUpEmail({
         name: name.trim(),
@@ -64,7 +81,7 @@ export function AuthPage() {
     password.trim().length > 0 &&
     (mode === "sign_in" || (name.trim().length > 0 && password.trim().length >= 8));
 
-  if (isSessionLoading) {
+  if (isSessionLoading || isHealthLoading) {
     return (
       <div className="fixed inset-0 flex items-center justify-center">
         <p className="text-sm text-muted-foreground">Loading…</p>
@@ -159,19 +176,21 @@ export function AuthPage() {
             </Button>
           </form>
 
-          <div className="mt-5 text-sm text-muted-foreground">
-            {mode === "sign_in" ? "Need an account?" : "Already have an account?"}{" "}
-            <button
-              type="button"
-              className="font-medium text-foreground underline underline-offset-2"
-              onClick={() => {
-                setError(null);
-                setMode(mode === "sign_in" ? "sign_up" : "sign_in");
-              }}
-            >
-              {mode === "sign_in" ? "Create one" : "Sign in"}
-            </button>
-          </div>
+          {!signUpDisabled && (
+            <div className="mt-5 text-sm text-muted-foreground">
+              {mode === "sign_in" ? "Need an account?" : "Already have an account?"}{" "}
+              <button
+                type="button"
+                className="font-medium text-foreground underline underline-offset-2"
+                onClick={() => {
+                  setError(null);
+                  setMode(mode === "sign_in" ? "sign_up" : "sign_in");
+                }}
+              >
+                {mode === "sign_in" ? "Create one" : "Sign in"}
+              </button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearchParams } from "@/lib/router";
 import { authApi } from "../api/auth";
+import { healthApi } from "../api/health";
 import { queryKeys } from "../lib/queryKeys";
 import { getRememberedInvitePath } from "../lib/invite-memory";
 import { Button } from "@/components/ui/button";
@@ -31,6 +32,12 @@ export function AuthPage() {
     queryFn: () => authApi.getSession(),
     retry: false,
   });
+  const { data: health, isLoading: isHealthLoading } = useQuery({
+    queryKey: queryKeys.health,
+    queryFn: () => healthApi.get(),
+    retry: false,
+  });
+  const signUpDisabled = health?.features?.authDisableSignUp === true;
 
   useEffect(() => {
     if (session) {
@@ -38,11 +45,20 @@ export function AuthPage() {
     }
   }, [session, navigate, nextPath]);
 
+  useEffect(() => {
+    if (signUpDisabled && mode === "sign_up") {
+      setMode("sign_in");
+    }
+  }, [mode, signUpDisabled]);
+
   const mutation = useMutation({
     mutationFn: async () => {
       if (mode === "sign_in") {
         await authApi.signInEmail({ email: email.trim(), password });
         return;
+      }
+      if (signUpDisabled) {
+        throw new Error("Account creation is disabled for this instance.");
       }
       await authApi.signUpEmail({
         name: name.trim(),
@@ -66,7 +82,7 @@ export function AuthPage() {
     password.trim().length > 0 &&
     (mode === "sign_in" || (name.trim().length > 0 && password.trim().length >= 8));
 
-  if (isSessionLoading) {
+  if (isSessionLoading || isHealthLoading) {
     return (
       <div className="fixed inset-0 flex items-center justify-center">
         <p className="text-sm text-muted-foreground">Loading…</p>
@@ -180,19 +196,21 @@ export function AuthPage() {
             </Button>
           </form>
 
-          <div className="mt-5 text-sm text-muted-foreground">
-            {mode === "sign_in" ? "Need an account?" : "Already have an account?"}{" "}
-            <button
-              type="button"
-              className="font-medium text-foreground underline underline-offset-2"
-              onClick={() => {
-                setError(null);
-                setMode(mode === "sign_in" ? "sign_up" : "sign_in");
-              }}
-            >
-              {mode === "sign_in" ? "Create one" : "Sign in"}
-            </button>
-          </div>
+          {!(mode === "sign_in" && signUpDisabled) && (
+            <div className="mt-5 text-sm text-muted-foreground">
+              {mode === "sign_in" ? "Need an account?" : "Already have an account?"}{" "}
+              <button
+                type="button"
+                className="font-medium text-foreground underline underline-offset-2"
+                onClick={() => {
+                  setError(null);
+                  setMode(mode === "sign_in" ? "sign_up" : "sign_in");
+                }}
+              >
+                {mode === "sign_in" ? "Create one" : "Sign in"}
+              </button>
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The authenticated deployment flow can disable public account creation through server configuration.
> - The auth page still showed the sign-up affordance even when account creation was disabled.
> - That creates a confusing path where users are invited to create an account that the instance will reject.
> - This pull request exposes the existing signup-disabled setting through health metadata and uses it on the auth page.
> - The benefit is a clearer login experience for private instances without changing the default sign-up behavior.

## Linked Issues or Issue Description

Closes #5697

## What Changed

- Expose `features.authDisableSignUp` through the health route.
- Pass the server `authDisableSignUp` config into health route setup.
- Read health metadata from the auth page.
- Hide the `Need an account? Create one` affordance when account creation is disabled.
- Guard the sign-up submit path if signup becomes disabled while the page is open.
- Add focused UI coverage for the hidden signup affordance.
- Update health route expectations for the new feature flag field.

## Verification

Passed locally:

```text
pnpm install --frozen-lockfile
pnpm --filter @paperclipai/ui exec vitest run src/pages/Auth.test.tsx
pnpm --filter @paperclipai/ui typecheck
pnpm --filter @paperclipai/server typecheck
```

Attempted locally but blocked by the local test environment's IPv6 loopback binding/connect behavior:

```text
pnpm --filter @paperclipai/server exec vitest run src/__tests__/health.test.ts src/__tests__/health-dev-server-token.test.ts
```

The failure was `EADDRNOTAVAIL ::1:<port>` during local loopback connection setup, before assertion-level validation.

## Risks

Low risk. The default remains signup-enabled unless the existing server config disables account creation. The UI only hides the signup affordance when health metadata explicitly reports `authDisableSignUp: true`.

## Model Used

Codex, GPT-5.5, with code execution and repository tooling.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
