### PR TITLE
fix(execution-policy): aceitar returnAssignee em transição approved quando único participant

### DIFF
--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -1081,6 +1081,83 @@ describe("issue execution policy transitions", () => {
     });
   });
 
+  describe("returnAssignee como único participant no path approved (SIMAA-2206)", () => {
+    it("avança para o próximo stage quando returnAssignee é o único participant (cenário bloqueante)", () => {
+      // Verifier (qa) é participant do stage approval; Builder (coder) é returnAssignee e único participant do stage review.
+      // Antes do fix, exclude=returnAssignee fazia selectStageParticipant retornar null → 422.
+      const policy = makePolicy([
+        { type: "approval", participants: [{ type: "agent", agentId: qaAgentId }] },
+        { type: "review", participants: [{ type: "agent", agentId: coderAgentId }] },
+      ]);
+      const approvalStageId = policy.stages[0].id;
+
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: {
+            status: "pending",
+            currentStageId: approvalStageId,
+            currentStageIndex: 0,
+            currentStageType: "approval",
+            currentParticipant: { type: "agent", agentId: qaAgentId },
+            returnAssignee: { type: "agent", agentId: coderAgentId },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: null,
+          },
+        },
+        policy,
+        requestedStatus: "done",
+        requestedAssigneePatch: {},
+        actor: { agentId: qaAgentId },
+        commentBody: "Contrato aprovado",
+      });
+
+      expect(result.patch.assigneeAgentId).toBe(coderAgentId);
+      expect(result.patch.executionState).toMatchObject({
+        status: "pending",
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: coderAgentId },
+        completedStageIds: [approvalStageId],
+      });
+    });
+
+    it("returnAssignee ainda é excluído ao submeter done (path inicial, não approved)", () => {
+      // Garante que o fix não afeta a exclusão do returnAssignee na transição inicial done→review,
+      // onde o exclude permanece para evitar auto-seleção do coder como próprio reviewer.
+      const policy = makePolicy([
+        {
+          type: "review",
+          participants: [
+            { type: "agent", agentId: coderAgentId },
+            { type: "agent", agentId: qaAgentId },
+          ],
+        },
+      ]);
+
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_progress",
+          assigneeAgentId: coderAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: null,
+        },
+        policy,
+        requestedStatus: "done",
+        requestedAssigneePatch: {},
+        actor: { agentId: coderAgentId },
+        commentBody: "Done",
+      });
+
+      // coderAgentId é returnAssignee e deve ser excluído; qaAgentId deve ser selecionado
+      expect(result.patch.assigneeAgentId).toBe(qaAgentId);
+    });
+  });
+
   describe("changes requested with no return assignee", () => {
     it("throws when requesting changes with no return assignee", () => {
       const policy = twoStagePolicy();

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -716,7 +716,6 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
 
         const participant = selectStageParticipant(nextStage, {
           preferred: explicitAssignee,
-          exclude: existingState?.returnAssignee ?? null,
         });
         if (!participant) {
           throw unprocessable(`No eligible ${nextStage.type} participant is configured for this issue`);


### PR DESCRIPTION
## Contexto

Bug crítico detectado em 2026-05-13 durante approval do contrato SIMAA-2181. Quando o Verifier aprovava um stage, o motor tentava avançar para o próximo stage (review/Builder), mas excluía o `returnAssignee` da seleção de participant. Se o Builder era o único participant do próximo stage, `selectStageParticipant` retornava `null` e o motor lançava 422 `No eligible participant`.

Issues blocadas: SIMAA-2180-2197 (toda a wave).

Diagnóstico completo: SIMAA-2205  
Issue de fix: SIMAA-2206

## Mudança

Remove `exclude: existingState?.returnAssignee ?? null` da chamada de `selectStageParticipant` dentro do branch `approved` (linha ~719 de `server/src/services/issue-execution-policy.ts`).

**Por que é seguro:** a garantia anti-auto-aprovação vem de `principalsEqual(currentParticipant, actor)` (linha 693) — apenas o currentParticipant ativo pode avançar seu próprio stage. O `exclude` no path positivo não era necessário e bloqueava transições legítimas. As outras 4 chamadas a `selectStageParticipant` (linhas 656, 664, 816, 841) mantêm `exclude: returnAssignee` inalterado.

## Checklist do contrato (SIMAA-2206)

- [x] Fix aplicado em `server/src/services/issue-execution-policy.ts` (1 linha removida)
- [x] Teste: approval stage → review stage onde returnAssignee é único participant (avança sem 422)
- [x] Teste: returnAssignee ainda excluído no path inicial `done→review` (anti-auto-aprovação preservado)
- [x] Smoke: `vitest run issue-execution-policy.test.ts` → 52/52 PASS
- [x] Build: `pnpm --filter @paperclipai/server build` → PASS
- [x] Typecheck: `pnpm --filter @paperclipai/server typecheck` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)