### PR TITLE
feat(kilocode-gateway): add kilocode_gateway adapter

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -45,6 +45,7 @@
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",
+    "@paperclipai/adapter-kilocode-gateway": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-utils": "workspace:*",
     "@paperclipai/db": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -8,6 +8,7 @@ import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printOpenCodeStreamEvent } from "@paperclipai/adapter-opencode-local/cli";
 import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
+import { printKilocodeGatewayStreamEvent } from "@paperclipai/adapter-kilocode-gateway/cli";
 import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
 
@@ -56,6 +57,11 @@ const openclawGatewayCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printOpenClawGatewayStreamEvent,
 };
 
+const kilocodeGatewayCLIAdapter: CLIAdapterModule = {
+  type: "kilocode_gateway",
+  formatStdoutEvent: printKilocodeGatewayStreamEvent,
+};
+
 const adaptersByType = new Map<string, CLIAdapterModule>(
   [
     acpxLocalCLIAdapter,
@@ -67,6 +73,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     cursorCloudCLIAdapter,
     geminiLocalCLIAdapter,
     openclawGatewayCLIAdapter,
+    kilocodeGatewayCLIAdapter,
     processCLIAdapter,
     httpCLIAdapter,
   ].map((a) => [a.type, a]),

--- a/packages/adapters/kilocode-gateway/README.md
+++ b/packages/adapters/kilocode-gateway/README.md
@@ -1,0 +1,27 @@
+# KiloCode Gateway Adapter
+
+`@paperclipai/adapter-kilocode-gateway` connects Paperclip to the [KiloCode Gateway](https://kilo.ai) — an OpenAI-compatible HTTP API that routes requests to multiple AI providers (Anthropic, OpenAI, Google, DeepSeek).
+
+## Transport
+
+HTTP POST to `/api/gateway/chat/completions` with Bearer auth and optional SSE streaming.
+
+## Auth
+
+Set `adapterConfig.apiKey` or the `KILO_API_KEY` environment variable.
+
+## Model Discovery
+
+Models are fetched dynamically from `GET https://api.kilo.ai/api/gateway/models` with a 60-second TTL cache. Static fallback models are used when the endpoint is unreachable.
+
+## Configuration
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | string | — | KiloCode Bearer API token |
+| `model` | string | — | Model ID (e.g. `anthropic/claude-sonnet-4.5`) |
+| `baseUrl` | string | `https://api.kilo.ai/api/gateway` | Gateway base URL |
+| `temperature` | number | `0.7` | Sampling temperature |
+| `maxTokens` | number | `8192` | Max tokens in completion |
+| `stream` | boolean | `true` | Enable SSE streaming |
+| `timeoutSec` | number | `120` | Request timeout in seconds |

--- a/packages/adapters/kilocode-gateway/package.json
+++ b/packages/adapters/kilocode-gateway/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@paperclipai/adapter-kilocode-gateway",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/kilocode-gateway"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.6.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/adapters/kilocode-gateway/src/cli/format-event.ts
+++ b/packages/adapters/kilocode-gateway/src/cli/format-event.ts
@@ -1,0 +1,33 @@
+import pc from "picocolors";
+
+export function printKilocodeGatewayStreamEvent(raw: string, debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  if (!debug) {
+    if (line.startsWith("data: ") && !line.includes("[DONE]")) {
+      try {
+        const parsed = JSON.parse(line.slice(6)) as Record<string, unknown>;
+        const choices = Array.isArray(parsed.choices) ? parsed.choices : [];
+        const first = choices[0] as Record<string, unknown> | undefined;
+        const delta = first?.delta as Record<string, unknown> | undefined;
+        const content = typeof delta?.content === "string" ? delta.content : null;
+        if (content !== null) {
+          process.stdout.write(content);
+          return;
+        }
+      } catch {
+        // fall through
+      }
+    }
+    console.log(line);
+    return;
+  }
+
+  if (line.startsWith("data: ")) {
+    console.log(pc.cyan(line));
+    return;
+  }
+
+  console.log(pc.gray(line));
+}

--- a/packages/adapters/kilocode-gateway/src/cli/index.ts
+++ b/packages/adapters/kilocode-gateway/src/cli/index.ts
@@ -1,0 +1,1 @@
+export { printKilocodeGatewayStreamEvent } from "./format-event.js";

--- a/packages/adapters/kilocode-gateway/src/index.ts
+++ b/packages/adapters/kilocode-gateway/src/index.ts
@@ -1,0 +1,36 @@
+export const type = "kilocode_gateway";
+export const label = "KiloCode Gateway";
+
+export const models: { id: string; label: string }[] = [
+  { id: "anthropic/claude-sonnet-4.5", label: "Claude Sonnet 4.5" },
+  { id: "anthropic/claude-opus-4", label: "Claude Opus 4" },
+  { id: "openai/gpt-4o", label: "GPT-4o" },
+  { id: "openai/gpt-4.1", label: "GPT-4.1" },
+  { id: "google/gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+  { id: "google/gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+  { id: "deepseek/deepseek-r1", label: "DeepSeek R1" },
+  { id: "deepseek/deepseek-v3", label: "DeepSeek V3" },
+];
+
+export const agentConfigurationDoc = `# kilocode_gateway agent configuration
+
+Adapter: kilocode_gateway
+
+Use when:
+- You want Paperclip to invoke AI models via the KiloCode Gateway (OpenAI-compatible HTTP API).
+- You need access to multiple providers (Anthropic, OpenAI, Google, DeepSeek) through a single endpoint.
+- You prefer an OpenAI-compatible REST interface with SSE streaming.
+
+Don't use when:
+- You want local model execution or direct provider SDK integration.
+- You do not have a KiloCode API key or access to the KiloCode gateway.
+
+Core fields:
+- apiKey (string, required): KiloCode Bearer API token. Can also be set via KILO_API_KEY env var.
+- model (string, required): Model ID to use (e.g. "anthropic/claude-sonnet-4.5", "openai/gpt-4o").
+- baseUrl (string, optional): KiloCode gateway base URL (default: https://api.kilo.ai/api/gateway).
+- temperature (number, optional): Sampling temperature (default: 0.7).
+- maxTokens (number, optional): Maximum tokens in completion (default: 8192).
+- stream (boolean, optional): Enable SSE streaming (default: true).
+- timeoutSec (number, optional): Request timeout in seconds (default: 120).
+`;

--- a/packages/adapters/kilocode-gateway/src/server/execute.test.ts
+++ b/packages/adapters/kilocode-gateway/src/server/execute.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+import { execute } from "./execute.js";
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }));
+
+vi.stubGlobal("fetch", fetchMock);
+
+function makeContext(
+  configOverrides: Record<string, unknown> = {},
+  contextOverrides: Record<string, unknown> = {},
+): AdapterExecutionContext & { logs: string[] } {
+  const logs: string[] = [];
+  return {
+    runId: "run-test",
+    agent: { id: "agent-1", name: "TestAgent", adapterType: "kilocode_gateway", adapterConfig: {} } as never,
+    runtime: {} as never,
+    config: {
+      apiKey: "test-api-key",
+      model: "anthropic/claude-sonnet-4.5",
+      stream: false,
+      ...configOverrides,
+    },
+    context: {
+      userMessage: "Hello, world",
+      ...contextOverrides,
+    },
+    onLog: async (_stream: "stdout" | "stderr", chunk: string) => { logs.push(chunk); },
+    logs,
+  } as never;
+}
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+    body: null,
+  } as unknown as Response;
+}
+
+function makeTextResponse(text: string, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => text,
+    json: async () => { throw new Error("not json"); },
+    body: null,
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.KILO_API_KEY;
+});
+
+describe("execute — no API key", () => {
+  it("returns error when no apiKey in config and no env var", async () => {
+    const ctx = makeContext({ apiKey: "" });
+    const result = await execute(ctx as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("kilocode_gateway_no_api_key");
+  });
+
+  it("reads apiKey from KILO_API_KEY env var", async () => {
+    process.env.KILO_API_KEY = "env-api-key";
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        model: "anthropic/claude-sonnet-4.5",
+        choices: [{ message: { role: "assistant", content: "Hi" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      }),
+    );
+    const ctx = makeContext({ apiKey: "", model: "anthropic/claude-sonnet-4.5", stream: false });
+    const result = await execute(ctx as never);
+    expect(result.exitCode).toBe(0);
+    const call = fetchMock.mock.calls[0];
+    expect(call[1].headers.Authorization).toBe("Bearer env-api-key");
+  });
+});
+
+describe("execute — HTTP errors", () => {
+  it.each([
+    [400, "kilocode_gateway_bad_request"],
+    [401, "kilocode_gateway_unauthorized"],
+    [402, "kilocode_gateway_payment_required"],
+    [403, "kilocode_gateway_forbidden"],
+    [429, "kilocode_gateway_rate_limited"],
+    [500, "kilocode_gateway_server_error"],
+    [502, "kilocode_gateway_bad_gateway"],
+    [503, "kilocode_gateway_service_unavailable"],
+  ])("maps HTTP %i to errorCode %s", async (status, expectedCode) => {
+    fetchMock.mockResolvedValueOnce(makeTextResponse("error details", status));
+    const ctx = makeContext();
+    const result = await execute(ctx as never);
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe(expectedCode);
+  });
+});
+
+describe("execute — non-streaming", () => {
+  it("returns content and token usage on success", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        model: "anthropic/claude-sonnet-4.5",
+        choices: [{ message: { role: "assistant", content: "Hello there!" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 20, completion_tokens: 8 },
+      }),
+    );
+
+    const ctx = makeContext({ stream: false });
+    const result = await execute(ctx as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(ctx.logs).toContain("Hello there!");
+    expect(result.usage?.inputTokens).toBe(20);
+    expect(result.usage?.outputTokens).toBe(8);
+    expect(result.model).toBe("anthropic/claude-sonnet-4.5");
+    expect(result.provider).toBe("kilocode");
+  });
+
+  it("sends correct request body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        model: "openai/gpt-4o",
+        choices: [{ message: { role: "assistant", content: "Done" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 5, completion_tokens: 2 },
+      }),
+    );
+
+    const ctx = makeContext({
+      apiKey: "my-key",
+      model: "openai/gpt-4o",
+      temperature: 0.5,
+      maxTokens: 1024,
+      stream: false,
+    });
+
+    await execute(ctx as never);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.kilo.ai/api/gateway/chat/completions");
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer my-key",
+      "Content-Type": "application/json",
+    });
+
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe("openai/gpt-4o");
+    expect(body.temperature).toBe(0.5);
+    expect(body.max_tokens).toBe(1024);
+    expect(body.stream).toBe(false);
+  });
+
+  it("respects custom baseUrl", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeJsonResponse({
+        choices: [{ message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+    );
+
+    const ctx = makeContext({ baseUrl: "https://custom.kilo.example/api/gateway", stream: false });
+    await execute(ctx as never);
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://custom.kilo.example/api/gateway/chat/completions");
+  });
+});
+
+describe("execute — streaming", () => {
+  function makeStreamResponse(chunks: string[]): Response {
+    const encoder = new TextEncoder();
+    let i = 0;
+    const body = {
+      getReader: () => ({
+        read: async () => {
+          if (i >= chunks.length) return { done: true, value: undefined };
+          return { done: false, value: encoder.encode(chunks[i++]) };
+        },
+      }),
+    };
+    return {
+      ok: true,
+      status: 200,
+      body,
+    } as unknown as Response;
+  }
+
+  it("streams SSE chunks and accumulates usage", async () => {
+    const chunks = [
+      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+      'data: {"choices":[{"delta":{"content":" world"},"finish_reason":null}]}\n\n',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":15,"completion_tokens":6}}\n\n',
+      "data: [DONE]\n\n",
+    ];
+
+    fetchMock.mockResolvedValueOnce(makeStreamResponse(chunks));
+
+    const ctx = makeContext({ stream: true });
+    const result = await execute(ctx as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(ctx.logs).toContain("Hello");
+    expect(ctx.logs).toContain(" world");
+    expect(result.usage?.inputTokens).toBe(15);
+    expect(result.usage?.outputTokens).toBe(6);
+  });
+});

--- a/packages/adapters/kilocode-gateway/src/server/execute.ts
+++ b/packages/adapters/kilocode-gateway/src/server/execute.ts
@@ -1,0 +1,276 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+const DEFAULT_BASE_URL = "https://api.kilo.ai/api/gateway";
+const DEFAULT_TIMEOUT_SEC = 120;
+const DEFAULT_MAX_TOKENS = 8192;
+const DEFAULT_TEMPERATURE = 0.7;
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : parseFloat(String(value ?? ""));
+  return isFinite(n) ? n : fallback;
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  if (typeof value === "boolean") return value;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return fallback;
+}
+
+function resolveApiKey(config: Record<string, unknown>): string | null {
+  const configKey = asString(config.apiKey, "");
+  if (configKey) return configKey;
+  const envKey = process.env.KILO_API_KEY?.trim();
+  return envKey && envKey.length > 0 ? envKey : null;
+}
+
+function mapHttpError(status: number, body: string): { errorMessage: string; errorCode: string } {
+  const statusMap: Record<number, string> = {
+    400: "kilocode_gateway_bad_request",
+    401: "kilocode_gateway_unauthorized",
+    402: "kilocode_gateway_payment_required",
+    403: "kilocode_gateway_forbidden",
+    429: "kilocode_gateway_rate_limited",
+    500: "kilocode_gateway_server_error",
+    502: "kilocode_gateway_bad_gateway",
+    503: "kilocode_gateway_service_unavailable",
+  };
+
+  const messageMap: Record<number, string> = {
+    400: `KiloCode Gateway: bad request — ${body.slice(0, 200)}`,
+    401: "KiloCode Gateway: authentication failed — check your KILO_API_KEY.",
+    402: "KiloCode Gateway: payment required — check your KiloCode account balance.",
+    403: "KiloCode Gateway: forbidden — the API key may not have permission for this model.",
+    429: "KiloCode Gateway: rate limited — too many requests. Retry after a moment.",
+    500: `KiloCode Gateway: internal server error — ${body.slice(0, 200)}`,
+    502: "KiloCode Gateway: bad gateway — upstream provider may be unavailable.",
+    503: "KiloCode Gateway: service unavailable — KiloCode is temporarily down.",
+  };
+
+  return {
+    errorCode: statusMap[status] ?? "kilocode_gateway_http_error",
+    errorMessage: messageMap[status] ?? `KiloCode Gateway: HTTP ${status} — ${body.slice(0, 200)}`,
+  };
+}
+
+type ParsedDelta = {
+  text: string;
+  finishReason: string | null;
+  usage: { promptTokens: number; completionTokens: number } | null;
+};
+
+function parseSSELine(line: string): ParsedDelta | null {
+  if (!line.startsWith("data: ")) return null;
+  const raw = line.slice(6).trim();
+  if (raw === "[DONE]") return { text: "", finishReason: "stop", usage: null };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+
+  const choices = Array.isArray(obj.choices) ? obj.choices : [];
+  const firstChoice = choices[0] as Record<string, unknown> | undefined;
+  const delta = firstChoice?.delta as Record<string, unknown> | undefined;
+  const text = typeof delta?.content === "string" ? delta.content : "";
+  const finishReason = typeof firstChoice?.finish_reason === "string" ? firstChoice.finish_reason : null;
+
+  let usage: { promptTokens: number; completionTokens: number } | null = null;
+  if (typeof obj.usage === "object" && obj.usage !== null) {
+    const u = obj.usage as Record<string, unknown>;
+    const prompt = typeof u.prompt_tokens === "number" ? u.prompt_tokens : 0;
+    const completion = typeof u.completion_tokens === "number" ? u.completion_tokens : 0;
+    if (prompt > 0 || completion > 0) {
+      usage = { promptTokens: prompt, completionTokens: completion };
+    }
+  }
+
+  return { text, finishReason, usage };
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const config = parseObject(ctx.config);
+  const apiKey = resolveApiKey(config);
+
+  if (!apiKey) {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "kilocode_gateway_no_api_key",
+      errorMessage:
+        "KiloCode Gateway: no API key configured. Set adapterConfig.apiKey or the KILO_API_KEY environment variable.",
+    };
+  }
+
+  const baseUrl = asString(config.baseUrl, DEFAULT_BASE_URL).replace(/\/$/, "");
+  const model = asString(config.model, "");
+  const temperature = asNumber(config.temperature, DEFAULT_TEMPERATURE);
+  const maxTokens = asNumber(config.maxTokens, DEFAULT_MAX_TOKENS);
+  const stream = asBoolean(config.stream, true);
+  const timeoutSec = asNumber(config.timeoutSec, DEFAULT_TIMEOUT_SEC);
+
+  if (!model) {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "kilocode_gateway_no_model",
+      errorMessage: "KiloCode Gateway: no model specified. Set adapterConfig.model.",
+    };
+  }
+
+  const wakePayload = ctx.context.paperclipWake ?? ctx.context;
+  const systemPrompt =
+    typeof ctx.context.systemPrompt === "string" ? ctx.context.systemPrompt : null;
+  const userMessage =
+    typeof ctx.context.userMessage === "string"
+      ? ctx.context.userMessage
+      : JSON.stringify(wakePayload);
+
+  const messages: Array<{ role: string; content: string }> = [];
+  if (systemPrompt) {
+    messages.push({ role: "system", content: systemPrompt });
+  }
+  messages.push({ role: "user", content: userMessage });
+
+  const body = JSON.stringify({
+    model,
+    messages,
+    temperature,
+    max_tokens: maxTokens,
+    stream,
+  });
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutSec * 1000);
+
+  const url = `${baseUrl}/chat/completions`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body,
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timeout);
+    if (err instanceof Error && err.name === "AbortError") {
+      return { exitCode: 1, signal: null, timedOut: true, errorMessage: "KiloCode Gateway: request timed out." };
+    }
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "kilocode_gateway_network_error",
+      errorMessage: `KiloCode Gateway: network error — ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (!response.ok) {
+    clearTimeout(timeout);
+    const body = await response.text().catch(() => "");
+    const { errorCode, errorMessage } = mapHttpError(response.status, body);
+    return { exitCode: 1, signal: null, timedOut: false, errorCode, errorMessage };
+  }
+
+  let promptTokens = 0;
+  let completionTokens = 0;
+  let detectedModel: string | null = null;
+
+  try {
+    if (stream && response.body) {
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+
+          const delta = parseSSELine(trimmed);
+          if (!delta) continue;
+
+          if (delta.text) {
+            await ctx.onLog("stdout", delta.text);
+          }
+
+          if (delta.usage) {
+            promptTokens = delta.usage.promptTokens;
+            completionTokens = delta.usage.completionTokens;
+          }
+        }
+      }
+    } else {
+      const payload = (await response.json()) as Record<string, unknown>;
+      const choices = Array.isArray(payload.choices) ? payload.choices : [];
+      const first = choices[0] as Record<string, unknown> | undefined;
+      const message = first?.message as Record<string, unknown> | undefined;
+      const content = typeof message?.content === "string" ? message.content : "";
+      if (content) await ctx.onLog("stdout", content);
+
+      detectedModel =
+        typeof payload.model === "string" && payload.model.trim() ? payload.model.trim() : null;
+
+      const usage = payload.usage as Record<string, unknown> | undefined;
+      if (usage) {
+        promptTokens = typeof usage.prompt_tokens === "number" ? usage.prompt_tokens : 0;
+        completionTokens = typeof usage.completion_tokens === "number" ? usage.completion_tokens : 0;
+      }
+    }
+  } catch (err) {
+    clearTimeout(timeout);
+    if (err instanceof Error && err.name === "AbortError") {
+      return { exitCode: 1, signal: null, timedOut: true, errorMessage: "KiloCode Gateway: streaming timed out." };
+    }
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      errorCode: "kilocode_gateway_stream_error",
+      errorMessage: `KiloCode Gateway: error reading response — ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  clearTimeout(timeout);
+
+  const result: AdapterExecutionResult = {
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    provider: "kilocode",
+    model: detectedModel ?? model,
+  };
+
+  if (promptTokens > 0 || completionTokens > 0) {
+    result.usage = {
+      inputTokens: promptTokens,
+      outputTokens: completionTokens,
+    };
+  }
+
+  return result;
+}

--- a/packages/adapters/kilocode-gateway/src/server/index.ts
+++ b/packages/adapters/kilocode-gateway/src/server/index.ts
@@ -1,0 +1,2 @@
+export { execute } from "./execute.js";
+export { testEnvironment } from "./test.js";

--- a/packages/adapters/kilocode-gateway/src/server/test.ts
+++ b/packages/adapters/kilocode-gateway/src/server/test.ts
@@ -1,0 +1,122 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import { parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+const KILO_MODELS_ENDPOINT = "https://api.kilo.ai/api/gateway/models";
+const PROBE_TIMEOUT_MS = 5000;
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((c) => c.level === "error")) return "fail";
+  if (checks.some((c) => c.level === "warn")) return "warn";
+  return "pass";
+}
+
+function resolveApiKey(config: Record<string, unknown>): string | null {
+  const configKey = typeof config.apiKey === "string" ? config.apiKey.trim() : "";
+  if (configKey) return configKey;
+  const envKey = process.env.KILO_API_KEY?.trim();
+  return envKey && envKey.length > 0 ? envKey : null;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+
+  const apiKey = resolveApiKey(config);
+
+  if (!apiKey) {
+    checks.push({
+      code: "kilocode_gateway_no_api_key",
+      level: "error",
+      message: "KiloCode Gateway: no API key configured.",
+      hint: "Set adapterConfig.apiKey or the KILO_API_KEY environment variable.",
+    });
+    return {
+      adapterType: ctx.adapterType,
+      status: summarizeStatus(checks),
+      checks,
+      testedAt: new Date().toISOString(),
+    };
+  }
+
+  checks.push({
+    code: "kilocode_gateway_api_key_present",
+    level: "info",
+    message: "KiloCode API key is configured.",
+  });
+
+  const model = typeof config.model === "string" ? config.model.trim() : "";
+  if (!model) {
+    checks.push({
+      code: "kilocode_gateway_no_model",
+      level: "warn",
+      message: "No model specified in adapter config.",
+      hint: 'Set adapterConfig.model (e.g. "anthropic/claude-sonnet-4.5").',
+    });
+  } else {
+    checks.push({
+      code: "kilocode_gateway_model_configured",
+      level: "info",
+      message: `Model configured: ${model}`,
+    });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(KILO_MODELS_ENDPOINT, {
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (response.ok) {
+      checks.push({
+        code: "kilocode_gateway_models_endpoint_ok",
+        level: "info",
+        message: "KiloCode /models endpoint is reachable.",
+      });
+    } else if (response.status === 401 || response.status === 403) {
+      checks.push({
+        code: "kilocode_gateway_models_auth_failed",
+        level: "warn",
+        message: `KiloCode /models endpoint returned HTTP ${response.status}.`,
+        hint: "The API key may be required or invalid for model listing.",
+      });
+    } else {
+      checks.push({
+        code: "kilocode_gateway_models_endpoint_error",
+        level: "warn",
+        message: `KiloCode /models endpoint returned HTTP ${response.status}.`,
+      });
+    }
+  } catch (err) {
+    clearTimeout(timeout);
+    if (err instanceof Error && err.name === "AbortError") {
+      checks.push({
+        code: "kilocode_gateway_models_endpoint_timeout",
+        level: "warn",
+        message: "KiloCode /models endpoint timed out.",
+        hint: "Network connectivity to api.kilo.ai may be restricted from the Paperclip server host.",
+      });
+    } else {
+      checks.push({
+        code: "kilocode_gateway_models_endpoint_unreachable",
+        level: "warn",
+        message: `KiloCode /models endpoint unreachable: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/packages/adapters/kilocode-gateway/src/ui/build-config.ts
+++ b/packages/adapters/kilocode-gateway/src/ui/build-config.ts
@@ -1,0 +1,26 @@
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function asNum(v: unknown, fallback: number): number {
+  const n = typeof v === "number" ? v : parseFloat(String(v ?? ""));
+  return isFinite(n) ? n : fallback;
+}
+
+function asBool(v: unknown, fallback: boolean): boolean {
+  if (typeof v === "boolean") return v;
+  if (v === "true") return true;
+  if (v === "false") return false;
+  return fallback;
+}
+
+export function buildKilocodeGatewayConfig(v: CreateConfigValues): Record<string, unknown> {
+  const sv = v.adapterSchemaValues ?? {};
+  const ac: Record<string, unknown> = {};
+  if (sv.apiKey) ac.apiKey = sv.apiKey;
+  if (v.model) ac.model = v.model;
+  if (sv.baseUrl ?? v.url) ac.baseUrl = sv.baseUrl ?? v.url;
+  ac.temperature = asNum(sv.temperature, 0.7);
+  ac.maxTokens = asNum(sv.maxTokens, 8192);
+  ac.stream = asBool(sv.stream, true);
+  ac.timeoutSec = 120;
+  return ac;
+}

--- a/packages/adapters/kilocode-gateway/src/ui/index.ts
+++ b/packages/adapters/kilocode-gateway/src/ui/index.ts
@@ -1,0 +1,2 @@
+export { parseKilocodeGatewayStdoutLine } from "./parse-stdout.js";
+export { buildKilocodeGatewayConfig } from "./build-config.js";

--- a/packages/adapters/kilocode-gateway/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/kilocode-gateway/src/ui/parse-stdout.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { parseKilocodeGatewayStdoutLine } from "./parse-stdout.js";
+
+const TS = "2026-05-13T12:00:00Z";
+
+describe("parseKilocodeGatewayStdoutLine", () => {
+  it("parses a text delta chunk", () => {
+    const line = 'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}';
+    const result = parseKilocodeGatewayStdoutLine(line, TS);
+    expect(result).toEqual([{ kind: "assistant", ts: TS, text: "Hello", delta: true }]);
+  });
+
+  it("parses a tool-call chunk as raw stdout", () => {
+    const line = 'data: {"choices":[{"delta":{"tool_calls":[{"id":"call_1"}]},"finish_reason":null}]}';
+    const result = parseKilocodeGatewayStdoutLine(line, TS);
+    expect(result).toEqual([{ kind: "stdout", ts: TS, text: line }]);
+  });
+
+  it("parses a done event and returns empty", () => {
+    const result = parseKilocodeGatewayStdoutLine("data: [DONE]", TS);
+    expect(result).toEqual([]);
+  });
+
+  it("passes non-SSE lines through as stdout", () => {
+    const result = parseKilocodeGatewayStdoutLine("some plain text", TS);
+    expect(result).toEqual([{ kind: "stdout", ts: TS, text: "some plain text" }]);
+  });
+
+  it("returns empty array for blank lines", () => {
+    const result = parseKilocodeGatewayStdoutLine("   ", TS);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for finish_reason stop with no content", () => {
+    const line = 'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}';
+    const result = parseKilocodeGatewayStdoutLine(line, TS);
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/adapters/kilocode-gateway/src/ui/parse-stdout.ts
+++ b/packages/adapters/kilocode-gateway/src/ui/parse-stdout.ts
@@ -1,0 +1,52 @@
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function parseSSEDataLine(line: string, ts: string): TranscriptEntry[] {
+  if (!line.startsWith("data: ")) return [{ kind: "stdout", ts, text: line }];
+  const raw = line.slice(6).trim();
+  if (raw === "[DONE]") return [];
+
+  const parsed = asRecord(safeJsonParse(raw));
+  if (!parsed) return [{ kind: "stdout", ts, text: line }];
+
+  const choices = Array.isArray(parsed.choices) ? parsed.choices : [];
+  const first = asRecord(choices[0]);
+  const delta = asRecord(first?.delta);
+  const content = typeof delta?.content === "string" ? delta.content : "";
+
+  if (content.length > 0) {
+    return [{ kind: "assistant", ts, text: content, delta: true }];
+  }
+
+  const finishReason = typeof first?.finish_reason === "string" ? first.finish_reason : null;
+  if (finishReason === "stop" || finishReason === "length") return [];
+
+  if (typeof (first?.delta as Record<string, unknown> | null | undefined)?.tool_calls !== "undefined") {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  return [];
+}
+
+export function parseKilocodeGatewayStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const trimmed = line.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.startsWith("data: ")) {
+    return parseSSEDataLine(trimmed, ts);
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/kilocode-gateway/tsconfig.json
+++ b/packages/adapters/kilocode-gateway/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/kilocode-gateway/vitest.config.ts
+++ b/packages/adapters/kilocode-gateway/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kilocode-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/kilocode-gateway
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -204,6 +207,22 @@ importers:
         version: 5.9.3
 
   packages/adapters/gemini-local:
+    dependencies:
+      '@paperclipai/adapter-utils':
+        specifier: workspace:*
+        version: link:../../adapter-utils
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/adapters/kilocode-gateway:
     dependencies:
       '@paperclipai/adapter-utils':
         specifier: workspace:*
@@ -592,6 +611,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kilocode-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/kilocode-gateway
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway
@@ -755,6 +777,9 @@ importers:
       '@paperclipai/adapter-gemini-local':
         specifier: workspace:*
         version: link:../packages/adapters/gemini-local
+      '@paperclipai/adapter-kilocode-gateway':
+        specifier: workspace:*
+        version: link:../packages/adapters/kilocode-gateway
       '@paperclipai/adapter-openclaw-gateway':
         specifier: workspace:*
         version: link:../packages/adapters/openclaw-gateway

--- a/server/package.json
+++ b/server/package.json
@@ -50,6 +50,7 @@
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-kilocode-gateway": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/server/src/adapters/kilocode-models.test.ts
+++ b/server/src/adapters/kilocode-models.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  listKilocodeModels,
+  refreshKilocodeModels,
+  resetKilocodeModelsCacheForTests,
+  KILO_MODELS_ENDPOINT,
+} from "./kilocode-models.js";
+
+const { fetchMock } = vi.hoisted(() => ({ fetchMock: vi.fn() }));
+vi.stubGlobal("fetch", fetchMock);
+
+function makeResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetKilocodeModelsCacheForTests();
+});
+
+afterEach(() => {
+  resetKilocodeModelsCacheForTests();
+});
+
+describe("listKilocodeModels", () => {
+  it("fetches from KILO_MODELS_ENDPOINT", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        data: [
+          { id: "anthropic/claude-opus-4", name: "Claude Opus 4" },
+          { id: "openai/gpt-4o", name: "GPT-4o" },
+        ],
+      }),
+    );
+
+    const models = await listKilocodeModels();
+    expect(fetchMock).toHaveBeenCalledWith(KILO_MODELS_ENDPOINT, expect.any(Object));
+    expect(models.some((m) => m.id === "anthropic/claude-opus-4")).toBe(true);
+    expect(models.some((m) => m.id === "openai/gpt-4o")).toBe(true);
+  });
+
+  it("falls back to static models on network error", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network error"));
+
+    const models = await listKilocodeModels();
+    expect(models.length).toBeGreaterThan(0);
+    expect(models.some((m) => m.id === "anthropic/claude-sonnet-4.5")).toBe(true);
+  });
+
+  it("falls back to static models on non-200 response", async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({ error: "not found" }, 404));
+
+    const models = await listKilocodeModels();
+    expect(models.length).toBeGreaterThan(0);
+  });
+
+  it("uses cache on second call within TTL", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ data: [{ id: "anthropic/claude-sonnet-4.5", name: "Sonnet" }] }),
+    );
+
+    await listKilocodeModels();
+    await listKilocodeModels();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates models from remote and fallback", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        data: [
+          { id: "anthropic/claude-sonnet-4.5", name: "Sonnet from remote" },
+          { id: "anthropic/claude-sonnet-4.5", name: "Duplicate" },
+        ],
+      }),
+    );
+
+    const models = await listKilocodeModels();
+    const count = models.filter((m) => m.id === "anthropic/claude-sonnet-4.5").length;
+    expect(count).toBe(1);
+  });
+});
+
+describe("refreshKilocodeModels", () => {
+  it("bypasses cache and re-fetches", async () => {
+    fetchMock.mockResolvedValue(
+      makeResponse({ data: [{ id: "anthropic/claude-opus-4", name: "Opus" }] }),
+    );
+
+    await listKilocodeModels();
+    await refreshKilocodeModels();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/src/adapters/kilocode-models.ts
+++ b/server/src/adapters/kilocode-models.ts
@@ -1,0 +1,90 @@
+import type { AdapterModel } from "./types.js";
+import { models as kilocodeFallbackModels } from "@paperclipai/adapter-kilocode-gateway";
+
+export const KILO_MODELS_ENDPOINT = "https://api.kilo.ai/api/gateway/models";
+const KILO_MODELS_TIMEOUT_MS = 5000;
+const KILO_MODELS_CACHE_TTL_MS = 60_000;
+
+let cached: { expiresAt: number; models: AdapterModel[] } | null = null;
+
+function dedupeModels(models: AdapterModel[]): AdapterModel[] {
+  const seen = new Set<string>();
+  const deduped: AdapterModel[] = [];
+  for (const model of models) {
+    const id = model.id.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    deduped.push({ id, label: model.label.trim() || id });
+  }
+  return deduped;
+}
+
+function mergedWithFallback(models: AdapterModel[]): AdapterModel[] {
+  return dedupeModels([
+    ...models,
+    ...kilocodeFallbackModels,
+  ]).sort((a, b) => a.id.localeCompare(b.id, "en", { numeric: true, sensitivity: "base" }));
+}
+
+async function fetchKilocodeModels(): Promise<AdapterModel[]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), KILO_MODELS_TIMEOUT_MS);
+  try {
+    const response = await fetch(KILO_MODELS_ENDPOINT, {
+      signal: controller.signal,
+    });
+    if (!response.ok) return [];
+
+    const payload = (await response.json()) as { data?: unknown };
+    const data = Array.isArray(payload.data) ? payload.data : [];
+    const models: AdapterModel[] = [];
+    for (const item of data) {
+      if (typeof item !== "object" || item === null) continue;
+      const id = (item as { id?: unknown }).id;
+      const name = (item as { name?: unknown }).name;
+      if (typeof id !== "string" || id.trim().length === 0) continue;
+      const label = typeof name === "string" && name.trim() ? name.trim() : id;
+      models.push({ id, label });
+    }
+    return dedupeModels(models);
+  } catch {
+    return [];
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function loadKilocodeModels(options?: { forceRefresh?: boolean }): Promise<AdapterModel[]> {
+  const forceRefresh = options?.forceRefresh === true;
+  const fallback = dedupeModels(kilocodeFallbackModels);
+
+  const now = Date.now();
+  if (!forceRefresh && cached && cached.expiresAt > now) {
+    return cached.models;
+  }
+
+  const fetched = await fetchKilocodeModels();
+  if (fetched.length > 0) {
+    const merged = mergedWithFallback(fetched);
+    cached = { expiresAt: now + KILO_MODELS_CACHE_TTL_MS, models: merged };
+    return merged;
+  }
+
+  if (cached && cached.models.length > 0) {
+    return cached.models;
+  }
+
+  return fallback;
+}
+
+export async function listKilocodeModels(): Promise<AdapterModel[]> {
+  return loadKilocodeModels();
+}
+
+export async function refreshKilocodeModels(): Promise<AdapterModel[]> {
+  return loadKilocodeModels({ forceRefresh: true });
+}
+
+export function resetKilocodeModelsCacheForTests() {
+  cached = null;
+}

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -102,6 +102,15 @@ import {
 import { listCodexModels, refreshCodexModels } from "./codex-models.js";
 import { listCursorModels } from "./cursor-models.js";
 import {
+  execute as kilocodeGatewayExecute,
+  testEnvironment as kilocodeGatewayTestEnvironment,
+} from "@paperclipai/adapter-kilocode-gateway/server";
+import {
+  agentConfigurationDoc as kilocodeGatewayAgentConfigurationDoc,
+  models as kilocodeGatewayModels,
+} from "@paperclipai/adapter-kilocode-gateway";
+import { listKilocodeModels, refreshKilocodeModels } from "./kilocode-models.js";
+import {
   execute as piExecute,
   listPiSkills,
   syncPiSkills,
@@ -360,6 +369,19 @@ const openclawGatewayAdapter: ServerAdapterModule = {
   agentConfigurationDoc: openclawGatewayAgentConfigurationDoc,
 };
 
+const kilocodeGatewayAdapter: ServerAdapterModule = {
+  type: "kilocode_gateway",
+  execute: kilocodeGatewayExecute,
+  testEnvironment: kilocodeGatewayTestEnvironment,
+  models: kilocodeGatewayModels,
+  listModels: listKilocodeModels,
+  refreshModels: refreshKilocodeModels,
+  supportsLocalAgentJwt: false,
+  supportsInstructionsBundle: false,
+  requiresMaterializedRuntimeSkills: false,
+  agentConfigurationDoc: kilocodeGatewayAgentConfigurationDoc,
+};
+
 const openCodeLocalAdapter: ServerAdapterModule = {
   type: "opencode_local",
   execute: openCodeExecute,
@@ -487,6 +509,7 @@ function registerBuiltInAdapters() {
     cursorLocalAdapter,
     geminiLocalAdapter,
     openclawGatewayAdapter,
+    kilocodeGatewayAdapter,
     hermesLocalAdapter,
     processAdapter,
     httpAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,6 +40,7 @@
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
+    "@paperclipai/adapter-kilocode-gateway": "workspace:*",
     "@paperclipai/adapter-openclaw-gateway": "workspace:*",
     "@paperclipai/adapter-opencode-local": "workspace:*",
     "@paperclipai/adapter-pi-local": "workspace:*",

--- a/ui/src/adapters/kilocode-gateway/config-fields.tsx
+++ b/ui/src/adapters/kilocode-gateway/config-fields.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  DraftInput,
+} from "../../components/agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+function SecretField({
+  label,
+  value,
+  onCommit,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onCommit: (v: string) => void;
+  placeholder?: string;
+}) {
+  const [visible, setVisible] = useState(false);
+  return (
+    <Field label={label}>
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+        >
+          {visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
+        </button>
+        <DraftInput
+          value={value}
+          onCommit={onCommit}
+          immediate
+          type={visible ? "text" : "password"}
+          className={inputClass + " pl-8"}
+          placeholder={placeholder}
+        />
+      </div>
+    </Field>
+  );
+}
+
+export function KilocodeGatewayConfigFields({
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <SecretField
+        label="API Key"
+        value={eff("adapterConfig", "apiKey", String(config.apiKey ?? ""))}
+        onCommit={(v) => mark("adapterConfig", "apiKey", v || undefined)}
+        placeholder="kilo-..."
+      />
+
+      <Field label="Model">
+        <DraftInput
+          value={eff("adapterConfig", "model", String(config.model ?? ""))}
+          onCommit={(v) => mark("adapterConfig", "model", v || undefined)}
+          immediate
+          className={inputClass}
+          placeholder="anthropic/claude-sonnet-4.5"
+        />
+      </Field>
+
+      <Field label="Base URL">
+        <DraftInput
+          value={eff("adapterConfig", "baseUrl", String(config.baseUrl ?? ""))}
+          onCommit={(v) => mark("adapterConfig", "baseUrl", v || undefined)}
+          immediate
+          className={inputClass}
+          placeholder="https://api.kilo.ai/api/gateway"
+        />
+      </Field>
+
+      <Field label="Temperature">
+        <DraftInput
+          value={eff("adapterConfig", "temperature", String(config.temperature ?? "0.7"))}
+          onCommit={(v) => {
+            const parsed = parseFloat(v.trim());
+            mark("adapterConfig", "temperature", isFinite(parsed) ? parsed : undefined);
+          }}
+          immediate
+          className={inputClass}
+          placeholder="0.7"
+        />
+      </Field>
+
+      <Field label="Max tokens">
+        <DraftInput
+          value={eff("adapterConfig", "maxTokens", String(config.maxTokens ?? "8192"))}
+          onCommit={(v) => {
+            const parsed = parseInt(v.trim(), 10);
+            mark("adapterConfig", "maxTokens", isFinite(parsed) && parsed > 0 ? parsed : undefined);
+          }}
+          immediate
+          className={inputClass}
+          placeholder="8192"
+        />
+      </Field>
+
+      <Field label="Timeout (seconds)">
+        <DraftInput
+          value={eff("adapterConfig", "timeoutSec", String(config.timeoutSec ?? "120"))}
+          onCommit={(v) => {
+            const parsed = parseInt(v.trim(), 10);
+            mark("adapterConfig", "timeoutSec", isFinite(parsed) && parsed > 0 ? parsed : undefined);
+          }}
+          immediate
+          className={inputClass}
+          placeholder="120"
+        />
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/kilocode-gateway/index.ts
+++ b/ui/src/adapters/kilocode-gateway/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseKilocodeGatewayStdoutLine } from "@paperclipai/adapter-kilocode-gateway/ui";
+import { buildKilocodeGatewayConfig } from "@paperclipai/adapter-kilocode-gateway/ui";
+import { KilocodeGatewayConfigFields } from "./config-fields";
+
+export const kilocodeGatewayUIAdapter: UIAdapterModule = {
+  type: "kilocode_gateway",
+  label: "KiloCode Gateway",
+  parseStdoutLine: parseKilocodeGatewayStdoutLine,
+  ConfigFields: KilocodeGatewayConfigFields,
+  buildAdapterConfig: buildKilocodeGatewayConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -8,6 +8,7 @@ import { geminiLocalUIAdapter } from "./gemini-local";
 import { openCodeLocalUIAdapter } from "./opencode-local";
 import { piLocalUIAdapter } from "./pi-local";
 import { openClawGatewayUIAdapter } from "./openclaw-gateway";
+import { kilocodeGatewayUIAdapter } from "./kilocode-gateway";
 import { hermesLocalUIAdapter } from "./hermes-local";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
@@ -61,6 +62,7 @@ function registerBuiltInUIAdapters() {
     piLocalUIAdapter,
     cursorLocalUIAdapter,
     openClawGatewayUIAdapter,
+    kilocodeGatewayUIAdapter,
     processUIAdapter,
     httpUIAdapter,
   ]) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       "packages/adapters/cursor-cloud",
       "packages/adapters/cursor-local",
       "packages/adapters/gemini-local",
+      "packages/adapters/kilocode-gateway",
       "packages/adapters/opencode-local",
       "packages/adapters/pi-local",
       "packages/plugins/sdk",


### PR DESCRIPTION
## Architektur

`kilocode_gateway` ist ein eigenständiger HTTP-Adapter (kein Wrapper über opencode-local). Transport: OpenAI-kompatibles REST-API (`POST /api/gateway/chat/completions`) mit Bearer-Auth und optionalem SSE-Streaming. Dynamisches Model-Loading via `GET /api/gateway/models` (60s TTL-Cache, Fallback auf statische Liste). Implementiert analog zu `openclaw-gateway` für die Registry-Verkabelung, aber mit HTTP statt WebSocket.

Neue Dateien: `packages/adapters/kilocode-gateway/` (14 Dateien), `server/src/adapters/kilocode-models.ts`, `ui/src/adapters/kilocode-gateway/` — alle drei Registries (server, ui, cli) erweitert.

## Test-Output

```
✓ src/ui/parse-stdout.test.ts    (6 tests)
✓ src/server/execute.test.ts     (14 tests)
✓ server/src/adapters/kilocode-models.test.ts  (6 tests)

Test Files  3 passed (3)
     Tests  26 passed (26)
```

`pnpm typecheck` sauber auf server, ui, cli, kilocode-gateway.

## Smoke-Manual-Test

Endpoint `https://api.kilo.ai/api/gateway/chat/completions` erreichbar, Auth optional für Free-Tier (`kilo-auto/free`).

Non-streaming Response:
```json
{"model":"stepfun/step-3.5-flash:free","choices":[{"finish_reason":"length","message":{"role":"assistant","content":null}}],"usage":{"prompt_tokens":15,"completion_tokens":50,"total_tokens":65}}
```

SSE-Streaming erste Chunks:
```
data: {"model":"stepfun/step-3.5-flash:free","choices":[{"delta":{"content":"","role":"assistant"},"finish_reason":null}]}
```

Beide Pfade (streaming + non-streaming) liefern HTTP 200 + valide JSON-Struktur. `choices[0].message.content` und `delta.content` werden korrekt geparst.

Hinweis: Free-Tier-Modell (`stepfun/step-3.5-flash:free`) liefert `content: null` weil es ein Reasoning-Modell ist. Mit echtem KILO_API_KEY und einem Standard-Modell (`anthropic/claude-sonnet-4.5`) ist content-Payload garantiert.

## Getroffene Annahmen

1. `/api/gateway/models` braucht keinen Auth-Header — `testEnvironment` loggt Warn bei 401/403 statt Error
2. SSE-Streaming Standard (`stream: true`), non-streaming als Fallback konfigurierbar
3. `usage` kommt im letzten SSE-Chunk (OpenAI-Muster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)