### PR TITLE
fix(agents): require board approval for non-CEO agent-actor hires

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1026,6 +1026,121 @@ describe.sequential("agent permission routes", () => {
     );
   });
 
+  it("forces approval when an agent-actor with canCreateAgents but role!=ceo files an agent-hire", async () => {
+    const nonCeoActorAgent = {
+      ...baseAgent,
+      role: "manager",
+      permissions: { canCreateAgents: true },
+    };
+    const pendingHired = {
+      ...baseAgent,
+      status: "pending_approval",
+    };
+    mockAgentService.getById.mockResolvedValue(nonCeoActorAgent);
+    mockAgentService.create.mockResolvedValue(pendingHired);
+    mockApprovalService.create.mockResolvedValue({
+      id: "approval-1",
+      type: "hire_agent",
+      status: "pending",
+    });
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .send({
+        name: "Hired",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {},
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.body.agent.status).toBe("pending_approval");
+    expect(res.body.approval).toEqual(
+      expect.objectContaining({ type: "hire_agent", status: "pending" }),
+    );
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({ status: "pending_approval" }),
+    );
+    expect(mockApprovalService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({
+        type: "hire_agent",
+        status: "pending",
+        requestedByAgentId: agentId,
+      }),
+    );
+  });
+
+  it("keeps the direct-create path when a CEO-role agent-actor files an agent-hire", async () => {
+    const ceoActorAgent = {
+      ...baseAgent,
+      role: "ceo",
+      permissions: { canCreateAgents: true },
+    };
+    mockAgentService.getById.mockResolvedValue(ceoActorAgent);
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .send({
+        name: "Direct Hire",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {},
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.body.approval).toBeNull();
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({ status: "idle" }),
+    );
+    expect(mockApprovalService.create).not.toHaveBeenCalled();
+  });
+
+  it("keeps the direct-create path when a board user-actor files an agent-hire", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .send({
+        name: "Board Hire",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: {},
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.body.approval).toBeNull();
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({ status: "idle" }),
+    );
+    expect(mockApprovalService.create).not.toHaveBeenCalled();
+  });
+
   it("allows board users to directly approve pending agents", async () => {
     const pendingAgent = {
       ...baseAgent,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1950,7 +1950,7 @@ export function agentRoutes(
 
   router.post("/companies/:companyId/agent-hires", validate(createAgentHireSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
-    await assertCanCreateAgentsForCompany(req, companyId);
+    const actorAgent = await assertCanCreateAgentsForCompany(req, companyId);
     const sourceIssueIds = parseSourceIssueIds(req.body);
     const {
       desiredSkills: requestedDesiredSkills,
@@ -2004,7 +2004,8 @@ export function agentRoutes(
       return;
     }
 
-    const requiresApproval = company.requireBoardApprovalForNewAgents;
+    const nonCeoAgentActor = actorAgent !== null && actorAgent.role !== "ceo";
+    const requiresApproval = company.requireBoardApprovalForNewAgents || nonCeoAgentActor;
     const status = requiresApproval ? "pending_approval" : "idle";
     const createdAgent = await svc.create(companyId, {
       ...normalizedHireInput,

--- a/skills/paperclip-create-agent/references/api-reference.md
+++ b/skills/paperclip-create-agent/references/api-reference.md
@@ -81,7 +81,7 @@ Response:
 }
 ```
 
-If company setting disables required approval, `approval` is `null` and the agent is created as `idle`.
+Approval is required whenever the actor is a non-CEO agent — `canCreateAgents` for a non-CEO agent grants the ability to *file* a hire for board review, not to mint agents directly. CEO-role agents and board users keep the direct-create path; if the company also disables `requireBoardApprovalForNewAgents`, their `approval` is `null` and the agent is created as `idle`. A non-CEO agent actor always receives `{ agent: { status: "pending_approval" }, approval: { type: "hire_agent", status: "pending" } }` regardless of company settings.
 
 `desiredSkills` accepts company skill ids, canonical keys, or a unique slug. The server resolves and stores canonical company skill keys.
 Leave timer heartbeats disabled by default. Only set `runtimeConfig.heartbeat.enabled=true` and include an `intervalSec` when the role truly needs scheduled recurring work or the user explicitly requested it.


### PR DESCRIPTION
## Summary

`POST /api/companies/:companyId/agent-hires` previously treated the caller's `canCreateAgents` grant as sufficient to mint an agent directly, even when the actor was a non-CEO agent. This change forces `pending_approval` whenever the actor is an agent with `role !== "ceo"`, regardless of `company.requireBoardApprovalForNewAgents`. CEO-role agents and board users keep the direct-create path.

This matches the intent of granting `canCreateAgents` to non-CEO agents: *"can file a hire for board review,"* not *"can mint agents."*

- `server/src/routes/agents.ts` — capture the actor agent from `assertCanCreateAgentsForCompany` and OR `nonCeoAgentActor` into `requiresApproval`. Existing approval-creation branch is unchanged.
- `server/src/__tests__/agent-permissions-routes.test.ts` — 3 new tests covering all actor paths.
- `skills/paperclip-create-agent/references/api-reference.md` — documents the actor-based gate.

## Test plan

- [x] `pnpm vitest run src/__tests__/agent-permissions-routes.test.ts` — 46/46 pass (3 new + 43 existing; no regression in the user/CEO flow)
- [x] `pnpm vitest run src/__tests__/agent-skills-routes.test.ts` — 17/17 pass (other file exercising `agent-hires`)
- [x] Non-CEO agent actor → `agent.status="pending_approval"`, `approval={ type: "hire_agent", status: "pending" }`
- [x] CEO agent actor → direct-create, `approval: null`
- [x] Board user actor → direct-create, `approval: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)