### PR TITLE
docs(skill): annotate version-gated routes in hot-routes table (ZERA-554)

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -323,6 +323,8 @@ If `plan` already exists, fetch the current document first and send its latest `
 
 ## Key Endpoints (Hot Routes)
 
+Rows tagged `(≥ vYYYY.MMDD.0)` ship in that server release and 404 on older deployments. To check the deployed version: `GET /api/health` returns `{ "status": "ok", "version": "<server-version>", ... }`. If a 404 surprises you on a documented route, compare `version` against the minimum below before assuming doc drift.
+
 | Action                                | Endpoint                                                                                                                        |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | My identity                           | `GET /api/agents/me`                                                                                                            |
@@ -334,7 +336,7 @@ If `plan` already exists, fetch the current document first and send its latest `
 | Update task                           | `PATCH /api/issues/:issueId` (optional `comment` field)                                                                         |
 | Get comments / delta / single         | `GET /api/issues/:issueId/comments[?after=:commentId&order=asc]` • `/comments/:commentId`                                       |
 | Add comment                           | `POST /api/issues/:issueId/comments`                                                                                            |
-| Issue-thread interactions             | `GET\|POST /api/issues/:issueId/interactions` • `POST /api/issues/:issueId/interactions/:interactionId/{accept,reject,respond}` |
+| Issue-thread interactions (≥ v2026.427.0) | `GET\|POST /api/issues/:issueId/interactions` • `POST /api/issues/:issueId/interactions/:interactionId/{accept,reject,respond}` |
 | Create subtask                        | `POST /api/companies/:companyId/issues`                                                                                         |
 | Release task                          | `POST /api/issues/:issueId/release`                                                                                             |
 | Search issues                         | `GET /api/companies/:companyId/issues?q=search+term`                                                                            |

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -756,6 +756,8 @@ Terminal states: `done`, `cancelled`
 
 ## Full API Reference
 
+Rows tagged `(≥ vYYYY.MMDD.0)` ship in that server release and 404 on older deployments. Confirm the deployed version with `GET /api/health` (`version` field) before assuming a 404 is doc drift — see the convention preface on the hot-routes table in `SKILL.md`.
+
 ### Agents
 
 | Method | Path                               | Description                          |
@@ -791,11 +793,11 @@ Terminal states: `done`, `cancelled`
 | GET    | `/api/issues/:issueId/comments`    | List comments                                                                            |
 | GET    | `/api/issues/:issueId/comments/:commentId` | Get a specific comment by ID                                                     |
 | POST   | `/api/issues/:issueId/comments`    | Add comment (@-mentions trigger wakeups)                                                 |
-| GET    | `/api/issues/:issueId/interactions` | List issue-thread interactions                                                          |
-| POST   | `/api/issues/:issueId/interactions` | Create issue-thread interaction (`suggest_tasks`, `ask_user_questions`, `request_confirmation`) |
-| POST   | `/api/issues/:issueId/interactions/:interactionId/accept` | Accept suggested tasks or confirmation                                       |
-| POST   | `/api/issues/:issueId/interactions/:interactionId/reject` | Reject suggested tasks or confirmation                                       |
-| POST   | `/api/issues/:issueId/interactions/:interactionId/respond` | Respond to structured questions                                             |
+| GET    | `/api/issues/:issueId/interactions` | List issue-thread interactions (≥ v2026.427.0)                                          |
+| POST   | `/api/issues/:issueId/interactions` | Create issue-thread interaction (`suggest_tasks`, `ask_user_questions`, `request_confirmation`) (≥ v2026.427.0) |
+| POST   | `/api/issues/:issueId/interactions/:interactionId/accept` | Accept suggested tasks or confirmation (≥ v2026.427.0)                       |
+| POST   | `/api/issues/:issueId/interactions/:interactionId/reject` | Reject suggested tasks or confirmation (≥ v2026.427.0)                       |
+| POST   | `/api/issues/:issueId/interactions/:interactionId/respond` | Respond to structured questions (≥ v2026.427.0)                             |
 | GET    | `/api/issues/:issueId/documents`   | List issue documents                                                                     |
 | GET    | `/api/issues/:issueId/documents/:key` | Get issue document by key                                                            |
 | PUT    | `/api/issues/:issueId/documents/:key` | Create or update issue document (send `baseRevisionId` when updating)                |


### PR DESCRIPTION
## Summary

- Annotate the `interactions` family rows in both the `SKILL.md` hot-routes table and the `api-reference.md` Issues table with `(≥ v2026.427.0)` — the version that first shipped those routes (commit `a9573944`, 2026-04-21).
- Add a one-paragraph preface above each table explaining the `(≥ vYYYY.MMDD.0)` convention and pointing operators at `GET /api/health` (`version` field) so a 404 on a documented route can be triaged as stale-CLI vs. doc drift in one step.
- No new behavior; pure docs.

## Why

[ZERA-553](https://github.com/paperclipai/paperclip/issues) burned ~4 weeks of CPO/CEO dogfooding noise tracking a 404 on `GET /api/issues/:id/interactions` — which turned out to be a stale CLI predating the feature. The skill's hot-routes table told operators the route exists; it didn't tell them which server release first shipped it. This PR closes that gap and sets a pattern for every future version-gated row.

## Audit notes

I audited every row in the hot-routes table and the api-reference Issues table for additions newer than `v2026.416.0` (the oldest still-deployable canary, per ZERA-554's scoping):

| Route family | First commit | First stable release | Needs annotation? |
| --- | --- | --- | --- |
| `interactions` (GET/POST + accept/reject/respond) | `a9573944` (2026-04-21) | `v2026.427.0` | **Yes** |
| `inbox-lite`, `heartbeat-context` | `7d1748b3` (2026-03-13) | `v2026.318.0` | No (pre-`v2026.416.0`) |
| `documents/:key` (GET/PUT/DELETE) | `45998aa9` (2026-03-13) | `v2026.318.0` | No |
| `runtime-services/{start,restart,stop}` | `1f1fe9c9` (2026-03-28) | `v2026.403.0` | No |
| `routine-triggers/*` | `8f5196f7` (2026-03-19) | `v2026.325.0` | No |
| `approvals/:id/{request-revision,resubmit}` | `c09037ff` (2026-02-19) | pre-`v2026.318.0` | No |
| `agents/:id/keys`, `agents/:id/config-revisions/*` | `abadd469`/`c09037ff` (2026-02) | pre-`v2026.318.0` | No |

The `interactions cancel` endpoint (commit `c4269bab`, 2026-04-30) isn't documented in either table, so no annotation needed there. The May 6 planning-mode work (`a1b30c9f`) enriches the `request_confirmation` interaction kind but doesn't add a new route — and isn't in a stable `v*` tag yet — so I left the table annotation at the route-level minimum (`≥ v2026.427.0`) and didn't fabricate a stable version for the planning-mode behavior.

## Bonus (not in this PR)

The issue mentions an optional automatic version check on first skill use (fetch `/api/health` and warn when `serverVersion` lags the latest documented min). I scoped that out of this PR to keep it purely documentation and avoid changing skill startup behavior — happy to follow up if there's appetite.

## Test plan

- [x] Diff is two files, pure docs, no code changes.
- [x] Markdown renders cleanly (header preface + amended table row label / row trailing tag in api-reference).
- [x] Audit table above accounts for every row in the SKILL.md hot-routes table and the api-reference Issues table.
- [ ] Skim render: confirm the parenthetical `(≥ v2026.427.0)` reads cleanly in both the "Action" column (SKILL.md) and the "Description" column (api-reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)