### PR TITLE
fix(productivity-review): default snooze 6h → 7d + env override

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { MAX_ISSUE_REQUEST_DEPTH } from "@paperclipai/shared";
 import {
+  __resetProductivityReviewEnvCacheForTests,
   DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS,
   DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
   DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
@@ -289,6 +290,7 @@ describeEmbeddedPostgres("productivity review service", () => {
     const result = await productivityReviewService(db).reconcileProductivityReviews({
       now,
       companyId: seeded.companyId,
+      thresholds: { resolvedSnoozeMs: 60 * 60 * 1000 },
     });
 
     expect(result.created).toBe(0);
@@ -535,6 +537,58 @@ describeEmbeddedPostgres("productivity review service", () => {
       .where(eq(activityLog.action, "issue.productivity_review_continuation_held"));
     expect(activities).toHaveLength(1);
     expect(activities[0]?.entityId).toBe(seeded.issueId);
+  });
+
+  it("applies env overrides to resolved-review snooze and creation-cap thresholds", async () => {
+    const prevSnooze = process.env.PAPERCLIP_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_HOURS;
+    const prevMaxCreations = process.env.PAPERCLIP_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW;
+    process.env.PAPERCLIP_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_HOURS = "2";
+    process.env.PAPERCLIP_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = "1";
+    __resetProductivityReviewEnvCacheForTests();
+    try {
+      const now = new Date("2026-04-28T12:00:00.000Z");
+      const seeded = await seedAssignedIssue();
+      await insertRuns({
+        companyId: seeded.companyId,
+        agentId: seeded.coderId,
+        issueId: seeded.issueId,
+        count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+        now,
+      });
+
+      const service = productivityReviewService(db);
+      await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+      const [review] = await listProductivityReviews(seeded.companyId);
+      await db
+        .update(issues)
+        .set({ status: "done", updatedAt: now })
+        .where(eq(issues.id, review!.id));
+
+      // 1h later: env snooze of 2h still in effect — the default 6h would also snooze, so the
+      // 30-min control covers the default. Push to 3h to exit the default behaviour as well.
+      const withinEnvSnooze = await service.reconcileProductivityReviews({
+        now: new Date(now.getTime() + 60 * 60 * 1000),
+        companyId: seeded.companyId,
+      });
+      expect(withinEnvSnooze.snoozed).toBe(1);
+
+      // 3h later: env snooze expired, so creation is attempted — but env maxCreationsPerWindow=1
+      // and one done review already counts, so the cap fires.
+      const afterEnvSnooze = await service.reconcileProductivityReviews({
+        now: new Date(now.getTime() + 3 * 60 * 60 * 1000),
+        companyId: seeded.companyId,
+      });
+      expect(afterEnvSnooze.snoozed).toBe(0);
+      expect(afterEnvSnooze.creationCapped).toBe(1);
+      expect(afterEnvSnooze.created).toBe(0);
+      expect(await listProductivityReviews(seeded.companyId)).toHaveLength(1);
+    } finally {
+      if (prevSnooze === undefined) delete process.env.PAPERCLIP_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_HOURS;
+      else process.env.PAPERCLIP_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_HOURS = prevSnooze;
+      if (prevMaxCreations === undefined) delete process.env.PAPERCLIP_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW;
+      else process.env.PAPERCLIP_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = prevMaxCreations;
+      __resetProductivityReviewEnvCacheForTests();
+    }
   });
 
   it("clamps poisoned requestDepth metadata instead of aborting productivity reconciliation", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -25,11 +25,41 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS = 10;
 export const DEFAULT_PRODUCTIVITY_REVIEW_LONG_ACTIVE_HOURS = 6;
 export const DEFAULT_PRODUCTIVITY_REVIEW_HIGH_CHURN_HOURLY = 10;
 export const DEFAULT_PRODUCTIVITY_REVIEW_HIGH_CHURN_SIX_HOURS = 30;
-export const DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS = 6 * 60 * 60 * 1000;
+export const DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS = 7 * 24 * 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS = 3;
 export const DEFAULT_PRODUCTIVITY_REVIEW_CREATION_WINDOW_MS = 24 * 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 3;
+
+const ENV_RESOLVED_SNOOZE_HOURS_KEY = "PAPERCLIP_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_HOURS";
+const ENV_MAX_CREATIONS_PER_WINDOW_KEY = "PAPERCLIP_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW";
+
+let cachedEnvThresholdOverrides: Partial<ProductivityReviewThresholds> | null = null;
+
+function readEnvThresholdOverrides(): Partial<ProductivityReviewThresholds> {
+  if (cachedEnvThresholdOverrides) return cachedEnvThresholdOverrides;
+  const overrides: Partial<ProductivityReviewThresholds> = {};
+  const snoozeHoursRaw = process.env[ENV_RESOLVED_SNOOZE_HOURS_KEY];
+  if (snoozeHoursRaw !== undefined && snoozeHoursRaw !== "") {
+    const hours = Number(snoozeHoursRaw);
+    if (Number.isFinite(hours) && hours > 0) {
+      overrides.resolvedSnoozeMs = Math.floor(hours * 60 * 60 * 1000);
+    }
+  }
+  const maxCreationsRaw = process.env[ENV_MAX_CREATIONS_PER_WINDOW_KEY];
+  if (maxCreationsRaw !== undefined && maxCreationsRaw !== "") {
+    const count = Number(maxCreationsRaw);
+    if (Number.isFinite(count) && count > 0) {
+      overrides.maxCreationsPerWindow = Math.floor(count);
+    }
+  }
+  cachedEnvThresholdOverrides = overrides;
+  return overrides;
+}
+
+export function __resetProductivityReviewEnvCacheForTests() {
+  cachedEnvThresholdOverrides = null;
+}
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
@@ -139,6 +169,7 @@ function coerceDate(value: Date | string | null | undefined) {
 }
 
 function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): ProductivityReviewThresholds {
+  const envOverrides = readEnvThresholdOverrides();
   return {
     noCommentStreakRuns: readPositiveInteger(
       overrides?.noCommentStreakRuns ?? DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
@@ -157,7 +188,7 @@ function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): Pro
       DEFAULT_PRODUCTIVITY_REVIEW_HIGH_CHURN_SIX_HOURS,
     ),
     resolvedSnoozeMs: readPositiveInteger(
-      overrides?.resolvedSnoozeMs ?? DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS,
+      overrides?.resolvedSnoozeMs ?? envOverrides.resolvedSnoozeMs ?? DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS,
       DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS,
     ),
     refreshIntervalMs: readPositiveInteger(
@@ -173,7 +204,7 @@ function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): Pro
       DEFAULT_PRODUCTIVITY_REVIEW_CREATION_WINDOW_MS,
     ),
     maxCreationsPerWindow: readPositiveInteger(
-      overrides?.maxCreationsPerWindow ?? DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW,
+      overrides?.maxCreationsPerWindow ?? envOverrides.maxCreationsPerWindow ?? DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW,
       DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW,
     ),
   };


### PR DESCRIPTION
## Summary

`reconcileProductivityReviews` was spawning a fresh productivity-review issue every 6 hours for the same parent assignment, even right after a manager closed the previous one — a 7-day window saw the same parent flagged 4× with no new symptoms in between.

Two changes:

1. `DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS` bumps from `6h` to `7d`. After a review is resolved (status `done`), the source issue is left alone for a week instead of for six hours.
2. Two env overrides for operators:
   - `PAPERCLIP_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_HOURS` — override the snooze window (hours).
   - `PAPERCLIP_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW` — override the rolling 24h creation cap. The current default 3 is fairly generous; operators who want a tighter "one review per day per parent" can set this to 1.

   The env is read once at first call into `buildThresholds` and cached, so the per-cycle overhead is zero. Explicit `thresholds` passed to `reconcileProductivityReviews` still take precedence — env is only a fallback default.

## Tests

- Added one new test covering the env-override path: with `PAPERCLIP_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_HOURS=2` and `MAX_CREATIONS_PER_WINDOW=1` set, a recently resolved review snoozes the source for 2h (not the default 6h or new 7d), and once the snooze expires the env cap fires on the second attempt.
- Updated `caps productivity review creation per source issue in the rolling creation window` to pass `thresholds.resolvedSnoozeMs: 1h` explicitly — its fixtures (done reviews at 8/9/10h ago) predate the new 7d default which would otherwise pull them into the snooze window before the cap check.
- All 12 productivity-review-service tests pass.

## Test plan

- [x] `pnpm -F @paperclipai/server exec vitest run src/__tests__/productivity-review-service.test.ts` → 12 passed
- [x] `pnpm -F @paperclipai/server build` → server dist updated, default in compiled JS is `7 * 24 * 60 * 60 * 1000`