### PR TITLE
fix(recovery): skip stale-run alert when source issue is already done

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -20,7 +20,7 @@ import {
   ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS,
   heartbeatService,
 } from "../services/heartbeat.ts";
-import { recoveryService } from "../services/recovery/service.ts";
+import { ACTIVE_RUN_DONE_SOURCE_GRACE_MS, recoveryService } from "../services/recovery/service.ts";
 import { getRunLogStore } from "../services/run-log-store.ts";
 
 const mockAdapterExecute = vi.hoisted(() =>
@@ -546,5 +546,57 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       createdByRunId: randomUUID(),
     });
     expect(decision.createdByRunId).toBe(managerRunId);
+  });
+
+  it("skips evaluation when source issue is done within the grace window of last output", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      withOutput: true,
+    });
+
+    // Mark the source issue done within the grace window of the run's last output.
+    // seedRunningRun sets lastOutputAt = now - 5min; completedAt = now - 4min is 1min skew.
+    const completedAt = new Date(now.getTime() - 4 * 60 * 1000);
+    await db.update(issues).set({ status: "done", completedAt }).where(eq(issues.id, issueId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result.scanned).toBe(1);
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+  });
+
+  it("still creates evaluation when source issue is done but completion is far from last output", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, issueId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      withOutput: true,
+    });
+
+    // Mark the source issue done, but completedAt is well outside the grace window.
+    const completedAt = new Date(now.getTime() - (ACTIVE_RUN_DONE_SOURCE_GRACE_MS + 60_000));
+    await db.update(issues).set({ status: "done", completedAt }).where(eq(issues.id, issueId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+    expect(result.scanned).toBe(1);
+    expect(result.created).toBe(1);
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(1);
   });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -64,6 +64,9 @@ const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "ti
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
+// When the source issue completed/cancelled within this window of the run's last output,
+// the run is considered gracefully finished — no stale-run alert is generated.
+export const ACTIVE_RUN_DONE_SOURCE_GRACE_MS = 5 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
@@ -1030,6 +1033,24 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
+
+    // Suppress alert when the source issue already reached a terminal state close to
+    // the run's last output — the run completed its work and just didn't exit cleanly.
+    if (sourceIssue && (sourceIssue.status === "done" || sourceIssue.status === "cancelled")) {
+      const terminalAt = sourceIssue.completedAt ?? sourceIssue.cancelledAt;
+      const runLastActiveAt = input.run.lastOutputAt ?? input.run.processStartedAt ?? input.run.startedAt ?? input.run.createdAt;
+      if (terminalAt && runLastActiveAt) {
+        const skewMs = Math.abs(terminalAt.getTime() - runLastActiveAt.getTime());
+        if (skewMs <= ACTIVE_RUN_DONE_SOURCE_GRACE_MS) {
+          logger.info(
+            { runId: input.run.id, sourceIssueId: sourceIssue.id, issueStatus: sourceIssue.status, skewMs },
+            "skipping stale-run evaluation: source issue reached terminal state within grace window of last run output",
+          );
+          return { kind: "skipped" as const };
+        }
+      }
+    }
+
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({
       run: input.run,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents that run heartbeats against assigned issues
> - The active-run output watchdog fires when a run has been silent for 1h, creating a stale-run evaluation issue
> - A run can be silent after its work is complete if the local process (e.g. Claude Code) didn't exit cleanly — the process is a zombie but the actual work succeeded
> - The watchdog has no way to distinguish "zombie with completed work" from "agent genuinely stuck", so it fires noise alerts that consume CEO + CTO heartbeat budget
> - KIV-2251 documented a real occurrence: SADE run `5a316f9f` closed its source issue at 05:04:46Z but pid 48992 lingered; the detector fired 1h 14m later
> - The fix: before creating an evaluation, check whether the run's source issue is already in a terminal state (`done`/`cancelled`) AND whether its `completedAt`/`cancelledAt` is within a 5-minute grace window of the run's last output timestamp — if so, the work is done and the run is a graceful zombie, not a stale agent
> - This is the same class of false positive behind the 500+ alert storm mitigated in KIV-2024 and KIV-2239; hardening the detector prevents recurrence

## What Changed

- **`server/src/services/recovery/service.ts`**: Exports new constant `ACTIVE_RUN_DONE_SOURCE_GRACE_MS = 5 * 60 * 1000`. In `createOrUpdateStaleRunEvaluation`, immediately after resolving the source issue, skip evaluation (return `{ kind: "skipped" }`) when the source issue is `done`/`cancelled` and its terminal timestamp is within the grace window of the run's `lastOutputAt` (falling back through `processStartedAt → startedAt → createdAt`). Logs the skip at `info` level with `runId`, `sourceIssueId`, `issueStatus`, and `skewMs` for observability.
- **`server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`**: Imports `ACTIVE_RUN_DONE_SOURCE_GRACE_MS`. Adds two new tests: (1) source issue `done` within grace window → no evaluation created, `skipped = 1`; (2) source issue `done` but `completedAt` outside grace window → evaluation fires normally.

## Verification

```bash
# Run the watchdog test suite
pnpm test server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
```

Expected: all existing tests pass; two new tests pass:
- `"skips evaluation when source issue is done within the grace window of last output"`
- `"still creates evaluation when source issue is done but completion is far from last output"`

Manual verification: no evaluation issue is created when the source issue `completedAt` ≈ `lastOutputAt` within 5 min.

## Risks

- **Grace window is asymmetric**: `Math.abs(terminalAt - runLastActiveAt)` handles either ordering, so clock skew or slightly out-of-order DB writes are tolerated.
- **No false suppression for genuinely stuck agents**: if a stuck run's source issue was closed manually (not by the run completing its work), the timestamps will be far apart and the alert still fires. The 5-minute window is narrow enough not to suppress real incidents.
- **Existing evaluations not retroactively closed**: this only prevents *new* evaluations; existing open evaluations for already-done source issues remain open for the CTO to review or dismiss. Low risk — those are one-time noise, not a loop.
- **Low overall risk**: additive early-return guard, no DB schema changes, no migration needed.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context window: 200k tokens
- Capabilities: tool use, extended context, code execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge