### PR TITLE
fix: suppress duplicate stale-run reviews after terminal cleanup (OXFA-1971)

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -15,6 +15,7 @@ import {
   parseSessionCompactionPolicy,
   resolveRuntimeSessionParamsForWorkspace,
   stripWorkspaceRuntimeFromExecutionRunConfig,
+  shouldAutoCheckoutIssueForWake,
   shouldResetTaskSessionForWake,
   type ResolvedWorkspaceForRun,
 } from "../services/heartbeat.ts";
@@ -355,6 +356,71 @@ describe("shouldResetTaskSessionForWake", () => {
         wakeTriggerDetail: "callback",
       }),
     ).toBe(false);
+  });
+});
+
+describe("shouldAutoCheckoutIssueForWake", () => {
+  it("does not auto-checkout a parked todo issue for a plain comment wake", () => {
+    expect(
+      shouldAutoCheckoutIssueForWake({
+        contextSnapshot: { wakeReason: "issue_commented" },
+        issueStatus: "todo",
+        issueAssigneeAgentId: "agent-1",
+        isDependencyReady: true,
+        agentId: "agent-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps auto-checkout for in-progress comment wakes", () => {
+    expect(
+      shouldAutoCheckoutIssueForWake({
+        contextSnapshot: { wakeReason: "issue_commented" },
+        issueStatus: "in_progress",
+        issueAssigneeAgentId: "agent-1",
+        isDependencyReady: true,
+        agentId: "agent-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows explicit resume intents to auto-checkout after a comment wake", () => {
+    expect(
+      shouldAutoCheckoutIssueForWake({
+        contextSnapshot: {
+          wakeReason: "issue_commented",
+          resumeIntent: true,
+        },
+        issueStatus: "todo",
+        issueAssigneeAgentId: "agent-1",
+        isDependencyReady: true,
+        agentId: "agent-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not auto-checkout a parked todo issue on a child-completed wake", () => {
+    expect(
+      shouldAutoCheckoutIssueForWake({
+        contextSnapshot: { wakeReason: "issue_children_completed" },
+        issueStatus: "todo",
+        issueAssigneeAgentId: "agent-1",
+        isDependencyReady: true,
+        agentId: "agent-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps auto-checkout for in-progress child-completed wakes", () => {
+    expect(
+      shouldAutoCheckoutIssueForWake({
+        contextSnapshot: { wakeReason: "issue_children_completed" },
+        issueStatus: "in_progress",
+        issueAssigneeAgentId: "agent-1",
+        isDependencyReady: true,
+        agentId: "agent-1",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -457,6 +457,9 @@ describe("agent issue mutation checkout ownership", () => {
         agentId: ownerAgentId,
         runId: ownerRunId,
       }),
+      expect.objectContaining({
+        authorType: "agent",
+      }),
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -48,6 +48,7 @@ const mockWorkProductService = vi.hoisted(() => ({
   getById: vi.fn(),
   update: vi.fn(),
 }));
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
 
 const mockStorageService = vi.hoisted(() => ({
   provider: "local_disk",
@@ -92,7 +93,7 @@ function registerRouteMocks() {
   }));
 
   vi.doMock("../services/activity-log.js", () => ({
-    logActivity: vi.fn(async () => undefined),
+    logActivity: mockLogActivity,
   }));
 
   vi.doMock("../services/index.js", () => ({
@@ -139,7 +140,7 @@ function registerRouteMocks() {
     }),
     issueService: () => mockIssueService,
     issueThreadInteractionService: () => mockIssueThreadInteractionService,
-    logActivity: vi.fn(async () => undefined),
+    logActivity: mockLogActivity,
     projectService: () => ({}),
     routineService: () => ({
       syncRunStatusForIssue: vi.fn(async () => undefined),
@@ -263,6 +264,7 @@ describe("agent issue mutation checkout ownership", () => {
     mockIssueService.removeAttachment.mockReset();
     mockIssueService.update.mockReset();
     mockIssueService.findMentionedAgents.mockReset();
+    mockLogActivity.mockReset();
     mockDocumentService.upsertIssueDocument.mockReset();
     mockWorkProductService.getById.mockReset();
     mockWorkProductService.update.mockReset();
@@ -435,6 +437,45 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status).toBe(200);
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).toHaveBeenCalled();
+  });
+
+  it("allows comment writes to adopt a stale checkout lock and records the adoption audit", async () => {
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({
+      adoptedFromRunId: "77777777-7777-4777-8777-777777777777",
+    });
+
+    const res = await request(await createApp(ownerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Recovered comment write" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.assertCheckoutOwner).toHaveBeenCalledWith(issueId, ownerAgentId, ownerRunId);
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Recovered comment write",
+      expect.objectContaining({
+        agentId: ownerAgentId,
+        runId: ownerRunId,
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        companyId,
+        actorType: "agent",
+        actorId: ownerAgentId,
+        agentId: ownerAgentId,
+        runId: ownerRunId,
+        action: "issue.checkout_lock_adopted",
+        entityType: "issue",
+        entityId: issueId,
+        details: {
+          previousCheckoutRunId: "77777777-7777-4777-8777-777777777777",
+          checkoutRunId: ownerRunId,
+          reason: "stale_checkout_run",
+        },
+      }),
+    );
   });
 
   it.each([

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -22,6 +22,10 @@ import { issueRoutes } from "../routes/issues.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+const EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS = Number.parseInt(
+  process.env.PAPERCLIP_EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS ?? "20000",
+  10,
+);
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -38,7 +42,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-stale-execution-lock-routes-");
     db = createDb(tempDb.connectionString);
-  }, 20_000);
+  }, Number.isFinite(EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS) ? EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS : 20_000);
 
   afterEach(async () => {
     await db.delete(issueComments);
@@ -52,7 +56,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
 
   afterAll(async () => {
     await tempDb?.cleanup();
-  });
+  }, Number.isFinite(EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS) ? EMBEDDED_POSTGRES_HOOK_TIMEOUT_MS : 20_000);
 
   function createApp(actor: Express.Request["actor"]) {
     const app = express();
@@ -109,6 +113,66 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     ]);
 
     return { companyId, agentId, failedRunId, currentRunId };
+  }
+
+  async function seedManagedCompanyAndRuns() {
+    const companyId = randomUUID();
+    const managerAgentId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const failedRunId = randomUUID();
+    const managerRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: managerAgentId,
+        companyId,
+        name: "ManagerAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "AssignedAgent",
+        role: "engineer",
+        reportsTo: managerAgentId,
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(heartbeatRuns).values([
+      {
+        id: failedRunId,
+        companyId,
+        agentId: assigneeAgentId,
+        status: "failed",
+        invocationSource: "manual",
+        finishedAt: new Date(),
+      },
+      {
+        id: managerRunId,
+        companyId,
+        agentId: managerAgentId,
+        status: "running",
+        invocationSource: "manual",
+        startedAt: new Date(),
+      },
+    ]);
+
+    return { companyId, managerAgentId, assigneeAgentId, failedRunId, managerRunId };
   }
 
   function agentActor(companyId: string, agentId: string, runId: string): Express.Request["actor"] {
@@ -171,6 +235,58 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     });
   });
 
+  it("adopts a stale same-assignee checkout during PATCH and records the prior run id", async () => {
+    const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Adopt stale checkout",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: failedRunId,
+      executionRunId: failedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Recovered stale checkout via PATCH" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: issueId,
+      title: "Recovered stale checkout via PATCH",
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+    });
+
+    const audit = await db
+      .select({
+        action: activityLog.action,
+        actorType: activityLog.actorType,
+        actorId: activityLog.actorId,
+        runId: activityLog.runId,
+        details: activityLog.details,
+      })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.checkout_lock_adopted"))
+      .then((rows) => rows[0]);
+    expect(audit).toMatchObject({
+      action: "issue.checkout_lock_adopted",
+      actorType: "agent",
+      actorId: agentId,
+      runId: currentRunId,
+      details: {
+        previousCheckoutRunId: failedRunId,
+        checkoutRunId: currentRunId,
+        reason: "stale_checkout_run",
+      },
+    });
+  });
+
   it("allows the rightful assignee to release after the owning run failed", async () => {
     const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
     const issueId = randomUUID();
@@ -213,7 +329,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     });
   });
 
-  it("restricts admin force-release to board users with company access and writes an audit event", async () => {
+  it("allows board force-release with an explicit reason and writes an audit event", async () => {
     const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
     const issueId = randomUUID();
     await db.insert(issues).values({
@@ -231,6 +347,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
 
     await request(createApp(agentActor(companyId, agentId, currentRunId)))
       .post(`/api/issues/${issueId}/admin/force-release`)
+      .send({ reason: "Agent should not be allowed to force-release without override" })
       .expect(403);
     await request(createApp({
       type: "board",
@@ -241,11 +358,12 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       source: "session",
     }))
       .post(`/api/issues/${issueId}/admin/force-release`)
+      .send({ reason: "Outside board user should not be allowed to force-release" })
       .expect(403);
 
     const res = await request(createApp(boardActor(companyId)))
       .post(`/api/issues/${issueId}/admin/force-release?clearAssignee=true`)
-      .send();
+      .send({ reason: "Clear stale run fixture after staged verification" });
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body.issue).toMatchObject({
@@ -280,7 +398,89 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
         prevCheckoutRunId: currentRunId,
         prevExecutionRunId: failedRunId,
         clearAssignee: true,
+        reason: "Clear stale run fixture after staged verification",
       },
     });
+  });
+
+  it("allows a reporting-line manager agent to force-release with a run-backed reason", async () => {
+    const { companyId, managerAgentId, assigneeAgentId, failedRunId, managerRunId } = await seedManagedCompanyAndRuns();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Manager release",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId,
+      checkoutRunId: failedRunId,
+      executionRunId: failedRunId,
+      executionAgentNameKey: "assignedagent",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, managerAgentId, managerRunId)))
+      .post(`/api/issues/${issueId}/admin/force-release`)
+      .send({ reason: "Recover stale child lock for same-company report" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.issue).toMatchObject({
+      id: issueId,
+      assigneeAgentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const audit = await db
+      .select({
+        action: activityLog.action,
+        actorType: activityLog.actorType,
+        actorId: activityLog.actorId,
+        agentId: activityLog.agentId,
+        runId: activityLog.runId,
+        details: activityLog.details,
+      })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.admin_force_release"))
+      .then((rows) => rows[0]);
+    expect(audit).toMatchObject({
+      action: "issue.admin_force_release",
+      actorType: "agent",
+      actorId: managerAgentId,
+      agentId: managerAgentId,
+      runId: managerRunId,
+      details: {
+        issueId,
+        actorUserId: null,
+        prevCheckoutRunId: failedRunId,
+        prevExecutionRunId: failedRunId,
+        clearAssignee: false,
+        reason: "Recover stale child lock for same-company report",
+      },
+    });
+  });
+
+  it("rejects force-release without an explicit reason", async () => {
+    const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Missing reason",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: currentRunId,
+      executionRunId: failedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(boardActor(companyId)))
+      .post(`/api/issues/${issueId}/admin/force-release`)
+      .send();
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -731,7 +731,18 @@ export function issueRoutes(
     }
     if (issue.assigneeAgentId === actorAgentId) return true;
     if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
-    return true;
+      return true;
+    }
+
+    res.status(403).json({
+      error: "Agent cannot request follow-up for another agent's issue",
+      details: {
+        issueId: issue.id,
+        assigneeAgentId: issue.assigneeAgentId,
+        actorAgentId,
+      },
+    });
+    return false;
   }
 
   async function assertCanForceReleaseIssue(
@@ -759,17 +770,6 @@ export function issueRoutes(
       return true;
     }
     res.status(403).json({ error: "Manager or admin checkout override required" });
-    return false;
-  }
-
-    res.status(403).json({
-      error: "Agent cannot request follow-up for another agent's issue",
-      details: {
-        issueId: issue.id,
-        assigneeAgentId: issue.assigneeAgentId,
-        actorAgentId,
-      },
-    });
     return false;
   }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -87,6 +87,9 @@ const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
+const adminForceReleaseRouteSchema = z.object({
+  reason: z.string().trim().min(1).max(500),
+});
 
 type ParsedExecutionState = NonNullable<ReturnType<typeof parseIssueExecutionState>>;
 type NormalizedExecutionPolicy = NonNullable<ReturnType<typeof normalizeIssueExecutionPolicy>>;
@@ -728,8 +731,36 @@ export function issueRoutes(
     }
     if (issue.assigneeAgentId === actorAgentId) return true;
     if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
+    return true;
+  }
+
+  async function assertCanForceReleaseIssue(
+    req: Request,
+    res: Response,
+    issue: { id: string; companyId: string; assigneeAgentId: string | null },
+  ) {
+    assertCompanyAccess(req, issue.companyId);
+    if (req.actor.type === "board") return true;
+    const actorAgentId = req.actor.agentId;
+    if (!actorAgentId) {
+      res.status(403).json({ error: "Agent authentication required" });
+      return false;
+    }
+    const runId = requireAgentRunId(req, res);
+    if (!runId) return false;
+    const allowedByGrant = await access.hasPermission(
+      issue.companyId,
+      "agent",
+      actorAgentId,
+      "tasks:manage_active_checkouts",
+    );
+    if (allowedByGrant) return true;
+    if (issue.assigneeAgentId && await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
       return true;
     }
+    res.status(403).json({ error: "Manager or admin checkout override required" });
+    return false;
+  }
 
     res.status(403).json({
       error: "Agent cannot request follow-up for another agent's issue",
@@ -2839,22 +2870,15 @@ export function issueRoutes(
     res.json(released);
   });
 
-  router.post("/issues/:id/admin/force-release", async (req, res) => {
-    if (req.actor.type !== "board") {
-      res.status(403).json({ error: "Board access required" });
-      return;
-    }
-    if (!req.actor.userId) {
-      throw forbidden("Board user context required");
-    }
-
+  router.post("/issues/:id/admin/force-release", validate(adminForceReleaseRouteSchema), async (req, res) => {
     const id = req.params.id as string;
     const existing = await svc.getById(id);
     if (!existing) {
       res.status(404).json({ error: "Issue not found" });
       return;
     }
-    assertCompanyAccess(req, existing.companyId);
+    if (!(await assertCanForceReleaseIssue(req, res, existing))) return;
+    const reason = String(req.body.reason).trim();
 
     const clearAssignee = req.query.clearAssignee === "true";
     const result = await svc.adminForceRelease(id, { clearAssignee });
@@ -2875,10 +2899,11 @@ export function issueRoutes(
       entityId: result.issue.id,
       details: {
         issueId: result.issue.id,
-        actorUserId: req.actor.userId,
+        actorUserId: req.actor.type === "board" ? req.actor.userId ?? null : null,
         prevCheckoutRunId: result.previous.checkoutRunId,
         prevExecutionRunId: result.previous.executionRunId,
         clearAssignee,
+        reason,
       },
     });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1431,6 +1431,13 @@ export function shouldAutoCheckoutIssueForWake(input: {
   if (wakeReason === "issue_comment_mentioned") return false;
   if (wakeReason.startsWith("execution_")) return false;
 
+  // For comment/child-completed wakes, only auto-checkout active issues
+  // or those with an explicit resume intent — parked todo/blocked issues stay parked.
+  if (wakeReason === "issue_commented" || wakeReason === "issue_children_completed") {
+    if (issueStatus === "in_progress") return true;
+    return Boolean(input.contextSnapshot?.resumeIntent);
+  }
+
   return true;
 }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1431,10 +1431,12 @@ export function shouldAutoCheckoutIssueForWake(input: {
   if (wakeReason === "issue_comment_mentioned") return false;
   if (wakeReason.startsWith("execution_")) return false;
 
-  // For comment/child-completed wakes, only auto-checkout active issues
-  // or those with an explicit resume intent — parked todo/blocked issues stay parked.
+  // For comment/child-completed wakes, only auto-checkout active issues,
+  // promoted deferred wakes that reopened the issue, or explicit resume intents.
+  // Parked todo/blocked issues stay parked on plain comment/child wakes.
   if (wakeReason === "issue_commented" || wakeReason === "issue_children_completed") {
     if (issueStatus === "in_progress") return true;
+    if (readNonEmptyString(input.contextSnapshot?.reopenedFrom)) return true;
     return Boolean(input.contextSnapshot?.resumeIntent);
   }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1406,7 +1406,7 @@ function describeSessionResetReason(
   return null;
 }
 
-function shouldAutoCheckoutIssueForWake(input: {
+export function shouldAutoCheckoutIssueForWake(input: {
   contextSnapshot: Record<string, unknown> | null | undefined;
   issueStatus: string | null;
   issueAssigneeAgentId: string | null;


### PR DESCRIPTION
## Summary

Implements the manager/admin force-release recovery path for runs that miss their terminal-state cleanup window.

Fixes:
- Suppresses duplicate stale-run review events after cancellation / terminal cleanup (OXFA-1971)
- Adds `issue.checkout_lock_adopted` coverage for the stale-run path
- Focused route-test updates

Related: OXFA-1513, OXFA-1503, OXFA-1971

CQE verification: OXFA-1569