### PR TITLE
fix(adapters): select GitHub token by model family

### DIFF
--- a/docs/deploy/secrets.md
+++ b/docs/deploy/secrets.md
@@ -51,6 +51,15 @@ Project env applies to every issue run in that project. When a project env key
 matches an agent env key, the project value wins before Paperclip injects its
 own `PAPERCLIP_*` runtime variables.
 
+GitHub tokens can be bound by model family instead of sharing one credential
+across every local coding adapter. Bind Codex/OpenAI credentials as
+`GH_TOKEN_CODEX`, `GITHUB_TOKEN_CODEX`, or `GITHUB_PAT_CODEX`; bind
+Claude/Anthropic credentials as `GH_TOKEN_CLAUDE`, `GITHUB_TOKEN_CLAUDE`, or
+`GITHUB_PAT_CLAUDE`. The Codex and Claude local adapters select the matching
+family token at launch, expose it to the child process as `GH_TOKEN`, and mask
+the family-specific source keys from the child environment. A legacy `GH_TOKEN`
+binding remains a fallback only when no matching family-specific token exists.
+
 ## Default Provider: `local_encrypted`
 
 Secrets are encrypted with a local master key stored at:

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   applyPaperclipWorkspaceEnv,
+  applyAgentGithubTokenSelection,
   appendWithByteCap,
   buildInvocationEnvForLogs,
   DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
@@ -61,6 +62,57 @@ describe("buildInvocationEnvForLogs", () => {
     expect(loggedEnv.PAPERCLIP_RESOLVED_COMMAND).toBe(
       "env OPENAI_API_KEY=***REDACTED*** custom-acp --token ***REDACTED***",
     );
+  });
+});
+
+describe("applyAgentGithubTokenSelection", () => {
+  it("uses the Codex token source and masks agent-specific source variables", () => {
+    const env: Record<string, string> = {
+      GH_TOKEN: "legacy",
+      GH_TOKEN_CODEX: "codex-token",
+      GH_TOKEN_CLAUDE: "claude-token",
+      SAFE_VALUE: "visible",
+    };
+
+    applyAgentGithubTokenSelection(env, "codex", {});
+
+    expect(env).toMatchObject({
+      GH_TOKEN: "codex-token",
+      GH_TOKEN_CODEX: "",
+      GH_TOKEN_CLAUDE: "",
+      SAFE_VALUE: "visible",
+    });
+  });
+
+  it("uses the Claude token source from inherited env when config does not provide one", () => {
+    const env: Record<string, string> = {
+      SAFE_VALUE: "visible",
+    };
+
+    applyAgentGithubTokenSelection(env, "claude", {
+      GH_TOKEN_CODEX: "codex-token",
+      GITHUB_TOKEN_CLAUDE: "claude-token",
+    });
+
+    expect(env.GH_TOKEN).toBe("claude-token");
+    expect(env.SAFE_VALUE).toBe("visible");
+    expect(env.GH_TOKEN_CODEX).toBe("");
+    expect(env.GITHUB_TOKEN_CLAUDE).toBe("");
+  });
+
+  it("preserves legacy GH_TOKEN fallback when no family-specific source is configured", () => {
+    const env: Record<string, string> = {
+      GH_TOKEN: "legacy",
+      GH_TOKEN_CODEX: "",
+    };
+
+    applyAgentGithubTokenSelection(env, "codex", {
+      GH_TOKEN_CLAUDE: "claude-token",
+    });
+
+    expect(env.GH_TOKEN).toBe("legacy");
+    expect(env.GH_TOKEN_CODEX).toBe("");
+    expect(env.GH_TOKEN_CLAUDE).toBe("");
   });
 });
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -235,6 +235,55 @@ export function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 }
 
+export type AgentGithubTokenFamily = "codex" | "claude";
+
+type EnvValueMap = Record<string, string | undefined>;
+
+const AGENT_GITHUB_TOKEN_SOURCE_KEYS: Record<AgentGithubTokenFamily, readonly string[]> = {
+  codex: ["GH_TOKEN_CODEX", "GITHUB_TOKEN_CODEX", "GITHUB_PAT_CODEX"],
+  claude: ["GH_TOKEN_CLAUDE", "GITHUB_TOKEN_CLAUDE", "GITHUB_PAT_CLAUDE"],
+};
+
+const ALL_AGENT_GITHUB_TOKEN_SOURCE_KEYS = Array.from(
+  new Set(Object.values(AGENT_GITHUB_TOKEN_SOURCE_KEYS).flat()),
+);
+
+function firstNonEmptyEnvValue(
+  keys: readonly string[],
+  envs: readonly EnvValueMap[],
+): string | null {
+  for (const env of envs) {
+    for (const key of keys) {
+      const value = env[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+export function applyAgentGithubTokenSelection(
+  env: Record<string, string>,
+  family: AgentGithubTokenFamily,
+  inheritedEnv: EnvValueMap = process.env,
+): Record<string, string> {
+  const token = firstNonEmptyEnvValue(
+    AGENT_GITHUB_TOKEN_SOURCE_KEYS[family],
+    [env, inheritedEnv],
+  );
+
+  if (token) {
+    env.GH_TOKEN = token;
+  }
+
+  for (const key of ALL_AGENT_GITHUB_TOKEN_SOURCE_KEYS) {
+    env[key] = "";
+  }
+
+  return env;
+}
+
 export function parseJson(value: string): Record<string, unknown> | null {
   try {
     return JSON.parse(value) as Record<string, unknown>;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -29,6 +29,7 @@ import {
   asStringArray,
   parseObject,
   parseJson,
+  applyAgentGithubTokenSelection,
   applyPaperclipWorkspaceEnv,
   buildPaperclipEnv,
   readPaperclipRuntimeSkillEntries,
@@ -260,6 +261,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     env.PAPERCLIP_API_KEY = authToken;
   }
 
+  applyAgentGithubTokenSelection(env, "claude", process.env);
   const runtimeEnv = Object.fromEntries(
     Object.entries(ensurePathInEnv({ ...process.env, ...env })).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -23,6 +23,7 @@ import {
   asString,
   asNumber,
   parseObject,
+  applyAgentGithubTokenSelection,
   buildPaperclipEnv,
   buildInvocationEnvForLogs,
   ensureAbsoluteDirectory,
@@ -499,6 +500,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       Object.assign(env, paperclipBridge.env);
     }
   }
+  applyAgentGithubTokenSelection(env, "codex", process.env);
   const effectiveEnv = Object.fromEntries(
     Object.entries({ ...process.env, ...env }).filter(
       (entry): entry is [string, string] => typeof entry[1] === "string",


### PR DESCRIPTION
## Summary
- select Codex and Claude GitHub credentials from family-specific env vars before spawning local adapters
- mask family-specific source token env keys from child processes after mapping the selected value to GH_TOKEN
- document GH_TOKEN_CODEX/GH_TOKEN_CLAUDE bindings and legacy GH_TOKEN fallback behavior

## Tests
- pnpm exec vitest run packages/adapter-utils/src/server-utils.test.ts
- pnpm --filter @paperclipai/adapter-utils typecheck
- pnpm --filter @paperclipai/adapter-codex-local typecheck
- pnpm --filter @paperclipai/adapter-claude-local typecheck