### PR TITLE
fix(platform): auto-pause routines owned by terminated agents (ZERA-548)

### DIFF
--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -24,6 +24,7 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
+import { agentService } from "../services/agents.ts";
 import { issueService } from "../services/issues.ts";
 import { instanceSettingsService } from "../services/instance-settings.ts";
 import * as providerRegistry from "../secrets/provider-registry.ts";
@@ -1421,5 +1422,109 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
 
     expect(run.source).toBe("webhook");
     expect(run.status).toBe("issue_created");
+  });
+
+  // ZERA-548: when an agent is terminated, routines they own must stop firing.
+  it("pauses active routines owned by an agent when that agent is terminated", async () => {
+    const { companyId, agentId, routine, svc } = await seedFixture();
+    const agents_svc = agentService(db);
+
+    const before = await svc.get(routine.id);
+    expect(before?.status).toBe("active");
+
+    const terminated = await agents_svc.terminate(agentId);
+    expect(terminated?.status).toBe("terminated");
+
+    const after = await svc.get(routine.id);
+    expect(after?.status).toBe("paused");
+    expect(after?.assigneeAgentId).toBe(agentId);
+
+    const logged = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.companyId, companyId));
+    const sweepEntry = logged.find(
+      (row) =>
+        row.action === "routine.auto_paused" &&
+        (row.details as Record<string, unknown> | null)?.cause === "agent_terminated",
+    );
+    expect(sweepEntry).toBeTruthy();
+    expect((sweepEntry?.details as Record<string, unknown>).routineIds).toEqual([routine.id]);
+    expect((sweepEntry?.details as Record<string, unknown>).count).toBe(1);
+  });
+
+  it("leaves paused/archived routines untouched on agent termination (only sweeps active)", async () => {
+    const { agentId, routine, svc } = await seedFixture();
+    const agents_svc = agentService(db);
+
+    // Manually move the routine to paused before termination — the sweep must
+    // not regress its updatedAt or otherwise touch it.
+    const pausedAtBefore = new Date("2026-01-01T00:00:00.000Z");
+    await db
+      .update(routines)
+      .set({ status: "paused", updatedAt: pausedAtBefore })
+      .where(eq(routines.id, routine.id));
+
+    await agents_svc.terminate(agentId);
+
+    const after = await db
+      .select({ status: routines.status, updatedAt: routines.updatedAt })
+      .from(routines)
+      .where(eq(routines.id, routine.id))
+      .then((rows) => rows[0]);
+    expect(after?.status).toBe("paused");
+    expect(after?.updatedAt.getTime()).toBe(pausedAtBefore.getTime());
+  });
+
+  it("pauses routines at fire time when the assignee was terminated before the sweep landed", async () => {
+    const { companyId, agentId, routine, svc } = await seedFixture();
+
+    // Simulate a routine that survived from before the per-agent sweep
+    // shipped: assignee is already terminated, but the routine is still
+    // active and has a due schedule trigger.
+    const dueAt = new Date(Date.now() - 60_000);
+    const { trigger } = await svc.createTrigger(
+      routine.id,
+      {
+        kind: "schedule",
+        label: "MWF",
+        cronExpression: "0 9 * * 1,3,5",
+        timezone: "UTC",
+      },
+      {},
+    );
+    await db
+      .update(routineTriggers)
+      .set({ nextRunAt: dueAt })
+      .where(eq(routineTriggers.id, trigger.id));
+    // Bypass the termination sweep so the routine stays "active" with a
+    // terminated assignee — this models the pre-existing dogfood state.
+    await db.update(agents).set({ status: "terminated" }).where(eq(agents.id, agentId));
+
+    const result = await svc.tickScheduledTriggers(new Date());
+    expect(result.triggered).toBe(0);
+    expect(result.pausedTerminated).toBe(1);
+
+    const paused = await svc.get(routine.id);
+    expect(paused?.status).toBe("paused");
+
+    const runs = await db
+      .select()
+      .from(routineRuns)
+      .where(eq(routineRuns.routineId, routine.id));
+    expect(runs).toHaveLength(0);
+
+    const logged = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.companyId, companyId));
+    const fireEntry = logged.find(
+      (row) =>
+        row.action === "routine.auto_paused" &&
+        (row.details as Record<string, unknown> | null)?.cause ===
+          "scheduler_detected_terminated_assignee",
+    );
+    expect(fireEntry).toBeTruthy();
+    expect(fireEntry?.entityId).toBe(routine.id);
   });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -164,7 +164,7 @@ vi.mock("../services/index.js", () => ({
   })),
   reconcilePersistedRuntimeServicesOnStartup: vi.fn(async () => ({ reconciled: 0 })),
   routineService: vi.fn(() => ({
-    tickScheduledTriggers: vi.fn(async () => ({ triggered: 0 })),
+    tickScheduledTriggers: vi.fn(async () => ({ triggered: 0, pausedTerminated: 0 })),
   })),
 }));
 

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -15,11 +15,13 @@ import {
   issueExecutionDecisions,
   issues,
   issueComments,
+  routines,
 } from "@paperclipai/db";
 import { AGENT_DEFAULT_MAX_CONCURRENT_RUNS, isUuidLike, normalizeAgentUrlKey } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import { normalizeAgentPermissions } from "./agent-permissions.js";
 import { REDACTED_EVENT_VALUE, sanitizeRecord } from "../redaction.js";
+import { logActivity } from "./activity-log.js";
 
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
@@ -494,6 +496,40 @@ export function agentService(db: Db) {
         .update(agentApiKeys)
         .set({ revokedAt: new Date() })
         .where(eq(agentApiKeys.agentId, id));
+
+      // Pause any active routines this agent owns so they stop firing into a
+      // dead address. Cross-owner routine reassignment is board-only, so
+      // without this sweep the routines would silently fail every scheduled
+      // fire until a board operator intervened.
+      const sweptRoutines = await db
+        .update(routines)
+        .set({
+          status: "paused",
+          updatedAt: new Date(),
+        })
+        .where(and(eq(routines.assigneeAgentId, id), eq(routines.status, "active")))
+        .returning({
+          id: routines.id,
+          companyId: routines.companyId,
+          title: routines.title,
+        });
+
+      if (sweptRoutines.length > 0) {
+        await logActivity(db, {
+          companyId: existing.companyId,
+          actorType: "system",
+          actorId: "agent-terminate-sweep",
+          action: "routine.auto_paused",
+          entityType: "agent",
+          entityId: id,
+          details: {
+            cause: "agent_terminated",
+            routineIds: sweptRoutines.map((row) => row.id),
+            routineTitles: sweptRoutines.map((row) => row.title),
+            count: sweptRoutines.length,
+          },
+        });
+      }
 
       return getById(id);
     },

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -19,6 +19,7 @@ import {
 } from "@paperclipai/db";
 import { AGENT_DEFAULT_MAX_CONCURRENT_RUNS, isUuidLike, normalizeAgentUrlKey } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
+import { logger } from "../middleware/logger.js";
 import { normalizeAgentPermissions } from "./agent-permissions.js";
 import { REDACTED_EVENT_VALUE, sanitizeRecord } from "../redaction.js";
 import { logActivity } from "./activity-log.js";
@@ -515,20 +516,27 @@ export function agentService(db: Db) {
         });
 
       if (sweptRoutines.length > 0) {
-        await logActivity(db, {
-          companyId: existing.companyId,
-          actorType: "system",
-          actorId: "agent-terminate-sweep",
-          action: "routine.auto_paused",
-          entityType: "agent",
-          entityId: id,
-          details: {
-            cause: "agent_terminated",
-            routineIds: sweptRoutines.map((row) => row.id),
-            routineTitles: sweptRoutines.map((row) => row.title),
-            count: sweptRoutines.length,
-          },
-        });
+        try {
+          await logActivity(db, {
+            companyId: existing.companyId,
+            actorType: "system",
+            actorId: "agent-terminate-sweep",
+            action: "routine.auto_paused",
+            entityType: "agent",
+            entityId: id,
+            details: {
+              cause: "agent_terminated",
+              routineIds: sweptRoutines.map((row) => row.id),
+              routineTitles: sweptRoutines.map((row) => row.title),
+              count: sweptRoutines.length,
+            },
+          });
+        } catch (err) {
+          logger.warn(
+            { err, agentId: id, routineIds: sweptRoutines.map((row) => row.id) },
+            "failed to log routine auto-pause sweep on agent termination",
+          );
+        }
       }
 
       return getById(id);

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -483,6 +483,38 @@ export function routineService(
       .then((rows) => rows[0] ?? null);
   }
 
+  async function pauseRoutineForTerminatedAssignee(
+    routine: typeof routines.$inferSelect,
+  ): Promise<boolean> {
+    const updated = await db
+      .update(routines)
+      .set({ status: "paused", updatedAt: new Date() })
+      .where(and(eq(routines.id, routine.id), eq(routines.status, "active")))
+      .returning({ id: routines.id });
+    if (updated.length === 0) return false;
+    try {
+      await logActivity(db, {
+        companyId: routine.companyId,
+        actorType: "system",
+        actorId: "routine-scheduler",
+        action: "routine.auto_paused",
+        entityType: "routine",
+        entityId: routine.id,
+        details: {
+          cause: "scheduler_detected_terminated_assignee",
+          assigneeAgentId: routine.assigneeAgentId,
+          routineTitle: routine.title,
+        },
+      });
+    } catch (err) {
+      logger.warn(
+        { err, routineId: routine.id },
+        "failed to log routine auto-pause for terminated assignee",
+      );
+    }
+    return true;
+  }
+
   async function getManagedRoutineBinding(routine: typeof routines.$inferSelect) {
     return db
       .select({
@@ -2235,9 +2267,11 @@ export function routineService(
         .select({
           trigger: routineTriggers,
           routine: routines,
+          assigneeStatus: agents.status,
         })
         .from(routineTriggers)
         .innerJoin(routines, eq(routineTriggers.routineId, routines.id))
+        .leftJoin(agents, eq(routines.assigneeAgentId, agents.id))
         .where(
           and(
             eq(routineTriggers.kind, "schedule"),
@@ -2250,8 +2284,19 @@ export function routineService(
         .orderBy(asc(routineTriggers.nextRunAt), asc(routineTriggers.createdAt));
 
       let triggered = 0;
+      let pausedTerminated = 0;
       for (const row of due) {
         if (!row.trigger.nextRunAt || !row.trigger.cronExpression || !row.trigger.timezone) continue;
+
+        // Defense in depth: if the routine's assignee was terminated between
+        // create/update and this tick (e.g. the agent was terminated before
+        // the per-agent sweep landed, or the row was created during a race),
+        // pause the routine instead of letting dispatch fail and keep firing.
+        if (row.routine.assigneeAgentId && row.assigneeStatus === "terminated") {
+          const paused = await pauseRoutineForTerminatedAssignee(row.routine);
+          if (paused) pausedTerminated += 1;
+          continue;
+        }
 
         let runCount = 1;
         let claimedNextRunAt = nextCronTickInTimeZone(row.trigger.cronExpression, row.trigger.timezone, now);
@@ -2293,7 +2338,7 @@ export function routineService(
         }
       }
 
-      return { triggered };
+      return { triggered, pausedTerminated };
     },
 
     syncRunStatusForIssue: async (issueId: string) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Routines are the recurring-work primitive; ownership is single-assignee and cross-owner reassignment is reserved for board operators
> - When an agent is terminated, any routines they own keep firing on schedule and fail with `Cannot assign work to terminated agents` on every cycle — silent indefinite failure because agents cannot self-heal across owners
> - The dogfood incident in ZERA-545 — a CMO Twitter MWF routine assigned to an agent that no longer existed — surfaced this; failures went unnoticed for at least one cycle
> - This pull request adds two defensive layers: a termination-time sweep that pauses every active routine owned by the agent, and a fire-time guard in the scheduler that pauses any routine whose assignee is already terminated
> - The benefit is that this entire bug class is closed platform-side: new terminations stop their routines immediately, and any pre-existing orphaned routines self-heal on next fire without a backfill migration or operator intervention

## What Changed

- `server/src/services/agents.ts` — `terminate()` now runs a single UPDATE keyed on `(assigneeAgentId, status='active')` to flip those routines to `paused`, then emits a `routine.auto_paused` activity log entry with structured `cause: "agent_terminated"`, `routineIds`, `routineTitles`, and `count`. The `logActivity` call is wrapped in try/catch + `logger.warn` to match the symmetric pattern in `routines.ts` (a transient audit-log failure must not make termination appear to fail after the DB mutations have committed). Idempotent — paused/archived routines are not regressed.
- `server/src/services/routines.ts` — `tickScheduledTriggers` LEFT JOINs `agents` to surface assignee status; routines with `assigneeStatus = terminated` route through a new helper `pauseRoutineForTerminatedAssignee` that flips status to paused, emits `routine.auto_paused` with `cause: "scheduler_detected_terminated_assignee"`, and skips dispatch. Tick result gains a `pausedTerminated` counter (additive).
- New tests in `routines-service.test.ts`:
  - Active routines owned by a terminated agent get paused on `agentService.terminate()` and the activity log row records `cause: agent_terminated`.
  - Paused/archived routines are not regressed by the sweep (frozen `updatedAt`).
  - At fire time, an active routine whose assignee was terminated outside the sweep path is paused, no run is dispatched, and the activity log records `cause: scheduler_detected_terminated_assignee`.

## Verification

- [x] `pnpm vitest run src/__tests__/routines-service.test.ts` — 35/35 passing (including the 3 new tests above)
- [x] Spot-checked `routines-routes` (15), `routines-e2e` (12), `plugin-managed-routines`, `routine-run-telemetry`, `server-startup-feedback-export`, `agent-shortname-collision` — no regressions
- [x] `tsc --noEmit` clean for changed files (pre-existing plugin-sdk errors are unrelated)
- [x] CI on this PR: policy + snyk green; verify/e2e/canary green at time of writing
- [x] Greptile review submitted (confidence 3/5); the `logActivity` try/catch asymmetry it flagged is addressed in the second commit on this branch

## Risks

Low–medium. The behavior change is conservative: pause-and-flag, never reassign. The two paths are idempotent:

- Termination-time sweep is guarded by `status='active'` so paused/archived routines are never regressed.
- Fire-time guard uses a CAS-style `eq(routines.status, "active")` guard so concurrent triggers on the same routine can't double-pause or race.

`logActivity` failures are now caught in both paths so termination/dispatch never fails because of an audit-log hiccup. No migration required — fire-time guard cleans up legacy orphaned routines on their next scheduled tick.

Out of scope (intentionally): option (2) "auto-reassign to role successor" — that is a policy decision (which successor? notify whom?) and the recreate-as-self workaround proven on ZERA-545/547 covers the operational gap. Can be a follow-up if the board wants it later.

## Model Used

- Provider: Anthropic
- Model: Claude (claude-opus-4-7), 1M context window
- Capabilities: extended thinking, tool use (file edits, shell, git, gh), code execution via test runs
- Operating as Founding Engineer agent in Paperclip; PR authored from the rsavitt fork against paperclipai/paperclip

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — *n/a, no UI surface; activity-log entries surface in existing dashboards*
- [x] I have updated relevant documentation to reflect my changes — *n/a for docs; activity-log `cause` field is structured for downstream telemetry consumers*
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes ZERA-548. Unblocks ZERA-545 on next scheduled fire after merge.
