### PR TITLE
Suppress duplicate stale-run watchdog tickets within 24h

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -315,6 +315,8 @@ The recovery service owns this contract:
 
 Suspicious silence creates a medium-priority review issue for the selected recovery owner. Critical silence raises that review issue to high priority and blocks the source issue on the explicit evaluation task without cancelling the active process.
 
+Watchdog evaluation dedup is keyed by `(companyId, originRunId)` for 24 hours, even if the earlier evaluation thread was already closed. Severity is intentionally not part of that dedup key: a critical escalation updates or reopens the existing watchdog thread instead of creating a second sibling issue for the same run.
+
 Watchdog decisions are explicit operator/recovery-owner decisions:
 
 - `snooze` records an operator-chosen future quiet-until time and suppresses scan-created review work during that window

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -353,7 +353,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     });
   });
 
-  it("re-arms continue decisions after the default quiet window", async () => {
+  it("suppresses duplicate watchdog issues when a closed evaluation is rescanned within 24h", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const { companyId, managerId, runId } = await seedRunningRun({
       now,
@@ -395,14 +395,54 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       now: new Date(rearmAt.getTime() + 60_000),
       companyId,
     });
-    expect(afterRearm.created).toBe(1);
-    expect(afterRearm.evaluationIssueIds[0]).not.toBe(evaluationIssueId);
+    expect(afterRearm).toMatchObject({ created: 0, existing: 1 });
+    expect(afterRearm.evaluationIssueIds[0]).toBe(evaluationIssueId);
 
     const evaluations = await db
       .select()
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
-    expect(evaluations.filter((issue) => !["done", "cancelled"].includes(issue.status))).toHaveLength(1);
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0]?.status).toBe("done");
+  });
+
+  it("reopens the recent watchdog thread on critical escalation instead of creating a sibling", async () => {
+    const firstScanAt = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId } = await seedRunningRun({
+      now: firstScanAt,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const suspicious = await heartbeat.scanSilentActiveRuns({ now: firstScanAt, companyId });
+    const evaluationIssueId = suspicious.evaluationIssueIds[0];
+    expect(evaluationIssueId).toBeTruthy();
+
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, evaluationIssueId));
+
+    const criticalScanAt = new Date(firstScanAt.getTime() + 3 * 60 * 60 * 1_000 + 1_000);
+    const rescanned = await heartbeat.scanSilentActiveRuns({ now: criticalScanAt, companyId });
+    expect(rescanned).toMatchObject({ created: 0, escalated: 1 });
+    expect(rescanned.evaluationIssueIds[0]).toBe(evaluationIssueId);
+
+    const [evaluation] = await db.select().from(issues).where(eq(issues.id, evaluationIssueId));
+    expect(evaluation).toMatchObject({
+      id: evaluationIssueId,
+      status: "todo",
+      priority: "high",
+    });
+
+    const [blocker] = await db
+      .select()
+      .from(issueRelations)
+      .where(and(eq(issueRelations.companyId, companyId), eq(issueRelations.issueId, evaluationIssueId), eq(issueRelations.relatedIssueId, issueId)));
+    expect(blocker).toBeTruthy();
+
+    const allEvaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(allEvaluations).toHaveLength(1);
   });
 
   it("rejects agent watchdog decisions using issues not bound to the target run", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -49,6 +49,7 @@ const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "ti
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
+const STALE_RUN_EVALUATION_DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
@@ -629,6 +630,33 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function findRecentClosedStaleRunEvaluation(companyId: string, runId: string, now: Date) {
+    const dedupSince = new Date(now.getTime() - STALE_RUN_EVALUATION_DEDUP_WINDOW_MS);
+    const [row] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        priority: issues.priority,
+        assigneeAgentId: issues.assigneeAgentId,
+        updatedAt: issues.updatedAt,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originId, runId),
+          isNull(issues.hiddenAt),
+          inArray(issues.status, ["done", "cancelled"]),
+          gt(issues.updatedAt, dedupSince),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.id))
+      .limit(1);
+    return row ?? null;
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -971,6 +999,73 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         });
       }
       return { kind: "existing" as const, evaluationIssueId: existing.id };
+    }
+
+    // Dedup uses (companyId, originRunId) for 24h regardless of prior terminal status.
+    // Severity is not part of the dedup key; it only controls whether we escalate the
+    // same thread back into an actionable review instead of creating a sibling ticket.
+    const recentClosed = await findRecentClosedStaleRunEvaluation(input.run.companyId, input.run.id, input.now);
+    if (recentClosed) {
+      if (level === "critical" && recentClosed.priority !== "high") {
+        const ownerAgentId = recentClosed.assigneeAgentId ??
+          await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });
+        await issuesSvc.update(recentClosed.id, {
+          status: "todo",
+          priority: "high",
+          assigneeAgentId: ownerAgentId,
+        });
+        await issuesSvc.addComment(recentClosed.id, [
+          "Critical output silence threshold crossed after a recent terminal evaluation.",
+          "",
+          `- Run: \`${input.run.id}\``,
+          `- Silent for: ${formatDuration(evidence.silenceAgeMs)}`,
+          `- Last output at: ${input.run.lastOutputAt?.toISOString() ?? "none recorded"}`,
+          "",
+          "Paperclip reopened this existing watchdog thread instead of creating a duplicate sibling issue.",
+        ].join("\n"), { runId: input.run.id });
+        const reopened = await db
+          .select({
+            id: issues.id,
+            status: issues.status,
+            priority: issues.priority,
+            identifier: issues.identifier,
+            assigneeAgentId: issues.assigneeAgentId,
+          })
+          .from(issues)
+          .where(eq(issues.id, recentClosed.id))
+          .then((rows) => rows[0] ?? null);
+        if (reopened) {
+          await ensureSourceIssueBlockedByStaleEvaluation({
+            sourceIssue,
+            evaluationIssue: reopened,
+            run: input.run,
+          });
+          if (reopened.assigneeAgentId) {
+            await deps.enqueueWakeup(reopened.assigneeAgentId, {
+              source: "assignment",
+              triggerDetail: "system",
+              reason: "issue_assigned",
+              payload: {
+                issueId: reopened.id,
+                staleRunId: input.run.id,
+                sourceIssueId: sourceIssue?.id ?? null,
+              },
+              requestedByActorType: "system",
+              requestedByActorId: null,
+              contextSnapshot: {
+                issueId: reopened.id,
+                taskId: reopened.id,
+                wakeReason: "issue_assigned",
+                source: STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND,
+                staleRunId: input.run.id,
+                sourceIssueId: sourceIssue?.id ?? null,
+              },
+            });
+          }
+        }
+        return { kind: "escalated" as const, evaluationIssueId: recentClosed.id };
+      }
+      return { kind: "existing" as const, evaluationIssueId: recentClosed.id };
     }
 
     const ownerAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });


### PR DESCRIPTION
## Summary
- dedup stale active-run evaluation issues for 24h even after the prior thread was closed
- reopen the existing evaluation thread on critical escalation instead of creating a sibling
- add regression coverage for closed-then-rescan suppression and closed-medium to critical reopen

## Verification
- pnpm --filter @paperclipai/server typecheck
- CI to validate the focused watchdog regression suite
