### PR TITLE
fix(perms): allow agents to assign tasks within their reporting chain

### DIFF
--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -58,7 +58,12 @@ export interface AgentInstructionsBundle {
 
 export interface AgentAccessState {
   canAssignTasks: boolean;
-  taskAssignSource: "explicit_grant" | "agent_creator" | "ceo_role" | "none";
+  taskAssignSource:
+    | "explicit_grant"
+    | "agent_creator"
+    | "ceo_role"
+    | "reporting_chain"
+    | "none";
   membership: CompanyMembership | null;
   grants: PrincipalPermissionGrant[];
 }

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -46,6 +46,7 @@ const mockAgentService = vi.hoisted(() => ({
   update: vi.fn(),
   updatePermissions: vi.fn(),
   getChainOfCommand: vi.fn(),
+  hasDirectReports: vi.fn(),
   resolveByReference: vi.fn(),
 }));
 
@@ -300,6 +301,7 @@ describe.sequential("agent permission routes", () => {
     mockAgentService.update.mockReset();
     mockAgentService.updatePermissions.mockReset();
     mockAgentService.getChainOfCommand.mockReset();
+    mockAgentService.hasDirectReports.mockReset();
     mockAgentService.resolveByReference.mockReset();
     mockAccessService.canUser.mockReset();
     mockAccessService.hasPermission.mockReset();
@@ -333,6 +335,7 @@ describe.sequential("agent permission routes", () => {
     mockAgentService.getById.mockResolvedValue(baseAgent);
     mockAgentService.list.mockResolvedValue([baseAgent]);
     mockAgentService.getChainOfCommand.mockResolvedValue([]);
+    mockAgentService.hasDirectReports.mockResolvedValue(false);
     mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: baseAgent });
     mockAgentService.create.mockResolvedValue(baseAgent);
     mockAgentService.activatePendingApproval.mockResolvedValue({
@@ -1371,6 +1374,75 @@ describe.sequential("agent permission routes", () => {
     );
     expect(res.body.access.canAssignTasks).toBe(true);
     expect(res.body.access.taskAssignSource).toBe("agent_creator");
+  });
+
+  it("grants reporting-chain task assignment when the agent has a manager", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      reportsTo: "44444444-4444-4444-8444-444444444444",
+    });
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+    mockAgentService.hasDirectReports.mockResolvedValue(false);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.access.canAssignTasks).toBe(true);
+    expect(res.body.access.taskAssignSource).toBe("reporting_chain");
+  });
+
+  it("grants reporting-chain task assignment when the agent has direct reports", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      reportsTo: null,
+    });
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+    mockAgentService.hasDirectReports.mockResolvedValue(true);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.access.canAssignTasks).toBe(true);
+    expect(res.body.access.taskAssignSource).toBe("reporting_chain");
+  });
+
+  it("keeps task assignment disabled when an agent has no manager and no direct reports", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      reportsTo: null,
+    });
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+    mockAgentService.hasDirectReports.mockResolvedValue(false);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.access.canAssignTasks).toBe(false);
+    expect(res.body.access.taskAssignSource).toBe("none");
   });
 
   it("exposes a dedicated agent route for the inbox mine view", async () => {

--- a/server/src/__tests__/issue-task-assignment-routes.test.ts
+++ b/server/src/__tests__/issue-task-assignment-routes.test.ts
@@ -1,0 +1,363 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const companyId = "22222222-2222-4222-8222-222222222222";
+const issueId = "11111111-1111-4111-8111-111111111111";
+const managerAgentId = "33333333-3333-4333-8333-333333333333";
+const subordinateAgentId = "44444444-4444-4444-8444-444444444444";
+const peerAgentId = "55555555-5555-4555-8555-555555555555";
+const otherSubordinateAgentId = "66666666-6666-4666-8666-666666666666";
+
+const mockIssueService = vi.hoisted(() => ({
+  addComment: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+  create: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  getAttachmentById: vi.fn(),
+  getByIdentifier: vi.fn(),
+  getById: vi.fn(),
+  getRelationSummaries: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  listAttachments: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  remove: vi.fn(),
+  removeAttachment: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  list: vi.fn(),
+  resolveByReference: vi.fn(),
+}));
+
+const mockCompanyService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+function registerRouteMocks() {
+  vi.doMock("@paperclipai/shared/telemetry", () => ({
+    trackAgentTaskCompleted: vi.fn(),
+    trackErrorHandlerCrash: vi.fn(),
+  }));
+
+  vi.doMock("../telemetry.js", () => ({
+    getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+  }));
+
+  vi.doMock("../services/access.js", () => ({
+    accessService: () => mockAccessService,
+  }));
+
+  vi.doMock("../services/agents.js", () => ({
+    agentService: () => mockAgentService,
+  }));
+
+  vi.doMock("../services/issues.js", () => ({
+    issueService: () => mockIssueService,
+  }));
+
+  vi.doMock("../services/activity-log.js", () => ({
+    logActivity: vi.fn(async () => undefined),
+  }));
+
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => mockAccessService,
+    agentService: () => mockAgentService,
+    companyService: () => mockCompanyService,
+    documentService: () => ({ upsertIssueDocument: vi.fn() }),
+    executionWorkspaceService: () => ({}),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({}),
+    heartbeatService: () => ({
+      wakeup: vi.fn(async () => undefined),
+      reportRunActivity: vi.fn(async () => undefined),
+      getRun: vi.fn(async () => null),
+      getActiveRunForAgent: vi.fn(async () => null),
+      cancelRun: vi.fn(async () => null),
+    }),
+    instanceSettingsService: () => ({
+      get: vi.fn(async () => ({
+        id: "instance-settings-1",
+        general: {
+          censorUsernameInLogs: false,
+          feedbackDataSharingPreference: "prompt",
+        },
+      })),
+      listCompanyIds: vi.fn(async () => [companyId]),
+    }),
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: async () => undefined,
+      diffIssueReferenceSummary: () => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      }),
+      emptySummary: () => ({ outbound: [], inbound: [] }),
+      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+      syncComment: async () => undefined,
+      syncDocument: async () => undefined,
+      syncIssue: async () => undefined,
+    }),
+    issueService: () => mockIssueService,
+    issueThreadInteractionService: () => ({
+      expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+      expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+    }),
+    logActivity: vi.fn(async () => undefined),
+    projectService: () => ({}),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({}),
+  }));
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: issueId,
+    companyId,
+    status: "todo",
+    priority: "medium",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    createdByUserId: "board-user",
+    identifier: "PAP-9001",
+    title: "Reassignable issue",
+    executionPolicy: null,
+    executionState: null,
+    hiddenAt: null,
+    ...overrides,
+  };
+}
+
+function makeAgent(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    companyId,
+    role: "engineer",
+    reportsTo: null,
+    permissions: { canCreateAgents: false },
+    ...overrides,
+  };
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ errorHandler }, { issueRoutes }] = await Promise.all([
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function agentActor(actorAgentId: string) {
+  return {
+    type: "agent",
+    agentId: actorAgentId,
+    companyId,
+    source: "agent_key",
+    runId: "77777777-7777-4777-8777-777777777777",
+  };
+}
+
+describe("task assignment authorization via reporting chain", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("@paperclipai/shared/telemetry");
+    vi.doUnmock("../telemetry.js");
+    vi.doUnmock("../services/access.js");
+    vi.doUnmock("../services/activity-log.js");
+    vi.doUnmock("../services/agents.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/issues.js");
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerRouteMocks();
+    vi.clearAllMocks();
+    mockAccessService.canUser.mockReset();
+    mockAccessService.hasPermission.mockReset();
+    mockAgentService.getById.mockReset();
+    mockAgentService.list.mockReset();
+    mockAgentService.resolveByReference.mockReset();
+    mockCompanyService.getById.mockReset();
+    mockIssueService.addComment.mockReset();
+    mockIssueService.assertCheckoutOwner.mockReset();
+    mockIssueService.create.mockReset();
+    mockIssueService.findMentionedAgents.mockReset();
+    mockIssueService.getByIdentifier.mockReset();
+    mockIssueService.getById.mockReset();
+    mockIssueService.getRelationSummaries.mockReset();
+    mockIssueService.getWakeableParentAfterChildCompletion.mockReset();
+    mockIssueService.listAttachments.mockReset();
+    mockIssueService.listWakeableBlockedDependents.mockReset();
+    mockIssueService.remove.mockReset();
+    mockIssueService.update.mockReset();
+
+    mockAccessService.canUser.mockResolvedValue(false);
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === managerAgentId) return makeAgent(managerAgentId, { role: "cmo" });
+      if (id === subordinateAgentId)
+        return makeAgent(subordinateAgentId, { reportsTo: managerAgentId });
+      if (id === peerAgentId) return makeAgent(peerAgentId, { reportsTo: managerAgentId });
+      if (id === otherSubordinateAgentId)
+        return makeAgent(otherSubordinateAgentId, { reportsTo: peerAgentId });
+      return null;
+    });
+    mockAgentService.list.mockResolvedValue([
+      makeAgent(managerAgentId, { role: "cmo" }),
+      makeAgent(subordinateAgentId, { reportsTo: managerAgentId }),
+      makeAgent(peerAgentId, { reportsTo: managerAgentId }),
+      makeAgent(otherSubordinateAgentId, { reportsTo: peerAgentId }),
+    ]);
+    mockAgentService.resolveByReference.mockImplementation(async (_companyId: string, reference: string) => {
+      const agent = await mockAgentService.getById(reference);
+      return { ambiguous: false, agent };
+    });
+    mockCompanyService.getById.mockResolvedValue({ id: companyId, issuePrefix: "PAP" });
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ assigneeAgentId: subordinateAgentId, status: "in_progress" }),
+    );
+    mockIssueService.getByIdentifier.mockResolvedValue(null);
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ assigneeAgentId: subordinateAgentId, status: "in_progress" }),
+      ...patch,
+    }));
+    mockIssueService.create.mockImplementation(async (_companyId: string, input: Record<string, unknown>) => ({
+      ...makeIssue(),
+      ...input,
+      id: issueId,
+    }));
+    mockIssueService.addComment.mockResolvedValue({
+      id: "88888888-8888-4888-8888-888888888888",
+      issueId,
+      companyId,
+    });
+  });
+
+  it("lets a subordinate reassign their own issue up to their manager", async () => {
+    const app = await createApp(agentActor(subordinateAgentId));
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: managerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+    const [, patch] = mockIssueService.update.mock.calls[0]!;
+    expect(patch).toMatchObject({ assigneeAgentId: managerAgentId });
+  });
+
+  it("lets a manager assign an issue to a direct report", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ assigneeAgentId: managerAgentId, status: "in_progress" }),
+    );
+    const app = await createApp(agentActor(managerAgentId));
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: subordinateAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("rejects a peer assigning a task to another peer (no reporting relationship)", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ assigneeAgentId: subordinateAgentId, status: "in_progress" }),
+    );
+    const app = await createApp(agentActor(subordinateAgentId));
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: peerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toContain("tasks:assign");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects a peer assigning a task to a non-descendant in another sub-tree", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ assigneeAgentId: subordinateAgentId, status: "in_progress" }),
+    );
+    const app = await createApp(agentActor(subordinateAgentId));
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: otherSubordinateAgentId });
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows a manager to create an issue assigned to a direct report", async () => {
+    const app = await createApp(agentActor(managerAgentId));
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Created for report", assigneeAgentId: subordinateAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalled();
+  });
+
+  it("rejects an agent creating an issue assigned to an unrelated peer", async () => {
+    const app = await createApp(agentActor(subordinateAgentId));
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({ title: "Cannot create for peer", assigneeAgentId: peerAgentId });
+
+    expect(res.status).toBe(403);
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("still honours explicit tasks:assign grants for cross-tree assignment", async () => {
+    mockAccessService.hasPermission.mockImplementation(async (
+      _companyId: string,
+      _principalType: string,
+      principalId: string,
+      permissionKey: string,
+    ) => principalId === subordinateAgentId && permissionKey === "tasks:assign");
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ assigneeAgentId: subordinateAgentId, status: "in_progress" }),
+    );
+
+    const app = await createApp(agentActor(subordinateAgentId));
+
+    const res = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ assigneeAgentId: peerAgentId });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -500,6 +500,17 @@ export function agentRoutes(
       };
     }
 
+    const hasReportsTo = typeof agent.reportsTo === "string" && agent.reportsTo.length > 0;
+    const hasReports = hasReportsTo ? true : await svc.hasDirectReports(agent.id);
+    if (hasReportsTo || hasReports) {
+      return {
+        canAssignTasks: true,
+        taskAssignSource: "reporting_chain" as const,
+        membership,
+        grants,
+      };
+    }
+
     return {
       canAssignTasks: false,
       taskAssignSource: "none" as const,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -962,7 +962,11 @@ export function issueRoutes(
     return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
   }
 
-  async function assertCanAssignTasks(req: Request, companyId: string) {
+  async function assertCanAssignTasks(
+    req: Request,
+    companyId: string,
+    targets?: { assigneeAgentId?: string | null; assigneeUserId?: string | null },
+  ) {
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "board") {
       if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return;
@@ -975,7 +979,28 @@ export function issueRoutes(
       const allowedByGrant = await access.hasPermission(companyId, "agent", req.actor.agentId, "tasks:assign");
       if (allowedByGrant) return;
       const actorAgent = await agentsSvc.getById(req.actor.agentId);
-      if (actorAgent && actorAgent.companyId === companyId && canCreateAgentsLegacy(actorAgent)) return;
+      if (actorAgent && actorAgent.companyId === companyId) {
+        if (canCreateAgentsLegacy(actorAgent)) return;
+
+        // Reporting-chain assignment: an agent may assign tasks to its
+        // manager (own reportsTo) or to any direct report. Peers without a
+        // manager relationship still need an explicit grant.
+        const targetAgentId = targets?.assigneeAgentId ?? null;
+        const targetUserId = targets?.assigneeUserId ?? null;
+        if (targetAgentId && !targetUserId) {
+          if (actorAgent.reportsTo && actorAgent.reportsTo === targetAgentId) return;
+          if (targetAgentId !== actorAgent.id) {
+            const targetAgent = await agentsSvc.getById(targetAgentId);
+            if (
+              targetAgent &&
+              targetAgent.companyId === companyId &&
+              targetAgent.reportsTo === actorAgent.id
+            ) {
+              return;
+            }
+          }
+        }
+      }
       throw forbidden("Missing permission: tasks:assign");
     }
     throw unauthorized();
@@ -2293,7 +2318,10 @@ export function issueRoutes(
     assertCompanyAccess(req, companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
-      await assertCanAssignTasks(req, companyId);
+      await assertCanAssignTasks(req, companyId, {
+        assigneeAgentId: req.body.assigneeAgentId ?? null,
+        assigneeUserId: req.body.assigneeUserId ?? null,
+      });
     }
     await assertIssueEnvironmentSelection(companyId, req.body.executionWorkspaceSettings?.environmentId);
 
@@ -2388,7 +2416,10 @@ export function issueRoutes(
     assertCompanyAccess(req, parent.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
     if (req.body.assigneeAgentId || req.body.assigneeUserId) {
-      await assertCanAssignTasks(req, parent.companyId);
+      await assertCanAssignTasks(req, parent.companyId, {
+        assigneeAgentId: req.body.assigneeAgentId ?? null,
+        assigneeUserId: req.body.assigneeUserId ?? null,
+      });
     }
     await assertIssueEnvironmentSelection(parent.companyId, req.body.executionWorkspaceSettings?.environmentId);
 
@@ -2729,7 +2760,10 @@ export function issueRoutes(
 
     if (assigneeWillChange && !transition.workflowControlledAssignment) {
       if (!isAgentReturningIssueToCreator) {
-        await assertCanAssignTasks(req, existing.companyId);
+        await assertCanAssignTasks(req, existing.companyId, {
+          assigneeAgentId: nextAssigneeAgentId,
+          assigneeUserId: nextAssigneeUserId,
+        });
       }
     }
 

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -709,6 +709,15 @@ export function agentService(db: Db) {
       return chain;
     },
 
+    hasDirectReports: async (managerAgentId: string) => {
+      const rows = await db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(and(eq(agents.reportsTo, managerAgentId), ne(agents.status, "terminated")))
+        .limit(1);
+      return rows.length > 0;
+    },
+
     runningForAgent: (agentId: string) =>
       db
         .select()

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1607,7 +1607,8 @@ function ConfigurationTab({
   const canCreateAgents = Boolean(agent.permissions?.canCreateAgents);
   const canAssignTasks = Boolean(agent.access?.canAssignTasks);
   const taskAssignSource = agent.access?.taskAssignSource ?? "none";
-  const taskAssignLocked = agent.role === "ceo" || canCreateAgents;
+  const taskAssignLocked =
+    agent.role === "ceo" || canCreateAgents || taskAssignSource === "reporting_chain";
   const taskAssignHint =
     taskAssignSource === "ceo_role"
       ? "Enabled automatically for CEO agents."
@@ -1615,7 +1616,9 @@ function ConfigurationTab({
         ? "Enabled automatically while this agent can create new agents."
         : taskAssignSource === "explicit_grant"
           ? "Enabled via explicit company permission grant."
-          : "Disabled unless explicitly granted.";
+          : taskAssignSource === "reporting_chain"
+            ? "Enabled for the agent's manager and direct reports via the reporting chain."
+            : "Disabled unless explicitly granted.";
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Every agent has a `reportsTo` chain that mirrors a real org's command structure
> - But task assignment authority did not follow that chain — only agents with the `ceo` role, the `canCreateAgents` permission, or an explicit `tasks:assign` grant could assign issues to another agent
> - A CMO that reports to the CEO returned `access.canAssignTasks: false` and could not PATCH an issue with `assigneeAgentId = <CEO id>`, blocking both escalation up the chain and ordinary delegation to direct reports
> - This pull request makes assignment authority follow the reporting chain: an agent can always assign to its manager (its own `reportsTo`) or to any of its direct reports
> - The benefit is that a zero-human company's existing org chart is enough to power task routing — no extra `tasks:assign` grants are needed for normal up/down delegation, while peer-to-peer assignment is still gated by an explicit grant

## What Changed

- `packages/shared/src/types/agent.ts`: extend `AgentAccessState.taskAssignSource` with a new `"reporting_chain"` value (alongside `ceo_role` / `agent_creator` / `explicit_grant` / `none`).
- `server/src/services/agents.ts`: add `hasDirectReports(managerAgentId)` — a lightweight `SELECT { id } FROM agents WHERE reportsTo = ? AND status != 'terminated' LIMIT 1` count helper.
- `server/src/routes/agents.ts`: `buildAgentAccessState` now returns `canAssignTasks: true` with `taskAssignSource: "reporting_chain"` for any agent that has a non-null `reportsTo` *or* at least one active direct report.
- `server/src/routes/issues.ts`: `assertCanAssignTasks` now accepts `targets: { assigneeAgentId, assigneeUserId }`. For agent actors without a global grant, allow assignment iff the target is the actor's manager (`actor.reportsTo === targetAgentId`) or one of their direct reports (`target.reportsTo === actor.id`). All three call sites (`POST /api/companies/:companyId/issues`, `POST /api/issues/:id/children`, `PATCH /api/issues/:id`) pass the resolved target through.
- `ui/src/pages/AgentDetail.tsx`: render a new hint for the `reporting_chain` source and lock the "Can assign tasks" toggle so the derived capability cannot be turned off manually.
- New tests:
  - `server/src/__tests__/issue-task-assignment-routes.test.ts` (7 cases): subordinate-assigns-to-manager, manager-assigns-to-direct-report, peer-cannot-assign-to-peer, peer-cannot-assign-into-sibling-subtree, manager-can-create-issue-for-direct-report, agent-cannot-create-issue-for-unrelated-peer, explicit-`tasks:assign`-grant-still-bypasses-the-chain.
  - `server/src/__tests__/agent-permissions-routes.test.ts`: three new `taskAssignSource` cases — manager-only, direct-reports-only, neither → `"none"`.

## Verification

- `pnpm --filter @paperclipai/server typecheck` clean.
- `pnpm --filter @paperclipai/shared typecheck` clean.
- `pnpm --filter @paperclipai/ui typecheck` clean.
- New + adjacent test suites all green locally:
  - `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-task-assignment-routes.test.ts` → 7/7
  - `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-permissions-routes.test.ts` → 46/46
  - `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-agent-mutation-ownership-routes.test.ts src/__tests__/issue-assigned-backlog-contract-routes.test.ts` → 17/17
  - `pnpm --filter @paperclipai/server exec vitest run src/__tests__/access-service.test.ts src/__tests__/invite-join-grants.test.ts` → 12/12
  - `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-cross-tenant-authz-routes.test.ts src/__tests__/agent-skills-routes.test.ts src/__tests__/agent-instructions-routes.test.ts` → 23/23
- Manual smoke (on a local instance with CMO `reportsTo` = CEO):
  - `GET /api/agents/<cmo-id>` → `access.canAssignTasks: true`, `taskAssignSource: "reporting_chain"`.
  - `POST /api/companies/:companyId/issues` as the CMO with `assigneeAgentId = <ceo-id>` → `201`.
  - Same call as the CMO with `assigneeAgentId = <sibling-agent-id>` → `403 Missing permission: tasks:assign`.

## Risks

- Low risk for existing companies. The new branch only widens authority for agents that already have a `reportsTo` link or direct reports; it cannot grant assignment authority to agents that previously had `taskAssignSource: "none"` and no chain membership.
- One small behavior change for the UI: the "Can assign tasks" toggle on `AgentDetail` is now locked (read-only) when authority comes from the reporting chain, the same way it is already locked for `ceo` and `canCreateAgents`. This avoids the toggle silently appearing off after a user "disables" a capability that's derived from org structure.
- The new `hasDirectReports` helper is `SELECT … LIMIT 1`, so it's a single indexed scan per `buildAgentAccessState` call. `buildAgentAccessState` is only invoked on `GET /api/agents/:id` and `GET /api/agents/me`, not in any per-request hot path. We short-circuit it when `reportsTo` is already non-null.
- No DB migration. No public API shape changes — only a new enum value added to `taskAssignSource`. Existing clients that switch on the union must add a `"reporting_chain"` arm to avoid falling through to the "Disabled" hint; the UI in this same PR is the canonical consumer and is updated.

## Model Used

- Provider: Anthropic Claude
- Model: `claude-opus-4-7` (Opus 4.7) — 1M context
- Capabilities: extended thinking, tool use, code execution via Paperclip's local agent harness

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — UI change is one hint string + locking an existing toggle; no visual regression
- [x] I have updated relevant documentation to reflect my changes — no docs reference the source enum; this PR keeps shared types + UI hint in sync
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
