### PR TITLE
feat(recovery): honor agent-declared disposition intent before flip-to-blocked

### DIFF
--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -458,6 +458,49 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return Boolean(run || deferredWake);
   }
 
+  // Agents declare disposition intent in their final comment per the
+  // disposition state-machine playbook (DONE / BLOCKED / FOR REVIEW / CANCELLED
+  // / DELEGATED / PARTIAL ... Continuation needed:). When the agent has
+  // declared an intent in their latest comment, the stranded-issue reconciler
+  // should NOT flip the issue to `blocked`. That would undo the agent's
+  // explicit decision (especially for DELEGATED and CONTINUATION, where the
+  // agent intentionally leaves the issue in_progress).
+  async function latestAgentDeclaredDispositionIntent(
+    companyId: string,
+    issueId: string,
+  ): Promise<
+    | "done"
+    | "blocked"
+    | "in_review"
+    | "cancelled"
+    | "delegated"
+    | "continuation"
+    | null
+  > {
+    const [row] = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, companyId),
+          eq(issueComments.issueId, issueId),
+          eq(issueComments.authorType, "agent"),
+        ),
+      )
+      .orderBy(desc(issueComments.createdAt))
+      .limit(1);
+    const body = row?.body;
+    if (!body) return null;
+    if (/\bcontinuation needed\s*:?\s*$/i.test(body)) return "continuation";
+    if (/^\s*PARTIAL\s*:/i.test(body)) return "continuation";
+    if (/^\s*DELEGATED\b/i.test(body)) return "delegated";
+    if (/^\s*DONE\s*:/i.test(body)) return "done";
+    if (/^\s*BLOCKED\s*:/i.test(body)) return "blocked";
+    if (/^\s*FOR\s+REVIEW\s*:/i.test(body)) return "in_review";
+    if (/^\s*CANCELLED\s*:/i.test(body)) return "cancelled";
+    return null;
+  }
+
   async function hasQueuedIssueWake(companyId: string, issueId: string) {
     return db
       .select({ id: agentWakeupRequests.id })
@@ -2021,6 +2064,19 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
+
+      // Honor agent-declared disposition intent: if the most recent agent
+      // comment on this issue carries an explicit disposition marker
+      // (DELEGATED, CONTINUATION/PARTIAL, DONE, BLOCKED, IN_REVIEW, CANCELLED),
+      // the reconciler should not subsequently flip the issue to `blocked`
+      // against the agent's stated intent. This is most important for
+      // DELEGATED (assignee changed; new owner has not yet acted) and
+      // CONTINUATION (agent intentionally left issue in_progress, awaiting
+      // the next wake or operator follow-up).
+      if (await latestAgentDeclaredDispositionIntent(issue.companyId, issue.id)) {
+        result.skipped += 1;
+        continue;
+      }
       if (isStrandedIssueRecoveryIssue(issue) && isUnsuccessfulTerminalIssueRun(latestRun)) {
         const updated = await escalateStrandedRecoveryIssueInPlace({
           issue,


### PR DESCRIPTION
## Summary

The stranded-issue reconciler in `services/recovery/service.ts` flips `in_progress` issues to `blocked` after a fixed number of retry attempts when no live execution path exists. This is too aggressive: it overrides the agent's explicit disposition decision in two cases.

**Case 1 — DELEGATED.** The disposition state-machine playbook (docs/guides/agent-developer/disposition-state-machine.md) directs agents to POST a delegation comment (\`DELEGATED to <agent>: ...\`) and PATCH \`assigneeAgentId\`. After the agent terminates, the reconciler sees no live execution path for the new assignee yet and flips status to \`blocked\`, undoing the delegation handoff.

**Case 2 — EXPLICIT CONTINUATION.** The playbook directs agents to POST a comment ending with the literal phrase \"Continuation needed:\" (or starting with \`PARTIAL:\`) and leave status as \`in_progress\`. The reconciler does not recognize this signal: after a few retries it escalates via \`isRepeatedProductiveContinuationRecovery\`.

## Fix

Introduce \`latestAgentDeclaredDispositionIntent(companyId, issueId)\` that inspects the most recent agent-authored comment and matches it against six known disposition prefixes/suffixes (DONE, BLOCKED, IN_REVIEW, CANCELLED, DELEGATED, CONTINUATION/PARTIAL). When the agent has declared intent in their latest comment, the reconciler skips this issue. The agent's explicit decision wins.

Cost: one additional indexed SELECT per stranded-issue iteration (authorType-filtered, LIMIT 1).

## Test plan

- [x] Verified locally against the AOS-18 (DELEGATED) and AOS-19 (CONTINUATION) test cases on the SparkEros AOS Inc. instance; both previously flipped to \`blocked\` despite valid agent disposition comments.
- [ ] Add unit test for the new helper (TODO if upstream wants).
- [ ] Integration test against the playbook from \`docs/guides/agent-developer/disposition-state-machine.md\` (TODO if upstream wants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)