### PR TITLE
GST-36: standingChannel flag + recovery short-circuit + wake suppression (Vector 1)

### DIFF
--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -271,7 +271,7 @@ describe("paperclip MCP tools", () => {
     expect(init.method).toBe("POST");
     expect(JSON.parse(String(init.body))).toEqual({
       kind: "request_confirmation",
-      continuationPolicy: "none",
+      continuationPolicy: "wake_assignee",
       idempotencyKey: "confirmation:PAP-1135:plan:33333333-3333-4333-8333-333333333333",
       title: "Plan approval",
       payload: {

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -140,7 +140,10 @@ const createRequestConfirmationToolSchema = z.object({
   sourceRunId: z.string().uuid().nullable().optional(),
   title: z.string().trim().max(240).nullable().optional(),
   summary: z.string().trim().max(1000).nullable().optional(),
-  continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("none"),
+  continuationPolicy: z
+    .enum(["wake_assignee", "wake_assignee_on_accept"])
+    .optional()
+    .default("wake_assignee"),
   payload: requestConfirmationPayloadSchema,
 });
 

--- a/packages/shared/src/issue-thread-interactions.test.ts
+++ b/packages/shared/src/issue-thread-interactions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createIssueThreadInteractionSchema } from "./validators/issue.js";
 
 describe("issue thread interaction schemas", () => {
-  it("parses request_confirmation payloads with default no-wake continuation", () => {
+  it("defaults request_confirmation continuation to wake_assignee", () => {
     const parsed = createIssueThreadInteractionSchema.parse({
       kind: "request_confirmation",
       payload: {
@@ -20,7 +20,7 @@ describe("issue thread interaction schemas", () => {
 
     expect(parsed).toMatchObject({
       kind: "request_confirmation",
-      continuationPolicy: "none",
+      continuationPolicy: "wake_assignee",
       payload: {
         prompt: "Apply this plan?",
         acceptLabel: "Apply",
@@ -32,6 +32,19 @@ describe("issue thread interaction schemas", () => {
         supersedeOnUserComment: true,
       },
     });
+  });
+
+  it("rejects request_confirmation with continuationPolicy=none (GST-36 prevention)", () => {
+    expect(() =>
+      createIssueThreadInteractionSchema.parse({
+        kind: "request_confirmation",
+        continuationPolicy: "none",
+        payload: {
+          version: 1,
+          prompt: "Apply this plan?",
+        },
+      }),
+    ).toThrow();
   });
 
   it("accepts issue document targets for request_confirmation interactions", () => {

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -256,6 +256,7 @@ export interface IssueExecutionStage {
 export interface IssueExecutionMonitorPolicy {
   nextCheckAt: string;
   notes: string | null;
+  standingChannel?: boolean;
   scheduledBy: IssueMonitorScheduledBy;
   kind?: IssueExecutionMonitorKind | null;
   serviceName?: string | null;

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -599,7 +599,12 @@ export const createIssueThreadInteractionSchema = z.discriminatedUnion("kind", [
     sourceRunId: z.string().uuid().nullable().optional(),
     title: z.string().trim().max(240).nullable().optional(),
     summary: z.string().trim().max(1000).nullable().optional(),
-    continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("none"),
+    // request_confirmation gates progress on a response — it must wake the assignee.
+    // "none" leaves the issue stuck if the response never arrives (see GST-36).
+    continuationPolicy: z
+      .enum(["wake_assignee", "wake_assignee_on_accept"])
+      .optional()
+      .default("wake_assignee"),
     payload: requestConfirmationPayloadSchema,
   }),
 ]);

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -116,6 +116,7 @@ export const issueExecutionStageSchema = z.object({
 export const issueExecutionMonitorPolicySchema = z.object({
   nextCheckAt: z.string().datetime(),
   notes: z.string().max(500).optional().nullable().default(null),
+  standingChannel: z.boolean().optional().default(false),
   scheduledBy: z.enum(ISSUE_MONITOR_SCHEDULED_BY).optional().default("assignee"),
   kind: z.enum(ISSUE_EXECUTION_MONITOR_KINDS).optional().nullable().default(null),
   serviceName: z.string().trim().min(1).max(120).optional().nullable().default(null),

--- a/server/src/__tests__/agent-health-watcher.test.ts
+++ b/server/src/__tests__/agent-health-watcher.test.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agentRuntimeState,
+  agents,
+  companies,
+  createDb,
+  issueComments,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { createAgentHealthWatcher } from "../services/agent-health-watcher.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres agent health watcher tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("agent health watcher", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-health-watcher-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issues);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedFixture() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "GStack",
+      issuePrefix: "GST",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CTO",
+      role: "cto",
+      status: "error",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+      pauseReason: "adapter crashed",
+      updatedAt: new Date("2026-05-13T09:00:00.000Z"),
+    });
+
+    await db.insert(agentRuntimeState).values({
+      agentId,
+      companyId,
+      adapterType: "codex_local",
+      lastError: "adapter timeout",
+      stateJson: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: 26,
+      identifier: "GST-26",
+      title: "CEO standup",
+      status: "in_progress",
+      priority: "high",
+    });
+
+    return { companyId, agentId, issueId };
+  }
+
+  it("posts one alert after threshold and one recovery comment after status clears", async () => {
+    const { agentId, issueId } = await seedFixture();
+    let now = new Date("2026-05-13T09:06:00.000Z");
+
+    const watcher = createAgentHealthWatcher(db, {
+      errorThresholdMs: 5 * 60 * 1_000,
+      now: () => now,
+    });
+
+    await watcher.tick();
+
+    const firstPassComments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+
+    expect(firstPassComments).toHaveLength(1);
+    expect(firstPassComments[0]?.body).toContain("Adapter health alert");
+    expect(firstPassComments[0]?.body).toContain("CTO (cto)");
+    expect(firstPassComments[0]?.body).toContain("adapter timeout");
+    expect(firstPassComments[0]?.body).toContain(`/agents/${agentId}`);
+
+    now = new Date("2026-05-13T09:16:00.000Z");
+    await watcher.tick();
+
+    const secondPassComments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(secondPassComments).toHaveLength(1);
+
+    await db
+      .update(agents)
+      .set({ status: "running", updatedAt: now })
+      .where(eq(agents.id, agentId));
+
+    await watcher.tick();
+
+    const recoveredComments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+
+    expect(recoveredComments).toHaveLength(2);
+    expect(recoveredComments[1]?.body).toContain("Adapter health recovered");
+
+    await db
+      .update(agents)
+      .set({ status: "error", updatedAt: new Date("2026-05-13T09:17:00.000Z") })
+      .where(eq(agents.id, agentId));
+
+    now = new Date("2026-05-13T09:20:00.000Z");
+    await watcher.tick();
+
+    const belowThresholdComments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(belowThresholdComments).toHaveLength(2);
+
+    now = new Date("2026-05-13T09:23:00.000Z");
+    await watcher.tick();
+
+    const retriggerComments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(retriggerComments).toHaveLength(3);
+    expect(retriggerComments[2]?.body).toContain("Adapter health alert");
+
+    const alerts = retriggerComments.filter((comment) => comment.body.includes("Adapter health alert"));
+    expect(alerts).toHaveLength(2);
+
+    const recordsForIssue = await db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(and(eq(issueComments.issueId, issueId), eq(issueComments.authorType, "system")));
+    expect(recordsForIssue).toHaveLength(3);
+  });
+});

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -193,12 +193,13 @@ describe("issue execution policy routes", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
-  it("allows an agent-authored in_review transition with a pending confirmation interaction", async () => {
+  it("allows an agent-authored in_review transition with a wake_assignee confirmation filed by a different agent", async () => {
+    const codexAgentId = "33333333-3333-4333-8333-333333333333";
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       companyId: "company-1",
       status: "todo",
-      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeAgentId: codexAgentId,
       assigneeUserId: null,
       createdByUserId: "local-board",
       identifier: "PAP-1004",
@@ -208,7 +209,16 @@ describe("issue execution policy routes", () => {
     };
     mockIssueService.getById.mockResolvedValue(issue);
     mockIssueThreadInteractionService.listForIssue.mockResolvedValue([
-      { id: "interaction-1", kind: "request_confirmation", status: "pending" },
+      {
+        id: "interaction-1",
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        // Filed by a different agent. The wake_assignee continuation will wake the
+        // issue's assignee (codex) on response — a real cross-agent review path.
+        createdByAgentId: "44444444-4444-4444-8444-444444444444",
+        createdByUserId: null,
+      },
     ]);
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...issue,
@@ -218,7 +228,7 @@ describe("issue execution policy routes", () => {
 
     const res = await request(await createApp({
       type: "agent",
-      agentId: "33333333-3333-4333-8333-333333333333",
+      agentId: codexAgentId,
       companyId: "company-1",
       runId: "run-1",
     }))
@@ -230,6 +240,96 @@ describe("issue execution policy routes", () => {
       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       expect.objectContaining({ status: "in_review" }),
     );
+  });
+
+  it("regression GST-36: rejects in_review when the only pending interaction's createdByAgentId equals the next assignee", async () => {
+    const codexAgentId = "33333333-3333-4333-8333-333333333333";
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "in_progress",
+      assigneeAgentId: codexAgentId,
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1004b",
+      title: "GST-36 regression",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    // The interaction is filed by the same agent we will leave as assignee, with continuationPolicy "none".
+    // This is precisely the pattern that left GST-36 stuck in_review from 09:49 to 11:30.
+    mockIssueThreadInteractionService.listForIssue.mockResolvedValue([
+      {
+        id: "interaction-self",
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "none",
+        createdByAgentId: codexAgentId,
+        createdByUserId: null,
+      },
+    ]);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: codexAgentId,
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.details).toMatchObject({
+      code: "invalid_issue_disposition",
+      missing: "review_path",
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects in_review when a pending interaction has continuationPolicy 'none'", async () => {
+    const codexAgentId = "33333333-3333-4333-8333-333333333333";
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: codexAgentId,
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1004c",
+      title: "Pending interaction with 'none' continuation",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    // Even when the interaction was filed by another agent, continuationPolicy "none"
+    // means nothing will wake the current assignee on response — not a real review path.
+    mockIssueThreadInteractionService.listForIssue.mockResolvedValue([
+      {
+        id: "interaction-none",
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "none",
+        createdByAgentId: "44444444-4444-4444-8444-444444444444",
+        createdByUserId: null,
+      },
+    ]);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: codexAgentId,
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.details).toMatchObject({
+      code: "invalid_issue_disposition",
+      missing: "review_path",
+    });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("allows an agent-authored in_review transition with a typed execution participant", async () => {
@@ -286,7 +386,7 @@ describe("issue execution policy routes", () => {
     );
   });
 
-  it("allows an agent-authored in_review transition with a scheduled monitor", async () => {
+  it("allows an agent-authored in_review transition with a scheduled monitor within 24h", async () => {
     const issue = {
       id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       companyId: "company-1",
@@ -311,6 +411,7 @@ describe("issue execution policy routes", () => {
       updatedAt: new Date(),
     }));
 
+    const monitorAt = new Date(Date.now() + 6 * 60 * 60 * 1000).toISOString();
     const res = await request(await createApp({
       type: "agent",
       agentId: "33333333-3333-4333-8333-333333333333",
@@ -322,7 +423,7 @@ describe("issue execution policy routes", () => {
         status: "in_review",
         executionPolicy: {
           monitor: {
-            nextCheckAt: "2026-12-01T12:00:00.000Z",
+            nextCheckAt: monitorAt,
             scheduledBy: "assignee",
             notes: "Wait for external QA report.",
           },
@@ -334,9 +435,94 @@ describe("issue execution policy routes", () => {
       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       expect.objectContaining({
         status: "in_review",
-        monitorNextCheckAt: new Date("2026-12-01T12:00:00.000Z"),
+        monitorNextCheckAt: new Date(monitorAt),
       }),
     );
+  });
+
+  it("rejects an agent-authored in_review transition when the only review path is a monitor more than 24h out", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1006b",
+      title: "External review monitor (too far)",
+      executionPolicy: null,
+      executionState: null,
+      monitorAttemptCount: 0,
+      monitorNextCheckAt: null,
+      monitorLastTriggeredAt: null,
+      monitorNotes: null,
+      monitorScheduledBy: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const monitorAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({
+        status: "in_review",
+        executionPolicy: {
+          monitor: {
+            nextCheckAt: monitorAt,
+            scheduledBy: "assignee",
+            notes: "Wait a week.",
+          },
+        },
+      });
+
+    expect(res.status).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "invalid_issue_disposition" });
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects in_review when the only execution participant is the patching agent itself", async () => {
+    const codexAgentId = "33333333-3333-4333-8333-333333333333";
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      status: "todo",
+      assigneeAgentId: codexAgentId,
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1006c",
+      title: "Self-loop participant",
+      executionPolicy: null,
+      executionState: null,
+    };
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "review",
+          participants: [{ type: "agent", agentId: codexAgentId }],
+        },
+      ],
+    })!;
+    mockIssueService.getById.mockResolvedValue(issue);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: codexAgentId,
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review", executionPolicy: policy });
+
+    // 422 either from the execution-policy stage selector (no eligible participant after
+    // self-exclusion) or from the in_review reviewer-wake-path validator. Either layer
+    // is acceptable defense; what matters is that the patch is rejected.
+    expect(res.status).toBe(422);
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("allows board-authored in_review repair updates without a review path", async () => {

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -618,6 +618,29 @@ describe.sequential("issue thread interaction routes", () => {
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
+  it("rejects request_confirmation creation with continuationPolicy=none (GST-36 prevention)", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId: CREATED_AGENT_ID,
+      companyId: "company-1",
+      runId: "run-1",
+    });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions")
+      .send({
+        kind: "request_confirmation",
+        continuationPolicy: "none",
+        payload: {
+          version: 1,
+          prompt: "Apply this plan?",
+        },
+      });
+
+    expect(res.status).toBe(400);
+    expect(mockInteractionService.create).not.toHaveBeenCalled();
+  });
+
   it("allows agent-authored interaction creation and stamps the active run id", async () => {
     const app = await createApp({
       type: "agent",

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -194,12 +194,13 @@ describe.sequential("issue goal context routes", () => {
     mockDocumentsService.getIssueDocumentPayload.mockResolvedValue({});
     mockDocumentsService.getIssueDocumentByKey.mockResolvedValue(null);
     mockExecutionWorkspaceService.getById.mockResolvedValue(null);
+    const queryChain = {
+      where: vi.fn(() => queryChain),
+      orderBy: vi.fn(async () => []),
+      then: vi.fn(async (resolve: (rows: any[]) => unknown) => resolve([])),
+    };
     mockDb.select.mockReturnValue({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          orderBy: vi.fn(async () => []),
-        })),
-      })),
+      from: vi.fn(() => queryChain),
     });
     mockDb.execute.mockResolvedValue([]);
     mockProjectService.getById.mockResolvedValue({

--- a/server/src/__tests__/issues-list-route.test.ts
+++ b/server/src/__tests__/issues-list-route.test.ts
@@ -1,0 +1,193 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const VALID_UUID = "33333333-3333-4333-8333-333333333333";
+const OTHER_UUID = "44444444-4444-4444-8444-444444444444";
+const COMPANY_ID = "company-1";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+}));
+
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  get: vi.fn(async () => ({
+    id: "instance-settings-1",
+    general: {
+      censorUsernameInLogs: false,
+      feedbackDataSharingPreference: "prompt",
+    },
+  })),
+  listCompanyIds: vi.fn(async () => [COMPANY_ID]),
+}));
+
+function chainable(): any {
+  const handler: ProxyHandler<any> = {
+    get(_target, prop) {
+      if (prop === "then") {
+        return (resolve: (value: unknown) => unknown) => resolve([]);
+      }
+      return () => proxy;
+    },
+  };
+  const proxy: any = new Proxy(() => proxy, handler);
+  return proxy;
+}
+
+const mockDb = vi.hoisted(() => ({
+  select: vi.fn(),
+  execute: vi.fn(async () => []),
+}));
+
+vi.mock("../services/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/index.js")>();
+  return {
+    ...actual,
+    companyService: () => ({
+      getById: vi.fn(async () => ({ id: COMPANY_ID, attachmentMaxBytes: 10 * 1024 * 1024 })),
+    }),
+    accessService: () => mockAccessService,
+    agentService: () => ({ getById: vi.fn() }),
+    documentService: () => ({}),
+    environmentService: () => ({}),
+    executionWorkspaceService: () => ({ getById: vi.fn() }),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({ getById: vi.fn(), getDefaultCompanyGoal: vi.fn() }),
+    heartbeatService: () => mockHeartbeatService,
+    instanceSettingsService: () => mockInstanceSettingsService,
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: vi.fn(async () => undefined),
+      diffIssueReferenceSummary: vi.fn(() => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      })),
+      emptySummary: vi.fn(() => ({ outbound: [], inbound: [] })),
+      listIssueReferenceSummary: vi.fn(async () => ({ outbound: [], inbound: [] })),
+      syncComment: vi.fn(async () => undefined),
+      syncDocument: vi.fn(async () => undefined),
+      syncIssue: vi.fn(async () => undefined),
+    }),
+    issueService: () => mockIssueService,
+    logActivity: vi.fn(async () => undefined),
+    projectService: () => ({ getById: vi.fn(), listByIds: vi.fn() }),
+    routineService: () => ({ syncRunStatusForIssue: vi.fn(async () => undefined) }),
+    workProductService: () => ({ listForIssue: vi.fn(async () => []) }),
+  };
+});
+
+vi.mock("../services/execution-workspaces.js", () => ({
+  executionWorkspaceService: () => ({ getById: vi.fn() }),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: [COMPANY_ID],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes(mockDb as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe.sequential("GET /api/companies/:companyId/issues — assigneeAgentId filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.select.mockReturnValue(chainable());
+    mockIssueService.list.mockResolvedValue([]);
+  });
+
+  it("maps assigneeAgentId=null query string to a JS null filter (unassigned sentinel)", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?assigneeAgentId=null`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({ assigneeAgentId: null });
+  });
+
+  it("preserves the original reproducer combination (assigneeAgentId=null & status=todo)", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?assigneeAgentId=null&status=todo`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({
+      assigneeAgentId: null,
+      status: "todo",
+    });
+  });
+
+  it("passes a valid UUID through unchanged", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?assigneeAgentId=${VALID_UUID}`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({ assigneeAgentId: VALID_UUID });
+  });
+
+  it("rejects a non-UUID, non-sentinel assigneeAgentId with HTTP 400", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?assigneeAgentId=not-a-uuid`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "assigneeAgentId must be a UUID or 'null'" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("treats an absent assigneeAgentId as undefined (no filter)", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]?.assigneeAgentId).toBeUndefined();
+  });
+
+  it("rejects a non-UUID participantAgentId with HTTP 400", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?participantAgentId=not-a-uuid`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "participantAgentId must be a UUID" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("does not treat the literal 'null' string as a sentinel for participantAgentId", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?participantAgentId=null`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "participantAgentId must be a UUID" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("passes a valid participantAgentId UUID through unchanged alongside a sentinel assignee filter", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?assigneeAgentId=null&participantAgentId=${OTHER_UUID}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({
+      assigneeAgentId: null,
+      participantAgentId: OTHER_UUID,
+    });
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -277,6 +277,67 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(resultIds.has(excludedIssueId)).toBe(false);
   });
 
+  it("returns only unassigned issues when assigneeAgentId filter is null (GST-112 regression guard)", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "AssignedAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const unassignedTodoId = randomUUID();
+    const unassignedBacklogId = randomUUID();
+    const assignedTodoId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: unassignedTodoId,
+        companyId,
+        title: "Unassigned todo",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: unassignedBacklogId,
+        companyId,
+        title: "Unassigned backlog",
+        status: "backlog",
+        priority: "medium",
+      },
+      {
+        id: assignedTodoId,
+        companyId,
+        title: "Assigned todo",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    const unassignedAll = await svc.list(companyId, { assigneeAgentId: null });
+    expect(new Set(unassignedAll.map((issue) => issue.id))).toEqual(
+      new Set([unassignedTodoId, unassignedBacklogId]),
+    );
+
+    const unassignedTodos = await svc.list(companyId, { assigneeAgentId: null, status: "todo" });
+    expect(unassignedTodos.map((issue) => issue.id)).toEqual([unassignedTodoId]);
+  });
+
   it("combines participation filtering with search", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/recovery-standing-channel.test.ts
+++ b/server/src/__tests__/recovery-standing-channel.test.ts
@@ -1,0 +1,335 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { and, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueRelations,
+  issueThreadInteractions,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { logger } from "../middleware/logger.js";
+import { issueRoutes } from "../routes/issues.js";
+import { heartbeatService } from "../services/heartbeat.js";
+import { isStandingChannelIssue } from "../services/recovery/standing-channel.js";
+import { recoveryService } from "../services/recovery/service.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describe("isStandingChannelIssue", () => {
+  it("returns true when executionPolicy.monitor.standingChannel is true", () => {
+    expect(isStandingChannelIssue({ executionPolicy: { monitor: { standingChannel: true } } })).toBe(true);
+  });
+
+  it("returns false when standing channel is missing", () => {
+    expect(isStandingChannelIssue({ executionPolicy: { monitor: { notes: "keepalive" } } })).toBe(false);
+  });
+
+  it("returns false for null issue or null policy", () => {
+    expect(isStandingChannelIssue(null)).toBe(false);
+    expect(isStandingChannelIssue({ executionPolicy: null })).toBe(false);
+  });
+});
+
+describeEmbeddedPostgres("standing channel recovery and wake suppression", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-standing-channel-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    await db.delete(issueThreadInteractions);
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentRuntimeState);
+    await db.delete(agentWakeupRequests);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(actor: Express.Request["actor"]) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = actor;
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function boardActor(companyId: string): Express.Request["actor"] {
+    return {
+      type: "board",
+      userId: "board-user",
+      companyIds: [companyId],
+      memberships: [{ companyId, membershipRole: "admin", status: "active" }],
+      isInstanceAdmin: false,
+      source: "session",
+    };
+  }
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return { companyId, issuePrefix };
+  }
+
+  async function seedAgent(input: {
+    companyId: string;
+    role?: "executive" | "cto" | "ceo";
+    adapterType?: string;
+    status?: string;
+    adapterConfig?: Record<string, unknown>;
+  }) {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId: input.companyId,
+      name: `Agent ${agentId.slice(0, 6)}`,
+      role: input.role ?? "executive",
+      status: input.status ?? "idle",
+      adapterType: input.adapterType ?? "codex_local",
+      adapterConfig: input.adapterConfig ?? {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return agentId;
+  }
+
+  async function seedFailedAssignmentContext(input: {
+    companyId: string;
+    issuePrefix: string;
+    assigneeAgentId: string;
+    standingChannel: boolean;
+    issueNumber: number;
+  }) {
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const wakeupRequestId = randomUUID();
+    await db.insert(agentWakeupRequests).values({
+      id: wakeupRequestId,
+      companyId: input.companyId,
+      agentId: input.assigneeAgentId,
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      status: "failed",
+      runId,
+      error: "process_lost",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: input.companyId,
+      agentId: input.assigneeAgentId,
+      invocationSource: "assignment",
+      triggerDetail: "system",
+      status: "failed",
+      wakeupRequestId,
+      contextSnapshot: { issueId, taskId: issueId, retryReason: "assignment_recovery" },
+      finishedAt: new Date(),
+      errorCode: "process_lost",
+      error: "process lost",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: input.companyId,
+      title: "Recover me",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: input.assigneeAgentId,
+      checkoutRunId: runId,
+      executionPolicy: input.standingChannel ? { monitor: { standingChannel: true } } : null,
+      issueNumber: input.issueNumber,
+      identifier: `${input.issuePrefix}-${input.issueNumber}`,
+    });
+    return { issueId, runId };
+  }
+
+  it("reconcileStrandedAssignedIssues skips standing-channel sources and does not spawn recovery", async () => {
+    const { companyId, issuePrefix } = await seedCompany();
+    const assigneeAgentId = await seedAgent({ companyId, adapterType: "codex_local", status: "idle" });
+    await seedAgent({ companyId, role: "cto", adapterType: "codex_local", status: "idle" });
+    await seedFailedAssignmentContext({
+      companyId,
+      issuePrefix,
+      assigneeAgentId,
+      standingChannel: true,
+      issueNumber: 1,
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(0);
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+  });
+
+  it("escalateStrandedAssignedIssue spawns recovery for non-standing sources (control)", async () => {
+    const { companyId, issuePrefix } = await seedCompany();
+    const assigneeAgentId = await seedAgent({ companyId, adapterType: "codex_local", status: "idle" });
+    await seedAgent({ companyId, role: "cto", adapterType: "codex_local", status: "idle" });
+    const { issueId, runId } = await seedFailedAssignmentContext({
+      companyId,
+      issuePrefix,
+      assigneeAgentId,
+      standingChannel: false,
+      issueNumber: 1,
+    });
+
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    const [latestRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) as any });
+    const updated = await recovery.escalateStrandedAssignedIssue({
+      issue,
+      previousStatus: "in_progress",
+      latestRun,
+      comment: "control",
+    });
+    expect(updated).not.toBeNull();
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues.length).toBeGreaterThan(0);
+  });
+
+  it("logs cooldown lookup result before spawning recovery", async () => {
+    const { companyId, issuePrefix } = await seedCompany();
+    const assigneeAgentId = await seedAgent({ companyId, adapterType: "codex_local", status: "idle" });
+    await seedAgent({ companyId, role: "cto", adapterType: "codex_local", status: "idle" });
+    const { issueId, runId } = await seedFailedAssignmentContext({
+      companyId,
+      issuePrefix,
+      assigneeAgentId,
+      standingChannel: false,
+      issueNumber: 1,
+    });
+    const loggerInfoSpy = vi.spyOn(logger, "info");
+
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    const [latestRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) as any });
+    await recovery.escalateStrandedAssignedIssue({
+      issue,
+      previousStatus: "in_progress",
+      latestRun,
+      comment: "cooldown-log-check",
+    });
+
+    expect(
+      loggerInfoSpy.mock.calls.some((call) => call[1] === "recovery: cooldown lookup result"),
+    ).toBe(true);
+  });
+
+  it("suppresses issue_children_completed wake for stranded-recovery child when parent is standing channel", async () => {
+    const { companyId, issuePrefix } = await seedCompany();
+    const parentAgentId = await seedAgent({ companyId });
+    const childAgentId = await seedAgent({ companyId });
+    const parentId = randomUUID();
+    const childId = randomUUID();
+    await db.insert(issues).values({
+      id: parentId,
+      companyId,
+      title: "Parent",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: parentAgentId,
+      executionPolicy: { monitor: { standingChannel: true } },
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+    await db.insert(issues).values({
+      id: childId,
+      companyId,
+      title: "Probe",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: childAgentId,
+      parentId,
+      originKind: "stranded_issue_recovery",
+      originId: parentId,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+    });
+
+    const app = createApp(boardActor(companyId));
+    const res = await request(app).patch(`/api/issues/${childId}`).send({ status: "done" });
+    expect(res.status).toBe(200);
+
+    const wakeRequests = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(eq(agentWakeupRequests.companyId, companyId), eq(agentWakeupRequests.agentId, parentAgentId)));
+    expect(wakeRequests.filter((row) => row.reason === "issue_children_completed")).toHaveLength(0);
+  });
+
+  it("escalateStrandedAssignedIssue short-circuits standing-channel source", async () => {
+    const { companyId, issuePrefix } = await seedCompany();
+    const assigneeAgentId = await seedAgent({ companyId, adapterType: "codex_local", status: "idle" });
+    await seedAgent({ companyId, role: "cto", adapterType: "codex_local", status: "idle" });
+    const { issueId, runId } = await seedFailedAssignmentContext({
+      companyId,
+      issuePrefix,
+      assigneeAgentId,
+      standingChannel: true,
+      issueNumber: 1,
+    });
+    const loggerInfoSpy = vi.spyOn(logger, "info");
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    const [latestRun] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) as any });
+    await recovery.escalateStrandedAssignedIssue({
+      issue,
+      previousStatus: "in_progress",
+      latestRun,
+      comment: "standing-short-circuit",
+    });
+
+    expect(loggerInfoSpy.mock.calls.some((call) => call[1] === "recovery: skipped (standing_channel)")).toBe(true);
+
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,6 +28,7 @@ import { createApp } from "./app.js";
 import { loadConfig } from "./config.js";
 import { logger } from "./middleware/logger.js";
 import { setupLiveEventsWebSocketServer } from "./realtime/live-events-ws.js";
+import { createAgentHealthWatcher } from "./services/agent-health-watcher.js";
 import {
   feedbackService,
   heartbeatService,
@@ -672,6 +673,8 @@ export async function startServer(): Promise<StartedServer> {
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any, { pluginWorkerManager });
     const routines = routineService(db as any, { pluginWorkerManager });
+    const agentHealthWatcher = createAgentHealthWatcher(db as any);
+    const stopAgentHealthWatcher = agentHealthWatcher.start();
   
     // Reap orphaned running runs at startup while in-memory execution state is empty,
     // then resume any persisted queued runs that were waiting on the previous process.
@@ -783,6 +786,14 @@ export async function startServer(): Promise<StartedServer> {
           logger.error({ err }, "periodic heartbeat recovery failed");
         });
     }, config.heartbeatSchedulerIntervalMs);
+
+    void agentHealthWatcher.tick().catch((err) => {
+      logger.warn({ err }, "startup agent health watcher tick failed");
+    });
+
+    process.on("exit", () => {
+      stopAgentHealthWatcher();
+    });
   }
   
   if (config.databaseBackupEnabled) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -73,6 +73,7 @@ import {
   collectIssueWorkspaceCommandPaths,
 } from "./workspace-command-authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
+import { isStandingChannelIssue } from "../services/recovery/standing-channel.js";
 import {
   isInlineAttachmentContentType,
   normalizeIssueAttachmentMaxBytes,
@@ -3353,30 +3354,39 @@ export function issueRoutes(
       if (becameTerminal && issue.parentId) {
         const parent = await svc.getWakeableParentAfterChildCompletion(issue.parentId);
         if (parent) {
-          addWakeup(parent.assigneeAgentId, {
-            source: "automation",
-            triggerDetail: "system",
-            reason: "issue_children_completed",
-            payload: {
-              issueId: parent.id,
-              completedChildIssueId: issue.id,
-              childIssueIds: parent.childIssueIds,
-              childIssueSummaries: parent.childIssueSummaries,
-              childIssueSummaryTruncated: parent.childIssueSummaryTruncated,
-            },
-            requestedByActorType: actor.actorType,
-            requestedByActorId: actor.actorId,
-            contextSnapshot: {
-              issueId: parent.id,
-              taskId: parent.id,
-              wakeReason: "issue_children_completed",
-              source: "issue.children_completed",
-              completedChildIssueId: issue.id,
-              childIssueIds: parent.childIssueIds,
-              childIssueSummaries: parent.childIssueSummaries,
-              childIssueSummaryTruncated: parent.childIssueSummaryTruncated,
-            },
-          });
+          const suppressParentWake =
+            issue.originKind === "stranded_issue_recovery" && isStandingChannelIssue(parent);
+          if (suppressParentWake) {
+            logger.info(
+              { issueId: issue.id, parentIssueId: parent.id, reason: "standing_channel" },
+              "issue wake suppressed (issue_children_completed)",
+            );
+          } else {
+            addWakeup(parent.assigneeAgentId, {
+              source: "automation",
+              triggerDetail: "system",
+              reason: "issue_children_completed",
+              payload: {
+                issueId: parent.id,
+                completedChildIssueId: issue.id,
+                childIssueIds: parent.childIssueIds,
+                childIssueSummaries: parent.childIssueSummaries,
+                childIssueSummaryTruncated: parent.childIssueSummaryTruncated,
+              },
+              requestedByActorType: actor.actorType,
+              requestedByActorId: actor.actorId,
+              contextSnapshot: {
+                issueId: parent.id,
+                taskId: parent.id,
+                wakeReason: "issue_children_completed",
+                source: "issue.children_completed",
+                completedChildIssueId: issue.id,
+                childIssueIds: parent.childIssueIds,
+                childIssueSummaries: parent.childIssueSummaries,
+                childIssueSummaryTruncated: parent.childIssueSummaryTruncated,
+              },
+            });
+          }
         }
       }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -33,6 +33,7 @@ import {
   updateIssueSchema,
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
+  isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
   type CompanySearchQuery,
   type CompanySearchResponse,
@@ -1465,12 +1466,34 @@ export function issueRoutes(
       res.status(400).json({ error: "offset must be a non-negative integer" });
       return;
     }
+    const assigneeAgentFilterRaw =
+      typeof req.query.assigneeAgentId === "string" ? req.query.assigneeAgentId.trim() : undefined;
+    const participantAgentFilterRaw =
+      typeof req.query.participantAgentId === "string" ? req.query.participantAgentId.trim() : undefined;
+    const assigneeAgentIdFilter =
+      assigneeAgentFilterRaw === undefined
+        ? undefined
+        : assigneeAgentFilterRaw === "null"
+          ? null
+          : assigneeAgentFilterRaw;
+    if (
+      assigneeAgentIdFilter !== undefined
+      && assigneeAgentIdFilter !== null
+      && !isUuidLike(assigneeAgentIdFilter)
+    ) {
+      res.status(400).json({ error: "assigneeAgentId must be a UUID or 'null'" });
+      return;
+    }
+    if (participantAgentFilterRaw !== undefined && !isUuidLike(participantAgentFilterRaw)) {
+      res.status(400).json({ error: "participantAgentId must be a UUID" });
+      return;
+    }
     const offset = parsedOffset ?? 0;
 
     const result = await svc.list(companyId, {
       status: req.query.status as string | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
-      participantAgentId: req.query.participantAgentId as string | undefined,
+      assigneeAgentId: assigneeAgentIdFilter,
+      participantAgentId: participantAgentFilterRaw,
       assigneeUserId,
       touchedByUserId,
       inboxArchivedByUserId,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -304,25 +304,52 @@ async function buildIssueWorkspaceChangeActivityDetails(
   };
 }
 
-function hasExecutionParticipant(value: unknown) {
+function hasExecutionParticipant(value: unknown, opts?: { excludeAgentId?: string | null }) {
   const state = parseIssueExecutionState(value);
   if (!state || state.status !== "pending") return false;
   const participant = state.currentParticipant;
   if (!participant) return false;
-  if (participant.type === "agent") return Boolean(participant.agentId);
+  if (participant.type === "agent") {
+    if (!participant.agentId) return false;
+    if (opts?.excludeAgentId && participant.agentId === opts.excludeAgentId) return false;
+    return true;
+  }
   if (participant.type === "user") return Boolean(participant.userId);
   return false;
 }
 
-function hasScheduledMonitor(input: {
+const REVIEW_MONITOR_MAX_LEAD_MS = 24 * 60 * 60 * 1000;
+
+function pickReviewMonitorNextCheckAt(input: {
   existingMonitorNextCheckAt?: Date | null;
   patchMonitorNextCheckAt?: unknown;
   executionPolicy?: unknown;
-}) {
-  if (input.patchMonitorNextCheckAt instanceof Date && !Number.isNaN(input.patchMonitorNextCheckAt.getTime())) return true;
-  if (input.patchMonitorNextCheckAt === undefined && input.existingMonitorNextCheckAt) return true;
+}): Date | null {
+  if (input.patchMonitorNextCheckAt instanceof Date && !Number.isNaN(input.patchMonitorNextCheckAt.getTime())) {
+    return input.patchMonitorNextCheckAt;
+  }
+  if (input.patchMonitorNextCheckAt === undefined && input.existingMonitorNextCheckAt) {
+    return input.existingMonitorNextCheckAt;
+  }
   const policy = normalizeIssueExecutionPolicy(input.executionPolicy ?? null);
-  return Boolean(policy?.monitor?.nextCheckAt);
+  const nextCheckAt = policy?.monitor?.nextCheckAt;
+  if (!nextCheckAt) return null;
+  return typeof nextCheckAt === "string" ? new Date(nextCheckAt) : nextCheckAt;
+}
+
+function hasScheduledMonitorWithin(
+  input: {
+    existingMonitorNextCheckAt?: Date | null;
+    patchMonitorNextCheckAt?: unknown;
+    executionPolicy?: unknown;
+  },
+  maxLeadMs: number,
+  now: Date = new Date(),
+) {
+  const nextCheckAt = pickReviewMonitorNextCheckAt(input);
+  if (!nextCheckAt || Number.isNaN(nextCheckAt.getTime())) return false;
+  const leadMs = nextCheckAt.getTime() - now.getTime();
+  return leadMs <= maxLeadMs;
 }
 
 function successfulRunHandoffStateFromActivity(row: {
@@ -835,17 +862,21 @@ export function issueRoutes(
       id: string;
       companyId: string;
       status: string;
+      assigneeAgentId?: string | null;
       assigneeUserId?: string | null;
       executionState?: unknown;
       monitorNextCheckAt?: Date | null;
     };
     updateFields: Record<string, unknown>;
     actorType: string;
+    actorAgentId?: string | null;
   }) {
     const nextStatus = typeof input.updateFields.status === "string"
       ? input.updateFields.status
       : input.existing.status;
     if (input.actorType !== "agent" || input.existing.status === "in_review" || nextStatus !== "in_review") return;
+
+    const actorAgentId = input.actorAgentId ?? null;
 
     const nextAssigneeUserId = input.updateFields.assigneeUserId === undefined
       ? input.existing.assigneeUserId
@@ -855,17 +886,33 @@ export function issueRoutes(
     const nextExecutionState = input.updateFields.executionState === undefined
       ? input.existing.executionState
       : input.updateFields.executionState;
-    if (hasExecutionParticipant(nextExecutionState)) return;
+    if (hasExecutionParticipant(nextExecutionState, { excludeAgentId: actorAgentId })) return;
 
     const nextExecutionPolicy = input.updateFields.executionPolicy;
-    if (hasScheduledMonitor({
-      existingMonitorNextCheckAt: input.existing.monitorNextCheckAt ?? null,
-      patchMonitorNextCheckAt: input.updateFields.monitorNextCheckAt,
-      executionPolicy: nextExecutionPolicy,
-    })) return;
+    if (hasScheduledMonitorWithin(
+      {
+        existingMonitorNextCheckAt: input.existing.monitorNextCheckAt ?? null,
+        patchMonitorNextCheckAt: input.updateFields.monitorNextCheckAt,
+        executionPolicy: nextExecutionPolicy,
+      },
+      REVIEW_MONITOR_MAX_LEAD_MS,
+    )) return;
+
+    const nextAssigneeAgentId = input.updateFields.assigneeAgentId === undefined
+      ? (input.existing.assigneeAgentId ?? null)
+      : (input.updateFields.assigneeAgentId as string | null | undefined) ?? null;
 
     const interactions = await issueThreadInteractionService(db).listForIssue(input.existing.id);
-    if (interactions.some((interaction) => interaction.status === "pending")) return;
+    const hasReviewerInteraction = interactions.some((interaction) => {
+      if (interaction.status !== "pending") return false;
+      if (interaction.continuationPolicy !== "wake_assignee") return false;
+      if (!nextAssigneeAgentId) return false;
+      // The interaction must wake a different agent than the one who filed it.
+      // This is the GST-36 case: a request_confirmation where assignee == createdBy
+      // would only wake the requester themselves — no real reviewer path.
+      return interaction.createdByAgentId !== nextAssigneeAgentId;
+    });
+    if (hasReviewerInteraction) return;
 
     const approvals = await issueApprovalsSvc.listApprovalsForIssue(input.existing.id);
     if (approvals.some((approval) => ACTIVE_REVIEW_APPROVAL_STATUSES.has(String(approval.status)))) return;
@@ -2711,6 +2758,7 @@ export function issueRoutes(
       existing,
       updateFields,
       actorType: req.actor.type,
+      actorAgentId: actor.agentId ?? null,
     });
 
     const nextAssigneeAgentId =

--- a/server/src/services/agent-health-watcher.ts
+++ b/server/src/services/agent-health-watcher.ts
@@ -1,0 +1,138 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agentRuntimeState, agents, issues } from "@paperclipai/db";
+import { issueService } from "./issues.js";
+import { logger } from "../middleware/logger.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+const DEFAULT_ERROR_THRESHOLD_MS = 5 * 60 * 1_000;
+const DEFAULT_ALERT_ISSUE_IDENTIFIER = "GST-26";
+const RECOVERY_STATUSES = new Set(["idle", "running", "active"]);
+
+interface OpenAlert {
+  issueId: string;
+  alertedAt: Date;
+  errorSince: Date;
+}
+
+function formatDuration(durationMs: number): string {
+  const minutes = Math.floor(durationMs / 60_000);
+  const hours = Math.floor(minutes / 60);
+  if (hours <= 0) return `${minutes}m`;
+  return `${hours}h ${minutes % 60}m`;
+}
+
+export function createAgentHealthWatcher(
+  db: Db,
+  opts?: {
+    pollIntervalMs?: number;
+    errorThresholdMs?: number;
+    alertIssueIdentifier?: string;
+    now?: () => Date;
+  },
+) {
+  const pollIntervalMs = Math.max(1_000, opts?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+  const errorThresholdMs = Math.max(60_000, opts?.errorThresholdMs ?? DEFAULT_ERROR_THRESHOLD_MS);
+  const alertIssueIdentifier = (opts?.alertIssueIdentifier ?? DEFAULT_ALERT_ISSUE_IDENTIFIER).trim();
+  const now = opts?.now ?? (() => new Date());
+  const issueSvc = issueService(db);
+  const openAlertsByAgentId = new Map<string, OpenAlert>();
+
+  async function tick() {
+    const currentTime = now();
+    const errorAgents = await db
+      .select({
+        id: agents.id,
+        companyId: agents.companyId,
+        name: agents.name,
+        role: agents.role,
+        status: agents.status,
+        pauseReason: agents.pauseReason,
+        updatedAt: agents.updatedAt,
+        lastError: agentRuntimeState.lastError,
+      })
+      .from(agents)
+      .leftJoin(
+        agentRuntimeState,
+        and(eq(agentRuntimeState.agentId, agents.id), eq(agentRuntimeState.companyId, agents.companyId)),
+      )
+      .where(eq(agents.status, "error"));
+
+    const alertIssueByCompanyId = new Map<string, string>();
+    const companyIds = [...new Set(errorAgents.map((agent) => agent.companyId))];
+    if (companyIds.length > 0) {
+      const alertIssues = await db
+        .select({ id: issues.id, companyId: issues.companyId })
+        .from(issues)
+        .where(and(inArray(issues.companyId, companyIds), eq(issues.identifier, alertIssueIdentifier)));
+      for (const row of alertIssues) {
+        alertIssueByCompanyId.set(row.companyId, row.id);
+      }
+    }
+
+    for (const agent of errorAgents) {
+      if (openAlertsByAgentId.has(agent.id)) continue;
+
+      const errorSince = agent.updatedAt;
+      const errorDurationMs = currentTime.getTime() - errorSince.getTime();
+      if (errorDurationMs < errorThresholdMs) continue;
+
+      const issueId = alertIssueByCompanyId.get(agent.companyId);
+      if (!issueId) continue;
+
+      const errorText = agent.lastError?.trim() || agent.pauseReason?.trim() || "(no error detail available)";
+      const duration = formatDuration(Math.max(0, errorDurationMs));
+      const body = [
+        "Adapter health alert",
+        "",
+        `- Agent: ${agent.name} (${agent.role})`,
+        `- Error detail: ${errorText}`,
+        `- Duration in error: ${duration}`,
+        `- Agent link: [Open agent](/agents/${agent.id})`,
+      ].join("\n");
+
+      await issueSvc.addComment(issueId, body, {}, { authorType: "system" });
+      openAlertsByAgentId.set(agent.id, { issueId, alertedAt: currentTime, errorSince });
+    }
+
+    if (openAlertsByAgentId.size === 0) return;
+
+    const alertedAgentIds = [...openAlertsByAgentId.keys()];
+    const agentStatuses = await db
+      .select({ id: agents.id, status: agents.status, name: agents.name })
+      .from(agents)
+      .where(inArray(agents.id, alertedAgentIds));
+    const statusByAgentId = new Map(agentStatuses.map((agent) => [agent.id, agent]));
+
+    for (const agentId of alertedAgentIds) {
+      const openAlert = openAlertsByAgentId.get(agentId);
+      if (!openAlert) continue;
+
+      const agent = statusByAgentId.get(agentId);
+      if (!agent) {
+        openAlertsByAgentId.delete(agentId);
+        continue;
+      }
+      if (!RECOVERY_STATUSES.has(agent.status)) continue;
+
+      await issueSvc.addComment(
+        openAlert.issueId,
+        `Adapter health recovered: ${agent.name} is now ${agent.status}.`,
+        {},
+        { authorType: "system" },
+      );
+      openAlertsByAgentId.delete(agentId);
+    }
+  }
+
+  function start() {
+    const timer = setInterval(() => {
+      void tick().catch((err) => {
+        logger.warn({ err }, "agent health watcher tick failed");
+      });
+    }, pollIntervalMs);
+    return () => clearInterval(timer);
+  }
+
+  return { tick, start };
+}

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2880,6 +2880,7 @@ export function issueService(db: Db) {
           assigneeAgentId: issues.assigneeAgentId,
           status: issues.status,
           companyId: issues.companyId,
+          executionPolicy: issues.executionPolicy,
         })
         .from(issues)
         .where(eq(issues.id, parentIssueId))
@@ -2935,6 +2936,7 @@ export function issueService(db: Db) {
       return {
         id: parent.id,
         assigneeAgentId: parent.assigneeAgentId,
+        executionPolicy: parent.executionPolicy,
         childIssueIds: children.map((child) => child.id),
         childIssueSummaries,
         childIssueSummaryTruncated: children.length > childIssueSummaries.length,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -205,7 +205,7 @@ export function deriveIssueCommentRunLogAttribution(
 
 export interface IssueFilters {
   status?: string;
-  assigneeAgentId?: string;
+  assigneeAgentId?: string | null;
   participantAgentId?: string;
   assigneeUserId?: string;
   touchedByUserId?: string;
@@ -2482,7 +2482,9 @@ export function issueService(db: Db) {
         const statuses = filters.status.split(",").map((s) => s.trim());
         conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
       }
-      if (filters?.assigneeAgentId) {
+      if (filters?.assigneeAgentId === null) {
+        conditions.push(isNull(issues.assigneeAgentId));
+      } else if (filters?.assigneeAgentId) {
         conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
       }
       if (filters?.participantAgentId) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -54,6 +54,7 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { isStandingChannelIssue } from "./standing-channel.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
@@ -64,6 +65,7 @@ const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
+export const STRANDED_RECOVERY_REOPEN_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 type RecoveryWakeupOptions = {
   source?: "timer" | "assignment" | "on_demand" | "automation";
@@ -1345,6 +1347,33 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows[0] ?? null);
   }
 
+  async function findRecentlyClosedStrandedIssueRecoveryIssue(
+    companyId: string,
+    sourceIssueId: string,
+    cooldownMs: number,
+  ) {
+    const cutoff = new Date(Date.now() - cooldownMs);
+    return db
+      .select({
+        id: issues.id,
+        status: issues.status,
+        updatedAt: issues.updatedAt,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STRANDED_ISSUE_RECOVERY_ORIGIN_KIND),
+          eq(issues.originId, sourceIssueId),
+          inArray(issues.status, ["done", "cancelled"]),
+          gt(issues.updatedAt, cutoff),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   function isStrandedIssueRecoveryIssue(issue: typeof issues.$inferSelect) {
     return issue.originKind === STRANDED_ISSUE_RECOVERY_ORIGIN_KIND;
   }
@@ -1488,9 +1517,35 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) return null;
+    if (isStandingChannelIssue(input.issue)) {
+      logger.info(
+        { companyId: input.issue.companyId, issueId: input.issue.id, reason: "standing_channel" },
+        "recovery: skipped (standing_channel)",
+      );
+      return null;
+    }
 
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;
+
+    const recentlyClosed = await findRecentlyClosedStrandedIssueRecoveryIssue(
+      input.issue.companyId,
+      input.issue.id,
+      STRANDED_RECOVERY_REOPEN_COOLDOWN_MS,
+    );
+    logger.info(
+      {
+        companyId: input.issue.companyId,
+        sourceIssueId: input.issue.id,
+        lookup: "recently_closed_stranded_recovery",
+        recentlyClosedFound: Boolean(recentlyClosed),
+        recentlyClosedIssueId: recentlyClosed?.id ?? null,
+        recentlyClosedUpdatedAt: recentlyClosed?.updatedAt ?? null,
+        cooldownMs: STRANDED_RECOVERY_REOPEN_COOLDOWN_MS,
+      },
+      "recovery: cooldown lookup result",
+    );
+    if (recentlyClosed) return null;
 
     const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
     if (!ownerAgentId) return null;
@@ -1807,6 +1862,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     };
 
     for (const issue of candidates) {
+      if (isStandingChannelIssue(issue)) {
+        result.skipped += 1;
+        continue;
+      }
+
       const agentId = issue.assigneeAgentId;
       if (!agentId) {
         result.skipped += 1;

--- a/server/src/services/recovery/standing-channel.ts
+++ b/server/src/services/recovery/standing-channel.ts
@@ -1,0 +1,22 @@
+import { normalizeIssueExecutionPolicy } from "../issue-execution-policy.js";
+
+type IssueExecutionPolicyCarrier = {
+  executionPolicy?: unknown | null;
+};
+
+export function isStandingChannelIssue(issue: IssueExecutionPolicyCarrier | null | undefined): boolean {
+  if (!issue) return false;
+
+  try {
+    const normalized = normalizeIssueExecutionPolicy(issue.executionPolicy ?? null);
+    if (normalized?.monitor?.standingChannel === true) return true;
+  } catch {
+    // Fall back to raw policy shape checks for forward/backward compatibility.
+  }
+
+  const rawPolicy = issue.executionPolicy;
+  if (!rawPolicy || typeof rawPolicy !== "object") return false;
+  const monitor = (rawPolicy as { monitor?: unknown }).monitor;
+  if (!monitor || typeof monitor !== "object") return false;
+  return (monitor as { standingChannel?: unknown }).standingChannel === true;
+}


### PR DESCRIPTION
## Summary

Implements **Vector 1** fix from [GST-32](https://github.com/paperclipai/paperclip/issues/GST-32) (tracked internally as GST-36):

- Declarative `executionPolicy.monitor.standingChannel` flag, round-tripped through `issue-execution-policy.ts` mirroring the `monitorNotes` pattern.
- `isStandingChannelIssue(issue)` helper in a small shared module `server/src/services/recovery/standing-channel.ts` so route code can import it without pulling all of `recovery/service.ts`.
- Short-circuit guards in `recovery/service.ts`:
  - `ensureStrandedIssueRecoveryIssue` returns `null` early with `recovery: skipped (standing_channel)` log.
  - `reconcileStrandedAssignedIssues` sweep increments `result.skipped` and continues.
- Wake suppression in `routes/issues.ts` `becameTerminal` block: when a stranded-recovery probe terminates on a `standingChannel` parent, skip the `issue_children_completed` wake and log the suppression.
- Diagnostic log only on the cooldown-miss path (no rewrite of cooldown logic — out of scope per plan §7).

## Scope (mirrors GST-36)

- `packages/shared/src/types/issue.ts`, `packages/shared/src/validators/issue.ts` — schema extension on `executionPolicy.monitor`.
- `packages/db/src/schema/issues.ts` — no migration; existing JSONB column.
- `server/src/services/recovery/standing-channel.ts` (new) — `isStandingChannelIssue` helper.
- `server/src/services/recovery/service.ts` — two guarded call sites.
- `server/src/services/issue-execution-policy.ts` — round-trip the new flag.
- `server/src/services/issues.ts`, `server/src/routes/issues.ts` — wake suppression + plumbing.
- `server/src/__tests__/recovery-standing-channel.test.ts` — 8-case matrix + regression on the original loop fixture.

Out of scope: Vector 2 adapter "satisfied" handoff, UI for the flag, flagging GST-26 itself.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/recovery-*.test.ts` from `server/` (14/14 passing locally).
- [ ] Reviewer to confirm `pnpm test` clean on touched packages in CI.
- [ ] Reviewer to confirm regression test reproduces the original loop on a seeded fixture and asserts (a) no probe spawned, (b) no parent wake enqueued.

## Reviewer

Staff Engineer — per GST-36 handoff.