### PR TITLE
fix: add recovery plan draft skeleton

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -724,6 +724,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(recovery.title).toContain("Recover stalled issue");
     expect(recovery.description).toContain(`Previous source status: \`${input.previousStatus}\``);
     expect(recovery.description).toContain(`Retry reason: \`${input.retryReason}\``);
+    expect(recovery.description).toContain("## Recovery Plan Draft");
+    expect(recovery.description).toContain("- [ ] Triage: inspect the latest run, retry history, and source issue state without copying raw transcripts or secrets.");
+    expect(recovery.description).toContain("- [ ] Repair: fix the runtime/adapter failure, reassign the source issue, or convert it into a clear manual-review or blocker state.");
+    expect(recovery.description).toContain("- [ ] Validation: confirm the source issue has a live execution path, explicit waiting path, or intentional terminal disposition.");
     expect(recovery.description).toContain("Fix the runtime/adapter problem");
 
     const relation = await db
@@ -1616,6 +1620,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(recovery?.description).toContain(`Source run: [\`${sourceRunId}\`]`);
     expect(recovery?.description).toContain("Missing disposition: `clear_next_step`");
     expect(recovery?.description).toContain("Source assignee: [CodexCoder]");
+    expect(recovery?.description).toContain("## Recovery Plan Draft");
+    expect(recovery?.description).toContain("- [ ] Triage: inspect the source issue, run metadata, and retry history without copying raw transcripts or secrets.");
+    expect(recovery?.description).toContain("- [ ] Repair: record exactly one valid disposition for the source issue");
+    expect(recovery?.description).toContain("- [ ] Validation: attach evidence that the chosen disposition satisfies acceptance criteria or names a first-class blocker.");
     expect(recovery?.description).not.toContain("sk-test-successful-handoff-secret");
 
     const sourceIssue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
@@ -1698,6 +1706,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     );
     expect(recovery?.description).toContain("Latest handoff run status: `succeeded`");
     expect(recovery?.description).toContain("Suggested");
+    expect(recovery?.description).toContain("## Recovery Plan Draft");
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/services/recovery/recovery-plan-draft.test.ts
+++ b/server/src/services/recovery/recovery-plan-draft.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildRecoveryPlanDraft } from "./recovery-plan-draft.js";
+
+describe("recovery plan draft skeleton", () => {
+  it("builds a safe missing-disposition repair draft", () => {
+    const draft = buildRecoveryPlanDraft({ cause: "successful_run_missing_state" });
+
+    expect(draft).toContain("## Recovery Plan Draft");
+    expect(draft).toContain("- [ ] Triage: inspect the source issue, run metadata, and retry history without copying raw transcripts or secrets.");
+    expect(draft).toContain("- [ ] Repair: record exactly one valid disposition for the source issue");
+    expect(draft).toContain("- [ ] Validation: attach evidence that the chosen disposition satisfies acceptance criteria or names a first-class blocker.");
+    expect(draft).toContain("- [ ] Closeout: update the source issue, link any delegated follow-up or blocker work, then mark this recovery issue done.");
+    expect(draft).toContain("Safety notes:");
+    expect(draft).toContain("Human approval is required before risky/live/destructive/social/spend/account/proxy actions.");
+    expect(draft).toContain("Do not mark the source issue done without validation / acceptance criteria evidence.");
+    expect(draft).not.toContain("sk-test-recovery-plan-secret");
+    expect(draft).not.toMatch(/Authorization:\s*Bearer\s+\S+/i);
+  });
+
+  it("builds a runtime stranded-work repair draft", () => {
+    const draft = buildRecoveryPlanDraft({ cause: "stranded_assigned_issue" });
+
+    expect(draft).toContain("## Recovery Plan Draft");
+    expect(draft).toContain("- [ ] Triage: inspect the latest run, retry history, and source issue state without copying raw transcripts or secrets.");
+    expect(draft).toContain("- [ ] Repair: fix the runtime/adapter failure, reassign the source issue, or convert it into a clear manual-review or blocker state.");
+    expect(draft).toContain("- [ ] Validation: confirm the source issue has a live execution path, explicit waiting path, or intentional terminal disposition.");
+    expect(draft).toContain("- [ ] Closeout: comment what changed, link safe evidence, then mark this recovery issue done.");
+    expect(draft).toContain("Human approval is required before risky/live/destructive/social/spend/account/proxy actions.");
+    expect(draft).toContain("Do not duplicate spend or live actions while repairing the source issue.");
+  });
+});

--- a/server/src/services/recovery/recovery-plan-draft.ts
+++ b/server/src/services/recovery/recovery-plan-draft.ts
@@ -1,0 +1,31 @@
+export type RecoveryPlanDraftCause = "stranded_assigned_issue" | "successful_run_missing_state";
+
+export function buildRecoveryPlanDraft(input: { cause: RecoveryPlanDraftCause }) {
+  const lines = input.cause === "successful_run_missing_state"
+    ? [
+        "## Recovery Plan Draft",
+        "",
+        "- [ ] Triage: inspect the source issue, run metadata, and retry history without copying raw transcripts or secrets.",
+        "- [ ] Repair: record exactly one valid disposition for the source issue: `done`/`cancelled`, `in_review` with an owner, `blocked` with first-class blockers, delegated follow-up work, or an explicit continuation path.",
+        "- [ ] Validation: attach evidence that the chosen disposition satisfies acceptance criteria or names a first-class blocker.",
+        "- [ ] Closeout: update the source issue, link any delegated follow-up or blocker work, then mark this recovery issue done.",
+      ]
+    : [
+        "## Recovery Plan Draft",
+        "",
+        "- [ ] Triage: inspect the latest run, retry history, and source issue state without copying raw transcripts or secrets.",
+        "- [ ] Repair: fix the runtime/adapter failure, reassign the source issue, or convert it into a clear manual-review or blocker state.",
+        "- [ ] Validation: confirm the source issue has a live execution path, explicit waiting path, or intentional terminal disposition.",
+        "- [ ] Closeout: comment what changed, link safe evidence, then mark this recovery issue done.",
+      ];
+
+  const safetyNotes = [
+    "",
+    "Safety notes:",
+    "- Human approval is required before risky/live/destructive/social/spend/account/proxy actions.",
+    "- Do not duplicate spend or live actions while repairing the source issue.",
+    "- Do not mark the source issue done without validation / acceptance criteria evidence.",
+  ];
+
+  return [...lines, ...safetyNotes].join("\n");
+}

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -54,6 +54,7 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { buildRecoveryPlanDraft } from "./recovery-plan-draft.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
@@ -1444,6 +1445,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         `- Missing disposition: \`${missingDisposition}\``,
         "- Suggested manager action: choose and record a valid issue disposition without copying transcript content.",
         "",
+        buildRecoveryPlanDraft({ cause: SUCCESSFUL_RUN_MISSING_STATE_REASON }),
+        "",
         "## Required Action",
         "",
         "- Inspect the source issue and run metadata, not raw transcript excerpts.",
@@ -1471,6 +1474,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       "## Ownership",
       "",
       "- Selected owner: the first invokable manager/creator/executive candidate with budget available.",
+      "",
+      buildRecoveryPlanDraft({ cause: "stranded_assigned_issue" }),
       "",
       "## Required Action",
       "",


### PR DESCRIPTION
## Summary
- Add a reusable recovery-plan draft skeleton builder for recovery issue descriptions.
- Include the skeleton in stranded assigned issue recovery and successful-run/missing-state handoff recovery.
- Add unit and integration expectations for triage, safe repair/re-run, validation/closeout, transcript/secret hygiene, approval gates, and duplicate live/spend warnings.

## Test Plan
- ✅ `pnpm exec vitest run server/src/services/recovery/recovery-plan-draft.test.ts`
- ✅ `pnpm exec vitest run server/src/services/recovery/recovery-plan-draft.test.ts server/src/services/recovery/successful-run-handoff.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts`
  - Note: heartbeat-process-recovery is skipped on this host because the embedded Postgres fixture is unavailable; recovery-plan-draft and successful-run-handoff pass.
- ✅ `git diff --check`
- ✅ Added-line secret/static scan: 76 added lines scanned, 0 findings.
- ⚠️ `pnpm --filter @paperclipai/server typecheck` currently fails on pre-existing `environment-runtime.ts` / `plugin-environment-driver.ts` plugin environment param type errors. Baseline `origin/master` has the same failures; no failures reference changed files.

## Safety
- Recovery drafts explicitly require human approval before risky/live/destructive/social/spend/account/proxy actions.
- Recovery drafts warn not to duplicate spend/live actions and not to mark source issues done without validation / acceptance-criteria evidence.
- Recovery drafts tell operators to inspect metadata/retry history without copying raw transcripts or secrets.

## Review
- Independent reviewer passed with no security concerns or logic errors.
