### PR TITLE
fix(server): cast comment-enrichment Date bind params to timestamptz

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1969,8 +1969,8 @@ export function issueService(db: Db) {
                 and ${activityLog.runId} = ${heartbeatRuns.id}
             )`,
           ),
-          sql`coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.createdAt}) >= ${new Date(minCommentCreatedAtMs)}`,
-          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${new Date(maxCommentCreatedAtMs + ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS)}`,
+          sql`coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.createdAt}) >= ${new Date(minCommentCreatedAtMs).toISOString()}::timestamptz`,
+          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${new Date(maxCommentCreatedAtMs + ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS).toISOString()}::timestamptz`,
         ),
       )
       .orderBy(desc(heartbeatRuns.createdAt));


### PR DESCRIPTION
## Thinking Path

> - Humans and agents collaborate on issues through threaded comments served by `GET /api/issues/:id/comments`
> - Some comments are posted by users but actually originate from agent runs, so the server enriches them with derived agent attribution by querying `heartbeat_runs` within the comments' time window
> - In `2026.512.0`, that enrichment query started failing with a 500 because the timestamp bounds were passed as raw `Date` objects, and Drizzle's compiled schema for these columns has `driverParam: string` — postgres-js then threw `ERR_INVALID_ARG_TYPE` ("Received an instance of Date")
> - As a result, comment threads that needed derived attribution (user-authored comments without a stored `createdByRunId`) could not load at all
> - This PR converts the two `Date` bind params to ISO strings and casts them with `::timestamptz` in the SQL template, matching the column type
> - The benefit is that comment threads load again on `2026.512.0` without changing query semantics or the underlying schema

## What Changed

- `server/src/services/issues.ts`: in `enrichCommentsWithDerivedAgentAttribution`, replace `${new Date(ms)}` bind params with `${new Date(ms).toISOString()}::timestamptz` for both `coalesce(finished_at, created_at) >= …` and `coalesce(started_at, created_at) <= …` predicates against `heartbeat_runs`.

## Verification

- `pnpm --filter @paperclipai/server exec tsc --noEmit` — passes.
- Manual: with the fix applied, `GET /api/issues/:id/comments?order=desc&limit=50` returns 200 for an issue containing a user-authored comment that has no `createdByRunId` and where matching `heartbeat_runs` exist (the data shape from issue #5796).
- Reviewer can confirm the compiled SQL is identical to what the issue reporter tested locally — `>= '…Z'::timestamptz` / `<= '…Z'::timestamptz`.

## Risks

- Low risk. The fix is localized to two `sql` template literals in one function. The values being bound are semantically the same (the same instants in time), only the wire-format changes from a `Date` instance (which the postgres driver rejected) to an ISO string explicitly cast to `timestamptz`. No schema, migration, or API contract changes.

## Model Used

- Claude Opus 4.7 (Anthropic, model ID `claude-opus-4-7`), 1M context window, via Claude Code CLI. No extended thinking mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (typecheck; this code path has no targeted unit test in the existing suite, and the bug requires populated `heartbeat_runs` to reproduce)
- [ ] I have added or updated tests where applicable — not added; reproducing requires inserting matching `heartbeat_runs` and the fix is a one-line driver-binding correction. Happy to add a regression test if requested.
- [x] If this change affects the UI, I have included before/after screenshots — N/A (server-only)
- [x] I have updated relevant documentation to reflect my changes — N/A
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Fixes #5796