### PR TITLE
Parse Anthropic rate_limit_event for structured retry-after

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -628,6 +628,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             stdout: proc.stdout,
             stderr: proc.stderr,
             errorMessage: fallbackErrorMessage,
+            rateLimitResetAtUnix: parsedStream.rateLimitResetAtUnix,
           })
         : null;
       const errorCode = loginMeta.requiresLogin
@@ -709,6 +710,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           stdout: proc.stdout,
           stderr: proc.stderr,
           errorMessage,
+          rateLimitResetAtUnix: parsedStream.rateLimitResetAtUnix,
         })
       : null;
     const resolvedErrorCode = loginMeta.requiresLogin

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractClaudeRetryNotBefore,
   isClaudeTransientUpstreamError,
+  parseClaudeStreamJson,
 } from "./parse.js";
 
 describe("isClaudeTransientUpstreamError", () => {
@@ -63,6 +64,17 @@ describe("isClaudeTransientUpstreamError", () => {
     ).toBe(true);
   });
 
+  it("classifies the 'You've hit your limit' message variant as transient", () => {
+    // Observed in claude CLI output 2026-05-12: assistant message text was
+    // "You've hit your limit · resets 2pm (Asia/Shanghai)" — does not match
+    // any of the legacy prefix variants, but should still be transient.
+    expect(
+      isClaudeTransientUpstreamError({
+        errorMessage: "You've hit your limit · resets 2pm (Asia/Shanghai)",
+      }),
+    ).toBe(true);
+  });
+
   it("does not classify login/auth failures as transient", () => {
     expect(
       isClaudeTransientUpstreamError({
@@ -119,5 +131,78 @@ describe("extractClaudeRetryNotBefore", () => {
     expect(
       extractClaudeRetryNotBefore({ errorMessage: "Overloaded. Try again later." }, new Date()),
     ).toBeNull();
+  });
+
+  it("extracts the reset time from the 'You've hit your limit' message variant", () => {
+    // claude CLI 2026-05-12 message format. Without the new prefix in the
+    // regex, this would return null and force a default-backoff retry storm.
+    const now = new Date("2026-05-12T05:38:40.000Z");
+    const extracted = extractClaudeRetryNotBefore(
+      { errorMessage: "You've hit your limit · resets 2pm (Asia/Shanghai)" },
+      now,
+    );
+    // 2pm Asia/Shanghai = 06:00 UTC same day.
+    expect(extracted?.toISOString()).toBe("2026-05-12T06:00:00.000Z");
+  });
+
+  it("prefers the structured rate_limit_event resetsAt over text regex", () => {
+    // Future resetsAt — should be used directly even when no regex would match.
+    const now = new Date("2026-05-12T05:38:40.000Z");
+    const futureResetsAt = Math.floor(new Date("2026-05-12T06:00:00.000Z").getTime() / 1000);
+    const extracted = extractClaudeRetryNotBefore(
+      {
+        errorMessage: "(no text reset hint here)",
+        rateLimitResetAtUnix: futureResetsAt,
+      },
+      now,
+    );
+    expect(extracted?.toISOString()).toBe("2026-05-12T06:00:00.000Z");
+  });
+
+  it("falls through to regex when structured rateLimitResetAtUnix is in the past", () => {
+    // Past resetsAt is treated as stale; regex path takes over.
+    const now = new Date("2026-05-12T10:00:00.000Z");
+    const pastResetsAt = Math.floor(new Date("2026-05-12T06:00:00.000Z").getTime() / 1000);
+    const extracted = extractClaudeRetryNotBefore(
+      {
+        errorMessage: "You're out of extra usage · resets 4pm (America/Chicago)",
+        rateLimitResetAtUnix: pastResetsAt,
+      },
+      now,
+    );
+    // Regex path: 4pm America/Chicago = 21:00 UTC.
+    expect(extracted?.toISOString()).toBe("2026-05-12T21:00:00.000Z");
+  });
+});
+
+describe("parseClaudeStreamJson — rate_limit_event", () => {
+  it("captures rate_limit_info.resetsAt as rateLimitResetAtUnix", () => {
+    // Real shape observed in claude CLI stdout 2026-05-12 (SIM-1753 incident).
+    const stdout = [
+      JSON.stringify({
+        type: "rate_limit_event",
+        rate_limit_info: {
+          status: "rejected",
+          resetsAt: 1778565600,
+          rateLimitType: "five_hour",
+          overageStatus: "rejected",
+          overageDisabledReason: "org_level_disabled_until",
+          isUsingOverage: false,
+        },
+      }),
+    ].join("\n");
+    const parsed = parseClaudeStreamJson(stdout);
+    expect(parsed.rateLimitResetAtUnix).toBe(1778565600);
+  });
+
+  it("leaves rateLimitResetAtUnix null when no rate_limit_event is present", () => {
+    const stdout = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      session_id: "abc",
+      result: "fine",
+    });
+    const parsed = parseClaudeStreamJson(stdout);
+    expect(parsed.rateLimitResetAtUnix).toBeNull();
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -10,14 +10,20 @@ const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s
 const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
-  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
+  /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|you['’]?ve\s+hit\s+your\s+limit)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =
-  /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
+  /(?:out\s+of\s+extra\s+usage|extra\s+usage|usage\s+limit\s+reached|usage\s+cap\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|claude\s+usage\s+limit\s+reached|you['’]?ve\s+hit\s+your\s+limit)[\s\S]{0,80}?\bresets?\s+(?:at\s+)?([^\n()]+?)(?:\s*\(([^)]+)\))?(?:[.!]|\n|$)/i;
 
 export function parseClaudeStreamJson(stdout: string) {
   let sessionId: string | null = null;
   let model = "";
   let finalResult: Record<string, unknown> | null = null;
+  // Structured rate-limit signal — claude CLI emits a `rate_limit_event` JSON
+  // line with `rate_limit_info.resetsAt` (Unix epoch seconds) when the account
+  // is over its Max-plan window. Prefer this over text regex on the human
+  // message — newer message variants (e.g. "You've hit your limit · resets …")
+  // don't always match the legacy text patterns.
+  let rateLimitResetAtUnix: number | null = null;
   const assistantTexts: string[] = [];
 
   for (const rawLine of stdout.split(/\r?\n/)) {
@@ -30,6 +36,13 @@ export function parseClaudeStreamJson(stdout: string) {
     if (type === "system" && asString(event.subtype, "") === "init") {
       sessionId = asString(event.session_id, sessionId ?? "") || sessionId;
       model = asString(event.model, model);
+      continue;
+    }
+
+    if (type === "rate_limit_event") {
+      const info = parseObject(event.rate_limit_info);
+      const resetsAt = asNumber(info.resetsAt, 0);
+      if (resetsAt > 0) rateLimitResetAtUnix = resetsAt;
       continue;
     }
 
@@ -62,6 +75,7 @@ export function parseClaudeStreamJson(stdout: string) {
       usage: null as UsageSummary | null,
       summary: assistantTexts.join("\n\n").trim(),
       resultJson: null as Record<string, unknown> | null,
+      rateLimitResetAtUnix,
     };
   }
 
@@ -82,6 +96,7 @@ export function parseClaudeStreamJson(stdout: string) {
     usage,
     summary,
     resultJson: finalResult,
+    rateLimitResetAtUnix,
   };
 }
 
@@ -350,9 +365,19 @@ export function extractClaudeRetryNotBefore(
     stdout?: string | null;
     stderr?: string | null;
     errorMessage?: string | null;
+    rateLimitResetAtUnix?: number | null;
   },
   now = new Date(),
 ): Date | null {
+  // Prefer the structured signal from claude CLI's `rate_limit_event` stream
+  // event. Unix epoch seconds — convert to ms. Only honor if it's in the
+  // future relative to `now`; a stale resetsAt falls through to the regex
+  // path (and ultimately to default backoff if that also fails).
+  const structured = input.rateLimitResetAtUnix;
+  if (typeof structured === "number" && structured > 0) {
+    const candidate = new Date(structured * 1000);
+    if (candidate.getTime() > now.getTime()) return candidate;
+  }
   const haystack = buildClaudeTransientHaystack(input);
   const match = haystack.match(CLAUDE_EXTRA_USAGE_RESET_RE);
   if (!match) return null;


### PR DESCRIPTION
## What

`claude` CLI emits a structured `rate_limit_event` stream line when an account is over its Max-plan window:

```json
{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1778565600,"rateLimitType":"five_hour","overageStatus":"rejected","overageDisabledReason":"org_level_disabled_until","isUsingOverage":false}}
```

`resetsAt` is Unix epoch seconds — machine-readable. The accompanying assistant message is now `"You've hit your limit · resets 2pm (Asia/Shanghai)"`, which does NOT match the legacy reset-time regex (prefix alternatives required `"out of extra usage"`, `"usage limit reached"`, etc.).

## Why this matters

The classifier (`isClaudeTransientUpstreamError`) still fires correctly — `parsed.errors[].error: "rate_limit"` is in the haystack and matches the existing regex. But `extractClaudeRetryNotBefore` returns `null` because the text regex's prefix alternatives don't match `"You've hit your limit"`.

Net effect: the run is classified as `claude_transient_upstream` but `retryNotBefore` is never set. The heartbeat scheduler falls back to default short backoff and retries every ~7 min — each retry hits the same cap, fails immediately, and burns more of the already-exhausted window.

We hit this in production today: one ticket triggered 4 cap-hit retries in 32 minutes after the human had stopped working, all from default backoff with no `retryNotBefore` guidance.

## Fix

Two parts, in priority order:

**1. (Primary) Consume the structured `rate_limit_event`.** `parseClaudeStreamJson` now reads this event type and surfaces `rate_limit_info.resetsAt` as `rateLimitResetAtUnix` on its return. `extractClaudeRetryNotBefore` accepts this as an optional input and prefers it (when in the future) over the text regex. A stale (past) `resetsAt` falls through to the regex path, so old behavior is preserved.

**2. (Defense in depth) Add `"you've hit your limit"` to both regexes.** If the structured event is absent or filtered, the older text-only path still detects and extracts.

## Files changed

- `packages/adapters/claude-local/src/server/parse.ts` — regex updates, `parseClaudeStreamJson` extension, `extractClaudeRetryNotBefore` priority
- `packages/adapters/claude-local/src/server/parse.test.ts` — 6 new test cases
- `packages/adapters/claude-local/src/server/execute.ts` — both call sites thread `parsedStream.rateLimitResetAtUnix` through

## Test plan

- [x] `pnpm vitest run src/server/parse.test.ts` — 15/15 (9 existing + 6 new)
- [x] Full `claude-local` suite — 18/18
- [x] `server/src/__tests__/claude-local-execute.test.ts` + `heartbeat-retry-scheduling.test.ts` — 19/19
- [x] `pnpm typecheck` clean

## Cross-adapter note

`codex-local` adapter may have an equivalent pattern (the file is structurally similar). Not touched in this PR — happy to file a follow-up if you'd like the same treatment there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)