### PR TITLE
feat(platform): surface approval lifecycle in linked issues (ZERA-552)

### DIFF
--- a/server/src/__tests__/approval-issue-comments.test.ts
+++ b/server/src/__tests__/approval-issue-comments.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { buildApprovalSystemCommentBody } from "../services/approval-issue-comments.js";
+
+const baseApproval = {
+  id: "approval-1",
+  type: "request_board_approval",
+  status: "pending",
+  payload: { title: "Approve monthly hosting spend" },
+  decisionNote: null,
+};
+
+describe("buildApprovalSystemCommentBody", () => {
+  it("formats a created comment with company-prefixed approval link", () => {
+    const body = buildApprovalSystemCommentBody({
+      event: "created",
+      approval: baseApproval,
+      issuePrefix: "ZERA",
+      requesterAgentName: "CPO",
+    });
+    expect(body).toContain("## Pending board approval");
+    expect(body).toContain("[Approve monthly hosting spend](/ZERA/approvals/approval-1)");
+    expect(body).toContain("`request_board_approval`");
+    expect(body).toContain("Requested by CPO.");
+  });
+
+  it("formats an approved comment and includes the decision note when present", () => {
+    const body = buildApprovalSystemCommentBody({
+      event: "approved",
+      approval: { ...baseApproval, status: "approved", decisionNote: "Endorsed by CEO." },
+      issuePrefix: "PAP",
+    });
+    expect(body).toContain("## Board approval granted");
+    expect(body).toContain("[Approve monthly hosting spend](/PAP/approvals/approval-1) approved.");
+    expect(body).toContain("**Decision note:** Endorsed by CEO.");
+  });
+
+  it("formats a rejected comment without a decision note when none is provided", () => {
+    const body = buildApprovalSystemCommentBody({
+      event: "rejected",
+      approval: { ...baseApproval, status: "rejected", decisionNote: null },
+      issuePrefix: "PAP",
+    });
+    expect(body).toContain("## Board approval rejected");
+    expect(body).toContain("[Approve monthly hosting spend](/PAP/approvals/approval-1) rejected.");
+    expect(body).not.toContain("Decision note");
+  });
+
+  it("treats whitespace-only decision notes as absent", () => {
+    const body = buildApprovalSystemCommentBody({
+      event: "approved",
+      approval: { ...baseApproval, decisionNote: "   \n  " },
+      issuePrefix: "PAP",
+    });
+    expect(body).not.toContain("Decision note");
+  });
+
+  it("formats a revision_requested comment", () => {
+    const body = buildApprovalSystemCommentBody({
+      event: "revision_requested",
+      approval: { ...baseApproval, status: "revision_requested", decisionNote: "Please tighten the risks section." },
+      issuePrefix: "ZERA",
+    });
+    expect(body).toContain("## Board requested revision");
+    expect(body).toContain("sent back for revision.");
+    expect(body).toContain("**Decision note:** Please tighten the risks section.");
+  });
+
+  it("formats a resubmitted comment", () => {
+    const body = buildApprovalSystemCommentBody({
+      event: "resubmitted",
+      approval: { ...baseApproval, status: "pending" },
+      issuePrefix: "ZERA",
+      requesterAgentName: "CPO",
+    });
+    expect(body).toContain("## Approval resubmitted");
+    expect(body).toContain("resubmitted to the board (status `pending`).");
+    expect(body).toContain("Requested by CPO.");
+  });
+
+  it("falls back to a generic title when payload title is missing or empty", () => {
+    const body = buildApprovalSystemCommentBody({
+      event: "created",
+      approval: { ...baseApproval, payload: { title: "   " } },
+      issuePrefix: "ZERA",
+    });
+    expect(body).toContain("[Board approval](/ZERA/approvals/approval-1)");
+  });
+
+  it("escapes nothing — payload title is rendered verbatim into the markdown link", () => {
+    const body = buildApprovalSystemCommentBody({
+      event: "created",
+      approval: { ...baseApproval, payload: { title: "Spend $500/month on hosting" } },
+      issuePrefix: "ZERA",
+    });
+    expect(body).toContain("[Spend $500/month on hosting](/ZERA/approvals/approval-1)");
+  });
+});

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -27,6 +27,18 @@ const mockSecretService = vi.hoisted(() => ({
   normalizeHireApprovalPayloadForPersistence: vi.fn(),
 }));
 
+const mockCompanyService = vi.hoisted(() => ({
+  getById: vi.fn(async () => null),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(async () => null),
+}));
+
+const mockIssueService = vi.hoisted(() => ({
+  addComment: vi.fn(async () => undefined),
+}));
+
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
 function registerModuleMocks() {
@@ -36,6 +48,9 @@ function registerModuleMocks() {
     issueApprovalService: () => mockIssueApprovalService,
     logActivity: mockLogActivity,
     secretService: () => mockSecretService,
+    companyService: () => mockCompanyService,
+    agentService: () => mockAgentService,
+    issueService: () => mockIssueService,
   }));
 }
 

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -10,15 +10,22 @@ import {
 import { validate } from "../middleware/validate.js";
 import { logger } from "../middleware/logger.js";
 import {
+  agentService,
   approvalService,
+  companyService,
   heartbeatService,
   issueApprovalService,
+  issueService,
   logActivity,
   secretService,
 } from "../services/index.js";
 import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { redactEventPayload } from "../redaction.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import {
+  buildApprovalSystemCommentBody,
+  type ApprovalIssueCommentEventKind,
+} from "../services/approval-issue-comments.js";
 
 function redactApprovalPayload<T extends { payload: Record<string, unknown> }>(approval: T): T {
   return {
@@ -38,7 +45,60 @@ export function approvalRoutes(
   });
   const issueApprovalsSvc = issueApprovalService(db);
   const secretsSvc = secretService(db);
+  const companiesSvc = companyService(db);
+  const agentsSvc = agentService(db);
+  const issuesSvc = issueService(db);
   const strictSecretsMode = process.env.PAPERCLIP_SECRETS_STRICT_MODE === "true";
+
+  async function postApprovalSystemCommentToLinkedIssues(
+    approvalId: string,
+    event: ApprovalIssueCommentEventKind,
+    options: { issueIds?: string[] } = {},
+  ) {
+    try {
+      const approval = await svc.getById(approvalId);
+      if (!approval) return;
+
+      const issueIds =
+        options.issueIds ??
+        (await issueApprovalsSvc.listIssuesForApproval(approvalId)).map((issue) => issue.id);
+      if (issueIds.length === 0) return;
+
+      const [company, requesterAgent] = await Promise.all([
+        companiesSvc.getById(approval.companyId),
+        approval.requestedByAgentId ? agentsSvc.getById(approval.requestedByAgentId) : null,
+      ]);
+      if (!company) return;
+
+      const body = buildApprovalSystemCommentBody({
+        event,
+        approval: {
+          id: approval.id,
+          type: approval.type,
+          status: approval.status,
+          payload: (approval.payload as Record<string, unknown> | null) ?? {},
+          decisionNote: approval.decisionNote,
+        },
+        issuePrefix: company.issuePrefix,
+        requesterAgentName: requesterAgent?.name ?? null,
+      });
+
+      await Promise.all(
+        issueIds.map((issueId) =>
+          issuesSvc
+            .addComment(issueId, body, {}, { authorType: "system" })
+            .catch((err) => {
+              logger.warn(
+                { err, approvalId, issueId, event },
+                "failed to post approval system comment to linked issue",
+              );
+            }),
+        ),
+      );
+    } catch (err) {
+      logger.warn({ err, approvalId, event }, "approval system-comment posting failed");
+    }
+  }
 
   async function requireApprovalAccess(req: Request, id: string) {
     const approval = await svc.getById(id);
@@ -105,6 +165,9 @@ export function approvalRoutes(
         agentId: actor.agentId,
         userId: actor.actorType === "user" ? actor.actorId : null,
       });
+      await postApprovalSystemCommentToLinkedIssues(approval.id, "created", {
+        issueIds: uniqueIssueIds,
+      });
     }
 
     await logActivity(db, {
@@ -147,6 +210,10 @@ export function approvalRoutes(
       const linkedIssues = await issueApprovalsSvc.listIssuesForApproval(approval.id);
       const linkedIssueIds = linkedIssues.map((issue) => issue.id);
       const primaryIssueId = linkedIssueIds[0] ?? null;
+
+      await postApprovalSystemCommentToLinkedIssues(approval.id, "approved", {
+        issueIds: linkedIssueIds,
+      });
 
       await logActivity(db, {
         companyId: approval.companyId,
@@ -240,6 +307,8 @@ export function approvalRoutes(
     const { approval, applied } = await svc.reject(id, decidedByUserId, req.body.decisionNote);
 
     if (applied) {
+      await postApprovalSystemCommentToLinkedIssues(approval.id, "rejected");
+
       await logActivity(db, {
         companyId: approval.companyId,
         actorType: "user",
@@ -266,6 +335,8 @@ export function approvalRoutes(
       }
       const decidedByUserId = req.actor.userId ?? "board";
       const approval = await svc.requestRevision(id, decidedByUserId, req.body.decisionNote);
+
+      await postApprovalSystemCommentToLinkedIssues(approval.id, "revision_requested");
 
       await logActivity(db, {
         companyId: approval.companyId,
@@ -305,6 +376,7 @@ export function approvalRoutes(
         : req.body.payload
       : undefined;
     const approval = await svc.resubmit(id, normalizedPayload);
+    await postApprovalSystemCommentToLinkedIssues(approval.id, "resubmitted");
     const actor = getActorInfo(req);
     await logActivity(db, {
       companyId: approval.companyId,

--- a/server/src/services/approval-issue-comments.ts
+++ b/server/src/services/approval-issue-comments.ts
@@ -1,0 +1,75 @@
+export type ApprovalIssueCommentEventKind =
+  | "created"
+  | "approved"
+  | "rejected"
+  | "revision_requested"
+  | "resubmitted";
+
+export interface ApprovalIssueCommentInput {
+  event: ApprovalIssueCommentEventKind;
+  approval: {
+    id: string;
+    type: string;
+    status: string;
+    payload: Record<string, unknown>;
+    decisionNote?: string | null;
+  };
+  issuePrefix: string;
+  requesterAgentName?: string | null;
+}
+
+function readPayloadTitle(payload: Record<string, unknown>): string {
+  const raw = typeof payload.title === "string" ? payload.title.trim() : "";
+  return raw.length > 0 ? raw : "Board approval";
+}
+
+function approvalLink(input: ApprovalIssueCommentInput): string {
+  const title = readPayloadTitle(input.approval.payload);
+  return `[${title}](/${input.issuePrefix}/approvals/${input.approval.id})`;
+}
+
+function trimmedNote(note: string | null | undefined): string | null {
+  if (typeof note !== "string") return null;
+  const trimmed = note.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function buildApprovalSystemCommentBody(input: ApprovalIssueCommentInput): string {
+  const link = approvalLink(input);
+  const note = trimmedNote(input.approval.decisionNote);
+  const requesterClause = input.requesterAgentName ? ` Requested by ${input.requesterAgentName}.` : "";
+  const noteSuffix = note ? `\n\n**Decision note:** ${note}` : "";
+
+  switch (input.event) {
+    case "created":
+      return [
+        "## Pending board approval",
+        "",
+        `This issue is gated on a board decision: ${link} (\`${input.approval.type}\`, status \`pending\`).${requesterClause}`,
+      ].join("\n");
+    case "approved":
+      return [
+        "## Board approval granted",
+        "",
+        `${link} approved.${noteSuffix}`,
+      ].join("\n");
+    case "rejected":
+      return [
+        "## Board approval rejected",
+        "",
+        `${link} rejected.${noteSuffix}`,
+      ].join("\n");
+    case "revision_requested":
+      return [
+        "## Board requested revision",
+        "",
+        `${link} sent back for revision.${noteSuffix}`,
+      ].join("\n");
+    case "resubmitted":
+      return [
+        "## Approval resubmitted",
+        "",
+        `${link} resubmitted to the board (status \`pending\`).${requesterClause}`,
+      ].join("\n");
+  }
+}


### PR DESCRIPTION
## Summary

- When a board approval is created with linked `issueIds`, or transitions via approve / reject / request-revision / resubmit, append a system-authored comment to each linked issue surfacing the governance state.
- Belt + suspenders pair to #5752 ([ZERA-543](https://github.com/paperclipai/paperclip/issues) — orphan-deliverable badge). Both make agent/board coordination state observable from the issue page itself, instead of requiring a cross-reference to the approvals view.
- Pure body builder + 8 unit tests; helper wrapped in try/catch + warn so a comment-post failure never blocks the approval lifecycle.

## Behavior

| Event | Linked issue comment |
| --- | --- |
| `POST /api/companies/:id/approvals` (with `issueIds`) | `## Pending board approval` — links to the approval, names the type, status, requester |
| `POST /api/approvals/:id/approve` | `## Board approval granted` + optional decision note |
| `POST /api/approvals/:id/reject` | `## Board approval rejected` + optional decision note |
| `POST /api/approvals/:id/request-revision` | `## Board requested revision` + optional decision note |
| `POST /api/approvals/:id/resubmit` | `## Approval resubmitted` |

All comments are `authorType: "system"` and include a deep link of the form `/<prefix>/approvals/<id>` (matches the Paperclip skill style for cross-entity links).

## Test plan

- [x] Unit tests for body builder (8 tests; created/approved/rejected/revision_requested/resubmitted, optional decision note, whitespace-only notes, fallback title, verbatim title)
- [x] Existing approval-routes idempotency tests still pass after extending the `services/index.js` mock with the new service deps
- [ ] Manual: create a board approval with `issueIds`, verify the system comment appears on the linked issue
- [ ] Manual: approve and reject flows produce the appropriate follow-up comments
- [ ] Manual: confirm comment failure path (e.g., transient DB error during `addComment`) does NOT block the approval lifecycle — only logs a `warn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)