### PR TITLE
fix(heartbeat): suppress transient retry when issue has an active checkout

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4745,6 +4745,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           | "issue_terminal_status"
           | "issue_not_in_progress"
           | "issue_execution_lock_changed"
+          | "issue_already_active"
           | "issue_review_participant_changed"
           | "issue_paused"
           | "issue_dependencies_blocked";
@@ -4868,6 +4869,33 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           issueId,
           expectedExecutionRunId: run.id,
           currentExecutionRunId: issue.executionRunId,
+        },
+      };
+    }
+
+    // For non-max_turns retries: if a newer run has already checked out the
+    // issue (executionRunId is set to a run that is neither the retry run
+    // itself nor the original failed run it retries), suppress this retry to
+    // prevent duplicate parallel execution.  This is the fix for the race
+    // where SIGTERM kills Run A → Run B takes over → recovery promotes Run C
+    // as a retry of A while B is still running.
+    if (
+      retryReason !== MAX_TURN_CONTINUATION_RETRY_REASON &&
+      issue.executionRunId !== null &&
+      issue.executionRunId !== run.id &&
+      issue.executionRunId !== run.retryOfRunId
+    ) {
+      return {
+        allowed: false,
+        reason:
+          "Scheduled retry suppressed because the issue is already held by a different active run",
+        errorCode: "issue_already_active",
+        issueId,
+        details: {
+          issueId,
+          activeRunId: issue.executionRunId,
+          retryRunId: run.id,
+          originalRunId: run.retryOfRunId,
         },
       };
     }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and drives their heartbeat lifecycle, including automatic retry on transient failures
> - The heartbeat recovery service runs periodically to promote `scheduled_retry` runs that are due
> - Before promoting a retry, `evaluateScheduledRetryGate` checks several conditions (budget, agent status, assignee, terminal status, etc.)
> - For `max_turns_continuation` retries, there is already a guard that checks `issue.executionRunId !== run.id` to detect when another run took over
> - For `transient_failure` retries, no equivalent guard exists — a retry can be promoted even when a newer run (started by a fresh wakeup event) already holds the issue checkout
> - This PR adds the missing guard: if `executionRunId` is set to a run that is neither the retry run nor the original failed run, a newer run has the checkout and we suppress the retry
> - The benefit is preventing the dual-run scenario where both the recovery retry and the new run execute the same issue in parallel, wasting tokens and producing duplicate file output

## What Changed

- `server/src/services/heartbeat.ts`: added `"issue_already_active"` to the `ScheduledRetryGate` errorCode union
- `server/src/services/heartbeat.ts`: added a gate in `evaluateScheduledRetryGate` — for all non-`max_turns_continuation` retry reasons, if `issue.executionRunId` is non-null and belongs to a run that is neither the scheduled retry run (`run.id`) nor the original failed run (`run.retryOfRunId`), return `allowed: false` with errorCode `issue_already_active`

## Verification

The race scenario can be confirmed by reading the issue timeline and log:

```
[15:05:32] WARN: periodic heartbeat recovery changed assigned issue state
  {"promotedScheduledRetries":1, "promotedScheduledRetryRunIds":["12efec7a-..."]}
```

With this fix, when Run B has already checked out the issue (`executionRunId = B.id`), the recovery scan will evaluate the gate for retry Run C:
- `issue.executionRunId` (B.id) ≠ `run.id` (C.id) ✓
- `issue.executionRunId` (B.id) ≠ `run.retryOfRunId` (A.id) ✓
- Gate returns `allowed: false`, errorCode `issue_already_active` — retry C is cancelled instead of promoted

The second run no longer starts. The `cancelScheduledRetryForGate` path clears the retry's `executionRunId` lock if it holds one (it won't in this scenario since Run C never ran), so no cleanup side-effects.

Typecheck passes: `pnpm --filter=@paperclipai/server typecheck` exits 0.

## Risks

- **Low risk.** The check only fires when `executionRunId` is explicitly set to a run that is neither the retry itself nor its original — this is a clearly anomalous state (a race). Legitimate retry promotion paths (Run A still holds the lock or no lock is held) are not affected.
- Existing `max_turns_continuation` logic is unchanged; the new check is guarded by `retryReason !== MAX_TURN_CONTINUATION_RETRY_REASON`.
- No database migrations required.

## Model Used

- Provider: Anthropic
- Model ID: `claude-sonnet-4-6`
- Context window: 200k tokens
- Capabilities: tool use, code execution, multi-step reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge