### PR TITLE
fix(server): apply priority filter on /companies/:id/issues (ZERA-490)

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1281,6 +1281,92 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(result?.description).toHaveLength(1200);
     expect(result?.description?.endsWith("—")).toBe(true);
   });
+
+  it("filters by single priority value (ZERA-490)", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const criticalId = randomUUID();
+    const highId = randomUUID();
+    const mediumId = randomUUID();
+    const lowId = randomUUID();
+
+    await db.insert(issues).values([
+      { id: criticalId, companyId, title: "Critical", status: "todo", priority: "critical" },
+      { id: highId, companyId, title: "High", status: "todo", priority: "high" },
+      { id: mediumId, companyId, title: "Medium", status: "todo", priority: "medium" },
+      { id: lowId, companyId, title: "Low", status: "todo", priority: "low" },
+    ]);
+
+    const highResult = await svc.list(companyId, { priority: "high" });
+    expect(highResult.map((issue) => issue.id)).toEqual([highId]);
+
+    const mediumResult = await svc.list(companyId, { priority: "medium" });
+    expect(mediumResult.map((issue) => issue.id)).toEqual([mediumId]);
+  });
+
+  it("filters by comma-separated priority list and combines with status (ZERA-490)", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const criticalTodoId = randomUUID();
+    const highTodoId = randomUUID();
+    const mediumTodoId = randomUUID();
+    const criticalDoneId = randomUUID();
+
+    await db.insert(issues).values([
+      { id: criticalTodoId, companyId, title: "Critical todo", status: "todo", priority: "critical" },
+      { id: highTodoId, companyId, title: "High todo", status: "todo", priority: "high" },
+      { id: mediumTodoId, companyId, title: "Medium todo", status: "todo", priority: "medium" },
+      { id: criticalDoneId, companyId, title: "Critical done", status: "done", priority: "critical" },
+    ]);
+
+    const criticalHigh = await svc.list(companyId, { priority: "critical,high" });
+    expect(new Set(criticalHigh.map((issue) => issue.id))).toEqual(new Set([criticalTodoId, highTodoId, criticalDoneId]));
+
+    const criticalHighTodo = await svc.list(companyId, {
+      priority: "critical,high",
+      status: "todo",
+    });
+    expect(new Set(criticalHighTodo.map((issue) => issue.id))).toEqual(new Set([criticalTodoId, highTodoId]));
+  });
+
+  it("ignores blank and empty priority filter values (ZERA-490)", async () => {
+    const companyId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const criticalId = randomUUID();
+    const mediumId = randomUUID();
+
+    await db.insert(issues).values([
+      { id: criticalId, companyId, title: "Critical", status: "todo", priority: "critical" },
+      { id: mediumId, companyId, title: "Medium", status: "todo", priority: "medium" },
+    ]);
+
+    const emptyResult = await svc.list(companyId, { priority: "" });
+    expect(new Set(emptyResult.map((issue) => issue.id))).toEqual(new Set([criticalId, mediumId]));
+
+    const blanksResult = await svc.list(companyId, { priority: " , " });
+    expect(new Set(blanksResult.map((issue) => issue.id))).toEqual(new Set([criticalId, mediumId]));
+  });
 });
 
 describeEmbeddedPostgres("issueService.create workspace inheritance", () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1473,6 +1473,7 @@ export function issueRoutes(
 
     const result = await svc.list(companyId, {
       status: req.query.status as string | undefined,
+      priority: req.query.priority as string | undefined,
       assigneeAgentId: req.query.assigneeAgentId as string | undefined,
       participantAgentId: req.query.participantAgentId as string | undefined,
       assigneeUserId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -206,6 +206,7 @@ export function deriveIssueCommentRunLogAttribution(
 
 export interface IssueFilters {
   status?: string;
+  priority?: string;
   assigneeAgentId?: string;
   participantAgentId?: string;
   assigneeUserId?: string;
@@ -2494,6 +2495,12 @@ export function issueService(db: Db) {
       if (filters?.status) {
         const statuses = filters.status.split(",").map((s) => s.trim());
         conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
+      }
+      if (filters?.priority) {
+        const priorities = filters.priority.split(",").map((p) => p.trim()).filter((p) => p.length > 0);
+        if (priorities.length > 0) {
+          conditions.push(priorities.length === 1 ? eq(issues.priority, priorities[0]) : inArray(issues.priority, priorities));
+        }
       }
       if (filters?.assigneeAgentId) {
         conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));


### PR DESCRIPTION
## Summary

`GET /api/companies/:id/issues?priority=...` silently dropped the priority filter — three previously-`done` regressions in five weeks on the same query surface (per [ZERA-571](/ZERA/issues/ZERA-571)). The route handler never passed `priority` to `svc.list`, and the service's WHERE builder had no priority branch. Combined-filter calls like `?assigneeAgentId=...&priority=critical` honored the assignee but ignored priority, masking a basic correctness bug behind partially-correct results.

Fix mirrors the existing `status` shape:

- `server/src/services/issues.ts` — add `priority?: string` to `IssueFilters`; add a comma-aware WHERE branch in `svc.list` (`eq` for single value, `inArray` for multi). Blank / whitespace-only segments are filtered, and an entirely empty filter is a no-op so we don't push an empty `inArray`.
- `server/src/routes/issues.ts` — forward `req.query.priority` into the `svc.list` filter map.
- `server/src/__tests__/issues-service.test.ts` — three new service-level regression tests: single-value, comma-separated combined with `status`, and blank-input ignore.

## Acceptance criteria (from issue)

- [x] Priority filter applied in the WHERE clause (single + multi-value).
- [x] Combined filters (`priority` + `status` / `assigneeAgentId`) keep working.
- [x] Regression test landed alongside the fix.
- [x] No change in default (no-filter) behavior.

Scope adherence: kept to the issues-list endpoint per CEO direction. The dashboard budget aggregation regression ([ZERA-468](/ZERA/issues/ZERA-468) Surface 2) is a separate code path and will land as its own ticket — not bundled here.

## Test plan

- [x] `vitest run server/src/__tests__/issues-service.test.ts` — 49/49 pass, including the three new `ZERA-490` cases.
- [x] `pnpm --filter @paperclipai/server typecheck` — clean.
- [ ] CI suites (verify, serialized, policy, e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)