### PR TITLE
feat(harness): runtime orphan reaper + pre-spawn process guard

### DIFF
--- a/server/src/__tests__/heartbeat-runtime-reaper.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-reaper.test.ts
@@ -1,0 +1,249 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { runningProcesses } from "../adapters/index.ts";
+
+const mockTelemetryClient = vi.hoisted(() => ({ track: vi.fn() }));
+const mockTrackAgentFirstHeartbeat = vi.hoisted(() => vi.fn());
+
+vi.mock("../telemetry.ts", () => ({
+  getTelemetryClient: () => mockTelemetryClient,
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: mockTrackAgentFirstHeartbeat,
+  };
+});
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: vi.fn(async () => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "ok",
+        provider: "test",
+        model: "test-model",
+      })),
+    })),
+  };
+});
+
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres runtime reaper tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+// A PID guaranteed to be dead: offset current pid far enough that it wraps to a nonsense value.
+// On most systems max pid is 4194304; using process.pid + 999999 will be dead.
+const deadPid = (process.pid + 999_999) % 4_194_304;
+
+describeEmbeddedPostgres("heartbeat runtime reaper", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-runtime-reaper-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    runningProcesses.clear();
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    runningProcesses.clear();
+    await tempDb?.cleanup();
+  });
+
+  async function seedRunFixture(input: {
+    processStartedAt: Date;
+    runStatus?: "running" | "queued" | "failed";
+    agentId?: string;
+    companyId?: string;
+  }) {
+    const companyId = input.companyId ?? randomUUID();
+    const agentId = input.agentId ?? randomUUID();
+    const runId = randomUUID();
+    const wakeupRequestId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const now = new Date();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "running",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId,
+      agentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: {},
+      status: "claimed",
+      runId,
+      claimedAt: now,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: input.runStatus ?? "running",
+      wakeupRequestId,
+      contextSnapshot: {},
+      processPid: deadPid,
+      processGroupId: null,
+      processStartedAt: input.processStartedAt,
+      startedAt: input.processStartedAt,
+      updatedAt: input.processStartedAt,
+    });
+
+    return { companyId, agentId, runId, wakeupRequestId };
+  }
+
+  it("reaps a stale running run older than maxRuntimeMs", async () => {
+    const processStartedAt = new Date(Date.now() - 20 * 60_000); // 20 min ago
+    const { runId } = await seedRunFixture({ processStartedAt });
+
+    const result = await heartbeat.reapStaleRunningRuns({ maxRuntimeMs: 15 * 60_000, graceMs: 1_000 });
+
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toContain(runId);
+
+    const [row] = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+
+    expect(row).toBeDefined();
+    expect(row.status).toBe("failed");
+    expect(row.errorCode).toBe("orphan_reaped_by_runtime");
+    expect(row.finishedAt).toBeDefined();
+    expect(row.error).toMatch(/Runtime reaper killed/);
+
+    // Should have an event logged
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+
+    expect(events.length).toBeGreaterThan(0);
+    const lifecycleEvent = events.find((e) => e.eventType === "lifecycle" && e.level === "error");
+    expect(lifecycleEvent).toBeDefined();
+    expect(lifecycleEvent?.message).toMatch(/Runtime reaper killed/);
+  });
+
+  it("leaves a fresh run alone (younger than maxRuntimeMs)", async () => {
+    const processStartedAt = new Date(Date.now() - 1 * 60_000); // 1 min ago
+    const { runId } = await seedRunFixture({ processStartedAt });
+
+    const result = await heartbeat.reapStaleRunningRuns({ maxRuntimeMs: 15 * 60_000, graceMs: 1_000 });
+
+    expect(result.reaped).toBe(0);
+    expect(result.runIds).not.toContain(runId);
+
+    const [row] = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+
+    expect(row?.status).toBe("running");
+  });
+
+  it("pre-spawn guard scopes to the specific agent: kills agent A stale run but not agent B", async () => {
+    const companyIdA = randomUUID();
+    const agentIdA = randomUUID();
+    const companyIdB = randomUUID();
+    const agentIdB = randomUUID();
+
+    const staleTime = new Date(Date.now() - 20 * 60_000);
+
+    // Seed agent A with a stale running run
+    const { runId: runIdA } = await seedRunFixture({
+      processStartedAt: staleTime,
+      agentId: agentIdA,
+      companyId: companyIdA,
+    });
+
+    // Seed agent B with a stale running run (separate company to avoid FK collisions)
+    const { runId: runIdB } = await seedRunFixture({
+      processStartedAt: staleTime,
+      agentId: agentIdB,
+      companyId: companyIdB,
+    });
+
+    const killed = await heartbeat.killStalePriorRunsForAgent(agentIdA, { maxRuntimeMs: 15 * 60_000, graceMs: 1_000 });
+
+    expect(killed).toBe(1);
+
+    const [rowA] = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runIdA));
+    expect(rowA?.status).toBe("failed");
+    expect(rowA?.errorCode).toBe("orphan_reaped_by_runtime");
+
+    const [rowB] = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runIdB));
+    expect(rowB?.status).toBe("running");
+  });
+});

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -108,15 +108,17 @@ async function cleanupHeartbeatInvalidationFixture(db: ReturnType<typeof createD
       await db.delete(companies);
       return;
     } catch (error) {
-      const isLateCommentRace =
+      // Heartbeat completion can write issue-thread comments and activity_log
+      // entries shortly after the run leaves queued/running. Retry the
+      // dependent deletes once those late writes land.
+      const isLateWriteRace =
         error instanceof Error &&
-        error.message.includes("issue_comments_issue_id_issues_id_fk");
-      if (!isLateCommentRace || attempt === 4) {
+        (error.message.includes("issue_comments_issue_id_issues_id_fk") ||
+          error.message.includes("activity_log_run_id_heartbeat_runs_id_fk"));
+      if (!isLateWriteRace || attempt === 4) {
         throw error;
       }
 
-      // Heartbeat completion can write issue-thread comments shortly after the
-      // run leaves queued/running. Retry the dependent deletes once those land.
       await new Promise((resolve) => setTimeout(resolve, 50));
     }
   }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -85,6 +85,8 @@ export interface Config {
   feedbackExportBackendToken: string | undefined;
   heartbeatSchedulerEnabled: boolean;
   heartbeatSchedulerIntervalMs: number;
+  heartbeatRunMaxRuntimeMs: number;
+  heartbeatRunReaperGraceMs: number;
   companyDeletionEnabled: boolean;
   telemetryEnabled: boolean;
 }
@@ -331,6 +333,8 @@ export function loadConfig(): Config {
     feedbackExportBackendToken,
     heartbeatSchedulerEnabled: process.env.HEARTBEAT_SCHEDULER_ENABLED !== "false",
     heartbeatSchedulerIntervalMs: Math.max(10000, Number(process.env.HEARTBEAT_SCHEDULER_INTERVAL_MS) || 30000),
+    heartbeatRunMaxRuntimeMs: Math.max(60_000, Number(process.env.HEARTBEAT_RUN_MAX_RUNTIME_MS) || 15 * 60_000),
+    heartbeatRunReaperGraceMs: Math.max(1_000, Number(process.env.HEARTBEAT_RUN_REAPER_GRACE_MS) || 30_000),
     companyDeletionEnabled,
     telemetryEnabled: fileConfig?.telemetry?.enabled ?? true,
   };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -744,8 +744,16 @@ export async function startServer(): Promise<StartedServer> {
   
       // Periodically reap orphaned runs (5-min staleness threshold) and make sure
       // persisted queued work is still being driven forward.
+      // reapStaleRunningRuns runs first so alive-but-wedged runs become process_pid_dead
+      // candidates that the standard reapOrphanedRuns can clean up in the same tick;
+      // serializing also prevents the two reapers from clobbering the same row.
       void heartbeat
-        .reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 })
+        .reapStaleRunningRuns({ maxRuntimeMs: config.heartbeatRunMaxRuntimeMs, graceMs: config.heartbeatRunReaperGraceMs })
+        .catch((err) => {
+          logger.error({ err }, "periodic runtime reaper failed");
+          return { reaped: 0, runIds: [] as string[] };
+        })
+        .then(() => heartbeat.reapOrphanedRuns({ staleThresholdMs: 5 * 60 * 1000 }))
         .then(() => heartbeat.promoteDueScheduledRetries())
         .then(async (promotion) => {
           await heartbeat.resumeQueuedRuns();
@@ -785,10 +793,6 @@ export async function startServer(): Promise<StartedServer> {
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");
         });
-
-      void heartbeat
-        .reapStaleRunningRuns({ maxRuntimeMs: config.heartbeatRunMaxRuntimeMs, graceMs: config.heartbeatRunReaperGraceMs })
-        .catch((err) => logger.error({ err }, "periodic runtime reaper failed"));
     }, config.heartbeatSchedulerIntervalMs);
   }
   

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -73,6 +73,7 @@ type EmbeddedPostgresCtor = new (opts: {
   port: number;
   persistent: boolean;
   initdbFlags?: string[];
+  postgresFlags?: string[];
   onLog?: (message: unknown) => void;
   onError?: (message: unknown) => void;
 }) => EmbeddedPostgresInstance;
@@ -386,6 +387,8 @@ export async function startServer(): Promise<StartedServer> {
           port,
           persistent: true,
           initdbFlags: ["--encoding=UTF8", "--locale=C", "--lc-messages=C"],
+          // TAP-1190: cap connections for local/embedded mode (single Paperclip server only).
+          postgresFlags: ["-c", "max_connections=20"],
           onLog: appendEmbeddedPostgresLog,
           onError: appendEmbeddedPostgresLog,
         });
@@ -670,7 +673,7 @@ export async function startServer(): Promise<StartedServer> {
     });
   
   if (config.heartbeatSchedulerEnabled) {
-    const heartbeat = heartbeatService(db as any, { pluginWorkerManager });
+    const heartbeat = heartbeatService(db as any, { pluginWorkerManager, runtimeReaper: { maxRuntimeMs: config.heartbeatRunMaxRuntimeMs, graceMs: config.heartbeatRunReaperGraceMs } });
     const routines = routineService(db as any, { pluginWorkerManager });
   
     // Reap orphaned running runs at startup while in-memory execution state is empty,
@@ -782,6 +785,10 @@ export async function startServer(): Promise<StartedServer> {
         .catch((err) => {
           logger.error({ err }, "periodic heartbeat recovery failed");
         });
+
+      void heartbeat
+        .reapStaleRunningRuns({ maxRuntimeMs: config.heartbeatRunMaxRuntimeMs, graceMs: config.heartbeatRunReaperGraceMs })
+        .catch((err) => logger.error({ err }, "periodic runtime reaper failed"));
     }, config.heartbeatSchedulerIntervalMs);
   }
   

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6588,7 +6588,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     // — caller is already about to dispatch, and re-entering startNextQueuedRunForAgent
     // would block on its own lock for AGENT_START_LOCK_STALE_MS.
     dispatchNext: boolean;
-  }) {
+  }): Promise<boolean> {
     const { run, adapterType, adapterConfig, graceMs, maxRuntimeMs, dispatchNext } = opts;
     const now = new Date();
     const startedAt = run.processStartedAt;
@@ -6620,7 +6620,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "running")))
       .returning()
       .then((rows) => rows[0] ?? null);
-    if (!claimed) return;
+    if (!claimed) return false;
 
     publishLiveEvent({
       companyId: claimed.companyId,
@@ -6667,6 +6667,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     if (dispatchNext) {
       await startNextQueuedRunForAgent(run.agentId);
     }
+    return true;
   }
 
   async function reapStaleRunningRuns(opts?: { maxRuntimeMs?: number; graceMs?: number }) {
@@ -6684,8 +6685,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ));
     const reaped: string[] = [];
     for (const { run, adapterType, adapterConfig } of stale) {
-      await terminateRunAsOrphanReaped({ run, adapterType, adapterConfig, graceMs, maxRuntimeMs, dispatchNext: true });
-      reaped.push(run.id);
+      // Only count runs whose CAS finalize won — a concurrent reaper or natural finalize
+      // may have already moved the row out of `running`, in which case we did no work here.
+      const didReap = await terminateRunAsOrphanReaped({ run, adapterType, adapterConfig, graceMs, maxRuntimeMs, dispatchNext: true });
+      if (didReap) reaped.push(run.id);
     }
     if (reaped.length > 0) {
       logger.warn({ reapedCount: reaped.length, runIds: reaped, maxRuntimeMs }, "reaped stale running heartbeat runs");
@@ -6707,12 +6710,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         isNotNull(heartbeatRuns.processStartedAt),
         lt(heartbeatRuns.processStartedAt, cutoff),
       ));
+    let killed = 0;
     for (const { run, adapterType, adapterConfig } of stale) {
       // dispatchNext=false: caller (claimQueuedRun) already holds withAgentStartLock(agentId)
       // and is about to start the next run itself. Re-entering would stall on the lock.
-      await terminateRunAsOrphanReaped({ run, adapterType, adapterConfig, graceMs, maxRuntimeMs, dispatchNext: false });
+      // Only count CAS wins so the caller's `killedRuns` warn log reflects work this path actually did.
+      const didReap = await terminateRunAsOrphanReaped({ run, adapterType, adapterConfig, graceMs, maxRuntimeMs, dispatchNext: false });
+      if (didReap) killed++;
     }
-    return stale.length;
+    return killed;
   }
 
   async function resumeQueuedRuns() {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6584,26 +6584,63 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     adapterConfig: Record<string, unknown>;
     graceMs: number;
     maxRuntimeMs: number;
+    // false when called from within a withAgentStartLock-held path (e.g. claimQueuedRun)
+    // — caller is already about to dispatch, and re-entering startNextQueuedRunForAgent
+    // would block on its own lock for AGENT_START_LOCK_STALE_MS.
+    dispatchNext: boolean;
   }) {
-    const { run, adapterType, adapterConfig, graceMs, maxRuntimeMs } = opts;
-    await terminateHeartbeatRunProcess({ pid: run.processPid, processGroupId: run.processGroupId, graceMs });
+    const { run, adapterType, adapterConfig, graceMs, maxRuntimeMs, dispatchNext } = opts;
     const now = new Date();
     const startedAt = run.processStartedAt;
     const etimeMs = startedAt ? now.getTime() - new Date(startedAt).getTime() : null;
     const message = `Runtime reaper killed pid ${run.processPid ?? "?"} after ${etimeMs != null ? Math.round(etimeMs / 1000) : "?"}s (limit ${Math.round(maxRuntimeMs / 1000)}s)`;
-    let finalizedRun = await setRunStatus(run.id, "failed", {
-      error: message,
-      errorCode: "orphan_reaped_by_runtime",
-      finishedAt: now,
-      resultJson: mergeRunStopMetadataForAgent(
-        { adapterType, adapterConfig },
-        "failed",
-        { resultJson: parseObject(run.resultJson), errorCode: "orphan_reaped_by_runtime", errorMessage: message },
-      ),
+
+    // Terminate first (idempotent on dead PIDs) so the OS process is gone whether or
+    // not we win the CAS — the pre-spawn guard caller in particular needs the prior
+    // process dead before it can safely claim and spawn the next run.
+    await terminateHeartbeatRunProcess({ pid: run.processPid, processGroupId: run.processGroupId, graceMs });
+
+    // Atomically claim the run for finalization. If another concurrent reaper or the
+    // natural finalize path already moved it out of "running", bail without
+    // double-publishing lifecycle events or double-releasing env leases.
+    const claimed = await db
+      .update(heartbeatRuns)
+      .set({
+        status: "failed",
+        error: message,
+        errorCode: "orphan_reaped_by_runtime",
+        finishedAt: now,
+        resultJson: mergeRunStopMetadataForAgent(
+          { adapterType, adapterConfig },
+          "failed",
+          { resultJson: parseObject(run.resultJson), errorCode: "orphan_reaped_by_runtime", errorMessage: message },
+        ),
+        updatedAt: now,
+      })
+      .where(and(eq(heartbeatRuns.id, run.id), eq(heartbeatRuns.status, "running")))
+      .returning()
+      .then((rows) => rows[0] ?? null);
+    if (!claimed) return;
+
+    publishLiveEvent({
+      companyId: claimed.companyId,
+      type: "heartbeat.run.status",
+      payload: {
+        runId: claimed.id,
+        agentId: claimed.agentId,
+        status: claimed.status,
+        invocationSource: claimed.invocationSource,
+        triggerDetail: claimed.triggerDetail,
+        error: claimed.error ?? null,
+        errorCode: claimed.errorCode ?? null,
+        startedAt: claimed.startedAt ? new Date(claimed.startedAt).toISOString() : null,
+        finishedAt: claimed.finishedAt ? new Date(claimed.finishedAt).toISOString() : null,
+      },
     });
+    publishRunLifecyclePluginEvent(claimed);
+
     await setWakeupStatus(run.wakeupRequestId, "failed", { finishedAt: now, error: message });
-    if (!finalizedRun) finalizedRun = await getRun(run.id);
-    if (!finalizedRun) return;
+    let finalizedRun: typeof heartbeatRuns.$inferSelect | null = claimed;
     finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
     await releaseEnvironmentLeasesForRun({
       runId: finalizedRun.id,
@@ -6627,7 +6664,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     await releaseIssueExecutionAndPromote(finalizedRun);
     await finalizeAgentStatus(run.agentId, "failed");
     runningProcesses.delete(run.id);
-    await startNextQueuedRunForAgent(run.agentId);
+    if (dispatchNext) {
+      await startNextQueuedRunForAgent(run.agentId);
+    }
   }
 
   async function reapStaleRunningRuns(opts?: { maxRuntimeMs?: number; graceMs?: number }) {
@@ -6645,7 +6684,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       ));
     const reaped: string[] = [];
     for (const { run, adapterType, adapterConfig } of stale) {
-      await terminateRunAsOrphanReaped({ run, adapterType, adapterConfig, graceMs, maxRuntimeMs });
+      await terminateRunAsOrphanReaped({ run, adapterType, adapterConfig, graceMs, maxRuntimeMs, dispatchNext: true });
       reaped.push(run.id);
     }
     if (reaped.length > 0) {
@@ -6669,7 +6708,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         lt(heartbeatRuns.processStartedAt, cutoff),
       ));
     for (const { run, adapterType, adapterConfig } of stale) {
-      await terminateRunAsOrphanReaped({ run, adapterType, adapterConfig, graceMs, maxRuntimeMs });
+      // dispatchNext=false: caller (claimQueuedRun) already holds withAgentStartLock(agentId)
+      // and is about to start the next run itself. Re-entering would stall on the lock.
+      await terminateRunAsOrphanReaped({ run, adapterType, adapterConfig, graceMs, maxRuntimeMs, dispatchNext: false });
     }
     return stale.length;
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import { randomUUID } from "node:crypto";
-import { and, asc, desc, eq, getTableColumns, gt, inArray, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, inArray, isNotNull, isNull, lt, lte, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   AGENT_DEFAULT_MAX_CONCURRENT_RUNS,
@@ -2308,6 +2308,7 @@ export type HeartbeatEnvironmentRuntime = ReturnType<typeof environmentRuntimeSe
 export interface HeartbeatServiceOptions {
   pluginWorkerManager?: PluginWorkerManager;
   environmentRuntime?: HeartbeatEnvironmentRuntime;
+  runtimeReaper?: { maxRuntimeMs: number; graceMs: number };
 }
 
 export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) {
@@ -2339,6 +2340,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   const recovery = recoveryService(db, { enqueueWakeup });
   const productivityReviews = productivityReviewService(db, { enqueueWakeup });
   let unsafeTextProjectionPromise: Promise<boolean> | null = null;
+  const defaultRuntimeReaper = options.runtimeReaper ?? { maxRuntimeMs: 15 * 60_000, graceMs: 30_000 };
 
   async function releaseEnvironmentLeasesForRun(input: {
     runId: string;
@@ -5787,6 +5789,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return null;
     }
 
+    const killed = await killStalePriorRunsForAgent(run.agentId, defaultRuntimeReaper);
+    if (killed > 0) {
+      logger.warn({ agentId: run.agentId, killedRuns: killed, runId: run.id }, "pre-heartbeat guard killed stale prior runs");
+    }
+
     const context = parseObject(run.contextSnapshot);
     const budgetBlock = await budgets.getInvocationBlock(run.companyId, run.agentId, {
       issueId: readNonEmptyString(context.issueId),
@@ -6569,6 +6576,102 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       logger.warn({ reapedCount: reaped.length, runIds: reaped }, "reaped orphaned heartbeat runs");
     }
     return { reaped: reaped.length, runIds: reaped };
+  }
+
+  async function terminateRunAsOrphanReaped(opts: {
+    run: typeof heartbeatRuns.$inferSelect;
+    adapterType: string;
+    adapterConfig: Record<string, unknown>;
+    graceMs: number;
+    maxRuntimeMs: number;
+  }) {
+    const { run, adapterType, adapterConfig, graceMs, maxRuntimeMs } = opts;
+    await terminateHeartbeatRunProcess({ pid: run.processPid, processGroupId: run.processGroupId, graceMs });
+    const now = new Date();
+    const startedAt = run.processStartedAt;
+    const etimeMs = startedAt ? now.getTime() - new Date(startedAt).getTime() : null;
+    const message = `Runtime reaper killed pid ${run.processPid ?? "?"} after ${etimeMs != null ? Math.round(etimeMs / 1000) : "?"}s (limit ${Math.round(maxRuntimeMs / 1000)}s)`;
+    let finalizedRun = await setRunStatus(run.id, "failed", {
+      error: message,
+      errorCode: "orphan_reaped_by_runtime",
+      finishedAt: now,
+      resultJson: mergeRunStopMetadataForAgent(
+        { adapterType, adapterConfig },
+        "failed",
+        { resultJson: parseObject(run.resultJson), errorCode: "orphan_reaped_by_runtime", errorMessage: message },
+      ),
+    });
+    await setWakeupStatus(run.wakeupRequestId, "failed", { finishedAt: now, error: message });
+    if (!finalizedRun) finalizedRun = await getRun(run.id);
+    if (!finalizedRun) return;
+    finalizedRun = await classifyAndPersistRunLiveness(finalizedRun, parseObject(finalizedRun.resultJson)) ?? finalizedRun;
+    await releaseEnvironmentLeasesForRun({
+      runId: finalizedRun.id,
+      companyId: finalizedRun.companyId,
+      agentId: finalizedRun.agentId,
+      status: finalizedRun.status,
+      failureReason: finalizedRun.error ?? undefined,
+    });
+    await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
+      eventType: "lifecycle",
+      stream: "system",
+      level: "error",
+      message,
+      payload: {
+        ...(run.processPid ? { processPid: run.processPid } : {}),
+        ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
+        ...(etimeMs != null ? { etimeMs } : {}),
+        maxRuntimeMs,
+      },
+    });
+    await releaseIssueExecutionAndPromote(finalizedRun);
+    await finalizeAgentStatus(run.agentId, "failed");
+    runningProcesses.delete(run.id);
+    await startNextQueuedRunForAgent(run.agentId);
+  }
+
+  async function reapStaleRunningRuns(opts?: { maxRuntimeMs?: number; graceMs?: number }) {
+    const maxRuntimeMs = opts?.maxRuntimeMs ?? defaultRuntimeReaper.maxRuntimeMs;
+    const graceMs = opts?.graceMs ?? defaultRuntimeReaper.graceMs;
+    const cutoff = new Date(Date.now() - maxRuntimeMs);
+    const stale = await db
+      .select({ run: heartbeatRuns, adapterType: agents.adapterType, adapterConfig: agents.adapterConfig })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+      .where(and(
+        eq(heartbeatRuns.status, "running"),
+        isNotNull(heartbeatRuns.processStartedAt),
+        lt(heartbeatRuns.processStartedAt, cutoff),
+      ));
+    const reaped: string[] = [];
+    for (const { run, adapterType, adapterConfig } of stale) {
+      await terminateRunAsOrphanReaped({ run, adapterType, adapterConfig, graceMs, maxRuntimeMs });
+      reaped.push(run.id);
+    }
+    if (reaped.length > 0) {
+      logger.warn({ reapedCount: reaped.length, runIds: reaped, maxRuntimeMs }, "reaped stale running heartbeat runs");
+    }
+    return { reaped: reaped.length, runIds: reaped };
+  }
+
+  async function killStalePriorRunsForAgent(agentId: string, opts?: { maxRuntimeMs?: number; graceMs?: number }) {
+    const maxRuntimeMs = opts?.maxRuntimeMs ?? defaultRuntimeReaper.maxRuntimeMs;
+    const graceMs = opts?.graceMs ?? defaultRuntimeReaper.graceMs;
+    const cutoff = new Date(Date.now() - maxRuntimeMs);
+    const stale = await db
+      .select({ run: heartbeatRuns, adapterType: agents.adapterType, adapterConfig: agents.adapterConfig })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+      .where(and(
+        eq(heartbeatRuns.agentId, agentId),
+        eq(heartbeatRuns.status, "running"),
+        isNotNull(heartbeatRuns.processStartedAt),
+        lt(heartbeatRuns.processStartedAt, cutoff),
+      ));
+    for (const { run, adapterType, adapterConfig } of stale) {
+      await terminateRunAsOrphanReaped({ run, adapterType, adapterConfig, graceMs, maxRuntimeMs });
+    }
+    return stale.length;
   }
 
   async function resumeQueuedRuns() {
@@ -9687,6 +9790,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     reportRunActivity: clearDetachedRunWarning,
 
     reapOrphanedRuns,
+
+    reapStaleRunningRuns,
+
+    killStalePriorRunsForAgent,
 
     promoteDueScheduledRetries,
     retryScheduledRetryNow,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies via a long-lived harness that spawns one CLI child process per agent heartbeat.
> - The `claude_local` adapter spawns a `claude` CLI child for each heartbeat run, each consuming ~350-400 MB RSS.
> - Today's harness has a **startup-only** orphan reaper — it cleans up after server restarts but offers no protection while the server is running.
> - When a heartbeat hangs (network stall, wedged subprocess, etc.) and another heartbeat fires before the old one exits, the old `claude` child stays alive indefinitely. Over hours of multi-agent operation, accumulation is unbounded. A downstream operator observed RAM exhaustion → 50 GB swap → required machine reboot.
> - This PR adds two pieces of runtime protection: a periodic reaper that finalises heartbeat runs alive past a configurable budget (default 15 min), and a pre-spawn guard inside `claimQueuedRun` that kills any leftover prior run for the same agent before claiming the next one.
> - It also caps embedded postgres `max_connections` at 20 to stop a separate fork-bomb-style RAM growth path observed alongside the heartbeat accumulation (a single Paperclip process never needs the 100-connection default).
> - The benefit is that long-running local installs and CI fixtures no longer trip the RAM-exhaustion failure mode, with new env knobs to tune both the timeout and the grace window per environment.

## What Changed

- New `reapStaleRunningRuns({ maxRuntimeMs, graceMs })` in `server/src/services/heartbeat.ts`. Queries `heartbeat_runs` for `status='running' AND process_started_at < now() - maxRuntimeMs` (default 15 min), SIGTERMs the process / process group, SIGKILLs after `graceMs` (default 30s), then marks the run `failed` with `errorCode = "orphan_reaped_by_runtime"`. Logs at WARN with run IDs and `etimeMs`.
- New `killStalePriorRunsForAgent` per-agent helper invoked inside `claimQueuedRun` immediately after the agent invokability check, so a new heartbeat cannot overlap with a stale prior one for the same agent.
- Shared `terminateRunAsOrphanReaped` helper guards finalisation with a CAS-style `UPDATE … WHERE id=? AND status='running'`. Concurrent reapers (or the natural finalize path) can no longer double-publish lifecycle events, double-release environment leases, or double-promote the next queued run.
- Wired `reapStaleRunningRuns` into the existing periodic `setInterval` chain in `server/src/index.ts`, before `reapOrphanedRuns` (sequential, not concurrent — eliminates a cross-reaper race on the same row).
- Plumbed two new config fields and env vars in `server/src/config.ts`:
  - `heartbeatRunMaxRuntimeMs` / `HEARTBEAT_RUN_MAX_RUNTIME_MS` (default 900_000 ms, floor 60_000 ms)
  - `heartbeatRunReaperGraceMs` / `HEARTBEAT_RUN_REAPER_GRACE_MS` (default 30_000 ms, floor 1_000 ms)
- Added `postgresFlags: ["-c", "max_connections=20"]` to the `EmbeddedPostgres` constructor in `server/src/index.ts`. Runtime override (works for both fresh and existing clusters); takes effect on next `paperclipai run` restart.
- New test file `server/src/__tests__/heartbeat-runtime-reaper.test.ts` (3 tests) covers the reaper and the pre-spawn guard against an embedded postgres harness.

## Verification

- Unit tests: `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-runtime-reaper.test.ts` — 3/3 pass.
- Adjacent suites unaffected: `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts src/__tests__/heartbeat-dependency-scheduling.test.ts` — 49/49 pass.
- Typecheck: `pnpm --filter @paperclipai/server typecheck` — clean.
- Manual reaper sanity check: with `HEARTBEAT_RUN_MAX_RUNTIME_MS=120000` and a `kill -STOP <pid>` on the spawned `claude` child, the next periodic tick after the 2-minute window logs `WARN reaped stale running heartbeat runs` and flips the row to `failed/orphan_reaped_by_runtime`.

## Risks

- **Killing a healthy long-running heartbeat.** The 15-minute default is well above the per-adapter `timeoutSec` enforced inside `runChildProcess` (typically ~10 minutes for `claude_local`), so anything past 15 min is by definition past its own timeout and probably wedged. The env override (`HEARTBEAT_RUN_MAX_RUNTIME_MS`) lets operators dial this up if they have legitimate long-running adapters.
- **PID recycling.** `isProcessAlive` is best-effort on Linux/macOS. `terminateHeartbeatRunProcess` prefers `processGroupId` over a bare PID where available, narrowing termination to descendants of the original spawn.
- **`max_connections=20`.** Drizzle's pg pool in this codebase defaults to ~10 connections per app; 20 leaves headroom for migrations + ad-hoc `psql` sessions. If a deployment runs multiple Paperclip processes against the same embedded cluster, this becomes too low — but that configuration is not supported today (embedded postgres is single-process-only).
- **Migration / breaking changes.** None. No schema change; `errorCode` is a `text` column and `"orphan_reaped_by_runtime"` is a new string value alongside the existing `process_lost`, `timeout`, etc.

## Model Used

- **Provider / model:** Anthropic Claude.
- **Model ID:** `claude-opus-4-7` (Opus 4.7) — planning, code review, integration.
- **Model ID:** `claude-sonnet-4-6` (Sonnet 4.6) — implementation pass under a separate subagent in an isolated worktree.
- **Context window:** 1M.
- **Capabilities used:** tool use (Bash, Read, Edit, Grep), agent dispatch with model overrides, code review subagent, isolated worktree execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-side only)
- [x] I have updated relevant documentation to reflect my changes (N/A — internal harness change, no public docs)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
