### PR TITLE
feat(run-liveness): PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX env-flag opt-out for regex auto-blocker

### DIFF
--- a/server/src/__tests__/run-liveness.test.ts
+++ b/server/src/__tests__/run-liveness.test.ts
@@ -133,6 +133,52 @@ describe("run liveness classifier", () => {
     expect(classification.actionability).toBe("blocked_external");
   });
 
+  it("suppresses regex-based blocker detection when PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX=true", () => {
+    const previous = process.env.PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX;
+    process.env.PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX = "true";
+    try {
+      const classification = classifyRunLiveness({
+        ...baseInput,
+        resultJson: {
+          summary: "I cannot proceed because I need access credentials.",
+        },
+      });
+
+      // Same input that triggers `livenessState: "blocked"` above is suppressed
+      // when the relax flag is set. The agent's prose still mentions credentials
+      // but the regex is not allowed to flip the issue state on its own.
+      expect(classification.livenessState).not.toBe("blocked");
+      expect(classification.actionability).not.toBe("blocked_external");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX;
+      } else {
+        process.env.PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX = previous;
+      }
+    }
+  });
+
+  it("still respects explicit issue.status === 'blocked' even when the relax flag is set", () => {
+    const previous = process.env.PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX;
+    process.env.PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX = "true";
+    try {
+      const classification = classifyRunLiveness({
+        ...baseInput,
+        issue: { ...(baseInput.issue ?? {}), status: "blocked" } as typeof baseInput.issue,
+        resultJson: { summary: "Working on it." },
+      });
+
+      // Genuine blocker (explicit issue.status) still flips even with relax flag.
+      expect(classification.livenessState).toBe("blocked");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX;
+      } else {
+        process.env.PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX = previous;
+      }
+    }
+  });
+
   it("treats PAP-2000-style validation output as runnable follow-up, not an external blocker", () => {
     const classification = classifyRunLiveness({
       ...baseInput,

--- a/server/src/services/run-liveness.ts
+++ b/server/src/services/run-liveness.ts
@@ -153,6 +153,16 @@ export function hasUsefulOutput(input: RunLivenessClassificationInput) {
 
 export function declaredBlocker(input: RunLivenessClassificationInput) {
   if (input.issue?.status === "blocked") return true;
+  // Opt-out for operators who find the regex-based blocker detection too
+  // aggressive in practice — see paperclipai/paperclip#5978 for the false-
+  // positive failure modes (incidental keyword matches in agent prose like
+  // "previously blocked", "I need clarification", "waiting on Y" flip the
+  // issue to blocked even when the agent's run was productive). When this
+  // flag is set, only the explicit `issue.status === "blocked"` branch above
+  // can flag a blocker; regex-based prose detection is suppressed.
+  if (process.env.PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX === "true") {
+    return false;
+  }
   const actionability = classifyRunActionability(input);
   return actionability === "blocked_external" || actionability === "approval_required";
 }


### PR DESCRIPTION
## Summary

`declaredBlocker()` in [`server/src/services/run-liveness.ts:154-158`](server/src/services/run-liveness.ts#L154-L158) calls `classifyRunActionability()` which runs `BLOCKER_RE` / `EXTERNAL_BLOCKER_RE` against agent stdout, comments, and work-product fields. A single incidental keyword match flips `livenessState` to `"blocked"`, which downstream consumers in `recovery/service.ts` propagate to `issues.status = "blocked"`.

The regex matches incidental occurrences in normal agent prose:
- "PAP-1949 was previously blocked but..."
- "I need clarification on the design"
- "waiting on the test suite to finish"

These trigger blocker classification even when the run was productive. Full diagnosis in #5978 (filed alongside this PR).

The regex is intentionally aggressive — it was added in #1117/#1997 to catch agents falsely reporting success while declaring blockage in prose. Fair design intent, but the false-positive cost is unaddressed.

## Fix

Adds a one-line env-flag escape hatch in `declaredBlocker()`:

```typescript
export function declaredBlocker(input: RunLivenessClassificationInput) {
  if (input.issue?.status === "blocked") return true;
  // NEW: opt-out for operators who find the regex too aggressive
  if (process.env.PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX === "true") {
    return false;
  }
  const actionability = classifyRunActionability(input);
  return actionability === "blocked_external" || actionability === "approval_required";
}
```

When `PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX=true`:
- Regex-based prose detection is suppressed
- Explicit `issue.status === "blocked"` (set by another path) **still** flags blockers correctly
- Default behavior is unchanged — all existing tests pass

Idiomatic to Paperclip — mirrors the existing `PAPERCLIP_*` env-var pattern in `server/src/config.ts` (precedents at lines 93, 124, 132, 139, 143-149, 152-157, 160, 166, 171, 181, 192-193).

## Test plan

- [x] `pnpm --filter @paperclipai/server typecheck` clean (no errors in modified files — pre-existing plugin-local-folders errors are unrelated)
- [x] All existing run-liveness tests still pass (env flag default-off)
- [x] **New test** — `suppresses regex-based blocker detection when PAPERCLIP_RELAX_LIVENESS_BLOCKER_REGEX=true`: same input that triggers `livenessState: "blocked"` in the existing test produces a non-blocked classification when the flag is set
- [x] **New test** — `still respects explicit issue.status === 'blocked' even when the relax flag is set`: genuine blockers still flip
- [x] Verified on a Paperclip instance running `sparkeros.55`: env var set via systemd drop-in, agent runs no longer hit the regex-based blocker path

## Companion to

- #5966 — adds disposition state-machine contract to `hermes_local` system prompt
- #5977 — skips `MISSING DISPOSITION` recovery when run produced visible progress
- #5978 — companion research issue documenting the false-positive failure mode in detail
- NousResearch/hermes-paperclip-adapter#121 — synthesize tool-transcript fallback so adapter still posts comment when agent omits final response

The combination of these four addresses the full cascade-recovery class of failures reported in #5947 / #4327 / #4643 / #5559 / #5126 / #5937 / #4460 / #3882 / #4688.

## Why opt-in (and not stricter regex by default)

The aggressive regex was added on purpose. Operators with disciplined agents may prefer to keep it. The env flag lets operators with false-positive failures opt out without losing the option entirely. A stricter regex by default would risk regressing the original silent-success failure mode the regex was designed to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)