### PR TITLE
fix(adapter-codex-local): add gpt-5.5 to model list (PLU-461)

### DIFF
--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -33,6 +33,7 @@ export function isCodexLocalFastModeSupported(model: string | null | undefined):
 }
 
 export const models = [
+  { id: "gpt-5.5", label: "gpt-5.5" },
   { id: "gpt-5.4", label: "gpt-5.4" },
   { id: DEFAULT_CODEX_LOCAL_MODEL, label: DEFAULT_CODEX_LOCAL_MODEL },
   { id: "gpt-5.3-codex-spark", label: "gpt-5.3-codex-spark" },

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -7,7 +7,7 @@ export const SANDBOX_INSTALL_COMMAND = "npm install -g @openai/codex";
 
 export const DEFAULT_CODEX_LOCAL_MODEL = "gpt-5.3-codex";
 export const DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX = true;
-export const CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS = ["gpt-5.4"] as const;
+export const CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS = ["gpt-5.4", "gpt-5.5"] as const;
 
 function normalizeModelId(model: string | null | undefined): string {
   return typeof model === "string" ? model.trim() : "";
@@ -70,7 +70,7 @@ Core fields:
 - modelReasoningEffort (string, optional): reasoning effort override (minimal|low|medium|high|xhigh) passed via -c model_reasoning_effort=...
 - promptTemplate (string, optional): run prompt template
 - search (boolean, optional): run codex with --search
-- fastMode (boolean, optional): enable Codex Fast mode; supported on GPT-5.4 and passed through for manual model IDs
+- fastMode (boolean, optional): enable Codex Fast mode; supported on GPT-5.4 and GPT-5.5 and passed through for manual model IDs
 - dangerouslyBypassApprovalsAndSandbox (boolean, optional): run with bypass flag
 - command (string, optional): defaults to "codex"
 - extraArgs (string[], optional): additional CLI args

--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -26,6 +26,28 @@ describe("buildCodexExecArgs", () => {
     ]);
   });
 
+  it("enables Codex fast mode overrides for GPT-5.5", () => {
+    const result = buildCodexExecArgs({
+      model: "gpt-5.5",
+      fastMode: true,
+    });
+
+    expect(result.fastModeRequested).toBe(true);
+    expect(result.fastModeApplied).toBe(true);
+    expect(result.fastModeIgnoredReason).toBeNull();
+    expect(result.args).toEqual([
+      "exec",
+      "--json",
+      "--model",
+      "gpt-5.5",
+      "-c",
+      'service_tier="fast"',
+      "-c",
+      "features.fast_mode=true",
+      "-",
+    ]);
+  });
+
   it("enables Codex fast mode overrides for manual models", () => {
     const result = buildCodexExecArgs({
       model: "manual-test-model",
@@ -57,7 +79,7 @@ describe("buildCodexExecArgs", () => {
     expect(result.fastModeRequested).toBe(true);
     expect(result.fastModeApplied).toBe(false);
     expect(result.fastModeIgnoredReason).toContain(
-      "currently only supported on gpt-5.4 or manually configured model IDs",
+      "currently only supported on gpt-5.4, gpt-5.5 or manually configured model IDs",
     );
     expect(result.args).toEqual([
       "exec",

--- a/packages/adapters/codex-local/src/server/codex-args.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-args.test.ts
@@ -28,7 +28,7 @@ describe("buildCodexExecArgs", () => {
 
   it("enables Codex fast mode overrides for manual models", () => {
     const result = buildCodexExecArgs({
-      model: "gpt-5.5",
+      model: "manual-test-model",
       fastMode: true,
     });
 
@@ -39,7 +39,7 @@ describe("buildCodexExecArgs", () => {
       "exec",
       "--json",
       "--model",
-      "gpt-5.5",
+      "manual-test-model",
       "-c",
       'service_tier="fast"',
       "-c",


### PR DESCRIPTION
## Thinking Path

PLU-461 reported that `gpt-5.5` was usable via the Codex CLI (`-m gpt-5.5`) but was missing from the Paperclip model picker for the `codex_local` adapter, blocking PLU-460 work. The static `models` array in `packages/adapters/codex-local/src/index.ts` is the source of truth for that picker, so the fix is to add `gpt-5.5` there.

Greptile's automated review then caught a hidden regression: once `gpt-5.5` becomes a *known* model, `isCodexLocalManualModel` returns `false` for it, so the manual-model fast-mode fallback stops applying. The model would silently lose Fast mode availability that it had before this PR (via the manual-model path). To preserve that behavior, `gpt-5.5` is also added to `CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS`.

## What Changed

- `packages/adapters/codex-local/src/index.ts`
  - Add `{ id: "gpt-5.5", label: "gpt-5.5" }` at the top of the exported `models` array.
  - Extend `CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS` from `["gpt-5.4"]` to `["gpt-5.4", "gpt-5.5"]`.
  - Update `agentConfigurationDoc` to mention GPT-5.4 and GPT-5.5 for `fastMode`.
- `packages/adapters/codex-local/src/server/codex-args.test.ts`
  - Add a vitest case asserting `gpt-5.5 + fastMode` yields `fastModeApplied=true` with the `service_tier="fast"` / `features.fast_mode=true` overrides.
  - Switch the existing manual-model case from `gpt-5.5` to `manual-test-model` so the manual path keeps coverage independent of registered IDs.
  - Update the unsupported-model expectation to match the new `fastModeIgnoredReason` string (`"gpt-5.4, gpt-5.5 or manually configured model IDs"`).

## Verification

- `pnpm --filter @paperclipai/adapter-codex-local exec vitest run src/server/codex-args.test.ts` — 5/5 pass locally on this branch (covers GPT-5.4, GPT-5.5, manual-model, unsupported-model, and `--skip-git-repo-check` cases).
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-models.test.ts` — 9 pass on the original commit.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-registry.test.ts` — 18 pass on the original commit.
- `pnpm --filter @paperclipai/adapter-codex-local build` — clean.
- PR CI (`verify`, `Verify serialized server suites 1-4/4`, `Canary Dry Run`, `e2e`, `policy`, `security/snyk`) was green on `a6c48b68`; the fast-mode commit only edits the same package, awaiting the new run.

## Risks

- Low. The only behavioral change is making `gpt-5.5` selectable in the picker and preserving its existing Fast mode availability. No other model's behavior moves. No persisted data, schema, or wire format changes. If `gpt-5.5` is ever withdrawn upstream, the picker entry becomes a no-op until the array is edited.

## Model Used

- Provider: Anthropic
- Model: `claude-opus-4-7` (Opus 4.7)
- Surface: Claude Code via Paperclip CTO heartbeat

## Checklist

- [x] Bug fix / config — no R&D pipeline required (per PLU-469).
- [x] No new public API surface.
- [x] Tests added for the new fast-mode path and adjusted for the renamed manual case.
- [x] Adapter doc string (`agentConfigurationDoc`) updated to match the new supported list.
- [x] No migration / data backfill.

Refs: PLU-461 / PLU-460 / PLU-469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
