### PR TITLE
SUP-1615 allow CEO closeout of runless active issues

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -443,6 +443,32 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).toHaveBeenCalled();
   });
 
+  it("allows a CEO-style assigned agent to close its own runless active issue", async () => {
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === ownerAgentId) return makeAgent(ownerAgentId, { role: "ceo", permissions: { canCreateAgents: true } });
+      if (id === peerAgentId) return makeAgent(peerAgentId);
+      return null;
+    });
+    mockAgentService.list.mockResolvedValue([
+      makeAgent(ownerAgentId, { role: "ceo", permissions: { canCreateAgents: true } }),
+      makeAgent(peerAgentId),
+    ]);
+
+    const res = await request(await createApp({ ...ownerActor(), runId: null }))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", comment: "Verified closeout evidence." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "done",
+        actorAgentId: ownerAgentId,
+      }),
+    );
+  });
+
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
     ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1117,6 +1117,9 @@ export function issueRoutes(
     if (issue.status !== "in_progress") {
       return true;
     }
+    if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
+      return true;
+    }
     const runId = requireAgentRunId(req, res);
     if (!runId) return false;
     const ownership = await svc.assertCheckoutOwner(issue.id, actorAgentId, runId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and tracks issue ownership through assignees, active runs, and checkout locks.
> - Issue mutations are guarded so peer agents cannot overwrite another agent's active work.
> - Some operational repair paths still need CEO/operator authority to close out runless active issues that were moved to `in_progress` without a checkout run.
> - The current guard allowed manager/CEO intervention for other agents' active checkouts, but required a run id before checking the same-assigned CEO/operator case.
> - That stranded verified work in a dead zone: the issue was assigned to the CEO-style agent, `in_progress`, and had no checkout run id to provide.
> - This pull request lets active-checkout management authority apply before the same-agent run-id requirement.
> - The benefit is a legitimate operator closeout path without fake run IDs or direct database writes, while peer-agent protections remain intact.

## What Changed

- Allow same-assigned agent actors with active-checkout management authority, including CEO-style agents, to mutate `in_progress` issues without requiring `X-Paperclip-Run-Id`.
- Add regression coverage for a CEO-style assigned agent closing its own runless active issue.

## Verification

- `pnpm vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
- Also verified against Andrew's local Paperclip runtime after restart: `SUP-1525` closed through the normal API without fake run IDs or database writes.

## Risks

- Low-to-moderate: this changes mutation authorization for same-assigned CEO/operator-style agents on active issues. The bypass is limited to actors that already pass `hasActiveCheckoutManagementOverride`, and the existing peer-agent denial tests still pass.

## Model Used

- OpenAI GPT-5 Codex via Codex CLI/API tooling, with local shell/test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge