### PR TITLE
feat: add AppError class and sanitize error responses (TEC-2754)

### DIFF
--- a/server/src/__tests__/error-handler.test.ts
+++ b/server/src/__tests__/error-handler.test.ts
@@ -32,7 +32,7 @@ describe("errorHandler", () => {
     errorHandler(err, req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
+    expect(res.json).toHaveBeenCalledWith({ error: "An unexpected error occurred", requestId: expect.any(String) });
     expect(res.err).toBe(err);
     expect(res.__errorContext?.error?.message).toBe("boom");
   });
@@ -46,7 +46,7 @@ describe("errorHandler", () => {
     errorHandler(err, req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({ error: "db exploded" });
+    expect(res.json).toHaveBeenCalledWith({ error: "An unexpected error occurred", requestId: expect.any(String) });
     expect(res.err).toBe(err);
     expect(res.__errorContext?.error?.message).toBe("db exploded");
   });

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -9,6 +9,19 @@ export class HttpError extends Error {
   }
 }
 
+export class AppError extends Error {
+  statusCode: number;
+  userMessage: string;
+  internalMessage: string;
+
+  constructor(opts: { userMessage: string; internalMessage: string; statusCode?: number }) {
+    super(opts.internalMessage);
+    this.userMessage = opts.userMessage;
+    this.internalMessage = opts.internalMessage;
+    this.statusCode = opts.statusCode ?? 500;
+  }
+}
+
 export function badRequest(message: string, details?: unknown) {
   return new HttpError(400, message, details);
 }

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -1,6 +1,7 @@
+import { randomUUID } from "node:crypto";
 import type { Request, Response, NextFunction } from "express";
 import { ZodError } from "zod";
-import { HttpError } from "../errors.js";
+import { HttpError, AppError } from "../errors.js";
 import { trackErrorHandlerCrash } from "@paperclipai/shared/telemetry";
 import { getTelemetryClient } from "../telemetry.js";
 
@@ -8,6 +9,7 @@ export interface ErrorContext {
   error: { message: string; stack?: string; name?: string; details?: unknown; raw?: unknown };
   method: string;
   url: string;
+  requestId: string;
   reqBody?: unknown;
   reqParams?: unknown;
   reqQuery?: unknown;
@@ -17,12 +19,14 @@ function attachErrorContext(
   req: Request,
   res: Response,
   payload: ErrorContext["error"],
+  requestId: string,
   rawError?: Error,
 ) {
   (res as any).__errorContext = {
     error: payload,
     method: req.method,
     url: req.originalUrl,
+    requestId,
     reqBody: req.body,
     reqParams: req.params,
     reqQuery: req.query,
@@ -32,47 +36,87 @@ function attachErrorContext(
   }
 }
 
+const SAFE_STATUS_MESSAGES: Record<number, string> = {
+  400: "Bad request",
+  401: "Unauthorized",
+  403: "Forbidden",
+  404: "Resource not found",
+  409: "Conflict",
+  422: "Validation error",
+};
+
+function safeMessageForStatus(status: number): string {
+  return SAFE_STATUS_MESSAGES[status] ?? (status >= 500 ? "An unexpected error occurred" : "Request error");
+}
+
 export function errorHandler(
   err: unknown,
   req: Request,
   res: Response,
   _next: NextFunction,
 ) {
+  const requestId = randomUUID();
+
+  if (err instanceof AppError) {
+    console.error(`[${requestId}] AppError (${err.statusCode}):`, err.internalMessage, err.stack);
+    attachErrorContext(
+      req,
+      res,
+      { message: err.internalMessage, stack: err.stack, name: err.name },
+      requestId,
+      err,
+    );
+    if (err.statusCode >= 500) {
+      const tc = getTelemetryClient();
+      if (tc) trackErrorHandlerCrash(tc, { errorCode: err.name });
+    }
+    res.status(err.statusCode).json({ error: err.userMessage, requestId });
+    return;
+  }
+
   if (err instanceof HttpError) {
+    const safeMessage = safeMessageForStatus(err.status);
+    console.error(`[${requestId}] HttpError (${err.status}):`, err.message, err.stack);
     if (err.status >= 500) {
       attachErrorContext(
         req,
         res,
         { message: err.message, stack: err.stack, name: err.name, details: err.details },
+        requestId,
         err,
       );
       const tc = getTelemetryClient();
       if (tc) trackErrorHandlerCrash(tc, { errorCode: err.name });
     }
     res.status(err.status).json({
-      error: err.message,
+      error: safeMessage,
+      requestId,
       ...(err.details ? { details: err.details } : {}),
     });
     return;
   }
 
   if (err instanceof ZodError) {
-    res.status(400).json({ error: "Validation error", details: err.errors });
+    const zodRequestId = randomUUID();
+    console.error(`[${zodRequestId}] ZodError:`, err.errors);
+    res.status(400).json({ error: "Validation error", details: err.errors, requestId: zodRequestId });
     return;
   }
 
   const rootError = err instanceof Error ? err : new Error(String(err));
+  console.error(`[${requestId}] Unhandled error:`, rootError.message, rootError.stack);
   attachErrorContext(
     req,
     res,
     err instanceof Error
       ? { message: err.message, stack: err.stack, name: err.name }
       : { message: String(err), raw: err, stack: rootError.stack, name: rootError.name },
+    requestId,
     rootError,
   );
 
   const tc = getTelemetryClient();
   if (tc) trackErrorHandlerCrash(tc, { errorCode: rootError.name });
 
-  res.status(500).json({ error: "Internal server error" });
+  res.status(500).json({ error: "An unexpected error occurred", requestId });
 }

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -97,9 +97,8 @@ export function errorHandler(
   }
 
   if (err instanceof ZodError) {
-    const zodRequestId = randomUUID();
-    console.error(`[${zodRequestId}] ZodError:`, err.errors);
-    res.status(400).json({ error: "Validation error", details: err.errors, requestId: zodRequestId });
+    console.error(`[${requestId}] ZodError:`, err.errors);
+    res.status(400).json({ error: "Validation error", details: err.errors, requestId });
     return;
   }
 

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -119,7 +119,7 @@ export function assetRoutes(db: Db, storage: StorageService) {
           res.status(422).json({ error: `File exceeds ${MAX_ATTACHMENT_BYTES} bytes` });
           return;
         }
-        res.status(400).json({ error: err.message });
+        res.status(400).json({ error: "File upload error" });
         return;
       }
       throw err;
@@ -222,7 +222,7 @@ export function assetRoutes(db: Db, storage: StorageService) {
           res.status(422).json({ error: `Image exceeds ${MAX_ATTACHMENT_BYTES} bytes` });
           return;
         }
-        res.status(400).json({ error: err.message });
+        res.status(400).json({ error: "File upload error" });
         return;
       }
       throw err;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4506,7 +4506,7 @@ export function issueRoutes(
           res.status(422).json({ error: `Attachment exceeds ${attachmentMaxBytes} bytes` });
           return;
         }
-        res.status(400).json({ error: err.message });
+        res.status(400).json({ error: "File upload error" });
         return;
       }
       throw err;


### PR DESCRIPTION
## Summary

- Adds `AppError` class in `server/src/errors.ts` with `userMessage` (client-safe) and `internalMessage` (server-only logged) fields, plus optional `statusCode`
- Updates `server/src/middleware/error-handler.ts` to sanitize all error responses: no raw `err.message` ever reaches the client; all responses include a UUID `requestId` for correlation
- Fixes 3 raw `err.message` leaks from MulterError in `server/src/routes/assets.ts` and `server/src/routes/issues.ts`

## Details

The error handler now classifies errors into three branches:
- `AppError`: returns `userMessage` to client, logs `internalMessage` server-side
- `HttpError`: returns safe status-based text (not raw message); logs details server-side for 5xx
- `ZodError`: returns "Validation error" with details
- Unhandled: returns "An unexpected error occurred"

Every response includes a `requestId` (UUID v4) that matches the server-side log entry.

## Test plan

- [x] Unit tests: `server/src/__tests__/error-handler.test.ts` (2 tests pass)
- [x] No raw `err.message` in any HTTP response (`grep -r "\.json.*err\.message" server/src/routes/` returns empty)
- [x] `errorHandler` registered as last middleware in `app.ts`

Closes TEC-2754
🤖 Generated with [Claude Code](https://claude.com/claude-code)