### PR TITLE
Enable CI publishing for cursor-cloud, cloudflare, and exe.dev release packages

### DIFF
--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -22,7 +22,7 @@
   {
     "dir": "packages/adapters/cursor-cloud",
     "name": "@paperclipai/adapter-cursor-cloud",
-    "publishFromCi": false
+    "publishFromCi": true
   },
   {
     "dir": "packages/adapters/cursor-local",
@@ -87,7 +87,7 @@
   {
     "dir": "packages/plugins/sandbox-providers/cloudflare",
     "name": "@paperclipai/plugin-cloudflare-sandbox",
-    "publishFromCi": false
+    "publishFromCi": true
   },
   {
     "dir": "packages/plugins/sandbox-providers/daytona",
@@ -97,7 +97,7 @@
   {
     "dir": "packages/plugins/sandbox-providers/exe-dev",
     "name": "@paperclipai/plugin-exe-dev",
-    "publishFromCi": false
+    "publishFromCi": true
   },
   {
     "dir": "packages/plugins/sandbox-providers/e2b",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents, and its release flow depends on explicit package enrollment for automated publishing.
> - The release registry tooling uses `scripts/release-package-manifest.json` as the source of truth for which public packages CI is allowed to publish.
> - The cursor cloud adapter plus the Cloudflare and exe.dev sandbox plugins are public packages that now need to ship through the normal CI release path.
> - Leaving those entries at `publishFromCi: false` keeps release automation and registry validation out of sync with the intended package set.
> - This pull request updates only those three manifest entries and leaves the release tooling itself unchanged.
> - The benefit is that CI release enrollment now matches the packages we intend to publish, with the existing manifest checks continuing to guard correctness.

## What Changed

- Enabled CI publishing for `@paperclipai/adapter-cursor-cloud` in `scripts/release-package-manifest.json`.
- Enabled CI publishing for `@paperclipai/plugin-cloudflare-sandbox` in `scripts/release-package-manifest.json`.
- Enabled CI publishing for `@paperclipai/plugin-exe-dev` in `scripts/release-package-manifest.json`.

## Verification

- `node ./scripts/release-package-map.mjs check`
- `pnpm test:release-registry`

## Risks

- Low risk. This is a manifest-only change, but a wrong enrollment flag would affect release automation, so the release-registry checks are the main guardrail.

## Model Used

- OpenAI GPT-5.4 via Paperclip `codex_local` (`adapterConfig.model: gpt-5.4`), high reasoning effort, with tool use and shell/code execution. The adapter does not expose a separate context-window value in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
