### PR TITLE
fix(server): translate concurrent document-write race to 409 (ZERA-578)

### DIFF
--- a/server/src/__tests__/documents-service.test.ts
+++ b/server/src/__tests__/documents-service.test.ts
@@ -112,4 +112,108 @@ describeEmbeddedPostgres("documentService system issue documents", () => {
       body: "# Handoff",
     }));
   });
+
+  async function createIssue() {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      identifier: "PAP-1700",
+      title: "Concurrent document writes",
+      description: "Validate race-path conflict handling",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    return { issueId };
+  }
+
+  it("translates concurrent update races on the same baseRevisionId to 409 with currentRevisionId", async () => {
+    const { issueId } = await createIssue();
+    const initial = await svc.upsertIssueDocument({
+      issueId,
+      key: "plan",
+      title: "Plan",
+      format: "markdown",
+      body: "# Plan v1",
+    });
+    const baseRevisionId = initial.document.latestRevisionId;
+    expect(baseRevisionId).not.toBeNull();
+
+    const settled = await Promise.allSettled([
+      svc.upsertIssueDocument({
+        issueId,
+        key: "plan",
+        title: "Plan",
+        format: "markdown",
+        body: "# Plan v2-A",
+        baseRevisionId,
+      }),
+      svc.upsertIssueDocument({
+        issueId,
+        key: "plan",
+        title: "Plan",
+        format: "markdown",
+        body: "# Plan v2-B",
+        baseRevisionId,
+      }),
+    ]);
+
+    const fulfilled = settled.filter((r): r is PromiseFulfilledResult<unknown> => r.status === "fulfilled");
+    const rejected = settled.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    const rejection = rejected[0].reason as { status?: number; details?: { currentRevisionId?: string | null } };
+    expect(rejection.status).toBe(409);
+    expect(rejection.details?.currentRevisionId).toBeDefined();
+    expect(rejection.details?.currentRevisionId).not.toBeNull();
+
+    const after = await svc.getIssueDocumentByKey(issueId, "plan");
+    expect(after?.latestRevisionNumber).toBe(2);
+    expect(rejection.details?.currentRevisionId).toBe(after?.latestRevisionId);
+  });
+
+  it("translates concurrent initial-create races on the same key to 409", async () => {
+    const { issueId } = await createIssue();
+
+    const settled = await Promise.allSettled([
+      svc.upsertIssueDocument({
+        issueId,
+        key: "plan",
+        title: "Plan",
+        format: "markdown",
+        body: "# Plan A",
+      }),
+      svc.upsertIssueDocument({
+        issueId,
+        key: "plan",
+        title: "Plan",
+        format: "markdown",
+        body: "# Plan B",
+      }),
+    ]);
+
+    const fulfilled = settled.filter((r): r is PromiseFulfilledResult<unknown> => r.status === "fulfilled");
+    const rejected = settled.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+
+    const rejection = rejected[0].reason as { status?: number; details?: { currentRevisionId?: string | null } };
+    expect(rejection.status).toBe(409);
+    expect(rejection.details?.currentRevisionId).toBeDefined();
+    expect(rejection.details?.currentRevisionId).not.toBeNull();
+
+    const after = await svc.getIssueDocumentByKey(issueId, "plan");
+    expect(after?.latestRevisionNumber).toBe(1);
+  });
 });

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -14,7 +14,16 @@ function normalizeDocumentKey(key: string) {
 }
 
 function isUniqueViolation(error: unknown): boolean {
-  return !!error && typeof error === "object" && "code" in error && (error as { code?: string }).code === "23505";
+  // drizzle-orm/postgres-js wraps the driver error in DrizzleQueryError and
+  // exposes the original PostgresError on `.cause` — walk the chain.
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    if ((current as { code?: unknown }).code === "23505") return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 export function extractLegacyPlanBody(description: string | null | undefined) {
@@ -355,7 +364,19 @@ export function documentService(db: Db) {
         });
       } catch (error) {
         if (isUniqueViolation(error)) {
-          throw conflict("Document key already exists on this issue", { key });
+          // Concurrent writers raced past the baseRevisionId check (or both tried
+          // to create the same key). Re-read the now-committed winner and surface
+          // the same 409 shape the single-writer-stale path returns so clients
+          // can re-base on `currentRevisionId`.
+          const winner = await db
+            .select({ latestRevisionId: documents.latestRevisionId })
+            .from(issueDocuments)
+            .innerJoin(documents, eq(issueDocuments.documentId, documents.id))
+            .where(and(eq(issueDocuments.issueId, issue.id), eq(issueDocuments.key, key)))
+            .then((rows) => rows[0] ?? null);
+          throw conflict("Document was updated by someone else", {
+            currentRevisionId: winner?.latestRevisionId ?? null,
+          });
         }
         throw error;
       }


### PR DESCRIPTION
## Summary

Concurrent `PUT /api/issues/:id/documents/:key` with the same `baseRevisionId` was returning `500 Internal server error` for both writers, dropping both writes. The unique-index conflict on `document_revisions (document_id, revision_number)` was raised inside the transaction — but `drizzle-orm/postgres-js` wraps the driver error in `DrizzleQueryError` and puts the original `PostgresError` on `.cause`, so the top-level `code === "23505"` check in `isUniqueViolation` missed it and the error fell through to the generic 500 handler.

Reproduces on the [Security Researcher cycle 16 artifact](https://github.com/paperclipai/paperclip/issues): 3/3 rounds, both `PUT`s returned `500`, no activity log entry. Reported as [ZERA-578](https://paperclip.local/ZERA/issues/ZERA-578) (MEDIUM — availability hit on multi-actor collaborative editing, no data corruption).

## Changes

- **`server/src/services/documents.ts`** — `isUniqueViolation` now walks the `.cause` chain so it sees the wrapped `PostgresError`. The catch around `upsertIssueDocument`'s transaction re-reads the now-committed winner and throws `conflict("Document was updated by someone else", { currentRevisionId })` — matching the single-writer-stale shape the route already returns on line 224. Covers both the update race (revision_number unique) and the initial-create race (company_id+issue_id+key unique).
- **`server/src/__tests__/documents-service.test.ts`** — embedded-postgres tests that fire `Promise.allSettled` on parallel `upsertIssueDocument` calls and assert exactly one fulfilled / one 409-rejected outcome with `currentRevisionId` populated, for both update races and initial-create races.

## Tracking

Fixes [ZERA-578](https://paperclip.local/ZERA/issues/ZERA-578). The adjacent auth-bypass on the same handler is [ZERA-576](https://paperclip.local/ZERA/issues/ZERA-576) — different layer, queue-gated behind two criticals; shipping that separately per CEO's prior approval.

## Test plan

- [x] `vitest run src/__tests__/documents-service.test.ts` — 4 pass (2 existing + 2 new)
- [x] `vitest run src/__tests__/documents.test.ts src/__tests__/issue-document-restore-routes.test.ts src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 22 pass (no regressions on adjacent suites)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)