### PR TITLE
fix: pass ISO string instead of Date to postgres.js in comment attrib…

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1969,8 +1969,8 @@ export function issueService(db: Db) {
                 and ${activityLog.runId} = ${heartbeatRuns.id}
             )`,
           ),
-          sql`coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.createdAt}) >= ${new Date(minCommentCreatedAtMs)}`,
-          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${new Date(maxCommentCreatedAtMs + ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS)}`,
+          sql`coalesce(${heartbeatRuns.finishedAt}, ${heartbeatRuns.createdAt}) >= ${new Date(minCommentCreatedAtMs).toISOString()}`,
+          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${new Date(maxCommentCreatedAtMs + ISSUE_COMMENT_RUN_LOG_DERIVATION_END_SLACK_MS).toISOString()}`,
         ),
       )
       .orderBy(desc(heartbeatRuns.createdAt));


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and tracks their work through issues and comments
> - When loading issue comments, `enrichCommentsWithDerivedAgentAttribution` runs a query against `heartbeat_runs` to derive which agent authored each comment
> - That query uses a time-range filter with two parameters: the earliest and latest comment timestamps
> - Those parameters were passed as JavaScript `Date` objects directly into drizzle `sql` template literals
> - `postgres.js` expects `string` or `Buffer` for interpolated values — not `Date` instances
> - This caused a `TypeError: The "string" argument must be of type string. Received an instance of Date` and a 500 response on `GET /api/issues/:id/comments`
> - This PR fixes both parameters by calling `.toISOString()` before interpolation, consistent with how other date values are handled elsewhere in the same file (e.g. `cutoff.toISOString()`)

## What Changed

- Called `.toISOString()` on the two `Date` objects passed to the `heartbeat_runs` time-range filter in `enrichCommentsWithDerivedAgentAttribution` (`server/src/services/issues.ts`)

## Verification

1. Set up an issue with `executionLockedAt` populated (occurs when a guest agent is running via mention wake)
2. Call `GET /api/issues/:id/comments` while the issue has an active execution lock
3. Before fix: 500 Internal Server Error with `TypeError [ERR_INVALID_ARG_TYPE]: Received an instance of Date`
4. After fix: 200 with comments returned correctly

## Risks

Low risk. Two-line change replacing `new Date(x)` with `new Date(x).toISOString()`. No schema changes, no behavioral changes - only fixes the serialization of existing values passed to postgres.js.

## Model Used

Gemini 3.1 Pro + Claude Sonnet 4.6 (claude-sonnet-4-6) - assisted with root cause analysis and patch generation. Fix verified manually against a live Paperclip instance running version 2026.512.0.