### PR TITLE
fix(auth): trust both runtime listen port and configured port

### DIFF
--- a/server/src/__tests__/better-auth.test.ts
+++ b/server/src/__tests__/better-auth.test.ts
@@ -59,20 +59,24 @@ describe("Better Auth cookie scoping", () => {
     ]));
   });
 
-  it("prefers an explicit resolved listen port over the configured port", () => {
+  it("includes both the resolved listen port AND the configured port when they differ", () => {
+    // detectPort may fall back to a free port if the configured one is busy,
+    // but users can still reach the install on the configured port via a
+    // reverse proxy, Tailscale funnel, container port mapping, or Cloudflare
+    // tunnel. Both ports must be trusted so neither path 403s on "Invalid origin".
     const trustedOrigins = deriveAuthTrustedOrigins({
       deploymentMode: "authenticated",
       authBaseUrlMode: "auto",
       authPublicBaseUrl: undefined,
       allowedHostnames: ["board.example.test"],
-      port: 3100,
-    } as Parameters<typeof deriveAuthTrustedOrigins>[0], { listenPort: 3101 });
+      port: 3101,
+    } as Parameters<typeof deriveAuthTrustedOrigins>[0], { listenPort: 3102 });
 
     expect(trustedOrigins).toEqual(expect.arrayContaining([
       "https://board.example.test:3101",
       "http://board.example.test:3101",
+      "https://board.example.test:3102",
+      "http://board.example.test:3102",
     ]));
-    expect(trustedOrigins).not.toContain("https://board.example.test:3100");
-    expect(trustedOrigins).not.toContain("http://board.example.test:3100");
   });
 });

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -73,14 +73,24 @@ export function deriveAuthTrustedOrigins(config: Config, opts?: { listenPort?: n
     }
   }
   if (config.deploymentMode === "authenticated") {
-    const port = opts?.listenPort ?? config.port;
-    const needsPortVariants = port !== 80 && port !== 443;
+    // Include both the runtime listen port AND the user-configured port. They
+    // differ whenever `detectPort` falls back to a free port because the
+    // requested one was busy at startup — but users may still be reaching
+    // Paperclip on the configured port via a reverse proxy, Tailscale funnel,
+    // container port mapping, or a Cloudflare tunnel. Trusting only the
+    // runtime listen port leaves those requests with a 403 "Invalid origin"
+    // and no obvious recovery path short of editing the systemd unit.
+    const ports = new Set<number>();
+    const runtimePort = opts?.listenPort ?? config.port;
+    ports.add(runtimePort);
+    ports.add(config.port);
     for (const hostname of config.allowedHostnames) {
       const trimmed = hostname.trim().toLowerCase();
       if (!trimmed) continue;
       trustedOrigins.add(`https://${trimmed}`);
       trustedOrigins.add(`http://${trimmed}`);
-      if (needsPortVariants) {
+      for (const port of ports) {
+        if (port === 80 || port === 443) continue;
         trustedOrigins.add(`https://${trimmed}:${port}`);
         trustedOrigins.add(`http://${trimmed}:${port}`);
       }


### PR DESCRIPTION
## Summary

`deriveAuthTrustedOrigins` was emitting hostname:port variants for only one port — either `config.port` (historically) or, since #4554, the runtime `listenPort` from `detectPort`. When the two differ (because `detectPort` slid to a free port at startup, while the user is still reaching Paperclip on the configured port via a reverse proxy, Tailscale funnel, container mapping, or Cloudflare tunnel), Better Auth 403s every login as `Invalid origin`. This PR unions both ports into the trusted-origins list.

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; the server ships with a Better Auth integration that gates the web UI behind email+password sessions.
> - Better Auth enforces a `trustedOrigins` allowlist on every authenticated request — a `403 Invalid origin` rejects anything whose `Origin` header isn't on the list.
> - `deriveAuthTrustedOrigins` in `server/src/auth/better-auth.ts` builds that allowlist from `allowedHostnames` plus a single port — historically the user-configured `config.port`, then since #4554 the runtime `listenPort` reported back from `detectPort`.
> - `detectPort` silently falls back to a free port when the configured one is busy at startup (e.g. a stale process holding `:3101`, so the new one binds `:3102`). That makes `listenPort !== config.port`.
> - But users may still be reaching Paperclip on the **configured** port via a reverse proxy, Tailscale funnel, container port mapping, or a Cloudflare tunnel — all of which target the configured port and don't care what the local listener landed on.
> - When that happens today, every login attempt 403s at Better Auth before reaching the auth handler, and the only recovery is editing the systemd / launchd unit or `.env` and restarting.
> - This pull request unions both ports into the trusted-origins list so neither path is locked out.
> - The benefit is that detectPort-fallback installs (and proxy/tunnel-fronted installs more generally) can log in without manual config surgery.

## What Changed

- `server/src/auth/better-auth.ts`: replaced the single-port branch with a `Set<number>` containing both `opts.listenPort ?? config.port` and `config.port`, then loop over them to emit hostname:port variants. `Set` dedup keeps output identical when the two are equal.
- `server/src/__tests__/better-auth.test.ts`: replaced the "prefers an explicit resolved listen port" test (which asserted the configured port should **not** appear — encoding the bug) with one that asserts both ports' variants appear when `listenPort !== config.port`. The "adds hostname port variants for authenticated mode on non-default ports" test still covers the equal-ports common case.

## Verification / Test plan

- **Automated:** `pnpm --filter @paperclipai/server test better-auth` exercises both the updated assertion (`listenPort=3102` + `config.port=3101` → both port variants in `trustedOrigins`) and the unchanged equal-ports case via the existing "adds hostname port variants for authenticated mode on non-default ports" test.
- **Manual:** start Paperclip with `port=3101` while `:3101` is already busy so `detectPort` slides to `:3102`. Confirm UI loaded on `:3101` (via reverse proxy / Tailscale funnel) and on `:3102` (direct) both log in without `403 Invalid origin`.
- **Negative:** confirm standard ports `80` and `443` are still skipped via the existing `continue` guard (no `:80` / `:443` suffixes leak into the trusted list).

## Risks

Low. The change is strictly additive — any origin previously trusted is still trusted, and the only new origins are hostname:port variants for `config.port` when it differs from `listenPort`. Standard ports (80, 443) are still skipped via the existing guard. No migration, no config surface change.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`), Anthropic, extended thinking mode, working through Claude Code CLI.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass (no `node_modules` in my disposable PR-prep checkout; CI vitest will exercise)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only)
- [ ] I have updated relevant documentation to reflect my changes (no doc surface affected)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge