### PR TITLE
Add run-log rotation policy + ENOSPC-safe append

### DIFF
--- a/server/src/__tests__/run-log-retention-e2e-large.test.ts
+++ b/server/src/__tests__/run-log-retention-e2e-large.test.ts
@@ -1,0 +1,66 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { afterAll, describe, expect, it } from "vitest";
+import { rotateRunLogs, formatRunLogRetentionSummary } from "../services/run-log-retention.js";
+
+// Opt-in: this test writes a real 600 MB file and gzips it. Gated on
+// PAPERCLIP_TEST_LARGE_FIXTURES=1 to keep CI from allocating that much disk
+// on every run. The unit tests in run-log-retention.test.ts cover the same
+// code paths with small fixtures; this test verifies the HFT-167 acceptance
+// criterion ("retention verified locally against a synthetic >500 MB log").
+const RUN_LARGE = process.env.PAPERCLIP_TEST_LARGE_FIXTURES === "1";
+const maybeIt = RUN_LARGE ? it : it.skip;
+
+let workDir: string;
+
+afterAll(async () => {
+  if (workDir) await fs.rm(workDir, { recursive: true, force: true });
+});
+
+describe("rotateRunLogs synthetic >500 MB e2e", () => {
+  maybeIt("gzips a 600 MB run-log past size threshold and reports a one-line summary", async () => {
+    workDir = await fs.mkdtemp(path.join(os.tmpdir(), "hft167-"));
+    const agentDir = path.join(workDir, "co-1", "agent-1");
+    await fs.mkdir(agentDir, { recursive: true });
+    const target = path.join(agentDir, "run-big.ndjson");
+
+    const sizeBytes = 600 * 1024 * 1024;
+    const chunk = Buffer.alloc(4 * 1024 * 1024, "a"); // 4 MiB filler
+    const handle = await fs.open(target, "w");
+    let written = 0;
+    while (written < sizeBytes) {
+      await handle.write(chunk);
+      written += chunk.length;
+    }
+    await handle.close();
+
+    // Force mtime well past grace window.
+    const twoHoursAgo = (Date.now() - 2 * 60 * 60 * 1000) / 1000;
+    await fs.utimes(target, twoHoursAgo, twoHoursAgo);
+
+    const result = await rotateRunLogs({
+      basePath: workDir,
+      policy: {
+        uncompressedDays: 3,
+        compressedDays: 7,
+        maxFileBytes: 500 * 1024 * 1024,
+        graceMinutes: 60,
+      },
+    });
+
+    await expect(fs.access(target)).rejects.toThrow();
+    const gz = `${target}.gz`;
+    const gzStat = await fs.stat(gz);
+    expect(gzStat.size).toBeGreaterThan(0);
+    expect(gzStat.size).toBeLessThan(sizeBytes);
+
+    expect(result.scannedFiles).toBe(1);
+    expect(result.gzippedFiles).toBe(1);
+    expect(result.rotatedBytes).toBe(sizeBytes);
+    expect(result.deletedFiles).toBe(0);
+    expect(result.errors).toBe(0);
+
+    console.log("summary:", formatRunLogRetentionSummary(result), "gz_size_bytes=", gzStat.size);
+  }, 600_000);
+});

--- a/server/src/__tests__/run-log-retention.test.ts
+++ b/server/src/__tests__/run-log-retention.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   formatRunLogRetentionSummary,
+  RECOVERABLE_RUN_LOG_RETENTION_FS_CODES,
   resolveRunLogRetentionPolicyFromEnv,
   rotateRunLogs,
 } from "../services/run-log-retention.js";
@@ -43,6 +44,22 @@ async function writeGzipPlaceholder(
   await fs.mkdir(agentDir, { recursive: true });
   const filePath = path.join(agentDir, `${runId}.ndjson.gz`);
   // Empty gz placeholder; rotator only checks extension + mtime for deletion.
+  await fs.writeFile(filePath, Buffer.alloc(16));
+  const mtimeSec = mtimeMs / 1000;
+  await fs.utimes(filePath, mtimeSec, mtimeSec);
+  return filePath;
+}
+
+async function writeGzipTmpPlaceholder(
+  basePath: string,
+  companyId: string,
+  agentId: string,
+  runId: string,
+  mtimeMs: number,
+): Promise<string> {
+  const agentDir = path.join(basePath, companyId, agentId);
+  await fs.mkdir(agentDir, { recursive: true });
+  const filePath = path.join(agentDir, `${runId}.ndjson.gz.tmp`);
   await fs.writeFile(filePath, Buffer.alloc(16));
   const mtimeSec = mtimeMs / 1000;
   await fs.utimes(filePath, mtimeSec, mtimeSec);
@@ -168,6 +185,22 @@ describe("rotateRunLogs", () => {
     expect(result.deletedFiles).toBe(1);
   });
 
+  it("deletes stale orphaned gzip temp files but leaves fresh temp files alone", async () => {
+    const now = new Date("2026-05-10T12:00:00.000Z");
+    const stale = now.getTime() - 2 * 60 * 60 * 1000;
+    const fresh = now.getTime() - 5 * 60 * 1000;
+    const staleTmp = await writeGzipTmpPlaceholder(workDir, "co-1", "agent-1", "run-stale", stale);
+    const freshTmp = await writeGzipTmpPlaceholder(workDir, "co-1", "agent-1", "run-fresh", fresh);
+
+    const result = await rotateRunLogs({ basePath: workDir, policy, now });
+
+    await expect(fs.access(staleTmp)).rejects.toThrow();
+    await expect(fs.access(freshTmp)).resolves.toBeUndefined();
+    expect(result.scannedFiles).toBe(2);
+    expect(result.deletedFiles).toBe(1);
+    expect(result.gzippedFiles).toBe(0);
+  });
+
   it("no-ops cleanly when the base path does not exist", async () => {
     const missing = path.join(workDir, "missing");
     const result = await rotateRunLogs({
@@ -225,5 +258,24 @@ describe("resolveRunLogRetentionPolicyFromEnv", () => {
     });
     expect(policy.uncompressedDays).toBe(3);
     expect(policy.compressedDays).toBe(7);
+  });
+
+  it("ignores zero env values because retention windows must be strictly positive", () => {
+    const policy = resolveRunLogRetentionPolicyFromEnv({
+      PAPERCLIP_RUN_LOG_UNCOMPRESSED_DAYS: "0",
+      PAPERCLIP_RUN_LOG_COMPRESSED_DAYS: "0",
+      PAPERCLIP_RUN_LOG_MAX_FILE_BYTES: "0",
+      PAPERCLIP_RUN_LOG_ROTATE_GRACE_MINUTES: "0",
+    });
+    expect(policy).toEqual({
+      uncompressedDays: 3,
+      compressedDays: 7,
+      maxFileBytes: 500 * 1024 * 1024,
+      graceMinutes: 60,
+    });
+  });
+
+  it("treats disk quota errors as recoverable during retention scans", () => {
+    expect(RECOVERABLE_RUN_LOG_RETENTION_FS_CODES.has("EDQUOT")).toBe(true);
   });
 });

--- a/server/src/__tests__/run-log-retention.test.ts
+++ b/server/src/__tests__/run-log-retention.test.ts
@@ -1,0 +1,229 @@
+import { promises as fs, createReadStream } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { createGunzip } from "node:zlib";
+import { pipeline } from "node:stream/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  formatRunLogRetentionSummary,
+  resolveRunLogRetentionPolicyFromEnv,
+  rotateRunLogs,
+} from "../services/run-log-retention.js";
+
+let workDir: string;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+async function writeRunLog(
+  basePath: string,
+  companyId: string,
+  agentId: string,
+  runId: string,
+  contents: string,
+  mtimeMs: number,
+): Promise<string> {
+  const agentDir = path.join(basePath, companyId, agentId);
+  await fs.mkdir(agentDir, { recursive: true });
+  const filePath = path.join(agentDir, `${runId}.ndjson`);
+  await fs.writeFile(filePath, contents);
+  const mtimeSec = mtimeMs / 1000;
+  await fs.utimes(filePath, mtimeSec, mtimeSec);
+  return filePath;
+}
+
+async function writeGzipPlaceholder(
+  basePath: string,
+  companyId: string,
+  agentId: string,
+  runId: string,
+  mtimeMs: number,
+): Promise<string> {
+  const agentDir = path.join(basePath, companyId, agentId);
+  await fs.mkdir(agentDir, { recursive: true });
+  const filePath = path.join(agentDir, `${runId}.ndjson.gz`);
+  // Empty gz placeholder; rotator only checks extension + mtime for deletion.
+  await fs.writeFile(filePath, Buffer.alloc(16));
+  const mtimeSec = mtimeMs / 1000;
+  await fs.utimes(filePath, mtimeSec, mtimeSec);
+  return filePath;
+}
+
+async function readGzipText(filePath: string): Promise<string> {
+  const chunks: Buffer[] = [];
+  await pipeline(createReadStream(filePath), createGunzip(), async function* (source) {
+    for await (const chunk of source) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+      yield chunk;
+    }
+  });
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+beforeEach(async () => {
+  workDir = await fs.mkdtemp(path.join(os.tmpdir(), "run-log-retention-"));
+});
+
+afterEach(async () => {
+  await fs.rm(workDir, { recursive: true, force: true });
+});
+
+describe("rotateRunLogs", () => {
+  const policy = {
+    uncompressedDays: 3,
+    compressedDays: 7,
+    maxFileBytes: 500 * 1024 * 1024,
+    graceMinutes: 60,
+  };
+
+  it("gzips run-log files older than the uncompressed window", async () => {
+    const now = new Date("2026-05-10T12:00:00.000Z");
+    const oldMtime = now.getTime() - 4 * DAY_MS;
+    const target = await writeRunLog(workDir, "co-1", "agent-1", "run-old", "hello\nworld\n", oldMtime);
+
+    const result = await rotateRunLogs({ basePath: workDir, policy, now });
+
+    await expect(fs.access(target)).rejects.toThrow();
+    const gz = `${target}.gz`;
+    await expect(fs.access(gz)).resolves.toBeUndefined();
+    expect(await readGzipText(gz)).toBe("hello\nworld\n");
+
+    expect(result.scannedFiles).toBe(1);
+    expect(result.gzippedFiles).toBe(1);
+    expect(result.rotatedBytes).toBe("hello\nworld\n".length);
+    expect(result.deletedFiles).toBe(0);
+    expect(result.errors).toBe(0);
+  });
+
+  it("keeps run-log files newer than the uncompressed window untouched", async () => {
+    const now = new Date("2026-05-10T12:00:00.000Z");
+    const recentMtime = now.getTime() - 2 * DAY_MS;
+    const target = await writeRunLog(workDir, "co-1", "agent-1", "run-recent", "x", recentMtime);
+
+    const result = await rotateRunLogs({ basePath: workDir, policy, now });
+
+    await expect(fs.access(target)).resolves.toBeUndefined();
+    await expect(fs.access(`${target}.gz`)).rejects.toThrow();
+    expect(result.gzippedFiles).toBe(0);
+    expect(result.deletedFiles).toBe(0);
+  });
+
+  it("respects the grace window for very recent files even if size-eligible", async () => {
+    const now = new Date("2026-05-10T12:00:00.000Z");
+    const justNow = now.getTime() - 5 * 60 * 1000; // 5 minutes ago
+    const target = await writeRunLog(workDir, "co-1", "agent-1", "run-active", "abc", justNow);
+
+    const result = await rotateRunLogs({
+      basePath: workDir,
+      policy: { ...policy, maxFileBytes: 1 }, // force size-eligible
+      now,
+    });
+
+    await expect(fs.access(target)).resolves.toBeUndefined();
+    await expect(fs.access(`${target}.gz`)).rejects.toThrow();
+    expect(result.scannedFiles).toBe(1);
+    expect(result.gzippedFiles).toBe(0);
+  });
+
+  it("gzips files past the max-size threshold even before the age window expires", async () => {
+    const now = new Date("2026-05-10T12:00:00.000Z");
+    const pastGrace = now.getTime() - 2 * 60 * 60 * 1000; // 2h ago > 60min grace
+    const big = Buffer.alloc(2048, "x").toString("utf8");
+    const target = await writeRunLog(workDir, "co-1", "agent-1", "run-big", big, pastGrace);
+
+    const result = await rotateRunLogs({
+      basePath: workDir,
+      policy: { ...policy, maxFileBytes: 1024 },
+      now,
+    });
+
+    await expect(fs.access(target)).rejects.toThrow();
+    await expect(fs.access(`${target}.gz`)).resolves.toBeUndefined();
+    expect(result.gzippedFiles).toBe(1);
+    expect(result.rotatedBytes).toBe(2048);
+  });
+
+  it("hard-deletes gzipped logs past the compressed window", async () => {
+    const now = new Date("2026-05-10T12:00:00.000Z");
+    const ancient = now.getTime() - 10 * DAY_MS;
+    const target = await writeGzipPlaceholder(workDir, "co-1", "agent-1", "run-ancient", ancient);
+
+    const result = await rotateRunLogs({ basePath: workDir, policy, now });
+
+    await expect(fs.access(target)).rejects.toThrow();
+    expect(result.scannedFiles).toBe(1);
+    expect(result.deletedFiles).toBe(1);
+    expect(result.gzippedFiles).toBe(0);
+  });
+
+  it("also deletes uncompressed files past the compressed window (catch-up)", async () => {
+    const now = new Date("2026-05-10T12:00:00.000Z");
+    const ancient = now.getTime() - 30 * DAY_MS;
+    const target = await writeRunLog(workDir, "co-1", "agent-1", "run-ancient", "yyy", ancient);
+
+    const result = await rotateRunLogs({ basePath: workDir, policy, now });
+
+    await expect(fs.access(target)).rejects.toThrow();
+    await expect(fs.access(`${target}.gz`)).rejects.toThrow();
+    expect(result.deletedFiles).toBe(1);
+  });
+
+  it("no-ops cleanly when the base path does not exist", async () => {
+    const missing = path.join(workDir, "missing");
+    const result = await rotateRunLogs({
+      basePath: missing,
+      policy,
+      now: new Date("2026-05-10T12:00:00.000Z"),
+    });
+    expect(result.scannedFiles).toBe(0);
+    expect(result.errors).toBe(0);
+  });
+
+  it("formats the one-line operator summary", () => {
+    expect(
+      formatRunLogRetentionSummary({
+        scannedFiles: 5,
+        rotatedBytes: 12345,
+        gzippedFiles: 2,
+        deletedFiles: 3,
+        errors: 0,
+      }),
+    ).toBe("runner-logs: rotated 12345 bytes, gz'd 2 files, deleted 3 files");
+  });
+});
+
+describe("resolveRunLogRetentionPolicyFromEnv", () => {
+  it("returns documented defaults when no env vars are set", () => {
+    const policy = resolveRunLogRetentionPolicyFromEnv({});
+    expect(policy).toEqual({
+      uncompressedDays: 3,
+      compressedDays: 7,
+      maxFileBytes: 500 * 1024 * 1024,
+      graceMinutes: 60,
+    });
+  });
+
+  it("accepts env overrides for each knob", () => {
+    const policy = resolveRunLogRetentionPolicyFromEnv({
+      PAPERCLIP_RUN_LOG_UNCOMPRESSED_DAYS: "1",
+      PAPERCLIP_RUN_LOG_COMPRESSED_DAYS: "5",
+      PAPERCLIP_RUN_LOG_MAX_FILE_BYTES: "1048576",
+      PAPERCLIP_RUN_LOG_ROTATE_GRACE_MINUTES: "10",
+    });
+    expect(policy).toEqual({
+      uncompressedDays: 1,
+      compressedDays: 5,
+      maxFileBytes: 1_048_576,
+      graceMinutes: 10,
+    });
+  });
+
+  it("ignores malformed env values", () => {
+    const policy = resolveRunLogRetentionPolicyFromEnv({
+      PAPERCLIP_RUN_LOG_UNCOMPRESSED_DAYS: "not-a-number",
+      PAPERCLIP_RUN_LOG_COMPRESSED_DAYS: "-3",
+    });
+    expect(policy.uncompressedDays).toBe(3);
+    expect(policy.compressedDays).toBe(7);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,6 +36,12 @@ import {
   routineService,
 } from "./services/index.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
+import {
+  formatRunLogRetentionSummary,
+  resolveDefaultRunLogBasePath,
+  resolveRunLogRetentionPolicyFromEnv,
+  rotateRunLogs,
+} from "./services/run-log-retention.js";
 import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
@@ -802,7 +808,78 @@ export async function startServer(): Promise<StartedServer> {
       });
     }, backupIntervalMs);
   }
-  
+
+  {
+    // Run-log retention: rotate uncompressed run logs into .gz once they age
+    // past PAPERCLIP_RUN_LOG_UNCOMPRESSED_DAYS or grow past
+    // PAPERCLIP_RUN_LOG_MAX_FILE_BYTES, then hard-delete anything older than
+    // PAPERCLIP_RUN_LOG_COMPRESSED_DAYS. Runs once at startup (after the
+    // server is listening) and on a steady interval afterwards. Failures in
+    // the rotator must never take down the server — the rotator already
+    // swallows per-file recoverable FS errors and the outer catch handles
+    // anything that escapes.
+    const rotationIntervalMinutes = (() => {
+      const raw = Number(process.env.PAPERCLIP_RUN_LOG_ROTATE_INTERVAL_MINUTES);
+      if (!Number.isFinite(raw) || raw <= 0) return 360;
+      return raw;
+    })();
+    const runLogBasePath = resolveDefaultRunLogBasePath();
+    const runLogPolicy = resolveRunLogRetentionPolicyFromEnv();
+    const runRunLogRotation = async () => {
+      try {
+        const result = await rotateRunLogs({
+          basePath: runLogBasePath,
+          policy: runLogPolicy,
+          onWarn: ({ path: target, err }) => {
+            logger.warn(
+              { err, path: target },
+              "run-log retention: recoverable filesystem error",
+            );
+          },
+        });
+        if (
+          result.scannedFiles > 0 ||
+          result.gzippedFiles > 0 ||
+          result.deletedFiles > 0 ||
+          result.errors > 0
+        ) {
+          logger.info(
+            {
+              basePath: runLogBasePath,
+              scannedFiles: result.scannedFiles,
+              gzippedFiles: result.gzippedFiles,
+              deletedFiles: result.deletedFiles,
+              rotatedBytes: result.rotatedBytes,
+              errors: result.errors,
+            },
+            formatRunLogRetentionSummary(result),
+          );
+        }
+      } catch (err) {
+        logger.error(
+          { err, basePath: runLogBasePath },
+          "run-log retention tick failed",
+        );
+      }
+    };
+    logger.info(
+      {
+        basePath: runLogBasePath,
+        intervalMinutes: rotationIntervalMinutes,
+        policy: runLogPolicy,
+      },
+      "Run-log retention scheduler enabled",
+    );
+    // Stagger the first tick a bit after listen so it doesn't race
+    // with the rest of startup recovery work.
+    setTimeout(() => {
+      void runRunLogRotation();
+    }, 30_000).unref();
+    setInterval(() => {
+      void runRunLogRotation();
+    }, rotationIntervalMinutes * 60 * 1000).unref();
+  }
+
   // Wait for external adapters to finish loading before accepting requests.
   // Without this, adapter type validation (assertKnownAdapterType) would
   // reject valid external adapter types during the startup loading window.

--- a/server/src/services/run-log-retention.ts
+++ b/server/src/services/run-log-retention.ts
@@ -40,7 +40,7 @@ const DEFAULT_POLICY: RunLogRetentionPolicy = {
 function parsePositiveNumber(raw: string | undefined, fallback: number): number {
   if (!raw) return fallback;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
   return parsed;
 }
 
@@ -62,12 +62,21 @@ export function resolveDefaultRunLogBasePath(): string {
  * Disk-pressure / permission / vanished-file conditions hit during a scan are
  * always logged but never escalate — the run-logs tree must not crash Paperclip.
  */
-const RECOVERABLE_FS_CODES = new Set(["ENOSPC", "EROFS", "EACCES", "EPERM", "ENOENT", "EBUSY", "EIO"]);
+export const RECOVERABLE_RUN_LOG_RETENTION_FS_CODES = new Set([
+  "ENOSPC",
+  "EROFS",
+  "EDQUOT",
+  "EACCES",
+  "EPERM",
+  "ENOENT",
+  "EBUSY",
+  "EIO",
+]);
 
 function isRecoverableFsError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const code = (err as { code?: unknown }).code;
-  return typeof code === "string" && RECOVERABLE_FS_CODES.has(code);
+  return typeof code === "string" && RECOVERABLE_RUN_LOG_RETENTION_FS_CODES.has(code);
 }
 
 async function gzipFileAtomic(srcPath: string): Promise<{ srcBytes: number }> {
@@ -179,12 +188,29 @@ export async function rotateRunLogs(opts: RotateRunLogsOptions = {}): Promise<Ru
       }
       result.scannedFiles += 1;
       const age = now - stat.mtimeMs;
-      const ext = entry.name.endsWith(".ndjson.gz")
+      const ext = entry.name.endsWith(".ndjson.gz.tmp")
+        ? "tmp"
+        : entry.name.endsWith(".ndjson.gz")
         ? "gz"
         : entry.name.endsWith(".ndjson")
           ? "ndjson"
           : "other";
       if (ext === "other") continue;
+
+      if (ext === "tmp") {
+        if (age < graceMs) continue;
+        try {
+          await fs.unlink(fullPath);
+          result.deletedFiles += 1;
+        } catch (err) {
+          if (isRecoverableFsError(err)) {
+            reportWarn(fullPath, err);
+            continue;
+          }
+          throw err;
+        }
+        continue;
+      }
 
       // Retention: delete files past the compressed-window age regardless of form.
       if (age > compressedMs) {

--- a/server/src/services/run-log-retention.ts
+++ b/server/src/services/run-log-retention.ts
@@ -1,0 +1,232 @@
+import { createReadStream, createWriteStream, type Dirent, promises as fs } from "node:fs";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+import { createGzip } from "node:zlib";
+import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+
+export interface RunLogRetentionPolicy {
+  /** Files newer than this stay uncompressed. Older files get gzipped. */
+  uncompressedDays: number;
+  /** Files older than this (compressed or not) are deleted. */
+  compressedDays: number;
+  /**
+   * Files larger than this byte threshold are gzipped on the next tick even if
+   * they are still inside the uncompressed window — corresponds to the
+   * "rotate at 500 MB or daily, whichever comes first" rule.
+   */
+  maxFileBytes: number;
+  /**
+   * Skip files whose mtime is within this grace window. Avoids racing with
+   * still-active run writers that haven't finalized yet.
+   */
+  graceMinutes: number;
+}
+
+export interface RunLogRetentionResult {
+  scannedFiles: number;
+  rotatedBytes: number;
+  gzippedFiles: number;
+  deletedFiles: number;
+  errors: number;
+}
+
+const DEFAULT_POLICY: RunLogRetentionPolicy = {
+  uncompressedDays: 3,
+  compressedDays: 7,
+  maxFileBytes: 500 * 1024 * 1024,
+  graceMinutes: 60,
+};
+
+function parsePositiveNumber(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return parsed;
+}
+
+export function resolveRunLogRetentionPolicyFromEnv(env: NodeJS.ProcessEnv = process.env): RunLogRetentionPolicy {
+  return {
+    uncompressedDays: parsePositiveNumber(env.PAPERCLIP_RUN_LOG_UNCOMPRESSED_DAYS, DEFAULT_POLICY.uncompressedDays),
+    compressedDays: parsePositiveNumber(env.PAPERCLIP_RUN_LOG_COMPRESSED_DAYS, DEFAULT_POLICY.compressedDays),
+    maxFileBytes: parsePositiveNumber(env.PAPERCLIP_RUN_LOG_MAX_FILE_BYTES, DEFAULT_POLICY.maxFileBytes),
+    graceMinutes: parsePositiveNumber(env.PAPERCLIP_RUN_LOG_ROTATE_GRACE_MINUTES, DEFAULT_POLICY.graceMinutes),
+  };
+}
+
+export function resolveDefaultRunLogBasePath(): string {
+  return process.env.RUN_LOG_BASE_PATH ?? path.resolve(resolvePaperclipInstanceRoot(), "data", "run-logs");
+}
+
+/**
+ * Retention errors that are safe to swallow without taking down the server.
+ * Disk-pressure / permission / vanished-file conditions hit during a scan are
+ * always logged but never escalate — the run-logs tree must not crash Paperclip.
+ */
+const RECOVERABLE_FS_CODES = new Set(["ENOSPC", "EROFS", "EACCES", "EPERM", "ENOENT", "EBUSY", "EIO"]);
+
+function isRecoverableFsError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" && RECOVERABLE_FS_CODES.has(code);
+}
+
+async function gzipFileAtomic(srcPath: string): Promise<{ srcBytes: number }> {
+  const stat = await fs.stat(srcPath);
+  const tmpPath = `${srcPath}.gz.tmp`;
+  const finalPath = `${srcPath}.gz`;
+  const source = createReadStream(srcPath);
+  const sink = createWriteStream(tmpPath);
+  try {
+    await pipeline(source, createGzip(), sink);
+  } catch (err) {
+    await fs.unlink(tmpPath).catch(() => undefined);
+    throw err;
+  }
+  await fs.rename(tmpPath, finalPath);
+  await fs.unlink(srcPath).catch(() => undefined);
+  return { srcBytes: stat.size };
+}
+
+async function walkRunLogDirs(basePath: string): Promise<string[]> {
+  const out: string[] = [];
+  let companyEntries: Dirent[];
+  try {
+    companyEntries = (await fs.readdir(basePath, { withFileTypes: true })) as Dirent[];
+  } catch (err) {
+    if ((err as { code?: unknown }).code === "ENOENT") return out;
+    throw err;
+  }
+  for (const company of companyEntries) {
+    if (!company.isDirectory()) continue;
+    const agentRoot = path.join(basePath, company.name);
+    let agentEntries: Dirent[];
+    try {
+      agentEntries = (await fs.readdir(agentRoot, { withFileTypes: true })) as Dirent[];
+    } catch (err) {
+      if (isRecoverableFsError(err)) continue;
+      throw err;
+    }
+    for (const agent of agentEntries) {
+      if (!agent.isDirectory()) continue;
+      out.push(path.join(agentRoot, agent.name));
+    }
+  }
+  return out;
+}
+
+export interface RotateRunLogsOptions {
+  basePath?: string;
+  policy?: RunLogRetentionPolicy;
+  now?: Date;
+  onWarn?: (event: { path: string; err: unknown }) => void;
+}
+
+export async function rotateRunLogs(opts: RotateRunLogsOptions = {}): Promise<RunLogRetentionResult> {
+  const basePath = opts.basePath ?? resolveDefaultRunLogBasePath();
+  const policy = opts.policy ?? resolveRunLogRetentionPolicyFromEnv();
+  const now = (opts.now ?? new Date()).getTime();
+  const result: RunLogRetentionResult = {
+    scannedFiles: 0,
+    rotatedBytes: 0,
+    gzippedFiles: 0,
+    deletedFiles: 0,
+    errors: 0,
+  };
+
+  const graceMs = policy.graceMinutes * 60 * 1000;
+  const uncompressedMs = policy.uncompressedDays * 24 * 60 * 60 * 1000;
+  const compressedMs = policy.compressedDays * 24 * 60 * 60 * 1000;
+
+  const reportWarn = (target: string, err: unknown) => {
+    result.errors += 1;
+    if (opts.onWarn) opts.onWarn({ path: target, err });
+  };
+
+  let agentDirs: string[];
+  try {
+    agentDirs = await walkRunLogDirs(basePath);
+  } catch (err) {
+    if (isRecoverableFsError(err)) {
+      reportWarn(basePath, err);
+      return result;
+    }
+    throw err;
+  }
+
+  for (const agentDir of agentDirs) {
+    let entries: Dirent[];
+    try {
+      entries = (await fs.readdir(agentDir, { withFileTypes: true })) as Dirent[];
+    } catch (err) {
+      if (isRecoverableFsError(err)) {
+        reportWarn(agentDir, err);
+        continue;
+      }
+      throw err;
+    }
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      const fullPath = path.join(agentDir, entry.name);
+      let stat;
+      try {
+        stat = await fs.stat(fullPath);
+      } catch (err) {
+        if (isRecoverableFsError(err)) {
+          reportWarn(fullPath, err);
+          continue;
+        }
+        throw err;
+      }
+      result.scannedFiles += 1;
+      const age = now - stat.mtimeMs;
+      const ext = entry.name.endsWith(".ndjson.gz")
+        ? "gz"
+        : entry.name.endsWith(".ndjson")
+          ? "ndjson"
+          : "other";
+      if (ext === "other") continue;
+
+      // Retention: delete files past the compressed-window age regardless of form.
+      if (age > compressedMs) {
+        try {
+          await fs.unlink(fullPath);
+          result.deletedFiles += 1;
+        } catch (err) {
+          if (isRecoverableFsError(err)) {
+            reportWarn(fullPath, err);
+            continue;
+          }
+          throw err;
+        }
+        continue;
+      }
+
+      if (ext !== "ndjson") continue;
+
+      // Skip files modified inside the grace window — likely still being appended.
+      if (age < graceMs) continue;
+
+      const sizeTrigger = stat.size >= policy.maxFileBytes;
+      const ageTrigger = age > uncompressedMs;
+      if (!sizeTrigger && !ageTrigger) continue;
+
+      try {
+        const { srcBytes } = await gzipFileAtomic(fullPath);
+        result.gzippedFiles += 1;
+        result.rotatedBytes += srcBytes;
+      } catch (err) {
+        if (isRecoverableFsError(err)) {
+          reportWarn(fullPath, err);
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
+
+  return result;
+}
+
+export function formatRunLogRetentionSummary(result: RunLogRetentionResult): string {
+  return `runner-logs: rotated ${result.rotatedBytes} bytes, gz'd ${result.gzippedFiles} files, deleted ${result.deletedFiles} files`;
+}

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -2,7 +2,16 @@ import { createReadStream, promises as fs } from "node:fs";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { notFound } from "../errors.js";
+import { logger } from "../middleware/logger.js";
 import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+
+const APPEND_FAILURE_RECOVERABLE_CODES = new Set(["ENOSPC", "EROFS", "EDQUOT", "EIO"]);
+
+function isRecoverableAppendError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const code = (err as { code?: unknown }).code;
+  return typeof code === "string" && APPEND_FAILURE_RECOVERABLE_CODES.has(code);
+}
 
 export type RunLogStoreType = "local_file";
 
@@ -115,8 +124,23 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
         chunk: event.chunk,
       });
       const persisted = `${line}\n`;
-      await fs.appendFile(absPath, persisted, "utf8");
-      return Buffer.byteLength(persisted, "utf8");
+      try {
+        await fs.appendFile(absPath, persisted, "utf8");
+        return Buffer.byteLength(persisted, "utf8");
+      } catch (err) {
+        // Disk pressure (ENOSPC/EROFS/EDQUOT/EIO) on the run-log path must
+        // not take down the server. Drop the chunk, log once, and report zero
+        // bytes so the heartbeat keeps running. Live-event delivery still
+        // happens upstream regardless of disk persistence.
+        if (isRecoverableAppendError(err)) {
+          logger.warn(
+            { err, logRef: handle.logRef, code: (err as { code?: unknown }).code },
+            "run-log append failed; dropping chunk to keep server alive",
+          );
+          return 0;
+        }
+        throw err;
+      }
     },
 
     async finalize(handle) {


### PR DESCRIPTION
## Summary

Adds a retention job for Paperclip runner logs (`data/run-logs/<companyId>/<agentId>/<runId>.ndjson`) plus crash-safety on the append path. Companion to the database-backup rotation work (HFT-163) — runner logs were the top SSD-growth offender on the board's machine (~3.8 GB/day on HFT workload).

Behavior, all tunable via env, with defaults that match the ticket:

- `PAPERCLIP_RUN_LOG_UNCOMPRESSED_DAYS` (default `3`) — files older than this get gzipped in place.
- `PAPERCLIP_RUN_LOG_COMPRESSED_DAYS` (default `7`) — `.ndjson` or `.ndjson.gz` past this age is hard-deleted.
- `PAPERCLIP_RUN_LOG_MAX_FILE_BYTES` (default `500 * 1024 * 1024`) — files at or above this size get gzipped on the next tick regardless of age (the "rotate at 500 MB or daily, whichever comes first" rule).
- `PAPERCLIP_RUN_LOG_ROTATE_GRACE_MINUTES` (default `60`) — files modified within this window are skipped to avoid racing with active run writers.
- `PAPERCLIP_RUN_LOG_ROTATE_INTERVAL_MINUTES` (default `360`) — how often the rotation job runs in-process. First tick is staggered 30 s after `server.listen`.

On each tick the operator log gets a one-line summary:

```text
runner-logs: rotated X bytes, gz'd Y files, deleted Z files
```

`run-log-store.append()` now catches `ENOSPC` / `EROFS` / `EDQUOT` / `EIO`, logs a structured warning, and returns `0` so the heartbeat keeps running on a full disk. Mirrors the crash-safety addition from HFT-163. The rotator itself uses the same swallow-and-report-per-file approach so a partial disk failure during retention can't kill the server either.

## Thinking Path

- Keep the change inside the Paperclip server runner-log layer; HFT trading logs remain out of scope.
- Prefer in-process retention with conservative grace windows over a separate daemon because Paperclip already owns the run-log path and can apply the policy consistently on startup and interval ticks.
- Treat disk pressure and vanished-file races as per-file recoverable events: log and continue so retention never becomes a server crash path.
- Keep crash leftovers bounded by recognizing stale `.ndjson.gz.tmp` files and deleting them after the grace window.

## Risks

- Active-file race risk is mitigated by `PAPERCLIP_RUN_LOG_ROTATE_GRACE_MINUTES` and by only touching files whose mtime is outside that window.
- Bad env values now fall back to defaults when non-finite, negative, or zero, so an operator cannot accidentally set a zero-day hard-delete policy.
- Compression consumes CPU and IO during retention ticks; the interval and thresholds are tunable, and the large-fixture e2e measured the 600 MiB synthetic case.
- Quota/full-disk errors can still prevent compression or deletion of a specific file, but they are reported per-file and do not take down the server.

## Test plan

- [x] `pnpm exec vitest run server/src/__tests__/run-log-retention.test.ts` — 14 passed, including regressions for zero env values, `EDQUOT` recoverability, and stale `.gz.tmp` cleanup.
- [x] `pnpm --filter @paperclipai/server typecheck`
- [x] `PAPERCLIP_TEST_LARGE_FIXTURES=1 vitest run src/__tests__/run-log-retention-e2e-large.test.ts` — synthetic 600 MiB `.ndjson` collapsed to ~600 KB `.gz` in ~1.4 s; one-line summary verified in the original implementation run.
- [x] `vitest run src/__tests__/heartbeat-run-log.test.ts` — existing 2 tests still pass in the original implementation run.

## Model Used

- Initial implementation: Claude Code local adapter.
- Review follow-up: Codex local adapter.

Refs: HFT-167.
