### PR TITLE
fix(inbox): keep resolved approvals out of Mine tab

### DIFF
--- a/ui/src/lib/inbox.ts
+++ b/ui/src/lib/inbox.ts
@@ -747,11 +747,14 @@ export function getApprovalsForTab(
 
 export function isApprovalVisibleInMine(
   approval: Approval,
-  currentUserId?: string | null,
+  _currentUserId?: string | null,
 ): boolean {
-  if (ACTIONABLE_APPROVAL_STATUSES.has(approval.status)) return true;
-  if (!currentUserId) return false;
-  return approval.requestedByUserId === currentUserId || approval.decidedByUserId === currentUserId;
+  // Mine should only surface approvals that still need action. Once an
+  // approval is approved/rejected it has no follow-up for the requester or
+  // the decider — keeping it visible just because the current user requested
+  // or decided it produces "ghost" rows (notably after a duplicate-approval
+  // storm: every rejected dupe stays pinned in Mine forever).
+  return ACTIONABLE_APPROVAL_STATUSES.has(approval.status);
 }
 
 export function approvalActivityTimestamp(approval: Approval): number {


### PR DESCRIPTION
## Summary

`isApprovalVisibleInMine()` kept rejected and approved approvals visible in the Mine tab whenever the current user was the requester or the decider. That means any resolved approval the user had touched stayed pinned in Mine indefinitely with no follow-up action attached.

The failure mode is most painful after a duplicate-approval storm: e.g. 5 rejected dupes get permanently stuck in Mine even though the canonical pending row is the only one Kent actually needs to act on. Resolved approvals belong in the All tab and the issue history, not in the actionable-work view.

This change: Mine surfaces only approvals in `ACTIONABLE_APPROVAL_STATUSES` (`pending`, `revision_requested`).

## Test plan

- [ ] `pnpm --filter @paperclipai/ui typecheck` passes
- [ ] Existing inbox unit tests pass (`pnpm --filter @paperclipai/ui test`)
- [ ] Manually:
  - Pending approval the user requested → visible in Mine ✓
  - Approval after approve/reject → not in Mine, visible in All ✓
  - Approval with `revision_requested` status → visible in Mine ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)