### PR TITLE
fix(adapter-acpx-local): resolve runtime binary via ancestor node_modules/.bin (#5932)

### DIFF
--- a/packages/adapters/acpx-local/src/server/execute.test.ts
+++ b/packages/adapters/acpx-local/src/server/execute.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { createAcpxLocalExecutor } from "./execute.js";
+import { createAcpxLocalExecutor, findAncestorBin } from "./execute.js";
 
 const tempRoots: string[] = [];
 
@@ -423,3 +423,52 @@ describe("acpx_local runtime skill isolation", () => {
     }
   });
 });
+
+describe("findAncestorBin", () => {
+  async function writeFakeBin(dir: string, name: string) {
+    const binDir = path.join(dir, "node_modules", ".bin");
+    await fs.mkdir(binDir, { recursive: true });
+    const binPath = path.join(binDir, name);
+    await fs.writeFile(binPath, "#!/usr/bin/env bash\necho ok\n", { mode: 0o755 });
+    return binPath;
+  }
+
+  it("finds the binary in the start directory's own node_modules/.bin", async () => {
+    const root = await makeTempRoot();
+    const adapterDir = path.join(root, "node_modules", "@paperclipai", "adapter-acpx-local");
+    await fs.mkdir(adapterDir, { recursive: true });
+    const expectedBin = await writeFakeBin(adapterDir, "claude-agent-acp");
+
+    const resolved = await findAncestorBin(adapterDir, "claude-agent-acp");
+
+    expect(resolved).toBe(expectedBin);
+  });
+
+  it("finds the binary hoisted to an ancestor (the npm-installed case)", async () => {
+    const root = await makeTempRoot();
+    const adapterDir = path.join(root, "node_modules", "@paperclipai", "adapter-acpx-local");
+    await fs.mkdir(adapterDir, { recursive: true });
+    // Only the consumer's root has .bin/, mimicking pnpm/npm hoisting.
+    const expectedBin = await writeFakeBin(root, "claude-agent-acp");
+
+    const resolved = await findAncestorBin(adapterDir, "claude-agent-acp");
+
+    expect(resolved).toBe(expectedBin);
+  });
+
+  it("returns null when the binary is not present in any ancestor", async () => {
+    const root = await makeTempRoot();
+    const adapterDir = path.join(root, "node_modules", "@paperclipai", "adapter-acpx-local");
+    await fs.mkdir(adapterDir, { recursive: true });
+
+    const resolved = await findAncestorBin(adapterDir, "claude-agent-acp");
+
+    expect(resolved).toBeNull();
+  });
+
+  it("terminates at the filesystem root instead of looping forever", async () => {
+    const resolved = await findAncestorBin("/", "definitely-not-a-real-bin-name-xyz");
+    expect(resolved).toBeNull();
+  });
+});
+

--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -134,7 +134,24 @@ function packageRootDir(): string {
   return path.resolve(__moduleDir, "../..");
 }
 
-function resolveBuiltInAgentCommand(agent: string): string | null {
+// Walk up from startDir looking for `node_modules/.bin/<binName>`. Matches how
+// npm/pnpm hoist binaries: in monorepo dev the binary lives in the adapter's
+// own `node_modules/.bin`, while in npm-installed consumers it's hoisted up to
+// the consumer's `node_modules/.bin`.
+export async function findAncestorBin(startDir: string, binName: string): Promise<string | null> {
+  let current = path.resolve(startDir);
+  while (true) {
+    const candidate = path.join(current, "node_modules", ".bin", binName);
+    if (await pathExists(candidate)) {
+      return candidate;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+async function resolveBuiltInAgentCommand(agent: string): Promise<string | null> {
   const binName =
     agent === "claude"
       ? "claude-agent-acp"
@@ -142,7 +159,10 @@ function resolveBuiltInAgentCommand(agent: string): string | null {
         ? "codex-acp"
         : null;
   if (!binName) return null;
-  return path.join(packageRootDir(), "node_modules", ".bin", binName);
+  // Prefer a resolved absolute path so the wrapper's `exec` line points at a
+  // known location. Falls back to the bare name so operators who install the
+  // runtime globally (or via a custom PATH) still get a working command.
+  return (await findAncestorBin(packageRootDir(), binName)) ?? binName;
 }
 
 function normalizeAgent(config: Record<string, unknown>): string {
@@ -754,7 +774,7 @@ async function buildRuntime(input: {
   }
 
   const configuredCommand = asString(config.agentCommand, "").trim();
-  const builtInCommand = resolveBuiltInAgentCommand(acpxAgent);
+  const builtInCommand = await resolveBuiltInAgentCommand(acpxAgent);
   const agentCommand = configuredCommand || builtInCommand || null;
   const agentCommandShell = configuredCommand || (builtInCommand ? shellQuote(builtInCommand) : "");
   const wrapper = agentCommand


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - One adapter category, `acpx_local`, runs Claude/Codex agents via Agent Client Protocol wrappers
> - Those wrappers `exec` a runtime binary like `claude-agent-acp` or `codex-acp`
> - The resolver built that as `<adapter-package>/node_modules/.bin/<bin>`, which only exists in monorepo dev
> - When `@paperclipai/adapter-acpx-local` is installed by `npx paperclipai`, npm/pnpm hoist the binary up to the consumer's `node_modules/.bin/`, so the adapter-local path is empty
> - The wrapper then `exec`s a non-existent absolute path, hits ENOENT, exits 1 before initialize, and Paperclip auto-creates a `stranded_assigned_issue` recovery card masking the root cause
> - This pull request walks up from the adapter dir looking for `node_modules/.bin/<name>` and falls back to the bare name for PATH lookup
> - The benefit is `acpx_local` works for `npx paperclipai` installs out of the box, closing #5932

## What Changed

- Added `findAncestorBin(startDir, binName)` that walks up the directory tree looking for `node_modules/.bin/<binName>`, matching pnpm/npm hoisting semantics
- Made `resolveBuiltInAgentCommand` async; uses the new helper; falls back to the bare binary name when no ancestor `.bin` is found (PATH escape hatch)
- Updated the single call site to `await` it
- Added 4 vitest cases: own-dir hit, ancestor hit (the regression case), absent everywhere, termination at filesystem root

## Verification

- `pnpm exec vitest run packages/adapters/acpx-local/src/server/execute.test.ts` — 13/13 pass (4 new + 9 existing untouched)
- `pnpm exec tsc --noEmit -p packages/adapters/acpx-local/tsconfig.json` — clean
- Confirmed `@agentclientprotocol/claude-agent-acp@0.33.1` exposes `bin: { "claude-agent-acp": "dist/index.js" }`, so the consumer-root `.bin/claude-agent-acp` symlink is the correct resolution target

## Risks

- **Low.** Monorepo dev case still hits the adapter's own `node_modules/.bin` on the first hop — unchanged.
- PATH fallback widens what `exec` can resolve, but only for closed enum `agent` values (`"claude"` or `"codex"`).
- One additional `await` at a single call site that was already inside an async function.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Anthropic Claude Opus 4.7 (`claude-opus-4-7`), 1M context window, extended-thinking off. Used for code analysis, fix design, and test authoring. Verified the resolver path independently against the published `@agentclientprotocol/claude-agent-acp` bin field on npm.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [ ] I have updated relevant documentation to reflect my changes — N/A, no public contract change
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge