### PR TITLE
Default native issue creation to the constitution body

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,9 @@
 export { agentAdapterTypeSchema, optionalAgentAdapterTypeSchema } from "./adapter-type.js";
 export {
+  DEFAULT_ISSUE_CONSTITUTION_BODY,
+  DEFAULT_ISSUE_WORKFLOW_CLASS,
+} from "./issue-default-description.js";
+export {
   COMPANY_STATUSES,
   DEFAULT_COMPANY_ATTACHMENT_MAX_BYTES,
   MAX_COMPANY_ATTACHMENT_MAX_BYTES,

--- a/packages/shared/src/issue-default-description.test.ts
+++ b/packages/shared/src/issue-default-description.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_ISSUE_CONSTITUTION_BODY,
+  DEFAULT_ISSUE_WORKFLOW_CLASS,
+} from "./issue-default-description.js";
+
+describe("DEFAULT_ISSUE_CONSTITUTION_BODY", () => {
+  it("includes the seven constitution-backed issue fields with Normal as the default workflow class", () => {
+    expect(DEFAULT_ISSUE_WORKFLOW_CLASS).toBe("Normal");
+    expect(DEFAULT_ISSUE_CONSTITUTION_BODY).toContain("## Workflow class");
+    expect(DEFAULT_ISSUE_CONSTITUTION_BODY).toContain("\nNormal\n");
+    expect(DEFAULT_ISSUE_CONSTITUTION_BODY).toContain("## Objective");
+    expect(DEFAULT_ISSUE_CONSTITUTION_BODY).toContain("## Source of truth");
+    expect(DEFAULT_ISSUE_CONSTITUTION_BODY).toContain("## Current state");
+    expect(DEFAULT_ISSUE_CONSTITUTION_BODY).toContain("## Acceptance criteria");
+    expect(DEFAULT_ISSUE_CONSTITUTION_BODY).toContain("## Required artifacts");
+    expect(DEFAULT_ISSUE_CONSTITUTION_BODY).toContain("## Human gate owner");
+  });
+});

--- a/packages/shared/src/issue-default-description.ts
+++ b/packages/shared/src/issue-default-description.ts
@@ -1,0 +1,24 @@
+export const DEFAULT_ISSUE_WORKFLOW_CLASS = "Normal";
+
+export const DEFAULT_ISSUE_CONSTITUTION_BODY = [
+  "## Workflow class",
+  DEFAULT_ISSUE_WORKFLOW_CLASS,
+  "",
+  "## Objective",
+  "이 일이 끝났을 때 무엇이 달라져야 하는가",
+  "",
+  "## Source of truth",
+  "Issue / Figma / Confluence / PR / log / file 경로",
+  "",
+  "## Current state",
+  "지금 관찰된 사실",
+  "",
+  "## Acceptance criteria",
+  "완료 판정 기준",
+  "",
+  "## Required artifacts",
+  "context-pack, verification report, risk/rollback note 등",
+  "",
+  "## Human gate owner",
+  "필요한 경우 승인자 또는 reviewer",
+].join("\n");

--- a/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
+++ b/server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { DEFAULT_ISSUE_CONSTITUTION_BODY } from "@paperclipai/shared";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -90,7 +91,26 @@ vi.mock("../services/index.js", () => ({
   }),
 }));
 
-async function createApp() {
+function boardActor() {
+  return {
+    type: "board" as const,
+    userId: "local-board",
+    companyIds: ["company-1"],
+    source: "local_implicit" as const,
+    isInstanceAdmin: false,
+  };
+}
+
+function agentActor() {
+  return {
+    type: "agent" as const,
+    agentId: "33333333-3333-4333-8333-333333333333",
+    companyId: "company-1",
+    runId: "44444444-4444-4444-8444-444444444444",
+  };
+}
+
+async function createApp(actor = boardActor()) {
   const [{ issueRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -98,13 +118,7 @@ async function createApp() {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", issueRoutes({} as any, {} as any));
@@ -194,6 +208,7 @@ describe("assigned backlog creation contract", () => {
       expect.objectContaining({
         title: "Assigned executable work",
         assigneeAgentId,
+        description: DEFAULT_ISSUE_CONSTITUTION_BODY,
         status: "todo",
       }),
     );
@@ -214,10 +229,63 @@ describe("assigned backlog creation contract", () => {
       expect.objectContaining({
         action: "issue.created",
         details: expect.objectContaining({
+          descriptionDefaulted: true,
           status: "todo",
           statusDefaulted: true,
           statusDefaultReason: "assigned_omitted_status",
           assignmentWakeSkipped: false,
+        }),
+      }),
+    );
+  });
+
+  it("preserves an explicitly cleared description instead of re-defaulting it", async () => {
+    const res = await request(await createApp())
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Blank body by choice",
+        description: "",
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        title: "Blank body by choice",
+        description: "",
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.created",
+        details: expect.objectContaining({
+          descriptionDefaulted: false,
+        }),
+      }),
+    );
+  });
+
+  it("does not inject the constitution body for agent-created issues", async () => {
+    const res = await request(await createApp(agentActor()))
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Agent-created issue",
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.not.objectContaining({
+        description: DEFAULT_ISSUE_CONSTITUTION_BODY,
+      }),
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.created",
+        details: expect.objectContaining({
+          descriptionDefaulted: false,
         }),
       }),
     );

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -13,6 +13,7 @@ import {
   projectWorkspaces,
 } from "@paperclipai/db";
 import {
+  DEFAULT_ISSUE_CONSTITUTION_BODY,
   addIssueCommentSchema,
   acceptIssueThreadInteractionSchema,
   cancelIssueThreadInteractionSchema,
@@ -162,6 +163,26 @@ function applyCreateIssueStatusDefault(req: Request, res: Response, next: () => 
       status: resolution.status,
     };
   }
+  next();
+}
+
+function applyCreateIssueDescriptionDefault(req: Request, res: Response, next: () => void) {
+  if (!req.body || typeof req.body !== "object" || Array.isArray(req.body)) {
+    next();
+    return;
+  }
+
+  const shouldDefaultDescription =
+    req.actor.type === "board" && typeof (req.body as Record<string, unknown>).description === "undefined";
+  res.locals.createIssueDescriptionDefaulted = shouldDefaultDescription;
+
+  if (shouldDefaultDescription) {
+    req.body = {
+      ...req.body,
+      description: DEFAULT_ISSUE_CONSTITUTION_BODY,
+    };
+  }
+
   next();
 }
 
@@ -2556,7 +2577,12 @@ export function issueRoutes(
     res.json({ ok: true });
   });
 
-  router.post("/companies/:companyId/issues", applyCreateIssueStatusDefault, validate(createIssueSchema), async (req, res) => {
+  router.post(
+    "/companies/:companyId/issues",
+    applyCreateIssueStatusDefault,
+    applyCreateIssueDescriptionDefault,
+    validate(createIssueSchema),
+    async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
@@ -2596,6 +2622,7 @@ export function issueRoutes(
       details: {
         title: issue.title,
         identifier: issue.identifier,
+        descriptionDefaulted: res.locals.createIssueDescriptionDefaulted === true,
         ...buildCreateIssueActivityStatusDetails(issue, res),
         ...(Array.isArray(req.body.blockedByIssueIds) ? { blockedByIssueIds: req.body.blockedByIssueIds } : {}),
         ...summarizeIssueReferenceActivityDetails({
@@ -2644,9 +2671,15 @@ export function issueRoutes(
       relatedWork: referenceSummary,
       referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
     });
-  });
+    },
+  );
 
-  router.post("/issues/:id/children", applyCreateIssueStatusDefault, validate(createChildIssueSchema), async (req, res) => {
+  router.post(
+    "/issues/:id/children",
+    applyCreateIssueStatusDefault,
+    applyCreateIssueDescriptionDefault,
+    validate(createChildIssueSchema),
+    async (req, res) => {
     const parentId = req.params.id as string;
     const parent = await svc.getById(parentId);
     if (!parent) {
@@ -2688,6 +2721,7 @@ export function issueRoutes(
         parentId: parent.id,
         identifier: issue.identifier,
         title: issue.title,
+        descriptionDefaulted: res.locals.createIssueDescriptionDefaulted === true,
         ...buildCreateIssueActivityStatusDetails(issue, res),
         inheritedExecutionWorkspaceFromIssueId: parent.id,
         ...(Array.isArray(req.body.blockedByIssueIds) ? { blockedByIssueIds: req.body.blockedByIssueIds } : {}),
@@ -2730,7 +2764,8 @@ export function issueRoutes(
     });
 
     res.status(201).json(issue);
-  });
+    },
+  );
 
   router.post("/issues/:id/monitor/check-now", async (req, res) => {
     const id = req.params.id as string;

--- a/ui/src/components/NewIssueDialog.test.tsx
+++ b/ui/src/components/NewIssueDialog.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react";
 import type { ComponentProps, ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { DEFAULT_ISSUE_CONSTITUTION_BODY } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NewIssueDialog } from "./NewIssueDialog";
 
@@ -582,6 +583,52 @@ describe("NewIssueDialog", () => {
         title: "Typed issue",
         description: "Typed description",
         workMode: "standard",
+      }),
+    );
+
+    act(() => root.unmount());
+  });
+
+  it("starts new issues with the shared constitution default description", async () => {
+    const { root } = renderDialog(container);
+    await flush();
+
+    const descriptionInput = container.querySelector('textarea[aria-label="Add description..."]') as HTMLTextAreaElement | null;
+    expect(descriptionInput).not.toBeNull();
+    expect(descriptionInput?.value).toBe(DEFAULT_ISSUE_CONSTITUTION_BODY);
+
+    act(() => root.unmount());
+  });
+
+  it("submits an explicitly cleared description as an empty string", async () => {
+    const { root } = renderDialog(container);
+    await flush();
+
+    const titleInput = container.querySelector('textarea[placeholder="Issue title"]') as HTMLTextAreaElement | null;
+    const descriptionInput = container.querySelector('textarea[aria-label="Add description..."]') as HTMLTextAreaElement | null;
+    expect(titleInput).not.toBeNull();
+    expect(descriptionInput).not.toBeNull();
+
+    await typeTextareaValue(titleInput!, "Typed issue");
+    await typeTextareaValue(descriptionInput!, "");
+
+    const submitButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("Create Issue"));
+    expect(submitButton).not.toBeUndefined();
+    await vi.waitFor(() => {
+      expect(submitButton?.hasAttribute("disabled")).toBe(false);
+    });
+
+    await act(async () => {
+      submitButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    expect(mockIssuesApi.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        title: "Typed issue",
+        description: "",
       }),
     );
 

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -1,6 +1,9 @@
 import { memo, useState, useEffect, useRef, useCallback, useMemo, type ChangeEvent, type DragEvent, type RefObject } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import type { IssueWorkMode } from "@paperclipai/shared";
+import {
+  DEFAULT_ISSUE_CONSTITUTION_BODY,
+  type IssueWorkMode,
+} from "@paperclipai/shared";
 import { pickTextColorForSolidBg } from "@/lib/color-contrast";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
@@ -137,6 +140,12 @@ const ISSUE_THINKING_EFFORT_OPTIONS = {
 
 function isIssueWorkMode(value: unknown): value is IssueWorkMode {
   return value === "standard" || value === "planning";
+}
+
+function resolveInitialIssueDescription(description: string | null | undefined) {
+  if (typeof description === "string") return description;
+  if (description === null) return "";
+  return DEFAULT_ISSUE_CONSTITUTION_BODY;
 }
 
 const ISSUE_WORK_MODE_OPTIONS: ReadonlyArray<{
@@ -736,7 +745,10 @@ export function NewIssueDialog() {
       const defaultProjectWorkspaceId = newIssueDefaults.projectWorkspaceId
         ?? defaultProjectWorkspaceIdForProject(defaultProject);
       const defaultExecutionWorkspaceMode = defaultExecutionWorkspaceModeForIssueDefaults(newIssueDefaults, defaultProject);
-      setIssueText(newIssueDefaults.title ?? "", newIssueDefaults.description ?? "");
+      setIssueText(
+        newIssueDefaults.title ?? "",
+        resolveInitialIssueDescription(newIssueDefaults.description),
+      );
       setStatus(newIssueDefaults.status ?? "todo");
       setPriority(newIssueDefaults.priority ?? "");
       setProjectId(defaultProjectId);
@@ -754,7 +766,10 @@ export function NewIssueDialog() {
         : null;
     } else if (newIssueDefaults.title) {
       const nextWorkMode = isIssueWorkMode(newIssueDefaults.workMode) ? newIssueDefaults.workMode : "standard";
-      setIssueText(newIssueDefaults.title, newIssueDefaults.description ?? "");
+      setIssueText(
+        newIssueDefaults.title,
+        resolveInitialIssueDescription(newIssueDefaults.description),
+      );
       setStatus(newIssueDefaults.status ?? "todo");
       setPriority(newIssueDefaults.priority ?? "");
       const defaultProjectId = newIssueDefaults.projectId ?? "";
@@ -827,7 +842,7 @@ export function NewIssueDialog() {
       const defaultProjectId = newIssueDefaults.projectId ?? "";
       const defaultProject = orderedProjects.find((project) => project.id === defaultProjectId);
       const hasExplicitProjectWorkspaceId = newIssueDefaults.projectWorkspaceId !== undefined;
-      setIssueText("", "");
+      setIssueText("", DEFAULT_ISSUE_CONSTITUTION_BODY);
       setStatus(newIssueDefaults.status ?? "todo");
       setPriority(newIssueDefaults.priority ?? "");
       setProjectId(defaultProjectId);
@@ -978,7 +993,7 @@ export function NewIssueDialog() {
       companyId: effectiveCompanyId,
       stagedFiles,
       title: currentTitle,
-      description: currentDescription || undefined,
+      description: currentDescription,
       status,
       priority: priority || "medium",
       workMode,

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState, useRef, useCallback, useMemo } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import type { AdapterEnvironmentTestResult } from "@paperclipai/shared";
+import {
+  DEFAULT_ISSUE_CONSTITUTION_BODY,
+  type AdapterEnvironmentTestResult,
+} from "@paperclipai/shared";
 import { useLocation, useNavigate, useParams } from "@/lib/router";
 import { useDialog } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
@@ -63,12 +66,6 @@ import {
 type Step = 1 | 2 | 3 | 4;
 type AdapterType = string;
 
-const DEFAULT_TASK_DESCRIPTION = `You are the CEO. You set the direction for the company.
-
-- hire a founding engineer
-- write a hiring plan
-- break the roadmap into concrete tasks and start delegating work`;
-
 export function OnboardingWizard() {
   const { onboardingOpen, onboardingOptions, closeOnboarding } = useDialog();
   const { companies, setSelectedCompanyId, loading: companiesLoading } = useCompany();
@@ -129,7 +126,7 @@ export function OnboardingWizard() {
     "Hire your first engineer and create a hiring plan"
   );
   const [taskDescription, setTaskDescription] = useState(
-    DEFAULT_TASK_DESCRIPTION
+    DEFAULT_ISSUE_CONSTITUTION_BODY
   );
 
   // Auto-grow textarea for task description
@@ -302,7 +299,7 @@ export function OnboardingWizard() {
     setForceUnsetAnthropicApiKey(false);
     setUnsetAnthropicLoading(false);
     setTaskTitle("Hire your first engineer and create a hiring plan");
-    setTaskDescription(DEFAULT_TASK_DESCRIPTION);
+    setTaskDescription(DEFAULT_ISSUE_CONSTITUTION_BODY);
     setCreatedCompanyId(null);
     setCreatedCompanyPrefix(null);
     setCreatedCompanyGoalId(null);

--- a/ui/src/lib/onboarding-launch.test.ts
+++ b/ui/src/lib/onboarding-launch.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { DEFAULT_ISSUE_CONSTITUTION_BODY } from "@paperclipai/shared";
 import {
   buildOnboardingIssuePayload,
   buildOnboardingProjectPayload,
@@ -123,9 +124,22 @@ describe("onboarding launch payloads", () => {
       }),
     ).toEqual({
       title: "Task",
+      description: "",
       assigneeAgentId: "agent-1",
       projectId: "project-1",
       status: "todo",
     });
+  });
+
+  it("passes the shared constitution default body through unchanged", () => {
+    expect(
+      buildOnboardingIssuePayload({
+        title: "Task",
+        description: DEFAULT_ISSUE_CONSTITUTION_BODY,
+        assigneeAgentId: "agent-1",
+        projectId: "project-1",
+        goalId: null,
+      }).description,
+    ).toBe(DEFAULT_ISSUE_CONSTITUTION_BODY);
   });
 });

--- a/ui/src/lib/onboarding-launch.ts
+++ b/ui/src/lib/onboarding-launch.ts
@@ -44,7 +44,7 @@ export function buildOnboardingIssuePayload(input: {
 
   return {
     title,
-    ...(description ? { description } : {}),
+    description,
     assigneeAgentId: input.assigneeAgentId,
     projectId: input.projectId,
     ...(input.goalId ? { goalId: input.goalId } : {}),


### PR DESCRIPTION
## Thinking Path

> - Paperclip's native issue surfaces are the control plane entrypoint for turning human requests into executable work.
> - This change touches the issue creation path across the shared defaults, the board-facing new issue dialog, onboarding's first-task flow, and the create-issue API fallback.
> - S.RIDE already adopted a seven-field constitution issue body, but Paperclip's native composer still opened with a blank body and onboarding still used a hardcoded CEO prompt.
> - That mismatch meant the same organization got different issue contracts depending on whether work started in GitHub or inside Paperclip itself.
> - This pull request introduces one shared constitution-backed default issue body and wires the native composer, onboarding, and board-authenticated create routes to the same source.
> - The benefit is that Paperclip-native issue creation now defaults to the same lightweight `Normal` workflow contract without forcing agent-created issues or explicit blank descriptions into a template.

## What Changed

- Added `DEFAULT_ISSUE_CONSTITUTION_BODY` and `DEFAULT_ISSUE_WORKFLOW_CLASS` in `@paperclipai/shared` so the seven-field template has one canonical source.
- Updated `NewIssueDialog` to prefill new issue descriptions with the shared constitution body whenever no explicit description was provided, while preserving deliberate empty descriptions on submit.
- Replaced onboarding's hardcoded CEO task body with the shared default issue body and made onboarding payloads preserve explicit empty descriptions.
- Added server-side board-only create-route fallback so omitted descriptions on native/API issue creation get the same constitution body, while agent-created issues keep their prior behavior.
- Added focused tests for the shared template, onboarding payloads, UI composer defaults, cleared-description submission, and board-vs-agent API behavior.

## Verification

- `pnpm run preflight:workspace-links`
- `pnpm exec vitest run packages/shared/src/issue-default-description.test.ts ui/src/lib/onboarding-launch.test.ts ui/src/components/NewIssueDialog.test.tsx server/src/__tests__/issue-assigned-backlog-contract-routes.test.ts`

## Risks

- Board-authenticated callers that previously omitted descriptions on the top-level or child issue-create APIs will now receive the constitution body by default. Explicit `description: ""` and agent-authenticated creates remain unchanged.
- This PR changes visible default text in two UI flows but does not add screenshots here because the layout itself is unchanged and the behavior is covered by focused UI tests.

## Model Used

- OpenAI Codex in the local Codex agent environment (GPT-5 family; exact runtime model ID was not exposed in this session), using tool-assisted code editing, shell execution, and focused test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge