### PR TITLE
feat(server): reject mismatched body authorAgentId/authorUserId on comment POST (ZERA-565)

### DIFF
--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -161,6 +161,26 @@ describe("issue validators", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("accepts optional uuid authorAgentId / authorUserId hints on issue comments", () => {
+    const parsed = addIssueCommentSchema.parse({
+      body: "hello",
+      authorAgentId: "11111111-1111-4111-8111-111111111111",
+      authorUserId: "22222222-2222-4222-8222-222222222222",
+    });
+
+    expect(parsed.authorAgentId).toBe("11111111-1111-4111-8111-111111111111");
+    expect(parsed.authorUserId).toBe("22222222-2222-4222-8222-222222222222");
+  });
+
+  it("rejects non-uuid authorAgentId / authorUserId on issue comments", () => {
+    expect(
+      addIssueCommentSchema.safeParse({ body: "hi", authorAgentId: "not-a-uuid" }).success,
+    ).toBe(false);
+    expect(
+      addIssueCommentSchema.safeParse({ body: "hi", authorUserId: "not-a-uuid" }).success,
+    ).toBe(false);
+  });
+
   it("normalizes escaped line breaks in generated task drafts", () => {
     const parsed = suggestedTaskDraftSchema.parse({
       clientKey: "task-1",

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -461,6 +461,8 @@ export type IssueCommentMetadata = z.infer<typeof issueCommentMetadataSchema>;
 export const addIssueCommentSchema = z.object({
   body: multilineTextSchema.pipe(z.string().min(1)),
   authorType: issueCommentAuthorTypeSchema.optional(),
+  authorAgentId: z.string().uuid().optional(),
+  authorUserId: z.string().uuid().optional(),
   presentation: issueCommentPresentationSchema.nullable().optional(),
   metadata: issueCommentMetadataSchema.nullable().optional(),
   reopen: z.boolean().optional(),

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1337,4 +1337,118 @@ describe.sequential("issue comment reopen routes", () => {
       }),
     ));
   });
+
+  describe("POST /issues/:id/comments body author validation (ZERA-565)", () => {
+    const SELF_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+    const OTHER_AGENT_ID = "80241e51-1c75-46f0-93f0-bea4506d51ff";
+    const OTHER_USER_ID = "9b646ead-f82b-430c-9536-f2bb661341b6";
+
+    it("returns 422 when body authorAgentId does not match the authenticated agent", async () => {
+      const app = await installActor(createApp(), agentActor(SELF_AGENT_ID));
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+      const res = await request(app)
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "impersonation probe", authorAgentId: OTHER_AGENT_ID });
+
+      expect(res.status).toBe(422);
+      expect(res.body.error).toMatch(/authorAgentId.*authenticated agent principal/);
+      expect(res.body.details).toEqual({ field: "authorAgentId" });
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    });
+
+    it("returns 422 when body authorAgentId is sent by a board user", async () => {
+      const app = await installActor(createApp());
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+      const res = await request(app)
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "board impersonating agent", authorAgentId: OTHER_AGENT_ID });
+
+      expect(res.status).toBe(422);
+      expect(res.body.details).toEqual({ field: "authorAgentId" });
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    });
+
+    it("returns 422 when body authorUserId does not match the authenticated board user", async () => {
+      const app = await installActor(createApp());
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+      const res = await request(app)
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "user impersonation probe", authorUserId: OTHER_USER_ID });
+
+      expect(res.status).toBe(422);
+      expect(res.body.error).toMatch(/authorUserId.*authenticated user principal/);
+      expect(res.body.details).toEqual({ field: "authorUserId" });
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    });
+
+    it("returns 422 when body authorUserId is sent by an agent principal", async () => {
+      const app = await installActor(createApp(), agentActor(SELF_AGENT_ID));
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+      const res = await request(app)
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "agent impersonating user", authorUserId: OTHER_USER_ID });
+
+      expect(res.status).toBe(422);
+      expect(res.body.details).toEqual({ field: "authorUserId" });
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-UUID body authorAgentId at the schema layer", async () => {
+      const app = await installActor(createApp(), agentActor(SELF_AGENT_ID));
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+      const res = await request(app)
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "bad uuid", authorAgentId: "not-a-uuid" });
+
+      expect(res.status).toBe(400);
+      expect(mockIssueService.addComment).not.toHaveBeenCalled();
+    });
+
+    it("accepts body authorAgentId that matches the authenticated agent", async () => {
+      const app = await installActor(createApp(), agentActor(SELF_AGENT_ID));
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+      const res = await request(app)
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "hello", authorAgentId: SELF_AGENT_ID });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
+    });
+
+    it("accepts body authorUserId that matches the authenticated board user", async () => {
+      const app = await installActor(createApp(), {
+        type: "board",
+        userId: OTHER_USER_ID,
+        companyIds: ["company-1"],
+        source: "local_implicit",
+        isInstanceAdmin: false,
+      });
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+      const res = await request(app)
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "hello", authorUserId: OTHER_USER_ID });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
+    });
+
+    it("baseline: omitting body author fields still posts a comment as before", async () => {
+      const app = await installActor(createApp(), agentActor(SELF_AGENT_ID));
+      mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+
+      const res = await request(app)
+        .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+        .send({ body: "no override" });
+
+      expect(res.status).toBe(201);
+      expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1158,6 +1158,43 @@ export function issueRoutes(
     return false;
   }
 
+  // Defense-in-depth: the stored comment author is always derived from the
+  // authenticated principal. If a client also sends `authorAgentId` or
+  // `authorUserId` in the body, treat any mismatch with the principal as a
+  // misconfigured request and reject loudly rather than silently overriding.
+  function assertCommentAuthorMatchesPrincipal(
+    req: Request,
+    res: Response,
+    input: { authorAgentId?: string; authorUserId?: string },
+  ) {
+    const { authorAgentId, authorUserId } = input;
+    if (authorAgentId === undefined && authorUserId === undefined) return true;
+
+    if (authorAgentId !== undefined) {
+      if (req.actor.type !== "agent" || req.actor.agentId !== authorAgentId) {
+        res.status(422).json({
+          error:
+            "Body `authorAgentId` must match the authenticated agent principal. Omit the field; the author is derived from the request principal.",
+          details: { field: "authorAgentId" },
+        });
+        return false;
+      }
+    }
+
+    if (authorUserId !== undefined) {
+      if (req.actor.type !== "board" || req.actor.userId !== authorUserId) {
+        res.status(422).json({
+          error:
+            "Body `authorUserId` must match the authenticated user principal. Omit the field; the author is derived from the request principal.",
+          details: { field: "authorUserId" },
+        });
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   async function assertExplicitResumeIntentAllowed(
     req: Request,
     res: Response,
@@ -4330,6 +4367,10 @@ export function issueRoutes(
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,
+    })) return;
+    if (!assertCommentAuthorMatchesPrincipal(req, res, {
+      authorAgentId: req.body.authorAgentId,
+      authorUserId: req.body.authorUserId,
     })) return;
     const closedExecutionWorkspace = await getClosedIssueExecutionWorkspace(issue);
     if (closedExecutionWorkspace) {


### PR DESCRIPTION
## Summary

Hardens `POST /api/issues/:id/comments` so misconfigured clients fail fast instead of having their `authorAgentId`/`authorUserId` body fields silently overridden by the principal-derived author. Defense-in-depth — the security boundary itself was already correct.

Filed as ZERA-565 from [ZERA-85](/ZERA/issues/ZERA-85) cycle 13 (Security Researcher dogfooding). CEO endorsed Option 1 (422 reject as default).

## Behavior

| Body field | Authenticated principal | Today | After this PR |
| --- | --- | --- | --- |
| `authorAgentId` matches actor agent id | agent | 201 (no-op) | 201 (no-op) |
| `authorAgentId` differs from actor agent id | agent | 201, stored author = actor (silent override) | **422** with `details.field = "authorAgentId"` |
| `authorAgentId` present | board user | 201, stored author = actor (silent override) | **422** |
| `authorUserId` matches actor user id | board | 201 (no-op) | 201 (no-op) |
| `authorUserId` differs from actor user id | board | 201, stored author = actor (silent override) | **422** with `details.field = "authorUserId"` |
| `authorUserId` present | agent | 201, stored author = actor (silent override) | **422** |
| neither field present | any | 201 | 201 (unchanged) |
| malformed uuid | any | 201 (zod-stripped) | **400** (zod) |

## Implementation

- `packages/shared/src/validators/issue.ts` — extend `addIssueCommentSchema` to accept optional `authorAgentId: z.string().uuid().optional()` / `authorUserId: z.string().uuid().optional()` so the fields reach the route handler instead of being stripped as unknown keys.
- `server/src/routes/issues.ts` — add `assertCommentAuthorMatchesPrincipal(req, res, input)` mirroring the `assertStructuredCommentFieldsAllowed` pattern. Wired into the `POST /issues/:id/comments` handler right after the structured-fields check. Returns 422 with a clear error message and `details.field`.

No change to the actual author-derivation logic — `svc.addComment` still binds the stored author to the authenticated principal.

## Out of scope

- Any change to the security boundary itself — principal-bound author derivation already holds.
- Hardening of analogous routes (PATCH comment edits, thread interactions) — separate issues if they exhibit the same silent-strip behavior.

## Test plan

- [x] `server/src/__tests__/issue-comment-reopen-routes.test.ts` — 7 new tests in a "POST /issues/:id/comments body author validation (ZERA-565)" describe block: 4 mismatch combinations → 422, malformed uuid → 400 (zod), matched agent → 201, matched user → 201, baseline omit → 201
- [x] `packages/shared/src/validators/issue.test.ts` — 2 new tests: schema accepts optional uuid `authorAgentId`/`authorUserId`, rejects non-uuid values
- [x] `pnpm --filter @paperclipai/shared typecheck` clean
- [x] `pnpm --filter @paperclipai/server typecheck` clean
- [x] All 44 tests in the three nearby comment-route test files pass (`issue-comment-reopen-routes`, `issue-comment-cancel-routes`, `issue-update-comment-wakeup-routes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)