### PR TITLE
[codex] Harden run log redaction

### DIFF
--- a/server/src/__tests__/run-log-store-redaction.test.ts
+++ b/server/src/__tests__/run-log-store-redaction.test.ts
@@ -1,0 +1,91 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getRunLogStore } from "../services/run-log-store.js";
+
+describe("run log store redaction", () => {
+  let tempDir: string;
+  let previousBasePath: string | undefined;
+  let previousJwtSecret: string | undefined;
+  let runCounter = 0;
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-run-log-redaction-"));
+    previousBasePath = process.env.RUN_LOG_BASE_PATH;
+    process.env.RUN_LOG_BASE_PATH = tempDir;
+  });
+
+  beforeEach(() => {
+    previousJwtSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = "redaction-test-secret-value-1234567890";
+  });
+
+  afterEach(() => {
+    if (previousJwtSecret === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    else process.env.PAPERCLIP_AGENT_JWT_SECRET = previousJwtSecret;
+  });
+
+  afterAll(async () => {
+    if (previousBasePath === undefined) delete process.env.RUN_LOG_BASE_PATH;
+    else process.env.RUN_LOG_BASE_PATH = previousBasePath;
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function createRunLog() {
+    const store = getRunLogStore();
+    const handle = await store.begin({
+      companyId: "company",
+      agentId: "agent",
+      runId: `run-${runCounter++}`,
+    });
+    return { store, handle, logPath: path.join(tempDir, handle.logRef) };
+  }
+
+  it("redacts mirrored env-var values and creates run logs with mode 600", async () => {
+    const { store, handle, logPath } = await createRunLog();
+
+    await store.append(handle, {
+      ts: "2026-05-13T00:00:00.000Z",
+      stream: "stdout",
+      chunk: `PAPERCLIP_AGENT_JWT_SECRET=${process.env.PAPERCLIP_AGENT_JWT_SECRET}\n`,
+    });
+
+    const persisted = await readFile(logPath, "utf8");
+    const mode = (await stat(logPath)).mode & 0o777;
+    expect(persisted).not.toContain(process.env.PAPERCLIP_AGENT_JWT_SECRET);
+    expect(persisted).toContain("PAPERCLIP_AGENT_JWT_SECRET=<REDACTED>");
+    expect(mode).toBe(0o600);
+  });
+
+  it("redacts quoted sensitive env assignments in command payloads", async () => {
+    const { store, handle, logPath } = await createRunLog();
+    const syntheticValue = "quoted-redaction-test-value-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    await store.append(handle, {
+      ts: "2026-05-13T00:00:00.000Z",
+      stream: "stdout",
+      chunk: `{"command":"KEL92_SYNTHETIC_SECRET='${syntheticValue}' sh -c env"}`,
+    });
+
+    const persisted = await readFile(logPath, "utf8");
+    expect(persisted).not.toContain(syntheticValue);
+    expect(persisted).toContain("KEL92_SYNTHETIC_SECRET='<REDACTED>'");
+  });
+
+  it("redacts generic unquoted sensitive env assignments", async () => {
+    const { store, handle, logPath } = await createRunLog();
+    const syntheticValue = "generic-redaction-test-value-ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    await store.append(handle, {
+      ts: "2026-05-13T00:00:00.000Z",
+      stream: "stderr",
+      chunk: `KEL92_GENERIC_SECRET=${syntheticValue} node ./scripts/task.js`,
+    });
+
+    const persisted = await readFile(logPath, "utf8");
+    expect(persisted).not.toContain(syntheticValue);
+    expect(persisted).toContain("KEL92_GENERIC_SECRET=<REDACTED>");
+  });
+});

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import { notFound } from "../errors.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { redactSensitiveText } from "../redaction.js";
 
 export type RunLogStoreType = "local_file";
 
@@ -35,6 +36,63 @@ export interface RunLogStore {
   ): Promise<number>;
   finalize(handle: RunLogHandle): Promise<RunLogFinalizeSummary>;
   read(handle: RunLogHandle, opts?: RunLogReadOptions): Promise<RunLogReadResult>;
+}
+
+const RUN_LOG_FILE_MODE = 0o600;
+const RUN_LOG_REDACTION_TOKEN = "<REDACTED>";
+const SENSITIVE_ENV_KEY_RE = /(?:_SECRET|_TOKEN|_KEY|_PASSWORD|_PRIVATE_KEY)$/;
+const EXPLICIT_SENSITIVE_ENV_KEYS = new Set([
+  "PAPERCLIP_AGENT_JWT_SECRET",
+  "PAPERCLIP_AGENT_JWT_PREVIOUS_SECRETS",
+]);
+const LONG_TOKEN_RE = /\b[A-Za-z0-9+/=_-]{32,}\b/g;
+const GENERIC_SENSITIVE_ENV_ASSIGNMENT_RE =
+  /(\b[A-Za-z0-9_]*(?:_SECRET|_TOKEN|_KEY|_PASSWORD|_PRIVATE_KEY)\s*=\s*)(["']?)[^\s"'`]+(\2)/g;
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isSensitiveEnvKey(key: string) {
+  return EXPLICIT_SENSITIVE_ENV_KEYS.has(key) || SENSITIVE_ENV_KEY_RE.test(key);
+}
+
+function getSensitiveEnvEntries() {
+  return Object.entries(process.env).filter(
+    ([key, value]) => isSensitiveEnvKey(key) && typeof value === "string" && value.length > 0,
+  ) as Array<[string, string]>;
+}
+
+function redactEnvKeyContext(input: string, sensitiveKeys: readonly string[]) {
+  let output = input.replace(GENERIC_SENSITIVE_ENV_ASSIGNMENT_RE, `$1$2${RUN_LOG_REDACTION_TOKEN}$3`);
+
+  for (const key of sensitiveKeys) {
+    const escapedKey = escapeRegExp(key);
+    output = output.replace(
+      new RegExp("(" + escapedKey + "\\s*=\\s*)([\"']?)[^\\s\"'`]+(\\2)", "g"),
+      `$1$2${RUN_LOG_REDACTION_TOKEN}$3`,
+    );
+    output = output.replace(new RegExp(`(${escapedKey}\\s*:\\s*)\\S+`, "g"), `$1${RUN_LOG_REDACTION_TOKEN}`);
+  }
+
+  if (sensitiveKeys.some((key) => output.includes(key))) {
+    const keySet = new Set(sensitiveKeys);
+    output = output.replace(LONG_TOKEN_RE, (candidate) => (keySet.has(candidate) ? candidate : RUN_LOG_REDACTION_TOKEN));
+  }
+
+  return output;
+}
+
+function sanitizeRunLogText(input: string) {
+  let output = redactSensitiveText(input);
+  const sensitiveEntries = getSensitiveEnvEntries();
+  const sensitiveKeys = [...new Set([...sensitiveEntries.map(([key]) => key), ...EXPLICIT_SENSITIVE_ENV_KEYS])];
+
+  for (const [, value] of sensitiveEntries) {
+    output = output.split(value).join(RUN_LOG_REDACTION_TOKEN);
+  }
+
+  return redactEnvKeyContext(output, sensitiveKeys);
 }
 
 function safeSegments(...segments: string[]) {
@@ -101,7 +159,8 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
       await ensureDir(relDir);
 
       const absPath = resolveWithin(basePath, relPath);
-      await fs.writeFile(absPath, "", "utf8");
+      await fs.writeFile(absPath, "", { encoding: "utf8", mode: RUN_LOG_FILE_MODE });
+      await fs.chmod(absPath, RUN_LOG_FILE_MODE);
 
       return { store: "local_file", logRef: relPath };
     },
@@ -112,7 +171,7 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
       const line = JSON.stringify({
         ts: event.ts,
         stream: event.stream,
-        chunk: event.chunk,
+        chunk: sanitizeRunLogText(event.chunk),
       });
       const persisted = `${line}\n`;
       await fs.appendFile(absPath, persisted, "utf8");


### PR DESCRIPTION
## Summary

- sanitize persisted run-log chunks through the existing redaction pipeline plus env-key specific redaction
- redact mirrored sensitive env values and generic `*_SECRET`/`*_TOKEN`/`*_KEY`/`*_PASSWORD`/`*_PRIVATE_KEY` assignments before writing NDJSON
- create local run-log files with mode `0600` and enforce it with `chmod`
- add focused regression coverage for mirrored env values, quoted sensitive assignments, generic unquoted sensitive assignments, and file mode

## Validation

- `corepack pnpm exec vitest run server/src/__tests__/run-log-store-redaction.test.ts`
- `corepack pnpm --filter @paperclipai/plugin-sdk ensure-build-deps`
- `corepack pnpm --filter @paperclipai/server exec tsc --noEmit`

## Notes

The normal `corepack pnpm --filter @paperclipai/server typecheck` wrapper could not run in this checkout because the package script shells out to `pnpm`, while this environment exposes pnpm through Corepack only. I ran the same build-dependency and `tsc --noEmit` steps explicitly through Corepack.
