### PR TITLE
docs(recovery): surface recovery-action resolve endpoint for blocked issues

### DIFF
--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1646,7 +1646,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         successfulRunHandoffEvidence: input.successfulRunHandoffEvidence,
       }),
       nextAction: recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON
-        ? "Choose and record a valid issue disposition without copying transcript content."
+        ? "Choose and record a valid issue disposition without copying transcript content. "
+          + "Resolve this recovery via POST /api/issues/{id}/recovery-actions/resolve "
+          + "(no checkout required). If the source issue is legitimately blocked by a "
+          + "first-class blocker, use outcome \"blocked\" + sourceIssueStatus \"blocked\" "
+          + "instead of attempting a checkout, which is rejected for blocked issues."
         : "Restore a live execution path, fix the runtime/adapter failure, or record an intentional manual resolution.",
       wakePolicy: ownerAgentId
         ? {

--- a/skills/diagnose-why-work-stopped/SKILL.md
+++ b/skills/diagnose-why-work-stopped/SKILL.md
@@ -147,6 +147,7 @@ When the phase chain is complete, post a board-level summary comment on the pare
 - **Bypassing company scoping.** Cross-company forensics needs a board-approved diagnostic path, not a database read.
 - **Recursive recovery.** Stranded-work recovery that recovers its own recovery issues is the canonical infinite loop ([PAP-2486](/PAP/issues/PAP-2486)). Detect it and refuse to deepen.
 - **Hiding the chain.** Don't silently delete or hide the symptomatic recovery issues — the operator needs the audit trail.
+- **Treating a stuck recovery action as unresolvable.** A `missing_disposition` recovery on a legitimately `blocked` source issue is not a dead end: resolve it with `POST /api/issues/{id}/recovery-actions/resolve` (`outcome: "blocked"`, `sourceIssueStatus: "blocked"`). This endpoint does not require checkout, so it works even though the issue's blockers reject `POST /api/issues/{id}/checkout`.
 
 ## Verification checklist (before posting the plan)
 

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -786,8 +786,10 @@ Terminal states: `done`, `cancelled`
 | GET    | `/api/issues/:issueId/heartbeat-context` | Compact context for heartbeat: issue state, ancestor summaries, comment cursor  |
 | POST   | `/api/companies/:companyId/issues` | Create issue (supports `blockedByIssueIds: string[]` for dependencies)                   |
 | PATCH  | `/api/issues/:issueId`             | Update issue (optional `comment` field; `blockedByIssueIds` replaces blocker set)        |
-| POST   | `/api/issues/:issueId/checkout`    | Atomic checkout (claim + start). Idempotent if you already own it.                       |
+| POST   | `/api/issues/:issueId/checkout`    | Atomic checkout (claim + start). Idempotent if you already own it. `422` if the issue has unresolved first-class blockers. |
 | POST   | `/api/issues/:issueId/release`     | Release task ownership                                                                   |
+| GET    | `/api/issues/:issueId/recovery-actions` | List the active recovery action for an issue (e.g. `missing_disposition`), if any   |
+| POST   | `/api/issues/:issueId/recovery-actions/resolve` | Resolve the active recovery action. Body: `outcome` (`restored` \| `blocked` \| `false_positive` \| `cancelled`), `sourceIssueStatus` (`done` \| `in_review` \| `blocked`), optional `actionId`, `resolutionNote`. Does **not** require checkout — works on a `blocked` issue. Use `outcome: "blocked"` + `sourceIssueStatus: "blocked"` to clear a `missing_disposition` recovery whose source issue is legitimately blocked by a first-class blocker (the handler verifies an unresolved first-class blocker still exists). `false_positive`/`cancelled` are board-only. |
 | GET    | `/api/issues/:issueId/comments`    | List comments                                                                            |
 | GET    | `/api/issues/:issueId/comments/:commentId` | Get a specific comment by ID                                                     |
 | POST   | `/api/issues/:issueId/comments`    | Add comment (@-mentions trigger wakeups)                                                 |


### PR DESCRIPTION
## Summary

Documentation + recovery-action wording fix for the `missing_disposition` recovery catch-22 reported in #5991.

The escape hatch already exists in the codebase — `POST /api/issues/:issueId/recovery-actions/resolve` handles `outcome: "blocked"` correctly and does not require checkout — but it is undiscoverable:

- It is **not** in `skills/paperclip/references/api-reference.md` (Issues table), so operators guessed action-id-scoped paths and got `404`.
- The `missing_disposition` recovery action's `nextAction` text (`server/src/services/recovery/service.ts`) tells the owner to "record a valid issue disposition" with no pointer to the resolve endpoint, leading straight into `POST /checkout` → `422 Issue is blocked by unresolved blockers` when the source issue is legitimately blocked.

This PR addresses suggested fix #3 from #5991 (the lowest-risk, immediately shippable one). It is purely additive — documentation rows and a recovery-action `nextAction` string. It does **not** attempt the deeper fixes (#1 auto-resolve during reconcile, #4 the `attemptCount`/`lastAttemptAt` re-evaluation freeze), which remain tracked in #5991.

## Changes

- `skills/paperclip/references/api-reference.md` — add `GET /api/issues/:issueId/recovery-actions` and `POST /api/issues/:issueId/recovery-actions/resolve` to the Issues table; document the no-checkout / `blocked`-outcome path; note that `checkout` returns `422` on issues with unresolved first-class blockers.
- `server/src/services/recovery/service.ts` — the `missing_disposition` (`successful_run_missing_state`) `nextAction` now points at `POST /api/issues/{id}/recovery-actions/resolve` and the `blocked` outcome, instead of an implied checkout.
- `skills/diagnose-why-work-stopped/SKILL.md` — add a pitfall so a stuck recovery on a blocked issue is not treated as unresolvable.

## Test plan

- Change is additive: three Markdown docs edits + one TypeScript string-literal change inside an existing object literal (no control-flow or type changes).
- I was not able to run the full monorepo lint/build/test gate in this environment (fresh shallow clone, no install); relying on repo CI on this PR for the authoritative run. Please surface any CI failure and I will address it.
- Manual verification of the underlying claim: probing a live server (`2026.513.0`) with `POST /api/issues/{id}/recovery-actions/resolve` and an empty body returns `400` (schema validation), confirming the route exists and is reachable — it is the discoverability, not the route, that was missing.

## Related

- #5991 — missing_disposition recovery action unresolvable on legitimately blocked source issues (this PR is the docs/wording portion; auto-resolve + re-evaluation-freeze fixes remain open there)
