### PR TITLE
Add api_retry-aware watchdog (AUR-33)

### DIFF
--- a/doc/RUNBOOK-watchdog.md
+++ b/doc/RUNBOOK-watchdog.md
@@ -1,0 +1,150 @@
+# Watchdog runbook — silent-run detection, retry-stall auto-recovery, cascade guard
+
+This runbook covers the api_retry-aware silent-run watchdog landed in AUR-33
+(implementation issue AUR-57). It complements the AUR-35 family
+(idempotency dedup, kill helper, source-issue wake) which provides the
+underlying primitives.
+
+## What the watchdog does
+
+There are now **three** detectors that read state written by the heartbeat
+runtime and may act on a long-running heartbeat run:
+
+| Detector                    | Threshold (default)                                                                                | Action on fire                                                                                                            |
+| --------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Silent-output (suspicious)  | `lastLivenessAt` ≥ 1h ago                                                                          | Create a `stale_active_run_evaluation` review issue assigned to the run owner.                                            |
+| Silent-output (critical)    | `lastLivenessAt` ≥ 4h ago                                                                          | Escalate the existing review issue, block the source issue.                                                               |
+| Retry-stall (api_retry)     | `lastRetryAttempt ≥ 3` **and** `retryStallStartedAt ≥ 5m` without an intervening non-retry event   | `killProcessGroup(pgid)` → mark run `failed` with `errorCode=runtime_api_retry_exhausted` → emit one `runtime_api_retry_exhausted` review issue. |
+
+All three detectors share a **single hard cascade guard** at the review-issue
+emission entry point. The guard short-circuits unconditionally when the source
+run's source issue has `originKind ∈ {stale_active_run_evaluation,
+runtime_api_retry_exhausted}` (i.e. the source issue was itself created by
+the watchdog) and emits a structured `cascade_suppressed` log line instead.
+This is the depth-cap that prevents an outage-driven cascade where a review
+issue spawns its own review issue.
+
+## Why `lastLivenessAt` exists separately from `lastOutputAt`
+
+The Claude CLI writes nothing to stdout while it is internally retrying
+transient upstream Anthropic API failures. It does emit
+`{"type":"system","subtype":"api_retry","attempt":N,...}` events on the
+run-log stream during each retry. AUR-33 parses those events in
+`server/src/services/recovery/api-retry-parser.ts`. When the chunk contains
+only api_retry events, the heartbeat runtime updates `lastLivenessAt` only;
+when the chunk contains real progress, it updates both `lastLivenessAt` and
+`lastOutputAt`. The silent-output thresholds evaluate against
+`lastLivenessAt`, so an actively-retrying CLI is no longer mis-classified as
+silent. `lastOutputAt` remains available for diagnostics and is still
+displayed on the evaluation issues.
+
+## What `runtime_api_retry_exhausted` means vs. `stale_active_run_evaluation`
+
+- **`stale_active_run_evaluation`** — the silent-output detector fired. The
+  CLI has been quiet (no liveness signal, including no api_retry events) for
+  ≥ 1h (suspicious) or ≥ 4h (critical). The run is still alive at the OS
+  level; a human or assigned recovery owner must decide whether to continue,
+  snooze, or cancel.
+- **`runtime_api_retry_exhausted`** — the retry-stall detector fired. The CLI
+  is alive and emitting api_retry events, but it has been stuck at
+  `attempt ≥ PAPERCLIP_WATCHDOG_RETRY_STALL_ATTEMPT` for longer than
+  `PAPERCLIP_WATCHDOG_RETRY_STALL_BUDGET_SEC` with no intervening real
+  output. The watchdog has already attempted SIGTERM → SIGKILL on the
+  process group and marked the run terminal (`status=failed`,
+  `errorCode=runtime_api_retry_exhausted`). The review issue is informational
+  — no recovery action is required if the source issue can simply be
+  requeued once the upstream API outage clears.
+
+## What `cascade_suppressed` log lines mean
+
+Look for log entries of shape:
+
+```json
+{
+  "event": "cascade_suppressed",
+  "runId": "...",
+  "sourceIssueId": "...",
+  "sourceOriginKind": "stale_active_run_evaluation" | "runtime_api_retry_exhausted",
+  "thresholdLevel": "suspicious" | "critical" | "retry_stall"
+}
+```
+
+These mean: the watchdog wanted to open a review issue for `runId`, but the
+source run's source issue was itself a watchdog-emitted recovery issue. The
+guard suppressed the emission so we do not stack a second layer of review
+work on top of an active outage. **No review issue was created.** If the
+underlying outage is real you will still see one review issue at the bottom
+of the chain (the one that triggered the first cascade); the cascade just
+does not deepen past that.
+
+## Manual recovery
+
+1. Identify the affected run via the review issue's `Run` link.
+2. If the CLI process is still alive (silent-output detectors only), decide
+   whether to `recordWatchdogDecision({decision: "continue"})` or cancel the
+   run via the existing cancel-run controls.
+3. If the run is already terminal (`runtime_api_retry_exhausted`), confirm the
+   upstream API has recovered, then requeue the source issue's heartbeat
+   (assignment wake, or create a fresh heartbeat run on the source issue).
+4. Close the review issue with a brief note (`done` if the source issue has
+   resumed, `cancelled` if the source issue was abandoned).
+
+## Rollback
+
+Toggle the master flag off to revert all three behaviours simultaneously:
+
+```bash
+PAPERCLIP_WATCHDOG_API_RETRY_AWARE=false
+```
+
+With the flag off:
+
+- The api_retry parser stops writing `lastLivenessAt`; silent-output
+  detectors fall back to `lastOutputAt` (legacy behaviour, bit-equivalent).
+- The retry-stall detector becomes a no-op.
+- The hard cascade guard becomes a no-op.
+
+No schema migration is required to roll back. The new columns (`last_liveness_at`,
+`last_retry_attempt`, `last_retry_error_status`, `last_retry_error_message`,
+`retry_stall_started_at`) and the partial unique index
+`issues_active_runtime_api_retry_exhausted_uq` can stay in place; they are
+inert when the flag is off.
+
+## Configuration reference
+
+All env vars are read at scan time so changes take effect on the next
+heartbeat tick — no restart required.
+
+| Env var                                       | Default       | Purpose                                                                              |
+| --------------------------------------------- | ------------- | ------------------------------------------------------------------------------------ |
+| `PAPERCLIP_WATCHDOG_API_RETRY_AWARE`          | `true`        | Master kill switch for AUR-33 behaviour.                                              |
+| `PAPERCLIP_WATCHDOG_AUTO_RECOVER`             | `true`        | When `false`, retry-stall detector still emits the review issue but does not signal. |
+| `PAPERCLIP_WATCHDOG_RETRY_STALL_ATTEMPT`      | `3`           | Minimum `attempt` value at which the retry-stall budget clock starts.                |
+| `PAPERCLIP_WATCHDOG_RETRY_STALL_BUDGET_SEC`   | `300`         | Seconds the run may sit at `attempt ≥ threshold` before the detector fires.          |
+| `PAPERCLIP_WATCHDOG_KILL_GRACE_MS`            | `10_000`      | Wait between SIGTERM and SIGKILL when terminating a stalled retry loop.              |
+
+## False-positive playbook
+
+Per the AUR-35 CEO directive, **any false-positive kill is treated as P1**.
+If you see a `runtime_api_retry_exhausted` review issue and the run was in
+fact making progress:
+
+1. Page the platform on-call.
+2. Capture the full run log (`run.logRef`) before any further action.
+3. Bump `PAPERCLIP_WATCHDOG_RETRY_STALL_ATTEMPT` and/or
+   `PAPERCLIP_WATCHDOG_RETRY_STALL_BUDGET_SEC` upward as a tactical mitigation.
+4. File a follow-up issue with the captured log so the parser/detector
+   thresholds can be tuned with evidence.
+
+## Compose with the AUR-35 family
+
+- AUR-37 — owns the `idempotencyKey` column. Until it lands, the AUR-33
+  retry-stall detector stores its idempotency key in `originFingerprint` and
+  is also protected by the partial unique index
+  `issues_active_runtime_api_retry_exhausted_uq`.
+- AUR-41 — owns the `process_auto_recovered` source-issue wake. The
+  AUR-33 hard cascade guard sits one layer above and prevents the
+  review-issue creation path from ever recursing.
+- AUR-42 — owns the production `killProcessGroup` helper. AUR-33 ships with
+  a minimal inline version in `server/src/services/recovery/kill-process-group.ts`
+  so the retry-stall detector is usable today; AUR-42 will replace it.

--- a/packages/db/src/migrations/0084_active_run_liveness_retry_stall.sql
+++ b/packages/db/src/migrations/0084_active_run_liveness_retry_stall.sql
@@ -1,0 +1,22 @@
+ALTER TABLE "heartbeat_runs" ADD COLUMN IF NOT EXISTS "last_liveness_at" timestamp with time zone;
+--> statement-breakpoint
+ALTER TABLE "heartbeat_runs" ADD COLUMN IF NOT EXISTS "last_retry_attempt" integer;
+--> statement-breakpoint
+ALTER TABLE "heartbeat_runs" ADD COLUMN IF NOT EXISTS "last_retry_error_status" text;
+--> statement-breakpoint
+ALTER TABLE "heartbeat_runs" ADD COLUMN IF NOT EXISTS "last_retry_error_message" text;
+--> statement-breakpoint
+ALTER TABLE "heartbeat_runs" ADD COLUMN IF NOT EXISTS "retry_stall_started_at" timestamp with time zone;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "heartbeat_runs_company_status_last_liveness_idx"
+  ON "heartbeat_runs" USING btree ("company_id","status","last_liveness_at");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "heartbeat_runs_company_status_retry_stall_idx"
+  ON "heartbeat_runs" USING btree ("company_id","status","retry_stall_started_at");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "issues_active_runtime_api_retry_exhausted_uq"
+  ON "issues" USING btree ("company_id","origin_kind","origin_id")
+  WHERE "origin_kind" = 'runtime_api_retry_exhausted'
+    AND "origin_id" IS NOT NULL
+    AND "hidden_at" IS NULL
+    AND "status" NOT IN ('done', 'cancelled');

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1778074536410,
       "tag": "0083_company_secret_provider_configs",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1778074800000,
+      "tag": "0084_active_run_liveness_retry_stall",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/heartbeat_runs.ts
+++ b/packages/db/src/schema/heartbeat_runs.ts
@@ -38,6 +38,11 @@ export const heartbeatRuns = pgTable(
     lastOutputSeq: integer("last_output_seq").notNull().default(0),
     lastOutputStream: text("last_output_stream"),
     lastOutputBytes: bigint("last_output_bytes", { mode: "number" }),
+    lastLivenessAt: timestamp("last_liveness_at", { withTimezone: true }),
+    lastRetryAttempt: integer("last_retry_attempt"),
+    lastRetryErrorStatus: text("last_retry_error_status"),
+    lastRetryErrorMessage: text("last_retry_error_message"),
+    retryStallStartedAt: timestamp("retry_stall_started_at", { withTimezone: true }),
     retryOfRunId: uuid("retry_of_run_id").references((): AnyPgColumn => heartbeatRuns.id, {
       onDelete: "set null",
     }),
@@ -77,6 +82,16 @@ export const heartbeatRuns = pgTable(
       table.companyId,
       table.status,
       table.processStartedAt,
+    ),
+    companyStatusLastLivenessIdx: index("heartbeat_runs_company_status_last_liveness_idx").on(
+      table.companyId,
+      table.status,
+      table.lastLivenessAt,
+    ),
+    companyStatusRetryStallIdx: index("heartbeat_runs_company_status_retry_stall_idx").on(
+      table.companyId,
+      table.status,
+      table.retryStallStartedAt,
     ),
   }),
 );

--- a/server/src/__tests__/api-retry-parser.test.ts
+++ b/server/src/__tests__/api-retry-parser.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { parseRunLogChunkForLiveness } from "../services/recovery/api-retry-parser.ts";
+
+describe("api-retry parser", () => {
+  it("treats a pure api_retry chunk as liveness-only", () => {
+    const chunk = `${JSON.stringify({ type: "system", subtype: "api_retry", attempt: 2, error_status: "529", error: "Overloaded" })}\n`;
+    const parsed = parseRunLogChunkForLiveness(chunk);
+    expect(parsed.hasApiRetry).toBe(true);
+    expect(parsed.hasNonRetryContent).toBe(false);
+    expect(parsed.latestRetry).toEqual({ attempt: 2, errorStatus: "529", errorMessage: "Overloaded" });
+  });
+
+  it("captures the latest attempt when multiple api_retry events are batched", () => {
+    const chunk = [
+      JSON.stringify({ type: "system", subtype: "api_retry", attempt: 1, error_status: "529" }),
+      JSON.stringify({ type: "system", subtype: "api_retry", attempt: 4, error_status: "529", error: "Overloaded" }),
+    ].join("\n");
+    const parsed = parseRunLogChunkForLiveness(chunk);
+    expect(parsed.hasApiRetry).toBe(true);
+    expect(parsed.hasNonRetryContent).toBe(false);
+    expect(parsed.latestRetry).toEqual({ attempt: 4, errorStatus: "529", errorMessage: "Overloaded" });
+  });
+
+  it("flags non-retry content even when api_retry events are interleaved", () => {
+    const chunk = [
+      JSON.stringify({ type: "system", subtype: "api_retry", attempt: 1 }),
+      "tool: writing file",
+      JSON.stringify({ type: "system", subtype: "api_retry", attempt: 2 }),
+    ].join("\n");
+    const parsed = parseRunLogChunkForLiveness(chunk);
+    expect(parsed.hasApiRetry).toBe(true);
+    expect(parsed.hasNonRetryContent).toBe(true);
+    expect(parsed.latestRetry?.attempt).toBe(2);
+  });
+
+  it("treats other system events as non-retry content", () => {
+    const chunk = `${JSON.stringify({ type: "system", subtype: "init" })}\n`;
+    const parsed = parseRunLogChunkForLiveness(chunk);
+    expect(parsed.hasApiRetry).toBe(false);
+    expect(parsed.hasNonRetryContent).toBe(true);
+    expect(parsed.latestRetry).toBeNull();
+  });
+
+  it("treats unparseable content as non-retry liveness", () => {
+    const chunk = `tool: running build\nstep complete\n`;
+    const parsed = parseRunLogChunkForLiveness(chunk);
+    expect(parsed.hasApiRetry).toBe(false);
+    expect(parsed.hasNonRetryContent).toBe(true);
+  });
+
+  it("handles empty chunks safely", () => {
+    expect(parseRunLogChunkForLiveness("")).toEqual({
+      hasApiRetry: false,
+      hasNonRetryContent: false,
+      latestRetry: null,
+    });
+    expect(parseRunLogChunkForLiveness("\n\n  \n")).toEqual({
+      hasApiRetry: false,
+      hasNonRetryContent: false,
+      latestRetry: null,
+    });
+  });
+});

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -547,4 +547,178 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     });
     expect(decision.createdByRunId).toBe(managerRunId);
   });
+
+  // ---------------------------------------------------------------------
+  // AUR-33: api_retry-aware liveness, retry-stall detector, cascade guard
+  // ---------------------------------------------------------------------
+
+  it("does not classify a retry-active run as silent when lastLivenessAt is fresh", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    // stdout has been stale beyond the suspicion threshold, but api_retry
+    // events have kept lastLivenessAt within the last 5 minutes. The
+    // watchdog must treat the run as healthy.
+    await db
+      .update(heartbeatRuns)
+      .set({ lastLivenessAt: new Date(now.getTime() - 5 * 60 * 1000) })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+    const scan = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(scan).toMatchObject({ scanned: 0, created: 0 });
+  });
+
+  it("falls back to lastOutputAt when PAPERCLIP_WATCHDOG_API_RETRY_AWARE=false", async () => {
+    const prev = process.env.PAPERCLIP_WATCHDOG_API_RETRY_AWARE;
+    process.env.PAPERCLIP_WATCHDOG_API_RETRY_AWARE = "false";
+    try {
+      const now = new Date("2026-04-22T20:00:00.000Z");
+      const { companyId, runId } = await seedRunningRun({
+        now,
+        ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      });
+      await db
+        .update(heartbeatRuns)
+        .set({ lastLivenessAt: new Date(now.getTime() - 5 * 60 * 1000) })
+        .where(eq(heartbeatRuns.id, runId));
+      const heartbeat = heartbeatService(db);
+      const scan = await heartbeat.scanSilentActiveRuns({ now, companyId });
+      // Flag off ⇒ liveness clock ignored ⇒ legacy behaviour creates the
+      // suspicious evaluation just like the original stdout-only watchdog.
+      expect(scan.created).toBe(1);
+    } finally {
+      if (prev === undefined) delete process.env.PAPERCLIP_WATCHDOG_API_RETRY_AWARE;
+      else process.env.PAPERCLIP_WATCHDOG_API_RETRY_AWARE = prev;
+    }
+  });
+
+  it("hard cascade guard suppresses emission when source issue is itself watchdog-emitted", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+    });
+    // Promote the source issue itself to a watchdog-emitted origin. This is
+    // the synthetic cascade scenario: a CLI started to "review a silent
+    // run" goes silent in turn — depth-cap MUST kick in.
+    await db
+      .update(issues)
+      .set({ originKind: "stale_active_run_evaluation" })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+    const scan = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(scan.cascadeSuppressed).toBe(1);
+    expect(scan.created).toBe(0);
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation"), eq(issues.originId, runId)));
+    expect(evaluations).toHaveLength(0);
+  });
+
+  it("hard cascade guard suppresses retry-stall emission for watchdog-emitted source issues too", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId, runId } = await seedRunningRun({
+      now,
+      ageMs: 30 * 60 * 1000,
+    });
+    await db
+      .update(issues)
+      .set({ originKind: "runtime_api_retry_exhausted" })
+      .where(eq(issues.id, issueId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        lastLivenessAt: new Date(now.getTime() - 2 * 60 * 1000),
+        retryStallStartedAt: new Date(now.getTime() - 10 * 60 * 1000),
+        lastRetryAttempt: 5,
+        lastRetryErrorStatus: "529",
+        lastRetryErrorMessage: "Overloaded",
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+    const scan = await heartbeat.scanRetryStalledRuns({ now, companyId });
+    expect(scan.cascadeSuppressed).toBe(1);
+    expect(scan.terminated).toBe(0);
+  });
+
+  it("retry-stall detector fires only after both attempt and budget thresholds are crossed", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: 30 * 60 * 1000,
+    });
+    // attempt below threshold ⇒ no fire
+    await db
+      .update(heartbeatRuns)
+      .set({
+        lastLivenessAt: new Date(now.getTime() - 2 * 60 * 1000),
+        retryStallStartedAt: new Date(now.getTime() - 10 * 60 * 1000),
+        lastRetryAttempt: 1,
+        lastRetryErrorStatus: "529",
+        lastRetryErrorMessage: "Overloaded",
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const heartbeat = heartbeatService(db);
+    expect(await heartbeat.scanRetryStalledRuns({ now, companyId })).toMatchObject({ scanned: 0, terminated: 0 });
+
+    // budget elapsed (≥300s default) AND attempt ≥ threshold (default 3)
+    await db
+      .update(heartbeatRuns)
+      .set({
+        lastRetryAttempt: 3,
+        retryStallStartedAt: new Date(now.getTime() - 6 * 60 * 1000),
+      })
+      .where(eq(heartbeatRuns.id, runId));
+    const fired = await heartbeat.scanRetryStalledRuns({ now, companyId });
+    expect(fired.scanned).toBe(1);
+    // The run had no real PID/PGID seeded, so killProcessGroup returns
+    // `{ skipped: "no_pid" }`. The detector still creates the review issue
+    // and marks the run terminal — that is the contract.
+    expect(fired.terminated + fired.existing).toBe(1);
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("runtime_api_retry_exhausted");
+    const [review] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "runtime_api_retry_exhausted"), eq(issues.originId, runId)));
+    expect(review).toBeTruthy();
+    expect(review?.originFingerprint).toBe(`runtime_api_retry_exhausted:${companyId}:${runId}`);
+  });
+
+  it("retry-stall detector no-ops when PAPERCLIP_WATCHDOG_API_RETRY_AWARE=false", async () => {
+    const prev = process.env.PAPERCLIP_WATCHDOG_API_RETRY_AWARE;
+    process.env.PAPERCLIP_WATCHDOG_API_RETRY_AWARE = "false";
+    try {
+      const now = new Date("2026-04-22T20:00:00.000Z");
+      const { companyId, runId } = await seedRunningRun({
+        now,
+        ageMs: 30 * 60 * 1000,
+      });
+      await db
+        .update(heartbeatRuns)
+        .set({
+          lastLivenessAt: new Date(now.getTime() - 2 * 60 * 1000),
+          retryStallStartedAt: new Date(now.getTime() - 10 * 60 * 1000),
+          lastRetryAttempt: 5,
+        })
+        .where(eq(heartbeatRuns.id, runId));
+      const heartbeat = heartbeatService(db);
+      const scan = await heartbeat.scanRetryStalledRuns({ now, companyId });
+      expect(scan).toEqual({
+        scanned: 0,
+        terminated: 0,
+        existing: 0,
+        cascadeSuppressed: 0,
+        skipped: 0,
+        evaluationIssueIds: [],
+      });
+    } finally {
+      if (prev === undefined) delete process.env.PAPERCLIP_WATCHDOG_API_RETRY_AWARE;
+      else process.env.PAPERCLIP_WATCHDOG_API_RETRY_AWARE = prev;
+    }
+  });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -142,6 +142,8 @@ import {
   withRecoveryModelProfileHint,
 } from "./recovery/model-profile-hint.js";
 import { recoveryService } from "./recovery/service.js";
+import { parseRunLogChunkForLiveness } from "./recovery/api-retry-parser.js";
+import { getWatchdogConfig } from "./recovery/watchdog-config.js";
 import { productivityReviewService } from "./productivity-review.js";
 import { withAgentStartLock } from "./agent-start-lock.js";
 import {
@@ -6601,6 +6603,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.scanSilentActiveRuns(opts);
   }
 
+  async function scanRetryStalledRuns(opts?: { now?: Date; companyId?: string }) {
+    return recovery.scanRetryStalledRuns(opts);
+  }
+
   async function reconcileProductivityReviews(opts?: { now?: Date; companyId?: string }) {
     return productivityReviews.reconcileProductivityReviews(opts);
   }
@@ -7431,12 +7437,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     let stderrExcerpt = "";
     let outputSeq = Number(run.lastOutputSeq ?? 0);
     let lastOutputFlushAt: Date | null = run.lastOutputAt ?? null;
+    const watchdogConfigForRun = getWatchdogConfig();
+    const retryStallAttemptThreshold = watchdogConfigForRun.retryStallAttemptThreshold;
+    const livenessRetryState: {
+      lastObservedAttempt: number | null;
+      retryStallStartedAt: Date | null;
+      lastErrorStatus: string | null;
+      lastErrorMessage: string | null;
+    } = {
+      lastObservedAttempt: run.lastRetryAttempt ?? null,
+      retryStallStartedAt: run.retryStallStartedAt ?? null,
+      lastErrorStatus: run.lastRetryErrorStatus ?? null,
+      lastErrorMessage: run.lastRetryErrorMessage ?? null,
+    };
     const outputProgressState: {
       pending: {
       at: Date;
       seq: number;
       stream: "stdout" | "stderr";
       bytes: number;
+      hasNonRetryContent: boolean;
+      hasApiRetry: boolean;
+      livenessAt: Date;
+      retryStateChanged: boolean;
       } | null;
     } = { pending: null };
     let persistedLogBytes = Number(run.logBytes ?? 0);
@@ -7448,15 +7471,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         !lastOutputFlushAt ||
         pendingOutputProgress.at.getTime() - lastOutputFlushAt.getTime() >= ACTIVE_RUN_OUTPUT_PROGRESS_FLUSH_INTERVAL_MS;
       if (!shouldFlush) return;
+      const updates: Record<string, unknown> = {
+        updatedAt: new Date(),
+        lastLivenessAt: pendingOutputProgress.livenessAt,
+      };
+      // Only bump the "output" clocks when the chunk carried real, non-retry
+      // content. A chunk made only of api_retry events keeps lastOutputAt
+      // stale so diagnostics still show when the agent last emitted real
+      // progress, while lastLivenessAt above tells the watchdog the process
+      // is actively retrying.
+      if (pendingOutputProgress.hasNonRetryContent) {
+        updates.lastOutputAt = pendingOutputProgress.at;
+        updates.lastOutputSeq = pendingOutputProgress.seq;
+        updates.lastOutputStream = pendingOutputProgress.stream;
+        updates.lastOutputBytes = pendingOutputProgress.bytes;
+      }
+      if (pendingOutputProgress.retryStateChanged) {
+        updates.lastRetryAttempt = livenessRetryState.lastObservedAttempt;
+        updates.retryStallStartedAt = livenessRetryState.retryStallStartedAt;
+        updates.lastRetryErrorStatus = livenessRetryState.lastErrorStatus;
+        updates.lastRetryErrorMessage = livenessRetryState.lastErrorMessage;
+      }
       await db
         .update(heartbeatRuns)
-        .set({
-          lastOutputAt: pendingOutputProgress.at,
-          lastOutputSeq: pendingOutputProgress.seq,
-          lastOutputStream: pendingOutputProgress.stream,
-          lastOutputBytes: pendingOutputProgress.bytes,
-          updatedAt: new Date(),
-        })
+        .set(updates)
         .where(eq(heartbeatRuns.id, run.id));
       lastOutputFlushAt = pendingOutputProgress.at;
       outputProgressState.pending = null;
@@ -7537,11 +7575,41 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           persistedLogBytes += appendedBytes;
         }
         outputSeq += 1;
+
+        // api_retry liveness parsing. When the feature flag is on, we look for
+        // `{"type":"system","subtype":"api_retry"}` events on stdout and treat
+        // them as a separate liveness signal that does NOT count as productive
+        // output. Stderr and disabled-flag fall back to the legacy behaviour.
+        const parsed = watchdogConfigForRun.apiRetryAware && stream === "stdout"
+          ? parseRunLogChunkForLiveness(sanitizedChunk)
+          : { hasApiRetry: false, hasNonRetryContent: true, latestRetry: null };
+        const at = new Date(ts);
+        let retryStateChanged = false;
+        if (parsed.hasApiRetry && parsed.latestRetry) {
+          livenessRetryState.lastObservedAttempt = parsed.latestRetry.attempt;
+          livenessRetryState.lastErrorStatus = parsed.latestRetry.errorStatus;
+          livenessRetryState.lastErrorMessage = parsed.latestRetry.errorMessage;
+          if (parsed.latestRetry.attempt >= retryStallAttemptThreshold && !livenessRetryState.retryStallStartedAt) {
+            livenessRetryState.retryStallStartedAt = at;
+          }
+          retryStateChanged = true;
+        }
+        if (parsed.hasNonRetryContent && livenessRetryState.retryStallStartedAt) {
+          // Real progress interrupts a retry stall — reset the tracker so the
+          // budget detector starts fresh next time attempts climb again.
+          livenessRetryState.retryStallStartedAt = null;
+          livenessRetryState.lastObservedAttempt = null;
+          retryStateChanged = true;
+        }
         outputProgressState.pending = {
-          at: new Date(ts),
+          at,
           seq: outputSeq,
           stream,
           bytes: persistedLogBytes,
+          hasNonRetryContent: parsed.hasNonRetryContent,
+          hasApiRetry: parsed.hasApiRetry,
+          livenessAt: at,
+          retryStateChanged,
         };
         await flushOutputProgress();
 
@@ -9714,6 +9782,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     reconcileIssueGraphLiveness,
 
     scanSilentActiveRuns,
+
+    scanRetryStalledRuns,
 
     reconcileProductivityReviews,
 

--- a/server/src/services/recovery/api-retry-parser.ts
+++ b/server/src/services/recovery/api-retry-parser.ts
@@ -1,0 +1,88 @@
+// Parses Claude CLI run-log chunks to detect `api_retry` system events.
+//
+// The Claude CLI emits no stdout while it is internally retrying transient
+// Anthropic API failures and writes a `{"type":"system","subtype":"api_retry",
+// "attempt":N,"error_status":"...","error":"..."}` event on its run-log stream
+// for each attempt. The watchdog uses this signal to keep `lastLivenessAt`
+// fresh (so an actively-retrying run is not flagged as silent) and to feed
+// the retry-stall detector (so a genuinely wedged retry loop is auto-killed
+// before the 4h critical-silent threshold).
+
+export type ApiRetryEvent = {
+  attempt: number;
+  errorStatus: string | null;
+  errorMessage: string | null;
+};
+
+export type ParsedRunLogChunk = {
+  // true when at least one parseable api_retry event was observed in the chunk.
+  hasApiRetry: boolean;
+  // true when the chunk contained ANY non-api_retry, non-whitespace content.
+  // When false the chunk is treated as retry-only liveness (does not bump
+  // lastOutputAt) — when true the chunk is real progress and bumps both
+  // clocks and resets the retry-stall tracker.
+  hasNonRetryContent: boolean;
+  // The latest api_retry event seen in the chunk (for state updates).
+  latestRetry: ApiRetryEvent | null;
+};
+
+function tryParseJsonLine(line: string): Record<string, unknown> | null {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number") return String(value);
+  return null;
+}
+
+function isApiRetryEvent(obj: Record<string, unknown>): boolean {
+  return obj.type === "system" && obj.subtype === "api_retry";
+}
+
+export function parseRunLogChunkForLiveness(chunk: string): ParsedRunLogChunk {
+  const result: ParsedRunLogChunk = {
+    hasApiRetry: false,
+    hasNonRetryContent: false,
+    latestRetry: null,
+  };
+  if (!chunk) return result;
+  const lines = chunk.split(/\r?\n/);
+  for (const line of lines) {
+    if (line.length === 0) continue;
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    const parsed = tryParseJsonLine(line);
+    if (parsed && isApiRetryEvent(parsed)) {
+      result.hasApiRetry = true;
+      const attempt = asNumber(parsed.attempt);
+      result.latestRetry = {
+        attempt: attempt ?? result.latestRetry?.attempt ?? 1,
+        errorStatus: asString(parsed.error_status) ?? result.latestRetry?.errorStatus ?? null,
+        errorMessage: asString(parsed.error) ?? result.latestRetry?.errorMessage ?? null,
+      };
+      continue;
+    }
+    result.hasNonRetryContent = true;
+  }
+  return result;
+}

--- a/server/src/services/recovery/kill-process-group.ts
+++ b/server/src/services/recovery/kill-process-group.ts
@@ -1,0 +1,101 @@
+// Best-effort SIGTERM -> SIGKILL helper for the watchdog auto-recovery path.
+//
+// AUR-42 will own the production-grade helper (with detailed structured logs,
+// pgid resolution helpers, and the `PAPERCLIP_WATCHDOG_AUTO_RECOVER` master
+// switch). Until that lands, the retry-stall detector needs a small inline
+// version so we can ship AUR-33 without waiting on the sibling. Behaviour:
+//
+//  1. Respect `PAPERCLIP_WATCHDOG_AUTO_RECOVER` (default true); when false,
+//     return `{ skipped: "auto_recover_disabled" }` without sending signals.
+//  2. `process.kill(-pgid, SIGTERM)` (or `pid` when pgid is unavailable).
+//  3. Wait up to `graceMs` for the process group to exit.
+//  4. If still alive, `process.kill(-pgid, SIGKILL)`.
+//  5. Return a structured outcome the caller can log.
+
+import { logger } from "../../middleware/logger.js";
+import { getWatchdogConfig } from "./watchdog-config.js";
+
+export type KillProcessGroupInput = {
+  pid?: number | null;
+  pgid?: number | null;
+  graceMs?: number;
+  runId?: string | null;
+};
+
+export type KillProcessGroupOutcome =
+  | { ok: true; term: true; killed: boolean; gracedMs: number }
+  | { ok: false; skipped: "auto_recover_disabled" | "process_not_found" | "no_pid"; }
+  | { ok: false; error: string };
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EPERM") return true;
+    return false;
+  }
+}
+
+async function waitForExit(pid: number, graceMs: number): Promise<{ killed: boolean; gracedMs: number }> {
+  const start = Date.now();
+  const pollIntervalMs = Math.max(25, Math.min(250, Math.floor(graceMs / 20) || 50));
+  while (Date.now() - start < graceMs) {
+    if (!processAlive(pid)) {
+      return { killed: false, gracedMs: Date.now() - start };
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+  return { killed: true, gracedMs: Date.now() - start };
+}
+
+export async function killProcessGroup(input: KillProcessGroupInput): Promise<KillProcessGroupOutcome> {
+  const config = getWatchdogConfig();
+  if (!config.autoRecover) {
+    logger.info(
+      { runId: input.runId ?? null, pid: input.pid ?? null, pgid: input.pgid ?? null, action: "kill", outcome: "skipped_auto_recover_disabled" },
+      "watchdog killProcessGroup skipped: PAPERCLIP_WATCHDOG_AUTO_RECOVER=false",
+    );
+    return { ok: false, skipped: "auto_recover_disabled" };
+  }
+  const graceMs = input.graceMs ?? config.killGraceMs;
+  const pid = input.pid ?? null;
+  const pgid = input.pgid ?? null;
+  const target = pgid ?? pid;
+  if (target === null) {
+    return { ok: false, skipped: "no_pid" };
+  }
+  // process.kill(-pgid) sends to the whole group; positive id sends to one pid.
+  const killTarget = pgid !== null ? -pgid : pid!;
+  const checkPid = pid ?? pgid!;
+  if (!processAlive(checkPid)) {
+    return { ok: false, skipped: "process_not_found" };
+  }
+  try {
+    process.kill(killTarget, "SIGTERM");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ESRCH") {
+      return { ok: false, skipped: "process_not_found" };
+    }
+    logger.warn({ err, runId: input.runId ?? null, pid, pgid, signal: "SIGTERM" }, "watchdog killProcessGroup SIGTERM failed");
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+  const { killed, gracedMs } = await waitForExit(checkPid, graceMs);
+  if (killed) {
+    try {
+      process.kill(killTarget, "SIGKILL");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== "ESRCH") {
+        logger.warn({ err, runId: input.runId ?? null, pid, pgid, signal: "SIGKILL" }, "watchdog killProcessGroup SIGKILL failed");
+      }
+    }
+  }
+  logger.info(
+    { runId: input.runId ?? null, pid, pgid, action: "kill", outcome: killed ? "killed" : "terminated", gracedMs },
+    "watchdog killProcessGroup signalled",
+  );
+  return { ok: true, term: true, killed, gracedMs };
+}

--- a/server/src/services/recovery/origins.ts
+++ b/server/src/services/recovery/origins.ts
@@ -3,7 +3,29 @@ export const RECOVERY_ORIGIN_KINDS = {
   issueProductivityReview: "issue_productivity_review",
   strandedIssueRecovery: "stranded_issue_recovery",
   staleActiveRunEvaluation: "stale_active_run_evaluation",
+  // Emitted by the AUR-33 retry-stall detector when a run has been retrying
+  // upstream API errors past `PAPERCLIP_WATCHDOG_RETRY_STALL_ATTEMPT` for
+  // longer than `PAPERCLIP_WATCHDOG_RETRY_STALL_BUDGET_SEC`. Listed alongside
+  // `staleActiveRunEvaluation` so the hard cascade guard treats both as
+  // watchdog-emitted origins that may not spawn further review issues.
+  runtimeApiRetryExhausted: "runtime_api_retry_exhausted",
 } as const;
+
+// Source originKinds whose review-issue emission must be unconditionally
+// suppressed by the hard cascade guard (depth=1). Per CEO comment on AUR-27.
+export const WATCHDOG_RECURSIVE_ORIGIN_KINDS: readonly string[] = [
+  RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation,
+  RECOVERY_ORIGIN_KINDS.runtimeApiRetryExhausted,
+];
+
+export function isWatchdogRecursiveOriginKind(originKind: string | null | undefined): boolean {
+  if (!originKind) return false;
+  return WATCHDOG_RECURSIVE_ORIGIN_KINDS.includes(originKind);
+}
+
+export function buildRuntimeApiRetryExhaustedIdempotencyKey(input: { companyId: string; runId: string }): string {
+  return `${RECOVERY_ORIGIN_KINDS.runtimeApiRetryExhausted}:${input.companyId}:${input.runId}`;
+}
 
 export const RECOVERY_REASON_KINDS = {
   runLivenessContinuation: "run_liveness_continuation",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -42,9 +42,13 @@ import {
 import {
   RECOVERY_ORIGIN_KINDS,
   buildIssueGraphLivenessLeafKey,
+  buildRuntimeApiRetryExhaustedIdempotencyKey,
   isStrandedIssueRecoveryOriginKind,
+  isWatchdogRecursiveOriginKind,
   parseIssueGraphLivenessIncidentKey,
 } from "./origins.js";
+import { getWatchdogConfig } from "./watchdog-config.js";
+import { killProcessGroup } from "./kill-process-group.js";
 import {
   classifyIssueGraphLiveness,
   type IssueLivenessFinding,
@@ -63,6 +67,7 @@ export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+const RUNTIME_API_RETRY_EXHAUSTED_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.runtimeApiRetryExhausted;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 
 type RecoveryWakeupOptions = {
@@ -672,8 +677,30 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return run.lastOutputAt ?? run.processStartedAt ?? run.startedAt ?? run.createdAt ?? null;
   }
 
+  // Liveness clock backs the suspicious/critical silent-output thresholds.
+  // Per AUR-33, an api_retry-emitting CLI is "alive" even with no stdout, so
+  // we evaluate against `lastLivenessAt` (falling back to lastOutputAt and
+  // then to processStartedAt) once the feature flag is on. The flag-off path
+  // preserves the legacy `lastOutputAt`-only semantics for emergency revert.
+  function livenessStartedAtForRun(
+    run: Pick<typeof heartbeatRuns.$inferSelect, "lastLivenessAt" | "lastOutputAt" | "processStartedAt" | "startedAt" | "createdAt">,
+  ) {
+    if (!getWatchdogConfig().apiRetryAware) {
+      return silenceStartedAtForRun(run);
+    }
+    return run.lastLivenessAt ?? run.lastOutputAt ?? run.processStartedAt ?? run.startedAt ?? run.createdAt ?? null;
+  }
+
   function silenceAgeMsForRun(run: Pick<typeof heartbeatRuns.$inferSelect, "lastOutputAt" | "processStartedAt" | "startedAt" | "createdAt">, now = new Date()) {
     const startedAt = silenceStartedAtForRun(run);
+    return startedAt ? Math.max(0, now.getTime() - startedAt.getTime()) : null;
+  }
+
+  function livenessAgeMsForRun(
+    run: Pick<typeof heartbeatRuns.$inferSelect, "lastLivenessAt" | "lastOutputAt" | "processStartedAt" | "startedAt" | "createdAt">,
+    now = new Date(),
+  ) {
+    const startedAt = livenessStartedAtForRun(run);
     return startedAt ? Math.max(0, now.getTime() - startedAt.getTime()) : null;
   }
 
@@ -722,22 +749,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
       "id" | "companyId" | "status" | "lastOutputAt" | "lastOutputSeq" | "lastOutputStream" | "processStartedAt" | "startedAt" | "createdAt"
-    >,
+    > & Partial<Pick<typeof heartbeatRuns.$inferSelect, "lastLivenessAt">>,
     now = new Date(),
   ): Promise<RunOutputSilenceSummary> {
     const [quietUntilDecision, evaluation] = await Promise.all([
       latestActiveOutputQuietUntilDecision(run.companyId, run.id, now),
       findOpenStaleRunEvaluation(run.companyId, run.id),
     ]);
+    // AUR-33: thresholds evaluate against the liveness clock (api_retry
+    // events keep this fresh) so a retrying CLI is not classified silent.
+    // silenceStartedAt remains the stdout-only clock for diagnostics.
     const silenceStartedAt = silenceStartedAtForRun(run);
+    const livenessAwareRun = { ...run, lastLivenessAt: run.lastLivenessAt ?? null };
+    const livenessAgeMs = run.status === "running" ? livenessAgeMsForRun(livenessAwareRun, now) : null;
     const silenceAgeMs = run.status === "running" ? silenceAgeMsForRun(run, now) : null;
     const level = run.status !== "running"
       ? "not_applicable"
       : quietUntilDecision
         ? "snoozed"
-        : (silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS
+        : (livenessAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS
           ? "critical"
-          : (silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS
+          : (livenessAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS
             ? "suspicious"
             : "ok";
     return {
@@ -1033,7 +1065,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       prefix,
       now: input.now,
     });
-    const level = (evidence.silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS ? "critical" : "suspicious";
+    const livenessAwareRun = {
+      ...input.run,
+      lastLivenessAt: input.run.lastLivenessAt ?? null,
+    };
+    const ageForLevel = livenessAgeMsForRun(livenessAwareRun, input.now) ?? evidence.silenceAgeMs ?? 0;
+    const level = ageForLevel >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS ? "critical" : "suspicious";
+    // AUR-33 hard cascade guard. Unconditional; runs at every threshold level.
+    if (await shouldSuppressForCascade({ run: input.run, thresholdLevel: level, sourceIssue })) {
+      return { kind: "cascade_suppressed" as const };
+    }
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
     if (existing) {
       if (level === "critical" && existing.priority !== "high") {
@@ -1150,7 +1191,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function scanSilentActiveRuns(opts?: { now?: Date; companyId?: string }) {
     const now = opts?.now ?? new Date();
+    const apiRetryAware = getWatchdogConfig().apiRetryAware;
     const suspicionBefore = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS);
+    // AUR-33: when api-retry-aware mode is on we scan against the liveness
+    // clock (api_retry events keep this fresh). When the flag is off we keep
+    // the legacy stdout-only clock so emergency rollback is bit-equivalent.
+    const livenessClockSql = apiRetryAware
+      ? sql`coalesce(${heartbeatRuns.lastLivenessAt}, ${heartbeatRuns.lastOutputAt}, ${heartbeatRuns.processStartedAt}, ${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt})`
+      : sql`coalesce(${heartbeatRuns.lastOutputAt}, ${heartbeatRuns.processStartedAt}, ${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt})`;
     const candidates = await db
       .select()
       .from(heartbeatRuns)
@@ -1158,7 +1206,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         and(
           opts?.companyId ? eq(heartbeatRuns.companyId, opts.companyId) : undefined,
           eq(heartbeatRuns.status, "running"),
-          sql`coalesce(${heartbeatRuns.lastOutputAt}, ${heartbeatRuns.processStartedAt}, ${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${suspicionBefore.toISOString()}::timestamptz`,
+          sql`${livenessClockSql} <= ${suspicionBefore.toISOString()}::timestamptz`,
         ),
       )
       .orderBy(asc(heartbeatRuns.createdAt))
@@ -1171,6 +1219,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       escalated: 0,
       snoozed: 0,
       skipped: 0,
+      cascadeSuppressed: 0,
       evaluationIssueIds: [] as string[],
     };
 
@@ -1183,12 +1232,267 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (outcome.kind === "created") result.created += 1;
       else if (outcome.kind === "existing") result.existing += 1;
       else if (outcome.kind === "escalated") result.escalated += 1;
+      else if (outcome.kind === "cascade_suppressed") result.cascadeSuppressed += 1;
       else result.skipped += 1;
       if ("evaluationIssueId" in outcome && outcome.evaluationIssueId) {
         result.evaluationIssueIds.push(outcome.evaluationIssueId);
       }
     }
 
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // AUR-33: hard cascade guard (depth cap = 1)
+  // -------------------------------------------------------------------------
+  // Per CEO comment on AUR-27: before the watchdog emits ANY review issue
+  // (suspicious-silent, critical-silent, or retry-stall), resolve the source
+  // run's source issue and short-circuit unconditionally when its originKind
+  // is itself a watchdog-emitted origin. No retry-state heuristic, no time
+  // window. The thing that caps recursion must not depend on the thing that
+  // is failing.
+  async function shouldSuppressForCascade(input: {
+    run: Pick<typeof heartbeatRuns.$inferSelect, "id" | "companyId" | "contextSnapshot">;
+    thresholdLevel: "suspicious" | "critical" | "retry_stall";
+    sourceIssue: Pick<typeof issues.$inferSelect, "id" | "originKind"> | null;
+  }): Promise<boolean> {
+    if (!getWatchdogConfig().apiRetryAware) return false;
+    const sourceOriginKind = input.sourceIssue?.originKind ?? null;
+    if (!isWatchdogRecursiveOriginKind(sourceOriginKind)) return false;
+    logger.info(
+      {
+        event: "cascade_suppressed",
+        runId: input.run.id,
+        sourceIssueId: input.sourceIssue?.id ?? null,
+        sourceOriginKind,
+        thresholdLevel: input.thresholdLevel,
+      },
+      "watchdog suppressed review-issue emission to prevent recursive cascade",
+    );
+    return true;
+  }
+
+  // -------------------------------------------------------------------------
+  // AUR-33: bounded retry-stall detector
+  // -------------------------------------------------------------------------
+  async function findOpenRuntimeApiRetryExhausted(companyId: string, runId: string) {
+    const [row] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, RUNTIME_API_RETRY_EXHAUSTED_ORIGIN_KIND),
+          eq(issues.originId, runId),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  }
+
+  function isUniqueRuntimeApiRetryExhaustedConflict(error: unknown) {
+    const maybe = unwrapDatabaseConflictError(error);
+    if (!maybe) return false;
+    return maybe.code === "23505" &&
+      (
+        maybe.constraint === "issues_active_runtime_api_retry_exhausted_uq" ||
+        maybe.constraint_name === "issues_active_runtime_api_retry_exhausted_uq" ||
+        typeof maybe.message === "string" && maybe.message.includes("issues_active_runtime_api_retry_exhausted_uq")
+      );
+  }
+
+  async function markRunRetryExhaustedTerminal(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    now: Date;
+    killOutcome: Awaited<ReturnType<typeof killProcessGroup>>;
+  }) {
+    const reasonParts = [`runtime_api_retry_exhausted`];
+    if (input.run.lastRetryAttempt !== null && input.run.lastRetryAttempt !== undefined) {
+      reasonParts.push(`attempt=${input.run.lastRetryAttempt}`);
+    }
+    if (input.run.lastRetryErrorStatus) reasonParts.push(`status=${input.run.lastRetryErrorStatus}`);
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "failed",
+        errorCode: "runtime_api_retry_exhausted",
+        error: reasonParts.join(" "),
+        finishedAt: input.now,
+        updatedAt: input.now,
+      })
+      .where(eq(heartbeatRuns.id, input.run.id));
+  }
+
+  async function createRuntimeApiRetryExhaustedReview(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    now: Date;
+    killOutcome: Awaited<ReturnType<typeof killProcessGroup>>;
+  }) {
+    const config = getWatchdogConfig();
+    const runningAgent = await getAgent(input.run.agentId);
+    if (!runningAgent || runningAgent.companyId !== input.run.companyId) {
+      return { kind: "skipped" as const };
+    }
+    const sourceIssue = await resolveStaleRunSourceIssue(input.run);
+    const prefix = await getCompanyIssuePrefix(input.run.companyId);
+
+    if (await shouldSuppressForCascade({ run: input.run, thresholdLevel: "retry_stall", sourceIssue })) {
+      return { kind: "cascade_suppressed" as const };
+    }
+
+    const existing = await findOpenRuntimeApiRetryExhausted(input.run.companyId, input.run.id);
+    if (existing) {
+      return { kind: "existing" as const, evaluationIssueId: existing.id };
+    }
+
+    const ownerAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });
+    const idempotencyKey = buildRuntimeApiRetryExhaustedIdempotencyKey({
+      companyId: input.run.companyId,
+      runId: input.run.id,
+    });
+    const description = [
+      `Paperclip's bounded retry-stall detector terminated an active heartbeat run.`,
+      "",
+      "## Run",
+      "",
+      `- Run: ${runUiLink(input.run, prefix)}`,
+      `- Agent: ${runningAgent.name} (${runningAgent.adapterType})`,
+      `- Source issue: ${sourceIssue ? issueUiLink({ identifier: sourceIssue.identifier, id: sourceIssue.id }, prefix) : "none"}`,
+      `- Started at: ${input.run.startedAt?.toISOString() ?? "unknown"}`,
+      `- Last output at: ${input.run.lastOutputAt?.toISOString() ?? "none recorded"}`,
+      `- Last liveness at: ${input.run.lastLivenessAt?.toISOString() ?? "none recorded"}`,
+      `- Last attempt observed: ${input.run.lastRetryAttempt ?? "unknown"}`,
+      `- Last error_status: ${input.run.lastRetryErrorStatus ?? "unknown"}`,
+      `- Last error: ${input.run.lastRetryErrorMessage ?? "unknown"}`,
+      `- Retry stall started at: ${input.run.retryStallStartedAt?.toISOString() ?? "unknown"}`,
+      "",
+      "## Kill Outcome",
+      "",
+      `\`\`\`json\n${JSON.stringify(input.killOutcome)}\n\`\`\``,
+      "",
+      "## Watchdog Config",
+      "",
+      `- retryStallAttemptThreshold: ${config.retryStallAttemptThreshold}`,
+      `- retryStallBudgetSec: ${config.retryStallBudgetSec}`,
+      `- autoRecover: ${config.autoRecover}`,
+      `- apiRetryAware: ${config.apiRetryAware}`,
+      "",
+      "## Idempotency",
+      "",
+      `\`${idempotencyKey}\``,
+      "",
+      "## Decision Checklist",
+      "",
+      "- Confirm the upstream API outage is resolved before requeueing.",
+      "- If the source issue should resume, re-trigger a heartbeat manually.",
+      "- Close as done once the source issue has been requeued or the root cause is documented.",
+    ].join("\n");
+
+    let evaluation: Awaited<ReturnType<typeof issuesSvc.create>>;
+    try {
+      evaluation = await issuesSvc.create(input.run.companyId, {
+        title: `Auto-terminated retry-stalled run for ${runningAgent.name}`,
+        description,
+        status: "todo",
+        priority: "high",
+        parentId: sourceIssue && !["done", "cancelled"].includes(sourceIssue.status) ? sourceIssue.id : null,
+        projectId: sourceIssue?.projectId ?? null,
+        goalId: sourceIssue?.goalId ?? null,
+        billingCode: sourceIssue?.billingCode ?? null,
+        assigneeAgentId: ownerAgentId,
+        assigneeAdapterOverrides: recoveryAssigneeAdapterOverrides(),
+        originKind: RUNTIME_API_RETRY_EXHAUSTED_ORIGIN_KIND,
+        originId: input.run.id,
+        originRunId: input.run.id,
+        // Round-trip the AUR-37 idempotency key here so dedup short-circuits
+        // duplicate fires. AUR-37 will wire a dedicated `idempotencyKey`
+        // column; until then `originFingerprint` carries the canonical value
+        // and is also covered by the partial unique index added in 0084.
+        originFingerprint: idempotencyKey,
+      });
+    } catch (error) {
+      if (!isUniqueRuntimeApiRetryExhaustedConflict(error)) throw error;
+      const raced = await findOpenRuntimeApiRetryExhausted(input.run.companyId, input.run.id);
+      if (!raced) throw error;
+      return { kind: "existing" as const, evaluationIssueId: raced.id };
+    }
+
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: ownerAgentId,
+      runId: input.run.id,
+      action: "heartbeat.retry_stall_detected",
+      entityType: "issue",
+      entityId: evaluation.id,
+      details: {
+        source: "recovery.scan_retry_stalled_runs",
+        idempotencyKey,
+        sourceIssueId: sourceIssue?.id ?? null,
+        lastRetryAttempt: input.run.lastRetryAttempt ?? null,
+        lastRetryErrorStatus: input.run.lastRetryErrorStatus ?? null,
+        killOutcome: input.killOutcome,
+      },
+    });
+    return { kind: "created" as const, evaluationIssueId: evaluation.id };
+  }
+
+  async function scanRetryStalledRuns(opts?: { now?: Date; companyId?: string }) {
+    const config = getWatchdogConfig();
+    const result = {
+      scanned: 0,
+      terminated: 0,
+      existing: 0,
+      cascadeSuppressed: 0,
+      skipped: 0,
+      evaluationIssueIds: [] as string[],
+    };
+    if (!config.apiRetryAware) return result;
+    const now = opts?.now ?? new Date();
+    const budgetMs = config.retryStallBudgetSec * 1000;
+    const stallBudgetThreshold = new Date(now.getTime() - budgetMs);
+    const candidates = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          opts?.companyId ? eq(heartbeatRuns.companyId, opts.companyId) : undefined,
+          eq(heartbeatRuns.status, "running"),
+          sql`${heartbeatRuns.retryStallStartedAt} is not null`,
+          sql`${heartbeatRuns.retryStallStartedAt} <= ${stallBudgetThreshold.toISOString()}::timestamptz`,
+          sql`coalesce(${heartbeatRuns.lastRetryAttempt}, 0) >= ${config.retryStallAttemptThreshold}`,
+        ),
+      )
+      .orderBy(asc(heartbeatRuns.createdAt))
+      .limit(100);
+    result.scanned = candidates.length;
+    for (const run of candidates) {
+      const killOutcome = await killProcessGroup({
+        pid: run.processPid ?? null,
+        pgid: run.processGroupId ?? null,
+        runId: run.id,
+      });
+      await markRunRetryExhaustedTerminal({ run, now, killOutcome });
+      const outcome = await createRuntimeApiRetryExhaustedReview({ run, now, killOutcome });
+      if (outcome.kind === "created") {
+        result.terminated += 1;
+        if (outcome.evaluationIssueId) result.evaluationIssueIds.push(outcome.evaluationIssueId);
+      } else if (outcome.kind === "existing") {
+        result.existing += 1;
+        if (outcome.evaluationIssueId) result.evaluationIssueIds.push(outcome.evaluationIssueId);
+      } else if (outcome.kind === "cascade_suppressed") {
+        result.cascadeSuppressed += 1;
+      } else {
+        result.skipped += 1;
+      }
+    }
     return result;
   }
 
@@ -2833,6 +3137,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     escalateStrandedAssignedIssue,
     recordWatchdogDecision,
     scanSilentActiveRuns,
+    scanRetryStalledRuns,
     reconcileStrandedAssignedIssues,
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileIssueGraphLiveness,

--- a/server/src/services/recovery/watchdog-config.ts
+++ b/server/src/services/recovery/watchdog-config.ts
@@ -1,0 +1,60 @@
+// Watchdog runtime configuration. All values are read from environment
+// variables so we can revert behaviour without redeploying.
+//
+// Master kill switch: PAPERCLIP_WATCHDOG_API_RETRY_AWARE (default true).
+// When false, the parser stops updating `lastLivenessAt`, the retry-stall
+// detector becomes a no-op, and the hard cascade guard short-circuits to the
+// pre-change behaviour. Used as the rollback lever for AUR-33.
+
+export const DEFAULT_RETRY_STALL_ATTEMPT_THRESHOLD = 3;
+export const DEFAULT_RETRY_STALL_BUDGET_SEC = 300;
+export const DEFAULT_KILL_GRACE_MS = 10_000;
+
+export type WatchdogConfig = {
+  apiRetryAware: boolean;
+  autoRecover: boolean;
+  retryStallAttemptThreshold: number;
+  retryStallBudgetSec: number;
+  killGraceMs: number;
+};
+
+function envBool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || raw === "") return fallback;
+  const normalized = raw.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return fallback;
+}
+
+function envInt(name: string, fallback: number, opts?: { min?: number }): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === null || raw === "") return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  const floored = Math.floor(parsed);
+  if (opts?.min !== undefined && floored < opts.min) return opts.min;
+  return floored;
+}
+
+export function getWatchdogConfig(): WatchdogConfig {
+  return {
+    apiRetryAware: envBool("PAPERCLIP_WATCHDOG_API_RETRY_AWARE", true),
+    autoRecover: envBool("PAPERCLIP_WATCHDOG_AUTO_RECOVER", true),
+    retryStallAttemptThreshold: envInt(
+      "PAPERCLIP_WATCHDOG_RETRY_STALL_ATTEMPT",
+      DEFAULT_RETRY_STALL_ATTEMPT_THRESHOLD,
+      { min: 1 },
+    ),
+    retryStallBudgetSec: envInt(
+      "PAPERCLIP_WATCHDOG_RETRY_STALL_BUDGET_SEC",
+      DEFAULT_RETRY_STALL_BUDGET_SEC,
+      { min: 1 },
+    ),
+    killGraceMs: envInt(
+      "PAPERCLIP_WATCHDOG_KILL_GRACE_MS",
+      DEFAULT_KILL_GRACE_MS,
+      { min: 0 },
+    ),
+  };
+}


### PR DESCRIPTION
Implementation child of [AUR-33](https://linear.app/paperclip/issue/AUR-33) (issue [AUR-57](https://linear.app/paperclip/issue/AUR-57)).

Eliminates the false "silent run" classification when the Claude CLI is internally retrying upstream API failures, auto-terminates genuinely stuck retry loops within a bounded budget, and caps watchdog review-issue recursion at depth 1 — the cascade that produced AUR-27 → AUR-30 → AUR-32.

## What this PR does (numbered per AUR-33 plan revision 2)

1. **Liveness parsing.** New `services/recovery/api-retry-parser.ts` reads run-log chunks for `{type:"system",subtype:"api_retry"}` events. The `onLog` handler in `services/heartbeat.ts` updates a new `lastLivenessAt` column distinct from `lastOutputAt`: a chunk made only of api_retry events bumps liveness only; a chunk with real progress bumps both clocks. `scanSilentActiveRuns` evaluates the 1h / 4h thresholds against `lastLivenessAt` instead of `lastOutputAt`.

2. **Bounded retry-stall auto-termination.** New `scanRetryStalledRuns` fires when `lastRetryAttempt >= PAPERCLIP_WATCHDOG_RETRY_STALL_ATTEMPT` (default `3`) **and** `retryStallStartedAt` is older than `PAPERCLIP_WATCHDOG_RETRY_STALL_BUDGET_SEC` (default `300s`). On fire: `killProcessGroup` (SIGTERM → SIGKILL with `PAPERCLIP_WATCHDOG_KILL_GRACE_MS` grace), mark the run `status=failed errorCode=runtime_api_retry_exhausted`, and emit one review issue with `originFingerprint = runtime_api_retry_exhausted:{companyId}:{runId}` (round-tripping the AUR-37 idempotency key until that sibling lands).

3. **Hard cascade guard (depth=1).** New `shouldSuppressForCascade` in `services/recovery/service.ts` runs at the review-issue emission entry point for every threshold level (suspicious-silent, critical-silent, retry-stall). When the source run's source issue has `originKind ∈ {stale_active_run_evaluation, runtime_api_retry_exhausted}` it suppresses emission and logs `{event: "cascade_suppressed", runId, sourceIssueId, sourceOriginKind, thresholdLevel}`. Unconditional — no retry-state heuristic, no time window — per the CEO comment on AUR-27.

4. **Feature flag.** `PAPERCLIP_WATCHDOG_API_RETRY_AWARE` (default `true`) is the master rollback lever. When `false`: parser stops writing `lastLivenessAt`; silent-output detectors fall back to `lastOutputAt` (legacy behaviour, bit-equivalent); retry-stall detector becomes a no-op; cascade guard becomes a no-op. Additional env knobs: `PAPERCLIP_WATCHDOG_AUTO_RECOVER`, `PAPERCLIP_WATCHDOG_RETRY_STALL_ATTEMPT`, `PAPERCLIP_WATCHDOG_RETRY_STALL_BUDGET_SEC`, `PAPERCLIP_WATCHDOG_KILL_GRACE_MS`.

5. **Runbook.** `doc/RUNBOOK-watchdog.md` covers detector semantics, `cascade_suppressed` log meaning, manual recovery (`runtime_api_retry_exhausted` vs `stale_active_run_evaluation`), rollback, configuration reference, and a false-positive playbook.

6. **Tests.**
   - `src/__tests__/api-retry-parser.test.ts` — six pure-unit tests for the parser (api_retry-only chunks, multi-attempt batching, mixed chunks, non-retry system events, unparseable content, empty input).
   - `src/__tests__/heartbeat-active-run-output-watchdog.test.ts` — six new integration tests: retry-active runs are not classified silent; feature-flag rollback restores legacy classification; cascade guard suppresses silent-output emission for watchdog-origin source issues; cascade guard suppresses retry-stall emission too; retry-stall detector fires only after both thresholds cross; retry-stall detector no-ops with the flag off.

## Schema

Migration `0084_active_run_liveness_retry_stall.sql` adds five nullable columns to `heartbeat_runs` (`last_liveness_at`, `last_retry_attempt`, `last_retry_error_status`, `last_retry_error_message`, `retry_stall_started_at`), two supporting indexes, and a partial unique index `issues_active_runtime_api_retry_exhausted_uq` for dedup of the new review-issue origin. No backfill needed; nulls fall through to legacy behaviour.

## Composes with the AUR-35 family

- AUR-37 — will replace `originFingerprint`-based dedup with a real `idempotencyKey` column. The key format already matches.
- AUR-41 — owns the `process_auto_recovered` source-issue wake at the critical threshold; the depth-cap here sits one layer above and prevents the review-issue creation path from ever recursing.
- AUR-42 — will replace the inline `killProcessGroup` helper with the production version. Same input shape.

## Verification

- `pnpm exec tsc --noEmit` clean for all changed files (pre-existing `@paperclipai/plugin-sdk` and `plugin-host-services` errors are unrelated).
- `pnpm exec vitest run src/__tests__/api-retry-parser.test.ts` → 6/6 pass.
- `pnpm exec vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts` skipped locally (`@embedded-postgres/darwin-arm64` binary missing on this dev host) — will execute in CI.

## Rollback

`PAPERCLIP_WATCHDOG_API_RETRY_AWARE=false`. No schema migration required.

## Test plan

- [ ] CI runs the watchdog integration suite (embedded postgres) and reports green
- [ ] CI runs the api-retry-parser unit suite
- [ ] Manual: trigger a synthetic api_retry stream on a sandbox run, observe `lastLivenessAt` advancing while `lastOutputAt` stays put, and confirm the silent-run thresholds do not fire
- [ ] Manual: force `lastRetryAttempt=3` and `retryStallStartedAt` 6m ago on a running run, confirm `scanRetryStalledRuns` terminates it and emits the review issue
- [ ] Manual: synthesise a recursive case (source issue with `originKind=stale_active_run_evaluation`), confirm `cascade_suppressed` log line and no new review issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)