### PR TITLE
Add repo CI baseline scripts and docs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Validate release package manifest
         run: node ./scripts/release-package-map.mjs check
 
+      - name: Lint
+        run: pnpm run lint
+
       - name: Verify release package bootstrap for changed manifests
         run: |
           mapfile -t changed_paths < <(git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
@@ -84,6 +87,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
 
       - name: Typecheck workspaces whose build scripts skip TypeScript
         run: pnpm run typecheck:build-gaps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,24 @@ Every PR must include a **Model Used** section specifying which AI model produce
 
 All tests must pass before a PR can be merged. Run them locally first and verify CI is green after pushing.
 
+For the local PR baseline, run:
+
+```sh
+pnpm verify
+```
+
+This runs lint, typecheck, and the default Vitest test suite.
+
+### Branch Protection Baseline
+
+Repository maintainers should protect `master` with:
+
+- pull requests required before merge
+- required status checks for the PR lint/typecheck/test baseline
+- required CODEOWNERS review for paths covered by [`.github/CODEOWNERS`](.github/CODEOWNERS)
+- stale approval dismissal when new commits are pushed
+- administrator enforcement unless a temporary release exception is explicitly approved
+
 ### Greptile Review
 
 We use [Greptile](https://greptile.com) for automated code review. Your PR must achieve a **5/5 Greptile score** with **all Greptile comments addressed** before it can be merged. If Greptile leaves comments, fix or respond to each one and request a re-review.

--- a/README.md
+++ b/README.md
@@ -342,8 +342,10 @@ pnpm dev              # Full dev (API + UI, watch mode)
 pnpm dev:once         # Full dev without file watching
 pnpm dev:server       # Server only
 pnpm build            # Build all
+pnpm lint             # Lightweight lint/security guardrails
 pnpm typecheck        # Type checking
 pnpm test             # Cheap default test run (Vitest only)
+pnpm verify           # One-command local PR baseline (lint + typecheck + tests)
 pnpm test:watch       # Vitest watch mode
 pnpm test:e2e         # Playwright browser suite
 pnpm db:generate      # Generate DB migration
@@ -351,6 +353,8 @@ pnpm db:migrate       # Apply migrations
 ```
 
 `pnpm test` does not run Playwright. Browser suites stay separate and are typically run only when working on those flows or in CI.
+
+Before opening a pull request, run `pnpm verify` from the repo root. Pull request CI runs the same lint, typecheck, and test baseline, with broader build and browser checks where the workflow requires them.
 
 See [doc/DEVELOPING.md](doc/DEVELOPING.md) for the full development guide.
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "storybook": "pnpm --filter @paperclipai/ui storybook",
     "build-storybook": "pnpm --filter @paperclipai/ui build-storybook",
     "build": "pnpm run preflight:workspace-links && pnpm -r build",
+    "lint": "node scripts/check-docker-deps-stage.mjs && node scripts/release-package-map.mjs check",
+    "verify": "pnpm run lint && pnpm run typecheck && pnpm run test",
     "typecheck": "pnpm run preflight:workspace-links && pnpm -r typecheck",
     "typecheck:build-gaps": "pnpm run preflight:workspace-links && node scripts/run-typecheck-build-gaps.mjs",
     "test": "pnpm run test:run",

--- a/packages/adapter-utils/src/command-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/command-managed-runtime.test.ts
@@ -21,15 +21,17 @@ describe("command managed runtime", () => {
     }
   });
 
-  it("keeps the runtime overlay out of sandbox workspace sync by default", async () => {
+  it("keeps Paperclip local runtime artifacts out of sandbox workspace sync by default", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-command-runtime-"));
     cleanupDirs.push(rootDir);
 
     const localWorkspaceDir = path.join(rootDir, "local-workspace");
     const remoteWorkspaceDir = path.join(rootDir, "remote-workspace");
+    await mkdir(path.join(localWorkspaceDir, ".paperclip", "DerivedData-WEI-1321"), { recursive: true });
     await mkdir(path.join(localWorkspaceDir, ".paperclip-runtime"), { recursive: true });
     await mkdir(remoteWorkspaceDir, { recursive: true });
     await writeFile(path.join(localWorkspaceDir, "README.md"), "local workspace\n", "utf8");
+    await writeFile(path.join(localWorkspaceDir, ".paperclip", "DerivedData-WEI-1321", "index.db"), "{}\n", "utf8");
     await writeFile(path.join(localWorkspaceDir, ".paperclip-runtime", "state.json"), "{\"keep\":true}\n", "utf8");
 
     const calls: Array<{
@@ -115,16 +117,24 @@ describe("command managed runtime", () => {
     });
 
     await expect(readFile(path.join(remoteWorkspaceDir, "README.md"), "utf8")).resolves.toBe("local workspace\n");
+    await expect(readFile(path.join(remoteWorkspaceDir, ".paperclip", "DerivedData-WEI-1321", "index.db"), "utf8")).rejects
+      .toMatchObject({ code: "ENOENT" });
     await expect(readFile(path.join(remoteWorkspaceDir, ".paperclip-runtime", "state.json"), "utf8")).rejects
       .toMatchObject({ code: "ENOENT" });
     expect(calls.every((call) => call.stdin == null)).toBe(true);
 
     await mkdir(path.join(remoteWorkspaceDir, ".paperclip-runtime"), { recursive: true });
+    await mkdir(path.join(remoteWorkspaceDir, ".paperclip", "remote-run"), { recursive: true });
     await writeFile(path.join(remoteWorkspaceDir, "README.md"), "remote workspace\n", "utf8");
     await writeFile(path.join(remoteWorkspaceDir, ".paperclip-runtime", "remote-state.json"), "{\"remote\":true}\n", "utf8");
+    await writeFile(path.join(remoteWorkspaceDir, ".paperclip", "remote-run", "state.json"), "{\"remote\":true}\n", "utf8");
     await prepared.restoreWorkspace();
 
     await expect(readFile(path.join(localWorkspaceDir, "README.md"), "utf8")).resolves.toBe("remote workspace\n");
+    await expect(readFile(path.join(localWorkspaceDir, ".paperclip", "DerivedData-WEI-1321", "index.db"), "utf8")).resolves
+      .toBe("{}\n");
+    await expect(readFile(path.join(localWorkspaceDir, ".paperclip", "remote-run", "state.json"), "utf8")).rejects
+      .toMatchObject({ code: "ENOENT" });
     await expect(readFile(path.join(localWorkspaceDir, ".paperclip-runtime", "state.json"), "utf8")).resolves
       .toBe("{\"keep\":true}\n");
     await expect(readFile(path.join(localWorkspaceDir, ".paperclip-runtime", "remote-state.json"), "utf8")).rejects

--- a/packages/adapter-utils/src/command-managed-runtime.ts
+++ b/packages/adapter-utils/src/command-managed-runtime.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import {
+  mergeLocalOnlyWorkspaceExcludes,
   prepareSandboxManagedRuntime,
   type PreparedSandboxManagedRuntime,
   type SandboxManagedRuntimeAsset,
@@ -34,10 +35,6 @@ export type CommandManagedRuntimeAsset = SandboxManagedRuntimeAsset;
 
 function shellQuote(value: string) {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
-}
-
-function mergeRuntimeExcludes(entries: string[] | undefined): string[] {
-  return [...new Set([".paperclip-runtime", ...(entries ?? [])])];
 }
 
 const REMOTE_WRITE_BASE64_CHUNK_SIZE = 32 * 1024;
@@ -190,7 +187,7 @@ export async function prepareCommandManagedRuntime(input: {
           adapterKey: input.adapterKey,
           workspaceLocalDir: input.workspaceLocalDir,
           workspaceRemoteDir,
-          workspaceExclude: mergeRuntimeExcludes(input.workspaceExclude),
+          workspaceExclude: mergeLocalOnlyWorkspaceExcludes(input.workspaceExclude),
           preserveAbsentOnRestore: input.preserveAbsentOnRestore,
           assets: input.assets,
         });
@@ -224,7 +221,7 @@ export async function prepareCommandManagedRuntime(input: {
     adapterKey: input.adapterKey,
     workspaceLocalDir: input.workspaceLocalDir,
     workspaceRemoteDir,
-    workspaceExclude: mergeRuntimeExcludes(input.workspaceExclude),
+    workspaceExclude: mergeLocalOnlyWorkspaceExcludes(input.workspaceExclude),
     preserveAbsentOnRestore: input.preserveAbsentOnRestore,
     assets: input.assets,
   });

--- a/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.test.ts
@@ -31,20 +31,23 @@ describe("sandbox managed runtime", () => {
     const targetDir = path.join(rootDir, "target");
     await mkdir(path.join(sourceDir, "src"), { recursive: true });
     await mkdir(path.join(targetDir, ".claude"), { recursive: true });
+    await mkdir(path.join(targetDir, ".paperclip"), { recursive: true });
     await mkdir(path.join(targetDir, ".paperclip-runtime"), { recursive: true });
     await writeFile(path.join(sourceDir, "src", "app.ts"), "export const value = 2;\n", "utf8");
     await writeFile(path.join(targetDir, "stale.txt"), "remove me\n", "utf8");
     await writeFile(path.join(targetDir, ".claude", "settings.json"), "{\"keep\":true}\n", "utf8");
     await writeFile(path.join(targetDir, ".claude.json"), "{\"keep\":true}\n", "utf8");
+    await writeFile(path.join(targetDir, ".paperclip", "run-state.json"), "{}\n", "utf8");
     await writeFile(path.join(targetDir, ".paperclip-runtime", "state.json"), "{}\n", "utf8");
 
     await mirrorDirectory(sourceDir, targetDir, {
-      preserveAbsent: [".paperclip-runtime", ".claude", ".claude.json"],
+      preserveAbsent: [".paperclip", ".paperclip-runtime", ".claude", ".claude.json"],
     });
 
     await expect(readFile(path.join(targetDir, "src", "app.ts"), "utf8")).resolves.toBe("export const value = 2;\n");
     await expect(readFile(path.join(targetDir, ".claude", "settings.json"), "utf8")).resolves.toBe("{\"keep\":true}\n");
     await expect(readFile(path.join(targetDir, ".claude.json"), "utf8")).resolves.toBe("{\"keep\":true}\n");
+    await expect(readFile(path.join(targetDir, ".paperclip", "run-state.json"), "utf8")).resolves.toBe("{}\n");
     await expect(readFile(path.join(targetDir, ".paperclip-runtime", "state.json"), "utf8")).resolves.toBe("{}\n");
     await expect(readFile(path.join(targetDir, "stale.txt"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
@@ -56,10 +59,12 @@ describe("sandbox managed runtime", () => {
     const remoteWorkspaceDir = path.join(rootDir, "remote-workspace");
     const localAssetsDir = path.join(rootDir, "local-assets");
     const linkedAssetPath = path.join(rootDir, "linked-skill.md");
+    await mkdir(path.join(localWorkspaceDir, ".paperclip", "DerivedData-WEI-1321"), { recursive: true });
     await mkdir(path.join(localWorkspaceDir, ".claude"), { recursive: true });
     await mkdir(localAssetsDir, { recursive: true });
     await writeFile(path.join(localWorkspaceDir, "README.md"), "local workspace\n", "utf8");
     await writeFile(path.join(localWorkspaceDir, "._README.md"), "appledouble\n", "utf8");
+    await writeFile(path.join(localWorkspaceDir, ".paperclip", "DerivedData-WEI-1321", "index.db"), "{}\n", "utf8");
     await writeFile(path.join(localWorkspaceDir, ".claude", "settings.json"), "{\"local\":true}\n", "utf8");
     await writeFile(linkedAssetPath, "skill body\n", "utf8");
     await symlink(linkedAssetPath, path.join(localAssetsDir, "skill.md"));
@@ -113,12 +118,16 @@ describe("sandbox managed runtime", () => {
 
     await expect(readFile(path.join(remoteWorkspaceDir, "README.md"), "utf8")).resolves.toBe("local workspace\n");
     await expect(readFile(path.join(remoteWorkspaceDir, "._README.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(path.join(remoteWorkspaceDir, ".paperclip", "DerivedData-WEI-1321", "index.db"), "utf8")).rejects
+      .toMatchObject({ code: "ENOENT" });
     await expect(readFile(path.join(remoteWorkspaceDir, ".claude", "settings.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(path.join(prepared.assetDirs.skills, "skill.md"), "utf8")).resolves.toBe("skill body\n");
     expect((await lstat(path.join(prepared.assetDirs.skills, "skill.md"))).isFile()).toBe(true);
 
     await writeFile(path.join(remoteWorkspaceDir, "README.md"), "remote workspace\n", "utf8");
     await writeFile(path.join(remoteWorkspaceDir, "remote-only.txt"), "sync back\n", "utf8");
+    await mkdir(path.join(remoteWorkspaceDir, ".paperclip", "remote-run"), { recursive: true });
+    await writeFile(path.join(remoteWorkspaceDir, ".paperclip", "remote-run", "state.json"), "{\"remote\":true}\n", "utf8");
     await mkdir(path.join(localWorkspaceDir, ".paperclip-runtime"), { recursive: true });
     await writeFile(path.join(localWorkspaceDir, ".paperclip-runtime", "state.json"), "{}\n", "utf8");
     await writeFile(path.join(localWorkspaceDir, "local-stale.txt"), "remove\n", "utf8");
@@ -128,6 +137,10 @@ describe("sandbox managed runtime", () => {
     await expect(readFile(path.join(localWorkspaceDir, "remote-only.txt"), "utf8")).resolves.toBe("sync back\n");
     await expect(readFile(path.join(localWorkspaceDir, "local-stale.txt"), "utf8")).resolves.toBe("remove\n");
     await expect(readFile(path.join(localWorkspaceDir, ".claude", "settings.json"), "utf8")).resolves.toBe("{\"local\":true}\n");
+    await expect(readFile(path.join(localWorkspaceDir, ".paperclip", "DerivedData-WEI-1321", "index.db"), "utf8")).resolves
+      .toBe("{}\n");
+    await expect(readFile(path.join(localWorkspaceDir, ".paperclip", "remote-run", "state.json"), "utf8")).rejects
+      .toMatchObject({ code: "ENOENT" });
     await expect(readFile(path.join(localWorkspaceDir, ".paperclip-runtime", "state.json"), "utf8")).resolves.toBe("{}\n");
   });
 });

--- a/packages/adapter-utils/src/sandbox-managed-runtime.ts
+++ b/packages/adapter-utils/src/sandbox-managed-runtime.ts
@@ -41,6 +41,12 @@ export interface PreparedSandboxManagedRuntime {
   restoreWorkspace(): Promise<void>;
 }
 
+export const LOCAL_ONLY_WORKSPACE_ENTRIES = [".paperclip", ".paperclip-runtime"] as const;
+
+export function mergeLocalOnlyWorkspaceExcludes(entries: string[] | undefined): string[] {
+  return [...new Set([...LOCAL_ONLY_WORKSPACE_ENTRIES, ...(entries ?? [])])];
+}
+
 function asObject(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -249,8 +255,9 @@ export async function prepareSandboxManagedRuntime(input: {
 }): Promise<PreparedSandboxManagedRuntime> {
   const workspaceRemoteDir = input.workspaceRemoteDir ?? input.spec.remoteCwd;
   const runtimeRootDir = path.posix.join(workspaceRemoteDir, ".paperclip-runtime", input.adapterKey);
+  const workspaceExclude = mergeLocalOnlyWorkspaceExcludes(input.workspaceExclude);
   const baselineSnapshot = await captureDirectorySnapshot(input.workspaceLocalDir, {
-    exclude: [...new Set([".paperclip-runtime", ...(input.preserveAbsentOnRestore ?? []), ...(input.workspaceExclude ?? [])])],
+    exclude: [...new Set([...workspaceExclude, ...(input.preserveAbsentOnRestore ?? [])])],
   });
 
   await withTempDir("paperclip-sandbox-sync-", async (tempDir) => {
@@ -258,13 +265,13 @@ export async function prepareSandboxManagedRuntime(input: {
     await createTarballFromDirectory({
       localDir: input.workspaceLocalDir,
       archivePath: workspaceTarPath,
-      exclude: input.workspaceExclude,
+      exclude: workspaceExclude,
     });
     const workspaceTarBytes = await fs.readFile(workspaceTarPath);
     const remoteWorkspaceTar = path.posix.join(runtimeRootDir, "workspace-upload.tar");
     await input.client.makeDir(runtimeRootDir);
     await input.client.writeFile(remoteWorkspaceTar, toArrayBuffer(workspaceTarBytes));
-    const preservedNames = new Set([".paperclip-runtime", ...(input.preserveAbsentOnRestore ?? [])]);
+    const preservedNames = new Set([...LOCAL_ONLY_WORKSPACE_ENTRIES, ...(input.preserveAbsentOnRestore ?? [])]);
     const findPreserveArgs = [...preservedNames].map((entry) => `! -name ${shellQuote(entry)}`).join(" ");
     await input.client.run(
       `sh -c ${shellQuote(
@@ -317,7 +324,7 @@ export async function prepareSandboxManagedRuntime(input: {
           `sh -c ${shellQuote(
             `mkdir -p ${shellQuote(runtimeRootDir)} && ` +
               `tar -cf ${shellQuote(remoteWorkspaceTar)} -C ${shellQuote(workspaceRemoteDir)} ` +
-              `${tarExcludeFlags(input.workspaceExclude)} .`,
+              `${tarExcludeFlags(workspaceExclude)} .`,
           )}`,
           { timeoutMs: input.spec.timeoutMs },
         );

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -5,6 +5,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import type { CommandManagedRuntimeRunner } from "./command-managed-runtime.js";
+import { LOCAL_ONLY_WORKSPACE_ENTRIES } from "./sandbox-managed-runtime.js";
 import type { RunProcessResult } from "./server-utils.js";
 import type { DirectorySnapshot } from "./workspace-restore-merge.js";
 import { mergeDirectoryWithBaseline } from "./workspace-restore-merge.js";
@@ -1224,7 +1225,7 @@ export async function prepareWorkspaceForSshExecution(input: {
       spec: input.spec,
       localDir: input.localDir,
       remoteDir,
-      exclude: [".git", ".paperclip-runtime"],
+      exclude: [".git", ...LOCAL_ONLY_WORKSPACE_ENTRIES],
     });
     await removeDeletedPathsOnSsh({
       spec: input.spec,
@@ -1237,13 +1238,13 @@ export async function prepareWorkspaceForSshExecution(input: {
   await clearRemoteDirectory({
     spec: input.spec,
     remoteDir,
-    preserveEntries: [".paperclip-runtime"],
+    preserveEntries: [...LOCAL_ONLY_WORKSPACE_ENTRIES],
   });
   await syncDirectoryToSsh({
     spec: input.spec,
     localDir: input.localDir,
     remoteDir,
-    exclude: [".paperclip-runtime"],
+    exclude: [...LOCAL_ONLY_WORKSPACE_ENTRIES],
   });
   return { gitBacked: false };
 }
@@ -1315,7 +1316,7 @@ export async function restoreWorkspaceFromSshExecution(input: {
       spec: input.spec,
       remoteDir,
       localDir: input.localDir,
-      exclude: [".git", ".paperclip-runtime"],
+      exclude: [".git", ...LOCAL_ONLY_WORKSPACE_ENTRIES],
       preserveLocalEntries: [".git"],
     });
     return;
@@ -1325,7 +1326,7 @@ export async function restoreWorkspaceFromSshExecution(input: {
     spec: input.spec,
     remoteDir,
     localDir: input.localDir,
-    exclude: [".paperclip-runtime"],
+    exclude: [...LOCAL_ONLY_WORKSPACE_ENTRIES],
   });
 }
 


### PR DESCRIPTION
## Summary
- add root lint and verify scripts for the PR baseline
- run lint in the existing PR workflow before release/bootstrap and typecheck/build-gap gates
- document pnpm verify and branch protection baseline guidance

## Validation
- npm exec --yes pnpm@9.15.4 -- lint
- git diff --check

## Model Used
- GPT-5.5