### PR TITLE
fix(claude-local): ship bundled paperclip-tools MCP shim for isolated remote runtimes

### DIFF
--- a/docs/adapters/claude-local.md
+++ b/docs/adapters/claude-local.md
@@ -22,6 +22,7 @@ The `claude_local` adapter runs Anthropic's Claude Code CLI locally. It supports
 | `graceSec` | number | No | Grace period before force-kill |
 | `maxTurnsPerRun` | number | No | Max agentic turns per heartbeat (defaults to `300`) |
 | `dangerouslySkipPermissions` | boolean | No | Skip permission prompts (default: `true`); required for headless runs where interactive approval is impossible |
+| `disablePluginToolsMcp` | boolean | No | Disable the bundled Paperclip tools MCP shim wiring (`--mcp-config`) when true; default is `false` |
 
 ## Prompt Templates
 
@@ -46,6 +47,8 @@ If resume fails with an unknown session error, the adapter automatically retries
 ## Skills Injection
 
 The adapter creates a temporary directory with symlinks to Paperclip skills and passes it via `--add-dir`. This makes skills discoverable without polluting the agent's working directory.
+
+By default the adapter also writes a per-run MCP config and starts a bundled stdio MCP shim (`paperclip-tools-mcp-shim`) so plugin-registered Paperclip tools (for example `paperclip-plugin-hindsight:hindsight_recall`) are available to Claude as native MCP tools. Set `disablePluginToolsMcp: true` to opt out.
 
 For manual local CLI usage outside heartbeat runs (for example running as `claudecoder` directly), use:
 

--- a/packages/adapters/claude-local/CHANGELOG.md
+++ b/packages/adapters/claude-local/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @paperclipai/adapter-claude-local
 
+## 0.4.0
+
+### Minor Changes
+
+- Add bundled Paperclip tools MCP shim wiring for Claude via per-run `--mcp-config`
+- Add `disablePluginToolsMcp` adapter config escape hatch
+
+### Patch Changes
+
+- Updated dependencies
+  - @modelcontextprotocol/sdk@^1.29.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/adapters/claude-local/CHANGELOG.md
+++ b/packages/adapters/claude-local/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @paperclipai/adapter-claude-local
 
+## 0.4.1
+
+### Patch Changes
+
+- Make the Paperclip tools MCP shim a self-contained esbuild bundle so remote execution targets can spawn it from an isolated runtime asset directory without needing @modelcontextprotocol/sdk on disk (SPO-50 QA blocking finding).
+- Add isolated remote startup test (`paperclip-tools-mcp-shim.isolated.test.ts`) that runs the built bundle from a fresh tmp dir and round-trips an MCP `initialize` + `tools/list` to guard against regression.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/adapter-claude-local",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",
   "bugs": {
@@ -46,7 +46,8 @@
     "skills"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && pnpm run build:shim",
+    "build:shim": "esbuild src/server/paperclip-tools-mcp-shim.ts --bundle --platform=node --format=esm --target=node20 --outfile=dist/server/paperclip-tools-mcp-shim.bundle.js --legal-comments=none --log-level=warning",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
     "probe:quota": "pnpm exec tsx src/cli/quota-probe.ts --json",
@@ -59,6 +60,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
+    "esbuild": "^0.27.3",
     "typescript": "^5.7.3"
   }
 }

--- a/packages/adapters/claude-local/package.json
+++ b/packages/adapters/claude-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/adapter-claude-local",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",
   "bugs": {
@@ -53,6 +53,7 @@
     "probe:quota:raw": "pnpm exec tsx src/cli/quota-probe.ts --json --raw-cli"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@paperclipai/adapter-utils": "workspace:*",
     "picocolors": "^1.1.1"
   },

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -45,6 +45,7 @@ Core fields:
 - env (object, optional): KEY=VALUE environment variables
 - workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }
 - workspaceRuntime (object, optional): reserved for workspace runtime metadata; workspace runtime services are manually controlled from the workspace UI and are not auto-started by heartbeats
+- disablePluginToolsMcp (boolean, optional, default false): when true, do not wire Paperclip plugin-registered tools (hindsight_recall/_retain, etc.) into Claude via a per-run --mcp-config. Use this to opt out of the bundled paperclip-tools MCP shim, for example when operating against a Claude CLI that pre-dates --mcp-config support.
 
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds
@@ -52,4 +53,5 @@ Operational fields:
 
 Notes:
 - When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars for agent-side tooling.
+- The adapter ships a stdio MCP shim (paperclip-tools-mcp-shim) and starts it per run via --mcp-config, projecting Paperclip plugin-registered tools (e.g. paperclip-plugin-hindsight) into Claude as mcp__paperclip__<bare_tool_name>. Requires Claude CLI >= 2.0 (any version that advertises --mcp-config in --help output); older CLIs are detected at startup and the wiring is skipped with a warning.
 `;

--- a/packages/adapters/claude-local/src/index.ts
+++ b/packages/adapters/claude-local/src/index.ts
@@ -54,4 +54,5 @@ Operational fields:
 Notes:
 - When Paperclip realizes a workspace/runtime for a run, it injects PAPERCLIP_WORKSPACE_* and PAPERCLIP_RUNTIME_* env vars for agent-side tooling.
 - The adapter ships a stdio MCP shim (paperclip-tools-mcp-shim) and starts it per run via --mcp-config, projecting Paperclip plugin-registered tools (e.g. paperclip-plugin-hindsight) into Claude as mcp__paperclip__<bare_tool_name>. Requires Claude CLI >= 2.0 (any version that advertises --mcp-config in --help output); older CLIs are detected at startup and the wiring is skipped with a warning.
+- The shim runtime artifact (dist/server/paperclip-tools-mcp-shim.bundle.js) is a self-contained esbuild bundle, so remote execution targets only need to receive that single .js file -- @modelcontextprotocol/sdk and its transitive deps are inlined and need no node_modules to be reachable from the isolated runtime asset directory.
 `;

--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -1,7 +1,11 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __clearProbeCacheForTesting,
+  __setShimSourcePathOverrideForTesting,
+} from "./paperclip-tools-mcp.js";
 
 const {
   runChildProcess,
@@ -79,8 +83,19 @@ import { execute } from "./execute.js";
 describe("claude remote execution", () => {
   const cleanupDirs: string[] = [];
 
+  beforeEach(() => {
+    // The compiled shim .js does not exist in source-only test runs; opt out of
+    // paperclip-tools MCP wiring so the existing remote test assertions about
+    // asset sync counts remain stable. The dedicated MCP wiring tests live in
+    // execute.test.ts and paperclip-tools-mcp-shim.test.ts.
+    __setShimSourcePathOverrideForTesting("/dev/null/nonexistent-shim.js");
+    __clearProbeCacheForTesting();
+  });
+
   afterEach(async () => {
     vi.clearAllMocks();
+    __setShimSourcePathOverrideForTesting(null);
+    __clearProbeCacheForTesting();
     while (cleanupDirs.length > 0) {
       const dir = cleanupDirs.pop();
       if (!dir) continue;
@@ -264,6 +279,66 @@ describe("claude remote execution", () => {
     expect(runChildProcess).toHaveBeenCalledTimes(1);
     const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
     expect(call?.[2]).not.toContain("--resume");
+  });
+
+  it("syncs the paperclip-tools-mcp shim asset and wires --mcp-config when wiring is enabled", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-remote-mcp-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    const fakeShimPath = path.join(rootDir, "paperclip-tools-mcp-shim.js");
+    await mkdir(workspaceDir, { recursive: true });
+    await writeFile(fakeShimPath, "// fixture\n", "utf8");
+    __setShimSourcePathOverrideForTesting(fakeShimPath);
+    const managedRemoteWorkspace = "/remote/workspace/.paperclip-runtime/runs/run-mcp/workspace";
+
+    await execute({
+      runId: "run-mcp",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: { command: "claude" },
+      context: { paperclipWorkspace: { cwd: workspaceDir, source: "project_primary" } },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async () => {},
+    });
+
+    expect(syncDirectoryToSsh).toHaveBeenCalledTimes(2);
+    const syncCalls = syncDirectoryToSsh.mock.calls as unknown as Array<[
+      Record<string, unknown>,
+    ]>;
+    const syncedRemoteDirs = syncCalls.map((call) => call[0]?.remoteDir);
+    expect(syncedRemoteDirs).toContain(
+      `${managedRemoteWorkspace}/.paperclip-runtime/claude/skills`,
+    );
+    expect(syncedRemoteDirs).toContain(
+      `${managedRemoteWorkspace}/.paperclip-runtime/claude/paperclip-tools-mcp`,
+    );
+
+    const call = runChildProcess.mock.calls[0] as unknown as
+      | [string, string, string[], { env: Record<string, string> }]
+      | undefined;
+    const args = call?.[2] ?? [];
+    const mcpIdx = args.indexOf("--mcp-config");
+    expect(mcpIdx).toBeGreaterThan(-1);
+    expect(args[mcpIdx + 1]).toBe(
+      `${managedRemoteWorkspace}/.paperclip-runtime/claude/paperclip-tools-mcp/paperclip-tools-mcp.json`,
+    );
   });
 
   it("resumes saved Claude sessions for remote SSH execution when the remote identity matches", async () => {

--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -285,7 +285,7 @@ describe("claude remote execution", () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-remote-mcp-"));
     cleanupDirs.push(rootDir);
     const workspaceDir = path.join(rootDir, "workspace");
-    const fakeShimPath = path.join(rootDir, "paperclip-tools-mcp-shim.js");
+    const fakeShimPath = path.join(rootDir, "paperclip-tools-mcp-shim.bundle.js");
     await mkdir(workspaceDir, { recursive: true });
     await writeFile(fakeShimPath, "// fixture\n", "utf8");
     __setShimSourcePathOverrideForTesting(fakeShimPath);

--- a/packages/adapters/claude-local/src/server/execute.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.test.ts
@@ -55,7 +55,7 @@ describe("claude local execution -- paperclip-tools MCP wiring", () => {
     __clearProbeCacheForTesting();
     const stagingDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-shim-fixture-"));
     cleanupDirs.push(stagingDir);
-    fakeShimPath = path.join(stagingDir, "paperclip-tools-mcp-shim.js");
+    fakeShimPath = path.join(stagingDir, "paperclip-tools-mcp-shim.bundle.js");
     await writeFile(fakeShimPath, "// fixture\n", "utf8");
     __setShimSourcePathOverrideForTesting(fakeShimPath);
   });

--- a/packages/adapters/claude-local/src/server/execute.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.test.ts
@@ -1,0 +1,142 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  runChildProcess,
+  ensureCommandResolvable,
+  resolveCommandForLogs,
+} = vi.hoisted(() => ({
+  runChildProcess: vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    stdout: [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "claude-session-1", model: "claude-sonnet" }),
+      JSON.stringify({
+        type: "result",
+        session_id: "claude-session-1",
+        result: "ok",
+        usage: { input_tokens: 1, cache_read_input_tokens: 0, output_tokens: 1 },
+      }),
+    ].join("\n"),
+    stderr: "",
+    pid: 123,
+    startedAt: new Date().toISOString(),
+  })),
+  ensureCommandResolvable: vi.fn(async () => undefined),
+  resolveCommandForLogs: vi.fn(async (command: string) => command),
+}));
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/server-utils")>(
+    "@paperclipai/adapter-utils/server-utils",
+  );
+  return {
+    ...actual,
+    ensureCommandResolvable,
+    resolveCommandForLogs,
+    runChildProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+import {
+  __clearProbeCacheForTesting,
+  __setShimSourcePathOverrideForTesting,
+} from "./paperclip-tools-mcp.js";
+
+describe("claude local execution -- paperclip-tools MCP wiring", () => {
+  const cleanupDirs: string[] = [];
+  let fakeShimPath: string;
+
+  beforeEach(async () => {
+    __clearProbeCacheForTesting();
+    const stagingDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-shim-fixture-"));
+    cleanupDirs.push(stagingDir);
+    fakeShimPath = path.join(stagingDir, "paperclip-tools-mcp-shim.js");
+    await writeFile(fakeShimPath, "// fixture\n", "utf8");
+    __setShimSourcePathOverrideForTesting(fakeShimPath);
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    __setShimSourcePathOverrideForTesting(null);
+    __clearProbeCacheForTesting();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  async function runLocalExecute(extraConfig: Record<string, unknown> = {}) {
+    const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-claude-local-cwd-"));
+    cleanupDirs.push(workspaceDir);
+
+    await execute({
+      runId: "run-local-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Claude Coder",
+        adapterType: "claude_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: {
+        command: "claude",
+        ...extraConfig,
+      },
+      context: {
+        paperclipWorkspace: { cwd: workspaceDir, source: "project_primary" },
+      },
+      authToken: "test-paperclip-token",
+      onLog: async () => {},
+    });
+
+    return runChildProcess.mock.calls[0] as unknown as
+      | [string, string, string[], { env: Record<string, string> }]
+      | undefined;
+  }
+
+  it("appends --mcp-config when MCP wiring is enabled (default)", async () => {
+    const call = await runLocalExecute();
+    expect(call).toBeTruthy();
+    const args = call?.[2] ?? [];
+    const idx = args.indexOf("--mcp-config");
+    expect(idx).toBeGreaterThan(-1);
+    const configPath = args[idx + 1];
+    expect(typeof configPath).toBe("string");
+    expect(configPath).toMatch(/paperclip-tools-mcp\.json$/);
+    const addDirIdx = args.indexOf("--add-dir");
+    expect(addDirIdx).toBeGreaterThan(-1);
+    expect(idx).toBeGreaterThan(addDirIdx);
+  });
+
+  it("omits --mcp-config when disablePluginToolsMcp is true", async () => {
+    const call = await runLocalExecute({ disablePluginToolsMcp: true });
+    expect(call).toBeTruthy();
+    const args = call?.[2] ?? [];
+    expect(args).not.toContain("--mcp-config");
+  });
+
+  it("places --mcp-config before operator-supplied extraArgs", async () => {
+    const call = await runLocalExecute({ extraArgs: ["--strict-mcp-config"] });
+    expect(call).toBeTruthy();
+    const args = call?.[2] ?? [];
+    const mcpIdx = args.indexOf("--mcp-config");
+    const strictIdx = args.indexOf("--strict-mcp-config");
+    expect(mcpIdx).toBeGreaterThan(-1);
+    expect(strictIdx).toBeGreaterThan(mcpIdx);
+  });
+
+  it("propagates PAPERCLIP_* env to the child process so the spawned shim can read them", async () => {
+    const call = await runLocalExecute();
+    expect(call).toBeTruthy();
+    const env = call?.[3]?.env ?? {};
+    expect(env.PAPERCLIP_RUN_ID).toBe("run-local-1");
+    expect(env.PAPERCLIP_API_KEY).toBe("test-paperclip-token");
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -60,6 +60,10 @@ import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
 import { buildClaudeExecutionPermissionArgs } from "./permissions.js";
+import {
+  preparePaperclipToolsMcp,
+  type PreparedPaperclipToolsMcp,
+} from "./paperclip-tools-mcp.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
@@ -459,6 +463,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const claudeConfigSeedDir = useManagedRemoteClaudeConfig
     ? await prepareClaudeConfigSeed(process.env, onLog, agent.companyId)
     : null;
+  const disablePluginToolsMcp = asBoolean(config.disablePluginToolsMcp, false);
+  const paperclipToolsMcp = await preparePaperclipToolsMcp({
+    runId,
+    command,
+    resolvedCommand,
+    executionTargetIsRemote,
+    disabled: disablePluginToolsMcp,
+  });
+  if (paperclipToolsMcp.warning) {
+    await onLog("stderr", `[paperclip] ${paperclipToolsMcp.warning}\n`);
+  }
+  let preparedPaperclipMcp: PreparedPaperclipToolsMcp = paperclipToolsMcp.prepared;
   const preparedExecutionTargetRuntime = executionTargetIsRemote
     ? await (async () => {
         await onLog(
@@ -485,6 +501,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
                 localDir: claudeConfigSeedDir,
                 followSymlinks: true,
               }]
+              : []),
+            ...(preparedPaperclipMcp && preparedPaperclipMcp.kind === "remote"
+              ? [preparedPaperclipMcp.asset]
               : []),
           ],
         });
@@ -555,6 +574,44 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         onLog,
       },
     );
+  }
+  let mcpConfigArgPath: string | null = null;
+  if (preparedPaperclipMcp) {
+    if (preparedPaperclipMcp.kind === "local") {
+      mcpConfigArgPath = preparedPaperclipMcp.mcpConfigPath;
+    } else if (preparedPaperclipMcp.kind === "remote") {
+      const remoteAssetDir =
+        preparedExecutionTargetRuntime?.assetDirs[preparedPaperclipMcp.remoteAssetKey] ??
+        (remoteClaudeRuntimeRoot
+          ? path.posix.join(remoteClaudeRuntimeRoot, preparedPaperclipMcp.remoteAssetKey)
+          : null);
+      if (!remoteAssetDir) {
+        await onLog(
+          "stderr",
+          `[paperclip] Skipping paperclip-tools MCP wiring: could not resolve remote asset directory for "${preparedPaperclipMcp.remoteAssetKey}".\n`,
+        );
+        await preparedPaperclipMcp.cleanup();
+        preparedPaperclipMcp = null;
+      } else {
+        const remoteMcpConfigPath = path.posix.join(remoteAssetDir, "paperclip-tools-mcp.json");
+        const contents = preparedPaperclipMcp.buildRemoteMcpConfigContents(remoteAssetDir);
+        const encoded = Buffer.from(contents, "utf8").toString("base64");
+        await runAdapterExecutionTargetShellCommand(
+          runId,
+          executionTarget,
+          `mkdir -p ${shellQuote(remoteAssetDir)} && ` +
+            `printf '%s' ${shellQuote(encoded)} | base64 -d > ${shellQuote(remoteMcpConfigPath)}`,
+          {
+            cwd,
+            env,
+            timeoutSec: Math.max(timeoutSec, 15),
+            graceSec,
+            onLog,
+          },
+        );
+        mcpConfigArgPath = remoteMcpConfigPath;
+      }
+    }
   }
   let paperclipBridge: Awaited<ReturnType<typeof startAdapterExecutionTargetPaperclipBridge>> = null;
   if (executionTargetIsRemote && adapterExecutionTargetUsesPaperclipBridge(runtimeExecutionTarget)) {
@@ -685,6 +742,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--append-system-prompt-file", attemptInstructionsFilePath);
     }
     args.push("--add-dir", effectivePromptBundleAddDir);
+    if (mcpConfigArgPath) args.push("--mcp-config", mcpConfigArgPath);
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
   };
@@ -956,6 +1014,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] Restoring workspace changes from ${describeAdapterExecutionTarget(executionTarget)}.\n`,
       );
       await restoreRemoteWorkspace();
+    }
+    if (preparedPaperclipMcp) {
+      await preparedPaperclipMcp.cleanup().catch(() => undefined);
     }
   }
 }

--- a/packages/adapters/claude-local/src/server/paperclip-tools-mcp-shim.isolated.test.ts
+++ b/packages/adapters/claude-local/src/server/paperclip-tools-mcp-shim.isolated.test.ts
@@ -1,0 +1,237 @@
+import fs from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, spawnSync } from "node:child_process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Isolated remote-startup smoke for the bundled paperclip-tools MCP shim.
+ *
+ * QA reported (SPO-50, 2026-05-12) that when only the shim source file is
+ * synced to a remote execution target, the Node process crashes with
+ * ERR_MODULE_NOT_FOUND because @modelcontextprotocol/sdk is not resolvable
+ * from the isolated runtime asset directory. These tests guard against
+ * regression by:
+ *
+ *  1. Spawning the *built* shim file from a freshly created tmp dir that has
+ *     no reachable node_modules and only the shim itself in scope, and
+ *  2. Talking real MCP stdio to it -- initialize + tools/list -- proving the
+ *     bundle is functional, not just importable.
+ *
+ * The test is skipped when the build artifact is absent so source-only test
+ * runs (pre-build) keep passing.
+ */
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+// The runtime artifact is the self-contained esbuild bundle, not the tsc-emitted
+// .js (which still imports @modelcontextprotocol/sdk from node_modules). The
+// bundle name is kept in sync with SHIM_FILENAME in paperclip-tools-mcp.ts.
+const SHIM_BUILD_PATH = path.resolve(
+  moduleDir,
+  "../../dist/server/paperclip-tools-mcp-shim.bundle.js",
+);
+
+const hasBuiltShim = fs.existsSync(SHIM_BUILD_PATH);
+const itIfBuilt = hasBuiltShim ? it : it.skip;
+
+interface FakeServer {
+  url: string;
+  close(): Promise<void>;
+}
+
+async function startFakePaperclip(): Promise<FakeServer> {
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      if (req.method === "GET" && req.url?.endsWith("/tools")) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify([
+            {
+              name: "paperclip-plugin-hindsight:hindsight_recall",
+              description: "Recall",
+              parametersSchema: {
+                type: "object",
+                required: ["query"],
+                properties: { query: { type: "string" } },
+              },
+            },
+          ]),
+        );
+        return;
+      }
+      res.writeHead(404).end();
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to bind fake paperclip server");
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe("paperclip-tools MCP shim isolated remote startup", () => {
+  let fake: FakeServer;
+  const cleanupDirs: string[] = [];
+
+  beforeAll(async () => {
+    if (!hasBuiltShim) return;
+    fake = await startFakePaperclip();
+  });
+
+  afterAll(async () => {
+    if (fake) await fake.close();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  itIfBuilt("exits cleanly when run from an isolated dir without env (no module-resolution errors)", () => {
+    const isolatedDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-shim-isolated-"));
+    cleanupDirs.push(isolatedDir);
+    const isolatedShim = path.join(isolatedDir, "paperclip-tools-mcp-shim.js");
+    fs.copyFileSync(SHIM_BUILD_PATH, isolatedShim);
+
+    const result = spawnSync(process.execPath, [isolatedShim], {
+      cwd: isolatedDir,
+      env: {
+        // Deliberately drop NODE_PATH and PATH so we mimic an isolated runtime
+        // and ensure the shim is not silently picking up a sibling tree.
+        PATH: "/usr/bin:/bin",
+        PAPERCLIP_API_URL: "",
+        PAPERCLIP_API_KEY: "",
+        PAPERCLIP_COMPANY_ID: "",
+        PAPERCLIP_AGENT_ID: "",
+      },
+      timeout: 10_000,
+      encoding: "utf8",
+    });
+
+    expect(result.stderr ?? "").not.toMatch(/ERR_MODULE_NOT_FOUND/);
+    expect(result.stderr ?? "").not.toMatch(/Cannot find package/);
+    expect(result.stderr ?? "").not.toMatch(/Cannot find module/);
+    expect(result.stderr ?? "").toMatch(/required env var PAPERCLIP_API_URL/);
+    expect(result.status).toBe(1);
+  });
+
+  itIfBuilt("answers MCP initialize + tools/list over stdio from an isolated dir", async () => {
+    const isolatedDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-shim-isolated-mcp-"));
+    cleanupDirs.push(isolatedDir);
+    const isolatedShim = path.join(isolatedDir, "paperclip-tools-mcp-shim.js");
+    fs.copyFileSync(SHIM_BUILD_PATH, isolatedShim);
+
+    const child = spawn(process.execPath, [isolatedShim], {
+      cwd: isolatedDir,
+      env: {
+        PATH: "/usr/bin:/bin",
+        PAPERCLIP_API_URL: fake.url,
+        PAPERCLIP_API_KEY: "test-token",
+        PAPERCLIP_COMPANY_ID: "company-x",
+        PAPERCLIP_AGENT_ID: "agent-x",
+        PAPERCLIP_RUN_ID: "run-iso",
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    const responses: Array<Record<string, unknown>> = [];
+    const responseDeadlinePerStep = 6_000;
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdoutBuf += chunk;
+      let idx = stdoutBuf.indexOf("\n");
+      while (idx !== -1) {
+        const line = stdoutBuf.slice(0, idx).trim();
+        stdoutBuf = stdoutBuf.slice(idx + 1);
+        if (line.length > 0) {
+          try {
+            responses.push(JSON.parse(line));
+          } catch {
+            // ignore non-JSON lines from the shim
+          }
+        }
+        idx = stdoutBuf.indexOf("\n");
+      }
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderrBuf += chunk;
+    });
+
+    const waitForResponseId = (id: number, timeoutMs: number) =>
+      new Promise<Record<string, unknown>>((resolve, reject) => {
+        const deadline = Date.now() + timeoutMs;
+        const tick = () => {
+          const found = responses.find((message) => (message as { id?: number }).id === id);
+          if (found) return resolve(found);
+          if (child.exitCode !== null) {
+            return reject(
+              new Error(
+                `shim exited with code ${child.exitCode} before responding to id=${id}; stderr=${stderrBuf}`,
+              ),
+            );
+          }
+          if (Date.now() > deadline) {
+            return reject(
+              new Error(`Timed out waiting for response id=${id}; stderr=${stderrBuf}`),
+            );
+          }
+          setTimeout(tick, 50);
+        };
+        tick();
+      });
+
+    const send = (payload: Record<string, unknown>) => {
+      child.stdin.write(`${JSON.stringify(payload)}\n`);
+    };
+
+    try {
+      send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "isolated-test", version: "0" },
+        },
+      });
+      const initResponse = await waitForResponseId(1, responseDeadlinePerStep);
+      expect(initResponse).toMatchObject({ id: 1 });
+      expect((initResponse as { error?: unknown }).error).toBeUndefined();
+
+      send({ jsonrpc: "2.0", method: "notifications/initialized" });
+
+      send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+      const listResponse = await waitForResponseId(2, responseDeadlinePerStep);
+      expect(listResponse).toMatchObject({ id: 2 });
+      const result = (listResponse as { result?: { tools?: Array<{ name: string }> } }).result;
+      expect(result?.tools?.map((t) => t.name)).toEqual(["hindsight_recall"]);
+
+      expect(stderrBuf).not.toMatch(/ERR_MODULE_NOT_FOUND/);
+      expect(stderrBuf).not.toMatch(/Cannot find package/);
+      expect(stderrBuf).not.toMatch(/Cannot find module/);
+    } finally {
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        if (child.exitCode !== null) return resolve();
+        child.once("exit", () => resolve());
+      });
+    }
+  });
+});

--- a/packages/adapters/claude-local/src/server/paperclip-tools-mcp-shim.test.ts
+++ b/packages/adapters/claude-local/src/server/paperclip-tools-mcp-shim.test.ts
@@ -1,0 +1,245 @@
+import http from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { __test as shim } from "./paperclip-tools-mcp-shim.js";
+
+const { planExposedTools, normalizeInputSchema, trimTrailingSlash, fetchPaperclipTools, callPaperclipTool } = shim;
+
+interface RecordedRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+interface FakeServer {
+  url: string;
+  requests: RecordedRequest[];
+  setListResponse(payload: unknown, status?: number): void;
+  setCallResponse(payload: unknown, status?: number): void;
+  close(): Promise<void>;
+}
+
+async function startFakePaperclip(): Promise<FakeServer> {
+  let listResponse: { status: number; body: string } = {
+    status: 200,
+    body: JSON.stringify([]),
+  };
+  let callResponse: { status: number; body: string } = {
+    status: 200,
+    body: JSON.stringify({ pluginId: "x", toolName: "x", result: { content: "ok" } }),
+  };
+
+  const requests: RecordedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => {
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      const body = Buffer.concat(chunks).toString("utf8");
+      requests.push({
+        method: req.method ?? "",
+        url: req.url ?? "",
+        headers: { ...req.headers } as Record<string, string>,
+        body,
+      });
+      if (req.method === "GET" && req.url?.endsWith("/tools")) {
+        res.writeHead(listResponse.status, { "content-type": "application/json" });
+        res.end(listResponse.body);
+        return;
+      }
+      if (req.method === "POST" && req.url?.endsWith("/tool-call")) {
+        res.writeHead(callResponse.status, { "content-type": "application/json" });
+        res.end(callResponse.body);
+        return;
+      }
+      res.writeHead(404).end();
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Failed to bind fake paperclip server");
+  }
+  const url = `http://127.0.0.1:${address.port}`;
+
+  return {
+    url,
+    requests,
+    setListResponse(payload: unknown, status = 200) {
+      listResponse = { status, body: typeof payload === "string" ? payload : JSON.stringify(payload) };
+    },
+    setCallResponse(payload: unknown, status = 200) {
+      callResponse = { status, body: typeof payload === "string" ? payload : JSON.stringify(payload) };
+    },
+    async close() {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+describe("paperclip-tools-mcp-shim helpers", () => {
+  describe("normalizeInputSchema", () => {
+    it("normalizes a missing schema to an empty object schema", () => {
+      expect(normalizeInputSchema(undefined)).toEqual({ type: "object", properties: {} });
+      expect(normalizeInputSchema(null)).toEqual({ type: "object", properties: {} });
+      expect(normalizeInputSchema("not-an-object")).toEqual({ type: "object", properties: {} });
+    });
+
+    it("preserves a paperclip parametersSchema with required array", () => {
+      const schema = {
+        type: "object",
+        required: ["query"],
+        properties: { query: { type: "string", description: "x" } },
+      };
+      expect(normalizeInputSchema(schema)).toEqual(schema);
+    });
+  });
+
+  describe("planExposedTools", () => {
+    it("exposes bare names when there are no collisions", () => {
+      const { exposed, collisions } = planExposedTools([
+        {
+          name: "paperclip-plugin-hindsight:hindsight_recall",
+          description: "Search memory",
+          parametersSchema: { type: "object", required: ["query"], properties: { query: { type: "string" } } },
+        },
+        {
+          name: "paperclip-plugin-hindsight:hindsight_retain",
+          description: "Save memory",
+          parametersSchema: { type: "object", required: ["content"], properties: { content: { type: "string" } } },
+        },
+      ]);
+      expect(collisions).toEqual([]);
+      expect(exposed.map((t) => [t.exposedName, t.fullName])).toEqual([
+        ["hindsight_recall", "paperclip-plugin-hindsight:hindsight_recall"],
+        ["hindsight_retain", "paperclip-plugin-hindsight:hindsight_retain"],
+      ]);
+    });
+
+    it("falls back to plugin-prefixed names on bare-name collisions and reports them", () => {
+      const { exposed, collisions } = planExposedTools([
+        { name: "paperclip-plugin-hindsight:hindsight_recall" },
+        { name: "paperclip-plugin-other:hindsight_recall" },
+        { name: "paperclip-plugin-other:unique_tool" },
+      ]);
+      expect(collisions).toEqual(["hindsight_recall", "hindsight_recall"]);
+      expect(exposed.map((t) => t.exposedName)).toEqual([
+        "paperclip_plugin_hindsight_hindsight_recall",
+        "paperclip_plugin_other_hindsight_recall",
+        "unique_tool",
+      ]);
+    });
+  });
+
+  describe("trimTrailingSlash", () => {
+    it("removes trailing slashes idempotently", () => {
+      expect(trimTrailingSlash("http://x/")).toBe("http://x");
+      expect(trimTrailingSlash("http://x///")).toBe("http://x");
+      expect(trimTrailingSlash("http://x")).toBe("http://x");
+    });
+  });
+});
+
+describe("paperclip-tools-mcp-shim HTTP behaviour", () => {
+  let server: FakeServer;
+
+  beforeAll(async () => {
+    server = await startFakePaperclip();
+  });
+
+  afterAll(async () => {
+    await server.close();
+  });
+
+  it("lists agent-scoped tools and forwards the bearer token", async () => {
+    server.setListResponse([
+      {
+        name: "paperclip-plugin-hindsight:hindsight_recall",
+        description: "Recall",
+        parametersSchema: { type: "object", required: ["query"], properties: { query: { type: "string" } } },
+      },
+    ]);
+    const tools = await fetchPaperclipTools({
+      apiUrl: server.url,
+      apiKey: "token-123",
+      companyId: "company-uuid",
+      agentId: "agent-uuid",
+    });
+    expect(tools.map((t) => t.name)).toEqual(["paperclip-plugin-hindsight:hindsight_recall"]);
+    const listRequest = server.requests.find((r) => r.method === "GET");
+    expect(listRequest).toBeTruthy();
+    expect(listRequest?.headers.authorization).toBe("Bearer token-123");
+    expect(listRequest?.url).toBe("/api/companies/company-uuid/agents/agent-uuid/tools");
+  });
+
+  it("forwards tool-call with namespaced tool name and run-id header, and translates result content", async () => {
+    server.setCallResponse({
+      pluginId: "paperclip-plugin-hindsight",
+      toolName: "hindsight_recall",
+      result: { content: "recalled-content" },
+    });
+    const result = await callPaperclipTool({
+      apiUrl: server.url,
+      apiKey: "token-x",
+      companyId: "co",
+      agentId: "ag",
+      runId: "run-abc",
+      toolName: "paperclip-plugin-hindsight:hindsight_recall",
+      parameters: { query: "what is up" },
+    });
+    expect(result).toEqual({ text: "recalled-content", isError: false });
+    const callRequest = server.requests.find((r) => r.method === "POST");
+    expect(callRequest?.headers["x-paperclip-run-id"]).toBe("run-abc");
+    expect(callRequest?.headers.authorization).toBe("Bearer token-x");
+    expect(callRequest?.url).toBe("/api/companies/co/agents/ag/tool-call");
+    expect(JSON.parse(callRequest?.body ?? "{}")).toEqual({
+      tool: "paperclip-plugin-hindsight:hindsight_recall",
+      parameters: { query: "what is up" },
+    });
+  });
+
+  it("translates an HTTP 401 into an MCP tool error rather than throwing", async () => {
+    server.setCallResponse("Unauthorized", 401);
+    const result = await callPaperclipTool({
+      apiUrl: server.url,
+      apiKey: "expired",
+      companyId: "co",
+      agentId: "ag",
+      toolName: "paperclip-plugin-hindsight:hindsight_recall",
+      parameters: {},
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain("HTTP 401");
+  });
+
+  it("translates a plugin-side `result.error` into an MCP tool error", async () => {
+    server.setCallResponse({
+      pluginId: "x",
+      toolName: "hindsight_recall",
+      result: { content: "partial", error: "downstream failure" },
+    });
+    const result = await callPaperclipTool({
+      apiUrl: server.url,
+      apiKey: "token-x",
+      companyId: "co",
+      agentId: "ag",
+      toolName: "paperclip-plugin-hindsight:hindsight_recall",
+      parameters: {},
+    });
+    expect(result.isError).toBe(true);
+    expect(result.text).toBe("partial");
+  });
+});
+
+describe("paperclip-tools-mcp-shim env handling", () => {
+  it("surfaces a clear missing-env error from fetchPaperclipTools when called with an empty URL", async () => {
+    await expect(
+      fetchPaperclipTools({ apiUrl: "http://127.0.0.1:1", apiKey: "x", companyId: "c", agentId: "a" }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/adapters/claude-local/src/server/paperclip-tools-mcp-shim.ts
+++ b/packages/adapters/claude-local/src/server/paperclip-tools-mcp-shim.ts
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+/**
+ * Stdio MCP server that projects Paperclip plugin-registered tools (e.g.
+ * paperclip-plugin-hindsight) into Claude Code's MCP surface.
+ *
+ * Reads PAPERCLIP_* env, fetches the agent-scoped tool list from
+ * `/api/companies/:companyId/agents/:agentId/tools`, exposes each tool with
+ * its bare name (collisions fall back to a `${pluginKey}_${toolName}` form),
+ * and forwards `tools/call` over HTTP to `/api/.../tool-call`.
+ *
+ * The shim outlives no run: claude_local spawns it per heartbeat and the
+ * Claude process disposes it via SIGTERM when the run completes. All HTTP
+ * errors surface as MCP tool errors (`isError: true`) rather than crashing
+ * the shim, so transient 401s mid-run do not take Claude down with them.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+interface PaperclipToolDescriptor {
+  name: string;
+  displayName?: string;
+  description?: string;
+  parametersSchema?: unknown;
+  pluginId?: string;
+}
+
+interface ExposedTool {
+  exposedName: string;
+  fullName: string;
+  description: string;
+  inputSchema: { type: "object"; properties?: Record<string, unknown>; required?: string[] };
+}
+
+const SERVER_NAME = "paperclip";
+const SERVER_VERSION = "0.1.0";
+const REQUIRED_ENV = [
+  "PAPERCLIP_API_URL",
+  "PAPERCLIP_API_KEY",
+  "PAPERCLIP_COMPANY_ID",
+  "PAPERCLIP_AGENT_ID",
+] as const;
+
+function readEnv(name: string): string {
+  const value = process.env[name];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`paperclip-tools-mcp-shim: required env var ${name} is missing or empty`);
+  }
+  return value.trim();
+}
+
+function readOptionalEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function sanitizePluginKey(value: string | undefined): string {
+  if (!value) return "plugin";
+  return value.replace(/[^A-Za-z0-9_]/g, "_").replace(/^_+|_+$/g, "") || "plugin";
+}
+
+function pluginKeyFromFullName(fullName: string, fallback?: string): string {
+  const colon = fullName.indexOf(":");
+  if (colon > 0) return fullName.slice(0, colon);
+  return fallback ?? fullName;
+}
+
+function bareToolName(fullName: string): string {
+  const colon = fullName.indexOf(":");
+  return colon >= 0 ? fullName.slice(colon + 1) : fullName;
+}
+
+function normalizeInputSchema(schema: unknown): ExposedTool["inputSchema"] {
+  if (schema && typeof schema === "object" && !Array.isArray(schema)) {
+    const record = schema as Record<string, unknown>;
+    const type = typeof record.type === "string" ? (record.type as string) : "object";
+    return {
+      type: type === "object" ? "object" : "object",
+      properties: (record.properties as Record<string, unknown> | undefined) ?? {},
+      ...(Array.isArray(record.required) ? { required: record.required as string[] } : {}),
+    };
+  }
+  return { type: "object", properties: {} };
+}
+
+function planExposedTools(tools: PaperclipToolDescriptor[]): {
+  exposed: ExposedTool[];
+  collisions: string[];
+} {
+  const counts = new Map<string, number>();
+  for (const tool of tools) {
+    const bare = bareToolName(tool.name);
+    counts.set(bare, (counts.get(bare) ?? 0) + 1);
+  }
+  const collisions: string[] = [];
+  const exposed: ExposedTool[] = [];
+  for (const tool of tools) {
+    const bare = bareToolName(tool.name);
+    const colliding = (counts.get(bare) ?? 0) > 1;
+    const exposedName = colliding
+      ? `${sanitizePluginKey(pluginKeyFromFullName(tool.name, tool.pluginId))}_${bare}`
+      : bare;
+    if (colliding) collisions.push(bare);
+    exposed.push({
+      exposedName,
+      fullName: tool.name,
+      description: tool.description ?? tool.displayName ?? "",
+      inputSchema: normalizeInputSchema(tool.parametersSchema),
+    });
+  }
+  return { exposed, collisions };
+}
+
+async function fetchPaperclipTools(opts: {
+  apiUrl: string;
+  apiKey: string;
+  companyId: string;
+  agentId: string;
+}): Promise<PaperclipToolDescriptor[]> {
+  const url = `${trimTrailingSlash(opts.apiUrl)}/api/companies/${encodeURIComponent(opts.companyId)}/agents/${encodeURIComponent(opts.agentId)}/tools`;
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${opts.apiKey}` },
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`Failed to list paperclip tools (HTTP ${response.status}): ${body.slice(0, 500)}`);
+  }
+  const parsed = await response.json().catch(() => null);
+  if (Array.isArray(parsed)) return parsed as PaperclipToolDescriptor[];
+  if (parsed && typeof parsed === "object" && Array.isArray((parsed as Record<string, unknown>).tools)) {
+    return (parsed as { tools: PaperclipToolDescriptor[] }).tools;
+  }
+  return [];
+}
+
+interface CallToolHttpResult {
+  text: string;
+  isError: boolean;
+}
+
+async function callPaperclipTool(opts: {
+  apiUrl: string;
+  apiKey: string;
+  companyId: string;
+  agentId: string;
+  runId?: string;
+  toolName: string;
+  parameters: Record<string, unknown>;
+}): Promise<CallToolHttpResult> {
+  const url = `${trimTrailingSlash(opts.apiUrl)}/api/companies/${encodeURIComponent(opts.companyId)}/agents/${encodeURIComponent(opts.agentId)}/tool-call`;
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    Authorization: `Bearer ${opts.apiKey}`,
+  };
+  if (opts.runId) headers["x-paperclip-run-id"] = opts.runId;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ tool: opts.toolName, parameters: opts.parameters }),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { text: `Network error calling paperclip tool "${opts.toolName}": ${msg}`, isError: true };
+  }
+  const status = response.status;
+  const bodyText = await response.text().catch(() => "");
+
+  if (!response.ok) {
+    const trimmed = bodyText.slice(0, 2_000) || "<empty body>";
+    return {
+      text: `Paperclip tool-call failed (HTTP ${status}) for "${opts.toolName}": ${trimmed}`,
+      isError: true,
+    };
+  }
+
+  let parsed: unknown = null;
+  try {
+    parsed = bodyText ? JSON.parse(bodyText) : null;
+  } catch {
+    parsed = null;
+  }
+
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const envelope = parsed as Record<string, unknown>;
+    const result = envelope.result;
+    if (result && typeof result === "object" && !Array.isArray(result)) {
+      const r = result as Record<string, unknown>;
+      const rawContent = r.content;
+      const isError = Boolean(r.error);
+      const text =
+        typeof rawContent === "string"
+          ? rawContent
+          : rawContent === undefined && typeof r.error === "string"
+            ? (r.error as string)
+            : JSON.stringify(rawContent ?? r, null, 2);
+      return { text, isError };
+    }
+    return { text: JSON.stringify(envelope, null, 2), isError: false };
+  }
+
+  return { text: bodyText, isError: false };
+}
+
+async function runServer(): Promise<void> {
+  for (const key of REQUIRED_ENV) readEnv(key);
+
+  const apiUrl = readEnv("PAPERCLIP_API_URL");
+  const apiKey = readEnv("PAPERCLIP_API_KEY");
+  const companyId = readEnv("PAPERCLIP_COMPANY_ID");
+  const agentId = readEnv("PAPERCLIP_AGENT_ID");
+  const runId = readOptionalEnv("PAPERCLIP_RUN_ID");
+
+  let cached: { exposed: ExposedTool[]; lookup: Map<string, string> } | null = null;
+  const loadTools = async () => {
+    if (cached) return cached;
+    const tools = await fetchPaperclipTools({ apiUrl, apiKey, companyId, agentId });
+    const { exposed, collisions } = planExposedTools(tools);
+    if (collisions.length > 0) {
+      const unique = Array.from(new Set(collisions));
+      process.stderr.write(
+        `[paperclip-tools-mcp-shim] tool-name collisions on ${unique.join(", ")}; falling back to plugin-prefixed exposed names for affected entries.\n`,
+      );
+    }
+    const lookup = new Map<string, string>();
+    for (const tool of exposed) lookup.set(tool.exposedName, tool.fullName);
+    cached = { exposed, lookup };
+    return cached;
+  };
+
+  const server = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { capabilities: { tools: { listChanged: false } } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const { exposed } = await loadTools();
+    return {
+      tools: exposed.map((tool) => ({
+        name: tool.exposedName,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      })),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const params = request.params as { name: string; arguments?: Record<string, unknown> };
+    const { lookup } = await loadTools();
+    const fullName = lookup.get(params.name);
+    if (!fullName) {
+      return {
+        content: [{ type: "text" as const, text: `Unknown paperclip tool: ${params.name}` }],
+        isError: true,
+      };
+    }
+    const result = await callPaperclipTool({
+      apiUrl,
+      apiKey,
+      companyId,
+      agentId,
+      runId,
+      toolName: fullName,
+      parameters: params.arguments ?? {},
+    });
+    return {
+      content: [{ type: "text" as const, text: result.text }],
+      isError: result.isError,
+    };
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+export const __test = {
+  planExposedTools,
+  normalizeInputSchema,
+  fetchPaperclipTools,
+  callPaperclipTool,
+  trimTrailingSlash,
+  sanitizePluginKey,
+  pluginKeyFromFullName,
+  bareToolName,
+};
+
+const isMain = (() => {
+  try {
+    const entry = process.argv[1];
+    if (!entry) return false;
+    const url = new URL(import.meta.url);
+    return url.pathname === entry || url.pathname.endsWith(entry);
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  void runServer().catch((err) => {
+    const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
+    process.stderr.write(`[paperclip-tools-mcp-shim] fatal: ${msg}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/adapters/claude-local/src/server/paperclip-tools-mcp-shim.ts
+++ b/packages/adapters/claude-local/src/server/paperclip-tools-mcp-shim.ts
@@ -12,6 +12,12 @@
  * Claude process disposes it via SIGTERM when the run completes. All HTTP
  * errors surface as MCP tool errors (`isError: true`) rather than crashing
  * the shim, so transient 401s mid-run do not take Claude down with them.
+ *
+ * The runtime artifact at `dist/server/paperclip-tools-mcp-shim.bundle.js`
+ * is a self-contained esbuild bundle (see `build:shim` in package.json) so
+ * that remote execution targets can run it from an isolated runtime asset
+ * directory with no reachable `node_modules` -- @modelcontextprotocol/sdk
+ * and its transitive deps are inlined into the bundle.
  */
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";

--- a/packages/adapters/claude-local/src/server/paperclip-tools-mcp.ts
+++ b/packages/adapters/claude-local/src/server/paperclip-tools-mcp.ts
@@ -7,7 +7,7 @@ import type { AdapterManagedRuntimeAsset } from "@paperclipai/adapter-utils/exec
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
-const SHIM_FILENAME = "paperclip-tools-mcp-shim.js";
+const SHIM_FILENAME = "paperclip-tools-mcp-shim.bundle.js";
 const MCP_CONFIG_FILENAME = "paperclip-tools-mcp.json";
 const REMOTE_ASSET_KEY = "paperclip-tools-mcp";
 
@@ -170,6 +170,12 @@ async function safeRemoveDir(dir: string): Promise<void> {
  * path. The remote variant prepares a staging directory containing the shim
  * file; the caller passes the directory through `prepareAdapterExecutionTargetRuntime`
  * and then writes the JSON server-side using `buildRemoteMcpConfigContents`.
+ *
+ * The shim file referenced here is the self-contained esbuild bundle produced
+ * by `pnpm run build:shim`. Because @modelcontextprotocol/sdk and its
+ * transitive deps are inlined into the bundle, shipping just the single .js
+ * to a remote target is sufficient -- the remote node process does not need
+ * any reachable `node_modules` to start the shim.
  */
 export async function preparePaperclipToolsMcp(
   input: ResolvePaperclipToolsMcpInput,

--- a/packages/adapters/claude-local/src/server/paperclip-tools-mcp.ts
+++ b/packages/adapters/claude-local/src/server/paperclip-tools-mcp.ts
@@ -1,0 +1,271 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFile } from "node:child_process";
+import type { AdapterManagedRuntimeAsset } from "@paperclipai/adapter-utils/execution-target";
+
+const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
+
+const SHIM_FILENAME = "paperclip-tools-mcp-shim.js";
+const MCP_CONFIG_FILENAME = "paperclip-tools-mcp.json";
+const REMOTE_ASSET_KEY = "paperclip-tools-mcp";
+
+export interface PreparedPaperclipToolsMcpLocal {
+  kind: "local";
+  mcpConfigPath: string;
+  cleanup(): Promise<void>;
+}
+
+export interface PreparedPaperclipToolsMcpRemote {
+  kind: "remote";
+  asset: AdapterManagedRuntimeAsset;
+  mcpConfigRemotePath: string;
+  /** Render the remote-side JSON contents once the asset is synced. */
+  buildRemoteMcpConfigContents(remoteAssetDir: string): string;
+  remoteAssetKey: string;
+  cleanup(): Promise<void>;
+}
+
+export type PreparedPaperclipToolsMcp =
+  | PreparedPaperclipToolsMcpLocal
+  | PreparedPaperclipToolsMcpRemote
+  | null;
+
+export interface ResolvePaperclipToolsMcpInput {
+  runId: string;
+  command: string;
+  resolvedCommand: string;
+  executionTargetIsRemote: boolean;
+  /**
+   * The deterministic remote dir for synced assets keyed by REMOTE_ASSET_KEY. When unknown,
+   * the helper falls back to `${effectiveRemoteCwd}/.paperclip-runtime/<adapterKey>/<asset key>`,
+   * which matches `runtimeAssetDir`'s fallback in @paperclipai/adapter-utils.
+   */
+  resolveRemoteAssetDir?(): string;
+  /** Set true to skip preparation entirely (config.disablePluginToolsMcp). */
+  disabled: boolean;
+  /** Override the resolved shim path (test hook). */
+  shimSourcePathOverride?: string;
+  /** Override the probe outcome (test hook). */
+  flagSupportOverride?: boolean;
+}
+
+export interface ResolvePaperclipToolsMcpOutput {
+  prepared: PreparedPaperclipToolsMcp;
+  reason?:
+    | "disabled"
+    | "no-claude-mcp-config-support"
+    | "shim-missing"
+    | "prepare-failed";
+  warning?: string;
+}
+
+let cachedShimResolution: { exists: boolean; resolvedAt: number } | null = null;
+let __shimSourcePathOverride: string | null = null;
+
+export function __setShimSourcePathOverrideForTesting(value: string | null): void {
+  __shimSourcePathOverride = value;
+}
+
+export function resolveLocalShimPath(): string {
+  if (__shimSourcePathOverride) return __shimSourcePathOverride;
+  return path.join(__moduleDir, SHIM_FILENAME);
+}
+
+async function shimFileExists(shimPath: string): Promise<boolean> {
+  const cacheBust = cachedShimResolution && Date.now() - cachedShimResolution.resolvedAt < 60_000;
+  if (cacheBust && cachedShimResolution) return cachedShimResolution.exists;
+  try {
+    const stat = await fs.stat(shimPath);
+    cachedShimResolution = { exists: stat.isFile(), resolvedAt: Date.now() };
+    return cachedShimResolution.exists;
+  } catch {
+    cachedShimResolution = { exists: false, resolvedAt: Date.now() };
+    return false;
+  }
+}
+
+const probeCache = new Map<string, Promise<boolean>>();
+const PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * Best-effort probe: spawn `<command> --help` once per resolved command and
+ * grep the stdout for `--mcp-config`. Result cached per-process keyed by the
+ * resolved command path. Returns true on probe failure (fail-open) so we do
+ * not silently disable MCP wiring on transient errors.
+ */
+export async function probeClaudeSupportsMcpConfig(input: {
+  command: string;
+  env?: Record<string, string>;
+}): Promise<boolean> {
+  const key = input.command;
+  const cached = probeCache.get(key);
+  if (cached) return cached;
+  const promise = new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    try {
+      const child = execFile(
+        input.command,
+        ["--help"],
+        { env: input.env ?? process.env, timeout: PROBE_TIMEOUT_MS, maxBuffer: 4 * 1024 * 1024 },
+        (_err, stdout, stderr) => {
+          const text = `${stdout ?? ""}\n${stderr ?? ""}`;
+          finish(text.includes("--mcp-config"));
+        },
+      );
+      child.on("error", () => finish(true));
+    } catch {
+      finish(true);
+    }
+  });
+  probeCache.set(key, promise);
+  return promise;
+}
+
+export function __clearProbeCacheForTesting(): void {
+  probeCache.clear();
+  cachedShimResolution = null;
+}
+
+export interface BuildMcpConfigContentsInput {
+  shimAbsolutePath: string;
+}
+
+export function buildMcpConfigContents(input: BuildMcpConfigContentsInput): string {
+  // env is intentionally omitted; the shim inherits PAPERCLIP_* from the Claude
+  // parent process, which is the only env shape that's consistent across local
+  // and remote (bridge-mediated) execution targets.
+  return `${JSON.stringify(
+    {
+      mcpServers: {
+        paperclip: {
+          command: "node",
+          args: [input.shimAbsolutePath],
+        },
+      },
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+async function makeLocalStagingDir(runId: string): Promise<string> {
+  const base = await fs.mkdtemp(path.join(os.tmpdir(), `paperclip-claude-mcp-${runId}-`));
+  return base;
+}
+
+async function safeRemoveDir(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+}
+
+/**
+ * Prepares Claude's MCP config so that paperclip plugin tools surface as native
+ * MCP tools. The local variant writes a `mcp.json` next to the absolute shim
+ * path. The remote variant prepares a staging directory containing the shim
+ * file; the caller passes the directory through `prepareAdapterExecutionTargetRuntime`
+ * and then writes the JSON server-side using `buildRemoteMcpConfigContents`.
+ */
+export async function preparePaperclipToolsMcp(
+  input: ResolvePaperclipToolsMcpInput,
+): Promise<ResolvePaperclipToolsMcpOutput> {
+  if (input.disabled) {
+    return { prepared: null, reason: "disabled" };
+  }
+
+  const shimSourcePath = input.shimSourcePathOverride ?? resolveLocalShimPath();
+  const exists = await shimFileExists(shimSourcePath);
+  if (!exists) {
+    return {
+      prepared: null,
+      reason: "shim-missing",
+      warning: `paperclip-tools MCP shim not found at ${shimSourcePath}; skipping MCP wiring.`,
+    };
+  }
+
+  const supportsFlag =
+    typeof input.flagSupportOverride === "boolean"
+      ? input.flagSupportOverride
+      : await probeClaudeSupportsMcpConfig({ command: input.command });
+  if (!supportsFlag) {
+    return {
+      prepared: null,
+      reason: "no-claude-mcp-config-support",
+      warning: `Claude CLI at "${input.resolvedCommand}" does not advertise --mcp-config; skipping paperclip-tools MCP wiring.`,
+    };
+  }
+
+  if (input.executionTargetIsRemote) {
+    const stagingDir = await makeLocalStagingDir(input.runId);
+    try {
+      await fs.copyFile(shimSourcePath, path.join(stagingDir, SHIM_FILENAME));
+    } catch (err) {
+      await safeRemoveDir(stagingDir);
+      return {
+        prepared: null,
+        reason: "prepare-failed",
+        warning: `Failed to stage paperclip-tools shim for remote sync: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    const buildRemoteMcpConfigContents = (remoteAssetDir: string) => {
+      const remoteShimPath = `${remoteAssetDir.replace(/\/+$/, "")}/${SHIM_FILENAME}`;
+      return buildMcpConfigContents({ shimAbsolutePath: remoteShimPath });
+    };
+
+    const assetDirFromCaller = input.resolveRemoteAssetDir?.();
+    const fallbackRemoteAssetDir = assetDirFromCaller
+      ? assetDirFromCaller.replace(/\/+$/, "")
+      : `.paperclip-runtime/${REMOTE_ASSET_KEY}`;
+    const mcpConfigRemotePath = `${fallbackRemoteAssetDir}/${MCP_CONFIG_FILENAME}`;
+
+    return {
+      prepared: {
+        kind: "remote",
+        asset: {
+          key: REMOTE_ASSET_KEY,
+          localDir: stagingDir,
+          followSymlinks: false,
+        },
+        remoteAssetKey: REMOTE_ASSET_KEY,
+        mcpConfigRemotePath,
+        buildRemoteMcpConfigContents,
+        async cleanup() {
+          await safeRemoveDir(stagingDir);
+        },
+      },
+    };
+  }
+
+  const stagingDir = await makeLocalStagingDir(input.runId);
+  const mcpConfigPath = path.join(stagingDir, MCP_CONFIG_FILENAME);
+  await fs.writeFile(
+    mcpConfigPath,
+    buildMcpConfigContents({ shimAbsolutePath: shimSourcePath }),
+    "utf8",
+  );
+
+  return {
+    prepared: {
+      kind: "local",
+      mcpConfigPath,
+      async cleanup() {
+        await safeRemoveDir(stagingDir);
+      },
+    },
+  };
+}
+
+export const __test = {
+  buildMcpConfigContents,
+  makeLocalStagingDir,
+  resolveLocalShimPath,
+  REMOTE_ASSET_KEY,
+  SHIM_FILENAME,
+  MCP_CONFIG_FILENAME,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@types/node':
         specifier: ^24.6.0
         version: 24.12.0
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -10997,14 +11000,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
-
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -14623,7 +14618,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,9 +138,6 @@ importers:
 
   packages/adapters/claude-local:
     dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
@@ -151,9 +148,6 @@ importers:
       '@types/node':
         specifier: ^24.6.0
         version: 24.12.0
-      esbuild:
-        specifier: ^0.27.3
-        version: 0.27.3
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -9212,28 +9206,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
-    dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - supports-color
-
   '@noble/ciphers@2.1.1': {}
 
   '@noble/hashes@1.8.0': {}
@@ -10999,6 +10971,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
@@ -14618,7 +14598,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -14781,10 +14761,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
 
   zod@3.25.76: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
 
   packages/adapters/claude-local:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
@@ -9206,6 +9209,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.13(hono@4.12.12)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.12
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
   '@noble/ciphers@2.1.1': {}
 
   '@noble/hashes@1.8.0': {}
@@ -14761,6 +14786,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary
- bundle `paperclip-tools-mcp-shim` into a self-contained runtime artifact (`paperclip-tools-mcp-shim.bundle.js`)
- switch shim resolver to the bundled artifact and keep source `.js` only for test imports
- add isolated startup integration test proving MCP `initialize` + `tools/list` works from an empty temp dir
- update adapter docs/changelog and package scripts/version for shim bundling

## QA review + validation
- Multi-pass review completed (code quality/security/performance/test coverage): no unresolved findings
- `pnpm --filter @paperclipai/adapter-claude-local run typecheck`
- `pnpm --filter @paperclipai/adapter-claude-local run build`
- `pnpm --filter @paperclipai/adapter-claude-local exec vitest run` (6 files / 31 tests)

## Issue
- SPO-50
