### PR TITLE
fix(openclaw-gateway): bump adapter PROTOCOL_VERSION to 4 to match gateway

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -86,7 +86,7 @@ type GatewayClientRequestOptions = {
   expectFinal?: boolean;
 };
 
-const PROTOCOL_VERSION = 3;
+const PROTOCOL_VERSION = 4;
 const DEFAULT_SCOPES = ["operator.admin"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";

--- a/packages/adapters/openclaw-gateway/src/server/test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/test.ts
@@ -145,8 +145,8 @@ async function probeGateway(input: {
             id: connectId,
             method: "connect",
             params: {
-              minProtocol: 3,
-              maxProtocol: 3,
+              minProtocol: 4,
+              maxProtocol: 4,
               client: {
                 id: "gateway-client",
                 version: "paperclip-probe",


### PR DESCRIPTION
## Summary

Local OpenClaw gateways since v2026.5.x require `MIN_CLIENT_PROTOCOL_VERSION = 4` (see [openclaw/src/gateway/protocol/version.ts](https://github.com/NousResearch/openclaw/blob/main/src/gateway/protocol/version.ts)). The Paperclip openclaw_gateway adapter at v0.3.1 still sends `PROTOCOL_VERSION = 3`, which produces a WebSocket close (code 1002 \`protocol mismatch\`) before any auth challenge is issued.

## Symptom

Every \`openclaw_gateway\` agent run fails with:
- \`errorCode: openclaw_gateway_request_failed\`
- \`error: protocol mismatch\`

OpenClaw gateway journal:
\`\`\`
[ws] protocol mismatch conn=... remote=127.0.0.1 client=gateway-client backend vpaperclip
[ws] closed before connect conn=... peer=...->127.0.0.1:18789 code=1002 reason=protocol mismatch
\`\`\`

## Fix

One-line bump in [\`packages/adapters/openclaw-gateway/src/server/execute.ts:89\`](packages/adapters/openclaw-gateway/src/server/execute.ts#L89): \`PROTOCOL_VERSION = 3\` → \`PROTOCOL_VERSION = 4\`. No protocol semantics changed — the adapter's existing frames are compatible with v4.

## Test plan

- [x] \`pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck\` clean
- [x] \`pnpm --filter @paperclipai/adapter-openclaw-gateway build\` clean
- [x] Verified locally: openclaw_gateway agent connects + receives challenge + completes auth handshake after the bump

## Related

- Same root cause affects every openclaw_gateway-backed agent in the field. Sparkeros companies SparkEros, Inc. and SparkEros AOS Inc. both hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)