### PR TITLE
fix(server): bound heartbeat run listing

### DIFF
--- a/docs/guides/agent-developer/heartbeat-protocol.md
+++ b/docs/guides/agent-developer/heartbeat-protocol.md
@@ -125,4 +125,5 @@ Paperclip records run liveness as metadata on heartbeat runs. It is not an issue
 - `continuationAttempt` counts semantic liveness continuations for a source run chain. It is separate from process recovery, queued wake delivery, adapter session resume, and other operational retries.
 - Liveness continuation wake prompts include the attempt, source run, liveness state, liveness reason, and the instruction for the next heartbeat.
 - Continuations do not mark the issue `blocked` or `done`. If automatic continuations are exhausted, Paperclip leaves an audit comment so a human or manager can clarify, block, or assign follow-up work.
+- Paperclip-created recovery or escalation issues are terminal manual artifacts. If one of those issues stalls, Paperclip does not create another recovery issue for it; a manager or operator must fix the runtime, reassign it, or close it with the manual resolution.
 - Workspace provisioning alone is not treated as concrete task progress. Durable progress should appear as tool/action events, issue comments, document or work-product revisions, activity log entries, commits, or tests.

--- a/packages/db/src/migrations/0085_heartbeat_runs_company_created_idx.sql
+++ b/packages/db/src/migrations/0085_heartbeat_runs_company_created_idx.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS "heartbeat_runs_company_created_idx"
+  ON "heartbeat_runs" USING btree ("company_id","created_at" DESC,"id" DESC);

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -596,6 +596,13 @@
       "when": 1778355326070,
       "tag": "0084_issue_recovery_actions",
       "breakpoints": true
+    },
+    {
+      "idx": 85,
+      "version": "7",
+      "when": 1778355326071,
+      "tag": "0085_heartbeat_runs_company_created_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/heartbeat-list.test.ts
+++ b/server/src/__tests__/heartbeat-list.test.ts
@@ -141,6 +141,64 @@ describeEmbeddedPostgres("heartbeat list", () => {
     expect(runs.at(-1)?.id).toBe(runIds[5]);
   });
 
+  it("uses run id as a deterministic newest-run tiebreaker", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const olderRunId = "11111111-1111-4111-8111-111111111111";
+    const lowerTieRunId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const higherTieRunId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values([
+      {
+        id: olderRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "succeeded",
+        createdAt: new Date("2026-04-18T11:59:59.000Z"),
+      },
+      {
+        id: lowerTieRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "succeeded",
+        createdAt: new Date("2026-04-18T12:00:00.000Z"),
+      },
+      {
+        id: higherTieRunId,
+        companyId,
+        agentId,
+        invocationSource: "assignment",
+        status: "succeeded",
+        createdAt: new Date("2026-04-18T12:00:00.000Z"),
+      },
+    ]);
+
+    const runs = await heartbeatService(db).list(companyId);
+
+    expect(runs.map((run) => run.id)).toEqual([higherTieRunId, lowerTieRunId, olderRunId]);
+  });
+
   it("returns small result json payloads unchanged from getRun", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/heartbeat-list.test.ts
+++ b/server/src/__tests__/heartbeat-list.test.ts
@@ -101,6 +101,46 @@ describeEmbeddedPostgres("heartbeat list", () => {
     }
   });
 
+  it("defaults list calls to the latest 200 runs", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runIds = Array.from({ length: 205 }, () => randomUUID());
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values(runIds.map((id, index) => ({
+      id,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "succeeded",
+      createdAt: new Date(Date.UTC(2026, 3, 18, 12, 0, index)),
+    })));
+
+    const runs = await heartbeatService(db).list(companyId);
+
+    expect(runs).toHaveLength(200);
+    expect(runs[0]?.id).toBe(runIds[204]);
+    expect(runs.at(-1)?.id).toBe(runIds[5]);
+  });
+
   it("returns small result json payloads unchanged from getRun", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -184,6 +184,8 @@ const MAX_RUN_EVENT_PAYLOAD_DEPTH = 6;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = AGENT_DEFAULT_MAX_CONCURRENT_RUNS;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MIN = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 50;
+const HEARTBEAT_RUN_LIST_DEFAULT_LIMIT = 200;
+const HEARTBEAT_RUN_LIST_MAX_LIMIT = 1000;
 const LIVENESS_BOOKKEEPING_ACTIVITY_ACTIONS = [
   "environment.lease_acquired",
   "environment.lease_released",
@@ -9459,6 +9461,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   return {
     list: async (companyId: string, agentId?: string, limit?: number) => {
       const safeForLegacyEncoding = await hasUnsafeTextProjectionDatabase();
+      const effectiveLimit = Number.isFinite(limit)
+        ? Math.max(1, Math.min(HEARTBEAT_RUN_LIST_MAX_LIMIT, Math.trunc(Number(limit))))
+        : HEARTBEAT_RUN_LIST_DEFAULT_LIMIT;
       const query = db
         .select(
           safeForLegacyEncoding
@@ -9481,7 +9486,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         )
         .orderBy(desc(heartbeatRuns.createdAt));
 
-      const rows = limit ? await query.limit(limit) : await query;
+      const rows = await query.limit(effectiveLimit);
       return rows.map((row) => {
         const {
           contextIssueId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -9484,7 +9484,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             ? and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.agentId, agentId))
             : eq(heartbeatRuns.companyId, companyId),
         )
-        .orderBy(desc(heartbeatRuns.createdAt));
+        .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id));
 
       const rows = await query.limit(effectiveLimit);
       return rows.map((row) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies through company-scoped issues, runs, and recovery workflows.
> - The heartbeat subsystem records agent execution history and powers the operator run list used during recovery incidents.
> - A recovery storm can create a large heartbeat_runs table even after the recovery-loop logic is fixed.
> - The current list path could be called without a limit, which leaves the UI/operator path exposed to unbounded scans during exactly the incidents where it is needed most.
> - This pull request bounds the default heartbeat run list, adds the supporting company-created index, and documents that recovery/escalation issues are terminal manual artifacts.
> - The benefit is lower blast radius during recovery incidents without changing explicit caller limits or normal run execution behavior.

## What Changed

- Defaulted `heartbeatService.list()` to the latest 200 runs and clamped explicit limits to 1-1000.
- Added `heartbeat_runs_company_created_idx` for company-scoped newest-run listing.
- Added regression coverage proving omitted list limits return only the latest 200 runs.
- Updated the heartbeat protocol docs to state that Paperclip-created recovery/escalation issues are terminal manual artifacts.

## Verification

- `corepack pnpm exec vitest run server/src/__tests__/heartbeat-list.test.ts`
- `corepack pnpm --filter @paperclipai/shared build`
- `corepack pnpm --filter @paperclipai/plugin-sdk exec tsc`
- `corepack pnpm --filter @paperclipai/server exec tsc --noEmit`

## Risks

- Low risk. Callers that intentionally omitted `limit` now receive the latest 200 rows instead of all historical rows. Existing explicit limits continue to work, with a max clamp of 1000.
- The migration adds a normal btree index on `heartbeat_runs(company_id, created_at desc, id desc)`; write overhead should be small relative to the operator-query stability it provides.

## Model Used

- OpenAI Codex, GPT-5 family coding agent, tool-assisted local development with shell, git, and tests.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge