### PR TITLE
fix(server): bind Date params as ISO strings in comment attribution query

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1159,6 +1159,46 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(comments.map((comment) => comment.id)).toEqual([firstCommentId]);
   });
 
+  it("lists comments without crashing when a user-authored comment triggers the run-log derivation query", async () => {
+    // Regression for postgres-js rejecting Date params bound to a raw sql`` template.
+    // enrichCommentsWithDerivedAgentAttribution enters its query path only when at
+    // least one comment is user-authored (authorUserId set, authorAgentId/createdByRunId
+    // unset). Before the fix, the query 500s with `Buffer.byteLength` ERR_INVALID_ARG_TYPE
+    // because Date objects are interpolated as-is into the sql template.
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const userCommentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "User-authored comment issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await db.insert(issueComments).values({
+      id: userCommentId,
+      companyId,
+      issueId,
+      body: "User comment",
+      authorUserId: "user-1",
+      createdAt: new Date("2026-05-11T18:55:00.000Z"),
+      updatedAt: new Date("2026-05-11T18:55:00.000Z"),
+    });
+
+    const comments = await svc.listComments(issueId, { limit: 50 });
+
+    expect(comments.map((comment) => comment.id)).toEqual([userCommentId]);
+  });
+
   it("includes blockedBy summaries on list rows in one batched pass", async () => {
     const companyId = randomUUID();
     const blockerId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1969,8 +1969,8 @@ export function issueService(db: Db) {
                 and ${activityLog.runId} = ${heartbeatRuns.id}
             )`,
           ),
-          sql`coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.createdAt}) >= ${new Date(minCommentCreatedAtMs)}`,
-          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${new Date(maxCommentCreatedAtMs + ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS)}`,
+          sql`coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.createdAt}) >= ${new Date(minCommentCreatedAtMs).toISOString()}`,
+          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${new Date(maxCommentCreatedAtMs + ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS).toISOString()}`,
         ),
       )
       .orderBy(desc(heartbeatRuns.createdAt));


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issue threads aggregate comments authored by both agents and human users; the server enriches each comment with derived agent attribution by joining against heartbeat runs
> - #5780 added a user-authored attribution path that introduced a SQL query in `enrichCommentsWithDerivedAgentAttribution` interpolating `new Date(...)` values into a raw `` sql`` `` template
> - postgres-js 3.4.8 cannot encode `Date` objects passed as raw template params and throws `Buffer.byteLength` `ERR_INVALID_ARG_TYPE`, so every `GET /issues/:id/comments` request on a thread containing a user-authored comment returns a 500
> - This pull request binds those two Date params as ISO strings so postgres-js encodes them the same way drizzle does on typed-column paths
> - The benefit is restored chat listing for any thread that has a user-authored comment, with no behavior change beyond parameter encoding

## What Changed

- `server/src/services/issues.ts`: call `.toISOString()` on the two `new Date(...)` interpolations inside `enrichCommentsWithDerivedAgentAttribution` (the `coalesce(finishedAt, createdAt) >= ...` and `coalesce(startedAt, createdAt) <= ...` predicates).
- `server/src/__tests__/issues-service.test.ts`: regression test asserting `listComments` succeeds when the thread contains a user-authored comment (the only path that enters the buggy query — `candidates.length > 0` requires `authorUserId` to be set).

## Verification

- `pnpm --filter @paperclipai/server test -- issues-service` passes locally, including the new regression test.
- Reproduced the original 500 against a real database before the fix: any issue with a user-authored comment 500s on `GET /issues/:id/comments`. After the patch, the same request returns 200 with the enriched comment list.
- Deployed the equivalent commit on an internal Paperclip fork for ~24h before opening this PR; chat listing is healthy.

## Risks

- Low risk. The change is parameter encoding only — drizzle and postgres-js both accept ISO strings for `timestamp` / `timestamptz` columns, and the predicate semantics are unchanged.
- No migration, no schema change, no API contract change.

## Model Used

- Claude (Anthropic) — `claude-opus-4-7`, extended-thinking mode, tool-use enabled. Human-reviewed before submission.

## Relation to #5884

This PR addresses the same symptom reported in #5884, but the RCA on that issue is incorrect — it fingered `readRunLogText` ENOENT noise. The actual cause is the `Date` binding in `enrichCommentsWithDerivedAgentAttribution`; the ENOENT log lines are unrelated and pre-date the 500. A corrective comment has been left on #5884.

Closes #5884.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only fix)
- [x] I have updated relevant documentation to reflect my changes (N/A — no doc surface affected)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
