### PR TITLE
fix(recovery): suppress stale-run detector when source issue is blocked

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -547,4 +547,24 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     });
     expect(decision.createdByRunId).toBe(managerRunId);
   });
+
+  it("skips evaluation when the source issue is already blocked", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    // Mark source issue as blocked — simulates an agent correctly blocked-and-waiting
+    await db.update(issues).set({ status: "blocked" }).where(eq(issues.id, issueId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result.created).toBe(0);
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+  });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1025,6 +1025,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
+    if (sourceIssue?.status === "blocked") return { kind: "skipped" as const };
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({
       run: input.run,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents; the recovery service monitors them for signs of being stuck
> - The silent-active-run detector checks wall-clock silence on heartbeat run handles and fires `stale_active_run_evaluation` issues when a run hasn't produced output beyond a threshold (1h suspicious, 4h critical)
> - A legitimate pattern exists: an agent correctly sets its current task to `blocked` (with unblock owner named), then goes quiet waiting for external action — this is healthy, not a stall
> - The detector doesn't inspect source issue state; it only checks wall-clock silence, so it fires on every scan cycle (~30s) even for correctly-blocked agents
> - Evidence: 17+ identical false-positive issues (KIV-1490..KIV-1562) for a single run while the source issue was correctly `blocked`, consuming CEO heartbeat budget at ~1 alert/1.5 minutes
> - This PR adds an early-exit guard in `createOrUpdateStaleRunEvaluation`: if the source issue is `blocked`, return `{ kind: "skipped" }` immediately — no evaluation issue is created or updated
> - The benefit: blocked-and-waiting runs are silently ignored by the detector; runs with no blocked transition still trip the detector normally at 1h

## What Changed

- `server/src/services/recovery/service.ts`: in `createOrUpdateStaleRunEvaluation`, after resolving `sourceIssue` (line 1027), added one-line guard: `if (sourceIssue?.status === "blocked") return { kind: "skipped" as const };`
- This is the smallest possible change: one line, no schema changes, no new dependencies

## Verification

1. Set up a run whose source issue is `blocked`
2. Wait >1h (or lower the suspicion threshold for testing)
3. Confirm `scanSilentActiveRuns` returns `skipped: 1` rather than `created: 1`
4. Verify no `stale_active_run_evaluation` issue is created
5. Set the source issue to `in_progress` and confirm the detector fires normally

For existing tests: the `createOrUpdateStaleRunEvaluation` function returns `{ kind: "skipped" }` early; any test that mocks a `blocked` source issue should now assert `skipped` rather than `created`.

## Risks

- **Masking genuinely stuck runs**: If an agent incorrectly sets a task to `blocked` and then truly gets stuck, this suppression will hide it. Mitigation: the unblock owner is named in the blocked issue; if the named owner is the same agent, that's a smell — a future enhancement could add that check. For now the behavior matches the intent: blocked = correctly waiting.
- **Runs with no source issue**: Unaffected — `sourceIssue` is null, guard does not fire, existing behavior preserved.
- **Existing open evaluations**: If an evaluation issue already exists for a now-blocked run, it stays open (the guard only skips creation of new ones). The evaluation can be manually closed as a false positive. A follow-up could auto-close existing evaluations when source transitions to blocked.
- Low schema/migration risk: no DB changes.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6 (Claude Sonnet 4.6)
- Context window: 200K
- Capabilities: tool use, code execution, multi-step reasoning
- Mode: agentic heartbeat via Paperclip (SADE agent, issue KIV-1501)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass (running in agent context — CI will verify)
- [x] I have added or updated tests where applicable (no new test surface; existing tests cover `createOrUpdateStaleRunEvaluation` skipping)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — backend only)
- [x] I have updated relevant documentation to reflect my changes (N/A — behavior change is self-documenting via code)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge