### PR TITLE
OpenCode DeepSeek model switch + PATH hardeningFeat/opencode deepseek v4 switch

### DIFF
--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -44,7 +44,7 @@ export const SANDBOX_INSTALL_COMMAND =
   'fi; ' +
   'fi';
 
-export const DEFAULT_OPENCODE_LOCAL_MODEL = "openai/gpt-5.2-codex";
+export const DEFAULT_OPENCODE_LOCAL_MODEL = "deepseek/deepseek-v4-pro";
 
 export function isValidOpenCodeModelId(value: unknown): value is string {
   if (typeof value !== "string") return false;
@@ -54,20 +54,24 @@ export function isValidOpenCodeModelId(value: unknown): value is string {
 }
 
 export const models: Array<{ id: string; label: string }> = [
-  { id: DEFAULT_OPENCODE_LOCAL_MODEL, label: DEFAULT_OPENCODE_LOCAL_MODEL },
-  { id: "openai/gpt-5.4", label: "openai/gpt-5.4" },
-  { id: "openai/gpt-5.2", label: "openai/gpt-5.2" },
-  { id: "openai/gpt-5.1-codex-max", label: "openai/gpt-5.1-codex-max" },
-  { id: "openai/gpt-5.1-codex-mini", label: "openai/gpt-5.1-codex-mini" },
+  { id: DEFAULT_OPENCODE_LOCAL_MODEL, label: "DeepSeek V4 Pro" },
+  { id: "deepseek/deepseek-v4-flash", label: "DeepSeek V4 Flash" },
+  { id: "deepseek/deepseek-chat", label: "DeepSeek Chat" },
+  { id: "deepseek/deepseek-reasoner", label: "DeepSeek Reasoner" },
+  { id: "opencode/deepseek-v4-flash-free", label: "OpenCode DeepSeek V4 Flash Free" },
+  { id: "opencode/big-pickle", label: "OpenCode Big Pickle" },
+  { id: "opencode/minimax-m2.5-free", label: "OpenCode MiniMax M2.5 Free" },
+  { id: "opencode/nemotron-3-super-free", label: "OpenCode Nemotron 3 Super Free" },
+  { id: "opencode/ring-2.6-1t-free", label: "OpenCode Ring 2.6 1T Free" },
 ];
 
 export const modelProfiles: AdapterModelProfileDefinition[] = [
   {
     key: "cheap",
     label: "Cheap",
-    description: "Use OpenCode's known Codex mini model as the budget lane.",
+    description: "Use OpenCode's free DeepSeek Flash model as the budget lane.",
     adapterConfig: {
-      model: "openai/gpt-5.1-codex-mini",
+      model: "opencode/deepseek-v4-flash-free",
       variant: "low",
     },
     source: "adapter_default",

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -29,6 +29,7 @@ import {
   asStringArray,
   parseObject,
   buildPaperclipEnv,
+  defaultPathForPlatform,
   joinPromptSections,
   buildInvocationEnvForLogs,
   ensureAbsoluteDirectory,
@@ -49,6 +50,7 @@ import {
   ensureOpenCodeModelConfiguredAndAvailable,
   parseOpenCodeModelsOutput,
   requireOpenCodeModelId,
+  resolveOpenCodeCommand,
 } from "./models.js";
 import { removeMaintainerOnlySkillSymlinks } from "@paperclipai/adapter-utils/server-utils";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
@@ -206,7 +208,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     config.promptTemplate,
     DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   );
-  const command = asString(config.command, "opencode");
+  const command = resolveOpenCodeCommand(config.command);
   const model = asString(config.model, "").trim();
   const variant = asString(config.variant, "").trim();
 
@@ -306,6 +308,42 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         (entry): entry is [string, string] => typeof entry[1] === "string",
       ),
     );
+    // Ensure common binary directories are in PATH for local execution.
+    // Three sources of PATH entries:
+    //   1. The server process's existing PATH (from process.env or config).
+    //   2. OpenCode-specific install locations: the official curl installer
+    //      puts the binary in $HOME/.opencode/bin and (when sudo is
+    //      unavailable) symlinks to $HOME/.local/bin. Non-login shells
+    //      don't source ~/.bashrc so these may be missing from PATH.
+    //   3. Default system paths from defaultPathForPlatform (e.g.,
+    //      /usr/local/bin, /usr/local/sbin). The server's process.env.PATH
+    //      may be set to a minimal value that omits these, so we ensure
+    //      they're present regardless.
+    if (!adapterExecutionTargetIsRemote(executionTarget)) {
+      const homeDir = os.homedir();
+      const openCodeBinDirs = [
+        path.join(homeDir, ".opencode", "bin"),
+        path.join(homeDir, ".local", "bin"),
+      ];
+      const defaultPathEntries = defaultPathForPlatform()
+        .split(":")
+        .filter(Boolean);
+      const pathEntries = (runtimeEnv["PATH"] ?? "").split(":").filter(Boolean);
+      const seen = new Set(pathEntries);
+      for (const dir of openCodeBinDirs) {
+        if (!seen.has(dir)) {
+          seen.add(dir);
+          pathEntries.unshift(dir);
+        }
+      }
+      for (const dir of defaultPathEntries) {
+        if (!seen.has(dir)) {
+          seen.add(dir);
+          pathEntries.push(dir);
+        }
+      }
+      runtimeEnv["PATH"] = pathEntries.join(":");
+    }
     const timeoutSec = resolveAdapterExecutionTargetTimeoutSec(
       executionTarget,
       asNumber(config.timeoutSec, 0),

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -11,7 +11,7 @@ import { isValidOpenCodeModelId } from "../index.js";
 const MODELS_CACHE_TTL_MS = 60_000;
 const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
 
-function resolveOpenCodeCommand(input: unknown): string {
+export function resolveOpenCodeCommand(input: unknown): string {
   const envOverride =
     typeof process.env.PAPERCLIP_OPENCODE_COMMAND === "string" &&
     process.env.PAPERCLIP_OPENCODE_COMMAND.trim().length > 0

--- a/packages/adapters/opencode-local/src/server/test.ts
+++ b/packages/adapters/opencode-local/src/server/test.ts
@@ -12,6 +12,7 @@ import {
   asNumber,
   asString,
   asStringArray,
+  defaultPathForPlatform,
   parseObject,
   ensurePathInEnv,
 } from "@paperclipai/adapter-utils/server-utils";
@@ -25,7 +26,7 @@ import {
   prepareAdapterExecutionTargetRuntime,
   overrideAdapterExecutionTargetRemoteCwd,
 } from "@paperclipai/adapter-utils/execution-target";
-import { discoverOpenCodeModels, ensureOpenCodeModelConfiguredAndAvailable } from "./models.js";
+import { discoverOpenCodeModels, ensureOpenCodeModelConfiguredAndAvailable, resolveOpenCodeCommand } from "./models.js";
 import { parseOpenCodeJsonl } from "./parse.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
@@ -70,7 +71,7 @@ export async function testEnvironment(
 ): Promise<AdapterEnvironmentTestResult> {
   const checks: AdapterEnvironmentCheck[] = [];
   const config = parseObject(ctx.config);
-  const command = asString(config.command, "opencode");
+  const command = resolveOpenCodeCommand(config.command);
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
   const targetIsSandbox = target?.kind === "remote" && target.transport === "sandbox";
@@ -174,6 +175,43 @@ export async function testEnvironment(
       }
     }
     const runtimeEnv = normalizeEnv(ensurePathInEnv({ ...process.env, ...preparedRuntimeConfig.env }));
+
+    // Ensure common binary directories are in PATH for local execution.
+    // Three sources of PATH entries:
+    //   1. The server process's existing PATH (from process.env or config).
+    //   2. OpenCode-specific install locations: the official curl installer
+    //      puts the binary in $HOME/.opencode/bin and (when sudo is
+    //      unavailable) symlinks to $HOME/.local/bin. Non-login shells
+    //      don't source ~/.bashrc so these may be missing from PATH.
+    //   3. Default system paths from defaultPathForPlatform (e.g.,
+    //      /usr/local/bin, /usr/local/sbin). The server's process.env.PATH
+    //      may be set to a minimal value that omits these, so we ensure
+    //      they're present regardless.
+    if (!targetIsRemote) {
+      const homeDir = os.homedir();
+      const openCodeBinDirs = [
+        path.join(homeDir, ".opencode", "bin"),
+        path.join(homeDir, ".local", "bin"),
+      ];
+      const defaultPathEntries = defaultPathForPlatform()
+        .split(":")
+        .filter(Boolean);
+      const pathEntries = (runtimeEnv["PATH"] ?? "").split(":").filter(Boolean);
+      const seen = new Set(pathEntries);
+      for (const dir of openCodeBinDirs) {
+        if (!seen.has(dir)) {
+          seen.add(dir);
+          pathEntries.unshift(dir);
+        }
+      }
+      for (const dir of defaultPathEntries) {
+        if (!seen.has(dir)) {
+          seen.add(dir);
+          pathEntries.push(dir);
+        }
+      }
+      runtimeEnv["PATH"] = pathEntries.join(":");
+    }
 
     const cwdInvalid = checks.some((check) => check.code === "opencode_cwd_invalid");
     if (cwdInvalid) {


### PR DESCRIPTION
## Summary

Implements the approved OpenCode DeepSeek model switch and PATH hardening.

## Changes

* Sets the default OpenCode model to `deepseek/deepseek-v4-pro`
* Adds the approved hardcoded list of 9 DeepSeek/OpenCode models
* Preserves dynamic model discovery as future work
* Hardens PATH resolution for OpenCode binary lookup
* Exports `resolveOpenCodeCommand`
* Keeps unrelated budget/workflow changes out of this PR

## Verification

* `opencode models` confirmed 9 available models
* TypeScript/typecheck previously passed during implementation
* Branch pushed from the VPS working tree after remote was moved to Jeff’s fork

## Parent issue

CRE-336
