### PR TITLE
fix(server): refuse silent worktree reuse of pre-existing divergent branches (ZERA-583)

### DIFF
--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -511,6 +511,100 @@ describe("realizeExecutionWorkspace", () => {
     ).rejects.toThrow(/not a reusable git worktree \(worktree HEAD is on "unexpected-branch" instead of "PAP-447-add-worktree-support"\)\./);
   });
 
+  it("refuses to attach a worktree to a pre-existing branch with divergent commits (ZERA-583)", async () => {
+    const repoRoot = await createTempRepo();
+    const branchName = "PAP-447-add-worktree-support";
+    const priorWorktree = path.join(repoRoot, ".paperclip", "worktrees", branchName);
+
+    // Simulate a prior agent session: create the branch + worktree, make a commit
+    // on it, then prune the worktree (mirroring cleanupExecutionWorkspaceArtifacts:
+    // `git worktree remove --force` followed by `git branch -d` that refuses to
+    // delete the unmerged branch and leaves it alive).
+    await fs.mkdir(path.dirname(priorWorktree), { recursive: true });
+    await execFileAsync("git", ["worktree", "add", "-b", branchName, priorWorktree, "HEAD"], { cwd: repoRoot });
+    await fs.writeFile(path.join(priorWorktree, "session-a-work.txt"), "prior session commit\n", "utf8");
+    await runGit(priorWorktree, ["add", "session-a-work.txt"]);
+    await runGit(priorWorktree, ["commit", "-m", "session A commit"]);
+    await execFileAsync("git", ["worktree", "remove", "--force", priorWorktree], { cwd: repoRoot });
+    await execFileAsync("git", ["worktree", "prune"], { cwd: repoRoot });
+
+    // Sanity: the branch survives the prune, divergent from HEAD.
+    const surviving = await execFileAsync("git", ["rev-parse", "--verify", `refs/heads/${branchName}`], { cwd: repoRoot });
+    expect(surviving.stdout.trim()).toMatch(/^[0-9a-f]{40}$/);
+
+    await expect(
+      realizeExecutionWorkspace({
+        base: {
+          baseCwd: repoRoot,
+          source: "project_primary",
+          projectId: "project-1",
+          workspaceId: "workspace-1",
+          repoUrl: null,
+          repoRef: "HEAD",
+        },
+        config: {
+          workspaceStrategy: {
+            type: "git_worktree",
+            branchTemplate: "{{issue.identifier}}-{{slug}}",
+          },
+        },
+        issue: {
+          id: "issue-1",
+          identifier: "PAP-447",
+          title: "Add Worktree Support",
+        },
+        agent: {
+          id: "agent-1",
+          name: "Codex Coder",
+          companyId: "company-1",
+        },
+      }),
+    ).rejects.toThrow(/Refusing to reuse branch "PAP-447-add-worktree-support".*ahead of base.*by 1 commit\(s\) from a prior agent session.*ZERA-583/s);
+  });
+
+  it("allows reuse of a pre-existing branch whose tip equals base (no divergent commits)", async () => {
+    const repoRoot = await createTempRepo();
+    const branchName = "PAP-447-add-worktree-support";
+    const priorWorktree = path.join(repoRoot, ".paperclip", "worktrees", branchName);
+
+    // Same prune-but-keep-branch scenario as above, except the prior session
+    // never committed beyond HEAD. Safe reuse: ahead=0, behind=0.
+    await fs.mkdir(path.dirname(priorWorktree), { recursive: true });
+    await execFileAsync("git", ["worktree", "add", "-b", branchName, priorWorktree, "HEAD"], { cwd: repoRoot });
+    await execFileAsync("git", ["worktree", "remove", "--force", priorWorktree], { cwd: repoRoot });
+    await execFileAsync("git", ["worktree", "prune"], { cwd: repoRoot });
+
+    const realized = await realizeExecutionWorkspace({
+      base: {
+        baseCwd: repoRoot,
+        source: "project_primary",
+        projectId: "project-1",
+        workspaceId: "workspace-1",
+        repoUrl: null,
+        repoRef: "HEAD",
+      },
+      config: {
+        workspaceStrategy: {
+          type: "git_worktree",
+          branchTemplate: "{{issue.identifier}}-{{slug}}",
+        },
+      },
+      issue: {
+        id: "issue-1",
+        identifier: "PAP-447",
+        title: "Add Worktree Support",
+      },
+      agent: {
+        id: "agent-1",
+        name: "Codex Coder",
+        companyId: "company-1",
+      },
+    });
+
+    expect(realized.branchName).toBe(branchName);
+    await expect(fs.realpath(realized.cwd)).resolves.toBe(await fs.realpath(priorWorktree));
+  });
+
   it("reuses an already checked out branch from git worktree metadata even when the target path differs", async () => {
     const repoRoot = await createTempRepo();
     const branchName = "PAP-1355-worktree-reuse";
@@ -1520,50 +1614,6 @@ describe("realizeExecutionWorkspace", () => {
     expect(provisionOperation?.result.stdout?.length ?? 0).toBeLessThan(300000);
   }, 10_000);
 
-  it("reuses an existing branch without resetting it when recreating a missing worktree", async () => {
-    const repoRoot = await createTempRepo();
-    const branchName = "PAP-450-recreate-missing-worktree";
-
-    await runGit(repoRoot, ["checkout", "-b", branchName]);
-    await fs.writeFile(path.join(repoRoot, "feature.txt"), "preserve me\n", "utf8");
-    await runGit(repoRoot, ["add", "feature.txt"]);
-    await runGit(repoRoot, ["commit", "-m", "Add preserved feature"]);
-    const expectedHead = (await execFileAsync("git", ["rev-parse", branchName], { cwd: repoRoot })).stdout.trim();
-    await runGit(repoRoot, ["checkout", "main"]);
-
-    const workspace = await realizeExecutionWorkspace({
-      base: {
-        baseCwd: repoRoot,
-        source: "project_primary",
-        projectId: "project-1",
-        workspaceId: "workspace-1",
-        repoUrl: null,
-        repoRef: "HEAD",
-      },
-      config: {
-        workspaceStrategy: {
-          type: "git_worktree",
-          branchTemplate: "{{issue.identifier}}-{{slug}}",
-        },
-      },
-      issue: {
-        id: "issue-1",
-        identifier: "PAP-450",
-        title: "Recreate missing worktree",
-      },
-      agent: {
-        id: "agent-1",
-        name: "Codex Coder",
-        companyId: "company-1",
-      },
-    });
-
-    expect(workspace.branchName).toBe(branchName);
-    await expect(fs.readFile(path.join(workspace.cwd, "feature.txt"), "utf8")).resolves.toBe("preserve me\n");
-    const actualHead = (await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: workspace.cwd })).stdout.trim();
-    expect(actualHead).toBe(expectedHead);
-  });
-
   it("reattaches a missing persisted git worktree before manual control starts it", async () => {
     const repoRoot = await createTempRepo();
     const branchName = "PAP-451-restore-persisted-worktree";
@@ -1580,13 +1630,6 @@ describe("realizeExecutionWorkspace", () => {
     await fs.chmod(path.join(repoRoot, "scripts", "restore.sh"), 0o755);
     await runGit(repoRoot, ["add", "scripts/restore.sh"]);
     await runGit(repoRoot, ["commit", "-m", "Add restore script"]);
-
-    await runGit(repoRoot, ["checkout", "-b", branchName]);
-    await fs.writeFile(path.join(repoRoot, "feature.txt"), "persisted\n", "utf8");
-    await runGit(repoRoot, ["add", "feature.txt"]);
-    await runGit(repoRoot, ["commit", "-m", "Add persisted feature"]);
-    const expectedHead = (await execFileAsync("git", ["rev-parse", branchName], { cwd: repoRoot })).stdout.trim();
-    await runGit(repoRoot, ["checkout", "main"]);
 
     const initial = await realizeExecutionWorkspace({
       base: {
@@ -1615,6 +1658,12 @@ describe("realizeExecutionWorkspace", () => {
         companyId: "company-1",
       },
     });
+
+    expect(initial.branchName).toBe(branchName);
+    await fs.writeFile(path.join(initial.cwd, "feature.txt"), "persisted\n", "utf8");
+    await runGit(initial.cwd, ["add", "feature.txt"]);
+    await runGit(initial.cwd, ["commit", "-m", "Add persisted feature"]);
+    const expectedHead = (await execFileAsync("git", ["rev-parse", branchName], { cwd: repoRoot })).stdout.trim();
 
     await fs.rm(initial.cwd, { recursive: true, force: true });
 

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -586,6 +586,53 @@ async function findRegisteredGitWorktreeByBranch(repoRoot: string, branchName: s
   return null;
 }
 
+// ZERA-583: when realizeExecutionWorkspace would silently attach a worktree to a
+// pre-existing local branch (because the prior session's worktree was pruned but
+// `git branch -d` refused to delete the unmerged branch), the new session would
+// inherit the prior session's commits. A subsequent push could clobber that work.
+// This guard refuses reuse when the existing branch tip carries commits not
+// reachable from `baseRef`. Safe reuse (branch tip == base, or branch lags base
+// only) still proceeds.
+async function assertExistingBranchSafeToReuse(input: {
+  repoRoot: string;
+  branchName: string;
+  baseRef: string;
+}): Promise<void> {
+  const { repoRoot, branchName, baseRef } = input;
+  const branchSha = await runGit(
+    ["rev-parse", "--verify", `refs/heads/${branchName}`],
+    repoRoot,
+  ).catch(() => null);
+  if (!branchSha) return; // branch doesn't actually exist locally; let git report it
+
+  const aheadRaw = await runGit(
+    ["rev-list", "--count", `${baseRef}..refs/heads/${branchName}`],
+    repoRoot,
+  ).catch(() => null);
+  if (aheadRaw === null) {
+    throw new Error(
+      `Refusing to reuse branch "${branchName}": cannot verify divergence from base "${baseRef}". ` +
+        `This branch already exists locally; reusing it without a divergence check risks clobbering ` +
+        `in-flight work from a prior agent session. Resolve by deleting/pushing the branch, or by ` +
+        `configuring a unique branch template. See ZERA-583.`,
+    );
+  }
+  const aheadCount = Number.parseInt(aheadRaw.trim(), 10);
+  if (!Number.isFinite(aheadCount) || aheadCount <= 0) return;
+
+  const baseSha = await runGit(["rev-parse", "--verify", baseRef], repoRoot).catch(() => null);
+  throw new Error(
+    `Refusing to reuse branch "${branchName}" at tip ${branchSha.slice(0, 12)}: ` +
+      `it is ahead of base "${baseRef}"${baseSha ? ` (${baseSha.slice(0, 12)})` : ""} by ` +
+      `${aheadCount} commit(s) from a prior agent session. Silently attaching a new worktree ` +
+      `would let a subsequent push clobber that work. Resolve by one of: ` +
+      `(a) push or otherwise preserve the commits, then \`git branch -D ${branchName}\`; ` +
+      `(b) delete the branch if those commits are abandoned; ` +
+      `(c) configure a unique branch template (e.g. include a run id) to avoid collisions. ` +
+      `See ZERA-583.`,
+  );
+}
+
 async function isGitCheckout(cwd: string): Promise<boolean> {
   return Boolean(await runGit(["rev-parse", "--git-dir"], cwd).catch(() => null));
 }
@@ -1118,6 +1165,7 @@ export async function realizeExecutionWorkspace(input: {
     if (!gitErrorIncludes(error, "already exists")) {
       throw error;
     }
+    await assertExistingBranchSafeToReuse({ repoRoot, branchName, baseRef });
     try {
       await recordGitOperation(input.recorder, {
         phase: "worktree_prepare",


### PR DESCRIPTION
## Summary

`realizeExecutionWorkspace`'s "branch already exists" fallback path (server/src/services/workspace-runtime.ts:1117–1147) silently attached new worktrees onto pre-existing local branches whose tips carried commits from a prior agent session. A subsequent push could clobber that work. Recovery has been relying on `git stash`/reflog (see ZERA-568 near-miss, where validator-sweep WIP only survived because it landed in `git stash@{0}`).

This PR adds a **divergence guard** at the silent-clobber path:

- Before falling back to `git worktree add <path> <branchName>`, compute `git rev-list --count baseRef..branchName`.
- If the branch is **ahead of base by any commits**, refuse loudly with an error naming the divergent count, the branch SHA, and the operator's three resolution paths (push/preserve, delete branch, or change template to include a uniqueness suffix).
- **Safe reuse (ahead = 0)** still proceeds — covers the legitimate "branch exists but nothing committed beyond base" resume case.
- `ensurePersistedExecutionWorkspaceAvailable` (the DB-record-driven legitimate-resume path) is untouched.

## Why divergence-detect over the other two suggestions

- **Run-id suffix**: changes operator-visible `{issue}/{slug}` naming (downstream tooling, COO's naming note). Also makes legitimate same-issue resume impossible.
- **Confirm-on-reuse**: needs an interactive operator surface — higher complexity, more code.
- **Divergence detection**: surgical guard at the exact silent-clobber path. No naming change. Loud failure when reuse would inherit foreign commits.

## Rollout note

No operator-visible change to branch naming. Downstream tooling that greps `{issue}/{slug}` is unaffected. The new behavior is "abort instead of silently attach when divergence > 0".

For the legitimate-resume case (branch with commits is genuinely yours), the operator now needs one of:
1. Push the branch, then `git branch -D <name>` and re-run.
2. `git branch -D <name>` if commits are abandoned.
3. Configure a unique branch template (e.g., include a run id) to avoid collisions.

## Test plan

- [x] `pnpm --filter @paperclipai/server exec vitest run --reporter=verbose src/__tests__/workspace-runtime.test.ts -t "(ZERA-583|allows reuse of a pre-existing|reattaches a missing persisted|reuses an already checked out|reuses the current linked|rejects reusing|creates and reuses a git worktree|slugifies unsafe|preserves intentional)"` — all 10 realize-related tests pass, including:
  - **new:** `refuses to attach a worktree to a pre-existing branch with divergent commits (ZERA-583)`
  - **new:** `allows reuse of a pre-existing branch whose tip equals base (no divergent commits)`
  - **updated:** `reattaches a missing persisted git worktree before manual control starts it` (setup restructured to use Paperclip-managed lifecycle for commits)
- [x] Removed the prior "reuses an existing branch without resetting it when recreating a missing worktree" test — it codified the silent-clobber behavior this PR fixes.
- [x] Server `typecheck`: no new errors. Pre-existing failures in `plugin-host-services.ts` / `plugin-local-folders.ts` / `plugin-worker-manager.ts` are tracked in ZERA-564 (same class flagged on the validator-sweep PR).
- [x] Pre-existing `provision-worktree.sh` / `paperclipai/dist/migrations` ENOENT test failures are infra-related and unchanged by this PR.

Closes [ZERA-583](/ZERA/issues/ZERA-583). Related near-miss: [ZERA-568](/ZERA/issues/ZERA-568#comment-8fc79039-96f3-4681-b30e-f2f64071e073).

🤖 Generated with [Claude Code](https://claude.com/claude-code)