### PR TITLE
feat(agents): surface fine-grained permission grants on /api/agents/me (ZERA-549)

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -45,12 +45,23 @@ Returns the agent record for the currently authenticated agent.
   "status": "running",
   "budgetMonthlyCents": 5000,
   "spentMonthlyCents": 1200,
+  "permissions": {
+    "canCreateAgents": false,
+    "grants": ["tasks:assign"]
+  },
   "chainOfCommand": [
     { "id": "mgr-1", "name": "EngineeringLead", "role": "manager" },
     { "id": "ceo-1", "name": "CEO", "role": "ceo" }
   ]
 }
 ```
+
+`permissions.grants` is a sorted, deduplicated list of fine-grained permission keys this
+agent currently holds (e.g. `tasks:assign`, `approvals:create`). It is advisory metadata
+for cheap client-side pre-checks — server-side enforcement remains authoritative, so
+attempting an action you do not hold the grant for will still 403. Agents without any
+explicit grants receive an empty array. The richer per-grant rows (with scope and
+`grantedByUserId`) are still available on `access.grants` for callers that need them.
 
 ## Create Agent
 

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1340,6 +1340,79 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(200);
     expect(res.body.access.canAssignTasks).toBe(true);
     expect(res.body.access.taskAssignSource).toBe("explicit_grant");
+    expect(res.body.permissions).toMatchObject({
+      canCreateAgents: false,
+      grants: ["tasks:assign"],
+    });
+  }, 15_000);
+
+  it("exposes fine-grained grants on GET /api/agents/me deduplicated and sorted", async () => {
+    mockAccessService.listPrincipalGrants.mockResolvedValue([
+      {
+        id: "grant-tasks",
+        companyId,
+        principalType: "agent",
+        principalId: agentId,
+        permissionKey: "tasks:assign",
+        scope: null,
+        grantedByUserId: "board-user",
+        createdAt: new Date("2026-03-19T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      },
+      {
+        id: "grant-approvals",
+        companyId,
+        principalType: "agent",
+        principalId: agentId,
+        permissionKey: "approvals:create",
+        scope: null,
+        grantedByUserId: "board-user",
+        createdAt: new Date("2026-03-19T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      },
+      {
+        id: "grant-tasks-scoped",
+        companyId,
+        principalType: "agent",
+        principalId: agentId,
+        permissionKey: "tasks:assign",
+        scope: "project:abc",
+        grantedByUserId: "board-user",
+        createdAt: new Date("2026-03-19T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+      },
+    ]);
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      runId: "run-1",
+      source: "agent_key",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/me`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.permissions.grants).toEqual(["approvals:create", "tasks:assign"]);
+    expect(res.body.permissions.canCreateAgents).toBe(false);
+  }, 15_000);
+
+  it("returns an empty grants array when the agent holds no grants", async () => {
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      runId: "run-1",
+      source: "agent_key",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/me`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.permissions.grants).toEqual([]);
   }, 15_000);
 
   it("keeps task assignment enabled when agent creation privilege is enabled", async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -517,8 +517,21 @@ export function agentRoutes(
       buildAgentAccessState(agent),
     ]);
 
+    const base = options?.restricted ? redactForRestrictedAgentView(agent) : agent;
+    const basePermissions =
+      base && typeof base.permissions === "object" && base.permissions !== null
+        ? (base.permissions as Record<string, unknown>)
+        : {};
+    const grantKeys = Array.from(
+      new Set(accessState.grants.map((grant) => grant.permissionKey)),
+    ).sort();
+
     return {
-      ...(options?.restricted ? redactForRestrictedAgentView(agent) : agent),
+      ...base,
+      permissions: {
+        ...basePermissions,
+        grants: grantKeys,
+      },
       chainOfCommand,
       access: accessState,
     };


### PR DESCRIPTION
## Summary

- Adds `permissions.grants: string[]` to the agent detail response (powers `GET /api/agents/me`), a sorted/deduped list of fine-grained permission keys the agent currently holds (e.g. `tasks:assign`).
- Keeps the richer `access.grants` row shape intact for callers that need scope and `grantedByUserId`.
- Lets manager-tier agents pre-check before attempting cross-team actions instead of inferring from `role` heuristics. Server-side enforcement remains authoritative.

Closes ZERA-549. Origin: hub thread on ZERA-401, green-lit by CEO; parent gap tracked in ZERA-484.

## Test plan

- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/agent-permissions-routes.test.ts` — 45 tests passing, including two new cases (multi-grant dedup/sort, empty array).
- [x] Existing "exposes explicit task assignment access on agent detail" test extended to also assert `permissions.grants` includes `tasks:assign`.
- [x] No new typecheck errors introduced (pre-existing master errors in `plugin-host-services.ts` / `plugin-local-folders.ts` are unrelated).
- [x] `docs/api/agents.md` `GET /api/agents/me` response example updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)