### PR TITLE
fix(recovery): one-hour cooldown to suppress immediate stranded recovery replacements (STO-833 / STO-259 follow-up)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2528,6 +2528,52 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([recoveries[0]?.id]);
   });
 
+  it("does not create a replacement stranded recovery issue immediately after one finished", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const recentRecoveryIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: recentRecoveryIssueId,
+      companyId,
+      parentId: issueId,
+      title: "Recover stalled issue from previous pass",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+      originKind: "stranded_issue_recovery",
+      originId: issueId,
+      updatedAt: new Date(),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const recoveries = await db
+      .select()
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, companyId),
+        eq(issues.originKind, "stranded_issue_recovery"),
+        eq(issues.originId, issueId),
+      ));
+    expect(recoveries.map((issue) => issue.id)).toEqual([recentRecoveryIssueId]);
+    await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([]);
+
+    const sourceIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(sourceIssue?.status).toBe("blocked");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments[0]?.body).toContain("recently terminal stranded recovery issues do not immediately create replacement recovery issues");
+  });
+
   it("blocks stranded recovery issues in place instead of creating nested recovery issues", async () => {
     const sourceIssueId = randomUUID();
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -63,6 +63,7 @@ export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+const STRANDED_ISSUE_RECOVERY_TERMINAL_COOLDOWN_MS = 60 * 60 * 1000;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 
 type RecoveryWakeupOptions = {
@@ -1345,6 +1346,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows[0] ?? null);
   }
 
+  async function findRecentTerminalStrandedIssueRecoveryIssue(companyId: string, sourceIssueId: string) {
+    const cooldownStartedAt = new Date(Date.now() - STRANDED_ISSUE_RECOVERY_TERMINAL_COOLDOWN_MS);
+    return db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STRANDED_ISSUE_RECOVERY_ORIGIN_KIND),
+          eq(issues.originId, sourceIssueId),
+          isNull(issues.hiddenAt),
+          inArray(issues.status, ["done", "cancelled"]),
+          gt(issues.updatedAt, cooldownStartedAt),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   function isStrandedIssueRecoveryIssue(issue: typeof issues.$inferSelect) {
     return issue.originKind === STRANDED_ISSUE_RECOVERY_ORIGIN_KIND;
   }
@@ -1491,6 +1512,29 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;
+
+    const recentTerminal = await findRecentTerminalStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
+    if (recentTerminal) {
+      await logActivity(db, {
+        companyId: input.issue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.stranded_recovery_suppressed",
+        entityType: "issue",
+        entityId: input.issue.id,
+        details: {
+          source: "recovery.ensure_stranded_issue_recovery_issue",
+          reason: "recent_terminal_recovery_issue",
+          recentRecoveryIssueId: recentTerminal.id,
+          recentRecoveryIdentifier: recentTerminal.identifier,
+          recentRecoveryStatus: recentTerminal.status,
+          cooldownMs: STRANDED_ISSUE_RECOVERY_TERMINAL_COOLDOWN_MS,
+        },
+      });
+      return null;
+    }
 
     const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
     if (!ownerAgentId) return null;
@@ -1684,6 +1728,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }) {
     const nestedRecoverySuppressed = isStrandedIssueRecoveryIssue(input.issue);
     let recoveryIssue: typeof issues.$inferSelect | null = null;
+    let recentTerminalRecoveryIssue: typeof issues.$inferSelect | null = null;
     if (!nestedRecoverySuppressed) {
       recoveryIssue = await ensureStrandedIssueRecoveryIssue({
         issue: input.issue,
@@ -1692,6 +1737,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         recoveryCause: input.recoveryCause,
         successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
       });
+      if (!recoveryIssue) {
+        recentTerminalRecoveryIssue = await findRecentTerminalStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
+      }
     }
     const blockerIds = await existingUnresolvedBlockerIssueIds(input.issue.companyId, input.issue.id);
     const nextBlockerIds = recoveryIssue
@@ -1731,6 +1779,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         `- Recovery issue: ${issueUiLink({ identifier: recoveryIssue.identifier, id: recoveryIssue.id }, prefix)}`,
         `- Recovery owner: ${agentUiLink(recoveryOwner, prefix)}`,
         "- Next action: the recovery owner should either restore a live execution path or record the manual resolution, then mark the recovery issue done.",
+      ].join("\n");
+    } else if (recentTerminalRecoveryIssue) {
+      recoveryLine = [
+        "",
+        `- Recovery issue: suppressed because recent recovery ${issueUiLink({ identifier: recentTerminalRecoveryIssue.identifier, id: recentTerminalRecoveryIssue.id }, prefix)} is already \`${recentTerminalRecoveryIssue.status}\`.`,
+        "- Guard: recently terminal stranded recovery issues do not immediately create replacement recovery issues.",
+        "- Next action: inspect the source issue and the recent recovery result before manually re-dispatching work.",
       ].join("\n");
     } else {
       recoveryLine = [


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The recovery service creates `stranded_issue_recovery` issues when an assigned issue's execution path goes silent, so an owner can re-dispatch work
> - STO-259 already added a generic guard against recovery-of-recovery cascades after a 17K-issue cascade event on 4/25
> - There is still a tighter window where, immediately after a stranded recovery issue is closed (`done`/`cancelled`), the next `reconcileStrandedAssignedIssues` pass on the same source issue creates a fresh replacement recovery issue — even if the source has just been intentionally resolved or marked `blocked`
> - This pull request adds a one-hour cooldown so a fresh stranded recovery issue cannot be created when a recent terminal recovery issue already exists for that source
> - Benefit: the source issue gets a clear "guard fired" comment + activity log instead of a churn cycle of recovery issues, and the operator only has to act once

## What Changed

- `server/src/services/recovery/service.ts`
  - Added `STRANDED_ISSUE_RECOVERY_TERMINAL_COOLDOWN_MS = 1h` and `findRecentTerminalStrandedIssueRecoveryIssue` helper (queries `done`/`cancelled` recovery issues for the same `originId` updated within the cooldown window).
  - In `ensureStrandedIssueRecoveryIssue`, after the existing open-recovery short-circuit, return `null` when a recent terminal recovery exists, and emit `issue.stranded_recovery_suppressed` activity with the recent recovery's identifier and status.
  - In the source-issue blocking flow, when no new recovery issue is created, look up the recent terminal recovery so the source-issue comment names it explicitly ("suppressed because recent recovery STO-XXX is already done") instead of the generic "no recovery owner" message.
- `server/src/__tests__/heartbeat-process-recovery.test.ts`
  - Added test `does not create a replacement stranded recovery issue immediately after one finished` that seeds a `done` recovery issue, runs `reconcileStrandedAssignedIssues`, and asserts (a) no new recovery row is created, (b) the source goes `blocked`, (c) the source comment mentions the cooldown guard.

## Verification

- Local `npx vitest run src/__tests__/heartbeat-process-recovery.test.ts -t "does not create a replacement stranded recovery"` — embedded postgres `beforeAll` hook timed out at 20s in this sandbox (all 45 tests skipped). The test itself is straightforward and follows the existing fixture pattern in the same file; expected to pass on CI which has the embedded-postgres lifecycle wired up.
- Manual reasoning: the new code path is reached only when `findOpenStrandedIssueRecoveryIssue` returns `null` (no current open recovery) AND a recent terminal recovery exists for the same source. Both pre-existing happy paths (new recovery created / no recovery owner found) are unchanged.
- Activity log enrichment: any operator inspecting `issue.stranded_recovery_suppressed` activities can see exactly which prior recovery issue caused the suppression and the cooldown duration that fired.

## Risks

- Low. The guard only short-circuits when there is already a recent terminal recovery — which means an operator already saw and disposed of the previous recovery issue within the last hour. Skipping a duplicate recovery issue in that window is the desired behavior.
- If the operator legitimately needs another recovery within the cooldown window, the source-issue comment names the prior recovery and instructs the operator to inspect and "manually re-dispatch work" — explicit human-in-the-loop, not a silent block.
- Cooldown is hard-coded at 1h; if we discover the right window is shorter/longer, it is a single constant to tune.
- No schema change, no new dependency, no public API change.

## Model Used

Claude Opus 4-7 (Anthropic, ~1M context, extended-thinking off). Used for code drafting, test design, and PR composition. Code reviewed by author before commit.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass — local vitest embedded-postgres beforeAll timed out (sandbox env), CI must validate
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A, server-only
- [x] I have updated relevant documentation to reflect my changes — N/A, internal recovery service behavior; activity log key documents itself
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
