### PR TITLE
[ETF-48] Widen interaction cancel to request_confirmation and suggest_tasks (draft)

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -518,6 +518,8 @@ export interface SuggestTasksResult {
   createdTasks?: SuggestTasksResultCreatedTask[];
   skippedClientKeys?: string[];
   rejectionReason?: string | null;
+  cancelled?: true;
+  cancellationReason?: string | null;
 }
 
 export interface AskUserQuestionsQuestionOption {
@@ -595,7 +597,12 @@ export interface RequestConfirmationPayload {
 
 export interface RequestConfirmationResult {
   version: 1;
-  outcome: "accepted" | "rejected" | "superseded_by_comment" | "stale_target";
+  outcome:
+    | "accepted"
+    | "rejected"
+    | "superseded_by_comment"
+    | "stale_target"
+    | "cancelled";
   reason?: string | null;
   commentId?: string | null;
   staleTarget?: RequestConfirmationTarget | null;

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -454,6 +454,8 @@ export const suggestTasksResultSchema = z.object({
   createdTasks: z.array(suggestTasksResultCreatedTaskSchema).max(50).optional(),
   skippedClientKeys: z.array(z.string().trim().min(1).max(120)).max(50).optional(),
   rejectionReason: z.string().trim().max(4000).nullable().optional(),
+  cancelled: z.literal(true).optional(),
+  cancellationReason: z.string().trim().max(4000).nullable().optional(),
 });
 
 export const askUserQuestionsQuestionOptionSchema = z.object({
@@ -564,7 +566,13 @@ export const requestConfirmationPayloadSchema = z.object({
 
 export const requestConfirmationResultSchema = z.object({
   version: z.literal(1),
-  outcome: z.enum(["accepted", "rejected", "superseded_by_comment", "stale_target"]),
+  outcome: z.enum([
+    "accepted",
+    "rejected",
+    "superseded_by_comment",
+    "stale_target",
+    "cancelled",
+  ]),
   reason: z.string().trim().max(4000).nullable().optional(),
   commentId: z.string().uuid().nullable().optional(),
   staleTarget: requestConfirmationTargetSchema.nullable().optional(),

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -17,7 +17,7 @@ const mockInteractionService = vi.hoisted(() => ({
   rejectInteraction: vi.fn(),
   rejectSuggestedTasks: vi.fn(),
   answerQuestions: vi.fn(),
-  cancelQuestions: vi.fn(),
+  cancelInteraction: vi.fn(),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({
@@ -88,6 +88,22 @@ function registerModuleMocks() {
     }),
     issueService: () => mockIssueService,
     issueThreadInteractionService: () => mockInteractionService,
+    getCancellationReasonFromResult: (interaction: any) => {
+      if (interaction?.kind === "ask_user_questions") {
+        return interaction.result?.cancellationReason ?? null;
+      }
+      if (interaction?.kind === "request_confirmation") {
+        return interaction.result?.outcome === "cancelled"
+          ? (interaction.result.reason ?? null)
+          : null;
+      }
+      if (interaction?.kind === "suggest_tasks") {
+        return interaction.result?.cancelled
+          ? (interaction.result.cancellationReason ?? null)
+          : null;
+      }
+      return null;
+    },
     logActivity: mockLogActivity,
     projectService: () => ({}),
     routineService: () => ({
@@ -250,7 +266,7 @@ describe.sequential("issue thread interaction routes", () => {
       updatedAt: "2026-04-20T12:06:00.000Z",
       resolvedAt: "2026-04-20T12:06:00.000Z",
     });
-    mockInteractionService.cancelQuestions.mockResolvedValue({
+    mockInteractionService.cancelInteraction.mockResolvedValue({
       id: "interaction-2",
       companyId: "company-1",
       issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
@@ -403,7 +419,7 @@ describe.sequential("issue thread interaction routes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.status).toBe("cancelled");
-    expect(mockInteractionService.cancelQuestions).toHaveBeenCalledWith(
+    expect(mockInteractionService.cancelInteraction).toHaveBeenCalledWith(
       expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
       "interaction-2",
       {},
@@ -428,6 +444,160 @@ describe.sequential("issue thread interaction routes", () => {
         action: "issue.thread_interaction_cancelled",
       }),
     );
+  });
+
+  it("cancels pending request_confirmation interactions and threads the kind into the activity log (ETF-48)", async () => {
+    mockInteractionService.cancelInteraction.mockResolvedValueOnce({
+      id: "interaction-confirm",
+      companyId: "company-1",
+      issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      kind: "request_confirmation",
+      status: "cancelled",
+      continuationPolicy: "none",
+      idempotencyKey: null,
+      sourceCommentId: null,
+      sourceRunId: null,
+      payload: { version: 1, prompt: "Apply?" },
+      result: {
+        version: 1,
+        outcome: "cancelled",
+        reason: "superseded",
+        commentId: null,
+        staleTarget: null,
+      },
+      createdAt: "2026-05-12T12:00:00.000Z",
+      updatedAt: "2026-05-12T12:05:00.000Z",
+      resolvedAt: "2026-05-12T12:05:00.000Z",
+    });
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-confirm/cancel")
+      .send({ reason: "superseded" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("cancelled");
+    expect(res.body.kind).toBe("request_confirmation");
+    expect(res.body.result.outcome).toBe("cancelled");
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.thread_interaction_cancelled",
+        details: expect.objectContaining({
+          interactionKind: "request_confirmation",
+          cancellationReason: "superseded",
+        }),
+      }),
+    );
+  });
+
+  it("cancels pending suggest_tasks interactions and threads the kind into the activity log (ETF-48)", async () => {
+    mockInteractionService.cancelInteraction.mockResolvedValueOnce({
+      id: "interaction-tasks",
+      companyId: "company-1",
+      issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      kind: "suggest_tasks",
+      status: "cancelled",
+      continuationPolicy: "wake_assignee",
+      idempotencyKey: null,
+      sourceCommentId: null,
+      sourceRunId: null,
+      payload: { version: 1, tasks: [{ clientKey: "draft-1", title: "T" }] },
+      result: {
+        version: 1,
+        createdTasks: [],
+        skippedClientKeys: [],
+        cancelled: true,
+        cancellationReason: "direction changed",
+      },
+      createdAt: "2026-05-12T12:00:00.000Z",
+      updatedAt: "2026-05-12T12:05:00.000Z",
+      resolvedAt: "2026-05-12T12:05:00.000Z",
+    });
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-tasks/cancel")
+      .send({ reason: "direction changed" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.kind).toBe("suggest_tasks");
+    expect(res.body.result.cancelled).toBe(true);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
+          interactionKind: "suggest_tasks",
+          cancellationReason: "direction changed",
+        }),
+      }),
+    );
+  });
+
+  it("returns 422 with code not_applicable when the service refuses the kind (ETF-48)", async () => {
+    const { HttpError } = await import("../errors.js");
+    mockInteractionService.cancelInteraction.mockRejectedValueOnce(
+      new HttpError(
+        422,
+        'Interactions of kind "notify" cannot be cancelled',
+        undefined,
+        "not_applicable",
+      ),
+    );
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-notify/cancel")
+      .send({});
+
+    expect(res.status).toBe(422);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: expect.stringContaining("notify"),
+      code: "not_applicable",
+    }));
+  });
+
+  it("returns 409 with code already_resolved when the interaction is no longer pending (ETF-48)", async () => {
+    const { HttpError } = await import("../errors.js");
+    mockInteractionService.cancelInteraction.mockRejectedValueOnce(
+      new HttpError(
+        409,
+        "Interaction has already been resolved",
+        undefined,
+        "already_resolved",
+      ),
+    );
+    const app = await createApp();
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-done/cancel")
+      .send({});
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Interaction has already been resolved",
+      code: "already_resolved",
+    }));
+  });
+
+  it("returns 403 with code blocked_by_authorization when actor is not board (ETF-48)", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId: "00000000-0000-4000-8000-000000000001",
+      companyId: "company-1",
+      runId: "00000000-0000-4000-8000-000000000002",
+    });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/cancel")
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual(expect.objectContaining({
+      error: "Board access required",
+      code: "blocked_by_authorization",
+    }));
+    expect(mockInteractionService.cancelInteraction).not.toHaveBeenCalled();
   });
 
   it("accepts request confirmations and wakes the current assignee when configured for accept-only wakeups", async () => {

--- a/server/src/__tests__/issue-thread-interactions-em-dash.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-em-dash.test.ts
@@ -1,0 +1,262 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ETF-45 evidence-collection test (founder-directed via ETF-48).
+// POST a request_confirmation whose payload.prompt contains U+2014 (em-dash)
+// through the real route layer with mocked services. Captures the response and
+// asserts that:
+//   - the HTTP layer accepts the em-dash payload without a 5xx,
+//   - the prompt arrives at the service with its U+2014 code point intact.
+// If the test ever flips from 201 to 5xx, the captured response is full
+// bytes-on-the-wire evidence for ETF-45 — and the test fails loudly.
+
+const ISSUE_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ASSIGNEE_AGENT_ID = "11111111-1111-4111-8111-111111111111";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockInteractionService = vi.hoisted(() => ({
+  listForIssue: vi.fn(async () => []),
+  create: vi.fn(),
+  acceptInteraction: vi.fn(),
+  acceptSuggestedTasks: vi.fn(),
+  rejectInteraction: vi.fn(),
+  rejectSuggestedTasks: vi.fn(),
+  answerQuestions: vi.fn(),
+  cancelInteraction: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentTaskCompleted: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    companyService: () => ({
+      getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+    }),
+    accessService: () => ({
+      canUser: vi.fn(async () => true),
+      hasPermission: vi.fn(async () => true),
+    }),
+    agentService: () => ({
+      getById: vi.fn(async () => null),
+      resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({
+        ambiguous: false,
+        agent: { id: raw },
+      })),
+    }),
+    clampIssueListLimit: (value: number) => value,
+    ISSUE_LIST_DEFAULT_LIMIT: 500,
+    ISSUE_LIST_MAX_LIMIT: 1000,
+    documentService: () => ({}),
+    executionWorkspaceService: () => ({}),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({}),
+    heartbeatService: () => mockHeartbeatService,
+    instanceSettingsService: () => ({
+      get: vi.fn(async () => ({
+        id: "instance-settings-1",
+        general: {
+          censorUsernameInLogs: false,
+          feedbackDataSharingPreference: "prompt",
+        },
+      })),
+      listCompanyIds: vi.fn(async () => ["company-1"]),
+    }),
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: async () => undefined,
+      diffIssueReferenceSummary: () => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      }),
+      emptySummary: () => ({ outbound: [], inbound: [] }),
+      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+      syncComment: async () => undefined,
+      syncDocument: async () => undefined,
+      syncIssue: async () => undefined,
+    }),
+    issueService: () => mockIssueService,
+    issueThreadInteractionService: () => mockInteractionService,
+    getCancellationReasonFromResult: () => null,
+    logActivity: mockLogActivity,
+    projectService: () => ({}),
+    routineService: () => ({
+      syncRunStatusForIssue: vi.fn(async () => undefined),
+    }),
+    workProductService: () => ({}),
+  }));
+}
+
+function createIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ISSUE_ID,
+    companyId: "company-1",
+    status: "in_progress",
+    priority: "medium",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    assigneeAgentId: ASSIGNEE_AGENT_ID,
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    identifier: "ETF-45-repro",
+    title: "Em-dash repro fixture",
+    executionPolicy: null,
+    executionState: null,
+    hiddenAt: null,
+    ...overrides,
+  };
+}
+
+async function createApp() {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/issues.js"),
+    import("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe.sequential("ETF-45 em-dash bytes-on-the-wire repro", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.doUnmock("../services/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    mockIssueService.getById.mockResolvedValue(createIssue());
+  });
+
+  it("accepts a request_confirmation prompt containing U+2014 and forwards it to the service", async () => {
+    const emDash = "—";
+    const prompt = `Founder, please confirm the proposed approach ${emDash} with em-dash.`;
+
+    mockInteractionService.create.mockImplementation(async (_issue: any, body: any) => {
+      return {
+        id: "interaction-em-dash",
+        companyId: "company-1",
+        issueId: ISSUE_ID,
+        kind: body.kind,
+        status: "pending",
+        continuationPolicy: body.continuationPolicy ?? "none",
+        idempotencyKey: body.idempotencyKey ?? null,
+        sourceCommentId: null,
+        sourceRunId: null,
+        payload: body.payload,
+        result: null,
+        createdAt: "2026-05-12T23:41:24.000Z",
+        updatedAt: "2026-05-12T23:41:24.000Z",
+      };
+    });
+
+    const app = await createApp();
+
+    const res = await request(app)
+      .post(`/api/issues/${ISSUE_ID}/interactions`)
+      .set("Content-Type", "application/json; charset=utf-8")
+      .send({
+        kind: "request_confirmation",
+        idempotencyKey: "etf45-emdash-test-1",
+        payload: {
+          version: 1,
+          prompt,
+        },
+      });
+
+    // Bytes-on-the-wire capture for the PR description.
+    const evidence = {
+      status: res.status,
+      statusText: res.res?.statusMessage ?? "",
+      headers: { ...res.headers },
+      bodyType: typeof res.body,
+      promptCodePoints: Array.from(prompt).map((c) => c.codePointAt(0)?.toString(16)).join(" "),
+      receivedPromptCodePoints: undefined as string | undefined,
+    };
+
+    if (res.status >= 500) {
+      // Bug reproduced — emit the full response so the PR description has
+      // the captured bytes for ETF-45.
+      throw new Error(
+        `ETF-45 reproduced locally. status=${res.status} body=${JSON.stringify(res.body)} ` +
+          `headers=${JSON.stringify(res.headers)} evidence=${JSON.stringify(evidence)}`,
+      );
+    }
+
+    expect(res.status).toBe(201);
+    expect(mockInteractionService.create).toHaveBeenCalledTimes(1);
+    const receivedPayload = mockInteractionService.create.mock.calls[0]?.[1]?.payload;
+    expect(receivedPayload?.prompt).toBe(prompt);
+    evidence.receivedPromptCodePoints = Array.from(receivedPayload?.prompt ?? "")
+      .map((c) => (c as string).codePointAt(0)?.toString(16))
+      .join(" ");
+    // U+2014 must survive the HTTP layer round-trip.
+    expect(evidence.receivedPromptCodePoints).toContain("2014");
+  });
+
+  it("accepts a control ASCII-hyphen prompt as a baseline", async () => {
+    const prompt = "Founder, please confirm the proposed approach - simple ASCII hyphen.";
+
+    mockInteractionService.create.mockResolvedValueOnce({
+      id: "interaction-ascii",
+      companyId: "company-1",
+      issueId: ISSUE_ID,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "none",
+      idempotencyKey: "etf45-ascii-test-1",
+      sourceCommentId: null,
+      sourceRunId: null,
+      payload: { version: 1, prompt },
+      result: null,
+      createdAt: "2026-05-12T23:41:24.000Z",
+      updatedAt: "2026-05-12T23:41:24.000Z",
+    });
+
+    const app = await createApp();
+
+    const res = await request(app)
+      .post(`/api/issues/${ISSUE_ID}/interactions`)
+      .send({
+        kind: "request_confirmation",
+        idempotencyKey: "etf45-ascii-test-1",
+        payload: { version: 1, prompt },
+      });
+
+    expect(res.status).toBe(201);
+  });
+});

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -493,7 +493,7 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       userId: "local-board",
     });
 
-    const cancelled = await interactionsSvc.cancelQuestions({
+    const cancelled = await interactionsSvc.cancelInteraction({
       id: issueId,
       companyId,
     }, created.id, {
@@ -519,6 +519,270 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     }, {
       userId: "local-board",
     })).rejects.toThrow("Interaction has already been resolved");
+  });
+
+  it("cancels pending request_confirmation interactions with outcome=cancelled (ETF-48)", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Cancel a confirmation",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const created = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Apply the proposed approach?",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const cancelled = await interactionsSvc.cancelInteraction({
+      id: issueId,
+      companyId,
+    }, created.id, {
+      reason: "Superseded by a fresh ask",
+    }, {
+      userId: "local-board",
+    });
+
+    expect(cancelled.kind).toBe("request_confirmation");
+    expect(cancelled.status).toBe("cancelled");
+    expect(cancelled.result).toEqual({
+      version: 1,
+      outcome: "cancelled",
+      reason: "Superseded by a fresh ask",
+      commentId: null,
+      staleTarget: null,
+    });
+
+    await expect(interactionsSvc.acceptInteraction({
+      id: issueId,
+      companyId,
+    }, created.id, {}, {
+      userId: "local-board",
+    })).rejects.toThrow("Interaction has already been resolved");
+  });
+
+  it("cancels pending suggest_tasks interactions and records cancellationReason (ETF-48)", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Cancel a suggestion",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const created = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "suggest_tasks",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        tasks: [{ clientKey: "draft-1", title: "Draft task" }],
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const cancelled = await interactionsSvc.cancelInteraction({
+      id: issueId,
+      companyId,
+    }, created.id, {
+      reason: "Direction changed",
+    }, {
+      userId: "local-board",
+    });
+
+    expect(cancelled.kind).toBe("suggest_tasks");
+    expect(cancelled.status).toBe("cancelled");
+    expect(cancelled.result).toEqual({
+      version: 1,
+      createdTasks: [],
+      skippedClientKeys: [],
+      cancelled: true,
+      cancellationReason: "Direction changed",
+    });
+
+    await expect(interactionsSvc.acceptSuggestedTasks({
+      id: issueId,
+      companyId,
+      goalId,
+      projectId: null,
+    }, created.id, {}, {
+      userId: "local-board",
+    })).rejects.toThrow("Interaction has already been resolved");
+  });
+
+  it("rejects cancellation of an already-resolved interaction with code already_resolved (ETF-48)", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Already resolved",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const created = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Apply?",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    await interactionsSvc.acceptInteraction({
+      id: issueId,
+      companyId,
+    }, created.id, {}, {
+      userId: "local-board",
+    });
+
+    try {
+      await interactionsSvc.cancelInteraction({
+        id: issueId,
+        companyId,
+      }, created.id, {}, {
+        userId: "local-board",
+      });
+      throw new Error("expected cancelInteraction to reject already-resolved interaction");
+    } catch (err: any) {
+      expect(err.status).toBe(409);
+      expect(err.code).toBe("already_resolved");
+    }
+  });
+
+  it("rejects cancellation of a notify-shaped (unknown) interaction with code not_applicable (ETF-48)", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+    const interactionId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Notify kind cannot be cancelled",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    // Insert a row with an unrecognised kind to stand in for a future "notify"-style entry.
+    // The service must refuse to cancel it with code: "not_applicable".
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "notify" as any,
+      status: "pending" as any,
+      continuationPolicy: "none" as any,
+      payload: { version: 1 },
+      result: null,
+      idempotencyKey: null,
+      sourceCommentId: null,
+      sourceRunId: null,
+      title: null,
+      summary: null,
+      createdByAgentId: null,
+      createdByUserId: "local-board",
+    });
+
+    try {
+      await interactionsSvc.cancelInteraction({
+        id: issueId,
+        companyId,
+      }, interactionId, {}, {
+        userId: "local-board",
+      });
+      throw new Error("expected cancelInteraction to reject non-cancellable kind");
+    } catch (err: any) {
+      expect(err.status).toBe(422);
+      expect(err.code).toBe("not_applicable");
+    }
   });
 
   it("reuses the existing interaction when the same idempotency key is submitted twice", async () => {

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -1,34 +1,36 @@
 export class HttpError extends Error {
   status: number;
   details?: unknown;
+  code?: string;
 
-  constructor(status: number, message: string, details?: unknown) {
+  constructor(status: number, message: string, details?: unknown, code?: string) {
     super(message);
     this.status = status;
     this.details = details;
+    this.code = code;
   }
 }
 
-export function badRequest(message: string, details?: unknown) {
-  return new HttpError(400, message, details);
+export function badRequest(message: string, details?: unknown, code?: string) {
+  return new HttpError(400, message, details, code);
 }
 
-export function unauthorized(message = "Unauthorized") {
-  return new HttpError(401, message);
+export function unauthorized(message = "Unauthorized", code?: string) {
+  return new HttpError(401, message, undefined, code);
 }
 
-export function forbidden(message = "Forbidden") {
-  return new HttpError(403, message);
+export function forbidden(message = "Forbidden", code?: string) {
+  return new HttpError(403, message, undefined, code);
 }
 
-export function notFound(message = "Not found") {
-  return new HttpError(404, message);
+export function notFound(message = "Not found", code?: string) {
+  return new HttpError(404, message, undefined, code);
 }
 
-export function conflict(message: string, details?: unknown) {
-  return new HttpError(409, message, details);
+export function conflict(message: string, details?: unknown, code?: string) {
+  return new HttpError(409, message, details, code);
 }
 
-export function unprocessable(message: string, details?: unknown) {
-  return new HttpError(422, message, details);
+export function unprocessable(message: string, details?: unknown, code?: string) {
+  return new HttpError(422, message, details, code);
 }

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -51,6 +51,7 @@ export function errorHandler(
     }
     res.status(err.status).json({
       error: err.message,
+      ...(err.code ? { code: err.code } : {}),
       ...(err.details ? { details: err.details } : {}),
     });
     return;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -53,6 +53,7 @@ import {
   goalService,
   heartbeatService,
   issueApprovalService,
+  getCancellationReasonFromResult,
   issueThreadInteractionService,
   ISSUE_LIST_DEFAULT_LIMIT,
   ISSUE_LIST_MAX_LIMIT,
@@ -3896,10 +3897,12 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
-      assertBoard(req);
+      if (req.actor.type !== "board") {
+        throw forbidden("Board access required", "blocked_by_authorization");
+      }
 
       const actor = getActorInfo(req);
-      const interaction = await issueThreadInteractionService(db).cancelQuestions(issue, interactionId, req.body, {
+      const interaction = await issueThreadInteractionService(db).cancelInteraction(issue, interactionId, req.body, {
         agentId: actor.agentId,
         userId: actor.actorType === "user" ? actor.actorId : null,
       });
@@ -3917,10 +3920,7 @@ export function issueRoutes(
           interactionId: interaction.id,
           interactionKind: interaction.kind,
           interactionStatus: interaction.status,
-          cancellationReason:
-            interaction.kind === "ask_user_questions"
-              ? (interaction.result?.cancellationReason ?? null)
-              : null,
+          cancellationReason: getCancellationReasonFromResult(interaction),
         },
       });
 

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -20,7 +20,10 @@ export {
   issueService,
   type IssueFilters,
 } from "./issues.js";
-export { issueThreadInteractionService } from "./issue-thread-interactions.js";
+export {
+  issueThreadInteractionService,
+  getCancellationReasonFromResult,
+} from "./issue-thread-interactions.js";
 export { issueTreeControlService } from "./issue-tree-control.js";
 export { issueApprovalService } from "./issue-approvals.js";
 export { issueReferenceService } from "./issue-references.js";

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1152,7 +1152,7 @@ export function issueThreadInteractionService(db: Db) {
       return hydrateInteraction(updated);
     },
 
-    cancelQuestions: async (
+    cancelInteraction: async (
       issue: { id: string; companyId: string },
       interactionId: string,
       input: CancelIssueThreadInteraction,
@@ -1169,25 +1169,28 @@ export function issueThreadInteractionService(db: Db) {
       if (current.companyId !== issue.companyId || current.issueId !== issue.id) {
         throw notFound("Interaction not found");
       }
-      if (current.kind !== "ask_user_questions") {
-        throw unprocessable("Only ask_user_questions interactions can be cancelled");
+      const reason = data.reason?.trim() || null;
+      const cancellationResult = buildCancellationResult(current.kind, reason);
+      if (!cancellationResult) {
+        throw unprocessable(
+          `Interactions of kind "${current.kind}" cannot be cancelled`,
+          undefined,
+          "not_applicable",
+        );
       }
       if (current.status !== "pending") {
-        throw conflict("Interaction has already been resolved");
+        throw conflict(
+          "Interaction has already been resolved",
+          undefined,
+          "already_resolved",
+        );
       }
 
-      const reason = data.reason?.trim() || null;
       const [updated] = await db
         .update(issueThreadInteractions)
         .set({
           status: "cancelled",
-          result: {
-            version: 1,
-            answers: [],
-            cancelled: true,
-            cancellationReason: reason,
-            summaryMarkdown: null,
-          },
+          result: cancellationResult,
           resolvedByAgentId: actor.agentId ?? null,
           resolvedByUserId: actor.userId ?? null,
           resolvedAt: new Date(),
@@ -1200,11 +1203,68 @@ export function issueThreadInteractionService(db: Db) {
         .returning();
 
       if (!updated) {
-        throw conflict("Interaction has already been resolved");
+        throw conflict(
+          "Interaction has already been resolved",
+          undefined,
+          "already_resolved",
+        );
       }
 
       await touchIssue(db, issue.id);
       return hydrateInteraction(updated);
     },
   };
+}
+
+function buildCancellationResult(
+  kind: string,
+  reason: string | null,
+): IssueThreadInteractionRow["result"] | null {
+  switch (kind) {
+    case "ask_user_questions":
+      return {
+        version: 1,
+        answers: [],
+        cancelled: true,
+        cancellationReason: reason,
+        summaryMarkdown: null,
+      };
+    case "request_confirmation":
+      return {
+        version: 1,
+        outcome: "cancelled",
+        reason,
+        commentId: null,
+        staleTarget: null,
+      };
+    case "suggest_tasks":
+      return {
+        version: 1,
+        createdTasks: [],
+        skippedClientKeys: [],
+        cancelled: true,
+        cancellationReason: reason,
+      };
+    default:
+      return null;
+  }
+}
+
+export function getCancellationReasonFromResult(
+  interaction: IssueThreadInteraction,
+): string | null {
+  switch (interaction.kind) {
+    case "ask_user_questions":
+      return interaction.result?.cancellationReason ?? null;
+    case "request_confirmation":
+      return interaction.result?.outcome === "cancelled"
+        ? (interaction.result.reason ?? null)
+        : null;
+    case "suggest_tasks":
+      return interaction.result?.cancelled
+        ? (interaction.result.cancellationReason ?? null)
+        : null;
+    default:
+      return null;
+  }
 }

--- a/ui/src/lib/issue-thread-interactions.ts
+++ b/ui/src/lib/issue-thread-interactions.ts
@@ -68,6 +68,9 @@ export function buildIssueThreadInteractionSummary(
     if (interaction.status === "rejected") {
       return count === 1 ? "Rejected 1 task" : `Rejected ${count} tasks`;
     }
+    if (interaction.status === "cancelled") {
+      return count === 1 ? "Cancelled 1 task" : `Cancelled ${count} tasks`;
+    }
     return count === 1 ? "Suggested 1 task" : `Suggested ${count} tasks`;
   }
 
@@ -80,6 +83,7 @@ export function buildIssueThreadInteractionSummary(
       if (outcome === "stale_target") return "Confirmation expired after target changed";
       return "Confirmation expired";
     }
+    if (interaction.status === "cancelled") return "Cancelled confirmation";
     return "Requested confirmation";
   }
 


### PR DESCRIPTION
## Summary

`POST /api/issues/:id/interactions/:interactionId/cancel` previously hard-coded `current.kind === "ask_user_questions"`, so pending `request_confirmation` and `suggest_tasks` interactions could never be retracted by the board. When an agent retried a `request_confirmation` POST with a bumped idempotency key, the earlier `pending` entries stayed in the founder's approval queue forever — the only exits were accept or reject.

This widens the cancel path to handle all three resolvable kinds with kind-appropriate result payloads, plus stable JSON `code` fields on the three failure modes so callers can branch on machine-readable errors:

- **200** succeeded — writes per-kind cancellation `result`.
- **422** `{ error, code: "not_applicable" }` — interaction kind cannot be cancelled (e.g. `notify`).
- **409** `{ error, code: "already_resolved" }` — interaction is no longer `pending`.
- **403** `{ error, code: "blocked_by_authorization" }` — actor is not board.

Auth stays board-only per founder direction; agent self-cancel is deferred to a follow-up issue. Supersede-on-create remains a design note only and is not implemented here.

**Local commit:** `351fae58ff12c6187cf2804ae988ac675bfc1f90` (`[ETF-48] Widen interaction cancel to request_confirmation and suggest_tasks`).

**Tracking:**

- **Implementation issue:** ETF-48 — `[infra] Allow cancelling stale pending request_confirmation interactions`.
- **Parent investigation issue:** ETF-45 — `[infra] HTTP 500 on em-dash (U+2014) in request_confirmation payload.prompt`. The em-dash repro test in this PR captures bytes-on-the-wire evidence; it does **not** fix ETF-45.

> **Status:** draft, review-only. No merge, no deploy, no production change. Founder is the explicit merge gate.

## Changes

| File | What changed |
|---|---|
| `packages/shared/src/validators/issue.ts` | `requestConfirmationResultSchema.outcome` adds `"cancelled"`. `suggestTasksResultSchema` adds optional `cancelled: literal(true)` + `cancellationReason`. |
| `packages/shared/src/types/issue.ts` | Matching `RequestConfirmationResult` + `SuggestTasksResult` TS interfaces. |
| `server/src/errors.ts` | `HttpError` gains optional `code`. Helpers (`badRequest` / `unauthorized` / `forbidden` / `notFound` / `conflict` / `unprocessable`) accept it. |
| `server/src/middleware/error-handler.ts` | Spreads `code` at the top level of the JSON error body alongside existing `error` + `details`. Additive; existing responses unchanged when `code` is undefined. |
| `server/src/services/issue-thread-interactions.ts` | Renamed `cancelQuestions` → `cancelInteraction`. New `buildCancellationResult(kind, reason)` writes the per-kind result. New `getCancellationReasonFromResult(interaction)` reads the cancellation reason from whichever location the new result shape stores it. Service throws `unprocessable(..., "not_applicable")` for non-cancellable kinds and `conflict(..., "already_resolved")` for already-resolved. |
| `server/src/services/index.ts` | Re-exports `getCancellationReasonFromResult`. |
| `server/src/routes/issues.ts` | Replaces `assertBoard(req)` with an inline `req.actor.type !== "board"` check that throws `forbidden("Board access required", "blocked_by_authorization")` so the 403 carries a stable `code` on the JSON body. Calls `cancelInteraction` instead of `cancelQuestions`. Activity log `details.cancellationReason` reads from the per-kind helper instead of the previous hard-coded `ask_user_questions` branch. |
| `server/src/__tests__/issue-thread-interactions-service.test.ts` | Adds four ETF-48 service cases (request_confirmation cancel, suggest_tasks cancel, 409 already_resolved, 422 not_applicable). Existing ask_user_questions regression test stays unchanged. |
| `server/src/__tests__/issue-thread-interaction-routes.test.ts` | Adds five ETF-48 route cases (request_confirmation + suggest_tasks success log threading, 422/409/403 each asserting the JSON `code` field). |
| `server/src/__tests__/issue-thread-interactions-em-dash.test.ts` | **New file.** Captures ETF-45 bytes-on-the-wire evidence: posts a `request_confirmation` with U+2014 in `payload.prompt` through the real express + route + middleware stack with a mocked service; if the response ever flips from `201` to `5xx` the test fails loudly with the captured response. |
| `ui/src/lib/issue-thread-interactions.ts` | Adds `"Cancelled confirmation"` / `"Cancelled N tasks"` summary strings for the new cancelled statuses on `request_confirmation` and `suggest_tasks`. The existing `ask_user_questions` branch already handled `cancelled`. |

Stat: **11 files changed, +820 / −39.**

## Verification

Run locally on `351fae58` (Windows, pnpm + vitest 3.2.4, Node via `pnpm exec`).

| Check | Result |
|---|---|
| `pnpm --filter @paperclipai/server typecheck` | clean |
| `pnpm --filter @paperclipai/shared typecheck` | clean |
| `pnpm --filter @paperclipai/ui typecheck` | clean |
| `vitest run src/__tests__/issue-thread-interaction-routes.test.ts --testTimeout=30000` | **14/14 passed** (file's first-test cold-import is genuinely > 5 s on this Windows box; same flake reproduces on `master` head — pre-existing, not introduced here). |
| `vitest run src/__tests__/issue-thread-interactions-service.test.ts --testTimeout=120000` | **14/14 passed** (afterAll `rmdir` of the embedded-postgres temp dir hits `EBUSY` on Windows; same pre-existing Windows teardown noise — all tests pass before cleanup). |
| `vitest run src/__tests__/issue-thread-interactions-em-dash.test.ts --testTimeout=30000` | **2/2 passed** |
| `vitest run src/__tests__/error-handler.test.ts` | **2/2 passed** (new `code` spread is additive). |

### ETF-45 em-dash bytes-on-the-wire evidence

The new repro test posts a `request_confirmation` whose `payload.prompt` is `Founder, please confirm the proposed approach — with em-dash.` (codepoints `…0070 0072 006f 0061 0063 0068 0020 2014 0020 0077 0069 0074 0068…`) through the real express + route + middleware stack with a mocked service.

```
status:  201
body:    hydrated interaction (kind=request_confirmation, status=pending)
prompt arrives at service with U+2014 intact
control ASCII-hyphen baseline:  201
```

An earlier live-API repro (against the dev server on the same workstation: `/api/issues/{id}/interactions` with the same em-dash payload) also returned **201** for em-dash, en-dash, ellipsis, curly quotes, and NBSP. So as of `351fae58` against the current dev server build the em-dash 500 **does not reproduce locally**, in test or live. That itself is the evidence ETF-45 asked for — the failure path is not in the obvious HTTP/zod/body-parse layer. ETF-45 needs the captured 500 response (status, headers, body) from the production-shaped instance where the original failure was observed before a fix can land; this test stays so any future regression in the local path flips it from `201` to `5xx` and prints the full response.

## Acceptance criteria — per-item disposition (from ETF-48)

| AC | Disposition |
|---|---|
| 200 succeeds on pending request_confirmation, `result.outcome="cancelled"`, `result.reason` from request | ✅ service test `cancels pending request_confirmation interactions with outcome=cancelled (ETF-48)` |
| 200 succeeds on pending suggest_tasks, `result.cancelled=true`, `result.cancellationReason` populated | ✅ service test `cancels pending suggest_tasks interactions and records cancellationReason (ETF-48)` |
| 200 succeeds on pending ask_user_questions, existing shape (regression) | ✅ pre-existing `persists cancelled ask_user_questions interactions without answer data` still green |
| 422 with `{ error, code: "not_applicable" }` on non-cancellable kind | ✅ service + route tests |
| 409 with `{ error, code: "already_resolved" }` on non-pending | ✅ service + route tests |
| 403 with `{ error, code: "blocked_by_authorization" }` on non-board actor | ✅ route test (agent actor) |
| Board-only auth, decision recorded in PR description (agent self-cancel deferred) | ✅ this PR description + commit message |
| Activity log reads `cancellationReason` per-kind, includes kind in details | ✅ route uses `getCancellationReasonFromResult`; both new route tests assert the `details.cancellationReason` and `details.interactionKind` shape |
| Em-dash repro test ships in this branch, response documented | ✅ test landed at `server/src/__tests__/issue-thread-interactions-em-dash.test.ts` (paperclip puts server tests in `server/src/__tests__/`, not `server/test/routes/`); response captured above |
| Supersede-on-create stays as a design note, no code | ✅ no schema or service code for it in this commit |
| Founder approval queue listing no longer includes the cancelled interaction | ✅ implicit — status flips to `cancelled`, so any pending-filter on `GET /issues/:id/interactions` drops it; existing list endpoint unchanged |

## Founder-directed decisions (recorded for the merge gate)

1. **Auth stays board-only.** Agent self-cancel is **deferred** to a separate follow-up issue — different risk envelope (any agent could retract a board-facing ask) and warrants its own approval cycle. Not in this PR.
2. **Supersede-on-create** is a **design note only** in the ETF-48 description; no schema or service code for it lands here.
3. **Em-dash fix** stays on ETF-45 (parent). This PR ships only the bytes-on-the-wire evidence test, never a fix to the underlying em-dash 500.
4. **Error code naming** approved as-drafted: `not_applicable`, `already_resolved`, `blocked_by_authorization`.

## Backwards compatibility

- `HttpError` and the JSON error body gain an optional `code` field; existing endpoints that don't set it produce byte-identical responses (`error` + optional `details`).
- `suggestTasksResultSchema` and `requestConfirmationResultSchema` are extended additively — existing persisted results stay valid; only the new cancellation path writes the new fields/outcome.
- The service method rename `cancelQuestions` → `cancelInteraction` is internal; no external API contract changes. The HTTP route, URL, and request body are unchanged.

## Test plan for reviewer

- [ ] Re-run the relevant scoped vitest cases on the reviewer's environment (`pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-thread-interaction*.test.ts --testTimeout=30000`).
- [ ] Re-run all three workspace typechecks.
- [ ] Read the per-kind `buildCancellationResult` switch and confirm the result shapes match what each kind's downstream consumers expect.
- [ ] Read the inline `if (req.actor.type !== "board")` 403 path and confirm the `code` field semantics are acceptable.
- [ ] Manual: file a `request_confirmation` on a scratch issue, POST `/cancel`, confirm the board UI surfaces it as cancelled (the new `"Cancelled confirmation"` summary string) and the pending-filtered list drops it.
- [ ] Manual: attempt to cancel an already-resolved interaction; expect `409` with `code: "already_resolved"`.

---

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
