### PR TITLE
Allow agent evidence comments on open issues

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -364,7 +364,6 @@ describe("agent issue mutation checkout ownership", () => {
   it.each([
     ["patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked" })],
     ["delete", (app: express.Express) => request(app).delete(`/api/issues/${issueId}`)],
-    ["comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "blocked" })],
     [
       "document upsert",
       (app: express.Express) =>
@@ -391,6 +390,30 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockWorkProductService.update).not.toHaveBeenCalled();
     expect(mockStorageService.putFile).not.toHaveBeenCalled();
     expect(mockStorageService.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it("allows peer agent comments on another agent's open active checkout", async () => {
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Ops evidence: remote log cursor is stranded behind maxBuffer." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Ops evidence: remote log cursor is stranded behind maxBuffer.",
+      {
+        agentId: peerAgentId,
+        userId: undefined,
+        runId: "66666666-6666-4666-8666-666666666666",
+      },
+      {
+        authorType: "agent",
+        presentation: null,
+        metadata: null,
+      },
+    );
   });
 
   it("allows the checked-out owner with the matching run id to patch and update documents", async () => {
@@ -445,12 +468,54 @@ describe("agent issue mutation checkout ownership", () => {
 
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
-    ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],
     ["blocked", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Blocked update" })],
   ])("rejects peer agent %s issue %s mutations outside active checkout ownership", async (status, _kind, sendRequest) => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ status: status as "todo" | "blocked", assigneeAgentId: ownerAgentId }));
 
     const res = await sendRequest(await createApp(peerActor()));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it.each(["todo", "blocked", "in_review"] as const)(
+    "allows peer agent comments on another agent's open %s issue outside active checkout ownership",
+    async (status) => {
+      mockIssueService.getById.mockResolvedValue(makeIssue({ status, assigneeAgentId: ownerAgentId }));
+
+      const res = await request(await createApp(peerActor()))
+        .post(`/api/issues/${issueId}/comments`)
+        .send({ body: `${status} evidence handoff` });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(201);
+      expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+      expect(mockIssueService.addComment).toHaveBeenCalledWith(
+        issueId,
+        `${status} evidence handoff`,
+        {
+          agentId: peerAgentId,
+          userId: undefined,
+          runId: "66666666-6666-4666-8666-666666666666",
+        },
+        {
+          authorType: "agent",
+          presentation: null,
+          metadata: null,
+        },
+      );
+    },
+  );
+
+  it("rejects peer agent comments that request issue state mutation", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }));
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "resume this", resume: true });
 
     expect(res.status, JSON.stringify(res.body)).toBe(403);
     expect(res.body.error).toBe("Agent cannot mutate another agent's issue");

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1141,6 +1141,47 @@ export function issueRoutes(
     return true;
   }
 
+  async function assertAgentIssueCommentAllowed(
+    req: Request,
+    res: Response,
+    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    options: { requiresMutationOwnership: boolean },
+  ) {
+    if (options.requiresMutationOwnership || req.actor.type !== "agent") {
+      return assertAgentIssueMutationAllowed(req, res, issue);
+    }
+
+    const actorAgentId = req.actor.agentId;
+    if (!actorAgentId) {
+      res.status(403).json({ error: "Agent authentication required" });
+      return false;
+    }
+
+    if (issue.assigneeAgentId === null || issue.assigneeAgentId === actorAgentId) {
+      return assertAgentIssueMutationAllowed(req, res, issue);
+    }
+
+    if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
+      return true;
+    }
+
+    if (isClosedIssueStatus(issue.status)) {
+      res.status(403).json({
+        error: "Agent cannot mutate another agent's issue",
+        details: {
+          issueId: issue.id,
+          assigneeAgentId: issue.assigneeAgentId,
+          actorAgentId,
+          status: issue.status,
+          securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+        },
+      });
+      return false;
+    }
+
+    return true;
+  }
+
   function assertStructuredCommentFieldsAllowed(
     req: Request,
     res: Response,
@@ -4326,7 +4367,9 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    if (!(await assertAgentIssueCommentAllowed(req, res, issue, {
+      requiresMutationOwnership: req.body.reopen === true || req.body.resume === true,
+    }))) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Issue comments are the control-plane handoff surface for evidence, corrections, and cross-agent coordination.
> - Checkout ownership correctly protects task mutations such as status changes, document edits, attachments, and deletes.
> - The same ownership gate also rejected plain comments from same-company peer agents, which blocked monitoring agents from attaching verified evidence to an already-routed incident.
> - This pull request separates communicative comments from task-state mutations for open issues.
> - The benefit is that evidence can reach the active assignee without letting peer agents resume, reopen, or otherwise mutate another agent's issue.

## What Changed

- Added a comment-specific permission check for `POST /api/issues/:id/comments`.
- Allows same-company peer agents to add plain comments to open assigned issues.
- Keeps explicit `reopen` / `resume` comment requests behind the existing mutation ownership gate.
- Preserves the existing closed-issue restriction for non-assignee agent comments.
- Updated ownership route tests for allowed evidence comments and denied peer state mutation requests.

## Verification

- `pnpm vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
- `pnpm vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts`

## Risks

- Low to moderate behavior change: same-company agents can now add comments to open issues assigned to other agents.
- Mutation paths remain protected: peer agents still cannot patch status, edit docs, upload/delete attachments, or resume/reopen another agent's issue through comments.
- Closed issues remain protected from non-assignee agent comments, preserving the prior inert-comment guard.

## Model Used

- OpenAI Codex, GPT-5-based coding agent, tool-enabled local repository editing and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
