### PR TITLE
fix(issues): serialize Date params to ISO string in enrichCommentsWithDerivedAgentAttribution

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1956,8 +1956,8 @@ export function issueService(db: Db) {
                 and ${activityLog.runId} = ${heartbeatRuns.id}
             )`,
           ),
-          sql`coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.createdAt}) >= ${new Date(minCommentCreatedAtMs)}`,
-          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${new Date(maxCommentCreatedAtMs + ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS)}`,
+          sql`coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.createdAt}) >= ${new Date(minCommentCreatedAtMs).toISOString()}`,
+          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${new Date(maxCommentCreatedAtMs + ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS).toISOString()}`,
         ),
       )
       .orderBy(desc(heartbeatRuns.createdAt));


### PR DESCRIPTION
## Thinking Path

1. Paperclip serves a Web UI at \`localhost:3100\` that lists issue comments with agent attribution.
2. The dashboard calls \`GET /api/issues/:id/comments\` to render comment threads.
3. That route resolves through \`services/issues.ts::listComments\`, which calls \`enrichCommentsWithDerivedAgentAttribution\` to map comments back to their originating heartbeat runs.
4. \`enrichCommentsWithDerivedAgentAttribution\` queries \`heartbeat_runs\` filtered by a time window using two \`coalesce(...) >= ...\` / \`<= ...\` predicates in raw \`sql\` template literals.
5. The bind values for those predicates are constructed as \`new Date(minCommentCreatedAtMs)\` and \`new Date(maxCommentCreatedAtMs + SLACK)\` — raw JS \`Date\` objects.
6. drizzle-orm's postgres-js driver does not auto-coerce \`Date\` objects passed via \`sql\`\`\` template literals at these bind sites; it forwards them to postgres.js, which expects \`string | Buffer | ArrayBuffer\`.
7. Result: every \`GET /api/issues/:id/comments\` request that exercises attribution enrichment returns 500 with \`TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Date\`.
8. This PR coerces those two Date params to ISO strings at the call site, matching the pattern already used for date binds elsewhere in this file.

## What Changed

- \`server/src/services/issues.ts\` — Added \`.toISOString()\` to the two \`new Date(...)\` bind values inside \`enrichCommentsWithDerivedAgentAttribution\`'s time-window predicates.

## Verification

1. Start a local Paperclip instance with at least one issue that has comments authored by a heartbeat-run agent.
2. **Before patch:** \`GET /api/issues/<id>/comments?order=desc&limit=50\` returns \`500\` with \`Received an instance of Date\` in server logs (stack pointing into \`enrichCommentsWithDerivedAgentAttribution\`).
3. **After patch:** same request returns \`200\` with the normal comments payload and correct derived agent attribution.
4. \`pnpm typecheck\` — clean.
5. \`pnpm --filter @paperclipai/server vitest run src/__tests__/issues-service.test.ts\` — 46/46 pass.

## Risks

Low risk. Pure string coercion of two SQL bind parameters; no behavioral change in the resulting query semantics. The exact same \`.toISOString()\` pattern is already used for date binds elsewhere in this file, so this only brings these two binds in line with the rest of the codebase.

## Model Used

Claude Opus 4.7 (\`claude-opus-4-7\`), 1M context window, extended thinking enabled. The patch location was identified from a production stack trace; the fix was derived by symmetry with adjacent code paths in the same file that already serialize Date binds via \`.toISOString()\`.

## Checklist

- [x] Checked \`ROADMAP.md\` — not a planned feature, purely a bug fix.
- [x] Tested locally on macOS arm64, repo at v2026.512.0.
- [x] \`pnpm typecheck\` clean.
- [x] \`pnpm --filter @paperclipai/server vitest run src/__tests__/issues-service.test.ts\` clean (46/46).
- [x] No new dependencies.
- [x] No UI changes (no screenshots required).
- [x] No documentation updates required.
- [x] Single-purpose, minimal diff (2 lines, one file).

---

Related: #3583 (same root cause, but a **different call site** from the cursor pagination work in #5018 / #4226 / #3859 / #3787 — those PRs fix the \`listComments\` cursor binds, while this one fixes the binds inside \`enrichCommentsWithDerivedAgentAttribution\`, which is on the same hot path but a separate function).