### PR TITLE
ui(issue-chat): default-expand text transcripts and persist fold state

### DIFF
--- a/ui/src/components/IssueChatThread.test.tsx
+++ b/ui/src/components/IssueChatThread.test.tsx
@@ -7,12 +7,16 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Agent } from "@paperclipai/shared";
 import {
+  ISSUE_CHAT_FOLD_STORAGE_PREFIX,
   IssueChatThread,
   VIRTUALIZED_THREAD_ROW_THRESHOLD,
   canStopIssueChatRun,
   findLatestCommentMessageIndex,
+  hasVisibleAssistantText,
+  readPersistedAssistantFoldedState,
   resolveAssistantMessageFoldedState,
   resolveIssueChatHumanAuthor,
+  writePersistedAssistantFoldedState,
 } from "./IssueChatThread";
 import { ToastProvider } from "../context/ToastContext";
 import { ToastViewport } from "./ToastViewport";
@@ -2611,6 +2615,8 @@ describe("IssueChatThread", () => {
       messageId: "message-1",
       currentFolded: false,
       isFoldable: true,
+      defaultFolded: true,
+      persistedFolded: null,
       previousMessageId: "message-1",
       previousIsFoldable: false,
     })).toBe(true);
@@ -2621,9 +2627,162 @@ describe("IssueChatThread", () => {
       messageId: "message-1",
       currentFolded: false,
       isFoldable: true,
+      defaultFolded: true,
+      persistedFolded: null,
       previousMessageId: "message-1",
       previousIsFoldable: true,
     })).toBe(false);
+  });
+
+  it("leaves a text-bearing transcript unfolded by default once the run completes", () => {
+    expect(resolveAssistantMessageFoldedState({
+      messageId: "message-1",
+      currentFolded: false,
+      isFoldable: true,
+      defaultFolded: false,
+      persistedFolded: null,
+      previousMessageId: "message-1",
+      previousIsFoldable: false,
+    })).toBe(false);
+  });
+
+  it("starts a brand-new text-bearing transcript unfolded", () => {
+    expect(resolveAssistantMessageFoldedState({
+      messageId: "message-1",
+      currentFolded: true,
+      isFoldable: true,
+      defaultFolded: false,
+      persistedFolded: null,
+      previousMessageId: null,
+      previousIsFoldable: false,
+    })).toBe(false);
+  });
+
+  it("starts a brand-new thinking-only transcript folded", () => {
+    expect(resolveAssistantMessageFoldedState({
+      messageId: "message-1",
+      currentFolded: false,
+      isFoldable: true,
+      defaultFolded: true,
+      persistedFolded: null,
+      previousMessageId: null,
+      previousIsFoldable: false,
+    })).toBe(true);
+  });
+
+  it("keeps the message unfolded while it is still running (not foldable yet)", () => {
+    expect(resolveAssistantMessageFoldedState({
+      messageId: "message-1",
+      currentFolded: true,
+      isFoldable: false,
+      defaultFolded: true,
+      persistedFolded: true,
+      previousMessageId: "message-1",
+      previousIsFoldable: false,
+    })).toBe(false);
+  });
+
+  it("prefers the persisted choice over the default when a transcript first renders", () => {
+    expect(resolveAssistantMessageFoldedState({
+      messageId: "message-1",
+      currentFolded: true,
+      isFoldable: true,
+      defaultFolded: true,
+      persistedFolded: false,
+      previousMessageId: null,
+      previousIsFoldable: false,
+    })).toBe(false);
+
+    expect(resolveAssistantMessageFoldedState({
+      messageId: "message-2",
+      currentFolded: false,
+      isFoldable: true,
+      defaultFolded: false,
+      persistedFolded: true,
+      previousMessageId: null,
+      previousIsFoldable: false,
+    })).toBe(true);
+  });
+
+  it("treats a transcript with visible text as text-bearing", () => {
+    expect(hasVisibleAssistantText({
+      id: "message-1",
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking" },
+        { type: "text", text: "Here is the answer." },
+      ],
+      createdAt: new Date(0),
+      metadata: { custom: {}, steps: [], unstable_annotations: [], unstable_data: [] },
+      status: { type: "complete", reason: "stop" },
+    } as unknown as Parameters<typeof hasVisibleAssistantText>[0])).toBe(true);
+  });
+
+  it("treats a transcript with whitespace-only text as text-empty", () => {
+    expect(hasVisibleAssistantText({
+      id: "message-1",
+      role: "assistant",
+      content: [
+        { type: "text", text: "   \n  " },
+        { type: "tool-call", toolCallId: "t1", toolName: "x", args: {}, argsText: "" },
+      ],
+      createdAt: new Date(0),
+      metadata: { custom: {}, steps: [], unstable_annotations: [], unstable_data: [] },
+      status: { type: "complete", reason: "stop" },
+    } as unknown as Parameters<typeof hasVisibleAssistantText>[0])).toBe(false);
+  });
+
+  it("treats a thinking/tool-call-only transcript as text-empty", () => {
+    expect(hasVisibleAssistantText({
+      id: "message-1",
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "thinking" },
+        { type: "tool-call", toolCallId: "t1", toolName: "x", args: {}, argsText: "" },
+      ],
+      createdAt: new Date(0),
+      metadata: { custom: {}, steps: [], unstable_annotations: [], unstable_data: [] },
+      status: { type: "complete", reason: "stop" },
+    } as unknown as Parameters<typeof hasVisibleAssistantText>[0])).toBe(false);
+  });
+
+  describe("persisted fold storage", () => {
+    afterEach(() => {
+      try { window.localStorage.clear(); } catch { /* ignore */ }
+      vi.restoreAllMocks();
+    });
+
+    it("round-trips folded and unfolded values via localStorage", () => {
+      writePersistedAssistantFoldedState("msg-a", true);
+      writePersistedAssistantFoldedState("msg-b", false);
+      expect(window.localStorage.getItem(`${ISSUE_CHAT_FOLD_STORAGE_PREFIX}msg-a`)).toBe("folded");
+      expect(window.localStorage.getItem(`${ISSUE_CHAT_FOLD_STORAGE_PREFIX}msg-b`)).toBe("unfolded");
+      expect(readPersistedAssistantFoldedState("msg-a")).toBe(true);
+      expect(readPersistedAssistantFoldedState("msg-b")).toBe(false);
+    });
+
+    it("returns null for messages with no stored choice", () => {
+      expect(readPersistedAssistantFoldedState("msg-missing")).toBeNull();
+    });
+
+    it("returns null for an unexpected stored value", () => {
+      window.localStorage.setItem(`${ISSUE_CHAT_FOLD_STORAGE_PREFIX}msg-c`, "garbled");
+      expect(readPersistedAssistantFoldedState("msg-c")).toBeNull();
+    });
+
+    it("swallows localStorage write errors (quota / private mode)", () => {
+      const setItem = vi.spyOn(Storage.prototype, "setItem")
+        .mockImplementation(() => { throw new Error("QuotaExceededError"); });
+      expect(() => writePersistedAssistantFoldedState("msg-d", true)).not.toThrow();
+      expect(setItem).toHaveBeenCalled();
+    });
+
+    it("swallows localStorage read errors and returns null", () => {
+      const getItem = vi.spyOn(Storage.prototype, "getItem")
+        .mockImplementation(() => { throw new Error("SecurityError"); });
+      expect(readPersistedAssistantFoldedState("msg-e")).toBeNull();
+      expect(getItem).toHaveBeenCalled();
+    });
   });
 
   it("shows the stop-run action for active run-linked messages even without embedded run status", () => {

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -182,10 +182,42 @@ const IssueChatCtx = createContext<IssueChatMessageContext>({
   successfulRunHandoff: null,
 });
 
+export const ISSUE_CHAT_FOLD_STORAGE_PREFIX = "paperclip:issue-chat-fold:";
+
+export function hasVisibleAssistantText(message: ThreadMessage): boolean {
+  return message.content.some((part) => part.type === "text" && part.text.trim().length > 0);
+}
+
+export function readPersistedAssistantFoldedState(messageId: string): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(`${ISSUE_CHAT_FOLD_STORAGE_PREFIX}${messageId}`);
+    if (raw === "folded") return true;
+    if (raw === "unfolded") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function writePersistedAssistantFoldedState(messageId: string, folded: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      `${ISSUE_CHAT_FOLD_STORAGE_PREFIX}${messageId}`,
+      folded ? "folded" : "unfolded",
+    );
+  } catch {
+    // localStorage may be unavailable (quota exceeded, private mode); ignore silently.
+  }
+}
+
 export function resolveAssistantMessageFoldedState(args: {
   messageId: string;
   currentFolded: boolean;
   isFoldable: boolean;
+  defaultFolded: boolean;
+  persistedFolded: boolean | null;
   previousMessageId: string | null;
   previousIsFoldable: boolean;
 }) {
@@ -193,13 +225,16 @@ export function resolveAssistantMessageFoldedState(args: {
     messageId,
     currentFolded,
     isFoldable,
+    defaultFolded,
+    persistedFolded,
     previousMessageId,
     previousIsFoldable,
   } = args;
 
-  if (messageId !== previousMessageId) return isFoldable;
   if (!isFoldable) return false;
-  if (!previousIsFoldable) return true;
+  const initial = persistedFolded ?? defaultFolded;
+  if (messageId !== previousMessageId) return initial;
+  if (!previousIsFoldable) return initial;
   return currentFolded;
 }
 
@@ -1461,7 +1496,12 @@ function IssueChatAssistantMessage({
   const chainOfThoughtLabel = typeof custom.chainOfThoughtLabel === "string" ? custom.chainOfThoughtLabel : null;
   const hasCoT = message.content.some((p) => p.type === "reasoning" || p.type === "tool-call");
   const isFoldable = !isRunning && !!chainOfThoughtLabel;
-  const [folded, setFolded] = useState(isFoldable);
+  const defaultFolded = !hasVisibleAssistantText(message);
+  const [folded, setFolded] = useState(() => {
+    if (!isFoldable) return false;
+    const persisted = readPersistedAssistantFoldedState(message.id);
+    return persisted ?? defaultFolded;
+  });
   const [prevFoldKey, setPrevFoldKey] = useState({ messageId: message.id, isFoldable });
   const [copied, setCopied] = useState(false);
   const copyText = getThreadMessageCopyText(message);
@@ -1474,6 +1514,8 @@ function IssueChatAssistantMessage({
       messageId: message.id,
       currentFolded: folded,
       isFoldable,
+      defaultFolded,
+      persistedFolded: readPersistedAssistantFoldedState(message.id),
       previousMessageId: prevFoldKey.messageId,
       previousIsFoldable: prevFoldKey.isFoldable,
     });
@@ -1482,6 +1524,14 @@ function IssueChatAssistantMessage({
       setFolded(nextFolded);
     }
   }
+
+  const toggleFolded = useCallback(() => {
+    setFolded((current) => {
+      const next = !current;
+      writePersistedAssistantFoldedState(message.id, next);
+      return next;
+    });
+  }, [message.id]);
 
   const handleVote = async (
     vote: FeedbackVoteValue,
@@ -1509,7 +1559,7 @@ function IssueChatAssistantMessage({
             <button
               type="button"
               className="group flex w-full items-center gap-2 py-0.5 text-left"
-              onClick={() => setFolded((v) => !v)}
+              onClick={toggleFolded}
             >
               <span className="text-sm font-medium text-foreground">{authorName}</span>
               <span className="text-xs text-muted-foreground/60">{chainOfThoughtLabel?.toLowerCase()}</span>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The issue chat in `ui/src/components/IssueChatThread.tsx` renders both raw user/assistant comments and run-derived transcripts.
> - Every run transcript carries a `chainOfThoughtLabel` (set in `ui/src/lib/issue-chat-messages.ts` via `runDurationLabel`), so historical and live-run-derived assistant messages were always classed as foldable and folded by default.
> - That hid plain-text run replies (e.g. CEO/CTO answers posted as a run) behind a collapsed chevron, and the fold state lived only in component state — page reload re-collapsed everything every time.
> - This pull request strengthens the default to "unfold when the transcript actually has visible text" and persists the user's fold choice in `localStorage` so the same message keeps its state across reloads.
> - The benefit is that real text replies in issue chat are visible on first paint and the user's manual collapse/expand choice no longer evaporates on every render of the page.

## What Changed

- Added `hasVisibleAssistantText` to detect transcripts containing a `type: "text"` part with non-whitespace content, and use it as the new `defaultFolded` value (text-bearing transcripts default to unfolded; thinking/tool-call-only stay folded).
- Added `readPersistedAssistantFoldedState` / `writePersistedAssistantFoldedState` helpers backed by `localStorage` key `paperclip:issue-chat-fold:{messageId}` with `"folded" | "unfolded"` values. Both wrap storage access in `try/catch` so quota/private-mode failures stay silent.
- Extended `resolveAssistantMessageFoldedState` with `defaultFolded` and `persistedFolded`; persisted user choice wins over the default both on the first render of a message and on the running→complete transition. Non-foldable (still-running) messages still stay expanded.
- Wired `IssueChatAssistantMessage` to seed `useState` from persisted storage (or the default) and to persist on every toggle click via `writePersistedAssistantFoldedState`.
- Updated existing `resolveAssistantMessageFoldedState` tests to the new signature and added unit tests for: text-bearing default-expand, thinking-only default-fold, running guard, persisted-overrides-default, `hasVisibleAssistantText` (text/whitespace-only/non-text), and a `localStorage` round-trip plus read/write error swallowing.

## Verification

- `pnpm --filter @paperclipai/ui vitest run src/components/IssueChatThread.test.tsx` — 63 tests, all pass.
- `pnpm --filter @paperclipai/ui vitest run` — 947 tests across 150 files, all pass.
- `pnpm --filter @paperclipai/ui typecheck` — clean.
- Manual: in the issue chat, a run-derived transcript whose body is just a text reply now renders expanded on first paint; expanding or collapsing it and reloading the page preserves that choice. A reasoning/tool-call-only transcript still renders collapsed by default, and a live (running) transcript still renders expanded.

## Risks

- Low risk. Change is scoped to the issue-chat assistant message fold logic. The only persistent side effect is writing `paperclip:issue-chat-fold:{messageId}` keys to `localStorage`; storage failures are caught. Behavior for live transcripts and stop-run actions is untouched.
- One nuance: persistence is keyed on `messageId`. Historical run-derived messages use stable ids (`run-${runId}` / `run-assistant:${runId}`), so persisted choices survive reloads. If a future change reshuffles message ids, persisted entries become inert (not wrong, just orphaned), which is acceptable.

## Model Used

- Claude — `claude-opus-4-7` (Opus 4.7), large context, tool use enabled. Extended thinking was not specifically toggled for this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (UI affordance unchanged — same chevron button; visible difference is the default folded/expanded state on first paint)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Refs DOGAA-2715.
