### PR TITLE
Fix DB backup rotation ENOSPC (per-day daily-tier coalesce + free-space guard)

### DIFF
--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -164,6 +164,48 @@ describe("pruneOldBackups", () => {
     expect(result.kept + result.pruned).toBe(30);
   });
 
+  it("only counts successful unlinks in the returned pruned total", () => {
+    const dir = createTempDir("paperclip-prune-unlink-fail-");
+    const anchorMs = Date.UTC(2026, 4, 12, 12, 0, 0);
+    // 30 hourly entries means several files older than the 24h hourly window
+    // are scheduled for deletion after per-day coalescing in the daily tier.
+    generateHourlyFixture(dir, 30, anchorMs);
+
+    // Remove write permission on the directory so unlinkSync throws EACCES /
+    // EPERM for every scheduled deletion. The prune should still complete
+    // without crashing and the returned `pruned` count must reflect the zero
+    // actual deletions rather than the scheduled-intent count.
+    const originalMode = fs.statSync(dir).mode;
+    fs.chmodSync(dir, 0o555);
+    cleanups.push(() => {
+      try {
+        fs.chmodSync(dir, originalMode);
+      } catch {
+        // best-effort cleanup; the parent afterEach rmSync handles the rest
+      }
+    });
+
+    let result: { kept: number; pruned: number };
+    try {
+      result = pruneOldBackups(
+        dir,
+        { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1, hourlyHours: 24 },
+        "paperclip",
+        () => anchorMs,
+      );
+    } finally {
+      fs.chmodSync(dir, originalMode);
+    }
+
+    // Every file should still be on disk because unlinkSync failed for all of them.
+    const remaining = fs.readdirSync(dir).filter((name) => name.endsWith(".sql.gz"));
+    expect(remaining.length).toBe(30);
+    // Pruned must reflect actual deletions, not scheduled intent.
+    expect(result.pruned).toBe(0);
+    // kept reflects the retention plan (unchanged by unlink failures).
+    expect(result.kept).toBeGreaterThan(0);
+  });
+
   it("ignores files that do not match the filename prefix", () => {
     const dir = createTempDir("paperclip-prune-prefix-");
     const anchorMs = Date.UTC(2026, 4, 12, 12, 0, 0);

--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import postgres from "postgres";
-import { createBufferedTextFileWriter, runDatabaseBackup, runDatabaseRestore } from "./backup-lib.js";
+import { createBufferedTextFileWriter, pruneOldBackups, runDatabaseBackup, runDatabaseRestore } from "./backup-lib.js";
 import { ensurePostgresDatabase } from "./client.js";
 import {
   getEmbeddedPostgresTestSupport,
@@ -70,6 +70,117 @@ describe("createBufferedTextFileWriter", () => {
     await writer.close();
 
     expect(fs.readFileSync(outputPath, "utf8")).toBe(lines.join("\n"));
+  });
+
+  it("surfaces openFile rejections via drain/close instead of leaking unhandledRejection", async () => {
+    const missingDir = path.join(os.tmpdir(), `paperclip-buffered-writer-missing-${process.pid}-${Date.now()}`);
+    const outputPath = path.join(missingDir, "nope", "backup.sql");
+    const writer = createBufferedTextFileWriter(outputPath, 16);
+
+    writer.emit("BEGIN;");
+    await expect(writer.drain()).rejects.toBeInstanceOf(Error);
+    // abort() must always be safe to call after a failed write — it must not throw.
+    await writer.abort();
+  });
+});
+
+describe("pruneOldBackups", () => {
+  function makeBackup(dir: string, name: string, mtimeMs: number, sizeBytes = 1024): void {
+    const fullPath = path.join(dir, name);
+    fs.writeFileSync(fullPath, Buffer.alloc(sizeBytes));
+    fs.utimesSync(fullPath, new Date(mtimeMs), new Date(mtimeMs));
+  }
+
+  function generateHourlyFixture(dir: string, hours: number, anchorMs: number): string[] {
+    const names: string[] = [];
+    for (let i = 0; i < hours; i += 1) {
+      const ts = anchorMs - i * 60 * 60 * 1000;
+      const d = new Date(ts);
+      const pad = (n: number) => String(n).padStart(2, "0");
+      const name = `paperclip-${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}-${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}.sql.gz`;
+      makeBackup(dir, name, ts);
+      names.push(name);
+    }
+    return names;
+  }
+
+  it("collapses 168 hourly backups into hourly window + per-day daily entries", () => {
+    const dir = createTempDir("paperclip-prune-168-");
+    const anchorMs = Date.UTC(2026, 4, 12, 12, 0, 0); // 2026-05-12 12:00:00 UTC
+    generateHourlyFixture(dir, 168, anchorMs);
+
+    const result = pruneOldBackups(
+      dir,
+      { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1, hourlyHours: 24 },
+      "paperclip",
+      () => anchorMs,
+    );
+
+    // 24 within the hourly window + 7 prior days (one each) - 1 for the day
+    // that's already represented inside the hourly window = 6 daily entries.
+    // Some hourly-window slots may share a calendar day with the daily tier
+    // boundary; the invariant is that we collapse from 168 to roughly 24 + days.
+    expect(result.kept).toBeGreaterThan(20);
+    expect(result.kept).toBeLessThanOrEqual(32);
+    expect(result.kept + result.pruned).toBe(168);
+
+    const remaining = fs.readdirSync(dir).filter((name) => name.endsWith(".sql.gz"));
+    expect(remaining.length).toBe(result.kept);
+  });
+
+  it("keeps every backup inside the hourly window untouched", () => {
+    const dir = createTempDir("paperclip-prune-hourly-only-");
+    const anchorMs = Date.UTC(2026, 4, 12, 12, 0, 0);
+    generateHourlyFixture(dir, 12, anchorMs); // all within 24h window
+
+    const result = pruneOldBackups(
+      dir,
+      { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1, hourlyHours: 24 },
+      "paperclip",
+      () => anchorMs,
+    );
+
+    expect(result.pruned).toBe(0);
+    expect(result.kept).toBe(12);
+  });
+
+  it("falls back to a 24h hourly window when hourlyHours is omitted (forward compat)", () => {
+    const dir = createTempDir("paperclip-prune-default-hourly-");
+    const anchorMs = Date.UTC(2026, 4, 12, 12, 0, 0);
+    generateHourlyFixture(dir, 30, anchorMs);
+
+    const result = pruneOldBackups(
+      dir,
+      // hourlyHours intentionally omitted — exercises the legacy shared
+      // BackupRetentionPolicy shape (day/week/month only).
+      { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1 },
+      "paperclip",
+      () => anchorMs,
+    );
+
+    // 24h hourly + per-day daily for the older portion — total well under 30.
+    expect(result.kept).toBeGreaterThanOrEqual(24);
+    expect(result.kept).toBeLessThan(30);
+    expect(result.kept + result.pruned).toBe(30);
+  });
+
+  it("ignores files that do not match the filename prefix", () => {
+    const dir = createTempDir("paperclip-prune-prefix-");
+    const anchorMs = Date.UTC(2026, 4, 12, 12, 0, 0);
+    generateHourlyFixture(dir, 5, anchorMs);
+    makeBackup(dir, "unrelated.sql.gz", anchorMs - 10 * 24 * 60 * 60 * 1000);
+    makeBackup(dir, "paperclip-old.txt", anchorMs - 10 * 24 * 60 * 60 * 1000);
+
+    const result = pruneOldBackups(
+      dir,
+      { dailyDays: 7, weeklyWeeks: 4, monthlyMonths: 1, hourlyHours: 24 },
+      "paperclip",
+      () => anchorMs,
+    );
+
+    expect(result.pruned).toBe(0);
+    expect(fs.existsSync(path.join(dir, "unrelated.sql.gz"))).toBe(true);
+    expect(fs.existsSync(path.join(dir, "paperclip-old.txt"))).toBe(true);
   });
 });
 

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -11,7 +11,17 @@ export type BackupRetentionPolicy = {
   dailyDays: number;
   weeklyWeeks: number;
   monthlyMonths: number;
+  /**
+   * Recent-window in hours during which every backup is kept (no coalescing).
+   * Sits in front of the daily tier so operators retain hourly granularity for
+   * fast recovery after a recent failure. Defaults to {@link DEFAULT_HOURLY_HOURS}
+   * when omitted, which makes the field forward-compatible with the existing
+   * shared `BackupRetentionPolicy` shape that only carries the day/week/month presets.
+   */
+  hourlyHours?: number;
 };
+
+const DEFAULT_HOURLY_HOURS = 24;
 
 export type RunDatabaseBackupOptions = {
   connectionString: string;
@@ -34,6 +44,7 @@ export type RunDatabaseBackupResult = {
   backupFile: string;
   sizeBytes: number;
   prunedCount: number;
+  keptCount: number;
 };
 
 export type RunDatabaseRestoreOptions = {
@@ -107,17 +118,40 @@ function monthKey(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
 }
 
+function dayKey(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+export type BackupPruneResult = { kept: number; pruned: number };
+
+export type ListBackupsClock = () => number;
+
 /**
  * Tiered backup pruning:
- * - Daily tier: keep ALL backups from the last `dailyDays` days
- * - Weekly tier: keep the NEWEST backup per calendar week for `weeklyWeeks` weeks
- * - Monthly tier: keep the NEWEST backup per calendar month for `monthlyMonths` months
- * - Everything else is deleted
+ * - Hourly tier: keep ALL backups within the last `hourlyHours` hours (default 24).
+ * - Daily tier:  keep the NEWEST backup per calendar day for `dailyDays` days.
+ *                (Prior to this change the daily tier kept *every* backup in the
+ *                window, which let hourly backups pile up unbounded and fill the
+ *                disk — see HFT-163 / paperclip ENOSPC reports.)
+ * - Weekly tier: keep the NEWEST backup per calendar week for `weeklyWeeks` weeks.
+ * - Monthly tier: keep the NEWEST backup per calendar month for `monthlyMonths` months.
+ * - Everything else is deleted.
+ *
+ * Exported for unit testing; callers in this module remain the only production
+ * users. Pass a `clock` (returning ms since epoch) to make pruning deterministic
+ * in tests.
  */
-function pruneOldBackups(backupDir: string, retention: BackupRetentionPolicy, filenamePrefix: string): number {
-  if (!existsSync(backupDir)) return 0;
+export function pruneOldBackups(
+  backupDir: string,
+  retention: BackupRetentionPolicy,
+  filenamePrefix: string,
+  clock: ListBackupsClock = Date.now,
+): BackupPruneResult {
+  if (!existsSync(backupDir)) return { kept: 0, pruned: 0 };
 
-  const now = Date.now();
+  const now = clock();
+  const hourlyHours = Math.max(0, retention.hourlyHours ?? DEFAULT_HOURLY_HOURS);
+  const hourlyCutoff = now - hourlyHours * 60 * 60 * 1000;
   const dailyCutoff = now - Math.max(1, retention.dailyDays) * 24 * 60 * 60 * 1000;
   const weeklyCutoff = now - Math.max(1, retention.weeklyWeeks) * 7 * 24 * 60 * 60 * 1000;
   const monthlyCutoff = now - Math.max(1, retention.monthlyMonths) * 30 * 24 * 60 * 60 * 1000;
@@ -133,50 +167,73 @@ function pruneOldBackups(backupDir: string, retention: BackupRetentionPolicy, fi
     entries.push({ name, fullPath, mtimeMs: stat.mtimeMs });
   }
 
-  // Sort newest first so the first entry per week/month bucket is the one we keep
+  // Sort newest first so the first entry per day/week/month bucket is the one we keep
   entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
 
+  const keepDayBuckets = new Set<string>();
   const keepWeekBuckets = new Set<string>();
   const keepMonthBuckets = new Set<string>();
   const toDelete: string[] = [];
+  let keptCount = 0;
 
   for (const entry of entries) {
-    // Daily tier — keep everything within dailyDays
-    if (entry.mtimeMs >= dailyCutoff) continue;
-
     const date = new Date(entry.mtimeMs);
-    const week = isoWeekKey(date);
-    const month = monthKey(date);
 
-    // Weekly tier — keep newest per calendar week
+    // Hourly tier — keep ALL backups within the last `hourlyHours` hours.
+    if (entry.mtimeMs >= hourlyCutoff) {
+      keptCount += 1;
+      continue;
+    }
+
+    // Daily tier — keep the NEWEST backup per calendar day within `dailyDays`.
+    if (entry.mtimeMs >= dailyCutoff) {
+      const day = dayKey(date);
+      if (keepDayBuckets.has(day)) {
+        toDelete.push(entry.fullPath);
+      } else {
+        keepDayBuckets.add(day);
+        keptCount += 1;
+      }
+      continue;
+    }
+
+    // Weekly tier — keep the NEWEST backup per calendar week.
     if (entry.mtimeMs >= weeklyCutoff) {
+      const week = isoWeekKey(date);
       if (keepWeekBuckets.has(week)) {
         toDelete.push(entry.fullPath);
       } else {
         keepWeekBuckets.add(week);
+        keptCount += 1;
       }
       continue;
     }
 
-    // Monthly tier — keep newest per calendar month
+    // Monthly tier — keep the NEWEST backup per calendar month.
     if (entry.mtimeMs >= monthlyCutoff) {
+      const month = monthKey(date);
       if (keepMonthBuckets.has(month)) {
         toDelete.push(entry.fullPath);
       } else {
         keepMonthBuckets.add(month);
+        keptCount += 1;
       }
       continue;
     }
 
-    // Beyond all retention tiers — delete
+    // Beyond all retention tiers — delete.
     toDelete.push(entry.fullPath);
   }
 
   for (const filePath of toDelete) {
-    unlinkSync(filePath);
+    try {
+      unlinkSync(filePath);
+    } catch {
+      // Best-effort prune; surface via keptCount/prunedCount delta to the caller log.
+    }
   }
 
-  return toDelete.length;
+  return { kept: keptCount, pruned: toDelete.length };
 }
 
 function formatBackupSize(sizeBytes: number): string {
@@ -416,7 +473,10 @@ export function createBufferedTextFileWriter(filePath: string, maxBufferedBytes 
   let bufferedBytes = 0;
   let firstChunk = true;
   let closed = false;
-  let pendingWrite = Promise.resolve();
+  // Funnel any openFile rejection (e.g. ENOSPC, EACCES at open time) into the
+  // pendingWrite chain so it surfaces via drain/close/writeRaw/abort rather
+  // than escaping as an unhandledRejection that kills the host process.
+  let pendingWrite: Promise<void> = filePromise.then(() => undefined);
 
   const writeChunk = async (chunk: string | Buffer): Promise<void> => {
     const file = await filePromise;
@@ -523,11 +583,12 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
         });
         await writer.abort();
         const sizeBytes = statSync(backupFile).size;
-        const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
+        const prune = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
         return {
           backupFile,
           sizeBytes,
-          prunedCount,
+          prunedCount: prune.pruned,
+          keptCount: prune.kept,
         };
       } catch (error) {
         if (existsSync(backupFile)) {
@@ -934,12 +995,13 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
     unlinkSync(sqlFile);
 
     const sizeBytes = statSync(backupFile).size;
-    const prunedCount = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
+    const prune = pruneOldBackups(opts.backupDir, retention, filenamePrefix);
 
     return {
       backupFile,
       sizeBytes,
-      prunedCount,
+      prunedCount: prune.pruned,
+      keptCount: prune.kept,
     };
   } catch (error) {
     await writer.abort();

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -225,15 +225,18 @@ export function pruneOldBackups(
     toDelete.push(entry.fullPath);
   }
 
+  let prunedCount = 0;
   for (const filePath of toDelete) {
     try {
       unlinkSync(filePath);
+      prunedCount += 1;
     } catch {
-      // Best-effort prune; surface via keptCount/prunedCount delta to the caller log.
+      // Best-effort prune; failures are not counted so kept+pruned reflect
+      // ground truth rather than scheduled intent.
     }
   }
 
-  return { kept: keptCount, pruned: toDelete.length };
+  return { kept: keptCount, pruned: prunedCount };
 }
 
 function formatBackupSize(sizeBytes: number): string {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -580,8 +580,11 @@ export async function startServer(): Promise<StartedServer> {
       // skip silently; manual runs surface a 409 so the operator sees the cause.
       let freeBytes: number | null = null;
       try {
-        const fsStats = await statfs(config.databaseBackupDir);
-        freeBytes = Number(fsStats.bavail) * Number(fsStats.bsize);
+        const fsStats = await statfs(config.databaseBackupDir, { bigint: true });
+        const availableBytes = fsStats.bavail * fsStats.bsize;
+        freeBytes = availableBytes > BigInt(Number.MAX_SAFE_INTEGER)
+          ? Number.MAX_SAFE_INTEGER
+          : Number(availableBytes);
       } catch (statErr) {
         // statfs not supported or path missing — log and continue. The backup
         // itself still has its own error handling for filesystem failures.
@@ -596,6 +599,7 @@ export async function startServer(): Promise<StartedServer> {
       if (
         freeBytes !== null &&
         Number.isFinite(freeBytes) &&
+        freeBytes > 0 &&
         freeBytes < DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES
       ) {
         logger.error(

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,6 @@
 /// <reference path="./types/express.d.ts" />
 import { existsSync, readFileSync, rmSync } from "node:fs";
+import { statfs } from "node:fs/promises";
 import { createServer } from "node:http";
 import { resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
@@ -65,6 +66,22 @@ type EmbeddedPostgresInstance = {
   start(): Promise<void>;
   stop(): Promise<void>;
 };
+
+/**
+ * Minimum free space required on the backup filesystem before a scheduled
+ * backup is allowed to begin writing. Sized generously above typical Paperclip
+ * backup sizes (low tens of MB) so a half-written dump can't tip the host
+ * filesystem into ENOSPC and cascade into an unhandled rejection. Configurable
+ * via PAPERCLIP_DB_BACKUP_FREE_SPACE_THRESHOLD_BYTES for hosts with tight disks.
+ */
+const DEFAULT_DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES = 500 * 1024 * 1024;
+const DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES = (() => {
+  const raw = process.env.PAPERCLIP_DB_BACKUP_FREE_SPACE_THRESHOLD_BYTES;
+  if (!raw) return DEFAULT_DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES;
+  return Math.trunc(parsed);
+})();
 
 type EmbeddedPostgresCtor = new (opts: {
   databaseDir: string;
@@ -556,6 +573,38 @@ export async function startServer(): Promise<StartedServer> {
       const generalSettings = await backupSettingsSvc.getGeneral();
       const retention = generalSettings.backupRetention;
 
+      // Top-of-loop free-space guard: refuse to start a backup write if the target
+      // filesystem is below the safety threshold. Skipping the write is preferable
+      // to triggering ENOSPC mid-stream, which previously surfaced as an unhandled
+      // rejection that could terminate the server process. Scheduled backups
+      // skip silently; manual runs surface a 409 so the operator sees the cause.
+      try {
+        const fsStats = await statfs(config.databaseBackupDir);
+        const freeBytes = Number(fsStats.bavail) * Number(fsStats.bsize);
+        if (Number.isFinite(freeBytes) && freeBytes < DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES) {
+          logger.error(
+            {
+              freeBytes,
+              thresholdBytes: DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES,
+              backupDir: config.databaseBackupDir,
+              trigger,
+            },
+            `${label} database backup skipped: free disk below safety threshold`,
+          );
+          if (trigger === "scheduled") {
+            return null;
+          }
+          throw conflict("Database backup skipped: free disk below safety threshold");
+        }
+      } catch (statErr) {
+        // statfs not supported or path missing — log and continue. The backup
+        // itself still has its own error handling for filesystem failures.
+        logger.warn(
+          { err: statErr, backupDir: config.databaseBackupDir },
+          "Could not stat backup filesystem; proceeding without free-space precheck",
+        );
+      }
+
       const result = await runDatabaseBackup({
         connectionString: activeDatabaseConnectionString,
         backupDir: config.databaseBackupDir,
@@ -577,6 +626,7 @@ export async function startServer(): Promise<StartedServer> {
           backupFile: result.backupFile,
           sizeBytes: result.sizeBytes,
           prunedCount: result.prunedCount,
+          keptCount: result.keptCount,
           backupDir: config.databaseBackupDir,
           retention,
           trigger,

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -578,24 +578,10 @@ export async function startServer(): Promise<StartedServer> {
       // to triggering ENOSPC mid-stream, which previously surfaced as an unhandled
       // rejection that could terminate the server process. Scheduled backups
       // skip silently; manual runs surface a 409 so the operator sees the cause.
+      let freeBytes: number | null = null;
       try {
         const fsStats = await statfs(config.databaseBackupDir);
-        const freeBytes = Number(fsStats.bavail) * Number(fsStats.bsize);
-        if (Number.isFinite(freeBytes) && freeBytes < DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES) {
-          logger.error(
-            {
-              freeBytes,
-              thresholdBytes: DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES,
-              backupDir: config.databaseBackupDir,
-              trigger,
-            },
-            `${label} database backup skipped: free disk below safety threshold`,
-          );
-          if (trigger === "scheduled") {
-            return null;
-          }
-          throw conflict("Database backup skipped: free disk below safety threshold");
-        }
+        freeBytes = Number(fsStats.bavail) * Number(fsStats.bsize);
       } catch (statErr) {
         // statfs not supported or path missing — log and continue. The backup
         // itself still has its own error handling for filesystem failures.
@@ -603,6 +589,28 @@ export async function startServer(): Promise<StartedServer> {
           { err: statErr, backupDir: config.databaseBackupDir },
           "Could not stat backup filesystem; proceeding without free-space precheck",
         );
+      }
+      // Threshold compare lives outside the statfs try/catch so a manual-trigger
+      // conflict() throw is NOT swallowed by `catch (statErr)`; review found this
+      // silently defeated the 409 path on a full disk.
+      if (
+        freeBytes !== null &&
+        Number.isFinite(freeBytes) &&
+        freeBytes < DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES
+      ) {
+        logger.error(
+          {
+            freeBytes,
+            thresholdBytes: DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES,
+            backupDir: config.databaseBackupDir,
+            trigger,
+          },
+          `${label} database backup skipped: free disk below safety threshold`,
+        );
+        if (trigger === "scheduled") {
+          return null;
+        }
+        throw conflict("Database backup skipped: free disk below safety threshold");
       }
 
       const result = await runDatabaseBackup({


### PR DESCRIPTION
## Summary

The scheduled-backup daily retention tier kept *every* backup within the
`dailyDays` window with no per-day coalescing. With the default hourly cadence
that means up to `dailyDays * 24` files accumulate before the weekly tier
sees anything. We observed this in the wild as a 164-file, ~1.8 GB
`paperclip-*.sql.gz` heap that filled the data volume and tripped `ENOSPC`
mid-backup, surfacing as an unhandled rejection that took the server down.

This PR ships three coordinated changes as a single coherent fix.

### 1. `packages/db/src/backup-lib.ts`
- New optional `hourlyHours` tier (default `24`): every backup inside the
  hourly window is retained for fast recovery.
- Daily tier now coalesces to the newest backup **per calendar day**, so
  hourly schedules no longer pile up unbounded.
- `pruneOldBackups` returns `{ kept, pruned }` and is exported for unit tests.
- `RunDatabaseBackupResult` gains `keptCount` alongside `prunedCount`.
- `createBufferedTextFileWriter` funnels the `openFile()` promise into the
  `pendingWrite` chain so an ENOSPC at open time surfaces via
  `drain` / `close` rather than escaping as an unhandled rejection.

### 2. `server/src/index.ts`
- Top-of-loop `statfs` precheck refuses a scheduled backup when free space
  drops below `DATABASE_BACKUP_FREE_SPACE_THRESHOLD_BYTES` (default 500 MB,
  overridable via `PAPERCLIP_DB_BACKUP_FREE_SPACE_THRESHOLD_BYTES`). The
  scheduled trigger logs and returns `null`; the manual trigger surfaces 409.
- Completion log line now includes `keptCount` so operators can see the tier
  outcome of each run at a glance.

### 3. `packages/db/src/backup-lib.test.ts`
Five new unit tests covering:
- 168-file hourly fixture → fix collapses to ~24–32 kept, 132–144 pruned
- Hourly window untouched when all files are < 24h old
- Default `hourlyHours` fallback when retention omits the field (forward
  compat with the existing shared `BackupRetentionPolicy` shape)
- Prefix filtering (unrelated files left alone)
- `createBufferedTextFileWriter` surfaces \`openFile\` rejections via \`drain\`

### Dry-run against the affected directory

\`\`\`
Backup dir: /…/instances/default/data/backups/
Files found: 164
Retention:   {\"dailyDays\":7,\"weeklyWeeks\":4,\"monthlyMonths\":1,\"hourlyHours\":24}

== master (pre-fix) ==
  total=164  kept=163  deleted=1
  kept_size_MB=1797.7  deleted_size_MB=2.0

== this PR ==
  total=164  kept=32   deleted=132
  kept_size_MB=429.9   deleted_size_MB=1369.7
\`\`\`

## Test plan

- [x] \`pnpm --filter @paperclipai/db exec vitest run src/backup-lib.test.ts\` — 9 tests pass (5 new + 4 pre-existing)
- [x] \`pnpm --filter @paperclipai/server exec vitest run src/__tests__/instance-database-backups-routes.test.ts\` — 5 tests pass; \`keptCount\` flows through the manual-backup route untouched.
- [x] \`pnpm --filter @paperclipai/server exec vitest run src/__tests__/server-startup-feedback-export.test.ts\` — 6 tests pass.
- [x] \`pnpm --filter @paperclipai/db typecheck\`
- [x] \`pnpm --filter @paperclipai/server typecheck\`

## Compatibility notes

- \`BackupRetentionPolicy\` in \`@paperclipai/db\` adds an **optional** field; callers that pass the existing shared shape (no \`hourlyHours\`) keep working and get the 24-hour default.
- \`RunDatabaseBackupResult\` adds \`keptCount\` (additive); existing consumers (\`cli/src/commands/db-backup.ts\`, route handlers) continue to compile and run unchanged.