### PR TITLE
Prevent workspace-root plan links

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -876,7 +876,12 @@ export {
 } from "./execution-workspace-guards.js";
 
 export {
+  WORKSPACE_ROOT_PLAN_LINK_ERROR,
+  containsWorkspaceRootPlanLinks,
   instanceGeneralSettingsSchema,
+  isWorkspaceRootPlanLinkTarget,
+  normalizeEscapedLineBreaks,
+  paperclipTextSurfaceSchema,
   patchInstanceGeneralSettingsSchema,
   type PatchInstanceGeneralSettings,
   instanceExperimentalSettingsSchema,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -667,7 +667,12 @@ export {
 } from "./execution-workspace-guards.js";
 
 export {
+  WORKSPACE_ROOT_PLAN_LINK_ERROR,
+  containsWorkspaceRootPlanLinks,
   instanceGeneralSettingsSchema,
+  isWorkspaceRootPlanLinkTarget,
+  normalizeEscapedLineBreaks,
+  paperclipTextSurfaceSchema,
   patchInstanceGeneralSettingsSchema,
   type PatchInstanceGeneralSettings,
   instanceExperimentalSettingsSchema,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1,4 +1,12 @@
 export {
+  WORKSPACE_ROOT_PLAN_LINK_ERROR,
+  containsWorkspaceRootPlanLinks,
+  isWorkspaceRootPlanLinkTarget,
+  normalizeEscapedLineBreaks,
+  paperclipTextSurfaceSchema,
+} from "./text.js";
+
+export {
   instanceGeneralSettingsSchema,
   patchInstanceGeneralSettingsSchema,
   type InstanceGeneralSettings,

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { MAX_ISSUE_REQUEST_DEPTH } from "../index.js";
+import { WORKSPACE_ROOT_PLAN_LINK_ERROR } from "./text.js";
 import {
   addIssueCommentSchema,
+  createIssueThreadInteractionSchema,
   createIssueSchema,
   issueBlockedInboxAttentionSchema,
   resolveIssueRecoveryActionSchema,
@@ -203,6 +205,38 @@ describe("issue validators", () => {
 
     expect(response.summaryMarkdown).toBe("Summary\n\nNext action");
     expect(document.body).toBe("# Plan\n\nShip it");
+  });
+
+  it("rejects workspace-root plans links on Paperclip text surfaces", () => {
+    expect(() => addIssueCommentSchema.parse({
+      body: "Review [the plan](/plans/DAT-4136-unified-app-tab-proposal.md).",
+    })).toThrow(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+    expect(() => updateIssueSchema.parse({
+      description: "Broken local plan: plans/DAT-4136-unified-app-tab-proposal.md",
+    })).toThrow(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+    expect(() => upsertIssueDocumentSchema.parse({
+      format: "markdown",
+      body: "Review [the plan](plans/DAT-4136-unified-app-tab-proposal.md).",
+    })).toThrow(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+    expect(() => createIssueThreadInteractionSchema.parse({
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Approve /plans/DAT-4136-unified-app-tab-proposal.md?",
+      },
+    })).toThrow(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+  });
+
+  it("keeps valid Paperclip, issue document, and external repository links working", () => {
+    expect(addIssueCommentSchema.parse({
+      body: [
+        "Issue: [DAT-123](/DAT/issues/DAT-123)",
+        "Plan document: [plan](/DAT/issues/DAT-123#document-plan)",
+        "Repo docs: https://github.com/Data-Advantage/app/blob/main/plans/launch.md",
+        "Repo docs label: [plans/launch.md](https://github.com/Data-Advantage/app/blob/main/plans/launch.md)",
+        "Literal example: `/plans/DAT-4136-unified-app-tab-proposal.md`",
+      ].join("\n"),
+    }).body).toContain("/DAT/issues/DAT-123");
   });
 
   it("clamps oversized requestDepth values on create", () => {

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { MAX_ISSUE_REQUEST_DEPTH } from "../index.js";
+import { WORKSPACE_ROOT_PLAN_LINK_ERROR } from "./text.js";
 import {
   addIssueCommentSchema,
+  createIssueThreadInteractionSchema,
   createIssueSchema,
   respondIssueThreadInteractionSchema,
   suggestedTaskDraftSchema,
@@ -118,6 +120,37 @@ describe("issue validators", () => {
 
     expect(response.summaryMarkdown).toBe("Summary\n\nNext action");
     expect(document.body).toBe("# Plan\n\nShip it");
+  });
+
+  it("rejects workspace-root plans links on Paperclip text surfaces", () => {
+    expect(() => addIssueCommentSchema.parse({
+      body: "Review [the plan](/plans/DAT-4136-unified-app-tab-proposal.md).",
+    })).toThrow(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+    expect(() => updateIssueSchema.parse({
+      description: "Broken local plan: plans/DAT-4136-unified-app-tab-proposal.md",
+    })).toThrow(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+    expect(() => upsertIssueDocumentSchema.parse({
+      format: "markdown",
+      body: "Review [the plan](plans/DAT-4136-unified-app-tab-proposal.md).",
+    })).toThrow(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+    expect(() => createIssueThreadInteractionSchema.parse({
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Approve /plans/DAT-4136-unified-app-tab-proposal.md?",
+      },
+    })).toThrow(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+  });
+
+  it("keeps valid Paperclip, issue document, and external repository links working", () => {
+    expect(addIssueCommentSchema.parse({
+      body: [
+        "Issue: [DAT-123](/DAT/issues/DAT-123)",
+        "Plan document: [plan](/DAT/issues/DAT-123#document-plan)",
+        "Repo docs: https://github.com/Data-Advantage/app/blob/main/plans/launch.md",
+        "Literal example: `/plans/DAT-4136-unified-app-tab-proposal.md`",
+      ].join("\n"),
+    }).body).toContain("/DAT/issues/DAT-123");
   });
 
   it("clamps oversized requestDepth values on create", () => {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -27,7 +27,12 @@ import {
   MODEL_PROFILE_KEYS,
   REQUEST_CHECKBOX_CONFIRMATION_OPTION_LIMIT,
 } from "../constants.js";
-import { multilineTextSchema } from "./text.js";
+import {
+  containsWorkspaceRootPlanLinks,
+  multilineTextSchema,
+  paperclipTextSurfaceSchema,
+  WORKSPACE_ROOT_PLAN_LINK_ERROR,
+} from "./text.js";
 import { lowTrustReviewPresetPolicySchema, trustAuthorizationPolicySchema } from "./trust-policy.js";
 
 export const issueBlockedInboxStateSchema = z.enum([
@@ -380,7 +385,7 @@ const createIssueBaseSchema = z.object({
   blockedByIssueIds: z.array(z.string().uuid()).optional(),
   inheritExecutionWorkspaceFromIssueId: z.string().uuid().optional().nullable(),
   title: z.string().min(1),
-  description: multilineTextSchema.optional().nullable(),
+  description: paperclipTextSurfaceSchema.optional().nullable(),
   status: z.enum(ISSUE_STATUSES),
   workMode: z.enum(ISSUE_WORK_MODES).optional().default("standard"),
   priority: z.enum(ISSUE_PRIORITIES).optional().default("medium"),
@@ -433,7 +438,7 @@ export type CreateIssueLabel = z.infer<typeof createIssueLabelSchema>;
 export const updateIssueSchema = createIssueBaseSchema.partial().extend({
   requestDepth: issueRequestDepthInputSchema.optional(),
   assigneeAgentId: z.string().trim().min(1).optional().nullable(),
-  comment: multilineTextSchema.pipe(z.string().min(1)).optional(),
+  comment: paperclipTextSurfaceSchema.pipe(z.string().min(1)).optional(),
   reviewRequest: issueReviewRequestSchema.optional().nullable(),
   reopen: z.boolean().optional(),
   resume: z.boolean().optional(),
@@ -537,7 +542,7 @@ export const issueCommentMetadataSchema = z.object({
 export type IssueCommentMetadata = z.infer<typeof issueCommentMetadataSchema>;
 
 export const addIssueCommentSchema = z.object({
-  body: multilineTextSchema.pipe(z.string().min(1)),
+  body: paperclipTextSurfaceSchema.pipe(z.string().min(1)),
   authorType: issueCommentAuthorTypeSchema.optional(),
   presentation: issueCommentPresentationSchema.nullable().optional(),
   metadata: issueCommentMetadataSchema.nullable().optional(),
@@ -566,7 +571,7 @@ export const suggestedTaskDraftSchema = z.object({
   parentClientKey: z.string().trim().min(1).max(120).nullable().optional(),
   parentId: z.string().uuid().nullable().optional(),
   title: z.string().trim().min(1).max(240),
-  description: multilineTextSchema.pipe(z.string().trim().max(20000)).nullable().optional(),
+  description: paperclipTextSurfaceSchema.pipe(z.string().trim().max(20000)).nullable().optional(),
   priority: z.enum(ISSUE_PRIORITIES).nullable().optional(),
   workMode: z.enum(ISSUE_WORK_MODES).nullable().optional(),
   assigneeAgentId: z.string().uuid().nullable().optional(),
@@ -623,14 +628,14 @@ export const suggestTasksResultSchema = z.object({
 
 export const askUserQuestionsQuestionOptionSchema = z.object({
   id: z.string().trim().min(1).max(120),
-  label: z.string().trim().min(1).max(120),
-  description: z.string().trim().max(500).nullable().optional(),
+  label: z.string().trim().min(1).max(120).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR),
+  description: z.string().trim().max(500).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
 });
 
 export const askUserQuestionsQuestionSchema = z.object({
   id: z.string().trim().min(1).max(120),
-  prompt: z.string().trim().min(1).max(500),
-  helpText: z.string().trim().max(1000).nullable().optional(),
+  prompt: z.string().trim().min(1).max(500).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR),
+  helpText: z.string().trim().max(1000).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
   selectionMode: z.enum(["single", "multi"]),
   required: z.boolean().optional(),
   options: z.array(askUserQuestionsQuestionOptionSchema).min(1).max(10),
@@ -638,8 +643,8 @@ export const askUserQuestionsQuestionSchema = z.object({
 
 export const askUserQuestionsPayloadSchema = z.object({
   version: z.literal(1),
-  title: z.string().trim().max(240).nullable().optional(),
-  submitLabel: z.string().trim().max(120).nullable().optional(),
+  title: z.string().trim().max(240).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+  submitLabel: z.string().trim().max(120).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
   questions: z.array(askUserQuestionsQuestionSchema).min(1).max(10),
 }).superRefine((value, ctx) => {
   const seenQuestionIds = new Set<string>();
@@ -715,14 +720,14 @@ export const requestConfirmationTargetSchema = z.discriminatedUnion("type", [
 
 export const requestConfirmationPayloadSchema = z.object({
   version: z.literal(1),
-  prompt: z.string().trim().min(1).max(1000),
-  acceptLabel: z.string().trim().min(1).max(80).nullable().optional(),
-  rejectLabel: z.string().trim().min(1).max(80).nullable().optional(),
+  prompt: z.string().trim().min(1).max(1000).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR),
+  acceptLabel: z.string().trim().min(1).max(80).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+  rejectLabel: z.string().trim().min(1).max(80).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
   rejectRequiresReason: z.boolean().optional(),
-  rejectReasonLabel: z.string().trim().min(1).max(160).nullable().optional(),
+  rejectReasonLabel: z.string().trim().min(1).max(160).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
   allowDeclineReason: z.boolean().optional().default(true),
-  declineReasonPlaceholder: z.string().trim().min(1).max(240).nullable().optional(),
-  detailsMarkdown: z.string().max(20000).nullable().optional(),
+  declineReasonPlaceholder: z.string().trim().min(1).max(240).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+  detailsMarkdown: paperclipTextSurfaceSchema.pipe(z.string().max(20000)).nullable().optional(),
   supersedeOnUserComment: z.boolean().optional(),
   target: requestConfirmationTargetSchema.nullable().optional(),
 });
@@ -860,8 +865,8 @@ export const createIssueThreadInteractionSchema = z.discriminatedUnion("kind", [
     idempotencyKey: z.string().trim().max(255).nullable().optional(),
     sourceCommentId: z.string().uuid().nullable().optional(),
     sourceRunId: z.string().uuid().nullable().optional(),
-    title: z.string().trim().max(240).nullable().optional(),
-    summary: z.string().trim().max(1000).nullable().optional(),
+    title: z.string().trim().max(240).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+    summary: z.string().trim().max(1000).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
     continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("wake_assignee"),
     payload: suggestTasksPayloadSchema,
   }),
@@ -870,8 +875,8 @@ export const createIssueThreadInteractionSchema = z.discriminatedUnion("kind", [
     idempotencyKey: z.string().trim().max(255).nullable().optional(),
     sourceCommentId: z.string().uuid().nullable().optional(),
     sourceRunId: z.string().uuid().nullable().optional(),
-    title: z.string().trim().max(240).nullable().optional(),
-    summary: z.string().trim().max(1000).nullable().optional(),
+    title: z.string().trim().max(240).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+    summary: z.string().trim().max(1000).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
     continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("wake_assignee"),
     payload: askUserQuestionsPayloadSchema,
   }),
@@ -880,8 +885,8 @@ export const createIssueThreadInteractionSchema = z.discriminatedUnion("kind", [
     idempotencyKey: z.string().trim().max(255).nullable().optional(),
     sourceCommentId: z.string().uuid().nullable().optional(),
     sourceRunId: z.string().uuid().nullable().optional(),
-    title: z.string().trim().max(240).nullable().optional(),
-    summary: z.string().trim().max(1000).nullable().optional(),
+    title: z.string().trim().max(240).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+    summary: z.string().trim().max(1000).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
     continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("none"),
     payload: requestConfirmationPayloadSchema,
   }),
@@ -945,7 +950,7 @@ export type CancelIssueThreadInteraction = z.infer<typeof cancelIssueThreadInter
 
 export const respondIssueThreadInteractionSchema = z.object({
   answers: z.array(askUserQuestionsAnswerSchema).max(20),
-  summaryMarkdown: multilineTextSchema.pipe(z.string().max(20000)).nullable().optional(),
+  summaryMarkdown: paperclipTextSurfaceSchema.pipe(z.string().max(20000)).nullable().optional(),
 });
 export type RespondIssueThreadInteraction = z.infer<typeof respondIssueThreadInteractionSchema>;
 
@@ -968,7 +973,7 @@ export const issueDocumentFormatSchema = z.enum(ISSUE_DOCUMENT_FORMATS);
 export const upsertIssueDocumentSchema = z.object({
   title: z.string().trim().max(200).nullable().optional(),
   format: issueDocumentFormatSchema,
-  body: multilineTextSchema.pipe(z.string().max(524288)),
+  body: paperclipTextSurfaceSchema.pipe(z.string().max(524288)),
   changeSummary: z.string().trim().max(500).nullable().optional(),
   baseRevisionId: z.string().uuid().nullable().optional(),
 });

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -22,7 +22,11 @@ import {
   ISSUE_THREAD_INTERACTION_STATUSES,
   MODEL_PROFILE_KEYS,
 } from "../constants.js";
-import { multilineTextSchema } from "./text.js";
+import {
+  containsWorkspaceRootPlanLinks,
+  paperclipTextSurfaceSchema,
+  WORKSPACE_ROOT_PLAN_LINK_ERROR,
+} from "./text.js";
 
 export const ISSUE_EXECUTION_WORKSPACE_PREFERENCES = [
   "inherit",
@@ -222,7 +226,7 @@ const createIssueBaseSchema = z.object({
   blockedByIssueIds: z.array(z.string().uuid()).optional(),
   inheritExecutionWorkspaceFromIssueId: z.string().uuid().optional().nullable(),
   title: z.string().min(1),
-  description: multilineTextSchema.optional().nullable(),
+  description: paperclipTextSurfaceSchema.optional().nullable(),
   status: z.enum(ISSUE_STATUSES),
   workMode: z.enum(ISSUE_WORK_MODES).optional().default("standard"),
   priority: z.enum(ISSUE_PRIORITIES).optional().default("medium"),
@@ -268,7 +272,7 @@ export type CreateIssueLabel = z.infer<typeof createIssueLabelSchema>;
 export const updateIssueSchema = createIssueBaseSchema.partial().extend({
   requestDepth: issueRequestDepthInputSchema.optional(),
   assigneeAgentId: z.string().trim().min(1).optional().nullable(),
-  comment: multilineTextSchema.pipe(z.string().min(1)).optional(),
+  comment: paperclipTextSurfaceSchema.pipe(z.string().min(1)).optional(),
   reviewRequest: issueReviewRequestSchema.optional().nullable(),
   reopen: z.boolean().optional(),
   resume: z.boolean().optional(),
@@ -372,7 +376,7 @@ export const issueCommentMetadataSchema = z.object({
 export type IssueCommentMetadata = z.infer<typeof issueCommentMetadataSchema>;
 
 export const addIssueCommentSchema = z.object({
-  body: multilineTextSchema.pipe(z.string().min(1)),
+  body: paperclipTextSurfaceSchema.pipe(z.string().min(1)),
   authorType: issueCommentAuthorTypeSchema.optional(),
   presentation: issueCommentPresentationSchema.nullable().optional(),
   metadata: issueCommentMetadataSchema.nullable().optional(),
@@ -401,7 +405,7 @@ export const suggestedTaskDraftSchema = z.object({
   parentClientKey: z.string().trim().min(1).max(120).nullable().optional(),
   parentId: z.string().uuid().nullable().optional(),
   title: z.string().trim().min(1).max(240),
-  description: multilineTextSchema.pipe(z.string().trim().max(20000)).nullable().optional(),
+  description: paperclipTextSurfaceSchema.pipe(z.string().trim().max(20000)).nullable().optional(),
   priority: z.enum(ISSUE_PRIORITIES).nullable().optional(),
   workMode: z.enum(ISSUE_WORK_MODES).nullable().optional(),
   assigneeAgentId: z.string().uuid().nullable().optional(),
@@ -458,14 +462,14 @@ export const suggestTasksResultSchema = z.object({
 
 export const askUserQuestionsQuestionOptionSchema = z.object({
   id: z.string().trim().min(1).max(120),
-  label: z.string().trim().min(1).max(120),
-  description: z.string().trim().max(500).nullable().optional(),
+  label: z.string().trim().min(1).max(120).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR),
+  description: z.string().trim().max(500).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
 });
 
 export const askUserQuestionsQuestionSchema = z.object({
   id: z.string().trim().min(1).max(120),
-  prompt: z.string().trim().min(1).max(500),
-  helpText: z.string().trim().max(1000).nullable().optional(),
+  prompt: z.string().trim().min(1).max(500).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR),
+  helpText: z.string().trim().max(1000).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
   selectionMode: z.enum(["single", "multi"]),
   required: z.boolean().optional(),
   options: z.array(askUserQuestionsQuestionOptionSchema).min(1).max(10),
@@ -473,8 +477,8 @@ export const askUserQuestionsQuestionSchema = z.object({
 
 export const askUserQuestionsPayloadSchema = z.object({
   version: z.literal(1),
-  title: z.string().trim().max(240).nullable().optional(),
-  submitLabel: z.string().trim().max(120).nullable().optional(),
+  title: z.string().trim().max(240).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+  submitLabel: z.string().trim().max(120).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
   questions: z.array(askUserQuestionsQuestionSchema).min(1).max(10),
 }).superRefine((value, ctx) => {
   const seenQuestionIds = new Set<string>();
@@ -550,14 +554,14 @@ export const requestConfirmationTargetSchema = z.discriminatedUnion("type", [
 
 export const requestConfirmationPayloadSchema = z.object({
   version: z.literal(1),
-  prompt: z.string().trim().min(1).max(1000),
-  acceptLabel: z.string().trim().min(1).max(80).nullable().optional(),
-  rejectLabel: z.string().trim().min(1).max(80).nullable().optional(),
+  prompt: z.string().trim().min(1).max(1000).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR),
+  acceptLabel: z.string().trim().min(1).max(80).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+  rejectLabel: z.string().trim().min(1).max(80).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
   rejectRequiresReason: z.boolean().optional(),
-  rejectReasonLabel: z.string().trim().min(1).max(160).nullable().optional(),
+  rejectReasonLabel: z.string().trim().min(1).max(160).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
   allowDeclineReason: z.boolean().optional().default(true),
-  declineReasonPlaceholder: z.string().trim().min(1).max(240).nullable().optional(),
-  detailsMarkdown: z.string().max(20000).nullable().optional(),
+  declineReasonPlaceholder: z.string().trim().min(1).max(240).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+  detailsMarkdown: paperclipTextSurfaceSchema.pipe(z.string().max(20000)).nullable().optional(),
   supersedeOnUserComment: z.boolean().optional(),
   target: requestConfirmationTargetSchema.nullable().optional(),
 });
@@ -576,8 +580,8 @@ export const createIssueThreadInteractionSchema = z.discriminatedUnion("kind", [
     idempotencyKey: z.string().trim().max(255).nullable().optional(),
     sourceCommentId: z.string().uuid().nullable().optional(),
     sourceRunId: z.string().uuid().nullable().optional(),
-    title: z.string().trim().max(240).nullable().optional(),
-    summary: z.string().trim().max(1000).nullable().optional(),
+    title: z.string().trim().max(240).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+    summary: z.string().trim().max(1000).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
     continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("wake_assignee"),
     payload: suggestTasksPayloadSchema,
   }),
@@ -586,8 +590,8 @@ export const createIssueThreadInteractionSchema = z.discriminatedUnion("kind", [
     idempotencyKey: z.string().trim().max(255).nullable().optional(),
     sourceCommentId: z.string().uuid().nullable().optional(),
     sourceRunId: z.string().uuid().nullable().optional(),
-    title: z.string().trim().max(240).nullable().optional(),
-    summary: z.string().trim().max(1000).nullable().optional(),
+    title: z.string().trim().max(240).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+    summary: z.string().trim().max(1000).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
     continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("wake_assignee"),
     payload: askUserQuestionsPayloadSchema,
   }),
@@ -596,8 +600,8 @@ export const createIssueThreadInteractionSchema = z.discriminatedUnion("kind", [
     idempotencyKey: z.string().trim().max(255).nullable().optional(),
     sourceCommentId: z.string().uuid().nullable().optional(),
     sourceRunId: z.string().uuid().nullable().optional(),
-    title: z.string().trim().max(240).nullable().optional(),
-    summary: z.string().trim().max(1000).nullable().optional(),
+    title: z.string().trim().max(240).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
+    summary: z.string().trim().max(1000).refine((value) => !containsWorkspaceRootPlanLinks(value), WORKSPACE_ROOT_PLAN_LINK_ERROR).nullable().optional(),
     continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("none"),
     payload: requestConfirmationPayloadSchema,
   }),
@@ -635,7 +639,7 @@ export type CancelIssueThreadInteraction = z.infer<typeof cancelIssueThreadInter
 
 export const respondIssueThreadInteractionSchema = z.object({
   answers: z.array(askUserQuestionsAnswerSchema).max(20),
-  summaryMarkdown: multilineTextSchema.pipe(z.string().max(20000)).nullable().optional(),
+  summaryMarkdown: paperclipTextSurfaceSchema.pipe(z.string().max(20000)).nullable().optional(),
 });
 export type RespondIssueThreadInteraction = z.infer<typeof respondIssueThreadInteractionSchema>;
 
@@ -658,7 +662,7 @@ export const issueDocumentFormatSchema = z.enum(ISSUE_DOCUMENT_FORMATS);
 export const upsertIssueDocumentSchema = z.object({
   title: z.string().trim().max(200).nullable().optional(),
   format: issueDocumentFormatSchema,
-  body: multilineTextSchema.pipe(z.string().max(524288)),
+  body: paperclipTextSurfaceSchema.pipe(z.string().max(524288)),
   changeSummary: z.string().trim().max(500).nullable().optional(),
   baseRevisionId: z.string().uuid().nullable().optional(),
 });

--- a/packages/shared/src/validators/text.ts
+++ b/packages/shared/src/validators/text.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const WORKSPACE_ROOT_PLAN_LINK_ERROR =
+  "Workspace-root /plans links are not served. Publish this as an issue plan document or link a committed project repo docs file.";
+
 export function normalizeEscapedLineBreaks(value: string): string {
   return value
     .replace(/\\r\\n/g, "\n")
@@ -8,3 +11,57 @@ export function normalizeEscapedLineBreaks(value: string): string {
 }
 
 export const multilineTextSchema = z.string().transform(normalizeEscapedLineBreaks);
+
+const fencedCodeBlockPattern = /(^|\n)(```|~~~)[^\n]*\n[\s\S]*?(?:\n\2(?=\n|$)|$)/g;
+const inlineCodePattern = /`[^`\n]*`/g;
+const markdownInlineLinkPattern = /!?\[[^\]\n]*\]\(\s*(<[^>\n]+>|[^)\s]+)(?:\s+["'][^"'\n]*["'])?\s*\)/g;
+const markdownReferenceLinkPattern = /^[ \t]{0,3}\[[^\]\n]+]:[ \t]*(<[^>\n]+>|[^ \t\n]+)/gim;
+const rawLocalPlanTargetPattern =
+  /(^|[\s<{"'( ])((?:\.\/)*(?:\/plans(?:[/?#][^\s<>)\]}"']*)?|plans\/[^\s<>)\]}"']*))/gi;
+
+function stripMarkdownCode(value: string): string {
+  return value
+    .replace(fencedCodeBlockPattern, " ")
+    .replace(inlineCodePattern, " ");
+}
+
+export function isWorkspaceRootPlanLinkTarget(rawTarget: string): boolean {
+  let target = rawTarget.trim();
+  if (target.startsWith("<") && target.endsWith(">")) {
+    target = target.slice(1, -1).trim();
+  }
+  target = target.replace(/\\([()<>])/g, "$1");
+  while (target.startsWith("./")) {
+    target = target.slice(2);
+  }
+
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target) || target.startsWith("//")) {
+    return false;
+  }
+
+  return /^\/?plans(?:\/|[?#]|$)/i.test(target);
+}
+
+export function containsWorkspaceRootPlanLinks(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const visibleMarkdown = stripMarkdownCode(value);
+
+  for (const match of visibleMarkdown.matchAll(markdownInlineLinkPattern)) {
+    if (match[1] && isWorkspaceRootPlanLinkTarget(match[1])) return true;
+  }
+
+  for (const match of visibleMarkdown.matchAll(markdownReferenceLinkPattern)) {
+    if (match[1] && isWorkspaceRootPlanLinkTarget(match[1])) return true;
+  }
+
+  for (const match of visibleMarkdown.matchAll(rawLocalPlanTargetPattern)) {
+    if (match[2] && isWorkspaceRootPlanLinkTarget(match[2])) return true;
+  }
+
+  return false;
+}
+
+export const paperclipTextSurfaceSchema = multilineTextSchema.refine(
+  (value) => !containsWorkspaceRootPlanLinks(value),
+  WORKSPACE_ROOT_PLAN_LINK_ERROR,
+);

--- a/packages/shared/src/validators/text.ts
+++ b/packages/shared/src/validators/text.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const WORKSPACE_ROOT_PLAN_LINK_ERROR =
+  "Workspace-root /plans links are not served. Publish this as an issue plan document or link a committed project repo docs file.";
+
 export function normalizeEscapedLineBreaks(value: string): string {
   return value
     .replace(/\\r\\n/g, "\n")
@@ -8,3 +11,57 @@ export function normalizeEscapedLineBreaks(value: string): string {
 }
 
 export const multilineTextSchema = z.string().transform(normalizeEscapedLineBreaks);
+
+const fencedCodeBlockPattern = /(^|\n)(```|~~~)[^\n]*\n[\s\S]*?(?:\n\2(?=\n|$)|$)/g;
+const inlineCodePattern = /`[^`\n]*`/g;
+const markdownInlineLinkPattern = /!?\[[^\]\n]*\]\(\s*(<[^>\n]+>|[^)\s]+)(?:\s+["'][^"'\n]*["'])?\s*\)/g;
+const markdownReferenceLinkPattern = /^[ \t]{0,3}\[[^\]\n]+]:[ \t]*(<[^>\n]+>|[^ \t\n]+)/gim;
+const rawLocalPlanTargetPattern =
+  /(^|[\s([<{"'])((?:\.\/)*(?:\/plans(?:[/?#][^\s<>)\]}"']*)?|plans\/[^\s<>)\]}"']*))/gi;
+
+function stripMarkdownCode(value: string): string {
+  return value
+    .replace(fencedCodeBlockPattern, " ")
+    .replace(inlineCodePattern, " ");
+}
+
+export function isWorkspaceRootPlanLinkTarget(rawTarget: string): boolean {
+  let target = rawTarget.trim();
+  if (target.startsWith("<") && target.endsWith(">")) {
+    target = target.slice(1, -1).trim();
+  }
+  target = target.replace(/\\([()<>])/g, "$1");
+  while (target.startsWith("./")) {
+    target = target.slice(2);
+  }
+
+  if (/^[a-z][a-z0-9+.-]*:/i.test(target) || target.startsWith("//")) {
+    return false;
+  }
+
+  return /^\/?plans(?:\/|[?#]|$)/i.test(target);
+}
+
+export function containsWorkspaceRootPlanLinks(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const visibleMarkdown = stripMarkdownCode(value);
+
+  for (const match of visibleMarkdown.matchAll(markdownInlineLinkPattern)) {
+    if (match[1] && isWorkspaceRootPlanLinkTarget(match[1])) return true;
+  }
+
+  for (const match of visibleMarkdown.matchAll(markdownReferenceLinkPattern)) {
+    if (match[1] && isWorkspaceRootPlanLinkTarget(match[1])) return true;
+  }
+
+  for (const match of visibleMarkdown.matchAll(rawLocalPlanTargetPattern)) {
+    if (match[2] && isWorkspaceRootPlanLinkTarget(match[2])) return true;
+  }
+
+  return false;
+}
+
+export const paperclipTextSurfaceSchema = multilineTextSchema.refine(
+  (value) => !containsWorkspaceRootPlanLinks(value),
+  WORKSPACE_ROOT_PLAN_LINK_ERROR,
+);

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1573,4 +1573,16 @@ describe.sequential("issue comment reopen routes", () => {
       }),
     ));
   });
+
+  it("rejects workspace-root plan links in direct issue comments", async () => {
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({
+        body: "See [plan](/plans/DAT-4136-unified-app-tab-proposal.md)",
+      });
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toContain("Workspace-root /plans links are not served");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1331,4 +1331,16 @@ describe.sequential("issue comment reopen routes", () => {
       }),
     ));
   });
+
+  it("rejects workspace-root plan links in direct issue comments", async () => {
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({
+        body: "See [plan](/plans/DAT-4136-unified-app-tab-proposal.md)",
+      });
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toContain("Workspace-root /plans links are not served");
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -358,4 +358,24 @@ describe("issue update comment wakeups", () => {
       }),
     );
   });
+
+  it("rejects workspace-root plan links in issue update comments", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({
+        comment: "See [plan](plans/DAT-4136-unified-app-tab-proposal.md)",
+      });
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toContain("Workspace-root /plans links are not served");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -290,4 +290,24 @@ describe("issue update comment wakeups", () => {
       }),
     );
   });
+
+  it("rejects workspace-root plan links in issue update comments", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({
+        comment: "See [plan](plans/DAT-4136-unified-app-tab-proposal.md)",
+      });
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toContain("Workspace-root /plans links are not served");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -1,8 +1,12 @@
 import { and, asc, desc, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { documentRevisions, documents, issueDocuments, issues } from "@paperclipai/db";
-import { isSystemIssueDocumentKey, issueDocumentKeySchema } from "@paperclipai/shared";
+import {
+  isSystemIssueDocumentKey,
+  issueDocumentKeySchema,
+} from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
+import { assertNoWorkspaceRootPlanLinks } from "./plan-links.js";
 
 function normalizeDocumentKey(key: string) {
   const normalized = key.trim().toLowerCase();
@@ -209,6 +213,7 @@ export function documentService(db: Db) {
       lockedDocumentStrategy?: "conflict" | "create_new_document";
     }) => {
       const key = normalizeDocumentKey(input.key);
+      assertNoWorkspaceRootPlanLinks(input.body);
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })
         .from(issues)
@@ -557,6 +562,7 @@ export function documentService(db: Db) {
             currentRevisionId: existing.latestRevisionId,
           });
         }
+        assertNoWorkspaceRootPlanLinks(revision.body);
 
         const now = new Date();
         const nextRevisionNumber = existing.latestRevisionNumber + 1;

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -1,7 +1,12 @@
 import { and, asc, desc, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { documentRevisions, documents, issueDocuments, issues } from "@paperclipai/db";
-import { isSystemIssueDocumentKey, issueDocumentKeySchema } from "@paperclipai/shared";
+import {
+  WORKSPACE_ROOT_PLAN_LINK_ERROR,
+  containsWorkspaceRootPlanLinks,
+  isSystemIssueDocumentKey,
+  issueDocumentKeySchema,
+} from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 
 function normalizeDocumentKey(key: string) {
@@ -15,6 +20,12 @@ function normalizeDocumentKey(key: string) {
 
 function isUniqueViolation(error: unknown): boolean {
   return !!error && typeof error === "object" && "code" in error && (error as { code?: string }).code === "23505";
+}
+
+function assertNoWorkspaceRootPlanLinks(value: string | null | undefined) {
+  if (containsWorkspaceRootPlanLinks(value)) {
+    throw unprocessable(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+  }
 }
 
 export function extractLegacyPlanBody(description: string | null | undefined) {
@@ -181,6 +192,7 @@ export function documentService(db: Db) {
       createdByRunId?: string | null;
     }) => {
       const key = normalizeDocumentKey(input.key);
+      assertNoWorkspaceRootPlanLinks(input.body);
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })
         .from(issues)
@@ -399,6 +411,7 @@ export function documentService(db: Db) {
             currentRevisionId: existing.latestRevisionId,
           });
         }
+        assertNoWorkspaceRootPlanLinks(revision.body);
 
         const now = new Date();
         const nextRevisionNumber = existing.latestRevisionNumber + 1;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -86,6 +86,7 @@ import {
   RECOVERY_ORIGIN_KINDS,
 } from "./recovery/origins.js";
 import { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/issue-graph-liveness.js";
+import { assertNoWorkspaceRootPlanLinks } from "./plan-links.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -4719,6 +4720,7 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
+      assertNoWorkspaceRootPlanLinks(issueData.description);
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         let projectWorkspaceId = issueData.projectWorkspaceId ?? null;
@@ -4965,6 +4967,7 @@ export function issueService(db: Db) {
         delete issueData.executionWorkspacePreference;
         delete issueData.executionWorkspaceSettings;
       }
+      assertNoWorkspaceRootPlanLinks(issueData.description);
 
       if (issueData.status) {
         assertTransition(existing.status, issueData.status);
@@ -5868,6 +5871,7 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!issue) throw notFound("Issue not found");
+      assertNoWorkspaceRootPlanLinks(body);
 
       const currentUserRedactionOptions = {
         enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -37,7 +37,9 @@ import type {
   IssueRelationIssueSummary,
 } from "@paperclipai/shared";
 import {
+  WORKSPACE_ROOT_PLAN_LINK_ERROR,
   clampIssueRequestDepth,
+  containsWorkspaceRootPlanLinks,
   extractAgentMentionIds,
   extractProjectMentionIds,
   issueCommentAuthorTypeSchema,
@@ -275,6 +277,12 @@ function appendAcceptanceCriteriaToDescription(description: string | null | unde
   const base = description?.trim() ?? "";
   const criteriaMarkdown = ["## Acceptance Criteria", "", ...criteria.map((item) => `- ${item}`)].join("\n");
   return base ? `${base}\n\n${criteriaMarkdown}` : criteriaMarkdown;
+}
+
+function assertNoWorkspaceRootPlanLinks(value: string | null | undefined) {
+  if (containsWorkspaceRootPlanLinks(value)) {
+    throw unprocessable(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+  }
 }
 
 function createIssueDependencyReadiness(issueId: string): IssueDependencyReadiness {
@@ -2823,6 +2831,7 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
+      assertNoWorkspaceRootPlanLinks(issueData.description);
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
@@ -3058,6 +3067,7 @@ export function issueService(db: Db) {
         delete issueData.executionWorkspacePreference;
         delete issueData.executionWorkspaceSettings;
       }
+      assertNoWorkspaceRootPlanLinks(issueData.description);
 
       if (issueData.status) {
         assertTransition(existing.status, issueData.status);
@@ -3860,6 +3870,7 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!issue) throw notFound("Issue not found");
+      assertNoWorkspaceRootPlanLinks(body);
 
       const currentUserRedactionOptions = {
         enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,

--- a/server/src/services/plan-links.ts
+++ b/server/src/services/plan-links.ts
@@ -1,0 +1,11 @@
+import {
+  WORKSPACE_ROOT_PLAN_LINK_ERROR,
+  containsWorkspaceRootPlanLinks,
+} from "@paperclipai/shared";
+import { unprocessable } from "../errors.js";
+
+export function assertNoWorkspaceRootPlanLinks(value: string | null | undefined) {
+  if (containsWorkspaceRootPlanLinks(value)) {
+    throw unprocessable(WORKSPACE_ROOT_PLAN_LINK_ERROR);
+  }
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through issue threads, comments, issue documents, and review interactions.
> - Agents and humans use those markdown surfaces as durable handoff records for plans and decisions.
> - Workspace-root `plans/...` links are not served by the Paperclip app, so comments that point there create broken board-review links.
> - Instructions can reduce the mistake, but API-level validation is needed so every adapter and direct service path gets the same protection.
> - This pull request adds a shared detector for Paperclip-local workspace-root plan targets and applies it to issue comments, issue descriptions, issue documents, and interaction text bodies.
> - The benefit is that invalid plan links fail fast with an actionable message while existing issue links, issue-document anchors, and external repository links still work.

## What Changed

- Added shared validation for markdown links, reference-style links, and raw local targets resolving to `plans/...` or `/plans/...`.
- Applied the guard to issue descriptions, issue update comments, direct comments, issue documents, suggested task text, question/confirmation interactions, and interaction responses.
- Added service-layer checks for issue descriptions/comments and document writes/restores so callers that bypass HTTP schemas still fail safely.
- Added validator and route coverage for direct comment creation and PATCH issue-update comments.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run packages/shared/src/validators/issue.test.ts server/src/__tests__/issue-update-comment-wakeup-routes.test.ts server/src/__tests__/issue-comment-reopen-routes.test.ts`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm build`

## Risks

- Low risk. This is additive validation on Paperclip markdown/text inputs.
- The main behavioral shift is intentional: newly submitted local `plans/...` references are rejected even if they appear in otherwise valid markdown.
- Inline code examples such as `` `/plans/example.md` `` remain allowed so users can explain the invalid pattern without creating a broken link.

## Model Used

- OpenAI Codex, GPT-5-based coding agent, accessed through the Codex CLI/API environment with shell, test, and git tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (not applicable; no UI changes)
- [x] I have updated relevant documentation to reflect my changes (not applicable; validation behavior is covered by tests and error text)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
