### PR TITLE
feat(server): strict zod validators across packages/shared/src/validators/ (ZERA-568)

### DIFF
--- a/packages/shared/src/validators/access.ts
+++ b/packages/shared/src/validators/access.ts
@@ -14,13 +14,13 @@ export const createCompanyInviteSchema = z.object({
   humanRole: z.enum(HUMAN_COMPANY_MEMBERSHIP_ROLES).optional().nullable(),
   defaultsPayload: z.record(z.string(), z.unknown()).optional().nullable(),
   agentMessage: z.string().max(4000).optional().nullable(),
-});
+}).strict();
 
 export type CreateCompanyInvite = z.infer<typeof createCompanyInviteSchema>;
 
 export const createOpenClawInvitePromptSchema = z.object({
   agentMessage: z.string().max(4000).optional().nullable(),
-});
+}).strict();
 
 export type CreateOpenClawInvitePrompt = z.infer<
   typeof createOpenClawInvitePromptSchema
@@ -38,14 +38,14 @@ export const acceptInviteSchema = z.object({
   responsesWebhookHeaders: z.record(z.string(), z.unknown()).optional().nullable(),
   paperclipApiUrl: z.string().max(4000).optional().nullable(),
   webhookAuthHeader: z.string().max(4000).optional().nullable(),
-});
+}).strict();
 
 export type AcceptInvite = z.infer<typeof acceptInviteSchema>;
 
 export const listJoinRequestsQuerySchema = z.object({
   status: z.enum(JOIN_REQUEST_STATUSES).optional(),
   requestType: z.enum(JOIN_REQUEST_TYPES).optional(),
-});
+}).strict();
 
 export type ListJoinRequestsQuery = z.infer<typeof listJoinRequestsQuerySchema>;
 
@@ -53,13 +53,13 @@ export const listCompanyInvitesQuerySchema = z.object({
   state: z.enum(["active", "revoked", "accepted", "expired"]).optional(),
   limit: z.coerce.number().int().min(1).max(100).optional().default(20),
   offset: z.coerce.number().int().min(0).optional().default(0),
-});
+}).strict();
 
 export type ListCompanyInvitesQuery = z.infer<typeof listCompanyInvitesQuerySchema>;
 
 export const claimJoinRequestApiKeySchema = z.object({
   claimSecret: z.string().min(16).max(256),
-});
+}).strict();
 
 export type ClaimJoinRequestApiKey = z.infer<typeof claimJoinRequestApiKeySchema>;
 
@@ -75,13 +75,13 @@ export const createCliAuthChallengeSchema = z.object({
   clientName: z.string().max(120).optional().nullable(),
   requestedAccess: boardCliAuthAccessLevelSchema.default("board"),
   requestedCompanyId: z.string().uuid().optional().nullable(),
-});
+}).strict();
 
 export type CreateCliAuthChallenge = z.infer<typeof createCliAuthChallengeSchema>;
 
 export const resolveCliAuthChallengeSchema = z.object({
   token: z.string().min(16).max(256),
-});
+}).strict();
 
 export type ResolveCliAuthChallenge = z.infer<typeof resolveCliAuthChallengeSchema>;
 
@@ -90,9 +90,9 @@ export const updateMemberPermissionsSchema = z.object({
     z.object({
       permissionKey: z.enum(PERMISSION_KEYS),
       scope: z.record(z.string(), z.unknown()).optional().nullable(),
-    }),
+    }).strict(),
   ),
-});
+}).strict();
 
 export type UpdateMemberPermissions = z.infer<typeof updateMemberPermissionsSchema>;
 
@@ -101,7 +101,7 @@ const editableMembershipStatuses = ["pending", "active", "suspended"] as const;
 export const updateCompanyMemberSchema = z.object({
   membershipRole: z.enum(HUMAN_COMPANY_MEMBERSHIP_ROLES).optional().nullable(),
   status: z.enum(editableMembershipStatuses).optional(),
-}).refine((value) => value.membershipRole !== undefined || value.status !== undefined, {
+}).strict().refine((value) => value.membershipRole !== undefined || value.status !== undefined, {
   message: "membershipRole or status is required",
 });
 
@@ -111,7 +111,7 @@ export const updateCompanyMemberWithPermissionsSchema = z.object({
   membershipRole: z.enum(HUMAN_COMPANY_MEMBERSHIP_ROLES).optional().nullable(),
   status: z.enum(editableMembershipStatuses).optional(),
   grants: updateMemberPermissionsSchema.shape.grants.default([]),
-}).refine((value) => value.membershipRole !== undefined || value.status !== undefined, {
+}).strict().refine((value) => value.membershipRole !== undefined || value.status !== undefined, {
   message: "membershipRole or status is required",
 });
 
@@ -123,9 +123,10 @@ export const archiveCompanyMemberSchema = z.object({
       assigneeAgentId: z.string().uuid().optional().nullable(),
       assigneeUserId: z.string().uuid().optional().nullable(),
     })
+    .strict()
     .optional()
     .nullable(),
-}).superRefine((value, ctx) => {
+}).strict().superRefine((value, ctx) => {
   if (value.reassignment?.assigneeAgentId && value.reassignment.assigneeUserId) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
@@ -139,13 +140,13 @@ export type ArchiveCompanyMember = z.infer<typeof archiveCompanyMemberSchema>;
 
 export const updateUserCompanyAccessSchema = z.object({
   companyIds: z.array(z.string().uuid()).default([]),
-});
+}).strict();
 
 export type UpdateUserCompanyAccess = z.infer<typeof updateUserCompanyAccessSchema>;
 
 export const searchAdminUsersQuerySchema = z.object({
   query: z.string().trim().max(120).optional().default(""),
-});
+}).strict();
 
 export type SearchAdminUsersQuery = z.infer<typeof searchAdminUsersQuerySchema>;
 
@@ -194,6 +195,6 @@ export const updateCurrentUserProfileSchema = z.object({
     .union([profileImageSchema, z.literal(""), z.null()])
     .optional()
     .transform((value) => value === "" ? null : value),
-});
+}).strict();
 
 export type UpdateCurrentUserProfile = z.infer<typeof updateCurrentUserProfileSchema>;

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -19,7 +19,7 @@ export const updateAgentInstructionsBundleSchema = z.object({
   rootPath: z.string().trim().min(1).nullable().optional(),
   entryFile: z.string().trim().min(1).optional(),
   clearLegacyPromptTemplate: z.boolean().optional().default(false),
-});
+}).strict();
 
 export type UpdateAgentInstructionsBundle = z.infer<typeof updateAgentInstructionsBundleSchema>;
 
@@ -27,7 +27,7 @@ export const upsertAgentInstructionsFileSchema = z.object({
   path: z.string().trim().min(1),
   content: z.string(),
   clearLegacyPromptTemplate: z.boolean().optional().default(false),
-});
+}).strict();
 
 export type UpsertAgentInstructionsFile = z.infer<typeof upsertAgentInstructionsFileSchema>;
 
@@ -49,7 +49,7 @@ export const createAgentInstructionsBundleSchema = z.object({
   files: z.record(z.string()).refine((files) => Object.keys(files).length > 0, {
     message: "instructionsBundle.files must contain at least one file",
   }),
-});
+}).strict();
 
 const agentModelProfileConfigSchema = z.object({
   enabled: z.boolean().optional(),
@@ -79,14 +79,14 @@ export const createAgentSchema = z.object({
   budgetMonthlyCents: z.number().int().nonnegative().optional().default(0),
   permissions: agentPermissionsSchema.optional(),
   metadata: z.record(z.unknown()).optional().nullable(),
-});
+}).strict();
 
 export type CreateAgent = z.infer<typeof createAgentSchema>;
 
 export const createAgentHireSchema = createAgentSchema.extend({
   sourceIssueId: z.string().uuid().optional().nullable(),
   sourceIssueIds: z.array(z.string().uuid()).optional(),
-});
+}).strict();
 
 export type CreateAgentHire = z.infer<typeof createAgentHireSchema>;
 
@@ -98,27 +98,27 @@ export const updateAgentSchema = createAgentSchema
     replaceAdapterConfig: z.boolean().optional(),
     status: z.enum(AGENT_STATUSES).optional(),
     spentMonthlyCents: z.number().int().nonnegative().optional(),
-  });
+  }).strict();
 
 export type UpdateAgent = z.infer<typeof updateAgentSchema>;
 
 export const updateAgentInstructionsPathSchema = z.object({
   path: z.string().trim().min(1).nullable(),
   adapterConfigKey: z.string().trim().min(1).optional(),
-});
+}).strict();
 
 export type UpdateAgentInstructionsPath = z.infer<typeof updateAgentInstructionsPathSchema>;
 
 export const createAgentKeySchema = z.object({
   name: z.string().min(1).default("default"),
-});
+}).strict();
 
 export type CreateAgentKey = z.infer<typeof createAgentKeySchema>;
 
 export const agentMineInboxQuerySchema = z.object({
   userId: z.string().trim().min(1),
   status: z.string().trim().min(1).optional().default(INBOX_MINE_ISSUE_STATUS_FILTER),
-});
+}).strict();
 
 export type AgentMineInboxQuery = z.infer<typeof agentMineInboxQuerySchema>;
 
@@ -132,13 +132,13 @@ export const wakeAgentSchema = z.object({
     (value) => (value === null ? undefined : value),
     z.boolean().optional().default(false),
   ),
-});
+}).strict();
 
 export type WakeAgent = z.infer<typeof wakeAgentSchema>;
 
 export const resetAgentSessionSchema = z.object({
   taskKey: z.string().min(1).optional().nullable(),
-});
+}).strict();
 
 export type ResetAgentSession = z.infer<typeof resetAgentSessionSchema>;
 
@@ -151,13 +151,13 @@ export const testAdapterEnvironmentSchema = z.object({
    * inside that environment so the result reflects real agent execution.
    */
   environmentId: z.string().uuid().optional().nullable(),
-});
+}).strict();
 
 export type TestAdapterEnvironment = z.infer<typeof testAdapterEnvironmentSchema>;
 
 export const updateAgentPermissionsSchema = z.object({
   canCreateAgents: z.boolean(),
   canAssignTasks: z.boolean(),
-});
+}).strict();
 
 export type UpdateAgentPermissions = z.infer<typeof updateAgentPermissionsSchema>;

--- a/packages/shared/src/validators/approval.test.ts
+++ b/packages/shared/src/validators/approval.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   addApprovalCommentSchema,
+  createApprovalSchema,
   requestApprovalRevisionSchema,
   resolveApprovalSchema,
+  resubmitApprovalSchema,
 } from "./approval.js";
 
 describe("approval validators", () => {
@@ -27,5 +29,19 @@ describe("approval validators", () => {
       .toBe("Decision\n\nApproved.");
     expect(requestApprovalRevisionSchema.parse({ decisionNote: "Decision\\r\\nRevise." }).decisionNote)
       .toBe("Decision\nRevise.");
+  });
+
+  it("rejects unknown body keys via .strict() (ZERA-568 sweep)", () => {
+    expect(() =>
+      createApprovalSchema.parse({
+        type: "general",
+        payload: {},
+        spoofedRequesterAgentId: "00000000-0000-0000-0000-000000000000",
+      }),
+    ).toThrow(/Unrecognized key/);
+    expect(() => resolveApprovalSchema.parse({ extra: "no" })).toThrow(/Unrecognized key/);
+    expect(() => requestApprovalRevisionSchema.parse({ extra: "no" })).toThrow(/Unrecognized key/);
+    expect(() => resubmitApprovalSchema.parse({ extra: "no" })).toThrow(/Unrecognized key/);
+    expect(() => addApprovalCommentSchema.parse({ body: "hi", extra: "no" })).toThrow(/Unrecognized key/);
   });
 });

--- a/packages/shared/src/validators/approval.ts
+++ b/packages/shared/src/validators/approval.ts
@@ -7,30 +7,30 @@ export const createApprovalSchema = z.object({
   requestedByAgentId: z.string().uuid().optional().nullable(),
   payload: z.record(z.unknown()),
   issueIds: z.array(z.string().uuid()).optional(),
-});
+}).strict();
 
 export type CreateApproval = z.infer<typeof createApprovalSchema>;
 
 export const resolveApprovalSchema = z.object({
   decisionNote: multilineTextSchema.optional().nullable(),
-});
+}).strict();
 
 export type ResolveApproval = z.infer<typeof resolveApprovalSchema>;
 
 export const requestApprovalRevisionSchema = z.object({
   decisionNote: multilineTextSchema.optional().nullable(),
-});
+}).strict();
 
 export type RequestApprovalRevision = z.infer<typeof requestApprovalRevisionSchema>;
 
 export const resubmitApprovalSchema = z.object({
   payload: z.record(z.unknown()).optional(),
-});
+}).strict();
 
 export type ResubmitApproval = z.infer<typeof resubmitApprovalSchema>;
 
 export const addApprovalCommentSchema = z.object({
   body: multilineTextSchema.pipe(z.string().min(1)),
-});
+}).strict();
 
 export type AddApprovalComment = z.infer<typeof addApprovalCommentSchema>;

--- a/packages/shared/src/validators/budget.ts
+++ b/packages/shared/src/validators/budget.ts
@@ -16,7 +16,7 @@ export const upsertBudgetPolicySchema = z.object({
   hardStopEnabled: z.boolean().optional().default(true),
   notifyEnabled: z.boolean().optional().default(true),
   isActive: z.boolean().optional().default(true),
-});
+}).strict();
 
 export type UpsertBudgetPolicy = z.infer<typeof upsertBudgetPolicySchema>;
 
@@ -24,7 +24,7 @@ export const resolveBudgetIncidentSchema = z.object({
   action: z.enum(BUDGET_INCIDENT_RESOLUTION_ACTIONS),
   amount: z.number().int().nonnegative().optional(),
   decisionNote: z.string().optional().nullable(),
-}).superRefine((value, ctx) => {
+}).strict().superRefine((value, ctx) => {
   if (value.action === "raise_budget_and_resume" && typeof value.amount !== "number") {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,

--- a/packages/shared/src/validators/company.ts
+++ b/packages/shared/src/validators/company.ts
@@ -18,7 +18,7 @@ export const createCompanySchema = z.object({
   description: z.string().optional().nullable(),
   budgetMonthlyCents: z.number().int().nonnegative().optional().default(0),
   attachmentMaxBytes: attachmentMaxBytesSchema.optional(),
-});
+}).strict();
 
 export type CreateCompany = z.infer<typeof createCompanySchema>;
 
@@ -35,7 +35,7 @@ export const updateCompanySchema = createCompanySchema
     brandColor: brandColorSchema,
     logoAssetId: logoAssetIdSchema,
     attachmentMaxBytes: attachmentMaxBytesSchema.optional(),
-  });
+  }).strict();
 
 export type UpdateCompany = z.infer<typeof updateCompanySchema>;
 

--- a/packages/shared/src/validators/feedback.ts
+++ b/packages/shared/src/validators/feedback.ts
@@ -17,6 +17,6 @@ export const upsertIssueFeedbackVoteSchema = z.object({
   vote: feedbackVoteValueSchema,
   reason: z.string().trim().max(1000).optional(),
   allowSharing: z.boolean().optional(),
-});
+}).strict();
 
 export type UpsertIssueFeedbackVote = z.infer<typeof upsertIssueFeedbackVoteSchema>;

--- a/packages/shared/src/validators/goal.ts
+++ b/packages/shared/src/validators/goal.ts
@@ -8,10 +8,10 @@ export const createGoalSchema = z.object({
   status: z.enum(GOAL_STATUSES).optional().default("planned"),
   parentId: z.string().uuid().optional().nullable(),
   ownerAgentId: z.string().uuid().optional().nullable(),
-});
+}).strict();
 
 export type CreateGoal = z.infer<typeof createGoalSchema>;
 
-export const updateGoalSchema = createGoalSchema.partial();
+export const updateGoalSchema = createGoalSchema.partial().strict();
 
 export type UpdateGoal = z.infer<typeof updateGoalSchema>;

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { MAX_ISSUE_REQUEST_DEPTH } from "../index.js";
 import {
   addIssueCommentSchema,
+  checkoutIssueSchema,
   createIssueSchema,
   resolveIssueRecoveryActionSchema,
   respondIssueThreadInteractionSchema,
@@ -316,5 +317,31 @@ describe("issue validators", () => {
     });
 
     expect(parsed.success).toBe(false);
+  });
+
+  it("rejects unknown body keys on issue body schemas (ZERA-568 sweep)", () => {
+    expect(() =>
+      createIssueSchema.parse({
+        title: "x",
+        spoofedCreatedByAgentId: "00000000-0000-0000-0000-000000000000",
+      }),
+    ).toThrow(/Unrecognized key/);
+    expect(() =>
+      updateIssueSchema.parse({ title: "x", spoofedField: 1 }),
+    ).toThrow(/Unrecognized key/);
+    expect(() =>
+      checkoutIssueSchema.parse({
+        agentId: "00000000-0000-0000-0000-000000000000",
+        expectedStatuses: ["todo"],
+        extra: 1,
+      }),
+    ).toThrow(/Unrecognized key/);
+    expect(() =>
+      suggestedTaskDraftSchema.parse({
+        clientKey: "x",
+        title: "y",
+        spoofedField: 1,
+      }),
+    ).toThrow(/Unrecognized key/);
   });
 });

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -323,11 +323,11 @@ const createIssueBaseSchema = z.object({
   executionWorkspacePreference: z.enum(ISSUE_EXECUTION_WORKSPACE_PREFERENCES).optional().nullable(),
   executionWorkspaceSettings: issueExecutionWorkspaceSettingsSchema.optional().nullable(),
   labelIds: z.array(z.string().uuid()).optional(),
-});
+}).strict();
 
 export const createIssueInputSchema = createIssueBaseSchema.extend({
   status: createIssueBaseSchema.shape.status.optional(),
-});
+}).strict();
 
 export const createIssueSchema = withCreateIssueStatusDefault(createIssueBaseSchema);
 
@@ -341,14 +341,14 @@ export const createChildIssueSchema = withCreateIssueStatusDefault(createIssueBa
   .extend({
     acceptanceCriteria: z.array(z.string().trim().min(1).max(500)).max(20).optional(),
     blockParentUntilDone: z.boolean().optional().default(false),
-  }));
+  }).strict());
 
 export type CreateChildIssue = z.infer<typeof createChildIssueSchema>;
 
 export const createIssueLabelSchema = z.object({
   name: z.string().trim().min(1).max(48),
   color: z.string().regex(/^#(?:[0-9a-fA-F]{6})$/, "Color must be a 6-digit hex value"),
-});
+}).strict();
 
 export type CreateIssueLabel = z.infer<typeof createIssueLabelSchema>;
 
@@ -361,7 +361,7 @@ export const updateIssueSchema = createIssueBaseSchema.partial().extend({
   resume: z.boolean().optional(),
   interrupt: z.boolean().optional(),
   hiddenAt: z.string().datetime().nullable().optional(),
-});
+}).strict();
 
 export type UpdateIssue = z.infer<typeof updateIssueSchema>;
 export type IssueExecutionWorkspaceSettings = z.infer<typeof issueExecutionWorkspaceSettingsSchema>;
@@ -369,7 +369,7 @@ export type IssueExecutionWorkspaceSettings = z.infer<typeof issueExecutionWorks
 export const checkoutIssueSchema = z.object({
   agentId: z.string().uuid(),
   expectedStatuses: z.array(z.enum(ISSUE_STATUSES)).nonempty(),
-});
+}).strict();
 
 export type CheckoutIssue = z.infer<typeof checkoutIssueSchema>;
 
@@ -498,7 +498,7 @@ export const suggestedTaskDraftSchema = z.object({
   billingCode: z.string().trim().max(120).nullable().optional(),
   labels: z.array(z.string().trim().min(1).max(48)).max(20).optional(),
   hiddenInPreview: z.boolean().optional(),
-}).superRefine((value, ctx) => {
+}).strict().superRefine((value, ctx) => {
   if (value.assigneeAgentId && value.assigneeUserId) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
@@ -512,7 +512,7 @@ export const suggestTasksPayloadSchema = z.object({
   version: z.literal(1),
   defaultParentId: z.string().uuid().nullable().optional(),
   tasks: z.array(suggestedTaskDraftSchema).min(1).max(50),
-}).superRefine((value, ctx) => {
+}).strict().superRefine((value, ctx) => {
   const seenClientKeys = new Set<string>();
   for (const [index, task] of value.tasks.entries()) {
     if (seenClientKeys.has(task.clientKey)) {

--- a/packages/shared/src/validators/project.ts
+++ b/packages/shared/src/validators/project.ts
@@ -84,14 +84,14 @@ function validateProjectWorkspace(value: Record<string, unknown>, ctx: z.Refinem
 export const createProjectWorkspaceSchema = z.object({
   ...projectWorkspaceFields,
   isPrimary: z.boolean().optional().default(false),
-}).superRefine(validateProjectWorkspace);
+}).strict().superRefine(validateProjectWorkspace);
 
 export type CreateProjectWorkspace = z.infer<typeof createProjectWorkspaceSchema>;
 
 export const updateProjectWorkspaceSchema = z.object({
   ...projectWorkspaceFields,
   isPrimary: z.boolean().optional(),
-}).partial();
+}).partial().strict();
 
 export type UpdateProjectWorkspace = z.infer<typeof updateProjectWorkspaceSchema>;
 
@@ -113,11 +113,11 @@ const projectFields = {
 export const createProjectSchema = z.object({
   ...projectFields,
   workspace: createProjectWorkspaceSchema.optional(),
-});
+}).strict();
 
 export type CreateProject = z.infer<typeof createProjectSchema>;
 
-export const updateProjectSchema = z.object(projectFields).partial();
+export const updateProjectSchema = z.object(projectFields).partial().strict();
 
 export type UpdateProject = z.infer<typeof updateProjectSchema>;
 

--- a/packages/shared/src/validators/routine.ts
+++ b/packages/shared/src/validators/routine.ts
@@ -60,13 +60,13 @@ export const createRoutineSchema = z.object({
   concurrencyPolicy: z.enum(ROUTINE_CONCURRENCY_POLICIES).optional().default("coalesce_if_active"),
   catchUpPolicy: z.enum(ROUTINE_CATCH_UP_POLICIES).optional().default("skip_missed"),
   variables: z.array(routineVariableSchema).optional().default([]),
-});
+}).strict();
 
 export type CreateRoutine = z.infer<typeof createRoutineSchema>;
 
 export const updateRoutineSchema = createRoutineSchema.partial().extend({
   baseRevisionId: z.string().uuid().optional().nullable(),
-});
+}).strict();
 export type UpdateRoutine = z.infer<typeof updateRoutineSchema>;
 
 export const routineRevisionSnapshotRoutineV1Schema = z.object({
@@ -137,7 +137,7 @@ export const updateRoutineTriggerSchema = z.object({
   timezone: z.string().trim().min(1).optional().nullable(),
   signingMode: z.enum(ROUTINE_TRIGGER_SIGNING_MODES).optional().nullable(),
   replayWindowSec: z.number().int().min(30).max(86_400).optional().nullable(),
-});
+}).strict();
 
 export type UpdateRoutineTrigger = z.infer<typeof updateRoutineTriggerSchema>;
 
@@ -152,9 +152,9 @@ export const runRoutineSchema = z.object({
   executionWorkspaceId: z.string().uuid().optional().nullable(),
   executionWorkspacePreference: z.enum(ISSUE_EXECUTION_WORKSPACE_PREFERENCES).optional().nullable(),
   executionWorkspaceSettings: issueExecutionWorkspaceSettingsSchema.optional().nullable(),
-});
+}).strict();
 
 export type RunRoutine = z.infer<typeof runRoutineSchema>;
 
-export const rotateRoutineTriggerSecretSchema = z.object({});
+export const rotateRoutineTriggerSecretSchema = z.object({}).strict();
 export type RotateRoutineTriggerSecret = z.infer<typeof rotateRoutineTriggerSecretSchema>;

--- a/packages/shared/src/validators/secret.ts
+++ b/packages/shared/src/validators/secret.ts
@@ -38,7 +38,7 @@ export const createSecretSchema = z.object({
   externalRef: z.string().optional().nullable(),
   providerMetadata: z.record(z.unknown()).optional().nullable(),
   providerVersionRef: z.string().optional().nullable(),
-}).superRefine((value, ctx) => {
+}).strict().superRefine((value, ctx) => {
   if ((value.managedMode ?? "paperclip_managed") === "external_reference") {
     if (!value.externalRef?.trim()) {
       ctx.addIssue({
@@ -72,7 +72,7 @@ export const rotateSecretSchema = z.object({
   externalRef: z.string().optional().nullable(),
   providerVersionRef: z.string().optional().nullable(),
   providerConfigId: z.string().uuid().optional().nullable(),
-});
+}).strict();
 
 export type RotateSecret = z.infer<typeof rotateSecretSchema>;
 
@@ -84,7 +84,7 @@ export const updateSecretSchema = z.object({
   description: z.string().optional().nullable(),
   externalRef: z.string().optional().nullable(),
   providerMetadata: z.record(z.unknown()).optional().nullable(),
-});
+}).strict();
 
 export type UpdateSecret = z.infer<typeof updateSecretSchema>;
 
@@ -99,7 +99,7 @@ export const createSecretBindingSchema = secretBindingTargetSchema.extend({
   versionSelector: z.union([z.literal("latest"), z.number().int().positive()]).default("latest"),
   required: z.boolean().default(true),
   label: z.string().optional().nullable(),
-});
+}).strict();
 
 export type CreateSecretBinding = z.infer<typeof createSecretBindingSchema>;
 
@@ -199,7 +199,7 @@ export const createSecretProviderConfigSchema = z.object({
   status: z.enum(SECRET_PROVIDER_CONFIG_STATUSES).optional(),
   isDefault: z.boolean().optional(),
   config: z.record(z.unknown()).default({}),
-}).superRefine((value, ctx) => {
+}).strict().superRefine((value, ctx) => {
   rejectSensitiveProviderConfigKeys(value.config, ctx);
   const parsed = secretProviderConfigPayloadSchema.safeParse({
     provider: value.provider,
@@ -237,7 +237,7 @@ export const updateSecretProviderConfigSchema = z.object({
   status: z.enum(SECRET_PROVIDER_CONFIG_STATUSES).optional(),
   isDefault: z.boolean().optional(),
   config: z.record(z.unknown()).optional(),
-}).superRefine((value, ctx) => {
+}).strict().superRefine((value, ctx) => {
   if (value.config !== undefined) {
     rejectSensitiveProviderConfigKeys(value.config, ctx);
     rejectUnsafeVaultAddress(value.config.address, ctx);
@@ -258,7 +258,7 @@ export const remoteSecretImportPreviewSchema = z.object({
   query: z.string().trim().max(200).optional().nullable(),
   nextToken: z.string().trim().min(1).max(4096).optional().nullable(),
   pageSize: z.number().int().min(1).max(100).optional(),
-});
+}).strict();
 
 export type RemoteSecretImportPreview = z.infer<typeof remoteSecretImportPreviewSchema>;
 
@@ -269,12 +269,12 @@ export const remoteSecretImportSelectionSchema = z.object({
   description: z.string().trim().max(500).optional().nullable(),
   providerVersionRef: z.string().trim().min(1).max(512).optional().nullable(),
   providerMetadata: z.record(z.unknown()).optional().nullable(),
-});
+}).strict();
 
 export const remoteSecretImportSchema = z.object({
   providerConfigId: z.string().uuid(),
   secrets: z.array(remoteSecretImportSelectionSchema).min(1).max(100),
-});
+}).strict();
 
 export type RemoteSecretImportSelection = z.infer<typeof remoteSecretImportSelectionSchema>;
 export type RemoteSecretImport = z.infer<typeof remoteSecretImportSchema>;

--- a/packages/shared/src/validators/work-product.ts
+++ b/packages/shared/src/validators/work-product.ts
@@ -45,10 +45,10 @@ export const createIssueWorkProductSchema = z.object({
   summary: z.string().optional().nullable(),
   metadata: z.record(z.unknown()).optional().nullable(),
   createdByRunId: z.string().uuid().optional().nullable(),
-});
+}).strict();
 
 export type CreateIssueWorkProduct = z.infer<typeof createIssueWorkProductSchema>;
 
-export const updateIssueWorkProductSchema = createIssueWorkProductSchema.partial();
+export const updateIssueWorkProductSchema = createIssueWorkProductSchema.partial().strict();
 
 export type UpdateIssueWorkProduct = z.infer<typeof updateIssueWorkProductSchema>;


### PR DESCRIPTION
## Summary

Sweep adding `.strict()` to all Category A body schemas in `packages/shared/src/validators/`. Unknown body keys on these endpoints now return `400` instead of being silently stripped — the same anti-pattern called out in [ZERA-565](/ZERA/issues/ZERA-565) for the comment endpoint, applied across the broader validator surface.

Filed as [ZERA-568](/ZERA/issues/ZERA-568) from the [Shared Learnings Hub](/ZERA/issues/ZERA-401) — full audit, classification, and rationale in the [pinned audit comment](/ZERA/issues/ZERA-568#comment-715b8278-c091-4817-a706-883eac64ce6c).

## Files touched

`access.ts`, `agent.ts`, `approval.ts`, `budget.ts`, `company.ts`, `feedback.ts`, `goal.ts`, `issue.ts`, `project.ts`, `routine.ts`, `secret.ts`, `work-product.ts` — plus test additions in `approval.test.ts` and `issue.test.ts`.

## Behavior change

Per body schema: unknown keys → `400 Unrecognized key(s) in object`. Previously the same payload would 201/200 and silently strip the unknown field — masking misconfigured clients exactly the way the comment endpoint did pre-[ZERA-565](/ZERA/issues/ZERA-565).

Ordering for chained schemas:
- `.partial().extend(...)` → `.strict()` applied after the `.extend()` block.
- `.superRefine(...)` / `.refine(...)` chains → `.strict()` applied before the refinement (refinements return `ZodEffects`, which doesn't have `.strict()`).
- `withCreateIssueStatusDefault(...)` wraps an inner object → `.strict()` applied on the inner object before the preprocess.

## Out of scope (separate follow-ups)

`.strict()` only fixes unknown-key behavior. Schemas that expose a body field which the route overrides from the authenticated principal need a separate route-side check (the [ZERA-565](/ZERA/issues/ZERA-565) pattern — typed-optional field + `assert*MatchesPrincipal`):

- `createApprovalSchema.requestedByAgentId`
- `createFinanceEventSchema.agentId`
- `createCostEventSchema.agentId` (note: **required** in current schema — the route trusts the body; this is its own bug)
- `updateAgentSchema.role` / `budgetMonthlyCents` etc. — covered by [ZERA-483](/ZERA/issues/ZERA-483) (self-escalation)

Each of these is per-route work with its own test coverage and will land separately.

Also out of scope: the `addIssueCommentSchema` (already touched by [PR #5825](https://github.com/paperclipai/paperclip/pull/5825) — this PR leaves that one alone to avoid a conflict).

## Test plan

- [x] `pnpm --filter @paperclipai/shared typecheck` clean
- [x] All 50 validator tests pass (5 files): `approval.test.ts` (+1 sweep test), `issue.test.ts` (+1 sweep test), `routine.test.ts`, `plugin.test.ts`, `secret.test.ts`
- [ ] CI server typecheck/tests (note: `master` HEAD has pre-existing typecheck breakage tracked in [ZERA-564](/ZERA/issues/ZERA-564) — unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>