### PR TITLE
Add issue_create_rate_limit to PAUSE_REASONS (DOGAA-2656)

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -389,7 +389,7 @@ export type RoutineRunStatus = (typeof ROUTINE_RUN_STATUSES)[number];
 export const ROUTINE_RUN_SOURCES = ["schedule", "manual", "api", "webhook"] as const;
 export type RoutineRunSource = (typeof ROUTINE_RUN_SOURCES)[number];
 
-export const PAUSE_REASONS = ["manual", "budget", "system"] as const;
+export const PAUSE_REASONS = ["manual", "budget", "system", "issue_create_rate_limit"] as const;
 export type PauseReason = (typeof PAUSE_REASONS)[number];
 
 export const PROJECT_COLORS = [

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -20,6 +20,7 @@ import type {
   BudgetScopeType,
   BudgetThresholdType,
   BudgetWindowKind,
+  PauseReason,
 } from "@paperclipai/shared";
 import { notFound, unprocessable } from "../errors.js";
 import { logActivity } from "./activity-log.js";
@@ -28,7 +29,7 @@ type ScopeRecord = {
   companyId: string;
   name: string;
   paused: boolean;
-  pauseReason: "manual" | "budget" | "system" | null;
+  pauseReason: PauseReason | null;
 };
 
 type PolicyRow = typeof budgetPolicies.$inferSelect;


### PR DESCRIPTION
## Summary

- ADR-008 follow-up to [DOGAA-2620](/DOGAA/issues/DOGAA-2620) / [DOGAA-2656](/DOGAA/issues/DOGAA-2656)
- Adds `"issue_create_rate_limit"` to the canonical `PAUSE_REASONS` constant in `@paperclipai/shared` so the ADR-008 reason is a first-class `PauseReason` value
- Replaces the inline `ScopeRecord["pauseReason"]` union in `server/src/services/budgets.ts` with the canonical `PauseReason` type to remove drift

## Why this shape

The `ScopeRecord` in `budgets.ts` was the one inline duplicate of the `PauseReason` union that did not flow from the shared constant. Other consumers (`Company`, `Agent`, `Project`, `BudgetPolicySummary`) already import `PauseReason` from shared, so updating the constant propagates everywhere; pointing `budgets.ts` at the same type closes the drift point that motivated this issue.

## Risk surface

- Public type widening only — no value writes change in this PR.
- All consumers do single-value equality checks (`=== "budget"`, `=== "system"`); no exhaustive `switch` on `PauseReason` exists, so widening is backwards-compatible.
- `services/budgets.ts` itself never writes `"issue_create_rate_limit"`; the cast at the three `resolveScopeRecord` read sites now accepts the value if a future writer (the ADR-008 rate-limit pause path) sets it on the column.

## How to verify

- `pnpm -F @paperclipai/shared typecheck` — clean.
- `pnpm -F @paperclipai/server vitest run src/__tests__/budgets-service.test.ts` — 5/5 pass.
- Pre-existing drizzle dual-resolution typecheck noise in `server` is unchanged and unrelated; verified by running the same `pnpm typecheck` against the un-edited tree.

## Follow-ups (out of scope)

- `server/src/services/agents.ts:438` carries a similar inline union for the `pause(reason)` input. Left untouched here because the issue scope is `budgets.ts` and the agent service `pause()` takes a caller-supplied reason — not the same value space as the ADR-008 auto-pause.

Co-Authored-By: Paperclip <noreply@paperclip.ing>