### PR TITLE
Serialize codex-local OAuth auth executions

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-auth-lock.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-lock.ts
@@ -1,0 +1,141 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+
+const LOCK_ROOT = path.join(os.tmpdir(), "paperclip-codex-auth-locks");
+const LOCK_POLL_MS = 100;
+const LOCK_HEARTBEAT_MS = 30_000;
+const STALE_LOCK_MS = 30 * 60_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAdapterApiKeyAuth(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const keys = Object.keys(value);
+  return (
+    keys.length === 1 &&
+    typeof value.OPENAI_API_KEY === "string" &&
+    value.OPENAI_API_KEY.trim().length > 0
+  );
+}
+
+async function authFileNeedsRefreshLock(authPath: string): Promise<boolean> {
+  const contents = await fs.readFile(authPath, "utf8").catch(() => null);
+  if (contents == null) return true;
+
+  try {
+    return !isAdapterApiKeyAuth(JSON.parse(contents));
+  } catch {
+    return true;
+  }
+}
+
+async function resolveCodexAuthLock(codexHome: string): Promise<{
+  realAuthPath: string;
+  lockDir: string;
+} | null> {
+  const authPath = path.join(codexHome, "auth.json");
+  const realAuthPath = await fs.realpath(authPath).catch(() => null);
+  if (!realAuthPath) return null;
+  if (!(await authFileNeedsRefreshLock(realAuthPath))) return null;
+
+  const digest = crypto.createHash("sha256").update(realAuthPath).digest("hex");
+  return {
+    realAuthPath,
+    lockDir: path.join(LOCK_ROOT, `${digest}.lock`),
+  };
+}
+
+async function removeStaleLock(
+  lockDir: string,
+  realAuthPath: string,
+  onLog: AdapterExecutionContext["onLog"],
+): Promise<boolean> {
+  const stat = await fs.stat(lockDir).catch(() => null);
+  if (!stat || Date.now() - stat.mtimeMs < STALE_LOCK_MS) return false;
+
+  await fs.rm(lockDir, { recursive: true, force: true }).catch(() => undefined);
+  await onLog(
+    "stdout",
+    `[paperclip] Removed stale Codex auth lock for "${realAuthPath}".\n`,
+  );
+  return true;
+}
+
+async function acquireCodexAuthLock(
+  codexHome: string,
+  onLog: AdapterExecutionContext["onLog"],
+): Promise<(() => Promise<void>) | null> {
+  const lock = await resolveCodexAuthLock(codexHome);
+  if (!lock) return null;
+
+  await fs.mkdir(LOCK_ROOT, { recursive: true, mode: 0o700 });
+
+  const startedAt = Date.now();
+  let loggedWait = false;
+  for (;;) {
+    try {
+      await fs.mkdir(lock.lockDir, { mode: 0o700 });
+      await fs.writeFile(
+        path.join(lock.lockDir, "owner.json"),
+        JSON.stringify({
+          pid: process.pid,
+          startedAt: new Date().toISOString(),
+          authPath: lock.realAuthPath,
+        }),
+      ).catch(() => undefined);
+
+      const heartbeat = setInterval(() => {
+        const now = new Date();
+        void fs.utimes(lock.lockDir, now, now).catch(() => undefined);
+      }, LOCK_HEARTBEAT_MS);
+      heartbeat.unref?.();
+
+      if (loggedWait) {
+        await onLog(
+          "stdout",
+          `[paperclip] Acquired Codex auth lock for "${lock.realAuthPath}" after ${Date.now() - startedAt}ms.\n`,
+        );
+      }
+
+      return async () => {
+        clearInterval(heartbeat);
+        await fs.rm(lock.lockDir, { recursive: true, force: true }).catch(() => undefined);
+      };
+    } catch (err) {
+      if (!isRecord(err) || err.code !== "EEXIST") throw err;
+
+      if (!loggedWait) {
+        loggedWait = true;
+        await onLog(
+          "stdout",
+          `[paperclip] Waiting for Codex auth lock for "${lock.realAuthPath}".\n`,
+        );
+      }
+
+      await removeStaleLock(lock.lockDir, lock.realAuthPath, onLog);
+      await sleep(LOCK_POLL_MS);
+    }
+  }
+}
+
+export async function withCodexAuthLock<T>(
+  codexHome: string,
+  onLog: AdapterExecutionContext["onLog"],
+  run: () => Promise<T>,
+): Promise<T> {
+  const release = await acquireCodexAuthLock(codexHome, onLog);
+  try {
+    return await run();
+  } finally {
+    await release?.();
+  }
+}

--- a/packages/adapters/codex-local/src/server/execute-auth-lock.test.ts
+++ b/packages/adapters/codex-local/src/server/execute-auth-lock.test.ts
@@ -1,0 +1,183 @@
+import { mkdir, mkdtemp, readlink, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const {
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  resolveAdapterExecutionTargetCommandForLogs,
+  runAdapterExecutionTargetProcess,
+} = vi.hoisted(() => ({
+  ensureAdapterExecutionTargetCommandResolvable: vi.fn(async () => undefined),
+  ensureAdapterExecutionTargetRuntimeCommandInstalled: vi.fn(async () => undefined),
+  resolveAdapterExecutionTargetCommandForLogs: vi.fn(async () => "/usr/bin/codex"),
+  runAdapterExecutionTargetProcess: vi.fn(),
+}));
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/adapter-utils/execution-target")>(
+    "@paperclipai/adapter-utils/execution-target",
+  );
+  return {
+    ...actual,
+    ensureAdapterExecutionTargetCommandResolvable,
+    ensureAdapterExecutionTargetRuntimeCommandInstalled,
+    resolveAdapterExecutionTargetCommandForLogs,
+    runAdapterExecutionTargetProcess,
+  };
+});
+
+import { execute } from "./execute.js";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function successfulCodexStdout(runId: string): string {
+  return [
+    JSON.stringify({ type: "thread.started", thread_id: `thread-${runId}` }),
+    JSON.stringify({
+      type: "item.completed",
+      item: { type: "agent_message", text: `done ${runId}` },
+    }),
+    JSON.stringify({
+      type: "turn.completed",
+      usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+    }),
+  ].join("\n");
+}
+
+describe("codex OAuth auth locking", () => {
+  const cleanupDirs: string[] = [];
+  let previousCodexHome: string | undefined;
+  let previousPaperclipHome: string | undefined;
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+    if (previousPaperclipHome === undefined) {
+      delete process.env.PAPERCLIP_HOME;
+    } else {
+      process.env.PAPERCLIP_HOME = previousPaperclipHome;
+    }
+    previousCodexHome = undefined;
+    previousPaperclipHome = undefined;
+
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("serializes simultaneous OAuth-backed launches whose managed homes symlink the same auth.json", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-auth-lock-"));
+    cleanupDirs.push(rootDir);
+    const sourceHome = path.join(rootDir, "shared-codex-home");
+    const paperclipHome = path.join(rootDir, "paperclip-home");
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(sourceHome, { recursive: true });
+    await mkdir(workspaceDir, { recursive: true });
+    await writeFile(
+      path.join(sourceHome, "auth.json"),
+      JSON.stringify({
+        tokens: {
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+        },
+      }),
+      "utf8",
+    );
+
+    previousCodexHome = process.env.CODEX_HOME;
+    previousPaperclipHome = process.env.PAPERCLIP_HOME;
+    process.env.CODEX_HOME = sourceHome;
+    process.env.PAPERCLIP_HOME = paperclipHome;
+
+    let activeProcesses = 0;
+    let maxActiveProcesses = 0;
+    const codexHomes: string[] = [];
+    runAdapterExecutionTargetProcess.mockImplementation(async (
+      runId: string,
+      _target: unknown,
+      _command: string,
+      _args: string[],
+      options: { env: Record<string, string> },
+    ) => {
+      activeProcesses += 1;
+      maxActiveProcesses = Math.max(maxActiveProcesses, activeProcesses);
+      codexHomes.push(options.env.CODEX_HOME);
+      await delay(125);
+      activeProcesses -= 1;
+
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: successfulCodexStdout(runId),
+        stderr: "",
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      };
+    });
+
+    const baseContext = {
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        command: "codex",
+      },
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_primary",
+          strategy: "git_worktree",
+        },
+      },
+      onLog: async () => {},
+    };
+
+    const [first, second] = await Promise.all([
+      execute({
+        ...baseContext,
+        runId: "run-1",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "CodexCoder1",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+      }),
+      execute({
+        ...baseContext,
+        runId: "run-2",
+        agent: {
+          id: "agent-2",
+          companyId: "company-2",
+          name: "CodexCoder2",
+          adapterType: "codex_local",
+          adapterConfig: {},
+        },
+      }),
+    ]);
+
+    expect(first.exitCode).toBe(0);
+    expect(second.exitCode).toBe(0);
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(2);
+    expect(maxActiveProcesses).toBe(1);
+    expect(new Set(codexHomes).size).toBe(2);
+    await expect(readlink(path.join(codexHomes[0]!, "auth.json"))).resolves.toBe(path.join(sourceHome, "auth.json"));
+    await expect(readlink(path.join(codexHomes[1]!, "auth.json"))).resolves.toBe(path.join(sourceHome, "auth.json"));
+  });
+});

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -44,6 +44,7 @@ import {
   isCodexTransientUpstreamError,
   isCodexUnknownSessionError,
 } from "./parse.js";
+import { withCodexAuthLock } from "./codex-auth-lock.js";
 import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolveSharedCodexHomeDir } from "./codex-home.js";
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 import { buildCodexExecArgs } from "./codex-args.js";
@@ -826,22 +827,24 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   try {
-    const initial = await runAttempt(sessionId);
-    if (
-      sessionId &&
-      !initial.proc.timedOut &&
-      (initial.proc.exitCode ?? 0) !== 0 &&
-      isCodexUnknownSessionError(initial.proc.stdout, initial.rawStderr)
-    ) {
-      await onLog(
-        "stdout",
-        `[paperclip] Codex resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
-      );
-      const retry = await runAttempt(null);
-      return toResult(retry, true, true);
-    }
+    return await withCodexAuthLock(effectiveCodexHome, onLog, async () => {
+      const initial = await runAttempt(sessionId);
+      if (
+        sessionId &&
+        !initial.proc.timedOut &&
+        (initial.proc.exitCode ?? 0) !== 0 &&
+        isCodexUnknownSessionError(initial.proc.stdout, initial.rawStderr)
+      ) {
+        await onLog(
+          "stdout",
+          `[paperclip] Codex resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+        );
+        const retry = await runAttempt(null);
+        return toResult(retry, true, true);
+      }
 
-    return toResult(initial, false, false);
+      return toResult(initial, false, false);
+    });
   } finally {
     if (paperclipBridge) {
       await paperclipBridge.stop();


### PR DESCRIPTION
## Summary
- Add a host-wide filesystem lock keyed by the real `CODEX_HOME/auth.json` path for refresh-capable codex-local auth files.
- Skip the lock for adapter-written API-key auth files.
- Cover concurrent managed Codex homes that symlink the same auth file with a regression test.

## Tests
- `pnpm exec vitest run packages/adapters/codex-local/src/server/execute-auth-lock.test.ts`
- `pnpm exec vitest run packages/adapters/codex-local/src/server/execute-auth-lock.test.ts packages/adapters/codex-local/src/server/execute.remote.test.ts packages/adapters/codex-local/src/server/test.remote.test.ts`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `pnpm --filter @paperclipai/adapter-codex-local build`