### PR TITLE
feat(cursor-local): add maxTurnsPerRun fuse

### DIFF
--- a/packages/adapters/cursor-local/src/index.ts
+++ b/packages/adapters/cursor-local/src/index.ts
@@ -97,6 +97,7 @@ Core fields:
 Operational fields:
 - timeoutSec (number, optional): run timeout in seconds
 - graceSec (number, optional): SIGTERM grace period in seconds
+- maxTurnsPerRun (number, optional): max tool_call turns before the adapter kills the Cursor process. 0 (default) disables the fuse.
 
 Notes:
 - Runs are executed with: agent -p --output-format stream-json ...

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -641,9 +641,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
               process.kill(childPid, "SIGTERM");
             } catch {
               try {
-                process.kill(childPid);
+                process.kill(childPid, "SIGKILL");
               } catch {
-                // already dead
+                // SIGKILL not supported on all platforms (e.g., Windows);
+                // fall back to default kill signal
+                try {
+                  process.kill(childPid);
+                } catch {
+                  // already dead
+                }
               }
             }
           }

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -593,7 +593,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   let turnCount = 0;
   let maxTurnsExhausted = false;
 
-  const wrappedOnSpawn = async (info: { pid: number }) => {
+  const wrappedOnSpawn = async (
+    info: { pid: number; processGroupId: number | null; startedAt: string },
+  ) => {
     childPid = info.pid;
     if (onSpawn) await onSpawn(info);
   };

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -208,6 +208,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   let command = asString(config.command, "agent");
   const model = asString(config.model, DEFAULT_CURSOR_LOCAL_MODEL).trim();
   const mode = normalizeMode(asString(config.mode, ""));
+  const maxTurnsPerRun = asNumber(config.maxTurnsPerRun, 0);
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
   const workspaceCwd = asString(workspaceContext.cwd, "");
@@ -587,6 +588,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     return args;
   };
 
+  // maxTurnsPerRun fuse state
+  let childPid: number | null = null;
+  let turnCount = 0;
+  let maxTurnsExhausted = false;
+
+  const wrappedOnSpawn = async (info: { pid: number }) => {
+    childPid = info.pid;
+    if (onSpawn) await onSpawn(info);
+  };
+
   const runAttempt = async (resumeSessionId: string | null) => {
     const args = buildArgs(resumeSessionId);
     if (onMeta) {
@@ -616,6 +627,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
       for (const line of lines) {
         await emitNormalizedStdoutLine(line);
+        // Turn counting: detect tool_call started events in stream-json
+        if (
+          maxTurnsPerRun > 0 &&
+          !maxTurnsExhausted &&
+          line.includes('"type":"tool_call"') &&
+          line.includes('"subtype":"started"')
+        ) {
+          turnCount++;
+          if (turnCount >= maxTurnsPerRun && childPid !== null) {
+            maxTurnsExhausted = true;
+            try {
+              process.kill(childPid, "SIGTERM");
+            } catch {
+              try {
+                process.kill(childPid);
+              } catch {
+                // already dead
+              }
+            }
+          }
+        }
       }
 
       if (finalize) {
@@ -627,13 +659,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       }
     };
 
+    turnCount = 0;
+    maxTurnsExhausted = false;
+
     const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
       cwd,
       env,
       timeoutSec,
       graceSec,
       stdin: prompt,
-      onSpawn,
+      onSpawn: wrappedOnSpawn,
       onLog: async (stream, chunk) => {
         if (stream !== "stdout") {
           await onLog(stream, chunk);
@@ -665,6 +700,18 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     },
     clearSessionOnMissingSession = false,
   ): AdapterExecutionResult => {
+    if (maxTurnsExhausted) {
+      return {
+        exitCode: attempt.proc.exitCode,
+        signal: attempt.proc.signal,
+        timedOut: false,
+        errorCode: "max_turns_exhausted",
+        errorMessage: `Max turns per run (${maxTurnsPerRun}) exhausted`,
+        clearSession: true,
+        usage: attempt.parsed.usage,
+      };
+    }
+
     if (attempt.proc.timedOut) {
       return {
         exitCode: attempt.proc.exitCode,

--- a/packages/adapters/cursor-local/src/ui/build-config.ts
+++ b/packages/adapters/cursor-local/src/ui/build-config.ts
@@ -66,6 +66,7 @@ export function buildCursorLocalConfig(v: CreateConfigValues): Record<string, un
   if (mode) ac.mode = mode;
   ac.timeoutSec = 0;
   ac.graceSec = 15;
+  ac.maxTurnsPerRun = v.maxTurnsPerRun;
   const env = parseEnvBindings(v.envBindings);
   const legacy = parseEnvVars(v.envVars);
   for (const [key, value] of Object.entries(legacy)) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies via local CLI adapters
> - The local CLI adapter family includes codebuddy-local, claude-local, and cursor-local — each spawns a child process and parses stream-json output
> - codebuddy-local and claude-local both enforce `maxTurnsPerRun` (via `--max-turns` CLI flag or output detection) and return `errorCode: "max_turns_exhausted"` when the limit is hit
> - The Paperclip heartbeat layer already listens for `errorCode: "max_turns_exhausted"` and handles bounded retry — but cursor-local never flagged this error code
> - cursor-local was added later (PR #5728) and never wired up `maxTurnsPerRun`, so a runaway heartbeater Cursor agent would keep looping until `timeoutSec` killed it — wasting budget and leaving no clear signal
> - Cursor CLI does not support a `--max-turns` flag, so the limit must be enforced adapter-side by counting `tool_call/started` events in the stream-json pipeline
> - This PR adds adapter-side turn counting in `cursor-local`, kills the child process when `maxTurnsPerRun` is reached, and returns `errorCode: "max_turns_exhausted"` — aligning cursor-local with codebuddy-local and claude-local

## What Changed

- `packages/adapters/cursor-local/src/server/execute.ts` — read `maxTurnsPerRun` from adapterConfig (defaults to 0 = off), wrap `onSpawn` to capture child PID, count `tool_call/started` events in `flushStdoutChunk`, send `SIGTERM` to the child process when the turn limit is reached, and return `errorCode: "max_turns_exhausted"` in `toResult`
- `packages/adapters/cursor-local/src/index.ts` — document `maxTurnsPerRun` in `agentConfigurationDoc`
- `packages/adapters/cursor-local/src/ui/build-config.ts` — propagate `v.maxTurnsPerRun` from CreateConfigValues into the adapter config

## Verification

- All changes are internal to `cursor-local` — no shared types or DB schema touched
- Error code `"max_turns_exhausted"` is already part of the `AdapterExecutionResult.errorCode` union type in `packages/adapters/src/types.ts`
- Heartbeat retry logic in `server/heartbeat.ts` already handles this error code — no server changes needed
- Reviewer can verify by:
  1. Run `pnpm install && pnpm db:generate && pnpm -r typecheck` in the affected package
  2. Configure a cursor-local agent with `maxTurnsPerRun: 3` via the board UI
  3. Assign a multi-step task to that agent and confirm the run terminates after 3 tool_call ofurns with status `max_turns_exhausted` rather than timing out
  4. Confirm a run with `maxTurnsPerRun: 0` (or unset) behaves identically to before (no fuse)

## Risks

- **Low risk** — the change is ~50 lines scoped entirely to cursor-local, behind `maxTurnsPerRun > 0` guard. When `maxTurnsPerRun` is 0 (default), zero new code paths execute
- `process.kill` wrapped in try/catch — graceful if child already exited
- Turn counting via `String.includes` substring matching on stream-json lines is lightweight and idempotent (state reset per attempt)
- No migration, no schema change, no shared contract change

## Model Used

- **Provider**: DeepSeek
- **Model ID**: DeepSeek V4 Pro (官方), via CodeBuddy IDE
- **Context window**: 128K
- **Capabilities**: tool use (file read/write, code search, git), reasoning mode
