### PR TITLE
fix(server): unwrap DrizzleQueryError so issue-prefix retry actually runs

### DIFF
--- a/server/src/__tests__/companies-unique-prefix-retry.test.ts
+++ b/server/src/__tests__/companies-unique-prefix-retry.test.ts
@@ -1,0 +1,132 @@
+import { DrizzleQueryError } from "drizzle-orm/errors";
+import { describe, expect, it, vi } from "vitest";
+import { companyService } from "../services/companies.ts";
+
+vi.mock("../services/environments.js", () => ({
+  environmentService: () => ({
+    ensureLocalEnvironment: vi.fn(async () => ({ id: "env-stub" })),
+  }),
+}));
+
+type StoredCompany = {
+  id: string;
+  name: string;
+  issuePrefix: string;
+};
+
+// JOE-58 regression. Drizzle wraps the underlying PostgresError in a
+// DrizzleQueryError, so the previous `isIssuePrefixConflict` check (which only
+// inspected the top-level `code`) never matched and the retry loop never ran.
+// This test fakes an insert that throws a wrapped 23505 the first time and
+// succeeds with a suffixed prefix the second time.
+function makeIssuePrefixConflictError() {
+  // Shape mirrors `postgres` driver errors. The fields are read by
+  // `isIssuePrefixConflict` only as strings, so we don't need to import the
+  // real PostgresError class.
+  const cause = Object.assign(new Error("duplicate key value violates unique constraint"), {
+    code: "23505",
+    constraint: "companies_issue_prefix_idx",
+    constraint_name: "companies_issue_prefix_idx",
+  });
+  return new DrizzleQueryError("insert into companies", [], cause);
+}
+
+function createDbStub(existing: StoredCompany[]) {
+  const stored: StoredCompany[] = [...existing];
+  const attemptedPrefixes: string[] = [];
+
+  const insertValues = vi.fn(({ issuePrefix, name }: { issuePrefix: string; name: string }) => {
+    attemptedPrefixes.push(issuePrefix);
+    const collides = stored.some((row) => row.issuePrefix === issuePrefix);
+    return {
+      returning: vi.fn(async () => {
+        if (collides) {
+          throw makeIssuePrefixConflictError();
+        }
+        const row: StoredCompany = {
+          id: `company-${stored.length + 1}`,
+          name,
+          issuePrefix,
+        };
+        stored.push(row);
+        return [row];
+      }),
+    };
+  });
+
+  const insert = vi.fn(() => ({ values: insertValues }));
+
+  // The public `create()` calls `getCompanyQuery(db).where(...).then((rows) => rows[0])`
+  // after the successful insert. Return the most recently inserted row so the
+  // call chain resolves to a non-null company.
+  const selectChain = {
+    from: vi.fn(() => selectChain),
+    leftJoin: vi.fn(() => selectChain),
+    where: vi.fn(() => selectChain),
+    groupBy: vi.fn(() => selectChain),
+    then: vi.fn((resolve: (value: unknown[]) => unknown) => {
+      const last = stored[stored.length - 1];
+      const row = last
+        ? {
+            ...last,
+            description: null,
+            status: "active",
+            issueCounter: 1,
+            budgetMonthlyCents: 0,
+            spentMonthlyCents: 0,
+            attachmentMaxBytes: null,
+            requireBoardApprovalForNewAgents: false,
+            feedbackDataSharingEnabled: false,
+            feedbackDataSharingConsentAt: null,
+            feedbackDataSharingConsentByUserId: null,
+            feedbackDataSharingTermsVersion: null,
+            brandColor: null,
+            logoAssetId: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          }
+        : null;
+      return Promise.resolve(resolve(row ? [row] : []));
+    }),
+  };
+
+  const select = vi.fn(() => selectChain);
+
+  return {
+    db: { insert, select } as any,
+    attemptedPrefixes,
+    stored,
+  };
+}
+
+describe("createCompanyWithUniquePrefix retry on issue-prefix conflict", () => {
+  it("retries with a suffixed prefix when the first attempt hits a Drizzle-wrapped 23505", async () => {
+    const { db, attemptedPrefixes, stored } = createDbStub([
+      { id: "company-pre-existing", name: "Demo Co", issuePrefix: "DEM" },
+    ]);
+
+    const companies = companyService(db);
+    const created = await companies.create({ name: "Demo Co" } as any);
+
+    expect(attemptedPrefixes).toEqual(["DEM", "DEMA"]);
+    expect(created.issuePrefix).toBe("DEMA");
+    expect(stored.map((row) => row.issuePrefix)).toEqual(["DEM", "DEMA"]);
+  });
+
+  it("propagates non-prefix-conflict errors instead of retrying", async () => {
+    const { db, attemptedPrefixes } = createDbStub([]);
+    const unrelated = Object.assign(new Error("connection refused"), { code: "ECONNREFUSED" });
+    const wrapped = new DrizzleQueryError("insert into companies", [], unrelated);
+    (db.insert as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      values: vi.fn(() => ({
+        returning: vi.fn(async () => {
+          throw wrapped;
+        }),
+      })),
+    });
+
+    const companies = companyService(db);
+    await expect(companies.create({ name: "Demo Co" } as any)).rejects.toBe(wrapped);
+    expect(attemptedPrefixes).toEqual([]);
+  });
+});

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -124,17 +124,35 @@ export function companyService(db: Db) {
     return "A".repeat(attempt - 1);
   }
 
+  // Drizzle wraps driver errors in `DrizzleQueryError` whose `cause` holds the
+  // underlying `PostgresError`. The `node-postgres` and `postgres` drivers also
+  // chain through `error.original` in some versions. Walk both links so a
+  // 23505 collision is detected regardless of wrapping depth.
+  function unwrapDbError(error: unknown): unknown[] {
+    const chain: unknown[] = [];
+    const seen = new Set<unknown>();
+    let current: unknown = error;
+    while (current && typeof current === "object" && !seen.has(current)) {
+      seen.add(current);
+      chain.push(current);
+      const next = (current as { cause?: unknown; original?: unknown }).cause
+        ?? (current as { cause?: unknown; original?: unknown }).original;
+      current = next;
+    }
+    return chain;
+  }
+
   function isIssuePrefixConflict(error: unknown) {
-    const constraint = typeof error === "object" && error !== null && "constraint" in error
-      ? (error as { constraint?: string }).constraint
-      : typeof error === "object" && error !== null && "constraint_name" in error
-        ? (error as { constraint_name?: string }).constraint_name
-        : undefined;
-    return typeof error === "object"
-      && error !== null
-      && "code" in error
-      && (error as { code?: string }).code === "23505"
-      && constraint === "companies_issue_prefix_idx";
+    for (const layer of unwrapDbError(error)) {
+      if (typeof layer !== "object" || layer === null) continue;
+      const code = (layer as { code?: string }).code;
+      if (code !== "23505") continue;
+      const constraint =
+        (layer as { constraint?: string }).constraint
+        ?? (layer as { constraint_name?: string }).constraint_name;
+      if (constraint === "companies_issue_prefix_idx") return true;
+    }
+    return false;
   }
 
   async function createCompanyWithUniquePrefix(data: typeof companies.$inferInsert) {


### PR DESCRIPTION
## Summary

`createCompanyWithUniquePrefix` was supposed to retry with a suffixed prefix
on unique-constraint collisions, but Drizzle wraps the driver's PostgresError
in a `DrizzleQueryError`. The previous `isIssuePrefixConflict` check only
inspected the top-level error, so the `code === \"23505\"` test never matched
and the retry loop never ran. Any `POST /api/companies` whose desired prefix
collided with an existing company returned 500 instead of silently retrying.

Surfaced while provisioning a demo company on a Joe-prefixed local instance
— the operator had no way to recover other than picking a different name
up front, and the prefix couldn't be changed post-create.

## Changes

- `server/src/services/companies.ts`: introduce `unwrapDbError` that walks
  both `error.cause` and `error.original` (with a cycle guard) and update
  `isIssuePrefixConflict` to scan every layer for \`code === \"23505\"\` and
  \`constraint === \"companies_issue_prefix_idx\"\`.
- `server/src/__tests__/companies-unique-prefix-retry.test.ts`: regression
  test using a real \`DrizzleQueryError\` wrapping a PostgresError-shaped
  cause. Verified the test fails on the old \`isIssuePrefixConflict\` and
  passes after the fix. Also covers the negative path so unrelated errors
  still propagate.

## Test plan

- [x] \`pnpm --filter @paperclipai/server exec vitest run src/__tests__/companies-unique-prefix-retry.test.ts\`
- [x] Adjacent: \`monthly-spend-service.test.ts\`, \`companies-route-path-guard.test.ts\` still pass
- [x] Verified regression test fails on master (stashed the service fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)