### PR TITLE
Fix loopback runtime API URL selection

### DIFF
--- a/releases/v2026.515.0.md
+++ b/releases/v2026.515.0.md
@@ -1,0 +1,11 @@
+# v2026.515.0
+
+> Released: 2026-05-15
+
+## Fixes
+
+- **Local agent Paperclip API callbacks** — `codex_local` and other loopback-bound local agent runs now prefer the loopback Paperclip API URL over configured private-network hostnames when injecting runtime callback URLs. Private-network and Tailscale routes remain available for remote-capable binds, avoiding local heartbeat failures where agents received a Tailscale URL that refused connections from the local runtime.
+
+## Upgrade Guide
+
+No database migrations or configuration changes are required.

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -180,4 +180,32 @@ describe("buildInviteOnboardingTextDocument", () => {
       networkSpy.mockRestore();
     }
   });
+
+  it("excludes allowed hostnames from onboarding candidates when the server is loopback-bound", () => {
+    const req = buildReq("127.0.0.1:3100");
+    const invite = {
+      id: "invite-5",
+      companyId: "company-1",
+      inviteType: "company_join",
+      allowedJoinTypes: "agent",
+      tokenHash: "hash",
+      defaultsPayload: null,
+      expiresAt: new Date("2026-03-05T00:00:00.000Z"),
+      invitedByUserId: null,
+      revokedAt: null,
+      acceptedAt: null,
+      createdAt: new Date("2026-03-04T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-04T00:00:00.000Z"),
+    } as const;
+
+    const text = buildInviteOnboardingTextDocument(req, "token-loopback", invite as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+    });
+
+    expect(text).toContain("http://127.0.0.1:3100");
+    expect(text).not.toContain("http://cb-threadripper.tail3a8e2d.ts.net:3100");
+  });
 });

--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -80,6 +80,52 @@ describe("runtime API discovery", () => {
     ]);
   });
 
+  it("uses the loopback bind host before allowed hostnames for local runtime URLs", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+      }),
+    ).toBe("http://127.0.0.1:3100");
+  });
+
+  it("keeps allowed hostnames ahead of non-loopback bind hosts for primary runtime URLs", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["paperclip.example.test"],
+        bindHost: "192.168.6.178",
+        port: 3100,
+      }),
+    ).toBe("http://paperclip.example.test:3100");
+  });
+
+  it("skips allowed hostnames when building candidates for loopback-bound runtimes", () => {
+    expect(
+      buildRuntimeApiCandidateUrls({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+        networkInterfacesMap: {},
+      }),
+    ).toEqual(["http://127.0.0.1:3100"]);
+  });
+
+  it("keeps allowed hostnames for wildcard-bound remote-capable runtimes", () => {
+    expect(
+      buildRuntimeApiCandidateUrls({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+        bindHost: "0.0.0.0",
+        port: 3100,
+        networkInterfacesMap: {},
+      }),
+    ).toEqual(["http://cb-threadripper.tail3a8e2d.ts.net:3100"]);
+  });
+
   it("adds host.docker.internal when the explicit base URL is loopback", () => {
     expect(
       buildRuntimeApiCandidateUrls({

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1491,10 +1491,13 @@ function buildOnboardingConnectionCandidates(input: {
     candidates.add(`${protocol}//${bindHost}${port}`);
   }
 
-  for (const rawHost of input.allowedHostnames) {
-    const host = normalizeHostname(rawHost);
-    if (!host) continue;
-    candidates.add(`${protocol}//${host}${port}`);
+  const includeAllowedHostnames = !bindHost || !isLoopbackHost(bindHost);
+  if (includeAllowedHostnames) {
+    for (const rawHost of input.allowedHostnames) {
+      const host = normalizeHostname(rawHost);
+      if (!host) continue;
+      candidates.add(`${protocol}//${host}${port}`);
+    }
   }
 
   if (base && isLoopbackHost(base.hostname)) {

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -61,6 +61,11 @@ export function choosePrimaryRuntimeApiUrl(input: {
     }
   }
 
+  const bindHost = normalizeHost(input.bindHost);
+  if (bindHost && isLoopbackHost(bindHost)) {
+    return formatOrigin("http:", bindHost, input.port);
+  }
+
   const allowedHostname = input.allowedHostnames
     .map((value) => value.trim())
     .find(Boolean);
@@ -68,7 +73,6 @@ export function choosePrimaryRuntimeApiUrl(input: {
     return formatOrigin("http:", allowedHostname, input.port);
   }
 
-  const bindHost = normalizeHost(input.bindHost);
   if (bindHost && !isWildcardHost(bindHost)) {
     return formatOrigin("http:", bindHost, input.port);
   }
@@ -128,13 +132,16 @@ export function buildRuntimeApiCandidateUrls(input: {
   pushCandidate(candidates, seen, input.preferredApiUrl);
   pushCandidate(candidates, seen, explicitOrigin);
 
-  for (const rawHost of input.allowedHostnames) {
-    const host = normalizeHost(rawHost);
-    if (!host) continue;
-    pushCandidate(candidates, seen, formatOrigin(protocol, host, input.port));
+  const bindHost = normalizeHost(input.bindHost);
+  const includeAllowedHostnames = !bindHost || !isLoopbackHost(bindHost);
+  if (includeAllowedHostnames) {
+    for (const rawHost of input.allowedHostnames) {
+      const host = normalizeHost(rawHost);
+      if (!host) continue;
+      pushCandidate(candidates, seen, formatOrigin(protocol, host, input.port));
+    }
   }
 
-  const bindHost = normalizeHost(input.bindHost);
   if (bindHost && !isWildcardHost(bindHost)) {
     pushCandidate(candidates, seen, formatOrigin(protocol, bindHost, input.port));
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through a control plane that injects runtime callback URLs into local and remote adapter runs.
> - The runtime API URL selector decides which Paperclip API origin a heartbeat should call back to.
> - Local `codex_local` runs can be loopback-bound while the instance also has a Tailscale/private hostname configured for remote access.
> - When allowed hostnames outrank a loopback bind, local agents can receive a Tailscale URL and fail with an immediate connection refusal.
> - The selector needs to preserve remote-capable Tailscale routes without overriding the local loopback path for loopback-bound runtimes.
> - This pull request carries the runtime selector fix into source and documents the stable release that should publish it.
> - The benefit is that reinstalling Paperclip no longer reintroduces the local API URL refusal bug.

## What Changed

- Prefer loopback bind hosts over configured allowed hostnames for primary local runtime API URLs.
- Skip allowed hostnames when building callback candidates for loopback-bound runtimes, while preserving allowed hostnames for wildcard/private-network binds.
- Keep reachable interface candidates deterministic and filter link-local addresses.
- Update invite onboarding text expectations for the local API URL behavior.
- Add release notes for `v2026.515.0` covering the fix and upgrade guidance.

## Verification

- `pnpm exec vitest run server/src/__tests__/runtime-api.test.ts server/src/__tests__/invite-onboarding-text.test.ts`
- `./scripts/release.sh stable --dry-run --skip-verify`
- Manual npm package check showed `@paperclipai/server@2026.513.0` still returned `http://cb-threadripper.tail3a8e2d.ts.net:3100` before this source patch, confirming the published latest package had not carried the fix yet.

## Risks

- Low risk for loopback-bound local runs: callback URLs become strictly local, which is the intended local adapter path.
- Remote/private-network binds still include allowed hostnames, so Tailscale-style remote routes remain available.
- Release is blocked until an npm-authenticated maintainer runs the non-dry-run release command.

## Model Used

- OpenAI Codex, GPT-5.5, coding agent with shell/tool access and medium reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge