### PR TITLE
fix(issues): filter bogus agent://id mentions before wakeup

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3709,7 +3709,14 @@ export function issueService(db: Db) {
       if (tokens.size === 0 && explicitAgentMentionIds.length === 0) return [];
       const rows = await db.select({ id: agents.id, name: agents.name })
         .from(agents).where(eq(agents.companyId, companyId));
-      const resolved = new Set<string>(explicitAgentMentionIds);
+      // Filter explicit mention IDs against the company's agents to drop bogus IDs
+      // (e.g. literal `agent://id` placeholders in example markdown) before they
+      // reach `heartbeat.wakeup`, where a non-UUID would raise a PostgresError.
+      const validAgentIds = new Set(rows.map((row) => row.id));
+      const resolved = new Set<string>();
+      for (const mentionedId of explicitAgentMentionIds) {
+        if (validAgentIds.has(mentionedId)) resolved.add(mentionedId);
+      }
       for (const agent of rows) {
         if (tokens.has(agent.name.toLowerCase())) {
           resolved.add(agent.id);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents communicate via issue comments; the comment route resolves `@`-mentions and `agent://<id>` links and wakes the mentioned agents via `heartbeat.wakeup(agentId, …)`, which queries Postgres on the agent's UUID
> - In production at equalizent media, an agent posted a comment that contained the literal placeholder `[@Name](agent://id)` while *explaining* the mention syntax to a peer agent
> - `findMentionedAgents` forwarded the parsed `"id"` straight to the wakeup path, which raised `PostgresError: invalid input syntax for type uuid: "id"`; the resulting orphaned `executionLocked` left the originating issue stuck in `in_progress`
> - The parser is intentionally permissive (any `agent://<host>` is parseable), so the validation belongs at the service boundary — right before any wakeup call
> - This pull request filters `explicitAgentMentionIds` against the company's actual agents before they reach `heartbeat.wakeup`
> - The benefit is that any future agent (or human) writing example/placeholder markdown like `agent://id`, `agent://abc`, or a stale UUID can no longer crash a wake-up or strand an issue lock

## What Changed

- `server/src/services/issues.ts` — `findMentionedAgents` now filters `explicitAgentMentionIds` against the company's agents table; only IDs that correspond to real agents are returned. Token-name resolution is unchanged.

## Verification

**Reproducer (pre-fix)** — post a comment on any issue containing both a real mention and a bogus one:

```
Hi [@RealAgent](agent://<valid-uuid>) — for cross-agent mentions use [@Name](agent://id).
```

Before the patch, `paperclip.service` logs:

```
WARN: failed to wake agent on issue comment {"issueId":"…","agentId":"id"}
PostgresError: invalid input syntax for type uuid: "id"
```

After the patch, the bogus mention is filtered before the wakeup loop and no PostgresError appears; the legitimate mention is still woken normally.

**Manual test:**
1. Apply the patch and restart the server
2. POST a comment to an issue with body `Test [@Name](agent://id) plus [@RealAgent](agent://<valid-agent-uuid>)`
3. Tail logs: `journalctl -u paperclip.service --since "1 minute ago" | grep -iE "wake|PostgresError"`
4. Expected: no `PostgresError`; the real agent is still notified

**Existing test suite:**

```
cd server && pnpm exec vitest run src/__tests__/issue-comment-reopen-routes.test.ts
```

→ 28/28 pass (these tests mock `findMentionedAgents`, so they exercise the comment-routing path and confirm the change does not break the surrounding contract).

## Risks

- **Behavioral risk:** Low. The new filter is a strict subset of what `findMentionedAgents` previously returned — any agent ID that *was* a real company agent will still be returned, so legitimate mentions are unaffected. Only IDs that did not match any agent row are dropped (and those would have crashed `heartbeat.wakeup` anyway).
- **Migration risk:** None. Pure runtime change, no schema or API contract change.
- **Performance risk:** None. The `agents` row fetch was already being performed for token-name resolution; this PR reuses it to build the validation set.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (model ID `claude-opus-4-7`, 1M context window)
- Mode: extended reasoning + tool use (Bash, Read, Edit, ssh-driven investigation against the production server where the bug was first observed)
- Reproduction: bug surfaced and root-caused in a live Paperclip deployment (v2026.428.0) before the fix was authored

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — see note below
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [ ] I have updated relevant documentation to reflect my changes — N/A (no doc surface)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

**Test note:** `findMentionedAgents` does not currently have a dedicated unit test — existing references in `__tests__/` mock the function at the routes layer. Adding a service-level test would require wiring up a Drizzle-mock or in-memory db harness that does not yet exist in this repo. Happy to add one (or refactor the agent-filter logic into a pure helper that is trivially testable, similar to `hasAgentShortnameCollision`) if reviewers prefer — let me know which path you'd like.
