### PR TITLE
Platform fix: mark runs as failed on issue release + harden stale-run…

### DIFF
--- a/server/src/services/access.ts
+++ b/server/src/services/access.ts
@@ -381,6 +381,7 @@ export function accessService(db: Db) {
           startedAt: null,
           checkoutRunId: null,
           executionRunId: null,
+          executionAgentNameKey: null,
           executionLockedAt: null,
         })
         .where(and(assignedOpenIssueWhere, eq(issues.status, "in_progress")))

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3143,6 +3143,30 @@ export function issueService(db: Db) {
         patch.executionLockedAt = null;
       }
 
+      // PIN-225 fix #2: Mark run as failed when stale evaluation is resolved
+      if (
+        existing.originKind === "stale_active_run_evaluation" &&
+        existing.originId &&
+        issueData.status &&
+        ["done", "cancelled"].includes(issueData.status) &&
+        !["done", "cancelled"].includes(existing.status)
+      ) {
+        await dbOrTx
+          .update(heartbeatRuns)
+          .set({
+            status: "failed",
+            finishedAt: new Date(),
+            error: "Stale run evaluation resolved",
+          })
+          .where(
+            and(
+              eq(heartbeatRuns.id, existing.originId),
+              eq(heartbeatRuns.status, "running"),
+              isNull(heartbeatRuns.finishedAt),
+            ),
+          );
+      }
+
       const runUpdate = async (tx: any) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, existing.companyId);
         const [currentProjectGoalId, nextProjectGoalId] = await Promise.all([
@@ -3634,6 +3658,24 @@ export function issueService(db: Db) {
         }
       }
 
+      // Mark executionRunId run as failed if still running (PIN-225 fix #1)
+      if (existing.executionRunId) {
+        await db
+          .update(heartbeatRuns)
+          .set({
+            status: "failed",
+            finishedAt: new Date(),
+            error: "Issue released while run was active",
+          })
+          .where(
+            and(
+              eq(heartbeatRuns.id, existing.executionRunId),
+              eq(heartbeatRuns.status, "running"),
+              isNull(heartbeatRuns.finishedAt),
+            ),
+          );
+      }
+
       const updated = await db
         .update(issues)
         .set({
@@ -3668,6 +3710,24 @@ export function issueService(db: Db) {
           .where(eq(issues.id, id))
           .then((rows) => rows[0] ?? null);
         if (!existing) return null;
+
+        // Mark executionRunId run as failed if still running (PIN-225 fix #1)
+        if (existing.executionRunId) {
+          await tx
+            .update(heartbeatRuns)
+            .set({
+              status: "failed",
+              finishedAt: new Date(),
+              error: "Issue force-released while run was active",
+            })
+            .where(
+              and(
+                eq(heartbeatRuns.id, existing.executionRunId),
+                eq(heartbeatRuns.status, "running"),
+                isNull(heartbeatRuns.finishedAt),
+              ),
+            );
+        }
 
         const patch: Partial<typeof issues.$inferInsert> = {
           checkoutRunId: null,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1025,6 +1025,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
+    // Defense in depth: skip if source issue was already released (checkoutRunId cleared)
+    if (sourceIssue && sourceIssue.checkoutRunId === null) {
+      return { kind: "skipped" as const };
+    }
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({
       run: input.run,


### PR DESCRIPTION
… monitor

Implements three systemic fixes to prevent zombie run records from generating duplicate stale-run alerts:

Fix #1 - Run cleanup on issue release/reset:
When an issue is released and executionRunId is cleared, mark that run as failed if still in running status. Applied to both release() and adminForceRelease() functions.

Fix #2 - Evaluation resolution auto-closes run:
When a stale_active_run_evaluation issue is resolved (done/cancelled), automatically mark the originId run as failed if still running.

Fix #3 - Monitor hardening (defense in depth):
Stale-run monitor now skips creating alerts when source issue has checkoutRunId IS NULL (indicates already-released issue).

Additional fix - Missing executionAgentNameKey in access.ts: Principal removal reset was missing executionAgentNameKey clear, leaving stale execution metadata.

Fixes PIN-225

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
