### PR TITLE
fix(activity): honor ?since= filter on GET /companies/:id/activity (#5893)

### DIFF
--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -67,4 +67,39 @@ describe("activity routes", () => {
     expect(mockActivityService.runsForIssue).toHaveBeenCalledWith("company-1", "issue-uuid-1");
     expect(res.body).toEqual([{ runId: "run-1" }]);
   });
+
+  it("forwards a valid ?since= ISO timestamp to the service as a Date", async () => {
+    mockActivityService.list.mockResolvedValue([]);
+
+    const res = await request(createApp())
+      .get("/api/companies/company-1/activity?since=2026-05-12T17:00:00Z");
+
+    expect(res.status).toBe(200);
+    expect(mockActivityService.list).toHaveBeenCalledTimes(1);
+    const filters = mockActivityService.list.mock.calls[0][0];
+    expect(filters.companyId).toBe("company-1");
+    expect(filters.since).toBeInstanceOf(Date);
+    expect(filters.since.toISOString()).toBe("2026-05-12T17:00:00.000Z");
+  });
+
+  it("returns 400 when ?since= is not a parseable timestamp", async () => {
+    const res = await request(createApp())
+      .get("/api/companies/company-1/activity?since=not-a-date");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/since/i);
+    expect(mockActivityService.list).not.toHaveBeenCalled();
+  });
+
+  it("omits since from filters when ?since= is missing or empty", async () => {
+    mockActivityService.list.mockResolvedValue([]);
+
+    const r1 = await request(createApp()).get("/api/companies/company-1/activity");
+    expect(r1.status).toBe(200);
+    expect(mockActivityService.list.mock.calls[0][0].since).toBeUndefined();
+
+    const r2 = await request(createApp()).get("/api/companies/company-1/activity?since=");
+    expect(r2.status).toBe(200);
+    expect(mockActivityService.list.mock.calls[1][0].since).toBeUndefined();
+  });
 });

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -33,11 +33,22 @@ export function activityRoutes(db: Db) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
 
+    let since: Date | undefined;
+    if (typeof req.query.since === "string" && req.query.since.length > 0) {
+      const parsed = new Date(req.query.since);
+      if (Number.isNaN(parsed.getTime())) {
+        res.status(400).json({ error: "Invalid `since` parameter — expected ISO 8601 timestamp" });
+        return;
+      }
+      since = parsed;
+    }
+
     const filters = {
       companyId,
       agentId: req.query.agentId as string | undefined,
       entityType: req.query.entityType as string | undefined,
       entityId: req.query.entityId as string | undefined,
+      since,
     };
     const result = await svc.list(filters);
     res.json(result);

--- a/server/src/services/activity.ts
+++ b/server/src/services/activity.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, isNull, or, sql } from "drizzle-orm";
+import { and, desc, eq, gt, isNull, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { activityLog, heartbeatRuns, issues } from "@paperclipai/db";
 
@@ -7,6 +7,8 @@ export interface ActivityFilters {
   agentId?: string;
   entityType?: string;
   entityId?: string;
+  /** Only return events created strictly after this timestamp. */
+  since?: Date;
 }
 
 export function activityService(db: Db) {
@@ -23,6 +25,9 @@ export function activityService(db: Db) {
       }
       if (filters.entityId) {
         conditions.push(eq(activityLog.entityId, filters.entityId));
+      }
+      if (filters.since) {
+        conditions.push(gt(activityLog.createdAt, filters.since));
       }
 
       return db


### PR DESCRIPTION
Fixes #5893.

`GET /api/companies/{companyId}/activity` previously dropped the documented `?since=<ISO timestamp>` query parameter on the floor — every call returned the full activity history, regardless of `since`. This breaks any client trying to use `since` as an incremental polling cursor.

## Verification (before the patch)

Against the deployed v0.3.1 build:

| `?since=` value | Returned events |
|---|---|
| (omitted) | 351 |
| now | 351 |
| 1 hour ago | 351 |
| 12 hours ago | 351 |
| **tomorrow** | **351** |

## Root cause

`server/src/routes/activity.ts` reads `agentId / entityType / entityId` from `req.query` but not `since`. `services/activity.ts#list()` has no `since` field on its filter interface either.

## Fix

- **Route**: parse `?since=` as ISO 8601 via `new Date(...)`, return `400 invalid request` on unparseable input, forward a `Date` to the service.
- **Service**: extend `ActivityFilters` with an optional `since: Date`. Push a `gt(activityLog.createdAt, since)` predicate when present.
- **Performance**: the existing `activity_log_company_created_idx` covers `(company_id, created_at)`, so the predicate uses the index — no extra cost for callers who don't pass `since`.

## Tests

Three new vitest cases in `server/src/__tests__/activity-routes.test.ts`:

1. Valid ISO timestamp → forwarded to service as a `Date`
2. Unparseable value (`?since=not-a-date`) → 400, service not called
3. Missing / empty `?since=` → omitted from filter (preserves prior behavior)

All four route tests pass:

\`\`\`
✓ src/__tests__/activity-routes.test.ts (4 tests) 14ms
Test Files  1 passed (1)
     Tests  4 passed (4)
\`\`\`

## Backward compatibility

No `since` → identical response to today. Existing callers unaffected.

## Related

The original incident on our side was a Discord relay bridge posting 2,551 duplicate messages over six hours because it assumed `since` worked as a cursor. We've now added client-side dedupe by `activity.id` as a belt-and-suspenders measure, but the API contract should hold.

A `limit` parameter would also be useful (the unbounded result set will grow with time) — happy to send as a follow-up if welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)