### PR TITLE
fix(docker): install gemini-cli and normalize persistent volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,12 +53,12 @@ ARG USER_UID=1000
 ARG USER_GID=1000
 WORKDIR /app
 COPY --chown=node:node --from=build /app /app
-RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
+RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai @google/gemini-cli \
   && apt-get update \
   && apt-get install -y --no-install-recommends openssh-client jq \
   && rm -rf /var/lib/apt/lists/* \
-  && mkdir -p /paperclip \
-  && chown node:node /paperclip
+  && mkdir -p /paperclip/.gemini \
+  && chown -R node:node /paperclip
 
 COPY scripts/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
This pull request addresses two critical issues in the production Docker image:

1. **Gemini CLI Integration**: Adds `@google/gemini-cli` to the global npm installation. This ensures that the `gemini` command (used by the Gemini local adapter) is available within the container.
2. 2. **Persistent Storage Permissions**: 
3.    - Normalizes directory ownership for `/paperclip`.
4.    - Pre-creates the `/paperclip/.gemini` directory with recursive ownership (`chown -R`).
5.    - This resolves frequent `EACCES: permission denied` errors encountered when the `node` user tries to write logs, credentials, or session history to mounted volumes in VPS environments like Coolify.
These changes have been tested in a production environment and provide a more robust out-of-the-box experience for users deploying via Docker.