### PR TITLE
fix(agents): default AGENT_DEFAULT_MAX_CONCURRENT_RUNS to 1

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -73,7 +73,7 @@ export const AGENT_ROLE_LABELS: Record<AgentRole, string> = {
   general: "General",
 };
 
-export const AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 20;
+export const AGENT_DEFAULT_MAX_CONCURRENT_RUNS = 1;
 export const WORKSPACE_BRANCH_ROUTINE_VARIABLE = "workspaceBranch";
 
 export const MODEL_PROFILE_KEYS = ["cheap"] as const;


### PR DESCRIPTION
## Summary

`AGENT_DEFAULT_MAX_CONCURRENT_RUNS` is currently `20`. For batch agents that genuinely process N issues in parallel that's a reasonable permissive ceiling, but for an interactive single-issue-flow agent (e.g. a CEO working one approval at a time) it is catastrophic: overlapping heartbeat runs each independently draft and submit work, producing duplicate approvals and storms of redundant comments.

The safe default is `1`. Batch agents should opt up explicitly via `heartbeat.maxConcurrentRuns` in their config; every other agent gets one-at-a-time semantics by default.

Companion to #5961 (approvals idempotency). That PR catches the dupe at the output boundary; this PR shrinks the window where dupes can form at all.

## Test plan

- [ ] Existing heartbeat tests pass (`pnpm --filter @paperclipai/server test heartbeat`)
- [ ] New agents created via `POST /companies/:id/agents` without an explicit `heartbeat.maxConcurrentRuns` get `1`
- [ ] Existing agents in the DB with custom `heartbeat.maxConcurrentRuns` are unaffected (their stored value wins)
- [ ] Manually: rapid wake of an interactive agent does not start more than one run at a time

🤖 Generated with [Claude Code](https://claude.com/claude-code)