### PR TITLE
GST-112: Fix Internal Server Error on assigneeAgentId=null query

### DIFF
--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -211,12 +211,13 @@ describe.sequential("issue goal context routes", () => {
     mockDocumentsService.getIssueDocumentPayload.mockResolvedValue({});
     mockDocumentsService.getIssueDocumentByKey.mockResolvedValue(null);
     mockExecutionWorkspaceService.getById.mockResolvedValue(null);
+    const queryChain = {
+      where: vi.fn(() => queryChain),
+      orderBy: vi.fn(async () => []),
+      then: vi.fn(async (resolve: (rows: any[]) => unknown) => resolve([])),
+    };
     mockDb.select.mockReturnValue({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          orderBy: vi.fn(async () => []),
-        })),
-      })),
+      from: vi.fn(() => queryChain),
     });
     mockDb.execute.mockResolvedValue([]);
     mockProjectService.getById.mockResolvedValue({

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -198,12 +198,13 @@ describe.sequential("issue goal context routes", () => {
     mockDocumentsService.getIssueDocumentPayload.mockResolvedValue({});
     mockDocumentsService.getIssueDocumentByKey.mockResolvedValue(null);
     mockExecutionWorkspaceService.getById.mockResolvedValue(null);
+    const queryChain = {
+      where: vi.fn(() => queryChain),
+      orderBy: vi.fn(async () => []),
+      then: vi.fn(async (resolve: (rows: any[]) => unknown) => resolve([])),
+    };
     mockDb.select.mockReturnValue({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          orderBy: vi.fn(async () => []),
-        })),
-      })),
+      from: vi.fn(() => queryChain),
     });
     mockDb.execute.mockResolvedValue([]);
     mockProjectService.getById.mockResolvedValue({

--- a/server/src/__tests__/issues-list-route.test.ts
+++ b/server/src/__tests__/issues-list-route.test.ts
@@ -1,0 +1,248 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const VALID_UUID = "33333333-3333-4333-8333-333333333333";
+const OTHER_UUID = "44444444-4444-4444-8444-444444444444";
+const COMPANY_ID = "company-1";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+  count: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+  decide: vi.fn(async () => ({ allowed: true })),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+}));
+
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  get: vi.fn(async () => ({
+    id: "instance-settings-1",
+    general: {
+      censorUsernameInLogs: false,
+      feedbackDataSharingPreference: "prompt",
+    },
+  })),
+  listCompanyIds: vi.fn(async () => [COMPANY_ID]),
+}));
+
+function chainable(): any {
+  const handler: ProxyHandler<any> = {
+    get(_target, prop) {
+      if (prop === "then") {
+        return (resolve: (value: unknown) => unknown) => resolve([]);
+      }
+      return () => proxy;
+    },
+  };
+  const proxy: any = new Proxy(() => proxy, handler);
+  return proxy;
+}
+
+const mockDb = vi.hoisted(() => ({
+  select: vi.fn(),
+  execute: vi.fn(async () => []),
+}));
+
+vi.mock("../services/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/index.js")>();
+  return {
+    ...actual,
+    companyService: () => ({
+      getById: vi.fn(async () => ({ id: COMPANY_ID, attachmentMaxBytes: 10 * 1024 * 1024 })),
+    }),
+    accessService: () => mockAccessService,
+    agentService: () => ({ getById: vi.fn() }),
+    documentService: () => ({}),
+    environmentService: () => ({}),
+    executionWorkspaceService: () => ({ getById: vi.fn() }),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({ getById: vi.fn(), getDefaultCompanyGoal: vi.fn() }),
+    heartbeatService: () => mockHeartbeatService,
+    instanceSettingsService: () => mockInstanceSettingsService,
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: vi.fn(async () => undefined),
+      diffIssueReferenceSummary: vi.fn(() => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      })),
+      emptySummary: vi.fn(() => ({ outbound: [], inbound: [] })),
+      listIssueReferenceSummary: vi.fn(async () => ({ outbound: [], inbound: [] })),
+      syncComment: vi.fn(async () => undefined),
+      syncDocument: vi.fn(async () => undefined),
+      syncIssue: vi.fn(async () => undefined),
+    }),
+    issueService: () => mockIssueService,
+    logActivity: vi.fn(async () => undefined),
+    projectService: () => ({ getById: vi.fn(), listByIds: vi.fn() }),
+    routineService: () => ({ syncRunStatusForIssue: vi.fn(async () => undefined) }),
+    workProductService: () => ({ listForIssue: vi.fn(async () => []) }),
+  };
+});
+
+vi.mock("../services/execution-workspaces.js", () => ({
+  executionWorkspaceService: () => ({ getById: vi.fn() }),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: [COMPANY_ID],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes(mockDb as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe.sequential("GET /api/companies/:companyId/issues — assigneeAgentId filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.select.mockReturnValue(chainable());
+    mockIssueService.list.mockResolvedValue([]);
+  });
+
+  it("maps assigneeAgentId=null query string to a JS null filter (unassigned sentinel)", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?assigneeAgentId=null`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({ assigneeAgentId: null });
+  });
+
+  it("preserves the original reproducer combination (assigneeAgentId=null & status=todo)", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?assigneeAgentId=null&status=todo`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({
+      assigneeAgentId: null,
+      status: "todo",
+    });
+  });
+
+  it("passes a valid UUID through unchanged", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?assigneeAgentId=${VALID_UUID}`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({ assigneeAgentId: VALID_UUID });
+  });
+
+  it("rejects a non-UUID, non-sentinel assigneeAgentId with HTTP 400", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?assigneeAgentId=not-a-uuid`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "assigneeAgentId must be a UUID or 'null'" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("treats an absent assigneeAgentId as undefined (no filter)", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]?.assigneeAgentId).toBeUndefined();
+  });
+
+  it("rejects a non-UUID participantAgentId with HTTP 400", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?participantAgentId=not-a-uuid`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "participantAgentId must be a UUID" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("does not treat the literal 'null' string as a sentinel for participantAgentId", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?participantAgentId=null`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "participantAgentId must be a UUID" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("passes a valid participantAgentId UUID through unchanged alongside a sentinel assignee filter", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?assigneeAgentId=null&participantAgentId=${OTHER_UUID}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({
+      assigneeAgentId: null,
+      participantAgentId: OTHER_UUID,
+    });
+  });
+});
+
+describe.sequential("GET /api/companies/:companyId/issues/count — assigneeAgentId filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.select.mockReturnValue(chainable());
+    mockIssueService.count.mockResolvedValue(0);
+  });
+
+  it("maps assigneeAgentId=null query string to a JS null filter (unassigned sentinel)", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues/count?attention=blocked&assigneeAgentId=null`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.count).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.count.mock.calls[0]?.[1]).toMatchObject({
+      attention: "blocked",
+      assigneeAgentId: null,
+    });
+  });
+
+  it("passes a valid UUID assigneeAgentId through unchanged", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues/count?attention=blocked&assigneeAgentId=${VALID_UUID}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.count.mock.calls[0]?.[1]).toMatchObject({
+      attention: "blocked",
+      assigneeAgentId: VALID_UUID,
+    });
+  });
+
+  it("rejects a non-UUID, non-sentinel assigneeAgentId with HTTP 400", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues/count?attention=blocked&assigneeAgentId=not-a-uuid`,
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "assigneeAgentId must be a UUID or 'null'" });
+    expect(mockIssueService.count).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-UUID participantAgentId with HTTP 400", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues/count?attention=blocked&participantAgentId=not-a-uuid`,
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "participantAgentId must be a UUID" });
+    expect(mockIssueService.count).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issues-list-route.test.ts
+++ b/server/src/__tests__/issues-list-route.test.ts
@@ -1,0 +1,193 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const VALID_UUID = "33333333-3333-4333-8333-333333333333";
+const OTHER_UUID = "44444444-4444-4444-8444-444444444444";
+const COMPANY_ID = "company-1";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+}));
+
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  get: vi.fn(async () => ({
+    id: "instance-settings-1",
+    general: {
+      censorUsernameInLogs: false,
+      feedbackDataSharingPreference: "prompt",
+    },
+  })),
+  listCompanyIds: vi.fn(async () => [COMPANY_ID]),
+}));
+
+function chainable(): any {
+  const handler: ProxyHandler<any> = {
+    get(_target, prop) {
+      if (prop === "then") {
+        return (resolve: (value: unknown) => unknown) => resolve([]);
+      }
+      return () => proxy;
+    },
+  };
+  const proxy: any = new Proxy(() => proxy, handler);
+  return proxy;
+}
+
+const mockDb = vi.hoisted(() => ({
+  select: vi.fn(),
+  execute: vi.fn(async () => []),
+}));
+
+vi.mock("../services/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../services/index.js")>();
+  return {
+    ...actual,
+    companyService: () => ({
+      getById: vi.fn(async () => ({ id: COMPANY_ID, attachmentMaxBytes: 10 * 1024 * 1024 })),
+    }),
+    accessService: () => mockAccessService,
+    agentService: () => ({ getById: vi.fn() }),
+    documentService: () => ({}),
+    environmentService: () => ({}),
+    executionWorkspaceService: () => ({ getById: vi.fn() }),
+    feedbackService: () => ({
+      listIssueVotesForUser: vi.fn(async () => []),
+      saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+    }),
+    goalService: () => ({ getById: vi.fn(), getDefaultCompanyGoal: vi.fn() }),
+    heartbeatService: () => mockHeartbeatService,
+    instanceSettingsService: () => mockInstanceSettingsService,
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: vi.fn(async () => undefined),
+      diffIssueReferenceSummary: vi.fn(() => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      })),
+      emptySummary: vi.fn(() => ({ outbound: [], inbound: [] })),
+      listIssueReferenceSummary: vi.fn(async () => ({ outbound: [], inbound: [] })),
+      syncComment: vi.fn(async () => undefined),
+      syncDocument: vi.fn(async () => undefined),
+      syncIssue: vi.fn(async () => undefined),
+    }),
+    issueService: () => mockIssueService,
+    logActivity: vi.fn(async () => undefined),
+    projectService: () => ({ getById: vi.fn(), listByIds: vi.fn() }),
+    routineService: () => ({ syncRunStatusForIssue: vi.fn(async () => undefined) }),
+    workProductService: () => ({ listForIssue: vi.fn(async () => []) }),
+  };
+});
+
+vi.mock("../services/execution-workspaces.js", () => ({
+  executionWorkspaceService: () => ({ getById: vi.fn() }),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: [COMPANY_ID],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes(mockDb as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe.sequential("GET /api/companies/:companyId/issues — assigneeAgentId filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDb.select.mockReturnValue(chainable());
+    mockIssueService.list.mockResolvedValue([]);
+  });
+
+  it("maps assigneeAgentId=null query string to a JS null filter (unassigned sentinel)", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?assigneeAgentId=null`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({ assigneeAgentId: null });
+  });
+
+  it("preserves the original reproducer combination (assigneeAgentId=null & status=todo)", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?assigneeAgentId=null&status=todo`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({
+      assigneeAgentId: null,
+      status: "todo",
+    });
+  });
+
+  it("passes a valid UUID through unchanged", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?assigneeAgentId=${VALID_UUID}`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({ assigneeAgentId: VALID_UUID });
+  });
+
+  it("rejects a non-UUID, non-sentinel assigneeAgentId with HTTP 400", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?assigneeAgentId=not-a-uuid`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "assigneeAgentId must be a UUID or 'null'" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("treats an absent assigneeAgentId as undefined (no filter)", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues`);
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]?.assigneeAgentId).toBeUndefined();
+  });
+
+  it("rejects a non-UUID participantAgentId with HTTP 400", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?participantAgentId=not-a-uuid`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "participantAgentId must be a UUID" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("does not treat the literal 'null' string as a sentinel for participantAgentId", async () => {
+    const res = await request(createApp()).get(`/api/companies/${COMPANY_ID}/issues?participantAgentId=null`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "participantAgentId must be a UUID" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("passes a valid participantAgentId UUID through unchanged alongside a sentinel assignee filter", async () => {
+    const res = await request(createApp()).get(
+      `/api/companies/${COMPANY_ID}/issues?assigneeAgentId=null&participantAgentId=${OTHER_UUID}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list.mock.calls[0]?.[1]).toMatchObject({
+      assigneeAgentId: null,
+      participantAgentId: OTHER_UUID,
+    });
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -497,6 +497,198 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(resultIds.has(excludedIssueId)).toBe(false);
   });
 
+  it("returns only unassigned issues when assigneeAgentId filter is null (GST-112 regression guard)", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "AssignedAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const unassignedTodoId = randomUUID();
+    const unassignedBacklogId = randomUUID();
+    const assignedTodoId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: unassignedTodoId,
+        companyId,
+        title: "Unassigned todo",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: unassignedBacklogId,
+        companyId,
+        title: "Unassigned backlog",
+        status: "backlog",
+        priority: "medium",
+      },
+      {
+        id: assignedTodoId,
+        companyId,
+        title: "Assigned todo",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    const unassignedAll = await svc.list(companyId, { assigneeAgentId: null });
+    expect(new Set(unassignedAll.map((issue) => issue.id))).toEqual(
+      new Set([unassignedTodoId, unassignedBacklogId]),
+    );
+
+    const unassignedTodos = await svc.list(companyId, { assigneeAgentId: null, status: "todo" });
+    expect(unassignedTodos.map((issue) => issue.id)).toEqual([unassignedTodoId]);
+  });
+
+  it("counts only unassigned issues when assigneeAgentId filter is null (GST-112 regression guard, count site)", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "AssignedAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values([
+      {
+        id: randomUUID(),
+        companyId,
+        title: "Unassigned todo A",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        title: "Unassigned backlog B",
+        status: "backlog",
+        priority: "medium",
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        title: "Assigned todo",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    await expect(svc.count(companyId, { assigneeAgentId: null })).resolves.toBe(2);
+    await expect(svc.count(companyId, { assigneeAgentId: null, status: "todo" })).resolves.toBe(1);
+    await expect(svc.count(companyId, { assigneeAgentId: agentId })).resolves.toBe(1);
+  });
+
+  it("filters blocked-inbox attention by null assigneeAgentId (GST-112 regression guard, blocked-inbox site)", async () => {
+    const companyId = randomUUID();
+    const ownerAgentId = randomUUID();
+    const blockerAssigneeAgentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: ownerAgentId,
+        companyId,
+        name: "OwnerAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: blockerAssigneeAgentId,
+        companyId,
+        name: "BlockerAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    const unassignedBlockedId = randomUUID();
+    const assignedBlockedId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: unassignedBlockedId,
+        companyId,
+        title: "Unassigned blocked issue",
+        status: "blocked",
+        priority: "medium",
+      },
+      {
+        id: assignedBlockedId,
+        companyId,
+        title: "Assigned blocked issue",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: ownerAgentId,
+      },
+    ]);
+
+    const unassignedBlocked = await svc.list(companyId, {
+      attention: "blocked",
+      assigneeAgentId: null,
+    });
+    expect(unassignedBlocked.map((issue) => issue.id)).toEqual([unassignedBlockedId]);
+
+    const assignedBlocked = await svc.list(companyId, {
+      attention: "blocked",
+      assigneeAgentId: ownerAgentId,
+    });
+    expect(assignedBlocked.map((issue) => issue.id)).toEqual([assignedBlockedId]);
+
+    await expect(
+      svc.count(companyId, { attention: "blocked", assigneeAgentId: null }),
+    ).resolves.toBe(1);
+    await expect(
+      svc.count(companyId, { attention: "blocked", assigneeAgentId: ownerAgentId }),
+    ).resolves.toBe(1);
+  });
+
   it("combines participation filtering with search", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -277,6 +277,67 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(resultIds.has(excludedIssueId)).toBe(false);
   });
 
+  it("returns only unassigned issues when assigneeAgentId filter is null (GST-112 regression guard)", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "AssignedAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const unassignedTodoId = randomUUID();
+    const unassignedBacklogId = randomUUID();
+    const assignedTodoId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: unassignedTodoId,
+        companyId,
+        title: "Unassigned todo",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: unassignedBacklogId,
+        companyId,
+        title: "Unassigned backlog",
+        status: "backlog",
+        priority: "medium",
+      },
+      {
+        id: assignedTodoId,
+        companyId,
+        title: "Assigned todo",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    const unassignedAll = await svc.list(companyId, { assigneeAgentId: null });
+    expect(new Set(unassignedAll.map((issue) => issue.id))).toEqual(
+      new Set([unassignedTodoId, unassignedBacklogId]),
+    );
+
+    const unassignedTodos = await svc.list(companyId, { assigneeAgentId: null, status: "todo" });
+    expect(unassignedTodos.map((issue) => issue.id)).toEqual([unassignedTodoId]);
+  });
+
   it("combines participation filtering with search", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -52,6 +52,7 @@ import {
   updateIssueSchema,
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
+  isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
   type CompanySearchQuery,
   type CompanySearchResponse,
@@ -2453,13 +2454,35 @@ export function issueRoutes(
       res.status(400).json({ error: "hasPlanDocument must be true or false when provided" });
       return;
     }
+    const assigneeAgentFilterRaw =
+      typeof req.query.assigneeAgentId === "string" ? req.query.assigneeAgentId.trim() : undefined;
+    const participantAgentFilterRaw =
+      typeof req.query.participantAgentId === "string" ? req.query.participantAgentId.trim() : undefined;
+    const assigneeAgentIdFilter =
+      assigneeAgentFilterRaw === undefined
+        ? undefined
+        : assigneeAgentFilterRaw === "null"
+          ? null
+          : assigneeAgentFilterRaw;
+    if (
+      assigneeAgentIdFilter !== undefined
+      && assigneeAgentIdFilter !== null
+      && !isUuidLike(assigneeAgentIdFilter)
+    ) {
+      res.status(400).json({ error: "assigneeAgentId must be a UUID or 'null'" });
+      return;
+    }
+    if (participantAgentFilterRaw !== undefined && !isUuidLike(participantAgentFilterRaw)) {
+      res.status(400).json({ error: "participantAgentId must be a UUID" });
+      return;
+    }
     const offset = parsedOffset ?? 0;
 
     const rawResult = await svc.list(companyId, {
       attention: attention === "blocked" ? "blocked" : undefined,
       status: req.query.status as string | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
-      participantAgentId: req.query.participantAgentId as string | undefined,
+      assigneeAgentId: assigneeAgentIdFilter,
+      participantAgentId: participantAgentFilterRaw,
       assigneeUserId,
       touchedByUserId,
       inboxArchivedByUserId,
@@ -2534,12 +2557,34 @@ export function issueRoutes(
       res.status(400).json({ error: "hasPlanDocument must be true or false when provided" });
       return;
     }
+    const countAssigneeAgentFilterRaw =
+      typeof req.query.assigneeAgentId === "string" ? req.query.assigneeAgentId.trim() : undefined;
+    const countParticipantAgentFilterRaw =
+      typeof req.query.participantAgentId === "string" ? req.query.participantAgentId.trim() : undefined;
+    const countAssigneeAgentIdFilter =
+      countAssigneeAgentFilterRaw === undefined
+        ? undefined
+        : countAssigneeAgentFilterRaw === "null"
+          ? null
+          : countAssigneeAgentFilterRaw;
+    if (
+      countAssigneeAgentIdFilter !== undefined
+      && countAssigneeAgentIdFilter !== null
+      && !isUuidLike(countAssigneeAgentIdFilter)
+    ) {
+      res.status(400).json({ error: "assigneeAgentId must be a UUID or 'null'" });
+      return;
+    }
+    if (countParticipantAgentFilterRaw !== undefined && !isUuidLike(countParticipantAgentFilterRaw)) {
+      res.status(400).json({ error: "participantAgentId must be a UUID" });
+      return;
+    }
 
     const blockedCountFilters = {
       attention: "blocked",
       status: req.query.status as string | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
-      participantAgentId: req.query.participantAgentId as string | undefined,
+      assigneeAgentId: countAssigneeAgentIdFilter,
+      participantAgentId: countParticipantAgentFilterRaw,
       assigneeUserId: req.query.assigneeUserId as string | undefined,
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -41,6 +41,7 @@ import {
   updateIssueSchema,
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
+  isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
   type CompanySearchQuery,
   type CompanySearchResponse,
@@ -1469,12 +1470,34 @@ export function issueRoutes(
       res.status(400).json({ error: "offset must be a non-negative integer" });
       return;
     }
+    const assigneeAgentFilterRaw =
+      typeof req.query.assigneeAgentId === "string" ? req.query.assigneeAgentId.trim() : undefined;
+    const participantAgentFilterRaw =
+      typeof req.query.participantAgentId === "string" ? req.query.participantAgentId.trim() : undefined;
+    const assigneeAgentIdFilter =
+      assigneeAgentFilterRaw === undefined
+        ? undefined
+        : assigneeAgentFilterRaw === "null"
+          ? null
+          : assigneeAgentFilterRaw;
+    if (
+      assigneeAgentIdFilter !== undefined
+      && assigneeAgentIdFilter !== null
+      && !isUuidLike(assigneeAgentIdFilter)
+    ) {
+      res.status(400).json({ error: "assigneeAgentId must be a UUID or 'null'" });
+      return;
+    }
+    if (participantAgentFilterRaw !== undefined && !isUuidLike(participantAgentFilterRaw)) {
+      res.status(400).json({ error: "participantAgentId must be a UUID" });
+      return;
+    }
     const offset = parsedOffset ?? 0;
 
     const result = await svc.list(companyId, {
       status: req.query.status as string | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
-      participantAgentId: req.query.participantAgentId as string | undefined,
+      assigneeAgentId: assigneeAgentIdFilter,
+      participantAgentId: participantAgentFilterRaw,
       assigneeUserId,
       touchedByUserId,
       inboxArchivedByUserId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -225,7 +225,7 @@ export function deriveIssueCommentRunLogAttribution(
 export interface IssueFilters {
   attention?: "blocked";
   status?: string;
-  assigneeAgentId?: string;
+  assigneeAgentId?: string | null;
   participantAgentId?: string;
   assigneeUserId?: string;
   touchedByUserId?: string;
@@ -2883,7 +2883,11 @@ async function blockedInboxIssueConditions(
       conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]!) : inArray(issues.status, statuses));
     }
   }
-  if (filters?.assigneeAgentId) conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
+  if (filters?.assigneeAgentId === null) {
+    conditions.push(isNull(issues.assigneeAgentId));
+  } else if (filters?.assigneeAgentId) {
+    conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
+  }
   if (filters?.participantAgentId) conditions.push(participatedByAgentCondition(companyId, filters.participantAgentId));
   if (filters?.assigneeUserId) conditions.push(eq(issues.assigneeUserId, filters.assigneeUserId));
   if (touchedByUserId) conditions.push(touchedByUserCondition(companyId, touchedByUserId));
@@ -3894,7 +3898,9 @@ export function issueService(db: Db) {
         const statuses = filters.status.split(",").map((s) => s.trim());
         conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
       }
-      if (filters?.assigneeAgentId) {
+      if (filters?.assigneeAgentId === null) {
+        conditions.push(isNull(issues.assigneeAgentId));
+      } else if (filters?.assigneeAgentId) {
         conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
       }
       if (filters?.participantAgentId) {
@@ -4078,7 +4084,11 @@ export function issueService(db: Db) {
         if (statuses.length === 1) conditions.push(eq(issues.status, statuses[0]!));
         else if (statuses.length > 1) conditions.push(inArray(issues.status, statuses));
       }
-      if (filters?.assigneeAgentId) conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
+      if (filters?.assigneeAgentId === null) {
+        conditions.push(isNull(issues.assigneeAgentId));
+      } else if (filters?.assigneeAgentId) {
+        conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
+      }
       if (filters?.assigneeUserId) conditions.push(eq(issues.assigneeUserId, filters.assigneeUserId));
       if (filters?.projectId) conditions.push(eq(issues.projectId, filters.projectId));
       if (filters?.workspaceId) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -206,7 +206,7 @@ export function deriveIssueCommentRunLogAttribution(
 
 export interface IssueFilters {
   status?: string;
-  assigneeAgentId?: string;
+  assigneeAgentId?: string | null;
   participantAgentId?: string;
   assigneeUserId?: string;
   touchedByUserId?: string;
@@ -2495,7 +2495,9 @@ export function issueService(db: Db) {
         const statuses = filters.status.split(",").map((s) => s.trim());
         conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
       }
-      if (filters?.assigneeAgentId) {
+      if (filters?.assigneeAgentId === null) {
+        conditions.push(isNull(issues.assigneeAgentId));
+      } else if (filters?.assigneeAgentId) {
         conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
       }
       if (filters?.participantAgentId) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issues service backs the public `GET /api/companies/{id}/issues` and `/issues/count` routes that agents, dispatchers, and the UI use to fetch work
> - `assigneeAgentId` was widened to `string | null` to support filtering for unassigned issues, but the route forwarded the raw query string `"null"` and the service compared it to a UUID column, so the endpoint returned 500
> - That broke the dispatcher heartbeat loop, which fetches unassigned backlog for routing, and the same null-handling bug existed at three filter sites in the service (only one had been fixed)
> - This pull request parses `?assigneeAgentId=null` as the JS `null` sentinel at both routes, validates non-sentinel values as UUID-like, and maps the sentinel to `isNull()` at all three filter sites (`list`, `count`, `blockedInboxIssueConditions`)
> - The benefit is that the unassigned-issues filter works against real Postgres, every entry point that supports it stays in agreement, and `participantAgentId` is also UUID-guarded so the same shape of bug cannot resurface there

## Linked Issues or Issue Description

Critical hotfix for [GST-112](https://github.com/paperclipai/paperclip/issues/GST-112) — `GET /api/companies/{id}/issues?assigneeAgentId=null` returned 500. This was blocking [GST-91](https://github.com/paperclipai/paperclip/issues/GST-91) (dispatcher heartbeat loop can't fetch unassigned backlog for routing).

### Root cause

- Route forwarded raw `assigneeAgentId` query string (`"null"`) to the service.
- Service used `eq(issues.assigneeAgentId, "null")` which Postgres rejected for a UUID column → 500.
- The fix was applied to one of three filter sites; the `count` and `blockedInboxIssueConditions` sites still fell through their truthy-checks and silently ignored the `null` sentinel, so:
  - `GET /api/companies/:id/issues?attention=blocked&assigneeAgentId=null` returned every blocked issue, regardless of assignment.
  - `GET /api/companies/:id/issues/count?attention=blocked&assigneeAgentId=null` counted every blocked issue.

## What Changed

- **Route (`server/src/routes/issues.ts`)**
  - `/issues` and `/issues/count`: parse `?assigneeAgentId=null` literal as the JS `null` sentinel.
  - Validate non-sentinel `assigneeAgentId` values as UUID-like (`isUuidLike`); reject otherwise with HTTP 400 instead of leaking the raw string into the SQL builder.
  - Validate `participantAgentId` as UUID-like (no `null` sentinel for that param).
- **Service (`server/src/services/issues.ts`)**
  - Handle `filters.assigneeAgentId === null` at all three filter sites (`list`, `count`, `blockedInboxIssueConditions`) by emitting `isNull(issues.assigneeAgentId)` via drizzle instead of `eq()`.
  - `IssueFilters.assigneeAgentId` type widened to `string | null`.
- **Tests**
  - `server/src/__tests__/issues-list-route.test.ts` (8 new cases): contract tests covering `=null`, `=null&status=todo` (the original 500 reproducer), valid UUID, non-UUID rejection, and `participantAgentId` rejection across `/issues` and `/issues/count`.
  - `server/src/__tests__/issues-service.test.ts` (+ regression guards): real-Postgres tests lock in `IS NULL` filtering against the real schema for the `list`, `count`, and blocked-inbox-attention sites.
  - `server/src/__tests__/issues-goal-context-routes.test.ts`: existing test plumbing updated.

## Verification

- `cd server && pnpm exec tsc --noEmit` → exit 0.
- `pnpm exec vitest run src/__tests__/issues-list-route.test.ts src/__tests__/issues-goal-context-routes.test.ts` → all pass.
- `pnpm exec vitest run src/__tests__/issues-service.test.ts` → all pass (real Postgres).

## Risks

Low. Change is scoped to filter-validation and SQL-predicate construction for one filterable column on the issues service. The new tests pin the `IS NULL` predicate and the route-level UUID/`null` validation against the real schema, and the same parsing is applied symmetrically across `/issues` and `/issues/count`. Known caveats (tracked separately):

- Sibling agent-ID query params (`creatorAgentId`, `assigneeUserId`, etc.) aren't UUID-validated yet — could 500 the same way.
- The `null` sentinel is case-sensitive (`NULL` would not be parsed as the sentinel). Acceptable for the internal API.

## Model Used

Claude Opus 4.7 (`claude-opus-4-7`) — extended-thinking, tool use, full repo read/write.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (n/a — server-only)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (in-flight)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (in-flight)
- [x] I will address all Greptile and reviewer comments before requesting merge

### Branch lineage

These 3 commits originally lived on `gst-36-standing-channel-v1` (PR #5888) but that PR was blocked on unrelated GST-36 review issues. Cherry-picked onto a clean branch off master so the critical fix can land independently. Rebased on current `master` and squashed for clean merge.

### Cross-references and status (maintainer)

- Rebased on current `master`; resolved CONFLICTING state.
- Extended the `IS NULL` filter handling to all three filter sites in `services/issues.ts` (`list`, `count`, `blockedInboxIssueConditions`). The original fix covered only the `list` site, so an `?attention=blocked&assigneeAgentId=null` query against `/issues` or `/issues/count` still returned every blocked issue regardless of assignment.
- Added matching regression tests in `issues-service.test.ts` (real Postgres) for the `count` and blocked-inbox-attention sites, mirroring the existing `list`-site guard.
- Extended the route-level `null` sentinel + UUID validation already present on `/issues` to the `/issues/count` endpoint, with contract tests in `issues-list-route.test.ts`.
- No duplicate open PRs were found describing the same `assigneeAgentId=null` bug.
