### PR TITLE
fix(issues): use ISO string for run-log date params in enrichCommentsWithDerivedAgentAttribution

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1969,8 +1969,8 @@ export function issueService(db: Db) {
                 and ${activityLog.runId} = ${heartbeatRuns.id}
             )`,
           ),
-          sql`coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.createdAt}) >= ${new Date(minCommentCreatedAtMs)}`,
-          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${new Date(maxCommentCreatedAtMs + ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS)}`,
+          sql`coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.createdAt}) >= ${new Date(minCommentCreatedAtMs).toISOString()}`,
+          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${new Date(maxCommentCreatedAtMs + ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS).toISOString()}`,
         ),
       )
       .orderBy(desc(heartbeatRuns.createdAt));


### PR DESCRIPTION
## Symptom

`GET /api/issues/:id/comments` returns **500** for any issue whose comment list contains at least one local-board (userAuthor / no `authorAgentId` / no `createdByRunId`) entry, when the issue also has heartbeat_runs whose `finished_at`/`started_at` fall inside the lookup window.

Server log:

```
DrizzleQueryError: Failed query: select ... where
  coalesce(finished_at, created_at) >= $5 ...
caused by: TypeError [ERR_INVALID_ARG_TYPE]: The "string" argument
  must be of type string or an instance of Buffer or ArrayBuffer.
  Received an instance of Date
```

## Root cause

`enrichCommentsWithDerivedAgentAttribution` (in `server/src/services/issues.ts`) interpolates two `Date` objects (`windowStart`, `windowEnd`) into a raw ``sql`...` `` template via drizzle-orm + postgres-js.

Inside a raw `sql` template the column type is unknown to drizzle, so it does not coerce `Date` to a string before handing the param to `postgres-js`. `postgres-js` then rejects the value with `ERR_INVALID_ARG_TYPE`.

## Fix

Convert both `Date` parameters to ISO strings before binding — `postgres-js` accepts ISO-8601 strings for `timestamptz` columns.

```ts
windowStart.toISOString()
windowEnd.toISOString()
```

Two-line change in `server/src/services/issues.ts:1972-1973`.

## Reproduction

1. Find any issue with a heartbeat_run inside `[earliestComment - 5min, latestComment + 5min]` and at least one comment from a board/user (no `authorAgentId`, no `createdByRunId`).
2. `GET /api/issues/<id>/comments` → 500 before this fix.
3. With this patch applied: returns 200 with the full comment list and correct derived agent attribution.

## Verification

`pnpm tsc --noEmit` is clean.

The fix has been running in a local instance against multiple board-authored comment threads for several days without recurrence of the 500.

---

Origin: filed as ZOL-2924 in our downstream tracker. We were running a workaround (PATCH `description` instead of `POST /comments` for one path), now removed once this lands.