### PR TITLE
fix(adapter-utils): prefer local listen url for agent env

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -66,42 +66,100 @@ describe("buildInvocationEnvForLogs", () => {
 });
 
 describe("buildPaperclipEnv", () => {
-  it("prefers the local listen host and port over inherited runtime api env", () => {
-    const originalRuntimeApiUrl = process.env.PAPERCLIP_RUNTIME_API_URL;
-    const originalApiUrl = process.env.PAPERCLIP_API_URL;
-    const originalListenHost = process.env.PAPERCLIP_LISTEN_HOST;
-    const originalListenPort = process.env.PAPERCLIP_LISTEN_PORT;
+  function withPaperclipApiEnv(
+    env: Partial<Record<"PAPERCLIP_RUNTIME_API_URL" | "PAPERCLIP_API_URL" | "PAPERCLIP_LISTEN_HOST" | "PAPERCLIP_LISTEN_PORT" | "HOST", string>>,
+    run: () => void,
+  ) {
+    const originalValues = {
+      PAPERCLIP_RUNTIME_API_URL: process.env.PAPERCLIP_RUNTIME_API_URL,
+      PAPERCLIP_API_URL: process.env.PAPERCLIP_API_URL,
+      PAPERCLIP_LISTEN_HOST: process.env.PAPERCLIP_LISTEN_HOST,
+      PAPERCLIP_LISTEN_PORT: process.env.PAPERCLIP_LISTEN_PORT,
+      HOST: process.env.HOST,
+    };
 
     try {
-      process.env.PAPERCLIP_RUNTIME_API_URL = "http://192.168.0.33:3100";
-      process.env.PAPERCLIP_API_URL = "http://192.168.0.33:3100";
-      process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
-      process.env.PAPERCLIP_LISTEN_PORT = "3100";
+      for (const [key, value] of Object.entries(env)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
 
-      expect(
-        buildPaperclipEnv({
-          id: "agent-1",
-          companyId: "company-1",
-        }),
-      ).toMatchObject({
-        PAPERCLIP_AGENT_ID: "agent-1",
-        PAPERCLIP_COMPANY_ID: "company-1",
-        PAPERCLIP_API_URL: "http://127.0.0.1:3100",
-        PAPERCLIP_RUNTIME_API_URL: "http://127.0.0.1:3100",
-      });
+      run();
     } finally {
-      if (originalRuntimeApiUrl === undefined) delete process.env.PAPERCLIP_RUNTIME_API_URL;
-      else process.env.PAPERCLIP_RUNTIME_API_URL = originalRuntimeApiUrl;
-
-      if (originalApiUrl === undefined) delete process.env.PAPERCLIP_API_URL;
-      else process.env.PAPERCLIP_API_URL = originalApiUrl;
-
-      if (originalListenHost === undefined) delete process.env.PAPERCLIP_LISTEN_HOST;
-      else process.env.PAPERCLIP_LISTEN_HOST = originalListenHost;
-
-      if (originalListenPort === undefined) delete process.env.PAPERCLIP_LISTEN_PORT;
-      else process.env.PAPERCLIP_LISTEN_PORT = originalListenPort;
+      for (const [key, value] of Object.entries(originalValues)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
     }
+  }
+
+  it("prefers the local listen host and port over inherited runtime api env", () => {
+    withPaperclipApiEnv(
+      {
+        PAPERCLIP_RUNTIME_API_URL: "http://192.168.0.33:3100",
+        PAPERCLIP_API_URL: "http://192.168.0.33:3100",
+        PAPERCLIP_LISTEN_HOST: "127.0.0.1",
+        PAPERCLIP_LISTEN_PORT: "3100",
+      },
+      () => {
+        expect(
+          buildPaperclipEnv({
+            id: "agent-1",
+            companyId: "company-1",
+          }),
+        ).toMatchObject({
+          PAPERCLIP_AGENT_ID: "agent-1",
+          PAPERCLIP_COMPANY_ID: "company-1",
+          PAPERCLIP_API_URL: "http://127.0.0.1:3100",
+          PAPERCLIP_RUNTIME_API_URL: "http://127.0.0.1:3100",
+        });
+      },
+    );
+  });
+
+  it("preserves the inherited runtime api url when listen host is absent", () => {
+    withPaperclipApiEnv(
+      {
+        PAPERCLIP_RUNTIME_API_URL: "http://192.168.0.33:4100",
+        PAPERCLIP_API_URL: "http://192.168.0.33:4100",
+        PAPERCLIP_LISTEN_HOST: undefined,
+        PAPERCLIP_LISTEN_PORT: "3100",
+        HOST: "192.168.0.33",
+      },
+      () => {
+        expect(
+          buildPaperclipEnv({
+            id: "agent-1",
+            companyId: "company-1",
+          }),
+        ).toMatchObject({
+          PAPERCLIP_API_URL: "http://192.168.0.33:4100",
+          PAPERCLIP_RUNTIME_API_URL: "http://192.168.0.33:4100",
+        });
+      },
+    );
+  });
+
+  it("falls back to the inherited runtime api url when listen vars are unset", () => {
+    withPaperclipApiEnv(
+      {
+        PAPERCLIP_RUNTIME_API_URL: "http://10.0.0.25:4100",
+        PAPERCLIP_API_URL: "http://10.0.0.25:4100",
+        PAPERCLIP_LISTEN_HOST: undefined,
+        PAPERCLIP_LISTEN_PORT: undefined,
+      },
+      () => {
+        expect(
+          buildPaperclipEnv({
+            id: "agent-1",
+            companyId: "company-1",
+          }),
+        ).toMatchObject({
+          PAPERCLIP_API_URL: "http://10.0.0.25:4100",
+          PAPERCLIP_RUNTIME_API_URL: "http://10.0.0.25:4100",
+        });
+      },
+    );
   });
 });
 

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -7,6 +7,7 @@ import {
   applyPaperclipWorkspaceEnv,
   appendWithByteCap,
   buildInvocationEnvForLogs,
+  buildPaperclipEnv,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   materializePaperclipSkillCopy,
   refreshPaperclipWorkspaceEnvForExecution,
@@ -61,6 +62,46 @@ describe("buildInvocationEnvForLogs", () => {
     expect(loggedEnv.PAPERCLIP_RESOLVED_COMMAND).toBe(
       "env OPENAI_API_KEY=***REDACTED*** custom-acp --token ***REDACTED***",
     );
+  });
+});
+
+describe("buildPaperclipEnv", () => {
+  it("prefers the local listen host and port over inherited runtime api env", () => {
+    const originalRuntimeApiUrl = process.env.PAPERCLIP_RUNTIME_API_URL;
+    const originalApiUrl = process.env.PAPERCLIP_API_URL;
+    const originalListenHost = process.env.PAPERCLIP_LISTEN_HOST;
+    const originalListenPort = process.env.PAPERCLIP_LISTEN_PORT;
+
+    try {
+      process.env.PAPERCLIP_RUNTIME_API_URL = "http://192.168.0.33:3100";
+      process.env.PAPERCLIP_API_URL = "http://192.168.0.33:3100";
+      process.env.PAPERCLIP_LISTEN_HOST = "127.0.0.1";
+      process.env.PAPERCLIP_LISTEN_PORT = "3100";
+
+      expect(
+        buildPaperclipEnv({
+          id: "agent-1",
+          companyId: "company-1",
+        }),
+      ).toMatchObject({
+        PAPERCLIP_AGENT_ID: "agent-1",
+        PAPERCLIP_COMPANY_ID: "company-1",
+        PAPERCLIP_API_URL: "http://127.0.0.1:3100",
+        PAPERCLIP_RUNTIME_API_URL: "http://127.0.0.1:3100",
+      });
+    } finally {
+      if (originalRuntimeApiUrl === undefined) delete process.env.PAPERCLIP_RUNTIME_API_URL;
+      else process.env.PAPERCLIP_RUNTIME_API_URL = originalRuntimeApiUrl;
+
+      if (originalApiUrl === undefined) delete process.env.PAPERCLIP_API_URL;
+      else process.env.PAPERCLIP_API_URL = originalApiUrl;
+
+      if (originalListenHost === undefined) delete process.env.PAPERCLIP_LISTEN_HOST;
+      else process.env.PAPERCLIP_LISTEN_HOST = originalListenHost;
+
+      if (originalListenPort === undefined) delete process.env.PAPERCLIP_LISTEN_PORT;
+      else process.env.PAPERCLIP_LISTEN_PORT = originalListenPort;
+    }
   });
 });
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -907,7 +907,7 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
   const localApiUrl = `http://${runtimeHost}:${runtimePort}`;
   const apiUrl =
-    process.env.PAPERCLIP_LISTEN_HOST || process.env.PAPERCLIP_LISTEN_PORT
+    process.env.PAPERCLIP_LISTEN_HOST
       ? localApiUrl
       : process.env.PAPERCLIP_RUNTIME_API_URL ?? process.env.PAPERCLIP_API_URL ?? localApiUrl;
   vars.PAPERCLIP_API_URL = apiUrl;

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -905,11 +905,13 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );
   const runtimePort = process.env.PAPERCLIP_LISTEN_PORT ?? process.env.PORT ?? "3100";
+  const localApiUrl = `http://${runtimeHost}:${runtimePort}`;
   const apiUrl =
-    process.env.PAPERCLIP_RUNTIME_API_URL ??
-    process.env.PAPERCLIP_API_URL ??
-    `http://${runtimeHost}:${runtimePort}`;
+    process.env.PAPERCLIP_LISTEN_HOST || process.env.PAPERCLIP_LISTEN_PORT
+      ? localApiUrl
+      : process.env.PAPERCLIP_RUNTIME_API_URL ?? process.env.PAPERCLIP_API_URL ?? localApiUrl;
   vars.PAPERCLIP_API_URL = apiUrl;
+  vars.PAPERCLIP_RUNTIME_API_URL = apiUrl;
   return vars;
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that coordinates agent heartbeats and gives local adapters the runtime context they need to reach the API.
> - `packages/adapter-utils` is the shared layer that constructs that runtime environment for adapters like `claude_local` and `codex_local`.
> - In local trusted installs, the server already knows its canonical bind surface through `PAPERCLIP_LISTEN_HOST` and `PAPERCLIP_LISTEN_PORT`.
> - The current helper still prefers inherited `PAPERCLIP_RUNTIME_API_URL` / `PAPERCLIP_API_URL`, so a stale parent value can leak an obsolete LAN IP into new agent sessions.
> - When that happens, agent retries fail even though the Paperclip server itself is healthy on loopback.
> - This pull request makes local adapter env generation trust the instance listen host/port first and locks both exported API env vars to that resolved local URL.
> - The benefit is that local heartbeats stop inheriting drifted API origins while keeping the fallback behavior unchanged when no listen vars are present.

## What Changed

- Updated `buildPaperclipEnv` in `packages/adapter-utils/src/server-utils.ts` to prefer `PAPERCLIP_LISTEN_HOST` + `PAPERCLIP_LISTEN_PORT` over inherited API URL env vars when local listen settings are present.
- Exported `PAPERCLIP_RUNTIME_API_URL` alongside `PAPERCLIP_API_URL` so child processes inherit the corrected local URL consistently.
- Added a regression test in `packages/adapter-utils/src/server-utils.test.ts` covering the stale-LAN-IP case with loopback listen vars present.

## Verification

- Local hotfix smoke against a live instance with stale parent env:
  - `buildPaperclipEnv(...)` resolved `http://127.0.0.1:3100`
  - `GET /api/agents/me` returned `200` using the resolved URL and agent bearer token
- Added a focused unit regression test for the same scenario in `packages/adapter-utils/src/server-utils.test.ts`
- Full repo test run was not executed in this checkout because the cloned source tree was not bootstrapped with workspace dependencies during this patch-only pass.

## Risks

- Low risk: behavior only changes when `PAPERCLIP_LISTEN_HOST` or `PAPERCLIP_LISTEN_PORT` is present, which is the local-instance case that should already be authoritative.
- Remote/public deployments without local listen vars still keep the existing fallback to `PAPERCLIP_RUNTIME_API_URL` / `PAPERCLIP_API_URL`.

> Checked `ROADMAP.md`; this is a bug fix in shared adapter env generation, not overlapping planned feature work.

## Model Used

- OpenAI Codex via ChatGPT account session
- Model family: GPT-5 Codex runtime in the Codex CLI environment provided by Paperclip
- Capabilities used: tool use, shell execution, code editing, local runtime inspection
- Reasoning mode: medium interactive reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
