### PR TITLE
feat(agents): surface per-agent token totals and run counts

### DIFF
--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -87,6 +87,11 @@ export interface Agent {
   defaultEnvironmentId?: string | null;
   budgetMonthlyCents: number;
   spentMonthlyCents: number;
+  inputTokensMonthly: number;
+  cachedInputTokensMonthly: number;
+  outputTokensMonthly: number;
+  subscriptionRunCount: number;
+  apiRunCount: number;
   pauseReason: PauseReason | null;
   pausedAt: Date | null;
   permissions: AgentPermissions;

--- a/server/src/services/agents.test.ts
+++ b/server/src/services/agents.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { agentService } from "./agents.js";
+
+function agentRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "Test Agent",
+    role: "general",
+    title: null,
+    icon: null,
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "claude-local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    defaultEnvironmentId: null,
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    metadata: null,
+    permissions: null,
+    status: "idle",
+    pauseReason: null,
+    pausedAt: null,
+    lastHeartbeatAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function createSelectSequenceDb(results: unknown[][]) {
+  const pending = [...results];
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    leftJoin: vi.fn(() => chain),
+    groupBy: vi.fn(() => chain),
+    then: vi.fn((resolve: (value: unknown[]) => unknown) => Promise.resolve(resolve(pending.shift() ?? []))),
+  };
+  return { db: { select: vi.fn(() => chain) } };
+}
+
+describe("agentService.list token summary hydration", () => {
+  it("returns zero token fields when no cost_events exist for the month", async () => {
+    const { db } = createSelectSequenceDb([
+      [agentRow()],
+      [],
+      [],
+    ]);
+    const agents = agentService(db as any);
+    const [agent] = await agents.list("company-1");
+    expect(agent).toBeDefined();
+    expect(agent!.inputTokensMonthly).toBe(0);
+    expect(agent!.cachedInputTokensMonthly).toBe(0);
+    expect(agent!.outputTokensMonthly).toBe(0);
+    expect(agent!.subscriptionRunCount).toBe(0);
+    expect(agent!.apiRunCount).toBe(0);
+  });
+
+  it("returns per-agent token totals and run counts split by billing type", async () => {
+    const agentA = agentRow({ id: "agent-a", name: "Agent A" });
+    const agentB = agentRow({ id: "agent-b", name: "Agent B" });
+
+    const { db } = createSelectSequenceDb([
+      [agentA, agentB],
+      [
+        { agentId: "agent-a", spentMonthlyCents: 100 },
+        { agentId: "agent-b", spentMonthlyCents: 0 },
+      ],
+      [
+        {
+          agentId: "agent-a",
+          inputTokensMonthly: 10000,
+          cachedInputTokensMonthly: 2000,
+          outputTokensMonthly: 5000,
+          subscriptionRunCount: 3,
+          apiRunCount: 0,
+        },
+        {
+          agentId: "agent-b",
+          inputTokensMonthly: 500,
+          cachedInputTokensMonthly: 0,
+          outputTokensMonthly: 200,
+          subscriptionRunCount: 0,
+          apiRunCount: 2,
+        },
+      ],
+    ]);
+
+    const agents = agentService(db as any);
+    const list = await agents.list("company-1");
+    const a = list.find((ag) => ag.id === "agent-a")!;
+    const b = list.find((ag) => ag.id === "agent-b")!;
+
+    expect(a.inputTokensMonthly).toBe(10000);
+    expect(a.cachedInputTokensMonthly).toBe(2000);
+    expect(a.outputTokensMonthly).toBe(5000);
+    expect(a.subscriptionRunCount).toBe(3);
+    expect(a.apiRunCount).toBe(0);
+
+    expect(b.inputTokensMonthly).toBe(500);
+    expect(b.cachedInputTokensMonthly).toBe(0);
+    expect(b.outputTokensMonthly).toBe(200);
+    expect(b.subscriptionRunCount).toBe(0);
+    expect(b.apiRunCount).toBe(2);
+  });
+
+  it("agents absent from token summary rows default to zero", async () => {
+    const agentA = agentRow({ id: "agent-a", name: "Agent A" });
+    const agentB = agentRow({ id: "agent-b", name: "Agent B" });
+
+    const { db } = createSelectSequenceDb([
+      [agentA, agentB],
+      [
+        { agentId: "agent-a", spentMonthlyCents: 50 },
+      ],
+      [
+        {
+          agentId: "agent-a",
+          inputTokensMonthly: 8000,
+          cachedInputTokensMonthly: 100,
+          outputTokensMonthly: 3000,
+          subscriptionRunCount: 1,
+          apiRunCount: 1,
+        },
+      ],
+    ]);
+
+    const agents = agentService(db as any);
+    const list = await agents.list("company-1");
+    const b = list.find((ag) => ag.id === "agent-b")!;
+
+    expect(b.inputTokensMonthly).toBe(0);
+    expect(b.cachedInputTokensMonthly).toBe(0);
+    expect(b.outputTokensMonthly).toBe(0);
+    expect(b.subscriptionRunCount).toBe(0);
+    expect(b.apiRunCount).toBe(0);
+  });
+});

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -232,6 +232,11 @@ export function agentService(db: Db) {
     return withUrlKey({
       ...row,
       permissions: normalizeAgentPermissions(row.permissions, row.role),
+      inputTokensMonthly: 0,
+      cachedInputTokensMonthly: 0,
+      outputTokensMonthly: 0,
+      subscriptionRunCount: 0,
+      apiRunCount: 0,
     });
   }
 
@@ -256,6 +261,50 @@ export function agentService(db: Db) {
     return new Map(rows.map((row) => [row.agentId, Number(row.spentMonthlyCents ?? 0)]));
   }
 
+  interface AgentTokenSummary {
+    inputTokensMonthly: number;
+    cachedInputTokensMonthly: number;
+    outputTokensMonthly: number;
+    subscriptionRunCount: number;
+    apiRunCount: number;
+  }
+
+  async function getMonthlyTokenSummaryByAgentIds(companyId: string, agentIds: string[]): Promise<Map<string, AgentTokenSummary>> {
+    if (agentIds.length === 0) return new Map();
+    const { start, end } = currentUtcMonthWindow();
+    const rows = await db
+      .select({
+        agentId: costEvents.agentId,
+        inputTokensMonthly: sql<number>`coalesce(sum(${costEvents.inputTokens}), 0)::bigint`,
+        cachedInputTokensMonthly: sql<number>`coalesce(sum(${costEvents.cachedInputTokens}), 0)::bigint`,
+        outputTokensMonthly: sql<number>`coalesce(sum(${costEvents.outputTokens}), 0)::bigint`,
+        subscriptionRunCount: sql<number>`count(*) filter (where ${costEvents.billingType} = 'subscription_included')`,
+        apiRunCount: sql<number>`count(*) filter (where ${costEvents.billingType} in ('metered_api', 'subscription_overage'))`,
+      })
+      .from(costEvents)
+      .where(
+        and(
+          eq(costEvents.companyId, companyId),
+          inArray(costEvents.agentId, agentIds),
+          gte(costEvents.occurredAt, start),
+          lt(costEvents.occurredAt, end),
+        ),
+      )
+      .groupBy(costEvents.agentId);
+    return new Map(
+      rows.map((row) => [
+        row.agentId,
+        {
+          inputTokensMonthly: Number(row.inputTokensMonthly ?? 0),
+          cachedInputTokensMonthly: Number(row.cachedInputTokensMonthly ?? 0),
+          outputTokensMonthly: Number(row.outputTokensMonthly ?? 0),
+          subscriptionRunCount: Number(row.subscriptionRunCount ?? 0),
+          apiRunCount: Number(row.apiRunCount ?? 0),
+        },
+      ]),
+    );
+  }
+
   async function hydrateAgentSpend<T extends { id: string; companyId: string; spentMonthlyCents: number }>(rows: T[]) {
     const agentIds = rows.map((row) => row.id);
     const companyId = rows[0]?.companyId;
@@ -264,6 +313,25 @@ export function agentService(db: Db) {
     return rows.map((row) => ({
       ...row,
       spentMonthlyCents: spendByAgentId.get(row.id) ?? 0,
+    }));
+  }
+
+  const ZERO_TOKEN_SUMMARY: AgentTokenSummary = {
+    inputTokensMonthly: 0,
+    cachedInputTokensMonthly: 0,
+    outputTokensMonthly: 0,
+    subscriptionRunCount: 0,
+    apiRunCount: 0,
+  };
+
+  async function hydrateAgentTokenSummary<T extends { id: string; companyId: string }>(rows: T[]) {
+    const agentIds = rows.map((row) => row.id);
+    const companyId = rows[0]?.companyId;
+    if (!companyId || agentIds.length === 0) return rows.map((row) => ({ ...row, ...ZERO_TOKEN_SUMMARY }));
+    const summaryByAgentId = await getMonthlyTokenSummaryByAgentIds(companyId, agentIds);
+    return rows.map((row) => ({
+      ...row,
+      ...(summaryByAgentId.get(row.id) ?? ZERO_TOKEN_SUMMARY),
     }));
   }
 
@@ -404,8 +472,9 @@ export function agentService(db: Db) {
         conditions.push(ne(agents.status, "terminated"));
       }
       const rows = await db.select().from(agents).where(and(...conditions));
-      const hydrated = await hydrateAgentSpend(rows);
-      return hydrated.map(normalizeAgentRow);
+      const withSpend = await hydrateAgentSpend(rows);
+      const normalized = withSpend.map(normalizeAgentRow);
+      return await hydrateAgentTokenSummary(normalized);
     },
 
     getById,

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -72,6 +72,9 @@ import {
   ChevronRight,
   ChevronDown,
   ArrowLeft,
+  ArrowUp,
+  ArrowDown,
+  ChevronsUpDown,
   HelpCircle,
   FolderOpen,
 } from "lucide-react";
@@ -1335,10 +1338,68 @@ function AgentOverview({
         )}
       </div>
 
+      {/* Tokens this month */}
+      <TokensThisMonthSection agent={agent} agentRouteId={agentRouteId} />
+
       {/* Costs */}
       <div className="space-y-3">
         <h3 className="text-sm font-medium">Costs</h3>
         <CostsSection runtimeState={runtimeState} runs={runs} />
+      </div>
+    </div>
+  );
+}
+
+/* ---- Tokens This Month Section ---- */
+
+function TokensThisMonthSection({
+  agent,
+  agentRouteId,
+}: {
+  agent: AgentDetailRecord;
+  agentRouteId: string;
+}) {
+  const totalMonthly =
+    (agent.inputTokensMonthly ?? 0) +
+    (agent.outputTokensMonthly ?? 0);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium text-muted-foreground">Tokens / month</h3>
+        <Link
+          to={`/agents/${agentRouteId}/runs`}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors no-underline"
+        >
+          Runs &rarr;
+        </Link>
+      </div>
+      <div className="border border-border/60 rounded-lg p-3 bg-muted/20">
+        <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 tabular-nums text-xs">
+          <div>
+            <span className="block text-muted-foreground mb-0.5">Input</span>
+            <span className="font-medium">{formatTokens(agent.inputTokensMonthly ?? 0)}</span>
+          </div>
+          <div>
+            <span className="block text-muted-foreground mb-0.5">Cached</span>
+            <span className="font-medium">{formatTokens(agent.cachedInputTokensMonthly ?? 0)}</span>
+          </div>
+          <div>
+            <span className="block text-muted-foreground mb-0.5">Output</span>
+            <span className="font-medium">{formatTokens(agent.outputTokensMonthly ?? 0)}</span>
+          </div>
+          <div>
+            <span className="block text-muted-foreground mb-0.5">Subscr. runs</span>
+            <span className="font-medium">{(agent.subscriptionRunCount ?? 0).toLocaleString()}</span>
+          </div>
+          <div>
+            <span className="block text-muted-foreground mb-0.5">API runs</span>
+            <span className="font-medium">{(agent.apiRunCount ?? 0).toLocaleString()}</span>
+          </div>
+        </div>
+        {totalMonthly === 0 && (
+          <p className="text-xs text-muted-foreground mt-2">No token usage recorded this month.</p>
+        )}
       </div>
     </div>
   );
@@ -2941,6 +3002,112 @@ function RunListItem({ run, isSelected, agentId }: { run: HeartbeatRun; isSelect
   );
 }
 
+type RunsSortField = "createdAt" | "costUsd";
+type RunsSortDir = "asc" | "desc";
+
+function sortRuns(runs: HeartbeatRun[], field: RunsSortField, dir: RunsSortDir): HeartbeatRun[] {
+  return [...runs].sort((a, b) => {
+    let cmp = 0;
+    if (field === "createdAt") {
+      cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    } else {
+      const costA = visibleRunCostUsd(a.usageJson as Record<string, unknown> | null, a.resultJson as Record<string, unknown> | null);
+      const costB = visibleRunCostUsd(b.usageJson as Record<string, unknown> | null, b.resultJson as Record<string, unknown> | null);
+      cmp = costA - costB;
+    }
+    return dir === "desc" ? -cmp : cmp;
+  });
+}
+
+function RunsTable({
+  runs,
+  agentRouteId,
+  sortField,
+  sortDir,
+  onSort,
+}: {
+  runs: HeartbeatRun[];
+  agentRouteId: string;
+  sortField: RunsSortField;
+  sortDir: RunsSortDir;
+  onSort: (field: RunsSortField) => void;
+}) {
+  function SortIcon({ field }: { field: RunsSortField }) {
+    if (sortField !== field) return <ChevronsUpDown className="h-3 w-3 opacity-40" />;
+    return sortDir === "asc"
+      ? <ArrowUp className="h-3 w-3" />
+      : <ArrowDown className="h-3 w-3" />;
+  }
+
+  return (
+    <div className="border border-border rounded-lg overflow-x-auto">
+      <table className="w-full text-xs min-w-[640px]">
+        <thead>
+          <tr className="border-b border-border bg-accent/20">
+            <th className="text-left px-3 py-2 font-medium text-muted-foreground">
+              <button
+                className="flex items-center gap-1 hover:text-foreground transition-colors"
+                onClick={() => onSort("createdAt")}
+              >
+                Timestamp
+                <SortIcon field="createdAt" />
+              </button>
+            </th>
+            <th className="text-left px-3 py-2 font-medium text-muted-foreground">Status</th>
+            <th className="text-left px-3 py-2 font-medium text-muted-foreground">Model</th>
+            <th className="text-right px-3 py-2 font-medium text-muted-foreground">Input</th>
+            <th className="text-right px-3 py-2 font-medium text-muted-foreground">Cached</th>
+            <th className="text-right px-3 py-2 font-medium text-muted-foreground">Output</th>
+            <th className="text-right px-3 py-2 font-medium text-muted-foreground">
+              <button
+                className="flex items-center gap-1 ml-auto hover:text-foreground transition-colors"
+                onClick={() => onSort("costUsd")}
+              >
+                Cost USD
+                <SortIcon field="costUsd" />
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => {
+            const metrics = runMetrics(run);
+            return (
+              <tr
+                key={run.id}
+                className="border-b border-border last:border-b-0 hover:bg-accent/10 transition-colors"
+              >
+                <td className="px-3 py-2 tabular-nums whitespace-nowrap">
+                  <Link
+                    to={`/agents/${agentRouteId}/runs/${run.id}`}
+                    className="hover:underline no-underline text-inherit"
+                  >
+                    {formatDate(run.createdAt)}
+                  </Link>
+                </td>
+                <td className="px-3 py-2">
+                  <Link to={`/agents/${agentRouteId}/runs/${run.id}`} className="no-underline">
+                    <StatusBadge status={run.status} />
+                  </Link>
+                </td>
+                <td className="px-3 py-2 font-mono text-muted-foreground max-w-[160px] truncate" title={metrics.model ?? undefined}>
+                  {metrics.model ?? "—"}
+                </td>
+                <td className="px-3 py-2 text-right tabular-nums">{formatTokens(metrics.input)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{formatTokens(metrics.cached)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">{formatTokens(metrics.output)}</td>
+                <td className="px-3 py-2 text-right tabular-nums">
+                  {metrics.cost > 0 ? `$${metrics.cost.toFixed(4)}` : "—"}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 function RunsTab({
   runs,
   companyId,
@@ -2959,19 +3126,28 @@ function RunsTab({
   adapterConfig: Record<string, unknown>;
 }) {
   const { isMobile } = useSidebar();
+  const [sortField, setSortField] = useState<RunsSortField>("createdAt");
+  const [sortDir, setSortDir] = useState<RunsSortDir>("desc");
+
+  function handleSort(field: RunsSortField) {
+    if (sortField === field) {
+      setSortDir((d) => (d === "desc" ? "asc" : "desc"));
+    } else {
+      setSortField(field);
+      setSortDir("desc");
+    }
+  }
 
   if (runs.length === 0) {
     return <p className="text-sm text-muted-foreground">No runs yet.</p>;
   }
 
-  // Sort by created descending
-  const sorted = [...runs].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  );
+  const sorted = sortRuns(runs, sortField, sortDir);
 
   // On mobile, don't auto-select so the list shows first; on desktop, auto-select latest
-  const effectiveRunId = isMobile ? selectedRunId : (selectedRunId ?? sorted[0]?.id ?? null);
-  const selectedRun = sorted.find((r) => r.id === effectiveRunId) ?? null;
+  const byDate = sortRuns(runs, "createdAt", "desc");
+  const effectiveRunId = isMobile ? selectedRunId : (selectedRunId ?? byDate[0]?.id ?? null);
+  const selectedRun = runs.find((r) => r.id === effectiveRunId) ?? null;
 
   // Mobile: show either run list OR run detail with back button
   if (isMobile) {
@@ -2991,34 +3167,41 @@ function RunsTab({
     }
     return (
       <div className="border border-border rounded-lg overflow-x-hidden">
-        {sorted.map((run) => (
+        {byDate.map((run) => (
           <RunListItem key={run.id} run={run} isSelected={false} agentId={agentRouteId} />
         ))}
       </div>
     );
   }
 
-  // Desktop: side-by-side layout
+  // Desktop: table when no run selected, sidebar list + detail when selected
+  if (!selectedRun) {
+    return (
+      <RunsTable
+        runs={sorted}
+        agentRouteId={agentRouteId}
+        sortField={sortField}
+        sortDir={sortDir}
+        onSort={handleSort}
+      />
+    );
+  }
+
   return (
     <div className="flex gap-0">
-      {/* Left: run list — border stretches full height, content sticks */}
-      <div className={cn(
-        "shrink-0 border border-border rounded-lg",
-        selectedRun ? "w-72" : "w-full",
-      )}>
+      {/* Left: compact run list */}
+      <div className="shrink-0 w-72 border border-border rounded-lg">
         <div className="sticky top-4 overflow-y-auto" style={{ maxHeight: "calc(100vh - 2rem)" }}>
-        {sorted.map((run) => (
-          <RunListItem key={run.id} run={run} isSelected={run.id === effectiveRunId} agentId={agentRouteId} />
-        ))}
+          {byDate.map((run) => (
+            <RunListItem key={run.id} run={run} isSelected={run.id === effectiveRunId} agentId={agentRouteId} />
+          ))}
         </div>
       </div>
 
       {/* Right: run detail — natural height, page scrolls */}
-      {selectedRun && (
-        <div className="flex-1 min-w-0 pl-4">
-          <RunDetail key={selectedRun.id} run={selectedRun} agentRouteId={agentRouteId} adapterType={adapterType} adapterConfig={adapterConfig} />
-        </div>
-      )}
+      <div className="flex-1 min-w-0 pl-4">
+        <RunDetail key={selectedRun.id} run={selectedRun} agentRouteId={agentRouteId} adapterType={adapterType} adapterConfig={adapterConfig} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds 5 new fields to `GET /api/companies/:companyId/agents`: `inputTokensMonthly`, `cachedInputTokensMonthly`, `outputTokensMonthly`, `subscriptionRunCount`, `apiRunCount` — aggregated from `cost_events` for the current UTC month
- Zero-defaults the new fields in `normalizeAgentRow` so `create`/`update`/`getById` paths stay consistent without a second DB round-trip
- Adds a compact **Tokens / month** row to the agent dashboard between "Recent Issues" and "Costs" sections
- Upgrades the Runs list tab to a **sortable 7-column table** (Timestamp, Status, Model, Input, Cached, Output, Cost USD) on desktop; compact list still shows on mobile / when a run is selected
- Adds 3 Vitest service-level tests covering zero, populated, and partial token summary hydration

## Test plan

- [ ] `vitest run "server/src/services/agents.test.ts"` — 3/3 pass locally
- [ ] `tsc --noEmit -p server/tsconfig.json` — 0 new errors vs baseline (105 errors; baseline pre-change had 125)
- [ ] Agent detail page: verify "Tokens / month" row appears on dashboard with correct values
- [ ] Runs tab: verify sortable table renders, click column headers to sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)