### PR TITLE
fix(routines): honor assigneeAgentId filter on LIST endpoint

### DIFF
--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -221,7 +221,50 @@ describe("routine routes", () => {
       .query({ projectId });
 
     expect(res.status).toBe(200);
-    expect(mockRoutineService.list).toHaveBeenCalledWith(companyId, { projectId });
+    expect(mockRoutineService.list).toHaveBeenCalledWith(companyId, {
+      projectId,
+      assigneeAgentId: undefined,
+    });
+  });
+
+  it("passes assigneeAgentId filter to the routine list service", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/routines`)
+      .query({ assigneeAgentId: agentId });
+
+    expect(res.status).toBe(200);
+    expect(mockRoutineService.list).toHaveBeenCalledWith(companyId, {
+      projectId: undefined,
+      assigneeAgentId: agentId,
+    });
+  });
+
+  it("passes both projectId and assigneeAgentId filters together", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "session",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/routines`)
+      .query({ projectId, assigneeAgentId: agentId });
+
+    expect(res.status).toBe(200);
+    expect(mockRoutineService.list).toHaveBeenCalledWith(companyId, {
+      projectId,
+      assigneeAgentId: agentId,
+    });
   });
 
   it("lists routine revisions for a board member in newest-first service order", async () => {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -218,6 +218,53 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(allRoutines.map((entry) => entry.id)).toEqual(expect.arrayContaining([routine.id, otherRoutine.id]));
   });
 
+  it("filters listed routines by assigneeAgentId", async () => {
+    const { companyId, agentId, routine, svc } = await seedFixture();
+
+    const otherAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    const otherAgentRoutine = await svc.create(
+      companyId,
+      {
+        projectId: routine.projectId,
+        goalId: null,
+        parentIssueId: null,
+        title: "other agent routine",
+        description: null,
+        assigneeAgentId: otherAgentId,
+        priority: "medium",
+        status: "active",
+        concurrencyPolicy: "coalesce_if_active",
+        catchUpPolicy: "skip_missed",
+      },
+      {},
+    );
+
+    const ownRoutines = await svc.list(companyId, { assigneeAgentId: agentId });
+    const otherRoutines = await svc.list(companyId, { assigneeAgentId: otherAgentId });
+    const bogusRoutines = await svc.list(companyId, {
+      assigneeAgentId: "00000000-0000-4000-8000-000000000000",
+    });
+    const allRoutines = await svc.list(companyId);
+
+    expect(ownRoutines.map((entry) => entry.id)).toEqual([routine.id]);
+    expect(otherRoutines.map((entry) => entry.id)).toEqual([otherAgentRoutine.id]);
+    expect(bogusRoutines).toEqual([]);
+    expect(allRoutines.map((entry) => entry.id)).toEqual(
+      expect.arrayContaining([routine.id, otherAgentRoutine.id]),
+    );
+  });
+
   it("creates a fresh execution issue when the previous routine issue is open but idle", async () => {
     const { companyId, issueSvc, routine, svc } = await seedFixture();
     const previousRunId = randomUUID();

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -89,7 +89,9 @@ export function routineRoutes(
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     const projectId = typeof req.query.projectId === "string" ? req.query.projectId : undefined;
-    const result = await svc.list(companyId, { projectId });
+    const assigneeAgentId =
+      typeof req.query.assigneeAgentId === "string" ? req.query.assigneeAgentId : undefined;
+    const result = await svc.list(companyId, { projectId, assigneeAgentId });
     res.json(result);
   });
 

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -1370,10 +1370,13 @@ export function routineService(
 
     list: async (
       companyId: string,
-      filters?: { projectId?: string | null },
+      filters?: { projectId?: string | null; assigneeAgentId?: string | null },
     ): Promise<RoutineListItem[]> => {
       const conditions = [eq(routines.companyId, companyId)];
       if (filters?.projectId) conditions.push(eq(routines.projectId, filters.projectId));
+      if (filters?.assigneeAgentId) {
+        conditions.push(eq(routines.assigneeAgentId, filters.assigneeAgentId));
+      }
 
       const rows = await db
         .select()

--- a/skills/paperclip/references/routines.md
+++ b/skills/paperclip/references/routines.md
@@ -184,4 +184,11 @@ GET /api/routines/{routineId}
 GET /api/routines/{routineId}/runs?limit=50
 ```
 
+The company-scoped list endpoint accepts these optional query params:
+
+- `projectId` — narrow to a single project
+- `assigneeAgentId` — narrow to routines assigned to a specific agent (e.g. `assigneeAgentId={your-agent-id}` to list only your own routines)
+
+Both filters can be combined.
+
 Use the generic API endpoint tables in `skills/paperclip/references/api-reference.md` when you need a full cross-domain reference. Use this file when you need routine-specific behaviour, payload shape, or policy details.

--- a/ui/src/api/routines.ts
+++ b/ui/src/api/routines.ts
@@ -35,9 +35,13 @@ export interface RestoreRoutineRevisionResponse {
 }
 
 export const routinesApi = {
-  list: (companyId: string, filters?: { projectId?: string | null }) => {
+  list: (
+    companyId: string,
+    filters?: { projectId?: string | null; assigneeAgentId?: string | null },
+  ) => {
     const params = new URLSearchParams();
     if (filters?.projectId) params.set("projectId", filters.projectId);
+    if (filters?.assigneeAgentId) params.set("assigneeAgentId", filters.assigneeAgentId);
     const query = params.toString();
     return api.get<RoutineListItem[]>(`/companies/${companyId}/routines${query ? `?${query}` : ""}`);
   },


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Routines are the recurring-work primitive — each agent owns their own routines, and policy says "agents can only manage routines assigned to themselves"
> - `GET /api/companies/:companyId/routines` accepts an `assigneeAgentId` query param and the skill docs imply it narrows by assignee, but during a Security Researcher dogfood cycle the param was found to be silently ignored — all callers get the full company list regardless of filter value (own, other, bogus UUID all return the same set)
> - Mutation paths (PATCH, /run, CREATE, triggers) gate correctly on assignee; only the LIST handler skipped the check, leaving an API-contract bug and a defense-in-depth gap that will grow as routines proliferate
> - This pull request wires `assigneeAgentId` through the route, service, UI client, and skill docs so the documented filter actually narrows; new tests assert single-filter, combined-filter, and bogus-UUID cases at both route and service layers
> - The benefit is that the documented contract holds, agents that scope work via "my routines" get correct results, and the latent multi-tenant safety net catches up to the mutation paths

## What Changed

- `server/src/routes/routines.ts` — route reads `assigneeAgentId` from `req.query` (same defensive `typeof === "string"` guard used for `projectId`) and forwards it to `svc.list`.
- `server/src/services/routines.ts` — `list` filter shape accepts `assigneeAgentId`; condition appended to SQL `where` when present, using Drizzle parameterised queries (consistent with the existing `projectId` pattern).
- `ui/src/api/routines.ts` — UI client `list` filter mirrors the new param and appends it to the query string only when truthy.
- `skills/paperclip/references/routines.md` — documents the supported query params (`projectId`, `assigneeAgentId`, combinable).
- New tests:
  - Route layer (`routines-routes.test.ts`): `assigneeAgentId` alone, combined with `projectId`, and the assertion that `undefined` is forwarded when the param is absent.
  - Service layer (`routines-service.test.ts`): embedded-Postgres test covering own-agent, other-agent, bogus-UUID, and no-filter cases.

## Verification

- [x] `pnpm vitest run src/__tests__/routines-routes.test.ts` — 15/15 passing
- [x] `pnpm vitest run src/__tests__/routines-service.test.ts -t "assigneeAgentId"` / `-t "project"` — passing
- [x] `tsc --noEmit` clean for changed files in `server/` and `ui/` (pre-existing plugin-sdk errors are unrelated)
- [x] CI on this PR: policy, verify (4 suites), Canary Dry Run, e2e, Greptile Review, snyk — all green

Manual repro from the bug report:

```bash
# All three previously returned the same 1 routine; now the bogus UUID returns []
curl .../routines
curl .../routines?assigneeAgentId=<own-agent-id>
curl .../routines?assigneeAgentId=00000000-0000-0000-0000-000000000000
```

## Risks

Low risk. Behavior change is purely additive — callers that omit `assigneeAgentId` get the same result set as before. Read-by-id (`GET /api/routines/:id`) and read-all (without filter) remain intentionally un-scoped per the documented "agents can read all routines in their company" authorization model. The bug was specifically the silently-ignored filter, not the read model — the latter is a separate governance question and out of scope here.

## Model Used

- Provider: Anthropic
- Model: Claude (claude-opus-4-7), 1M context window
- Capabilities: extended thinking, tool use (file edits, shell, git, gh), code execution via test runs
- Operating as Founding Engineer agent in Paperclip; PR authored from the rsavitt fork against paperclipai/paperclip

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — *n/a, no UI rendering change; UI client filter param is additive*
- [x] I have updated relevant documentation to reflect my changes (`skills/paperclip/references/routines.md`)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes ZERA-544.
