### PR TITLE
Fix LLM wiki type contracts

### DIFF
--- a/packages/plugins/plugin-llm-wiki/src/wiki/core.ts
+++ b/packages/plugins/plugin-llm-wiki/src/wiki/core.ts
@@ -48,6 +48,10 @@ export type WikiEventIngestionSettings = {
   maxCharacters: number;
 };
 
+export type WikiEventIngestionSettingsUpdate = Omit<Partial<WikiEventIngestionSettings>, "sources"> & {
+  sources?: Partial<Record<WikiEventIngestionSource, boolean>>;
+};
+
 export type PaperclipIngestionSourceScope =
   | { kind: "active_projects"; limit: number; statuses?: Array<"in_progress" | "todo" | "done"> }
   | { kind: "selected_projects"; projectIds: string[] }
@@ -1100,7 +1104,7 @@ export async function listPaperclipIngestionCandidates(ctx: PluginContext, input
 
 export async function updateEventIngestionSettings(
   ctx: PluginContext,
-  input: { companyId: string; settings: Partial<WikiEventIngestionSettings> & { sources?: Partial<Record<WikiEventIngestionSource, boolean>> } },
+  input: { companyId: string; settings: WikiEventIngestionSettingsUpdate },
 ): Promise<WikiEventIngestionSettings> {
   await requirePaperclipIngestionPolicy(ctx, {
     companyId: input.companyId,

--- a/packages/plugins/sdk/src/ui/components.ts
+++ b/packages/plugins/sdk/src/ui/components.ts
@@ -420,6 +420,12 @@ export interface ManagedRoutineMissingRef {
   resourceKey: string;
 }
 
+export interface ManagedRoutineDefaultDrift {
+  changedFields: string[];
+  defaultTitle?: string | null;
+  defaultDescription?: string | null;
+}
+
 export interface ManagedRoutinesListItem {
   key: string;
   title: string;
@@ -434,6 +440,7 @@ export interface ManagedRoutinesListItem {
   lastRunStatus?: string | null;
   managedByPluginDisplayName?: string | null;
   missingRefs?: ManagedRoutineMissingRef[];
+  defaultDrift?: ManagedRoutineDefaultDrift | null;
 }
 
 export interface ManagedRoutinesListProps {

--- a/ui/src/components/ManagedRoutinesList.tsx
+++ b/ui/src/components/ManagedRoutinesList.tsx
@@ -23,6 +23,12 @@ export type ManagedRoutineMissingRef = {
   resourceKey: string;
 };
 
+export type ManagedRoutineDefaultDrift = {
+  changedFields: string[];
+  defaultTitle?: string | null;
+  defaultDescription?: string | null;
+};
+
 export type ManagedRoutinesListItem = {
   key: string;
   title: string;
@@ -37,6 +43,7 @@ export type ManagedRoutinesListItem = {
   lastRunStatus?: string | null;
   managedByPluginDisplayName?: string | null;
   missingRefs?: ManagedRoutineMissingRef[];
+  defaultDrift?: ManagedRoutineDefaultDrift | null;
 };
 
 export type ManagedRoutinesListProps = {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies, and plugins extend that control plane without bloating core.
> - The LLM Wiki plugin adds a knowledge surface through the plugin runtime and shared plugin UI components.
> - After the LLM Wiki work merged to `master`, CI exposed TypeScript contract drift between plugin code, SDK component types, and update settings types.
> - The ingestion settings update path intentionally accepts partial source toggles, but its type intersected with the full settings shape and required every source key.
> - The LLM Wiki UI also passes managed routine default-drift metadata through the shared routine list item shape, but that metadata was missing from the public item type.
> - This pull request narrows those type contracts to match the existing runtime behavior.
> - The benefit is restoring typecheck on `master` with a small, non-behavioral follow-up.

## What Changed

- Added a `WikiEventIngestionSettingsUpdate` type that permits partial source updates without weakening normalized stored settings.
- Added managed routine default-drift metadata to the plugin SDK `ManagedRoutinesListItem` type.
- Mirrored that managed routine default-drift type in the host UI component item type.

## Verification

- `pnpm --filter @paperclipai/plugin-llm-wiki typecheck`
- `pnpm --filter @paperclipai/plugin-sdk typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `git diff --check`

## Risks

- Low risk. This is a TypeScript type-contract fix only; no runtime behavior or database schema changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent, tool-enabled local repository editing and command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Notes on checklist applicability: no screenshots are included because the UI change is a shared type-only contract update with no visual behavior change; no docs were required because no behavior or commands changed.