### PR TITLE
feat(plugins): agent-token-monitor plugin (SHE-255 plugin approach)

### DIFF
--- a/packages/plugins/examples/plugin-agent-token-monitor/.gitignore
+++ b/packages/plugins/examples/plugin-agent-token-monitor/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+.paperclip-sdk

--- a/packages/plugins/examples/plugin-agent-token-monitor/README.md
+++ b/packages/plugins/examples/plugin-agent-token-monitor/README.md
@@ -1,0 +1,27 @@
+# Plugin Agent Token Monitor
+
+A Paperclip plugin
+
+## Development
+
+```bash
+pnpm install
+pnpm dev            # watch builds
+pnpm dev:ui         # local dev server with hot-reload events
+pnpm test
+```
+
+
+
+## Install Into Paperclip
+
+```bash
+curl -X POST http://127.0.0.1:3100/api/plugins/install \
+  -H "Content-Type: application/json" \
+  -d '{"packageName":"/home/funcke/repos/paperclip/packages/plugins/examples/plugin-agent-token-monitor","isLocalPath":true}'
+```
+
+## Build Options
+
+- `pnpm build` uses esbuild presets from `@paperclipai/plugin-sdk/bundlers`.
+- `pnpm build:rollup` uses rollup presets from the same SDK.

--- a/packages/plugins/examples/plugin-agent-token-monitor/esbuild.config.mjs
+++ b/packages/plugins/examples/plugin-agent-token-monitor/esbuild.config.mjs
@@ -1,0 +1,17 @@
+import esbuild from "esbuild";
+import { createPluginBundlerPresets } from "@paperclipai/plugin-sdk/bundlers";
+
+const presets = createPluginBundlerPresets({ uiEntry: "src/ui/index.tsx" });
+const watch = process.argv.includes("--watch");
+
+const workerCtx = await esbuild.context(presets.esbuild.worker);
+const manifestCtx = await esbuild.context(presets.esbuild.manifest);
+const uiCtx = await esbuild.context(presets.esbuild.ui);
+
+if (watch) {
+  await Promise.all([workerCtx.watch(), manifestCtx.watch(), uiCtx.watch()]);
+  console.log("esbuild watch mode enabled for worker, manifest, and ui");
+} else {
+  await Promise.all([workerCtx.rebuild(), manifestCtx.rebuild(), uiCtx.rebuild()]);
+  await Promise.all([workerCtx.dispose(), manifestCtx.dispose(), uiCtx.dispose()]);
+}

--- a/packages/plugins/examples/plugin-agent-token-monitor/migrations/.keep
+++ b/packages/plugins/examples/plugin-agent-token-monitor/migrations/.keep
@@ -1,0 +1,1 @@
+# migrations placeholder

--- a/packages/plugins/examples/plugin-agent-token-monitor/package.json
+++ b/packages/plugins/examples/plugin-agent-token-monitor/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@paperclipai/plugin-agent-token-monitor",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "A Paperclip plugin",
+  "scripts": {
+    "build": "node ./esbuild.config.mjs",
+    "build:rollup": "rollup -c",
+    "dev": "node ./esbuild.config.mjs --watch",
+    "dev:ui": "paperclip-plugin-dev-server --root . --ui-dir dist/ui --port 4177",
+    "test": "vitest run --config ./vitest.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "keywords": [
+    "paperclip",
+    "plugin",
+    "connector"
+  ],
+  "author": "Plugin Author",
+  "license": "MIT",
+  "devDependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*",
+    "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-typescript": "^12.1.2",
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "esbuild": "^0.27.3",
+    "rollup": "^4.38.0",
+    "tslib": "^2.8.1",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/plugin-agent-token-monitor/rollup.config.mjs
+++ b/packages/plugins/examples/plugin-agent-token-monitor/rollup.config.mjs
@@ -1,0 +1,28 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+import { createPluginBundlerPresets } from "@paperclipai/plugin-sdk/bundlers";
+
+const presets = createPluginBundlerPresets({ uiEntry: "src/ui/index.tsx" });
+
+function withPlugins(config) {
+  if (!config) return null;
+  return {
+    ...config,
+    plugins: [
+      nodeResolve({
+        extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs"],
+      }),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        declaration: false,
+        declarationMap: false,
+      }),
+    ],
+  };
+}
+
+export default [
+  withPlugins(presets.rollup.manifest),
+  withPlugins(presets.rollup.worker),
+  withPlugins(presets.rollup.ui),
+].filter(Boolean);

--- a/packages/plugins/examples/plugin-agent-token-monitor/src/manifest.ts
+++ b/packages/plugins/examples/plugin-agent-token-monitor/src/manifest.ts
@@ -1,0 +1,74 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+const PLUGIN_ID = "paperclip.agent-token-monitor";
+const PLUGIN_VERSION = "0.1.0";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: PLUGIN_VERSION,
+  displayName: "Agent Token Monitor",
+  description:
+    "Surfaces per-agent monthly token totals and a per-run cost view as a dashboard widget and a dedicated page.",
+  author: "Paperclip",
+  categories: ["ui", "automation"],
+  capabilities: [
+    "agents.read",
+    "database.namespace.read",
+    "api.routes.register",
+    "ui.dashboardWidget.register",
+    "ui.page.register",
+    "ui.sidebar.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  database: {
+    migrationsDir: "migrations",
+    coreReadTables: ["cost_events", "heartbeat_runs", "agents"],
+  },
+  apiRoutes: [
+    {
+      routeKey: "token-totals",
+      method: "GET",
+      path: "/token-totals",
+      auth: "board-or-agent",
+      capability: "api.routes.register",
+      companyResolution: { from: "query", key: "companyId" },
+    },
+    {
+      routeKey: "runs",
+      method: "GET",
+      path: "/runs",
+      auth: "board-or-agent",
+      capability: "api.routes.register",
+      companyResolution: { from: "query", key: "companyId" },
+    },
+  ],
+  ui: {
+    slots: [
+      {
+        type: "dashboardWidget",
+        id: "token-totals-widget",
+        displayName: "Agent Token Totals",
+        exportName: "TokenTotalsWidget",
+      },
+      {
+        type: "page",
+        id: "runs-page",
+        displayName: "Agent Runs",
+        exportName: "RunsPage",
+        routePath: "agent-runs",
+      },
+      {
+        type: "sidebar",
+        id: "runs-sidebar",
+        displayName: "Agent Runs",
+        exportName: "RunsSidebarLink",
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-agent-token-monitor/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-agent-token-monitor/src/ui/index.tsx
@@ -1,0 +1,288 @@
+import { useState } from "react";
+import {
+  usePluginData,
+  useHostContext,
+  type PluginWidgetProps,
+  type PluginPageProps,
+  type PluginSidebarProps,
+} from "@paperclipai/plugin-sdk/ui";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function fmt(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+function fmtUsd(n: number | null | undefined): string {
+  if (n == null) return "—";
+  return `$${n.toFixed(4)}`;
+}
+
+function fmtTs(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString();
+}
+
+// ── shared types ──────────────────────────────────────────────────────────────
+
+type AgentTokenRow = {
+  agentId: string;
+  agentName: string;
+  inputTokensMonthly: number;
+  cachedInputTokensMonthly: number;
+  outputTokensMonthly: number;
+  subscriptionRunCount: number;
+  apiRunCount: number;
+};
+
+type RunRow = {
+  id: string;
+  agentId: string;
+  agentName: string;
+  status: string;
+  model: string | null;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  costUsd: number | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+};
+
+type SortKey = "startedAt" | "costUsd";
+type SortDir = "asc" | "desc";
+
+// ── dashboard widget ──────────────────────────────────────────────────────────
+
+export function TokenTotalsWidget({ context }: PluginWidgetProps) {
+  const { data, loading, error } = usePluginData<{ rows: AgentTokenRow[] }>("token-totals", {
+    companyId: context.companyId ?? "",
+  });
+
+  if (loading) {
+    return <div style={styles.widget}>Loading token totals…</div>;
+  }
+  if (error) {
+    return <div style={styles.widget}>Error: {error.message}</div>;
+  }
+
+  const rows = data?.rows ?? [];
+
+  return (
+    <section style={styles.widget}>
+      <div style={styles.widgetHeader}>
+        <strong>Agent Tokens / Month</strong>
+        <span style={styles.muted}>current UTC month</span>
+      </div>
+      {rows.length === 0 ? (
+        <div style={styles.muted}>No token events recorded this month.</div>
+      ) : (
+        <table style={styles.table}>
+          <thead>
+            <tr>
+              <th style={styles.th}>Agent</th>
+              <th style={{ ...styles.th, textAlign: "right" }}>Input</th>
+              <th style={{ ...styles.th, textAlign: "right" }}>Cached</th>
+              <th style={{ ...styles.th, textAlign: "right" }}>Output</th>
+              <th style={{ ...styles.th, textAlign: "right" }}>Sub runs</th>
+              <th style={{ ...styles.th, textAlign: "right" }}>API runs</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.agentId}>
+                <td style={styles.td}>{row.agentName}</td>
+                <td style={{ ...styles.td, textAlign: "right" }}>{fmt(row.inputTokensMonthly)}</td>
+                <td style={{ ...styles.td, textAlign: "right" }}>{fmt(row.cachedInputTokensMonthly)}</td>
+                <td style={{ ...styles.td, textAlign: "right" }}>{fmt(row.outputTokensMonthly)}</td>
+                <td style={{ ...styles.td, textAlign: "right" }}>{fmt(row.subscriptionRunCount)}</td>
+                <td style={{ ...styles.td, textAlign: "right" }}>{fmt(row.apiRunCount)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}
+
+// ── runs page ─────────────────────────────────────────────────────────────────
+
+export function RunsPage({ context }: PluginPageProps) {
+  const [agentFilter, setAgentFilter] = useState<string>("");
+  const [sortKey, setSortKey] = useState<SortKey>("startedAt");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+
+  const companyId = context.companyId ?? "";
+  const queryParams: Record<string, string> = { companyId };
+  if (agentFilter) queryParams.agentId = agentFilter;
+
+  const { data, loading, error } = usePluginData<{ rows: RunRow[] }>("runs", queryParams);
+  const { data: totalsData } = usePluginData<{ rows: AgentTokenRow[] }>("token-totals", {
+    companyId,
+  });
+
+  const agents = totalsData?.rows ?? [];
+  const rawRows = data?.rows ?? [];
+
+  const sorted = [...rawRows].sort((a, b) => {
+    let cmp = 0;
+    if (sortKey === "costUsd") {
+      cmp = (a.costUsd ?? -1) - (b.costUsd ?? -1);
+    } else {
+      cmp = (a.startedAt ?? "").localeCompare(b.startedAt ?? "");
+    }
+    return sortDir === "asc" ? cmp : -cmp;
+  });
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("desc");
+    }
+  }
+
+  function sortIndicator(key: SortKey) {
+    if (sortKey !== key) return null;
+    return sortDir === "asc" ? " ↑" : " ↓";
+  }
+
+  return (
+    <div style={styles.page}>
+      <div style={styles.pageHeader}>
+        <h2 style={{ margin: 0 }}>Agent Runs</h2>
+        <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+          <label htmlFor="agent-filter" style={styles.muted}>
+            Agent:
+          </label>
+          <select
+            id="agent-filter"
+            value={agentFilter}
+            onChange={(e) => setAgentFilter(e.target.value)}
+            style={styles.select}
+          >
+            <option value="">All agents</option>
+            {agents.map((a) => (
+              <option key={a.agentId} value={a.agentId}>
+                {a.agentName}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {loading && <div style={styles.muted}>Loading runs…</div>}
+      {error && <div>Error: {error.message}</div>}
+
+      {!loading && !error && (
+        <div style={{ overflowX: "auto" }}>
+          <table style={styles.table}>
+            <thead>
+              <tr>
+                <th style={styles.th}>Agent</th>
+                <th
+                  style={{ ...styles.th, cursor: "pointer" }}
+                  onClick={() => toggleSort("startedAt")}
+                >
+                  Started{sortIndicator("startedAt")}
+                </th>
+                <th style={styles.th}>Status</th>
+                <th style={styles.th}>Model</th>
+                <th style={{ ...styles.th, textAlign: "right" }}>Input tokens</th>
+                <th style={{ ...styles.th, textAlign: "right" }}>Cached tokens</th>
+                <th style={{ ...styles.th, textAlign: "right" }}>Output tokens</th>
+                <th
+                  style={{ ...styles.th, textAlign: "right", cursor: "pointer" }}
+                  onClick={() => toggleSort("costUsd")}
+                >
+                  Cost USD{sortIndicator("costUsd")}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.length === 0 ? (
+                <tr>
+                  <td colSpan={8} style={{ ...styles.td, textAlign: "center", ...styles.muted }}>
+                    No runs found.
+                  </td>
+                </tr>
+              ) : (
+                sorted.map((row) => (
+                  <tr key={row.id}>
+                    <td style={styles.td}>{row.agentName}</td>
+                    <td style={styles.td}>{fmtTs(row.startedAt)}</td>
+                    <td style={styles.td}>{row.status}</td>
+                    <td style={styles.td}>{row.model ?? "—"}</td>
+                    <td style={{ ...styles.td, textAlign: "right" }}>{fmt(row.inputTokens)}</td>
+                    <td style={{ ...styles.td, textAlign: "right" }}>{fmt(row.cachedInputTokens)}</td>
+                    <td style={{ ...styles.td, textAlign: "right" }}>{fmt(row.outputTokens)}</td>
+                    <td style={{ ...styles.td, textAlign: "right" }}>{fmtUsd(row.costUsd)}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── sidebar link ──────────────────────────────────────────────────────────────
+
+export function RunsSidebarLink(_props: PluginSidebarProps) {
+  return <span>Agent Runs</span>;
+}
+
+// ── styles ────────────────────────────────────────────────────────────────────
+
+const styles: Record<string, React.CSSProperties> = {
+  widget: {
+    padding: "0.75rem",
+    display: "grid",
+    gap: "0.5rem",
+  },
+  widgetHeader: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    gap: "0.5rem",
+  },
+  page: {
+    padding: "1.5rem",
+    display: "grid",
+    gap: "1rem",
+  },
+  pageHeader: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: "1rem",
+  },
+  table: {
+    width: "100%",
+    borderCollapse: "collapse",
+    fontSize: "0.875rem",
+  },
+  th: {
+    padding: "0.375rem 0.75rem",
+    textAlign: "left",
+    borderBottom: "1px solid currentColor",
+    whiteSpace: "nowrap",
+  },
+  td: {
+    padding: "0.375rem 0.75rem",
+    borderBottom: "1px solid rgba(128,128,128,0.2)",
+    whiteSpace: "nowrap",
+  },
+  muted: {
+    opacity: 0.6,
+    fontSize: "0.8125rem",
+  },
+  select: {
+    padding: "0.25rem 0.5rem",
+    borderRadius: "4px",
+  },
+};

--- a/packages/plugins/examples/plugin-agent-token-monitor/src/worker.ts
+++ b/packages/plugins/examples/plugin-agent-token-monitor/src/worker.ts
@@ -1,0 +1,188 @@
+import { definePlugin, runWorker, type PluginContext, type PluginApiRequestInput } from "@paperclipai/plugin-sdk";
+
+type AgentTokenRow = {
+  agentId: string;
+  agentName: string;
+  inputTokensMonthly: number;
+  cachedInputTokensMonthly: number;
+  outputTokensMonthly: number;
+  subscriptionRunCount: number;
+  apiRunCount: number;
+};
+
+type RunRow = {
+  id: string;
+  agentId: string;
+  agentName: string;
+  status: string;
+  model: string | null;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  costUsd: number | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+};
+
+function currentUtcMonthWindow() {
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  return {
+    start: new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)).toISOString(),
+    end: new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0)).toISOString(),
+  };
+}
+
+async function fetchTokenTotals(ctx: PluginContext, companyId: string): Promise<{ rows: AgentTokenRow[] }> {
+  const { start, end } = currentUtcMonthWindow();
+
+  const rows = await ctx.db.query<{
+    agent_id: string;
+    agent_name: string;
+    input_tokens_monthly: string;
+    cached_input_tokens_monthly: string;
+    output_tokens_monthly: string;
+    subscription_run_count: string;
+    api_run_count: string;
+  }>(
+    `SELECT
+       ce.agent_id,
+       a.name AS agent_name,
+       COALESCE(SUM(ce.input_tokens), 0)::bigint AS input_tokens_monthly,
+       COALESCE(SUM(ce.cached_input_tokens), 0)::bigint AS cached_input_tokens_monthly,
+       COALESCE(SUM(ce.output_tokens), 0)::bigint AS output_tokens_monthly,
+       COUNT(*) FILTER (WHERE ce.billing_type = 'subscription_included') AS subscription_run_count,
+       COUNT(*) FILTER (WHERE ce.billing_type IN ('metered_api', 'subscription_overage')) AS api_run_count
+     FROM cost_events ce
+     JOIN agents a ON a.id = ce.agent_id
+     WHERE ce.company_id = $1
+       AND ce.occurred_at >= $2::timestamptz
+       AND ce.occurred_at < $3::timestamptz
+     GROUP BY ce.agent_id, a.name
+     ORDER BY a.name`,
+    [companyId, start, end],
+  );
+
+  return {
+    rows: rows.map((r) => ({
+      agentId: r.agent_id,
+      agentName: r.agent_name,
+      inputTokensMonthly: Number(r.input_tokens_monthly),
+      cachedInputTokensMonthly: Number(r.cached_input_tokens_monthly),
+      outputTokensMonthly: Number(r.output_tokens_monthly),
+      subscriptionRunCount: Number(r.subscription_run_count),
+      apiRunCount: Number(r.api_run_count),
+    })),
+  };
+}
+
+async function fetchRuns(
+  ctx: PluginContext,
+  companyId: string,
+  agentId?: string,
+): Promise<{ rows: RunRow[] }> {
+  const bindParams: string[] = agentId ? [companyId, agentId] : [companyId];
+  const agentFilter = agentId ? `AND hr.agent_id = $2` : "";
+
+  const rows = await ctx.db.query<{
+    id: string;
+    agent_id: string;
+    agent_name: string;
+    status: string;
+    model: string | null;
+    input_tokens: string;
+    cached_input_tokens: string;
+    output_tokens: string;
+    cost_usd: string | null;
+    started_at: string | null;
+    finished_at: string | null;
+  }>(
+    `SELECT
+       hr.id,
+       hr.agent_id,
+       a.name AS agent_name,
+       hr.status,
+       (hr.usage_json ->> 'model') AS model,
+       COALESCE((hr.usage_json ->> 'input_tokens')::bigint, 0) AS input_tokens,
+       COALESCE((hr.usage_json ->> 'cache_read_input_tokens')::bigint, 0) AS cached_input_tokens,
+       COALESCE((hr.usage_json ->> 'output_tokens')::bigint, 0) AS output_tokens,
+       COALESCE(
+         (hr.result_json ->> 'costUsd')::numeric,
+         (hr.result_json ->> 'cost_usd')::numeric,
+         (hr.result_json ->> 'total_cost_usd')::numeric
+       ) AS cost_usd,
+       hr.started_at,
+       hr.finished_at
+     FROM heartbeat_runs hr
+     JOIN agents a ON a.id = hr.agent_id
+     WHERE hr.company_id = $1 ${agentFilter}
+     ORDER BY hr.started_at DESC NULLS LAST
+     LIMIT 200`,
+    bindParams,
+  );
+
+  return {
+    rows: rows.map((r) => ({
+      id: r.id,
+      agentId: r.agent_id,
+      agentName: r.agent_name,
+      status: r.status,
+      model: r.model ?? null,
+      inputTokens: Number(r.input_tokens),
+      cachedInputTokens: Number(r.cached_input_tokens),
+      outputTokens: Number(r.output_tokens),
+      costUsd: r.cost_usd != null ? Number(r.cost_usd) : null,
+      startedAt: r.started_at ?? null,
+      finishedAt: r.finished_at ?? null,
+    })),
+  };
+}
+
+let _ctx: PluginContext | null = null;
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    _ctx = ctx;
+    ctx.logger.info("agent-token-monitor plugin ready");
+
+    ctx.data.register("token-totals", async (params) => {
+      const companyId = String(params?.companyId ?? "");
+      if (!companyId) return { rows: [] };
+      return fetchTokenTotals(ctx, companyId);
+    });
+
+    ctx.data.register("runs", async (params) => {
+      const companyId = String(params?.companyId ?? "");
+      const agentId = params?.agentId ? String(params.agentId) : undefined;
+      if (!companyId) return { rows: [] };
+      return fetchRuns(ctx, companyId, agentId);
+    });
+  },
+
+  async onApiRequest(input: PluginApiRequestInput) {
+    const ctx = _ctx;
+    if (!ctx) return { status: 503, body: { error: "worker_not_ready" } };
+
+    const { routeKey, params, query } = input;
+    const companyId = String(params.companyId ?? "");
+
+    if (routeKey === "token-totals") {
+      return { status: 200, body: await fetchTokenTotals(ctx, companyId) };
+    }
+
+    if (routeKey === "runs") {
+      const agentId = typeof query.agentId === "string" ? query.agentId : undefined;
+      return { status: 200, body: await fetchRuns(ctx, companyId, agentId) };
+    }
+
+    return { status: 404, body: { error: "not_found" } };
+  },
+
+  async onHealth() {
+    return { status: "ok", message: "agent-token-monitor worker running" };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-agent-token-monitor/tests/plugin.spec.ts
+++ b/packages/plugins/examples/plugin-agent-token-monitor/tests/plugin.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import manifest from "../src/manifest.js";
+import plugin from "../src/worker.js";
+
+describe("agent-token-monitor plugin", () => {
+  it("setup registers token-totals and runs data handlers", async () => {
+    const harness = createTestHarness({ manifest, capabilities: [...manifest.capabilities] });
+    await plugin.definition.setup(harness.ctx);
+
+    const totals = await harness.getData<{ rows: unknown[] }>("token-totals", { companyId: "company-1" });
+    expect(totals.rows).toEqual([]);
+
+    expect(harness.dbQueries.length).toBeGreaterThanOrEqual(1);
+    const totalsSql = harness.dbQueries[0].sql;
+    expect(totalsSql).toContain("cost_events");
+    expect(totalsSql).toContain("input_tokens");
+    expect(totalsSql).toContain("subscription_run_count");
+    expect(harness.dbQueries[0].params).toContain("company-1");
+  });
+
+  it("runs data handler passes agentId filter when provided", async () => {
+    const harness = createTestHarness({ manifest, capabilities: [...manifest.capabilities] });
+    await plugin.definition.setup(harness.ctx);
+
+    const runsBefore = harness.dbQueries.length;
+    await harness.getData<{ rows: unknown[] }>("runs", {
+      companyId: "company-1",
+      agentId: "agent-99",
+    });
+
+    const runsQuery = harness.dbQueries[runsBefore];
+    expect(runsQuery.sql).toContain("heartbeat_runs");
+    expect(runsQuery.params).toContain("agent-99");
+  });
+
+  it("health check returns ok", async () => {
+    const harness = createTestHarness({ manifest, capabilities: [...manifest.capabilities] });
+    await plugin.definition.setup(harness.ctx);
+    const health = await plugin.definition.onHealth!();
+    expect(health.status).toBe("ok");
+  });
+});

--- a/packages/plugins/examples/plugin-agent-token-monitor/tsconfig.json
+++ b/packages/plugins/examples/plugin-agent-token-monitor/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/plugins/examples/plugin-agent-token-monitor/vitest.config.ts
+++ b/packages/plugins/examples/plugin-agent-token-monitor/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,6 +339,43 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/plugins/examples/plugin-agent-token-monitor:
+    dependencies:
+      react:
+        specifier: '>=18'
+        version: 19.2.4
+    devDependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.1
+        version: 16.0.3(rollup@4.60.1)
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.2
+        version: 12.3.0(rollup@4.60.1)(tslib@2.8.1)(typescript@5.9.3)
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
+      rollup:
+        specifier: '>=4.59.0'
+        version: 4.60.1
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/plugins/examples/plugin-authoring-smoke-example:
     dependencies:
       '@paperclipai/plugin-sdk':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,43 +339,6 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
-  packages/plugins/examples/plugin-agent-token-monitor:
-    dependencies:
-      react:
-        specifier: '>=18'
-        version: 19.2.4
-    devDependencies:
-      '@paperclipai/plugin-sdk':
-        specifier: workspace:*
-        version: link:../../sdk
-      '@rollup/plugin-node-resolve':
-        specifier: ^16.0.1
-        version: 16.0.3(rollup@4.60.1)
-      '@rollup/plugin-typescript':
-        specifier: ^12.1.2
-        version: 12.3.0(rollup@4.60.1)(tslib@2.8.1)(typescript@5.9.3)
-      '@types/node':
-        specifier: ^24.6.0
-        version: 24.12.0
-      '@types/react':
-        specifier: ^19.0.8
-        version: 19.2.14
-      esbuild:
-        specifier: ^0.27.3
-        version: 0.27.3
-      rollup:
-        specifier: '>=4.59.0'
-        version: 4.60.1
-      tslib:
-        specifier: ^2.8.1
-        version: 2.8.1
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-      vitest:
-        specifier: ^3.0.5
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
-
   packages/plugins/examples/plugin-authoring-smoke-example:
     dependencies:
       '@paperclipai/plugin-sdk':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,9 +6,10 @@ packages:
   # forcing root pnpm-lock.yaml churn for their third-party deps.
   - "!packages/plugins/sandbox-providers/**"
   - packages/plugins/examples/*
-  # Keep this smoke fixture installable as a local plugin example without
-  # forcing PRs to commit pnpm-lock.yaml for a new workspace importer.
+  # Keep these plugins installable as local plugin examples without
+  # forcing PRs to commit pnpm-lock.yaml for new workspace importers.
   - "!packages/plugins/examples/plugin-orchestration-smoke-example"
+  - "!packages/plugins/examples/plugin-agent-token-monitor"
   - server
   - ui
   - cli


### PR DESCRIPTION
## Summary

Board direction on SHE-255 changed to a plugin approach after reviewing feasibility (see issue thread).

- Adds `@paperclipai/plugin-agent-token-monitor` under `packages/plugins/examples/`
- **Dashboard widget**: per-agent monthly input / cached / output token totals + subscription and API run counts, read from `cost_events` via `ctx.db.query()` with `coreReadTables` access
- **Runs page** (`/agent-runs`): filterable by agent, sortable by start time or cost USD, token columns from `heartbeat_runs.usage_json`, cost from `result_json`
- **Sidebar link** to the runs page
- **Scoped API routes**: `GET /api/plugins/:pluginId/api/token-totals?companyId=…` and `GET /api/plugins/:pluginId/api/runs?companyId=…&agentId=…`

Closes #5740 (the core implementation PR; superseded by this plugin approach per board direction).

## Tradeoffs vs. core approach

| Deliverable | Core PR #5740 | This plugin |
|---|---|---|
| Token fields on `GET /api/.../agents` | ✅ | ❌ (plugin routes only) |
| Token row inline on agent cards | ✅ | ❌ (separate dashboard widget) |
| Runs list with token/cost columns | ✅ | ✅ |

## Test plan

- [x] Typecheck clean (`tsc --noEmit`)
- [x] 3/3 Vitest tests pass
- [x] Build succeeds (`esbuild.config.mjs`)
- [ ] Manual: install plugin via `POST /api/plugins/install` with local path, confirm dashboard widget renders per-agent token totals
- [ ] Manual: navigate to `/:company/agent-runs`, confirm runs list with token/cost columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)