### PR TITLE
fix(recovery): skip handoff wake when orchestrator has non-terminal delegated children

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4043,6 +4043,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       existingWake,
       budgetBlock,
       pauseHold,
+      nonTerminalChild,
     ] = await Promise.all([
       issue
         ? db
@@ -4168,6 +4169,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issue
         ? treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id)
         : Promise.resolve(null),
+      issue
+        ? db
+          .select({ id: issues.id })
+          .from(issues)
+          .where(
+            and(
+              eq(issues.companyId, issue.companyId),
+              eq(issues.parentId, issue.id),
+              inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
+              isNull(issues.hiddenAt),
+            ),
+          )
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
     ]);
 
     const decision = decideSuccessfulRunHandoff({
@@ -4181,6 +4197,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       hasQueuedWake: Boolean(queuedWake),
       hasPendingInteractionOrApproval: Boolean(pendingInteraction || pendingApproval),
       hasExplicitBlockerPath: Boolean(explicitBlocker),
+      hasNonTerminalChildren: Boolean(nonTerminalChild),
       hasOpenRecoveryIssue: Boolean(openRecoveryIssue),
       hasPauseHold: Boolean(pauseHold),
       budgetBlocked: Boolean(budgetBlock),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4177,7 +4177,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             and(
               eq(issues.companyId, issue.companyId),
               eq(issues.parentId, issue.id),
-              inArray(issues.status, ["todo", "in_progress", "in_review", "blocked"]),
+              inArray(issues.status, ["todo", "in_progress", "in_review"]),
               isNull(issues.hiddenAt),
             ),
           )

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -131,6 +131,13 @@ describe("successful run handoff decision", () => {
     });
   });
 
+  it("hasNonTerminalChildren guard fires before hasOpenRecoveryIssue", () => {
+    expect(decide({ hasNonTerminalChildren: true, hasOpenRecoveryIssue: true })).toEqual({
+      kind: "skip",
+      reason: "delegated non-terminal children own the active execution path",
+    });
+  });
+
   it("does not queue when a successful run has no progress signal", () => {
     expect(decide({ livenessState: null, detectedProgressSummary: null })).toEqual({
       kind: "skip",

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -49,6 +49,7 @@ function decide(overrides: Partial<Parameters<typeof decideSuccessfulRunHandoff>
     hasQueuedWake: false,
     hasPendingInteractionOrApproval: false,
     hasExplicitBlockerPath: false,
+    hasNonTerminalChildren: false,
     hasOpenRecoveryIssue: false,
     hasPauseHold: false,
     budgetBlocked: false,
@@ -120,6 +121,13 @@ describe("successful run handoff decision", () => {
     expect(decide({ hasExplicitBlockerPath: true })).toEqual({
       kind: "skip",
       reason: "explicit blocker path owns the next action",
+    });
+  });
+
+  it("does not queue when the issue has delegated non-terminal children in flight", () => {
+    expect(decide({ hasNonTerminalChildren: true })).toEqual({
+      kind: "skip",
+      reason: "delegated non-terminal children own the active execution path",
     });
   });
 

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -324,6 +324,9 @@ export function decideSuccessfulRunHandoff(input: {
   hasQueuedWake: boolean;
   hasPendingInteractionOrApproval: boolean;
   hasExplicitBlockerPath: boolean;
+  /** True when the issue has at least one child issue in a non-terminal status (todo, in_progress, in_review, blocked).
+   * Indicates the run ended a delegation heartbeat — the orchestrator stays in_progress while children are in flight. */
+  hasNonTerminalChildren: boolean;
   hasOpenRecoveryIssue: boolean;
   hasPauseHold: boolean;
   budgetBlocked: boolean;
@@ -360,6 +363,7 @@ export function decideSuccessfulRunHandoff(input: {
     return { kind: "skip", reason: "pending interaction or approval owns the next action" };
   }
   if (input.hasExplicitBlockerPath) return { kind: "skip", reason: "explicit blocker path owns the next action" };
+  if (input.hasNonTerminalChildren) return { kind: "skip", reason: "delegated non-terminal children own the active execution path" };
   if (input.hasOpenRecoveryIssue) return { kind: "skip", reason: "open recovery issue owns the ambiguity" };
   if (input.hasPauseHold) return { kind: "skip", reason: "issue is under an active pause hold" };
   if (input.budgetBlocked) return { kind: "skip", reason: "budget hard stop blocks corrective wake" };

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -324,8 +324,10 @@ export function decideSuccessfulRunHandoff(input: {
   hasQueuedWake: boolean;
   hasPendingInteractionOrApproval: boolean;
   hasExplicitBlockerPath: boolean;
-  /** True when the issue has at least one child issue in a non-terminal status (todo, in_progress, in_review, blocked).
-   * Indicates the run ended a delegation heartbeat — the orchestrator stays in_progress while children are in flight. */
+  /** True when the issue has at least one child issue in an actively-progressing status (todo, in_progress, in_review).
+   * Indicates the run ended a delegation heartbeat — the orchestrator stays in_progress while children are in flight.
+   * "blocked" is intentionally excluded: a blocked child has no guaranteed forward-progress path and should not
+   * permanently suppress corrective wakes on the parent. */
   hasNonTerminalChildren: boolean;
   hasOpenRecoveryIssue: boolean;
   hasPauseHold: boolean;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents that decompose work by creating child issues (parentId) and ending the heartbeat run
> - decideSuccessfulRunHandoff checks ~20 skip-paths before enqueueing a corrective handoff wake to surface genuinely stalled runs
> - The delegation heartbeat is a valid disposition — it ended intentionally because children are in flight — but no skip-path recognises parentId-with-active-children
> - hasExplicitBlockerPath only fires when issueRelations has a blocks row; parentId alone does not populate that table
> - Every delegation heartbeat therefore queued a corrective wake, building redundant runs and recovery sub-issues
> - This PR adds a LIMIT 1 existence query for non-terminal children (todo/in_progress/in_review) and short-circuits the corrective-wake path when any child is in flight

## What Changed

- **heartbeat.ts**: Adds a 10th query to the Promise.all block checking for child issues in todo/in_progress/in_review status. Passes result as `hasNonTerminalChildren`.
- **successful-run-handoff.ts**: Adds `hasNonTerminalChildren: boolean` to input type with JSDoc explaining the blocked exclusion. Skip guard inserted after `hasExplicitBlockerPath`, before `hasOpenRecoveryIssue`.
- **successful-run-handoff.test.ts**: Adds field to defaults; adds skip-path test and guard-ordering test.

## Verification

Staging smoke tests with in-container equivalent patch (2026-05-11):

| Scenario | Before | After |
|---|---|---|
| 3-child orchestration (UNOA-405 repro) | 17 runs + 6 recovery sub-issues | 5 runs, 0 recovery issues |
| 3-child multi-stage (SAP-224 repro) | 5 corrective-wake cancellations | 4 runs, 0 recovery issues |

Unit test: `pnpm test server/src/services/recovery/successful-run-handoff.test.ts`

## Risks

**blocked exclusion** — blocked children do not suppress the wake. A blocked child has no guaranteed forward-progress path; allowing the corrective wake lets the parent detect and handle the blockage. Low risk — blocked children are rare in normal delegation flows.

**Extra query per heartbeat** — one LIMIT 1 existence-check added to the hot path. Hits the existing issues_company_parent_idx (companyId, parentId) index; returns empty-set fast-path on non-delegation heartbeats.

**in_review included** — in_review is a valid active state in the executionPolicy stage machine. Excluding it would cause false wakes during QA review stages.

## Model Used

Claude Sonnet 4.6 (claude-sonnet-4-6) — Anthropic, 200K context, tool use enabled.

## Checklist

- [x] Thinking path included
- [x] Model specified
- [x] ROADMAP.md checked — no overlap with planned core work
- [x] Tests pass
- [x] Tests added/updated
- [x] Backend only — no UI changes
- [x] Risks documented
- [x] Will address all reviewer comments before merge

---

## Greptile findings addressed (commit 0c7abcaf)

**Findings 1+2 — blocked inclusion:** Removed "blocked" from both the DB query (heartbeat.ts) and the JSDoc. Added explicit comment: blocked children have no guaranteed forward-progress path and should not permanently suppress corrective wakes.

**Finding 3 — Guard ordering not tested:** Added `decide({ hasNonTerminalChildren: true, hasOpenRecoveryIssue: true })` asserting hasNonTerminalChildren reason is returned, confirming guard fires before hasOpenRecoveryIssue.

**Missing template sections:** All required sections now filled in.