### PR TITLE
Fix run-recovery uuid crash and stop transitioning agents to error on single failed runs (SIE-441)

### DIFF
--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { buildSkillMentionHref } from "@paperclipai/shared";
 import {
   applyRunScopedMentionedSkillKeys,
+  computeAgentStatusAfterRun,
   extractMentionedSkillIdsFromSources,
   filterValidSkillMentionIds,
   resolveExecutionRunAdapterConfig,
@@ -153,6 +154,37 @@ describe("filterValidSkillMentionIds (SIE-441 regression)", () => {
       ]),
     ).toEqual([]);
   });
+});
+
+describe("computeAgentStatusAfterRun (SIE-441 regression)", () => {
+  // Before the fix `finalizeAgentStatus` flipped the agent to `status: error`
+  // whenever the most recent run failed or timed out. That meant one bad
+  // recovery payload (e.g. the uuid crash above) took the entire CTO agent
+  // offline, blocking ALL of its other heartbeats until a human reset it.
+  // Errors belong to runs; the agent must stay invokable.
+  it.each(["failed", "timed_out"] as const)(
+    "does not flip the agent to error after a single %s run",
+    (outcome) => {
+      expect(
+        computeAgentStatusAfterRun({ runningCount: 0, outcome }),
+      ).toBe("idle");
+    },
+  );
+
+  it("stays running while other runs are still in flight", () => {
+    expect(
+      computeAgentStatusAfterRun({ runningCount: 2, outcome: "failed" }),
+    ).toBe("running");
+  });
+
+  it.each(["succeeded", "cancelled"] as const)(
+    "settles back to idle after a %s run with no other runs",
+    (outcome) => {
+      expect(
+        computeAgentStatusAfterRun({ runningCount: 0, outcome }),
+      ).toBe("idle");
+    },
+  );
 });
 
 describe("applyRunScopedMentionedSkillKeys", () => {

--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -3,6 +3,7 @@ import { buildSkillMentionHref } from "@paperclipai/shared";
 import {
   applyRunScopedMentionedSkillKeys,
   extractMentionedSkillIdsFromSources,
+  filterValidSkillMentionIds,
   resolveExecutionRunAdapterConfig,
 } from "../services/heartbeat.ts";
 
@@ -111,6 +112,46 @@ describe("extractMentionedSkillIdsFromSources", () => {
         `Duplicate mention [/release-changelog](${releaseHref})`,
       ]),
     ).toEqual(["skill-1", "skill-2"]);
+  });
+});
+
+describe("filterValidSkillMentionIds (SIE-441 regression)", () => {
+  // Reproduces the SIE-439 state shape: a hire-approval comment on the issue
+  // contained `[…](skill://paperclip-create-agent/references/agents/coder.md)`.
+  // Before the fix the slug-style id was forwarded to
+  // `inArray(companySkills.id, …)` against a `uuid` column, which Postgres
+  // rejected as `22P02 invalid input syntax for type uuid` and crashed the
+  // recovery continuation run.
+  it("drops non-UUID skill mention ids so they never reach the uuid lookup", () => {
+    const slugHref = buildSkillMentionHref(
+      "paperclip-create-agent/references/agents/coder.md",
+    );
+    const validHref = buildSkillMentionHref(
+      "550e8400-e29b-41d4-a716-446655440000",
+    );
+
+    const extracted = extractMentionedSkillIdsFromSources([
+      `Use [coder template](${slugHref}) please.`,
+      `Reference skill [/skill](${validHref}).`,
+    ]);
+    expect(extracted).toEqual([
+      "paperclip-create-agent/references/agents/coder.md",
+      "550e8400-e29b-41d4-a716-446655440000",
+    ]);
+
+    expect(filterValidSkillMentionIds(extracted)).toEqual([
+      "550e8400-e29b-41d4-a716-446655440000",
+    ]);
+  });
+
+  it("returns an empty list when every mention is non-UUID (no DB query needed)", () => {
+    expect(
+      filterValidSkillMentionIds([
+        "paperclip-create-agent/references/agents/coder.md",
+        "paperclip/paperclip-create-agent",
+        "",
+      ]),
+    ).toEqual([]);
   });
 });
 

--- a/server/src/__tests__/heartbeat-project-env.test.ts
+++ b/server/src/__tests__/heartbeat-project-env.test.ts
@@ -162,29 +162,13 @@ describe("computeAgentStatusAfterRun (SIE-441 regression)", () => {
   // recovery payload (e.g. the uuid crash above) took the entire CTO agent
   // offline, blocking ALL of its other heartbeats until a human reset it.
   // Errors belong to runs; the agent must stay invokable.
-  it.each(["failed", "timed_out"] as const)(
-    "does not flip the agent to error after a single %s run",
-    (outcome) => {
-      expect(
-        computeAgentStatusAfterRun({ runningCount: 0, outcome }),
-      ).toBe("idle");
-    },
-  );
-
-  it("stays running while other runs are still in flight", () => {
-    expect(
-      computeAgentStatusAfterRun({ runningCount: 2, outcome: "failed" }),
-    ).toBe("running");
+  it("settles the agent back to idle after a run finishes, regardless of outcome", () => {
+    expect(computeAgentStatusAfterRun({ runningCount: 0 })).toBe("idle");
   });
 
-  it.each(["succeeded", "cancelled"] as const)(
-    "settles back to idle after a %s run with no other runs",
-    (outcome) => {
-      expect(
-        computeAgentStatusAfterRun({ runningCount: 0, outcome }),
-      ).toBe("idle");
-    },
-  );
+  it("stays running while other runs are still in flight", () => {
+    expect(computeAgentStatusAfterRun({ runningCount: 2 })).toBe("running");
+  });
 });
 
 describe("applyRunScopedMentionedSkillKeys", () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -510,7 +510,6 @@ export function filterValidSkillMentionIds(ids: string[]): string[] {
 // `terminated` statuses are preserved by the caller before reaching here.
 export function computeAgentStatusAfterRun(input: {
   runningCount: number;
-  outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
 }): "running" | "idle" {
   if (input.runningCount > 0) return "running";
   return "idle";
@@ -6214,10 +6213,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const isFirstHeartbeat = !existing.lastHeartbeatAt;
 
     const runningCount = await countRunningRunsForAgent(agentId);
-    const nextStatus = computeAgentStatusAfterRun({
-      runningCount,
-      outcome,
-    });
+    const nextStatus = computeAgentStatusAfterRun({ runningCount });
 
     const updated = await db
       .update(agents)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -501,6 +501,21 @@ export function filterValidSkillMentionIds(ids: string[]): string[] {
   return ids.filter((id) => isUuidLike(id));
 }
 
+// SIE-441: a single failed/timed_out heartbeat run must not transition the
+// assigned agent to `status: error`. Errors belong to the run that produced
+// them, not the agent; otherwise one bad recovery payload (e.g. the uuid
+// crash filtered above) takes the agent's entire inbox offline until a
+// human resets it. After a run finishes, we settle the agent back to `idle`
+// when nothing else is running, regardless of outcome. The `paused` /
+// `terminated` statuses are preserved by the caller before reaching here.
+export function computeAgentStatusAfterRun(input: {
+  runningCount: number;
+  outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
+}): "running" | "idle" {
+  if (input.runningCount > 0) return "running";
+  return "idle";
+}
+
 function leaseReleaseStatusForRunStatus(
   status: string | null | undefined,
 ): Extract<EnvironmentLeaseStatus, "released" | "expired" | "failed"> {
@@ -6199,12 +6214,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const isFirstHeartbeat = !existing.lastHeartbeatAt;
 
     const runningCount = await countRunningRunsForAgent(agentId);
-    const nextStatus =
-      runningCount > 0
-        ? "running"
-        : outcome === "succeeded" || outcome === "cancelled"
-          ? "idle"
-          : "error";
+    const nextStatus = computeAgentStatusAfterRun({
+      runningCount,
+      outcome,
+    });
 
     const updated = await db
       .update(agents)

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -159,7 +159,7 @@ import {
   readPaperclipSkillSyncPreference,
   writePaperclipSkillSyncPreference,
 } from "@paperclipai/adapter-utils/server-utils";
-import { extractSkillMentionIds } from "@paperclipai/shared";
+import { extractSkillMentionIds, isUuidLike } from "@paperclipai/shared";
 import { environmentService } from "./environments.js";
 import { environmentRuntimeService } from "./environment-runtime.js";
 import { environmentRunOrchestrator } from "./environment-run-orchestrator.js";
@@ -461,11 +461,13 @@ async function resolveRunScopedMentionedSkillKeys(input: {
         eq(issueComments.companyId, input.companyId),
       ),
     );
-  const mentionedSkillIds = extractMentionedSkillIdsFromSources([
-    issue.title,
-    issue.description ?? "",
-    ...comments.map((comment) => comment.body),
-  ]);
+  const mentionedSkillIds = filterValidSkillMentionIds(
+    extractMentionedSkillIdsFromSources([
+      issue.title,
+      issue.description ?? "",
+      ...comments.map((comment) => comment.body),
+    ]),
+  );
   if (mentionedSkillIds.length === 0) return [];
 
   const skillRows = await input.db
@@ -484,6 +486,19 @@ async function resolveRunScopedMentionedSkillKeys(input: {
   return mentionedSkillIds
     .map((skillId) => skillKeyById.get(skillId) ?? null)
     .filter((skillKey): skillKey is string => Boolean(skillKey));
+}
+
+// SIE-441: `skill://...` mention hrefs are parsed by `parseSkillMentionHref`
+// as opaque strings, so authors can (and do) embed slug-style references like
+// `skill://paperclip-create-agent/references/agents/coder.md` in issue bodies.
+// `companySkills.id` is a `uuid` column, so feeding a non-UUID slug into the
+// `inArray(companySkills.id, ...)` lookup causes Postgres to raise `22P02
+// invalid input syntax for type uuid` and crashes the entire heartbeat run.
+// Skill mentions must reference a real company-skill UUID to resolve; filter
+// non-UUIDs out here so the lookup is safe and unresolved mentions are
+// silently ignored (the harness then proceeds without injecting them).
+export function filterValidSkillMentionIds(ids: string[]): string[] {
+  return ids.filter((id) => isUuidLike(id));
 }
 
 function leaseReleaseStatusForRunStatus(


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies through heartbeat runs that wake agents to act on assigned issues.
> - The heartbeat harness in `server/src/services/heartbeat.ts` resolves run-scoped skill mentions from the active issue's title/description/comments and looks them up in the `company_skills` table before invoking the adapter.
> - `parseSkillMentionHref` treats whatever follows `skill://` as an opaque id, so an issue body containing `[…](skill://paperclip-create-agent/references/agents/coder.md)` fed that slug straight into `inArray(companySkills.id, …)` against a `uuid` column.
> - Postgres rejected the statement with `22P02 invalid input syntax for type uuid`, the adapter execution died with `adapter_failed`, and the heartbeat continuation run crashed. `finalizeAgentStatus` then mapped the failed outcome directly onto `agents.status = 'error'`, taking the assigned agent's entire inbox offline until a human reset it. CTO and DBReliabilityEngineer both got cratered by this class.
> - This pull request lands two narrowly-scoped fixes — one per commit — for SIE-441: the payload bug (filter non-UUID skill mentions) and the resilience bug (errors stay scoped to the run, not the agent).
> - The benefit is that a single bad recovery payload can no longer crash recovery runs or silently disable an agent's whole heartbeat surface.

## What Changed

- `server/src/services/heartbeat.ts`: filter mention ids through a new pure helper `filterValidSkillMentionIds` (backed by `isUuidLike` from `@paperclipai/shared`) before passing them to `inArray(companySkills.id, …)`. Non-UUID slug-style references are silently dropped so the harness proceeds without injecting them rather than crashing the run.
- `server/src/services/heartbeat.ts`: extract `computeAgentStatusAfterRun` as a pure helper that returns \`running\`/\`idle\` only — no \`error\`. \`finalizeAgentStatus\` uses it so a failed/timed_out run settles the agent back to idle while it is otherwise invokable.
- `server/src/__tests__/heartbeat-project-env.test.ts`: regression tests cover (a) the SIE-439 state shape — a comment with `skill://paperclip-create-agent/references/agents/coder.md` is filtered out before any DB query — and (b) failed/timed_out outcomes no longer flip the agent to \`error\`.

## Verification

Each fix is its own commit; review them independently.

\`\`\`
$ node node_modules/vitest/vitest.mjs run server/src/__tests__/heartbeat-project-env.test.ts
 ✓ |@paperclipai/server| src/__tests__/heartbeat-project-env.test.ts (11 tests) 4ms
 Test Files  1 passed (1)
      Tests  11 passed (11)

$ node node_modules/vitest/vitest.mjs run server/src/__tests__/heartbeat-retry-scheduling.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts
 Test Files  2 passed (2)
      Tests  63 passed (63)

$ pnpm typecheck
… all workspaces Done
\`\`\`

\`heartbeat-comment-wake-batching.test.ts\` has one pre-existing failure (\"promotes deferred comment wakes after the active run closes the issue\") that reproduces on \`master\` unchanged — not introduced here.

Manual: re-running the SIE-439 continuation path against this branch no longer raises a uuid error because the slug-style mention is filtered before the lookup; DBReliabilityEngineer's last failure was a different (\`claude_transient_upstream\`) error, but the blast-radius fix prevents that class of single-run failure from putting any agent into \`error\` going forward.

## Risks

- Behavior change for agents that were previously parked in \`status: error\` after a failed run: they will now resolve to \`idle\`. The earlier short-circuit for \`paused\`/\`terminated\` is preserved, so operator-set states are unaffected. \`CONTINUATION_AGENT_STATUSES\` already includes \`error\` for recovery wakes, so no skipped wakes change behavior.
- Non-UUID skill mentions in user content used to crash; they now silently no-op. If an author intended such a mention to inject a skill, the run continues without that skill — same effect as a misspelled slug today.

## Model Used

- Claude (Anthropic), \`claude-opus-4-7\`. Extended-thinking / tool-use mode within the Claude Code harness. No other AI models contributed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (n/a — server-only)
- [x] I have updated relevant documentation to reflect my changes (root-cause comments in code; no public-API surface change)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge