### PR TITLE
Release changelog v2026.513.0

### DIFF
--- a/releases/v2026.513.0.md
+++ b/releases/v2026.513.0.md
@@ -1,0 +1,26 @@
+# v2026.513.0
+
+> Released: 2026-05-13
+
+## Highlights
+
+- **Source-scoped recovery actions** — Stalled or missing-disposition recovery now creates first-class recovery actions on the source issue itself, with owner, evidence, wake policy, and resolution outcome (`restored`, `blocked`, `cancelled`, or `false_positive`). Recovery indicators surface on issue rows, detail surfaces, active run panels, and blocker notices, and blocked resolutions require a real first-class blocker instead of a comment. ([#5599](https://github.com/paperclipai/paperclip/pull/5599))
+- **Blocked Inbox attention view** — A new Blocked Inbox tab surfaces blocked work alongside active assignments, with blocked-reason chips, filtering and search, deterministic urgency sorting, responsive layouts, and a backend blocker-attention contract so operators have a clear triage path for stalled tasks. ([#5603](https://github.com/paperclipai/paperclip/pull/5603))
+- **Local plugin development workflow** — `paperclipai plugin init` scaffolding now ships with a CLI-first authoring loop covering local-path installs, plugin key routing, dashboard capabilities, dev watcher startup and reload, and SDK worker entrypoint validation for symlinked package layouts. A new local plugin development guide and refreshed `paperclip-create-plugin` skill instructions document the full happy path. ([#5821](https://github.com/paperclipai/paperclip/pull/5821))
+
+## Improvements
+
+- **Ordered sub-issue navigation** — Issue detail footers now expose previous/next ordered navigation that walks siblings and continues into a parent's first ordered child, with hidden-issue filtering and dependency-aware ordering preserved. The quicklook blur/click race is also fixed so portaled link clicks complete reliably. ([#5938](https://github.com/paperclipai/paperclip/pull/5938))
+
+## Fixes
+
+- **Comment date binding regression** — Issue comment listing no longer fails with `ERR_INVALID_ARG_TYPE` when the derived-attribution heartbeat scan binds a `Date` into postgres-js. Window bounds are now bound as ISO timestamp strings with explicit `::timestamptz` casts so comments load on issues such as `PAP-9284` without weakening the conservative attribution recovery. ([#5919](https://github.com/paperclipai/paperclip/pull/5919))
+- **Remote sandbox host workspace resumes** — `claude_local` sessions now persist the host workspace cwd (not the remote sandbox cwd), reject saved cwds that point at system roots before falling back to the agent home workspace, skip sockets, FIFOs, devices, and other non-file entries during workspace restore snapshot capture, and pass only a small model-provider API-key allowlist to plugins that declare `environment.drivers.register`. ([#5922](https://github.com/paperclipai/paperclip/pull/5922))
+
+## Upgrade Guide
+
+One new database migration runs automatically on startup:
+
+- `0084_issue_recovery_actions` — adds the `issue_recovery_actions` table and supporting indexes for source-scoped recovery. The migration is idempotent so it is safe for anyone who previously applied an earlier branch-local recovery-action migration. Existing child recovery issue paths remain guarded; new source-scoped flows will surface recovery indicators in additional places on the board UI.
+
+No application configuration changes are required to take this release.


### PR DESCRIPTION
## Summary

- Add `releases/v2026.513.0.md` covering the stable release range `v2026.512.0..origin/master` (6 PRs).
- Includes one new DB migration (`0084_issue_recovery_actions`) under the Upgrade Guide.
- No breaking changes detected; all PRs are core-maintainer commits so the Contributors section is omitted.

## Highlights captured

- Source-scoped recovery actions ([#5599](https://github.com/paperclipai/paperclip/pull/5599))
- Blocked Inbox attention view ([#5603](https://github.com/paperclipai/paperclip/pull/5603))
- Local plugin development workflow ([#5821](https://github.com/paperclipai/paperclip/pull/5821))

## Test plan

- [ ] Reviewer confirms the highlight/improvement/fix categorization matches release intent
- [ ] Reviewer confirms `0084_issue_recovery_actions` upgrade note is accurate
- [ ] Reviewer signs off on `releases/v2026.513.0.md` for the stable release cut

Generated under [PAP-9378](/PAP/issues/PAP-9378) via the `release-changelog` skill.