### PR TITLE
Add pi coding agent to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ ARG USER_UID=1000
 ARG USER_GID=1000
 WORKDIR /app
 COPY --chown=node:node --from=build /app /app
-RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai \
+RUN npm install --global --omit=dev @anthropic-ai/claude-code@latest @openai/codex@latest opencode-ai @earendil-works/pi-coding-agent@latest \
   && apt-get update \
   && apt-get install -y --no-install-recommends openssh-client jq \
   && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agent adapters are spawned inside the container and need their runtime available on PATH
> - The container already ships claude-code, codex, and opencode as global npm packages
> - The pi-local adapter exists in the monorepo but pi itself is not installed in the image
> - Without pi in the image, the adapter cannot spawn agents — requiring manual PVC-side installation
> - This PR adds @earendil-works/pi-coding-agent to the global npm install step in the Dockerfile
> - The benefit is that pi is available out-of-the-box and the pi-local adapter works without post-deployment manual steps

## What Changed

- `Dockerfile`: added `@earendil-works/pi-coding-agent@latest` to the production-stage global npm install, alongside claude-code, codex, and opencode-ai

## Verification

- Build the image locally and confirm `pi --version` resolves from PATH inside the container
- Confirm the pi-local adapter in the monorepo can spawn pi without additional installation steps

## Risks

Low risk. Adds a single npm package to the global install step. No existing behaviour is changed.

## Model Used

None — human-authored (nferro).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge