### PR TITLE
feat(plugin-sdk): thread agentId into environmentAcquireLease + environmentResumeLease params

### DIFF
--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -393,6 +393,14 @@ export interface PluginEnvironmentAcquireLeaseParams extends PluginEnvironmentDr
 export interface PluginEnvironmentResumeLeaseParams extends PluginEnvironmentDriverBaseParams {
   providerLeaseId: string;
   leaseMetadata?: Record<string, unknown>;
+  /**
+   * UUID of the agent the run is being resumed for. Symmetric with
+   * `PluginEnvironmentAcquireLeaseParams.agentId`. Plugins can compare this
+   * to the agentId they stored in `leaseMetadata` at acquire time; if it
+   * doesn't match, return `{ providerLeaseId: null, metadata: { expired: true } }`
+   * to force the host to create a fresh lease for the current agent.
+   */
+  agentId?: string;
 }
 
 export interface PluginEnvironmentReleaseLeaseParams extends PluginEnvironmentDriverBaseParams {

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -379,6 +379,13 @@ export interface PluginEnvironmentLease {
 
 export interface PluginEnvironmentAcquireLeaseParams extends PluginEnvironmentDriverBaseParams {
   runId: string;
+  /**
+   * UUID of the agent the run is being acquired for. Omitted only for ad-hoc
+   * invocations (e.g. operator-initiated environment test probes) where no
+   * agent context exists. Plugins should treat undefined as "no per-agent
+   * partitioning available" and fall back to environment-level behavior.
+   */
+  agentId?: string;
   workspaceMode?: string;
   requestedCwd?: string;
 }

--- a/server/src/__tests__/agent-test-environment-routes.test.ts
+++ b/server/src/__tests__/agent-test-environment-routes.test.ts
@@ -196,6 +196,15 @@ describe("agent test-environment route", () => {
       }),
       status: "failed",
     });
+    // Ad-hoc operator probes have no agent context — the route must pass
+    // agentId: null so plugin-backed providers don't accidentally scope the
+    // probe lease against some leftover agentId from the heartbeat path.
+    expect(mockEnvironmentRuntime.acquireRunLease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: null,
+        heartbeatRunId: null,
+      }),
+    );
   });
 
   it("returns a diagnostic result instead of probing the host when the requested environment is missing", async () => {

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -10,6 +10,8 @@ const mockBuildWorkspaceRealizationRequest = vi.hoisted(() => vi.fn());
 const mockUpdateLeaseMetadata = vi.hoisted(() => vi.fn());
 const mockUpdateExecutionWorkspace = vi.hoisted(() => vi.fn());
 const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockEnvironmentsEnsureLocal = vi.hoisted(() => vi.fn());
+const mockEnvironmentsGetById = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/environment-execution-target.js", () => ({
   resolveEnvironmentExecutionTarget: mockResolveEnvironmentExecutionTarget,
@@ -26,8 +28,8 @@ vi.mock("../services/workspace-realization.js", () => ({
 
 vi.mock("../services/environments.js", () => ({
   environmentService: vi.fn(() => ({
-    ensureLocalEnvironment: vi.fn(),
-    getById: vi.fn(),
+    ensureLocalEnvironment: mockEnvironmentsEnsureLocal,
+    getById: mockEnvironmentsGetById,
     acquireLease: vi.fn(),
     releaseLease: vi.fn(),
     updateLeaseMetadata: mockUpdateLeaseMetadata,
@@ -546,5 +548,77 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     );
 
     expect(mockResolveEnvironmentExecutionTarget).not.toHaveBeenCalled();
+  });
+});
+
+describe("environmentRunOrchestrator — acquireForRun threads agentId", () => {
+  const mockDb = {} as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // selectedEnvironmentId !== defaultEnvironmentId in our inputs so the
+    // resolver goes through getById rather than ensureLocalEnvironment.
+    mockEnvironmentsGetById.mockResolvedValue(makeEnvironment("sandbox"));
+    mockResolveEnvironmentExecutionTarget.mockResolvedValue({
+      kind: "local",
+      environmentId: "env-1",
+      leaseId: "lease-1",
+    });
+    mockAdapterExecutionTargetToRemoteSpec.mockReturnValue(null);
+  });
+
+  function makeAcquireInput(overrides: { agentId?: string } = {}) {
+    return {
+      companyId: "company-1",
+      // distinct from defaultEnvironmentId so resolveEnvironment hits getById
+      selectedEnvironmentId: "env-1",
+      defaultEnvironmentId: "env-default",
+      adapterType: "claude_local",
+      issueId: null as string | null,
+      heartbeatRunId: "run-1",
+      agentId: overrides.agentId ?? "agent-uuid-abc",
+      persistedExecutionWorkspace: null,
+    };
+  }
+
+  it("passes agentId from acquireForRun's input through to runtime.acquireRunLease", async () => {
+    const runtime = makeMockRuntime({
+      acquireRunLease: vi.fn().mockResolvedValue({
+        lease: makeLease(),
+        leaseContext: { executionWorkspaceId: null, executionWorkspaceMode: null },
+      }),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    await orchestrator.acquireForRun(makeAcquireInput({ agentId: "agent-uuid-abc" }));
+
+    expect(runtime.acquireRunLease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "agent-uuid-abc",
+        heartbeatRunId: "run-1",
+        companyId: "company-1",
+      }),
+    );
+  });
+
+  it("logs the lease-acquired activity with the same agentId it threads to the runtime", async () => {
+    const runtime = makeMockRuntime({
+      acquireRunLease: vi.fn().mockResolvedValue({
+        lease: makeLease(),
+        leaseContext: { executionWorkspaceId: null, executionWorkspaceMode: null },
+      }),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    await orchestrator.acquireForRun(makeAcquireInput({ agentId: "agent-uuid-xyz" }));
+
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      mockDb,
+      expect.objectContaining({
+        action: "environment.lease_acquired",
+        agentId: "agent-uuid-xyz",
+        actorId: "agent-uuid-xyz",
+      }),
+    );
   });
 });

--- a/server/src/__tests__/environment-runtime.test.ts
+++ b/server/src/__tests__/environment-runtime.test.ts
@@ -216,6 +216,7 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
 
     return {
       companyId,
+      agentId,
       environment: {
         id: environmentId,
         companyId,
@@ -1393,5 +1394,299 @@ describeEmbeddedPostgres("environmentRuntimeService", () => {
     expect(localRelease).toHaveBeenCalledTimes(1);
     expect(sshRelease).not.toHaveBeenCalled();
     expect(acquired.lease.metadata?.driver).toBe("local");
+  });
+
+  // -------------------------------------------------------------------------
+  // agentId is threaded through plugin RPC params (see protocol.ts —
+  // PluginEnvironmentAcquireLeaseParams.agentId and
+  // PluginEnvironmentResumeLeaseParams.agentId). Plugin-backed sandbox
+  // providers can use this to scope lease state (subdirs, PVCs, etc.) per
+  // agent without callbacks or DB lookups. The runtime must forward it when
+  // present and omit it when null/undefined so older plugin SDKs that don't
+  // declare the field aren't surprised.
+  // -------------------------------------------------------------------------
+
+  it("plugin-driver acquireLease: forwards agentId in the RPC payload when present", async () => {
+    const pluginId = randomUUID();
+    const workerManager = {
+      isRunning: vi.fn(() => true),
+      call: vi.fn(async (_pluginId: string, method: string) => {
+        if (method === "environmentAcquireLease") {
+          return { providerLeaseId: "plugin-lease-agent", metadata: { remoteCwd: "/workspace" } };
+        }
+        return undefined;
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+    const { companyId, agentId, environment, runId } = await seedEnvironment({
+      driver: "plugin",
+      name: "Plugin agentId fwd",
+      config: {
+        pluginKey: "acme.environments",
+        driverKey: "fake-plugin",
+        driverConfig: { template: "base" },
+      },
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.environments",
+      packageName: "@acme/paperclip-environments",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.environments",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Acme",
+        description: "Test",
+        author: "Acme",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [{ driverKey: "fake-plugin", displayName: "Fake", configSchema: { type: "object" } }],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+
+    await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: null,
+    });
+
+    expect(workerManager.call).toHaveBeenCalledWith(
+      pluginId,
+      "environmentAcquireLease",
+      expect.objectContaining({ agentId }),
+    );
+  });
+
+  it("plugin-driver acquireLease: omits agentId from RPC payload when null", async () => {
+    const pluginId = randomUUID();
+    const workerManager = {
+      isRunning: vi.fn(() => true),
+      call: vi.fn(async (_pluginId: string, method: string) => {
+        if (method === "environmentAcquireLease") {
+          return { providerLeaseId: "plugin-lease-no-agent", metadata: { remoteCwd: "/workspace" } };
+        }
+        return undefined;
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+    const { companyId, environment, runId } = await seedEnvironment({
+      driver: "plugin",
+      name: "Plugin agentId null",
+      config: {
+        pluginKey: "acme.environments",
+        driverKey: "fake-plugin",
+        driverConfig: { template: "base" },
+      },
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.environments",
+      packageName: "@acme/paperclip-environments",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.environments",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Acme",
+        description: "Test",
+        author: "Acme",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [{ driverKey: "fake-plugin", displayName: "Fake", configSchema: { type: "object" } }],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+
+    await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId: null,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: null,
+    });
+
+    const payload = (workerManager.call as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([, method]) => method === "environmentAcquireLease",
+    )?.[2] as Record<string, unknown>;
+    expect(payload).toBeDefined();
+    expect(payload.agentId).toBeUndefined();
+    expect("agentId" in payload).toBe(false);
+  });
+
+  it("sandbox-provider acquireLease: forwards agentId when present", async () => {
+    const pluginId = randomUUID();
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string) => {
+        if (method === "environmentAcquireLease") {
+          return { providerLeaseId: "sandbox-agent-1", metadata: { reuseLease: false } };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+    const { companyId, agentId, environment, runId } = await seedEnvironment({
+      driver: "sandbox",
+      name: "Sandbox agentId fwd",
+      config: {
+        provider: "fake-plugin",
+        image: "fake:test",
+        timeoutMs: 30_000,
+        reuseLease: false,
+      },
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.sandbox",
+      packageName: "@acme/paperclip-sandbox",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.sandbox",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Acme Sandbox",
+        description: "Test",
+        author: "Acme",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [{
+          driverKey: "fake-plugin",
+          kind: "sandbox_provider",
+          displayName: "Fake",
+          configSchema: { type: "object" },
+        }],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+
+    await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: null,
+    });
+
+    expect(workerManager.call).toHaveBeenCalledWith(
+      pluginId,
+      "environmentAcquireLease",
+      expect.objectContaining({ agentId }),
+      expect.any(Number),
+    );
+  });
+
+  it("sandbox-provider resumeLease: forwards agentId when present", async () => {
+    const pluginId = randomUUID();
+    const calls: { method: string; params: Record<string, unknown> }[] = [];
+    const workerManager = {
+      isRunning: vi.fn((id: string) => id === pluginId),
+      call: vi.fn(async (_pluginId: string, method: string, params: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === "environmentAcquireLease") {
+          return { providerLeaseId: "sandbox-resume-1", metadata: { reuseLease: true } };
+        }
+        if (method === "environmentResumeLease") {
+          return { providerLeaseId: "sandbox-resume-1", metadata: { reuseLease: true } };
+        }
+        throw new Error(`Unexpected plugin method: ${method}`);
+      }),
+    } as unknown as PluginWorkerManager;
+    const runtimeWithPlugin = environmentRuntimeService(db, { pluginWorkerManager: workerManager });
+    const { companyId, agentId, environment, runId } = await seedEnvironment({
+      driver: "sandbox",
+      name: "Sandbox agentId resume",
+      config: {
+        provider: "fake-plugin",
+        image: "fake:test",
+        timeoutMs: 30_000,
+        reuseLease: true,
+      },
+    });
+    await db.insert(plugins).values({
+      id: pluginId,
+      pluginKey: "acme.sandbox",
+      packageName: "@acme/paperclip-sandbox",
+      version: "1.0.0",
+      apiVersion: 1,
+      categories: ["automation"],
+      manifestJson: {
+        id: "acme.sandbox",
+        apiVersion: 1,
+        version: "1.0.0",
+        displayName: "Acme Sandbox",
+        description: "Test",
+        author: "Acme",
+        categories: ["automation"],
+        capabilities: ["environment.drivers.register"],
+        entrypoints: { worker: "dist/worker.js" },
+        environmentDrivers: [{
+          driverKey: "fake-plugin",
+          kind: "sandbox_provider",
+          displayName: "Fake",
+          configSchema: { type: "object" },
+        }],
+      },
+      status: "ready",
+      installOrder: 1,
+      updatedAt: new Date(),
+    } as any);
+
+    // First acquire seeds a reusable lease row in DB
+    await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: runId,
+      persistedExecutionWorkspace: null,
+    });
+
+    // Second acquire on the same environment + reuseLease=true exercises the
+    // resume path (host's matcher finds the reusable lease, plugin's
+    // resumeLease is invoked).
+    const newRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: newRunId,
+      companyId,
+      agentId,
+      invocationSource: "manual",
+      status: "running",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any);
+    await runtimeWithPlugin.acquireRunLease({
+      companyId,
+      environment,
+      issueId: null,
+      agentId,
+      heartbeatRunId: newRunId,
+      persistedExecutionWorkspace: null,
+    });
+
+    const resumeCall = calls.find((c) => c.method === "environmentResumeLease");
+    expect(resumeCall).toBeDefined();
+    expect(resumeCall?.params.agentId).toBe(agentId);
   });
 });

--- a/server/src/__tests__/heartbeat-plugin-environment.test.ts
+++ b/server/src/__tests__/heartbeat-plugin-environment.test.ts
@@ -209,6 +209,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
       issueId: null,
       config: { template: "base" },
       runId: run!.id,
+      agentId,
       workspaceMode: "shared_workspace",
     });
     await vi.waitFor(() => {
@@ -426,6 +427,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
       issueId,
       config: { template: "new" },
       runId: run!.id,
+      agentId,
       workspaceMode: "shared_workspace",
     });
   }, 15_000);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -319,6 +319,7 @@ export function agentRoutes(
         companyId: input.companyId,
         environment,
         issueId: null,
+        agentId: null,
         heartbeatRunId: null,
         persistedExecutionWorkspace: null,
       });

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -206,6 +206,7 @@ export function environmentRunOrchestrator(
     companyId: string;
     environment: Environment;
     issueId: string | null;
+    agentId: string;
     heartbeatRunId: string;
     persistedExecutionWorkspace: Pick<ExecutionWorkspace, "id" | "mode"> | null;
   }): Promise<EnvironmentRuntimeLeaseRecord> {
@@ -280,6 +281,7 @@ export function environmentRunOrchestrator(
       companyId: input.companyId,
       environment,
       issueId: input.issueId,
+      agentId: input.agentId,
       heartbeatRunId: input.heartbeatRunId,
       persistedExecutionWorkspace: input.persistedExecutionWorkspace,
     });

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -104,6 +104,14 @@ export interface EnvironmentDriverAcquireInput {
   environment: Environment;
   issueId: string | null;
   /**
+   * UUID of the owning agent. Null for ad-hoc invocations (e.g.
+   * operator-initiated `Test` probes) that are not tied to a specific agent.
+   * Threaded through to plugin-backed sandbox providers so they can scope
+   * lease state (PVCs, subdirs, etc.) per-agent without needing to look it
+   * up via callback.
+   */
+  agentId: string | null;
+  /**
    * UUID of the owning heartbeat run, or null for ad-hoc invocations
    * (e.g. operator-initiated `Test` probes) that are not tied to a run.
    * Null leases must be released by id via `getDriver(...).releaseRunLease`
@@ -489,6 +497,7 @@ function createSandboxEnvironmentDriver(
             // UUID so providers that validate or persist the runId still see
             // a well-formed identifier.
             runId: input.heartbeatRunId ?? randomUUID(),
+            ...(input.agentId ? { agentId: input.agentId } : {}),
             workspaceMode: input.executionWorkspaceMode ?? undefined,
           },
           resolvePluginSandboxRpcTimeoutMs(workerConfig),
@@ -897,6 +906,7 @@ function createPluginEnvironmentDriver(
         issueId: input.issueId,
         config: parsed.config.driverConfig,
         runId: input.heartbeatRunId ?? randomUUID(),
+        ...(input.agentId ? { agentId: input.agentId } : {}),
         workspaceMode: input.executionWorkspaceMode ?? undefined,
       });
 
@@ -1110,6 +1120,11 @@ export function environmentRuntimeService(
       companyId: string;
       environment: Environment;
       issueId: string | null;
+      /**
+       * UUID of the owning agent. Null for ad-hoc invocations (e.g.
+       * operator-initiated `Test` probes).
+       */
+      agentId: string | null;
       /** Null for ad-hoc invocations (e.g. operator-initiated `Test` probes). */
       heartbeatRunId: string | null;
       persistedExecutionWorkspace: Pick<ExecutionWorkspace, "id" | "mode"> | null;
@@ -1126,6 +1141,7 @@ export function environmentRuntimeService(
         companyId: input.companyId,
         environment: input.environment,
         issueId: input.issueId,
+        agentId: input.agentId,
         heartbeatRunId: input.heartbeatRunId,
         executionWorkspaceId: leaseContext.executionWorkspaceId,
         executionWorkspaceMode: leaseContext.executionWorkspaceMode,

--- a/server/src/services/environment-runtime.ts
+++ b/server/src/services/environment-runtime.ts
@@ -476,6 +476,7 @@ function createSandboxEnvironmentDriver(
                 config: workerConfig,
                 providerLeaseId: reusableLease.providerLeaseId,
                 leaseMetadata: reusableLease.metadata ?? undefined,
+                ...(input.agentId ? { agentId: input.agentId } : {}),
               },
               resolvePluginSandboxRpcTimeoutMs(workerConfig),
             ).then((resumed) =>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Some of those agents need to run inside sandboxed environments — K8s pods, e2b, daytona, cloudflare, etc. — via the plugin-backed sandbox provider system
> - When `reuseLease=true` and one environment is shared across multiple agents, the host's lease matcher hands the same reusable lease to runs from different agents, because env-config-scoped lease metadata has no per-agent partition (`metadataMatchesPluginSandboxConfig` in `sandbox-provider-runtime.ts` only compares config keys, and `agentId` isn't a config key)
> - Plugins that want to scope lease state per agent (e.g. a per-agent subdir under `workspace.mountPath`, a per-agent PVC, a per-agent cache) have no way to know *which* agent the lease is being acquired or resumed for — `PluginEnvironmentAcquireLeaseParams` and `PluginEnvironmentResumeLeaseParams` expose `companyId`, `environmentId`, `issueId`, `runId`, but not `agentId`, and the SDK has no callback to look it up from `runId` either
> - This pull request adds an optional `agentId` field to both params types, threads it through the internal `EnvironmentDriverAcquireInput` and the runtime + orchestrator call chain, and updates the agent test-environment route to pass `null` for the ad-hoc operator probe path
> - The benefit is plugin-backed sandbox providers can now scope per-agent lease behavior with zero callback overhead; the field is optional/nullable so plugin worker SDKs that pre-date this PR aren't affected, and old hosts that don't populate it cause plugin code to fall through to environment-level behavior — the change is strictly additive on both ends of the wire

## What Changed

- **SDK (`packages/plugins/sdk/src/protocol.ts`)**
  - Add `agentId?: string` to `PluginEnvironmentAcquireLeaseParams`.
  - Add `agentId?: string` to `PluginEnvironmentResumeLeaseParams`. Symmetric with acquire so plugins managing per-agent state can compare the current run's agentId to one stored in `leaseMetadata` at acquire time and reject the resume (returning `{providerLeaseId: null, ...}`) when they don't match.
- **Host runtime (`server/src/services/environment-runtime.ts`)**
  - Add `agentId: string | null` to `EnvironmentDriverAcquireInput` (required-but-nullable so every internal call site has to think about whether an agent context exists).
  - Add `agentId: string | null` to `environmentRuntimeService(...).acquireRunLease(input)` and thread it through to `driver.acquireRunLease(...)`.
  - Plugin-driver path: spread `...(input.agentId ? { agentId: input.agentId } : {})` into the `environmentAcquireLease` RPC payload. Wire-compatible with pre-PR plugin SDKs (no surprise extra field when there's nothing to send).
  - Sandbox-provider plugin path: same spread on the `environmentAcquireLease` *and* `environmentResumeLease` RPC payloads.
- **Orchestrator (`server/src/services/environment-run-orchestrator.ts`)**
  - Add `agentId: string` to `acquireLease(...)`'s input shape (the outer call already had `agentId: string` on `acquireForRun(...)` so this just plumbs the existing value through one more layer).
- **Route (`server/src/routes/agents.ts`)**
  - The `POST /companies/:companyId/adapters/:type/test-environment` route's acquire call now passes `agentId: null` — operator-initiated probes have no agent context, and `null` makes that explicit at the type level.
- **Tests**
  - Update 2 existing assertions in `heartbeat-plugin-environment.test.ts` to include the new field.
  - 4 new tests in `environment-runtime.test.ts`:
    - plugin-driver `environmentAcquireLease` forwards `agentId` when present;
    - plugin-driver `environmentAcquireLease` omits `agentId` from the payload entirely when null (wire-compat regression test);
    - sandbox-provider `environmentAcquireLease` forwards `agentId`;
    - sandbox-provider `environmentResumeLease` forwards `agentId` (exercised via the reuseLease=true matcher hitting a pre-seeded reusable lease).
  - 2 new tests in `environment-run-orchestrator.test.ts`: `acquireForRun` threads `agentId` to the runtime; `logActivity` records the same `agentId` on the `environment.lease_acquired` activity row.
  - 1 new assertion in `agent-test-environment-routes.test.ts`: the test-environment route calls `acquireRunLease` with `{agentId: null, heartbeatRunId: null}`.
  - `seedEnvironment` helper in env-runtime tests now exposes the seeded `agentId` to callers.

## Verification

- `pnpm --filter @paperclipai/plugin-sdk build` — clean
- `pnpm --filter @paperclipai/server typecheck` — clean
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/environment-runtime.test.ts src/__tests__/environment-run-orchestrator.test.ts src/__tests__/agent-test-environment-routes.test.ts src/__tests__/heartbeat-plugin-environment.test.ts src/__tests__/environment-runtime-driver-contract.test.ts`
  → 39/39 pass (20 in env-runtime, 10 in orchestrator, 4 in agent-test-env routes, 2 in heartbeat-plugin-env, 3 in driver-contract). Includes 7 new tests added by this PR.
- Reference plugin consumer at [`@farhoodlabs/paperclip-plugin-k8s@0.3.7`](https://www.npmjs.com/package/@farhoodlabs/paperclip-plugin-k8s) reads `params.agentId` defensively (via a local SDK type augmentation, so it compiles against any SDK version) and uses it to derive `lease.metadata.remoteCwd = path.posix.join(config.workspace.mountPath, agentId)` so per-agent subdirs partition the workspace inside a shared `reuseLease=true` pod. 30/30 plugin tests pass (5 covering the agentId branch); falls back to bare `mountPath` when `params.agentId` is undefined.

## Risks

- **Wire compatibility (Low).** The RPC payload only carries `agentId` when the host has a non-null value, so plugin worker SDKs that pre-date this PR don't see an unexpected field. The reverse direction (new plugin SDK + old host) is also safe: plugins see `params.agentId === undefined` and fall through to today's environment-level behavior.
- **Type narrowing (Low).** `EnvironmentDriverAcquireInput.agentId: string | null` is required-but-nullable. This is intentional: it surfaces missing wiring at compile time. Every internal call site has been updated; the ad-hoc operator probe path passes `null` explicitly.
- **Behavior change (None).** Without a plugin that *reads* `agentId`, the only observable effect is one new optional key in the worker's `environmentAcquireLease` / `environmentResumeLease` JSON-RPC payload. Existing plugin worker code paths (e.g. `worker-rpc-host.ts` dispatch) are untouched.
- **Migration safety (None).** No DB schema changes; no migrations.
- **Concurrency (None).** No new in-memory state, locks, timers, or RPC fanout.
- **Test coverage of excluded files (Low).** `server/tsconfig.json` excludes `src/__tests__` from typecheck, so the new field is exercised at runtime in tests rather than statically checked there. The new tests pass at runtime and assert both the with-agentId and without-agentId branches of the wire format. Existing tests that didn't pass `agentId` still pass because they receive `undefined` at runtime, which is treated as "no agent context" by the new code.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

ROADMAP context: this PR sits squarely in the "✅ Plugin system" + "agents in remote and sandboxed environments" areas the roadmap explicitly invites contributions toward. It's a tightly scoped SDK API addition (one new optional field on two params types) that enables a class of per-agent lease isolation behavior in plugin-backed sandbox providers without adding new capabilities, new RPC methods, or new behavior at the core. Happy to move discussion to `#dev` if reviewers prefer.

## Model Used

- **Provider:** Anthropic
- **Model ID:** `claude-opus-4-7` (1M context window)
- **Reasoning mode:** standard
- Used for design discussion, code changes, test authoring, and PR drafting in collaboration with the human contributor.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A, server + SDK only
- [x] I have updated relevant documentation to reflect my changes — JSDoc on the new fields explains semantics and the ad-hoc-probe convention
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge