### PR TITLE
feat: add error_category_counts summary to run_summary.json

### DIFF
--- a/server/src/__tests__/heartbeat-run-summary.test.ts
+++ b/server/src/__tests__/heartbeat-run-summary.test.ts
@@ -21,7 +21,6 @@ describe("summarizeHeartbeatRunResultJson", () => {
       timeoutFired: true,
       nested: { ignored: true },
     });
-
     expect(summary).toEqual({
       summary: "a".repeat(500),
       result: "ok",
@@ -42,6 +41,110 @@ describe("summarizeHeartbeatRunResultJson", () => {
     expect(summarizeHeartbeatRunResultJson(["nope"] as unknown as Record<string, unknown>)).toBeNull();
     expect(summarizeHeartbeatRunResultJson({ nested: { only: "ignored" } })).toBeNull();
   });
+
+  it("counts errors with type field by category", () => {
+    const summary = summarizeHeartbeatRunResultJson({
+      summary: "done",
+      errors: [
+        { type: "rate_limit_error", message: "Rate limit reached" },
+        { type: "rate_limit_error", message: "Rate limit reached again" },
+        { type: "overloaded_error", message: "Overloaded" },
+      ],
+    });
+    expect(summary).not.toBeNull();
+    expect(summary!.error_category_counts).toEqual({
+      rate_limit_error: 2,
+      overloaded_error: 1,
+    });
+  });
+
+  it("counts string errors by classified category", () => {
+    const summary = summarizeHeartbeatRunResultJson({
+      summary: "done",
+      errors: [
+        "Rate limit exceeded for requests",
+        "Authentication required",
+        "Something unexpected happened",
+        "Timed out waiting for response",
+      ],
+    });
+    expect(summary).not.toBeNull();
+    expect(summary!.error_category_counts).toEqual({
+      rate_limit: 1,
+      authentication: 1,
+      unknown: 1,
+      timeout: 1,
+    });
+  });
+
+  it("includes errorFamily in category counts", () => {
+    const summary = summarizeHeartbeatRunResultJson({
+      summary: "done",
+      errorFamily: "transient_upstream",
+    });
+    expect(summary).not.toBeNull();
+    expect(summary!.error_category_counts).toEqual({
+      transient_upstream: 1,
+    });
+  });
+
+  it("combines errors array and errorFamily", () => {
+    const summary = summarizeHeartbeatRunResultJson({
+      summary: "done",
+      errors: [
+        { type: "rate_limit_error", message: "Rate limited" },
+        { type: "overloaded_error", message: "Overloaded" },
+      ],
+      errorFamily: "transient_upstream",
+    });
+    expect(summary).not.toBeNull();
+    expect(summary!.error_category_counts).toEqual({
+      rate_limit_error: 1,
+      overloaded_error: 1,
+      transient_upstream: 1,
+    });
+  });
+
+  it("uses category field as fallback for typed errors", () => {
+    const summary = summarizeHeartbeatRunResultJson({
+      summary: "done",
+      errors: [{ category: "api_error", message: "Something broke" }],
+    });
+    expect(summary).not.toBeNull();
+    expect(summary!.error_category_counts).toEqual({
+      api_error: 1,
+    });
+  });
+
+  it("omits error_category_counts when no errors or errorFamily", () => {
+    const summary = summarizeHeartbeatRunResultJson({
+      summary: "all good",
+    });
+    expect(summary).not.toBeNull();
+    expect(summary).not.toHaveProperty("error_category_counts");
+  });
+
+  it("skips empty string errors", () => {
+    const summary = summarizeHeartbeatRunResultJson({
+      summary: "done",
+      errors: ["", "   ", { type: "rate_limit_error", message: "limited" }],
+    });
+    expect(summary).not.toBeNull();
+    expect(summary!.error_category_counts).toEqual({
+      rate_limit_error: 1,
+    });
+  });
+
+  it("skips null and non-object/non-string error entries", () => {
+    const summary = summarizeHeartbeatRunResultJson({
+      summary: "done",
+      errors: [null, 42, true, { type: "permission_error", message: "Forbidden" }],
+    });
+    expect(summary).not.toBeNull();
+    expect(summary!.error_category_counts).toEqual({
+      permission_error: 1,
+    });
+  });
 });
 
 describe("buildHeartbeatRunIssueComment", () => {
@@ -49,7 +152,6 @@ describe("buildHeartbeatRunIssueComment", () => {
     const comment = buildHeartbeatRunIssueComment({
       summary: "## Summary\n\n- fixed deploy config\n- posted issue update",
     });
-
     expect(comment).toContain("## Summary");
     expect(comment).toContain("- fixed deploy config");
     expect(comment).not.toContain("Run summary");
@@ -71,13 +173,14 @@ describe("mergeHeartbeatRunResultJson", () => {
       { stdout: "raw stdout", stderr: "" },
       "## Summary\n\n1. first thing\n2. second thing",
     );
-
     expect(merged).toEqual({
       stdout: "raw stdout",
       stderr: "",
       summary: "## Summary\n\n1. first thing\n2. second thing",
     });
-    expect(buildHeartbeatRunIssueComment(merged)).toBe("## Summary\n\n1. first thing\n2. second thing");
+    expect(buildHeartbeatRunIssueComment(merged)).toBe(
+      "## Summary\n\n1. first thing\n2. second thing",
+    );
   });
 
   it("creates a result payload when only a summary exists", () => {
@@ -90,9 +193,6 @@ describe("mergeHeartbeatRunResultJson", () => {
         { summary: "adapter result", stdout: "raw stdout" },
         "fallback summary",
       ),
-    ).toEqual({
-      summary: "adapter result",
-      stdout: "raw stdout",
-    });
+    ).toEqual({ summary: "adapter result", stdout: "raw stdout" });
   });
 });

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -45,6 +45,48 @@ export function mergeHeartbeatRunResultJson(
   };
 }
 
+function classifyErrorText(text: string): string {
+  const lower = text.toLowerCase();
+  if (/\brate.?limit|429|too.?many.?requests|throttl/i.test(lower)) return "rate_limit";
+  if (/\boverloaded|503|529|service.?unavailable/i.test(lower)) return "overloaded";
+  if (/\bauth|unauthorized|401|login.?required/i.test(lower)) return "authentication";
+  if (/\bpermission|forbidden|403/i.test(lower)) return "permission";
+  if (/\btimeout|timed.?out/i.test(lower)) return "timeout";
+  if (/\bmax.?turn|turn.?limit/i.test(lower)) return "max_turns";
+  if (/\bnot.?found|404/i.test(lower)) return "not_found";
+  if (/\bprocess.?lost|child.?died|killed|signal/i.test(lower)) return "process_lost";
+  return "unknown";
+}
+
+function buildErrorCategoryCounts(
+  resultJson: Record<string, unknown>,
+): Record<string, number> | null {
+  const counts: Record<string, number> = {};
+
+  const errors = resultJson.errors;
+  if (Array.isArray(errors)) {
+    for (const entry of errors) {
+      if (typeof entry === "object" && entry !== null && !Array.isArray(entry)) {
+        const category =
+          readCommentText((entry as Record<string, unknown>).type) ??
+          readCommentText((entry as Record<string, unknown>).category) ??
+          "unknown";
+        counts[category] = (counts[category] ?? 0) + 1;
+      } else if (typeof entry === "string" && entry.trim().length > 0) {
+        const category = classifyErrorText(entry);
+        counts[category] = (counts[category] ?? 0) + 1;
+      }
+    }
+  }
+
+  const errorFamily = readCommentText(resultJson.errorFamily);
+  if (errorFamily) {
+    counts[errorFamily] = (counts[errorFamily] ?? 0) + 1;
+  }
+
+  return Object.keys(counts).length > 0 ? counts : null;
+}
+
 export function summarizeHeartbeatRunResultJson(
   resultJson: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> | null {
@@ -53,6 +95,7 @@ export function summarizeHeartbeatRunResultJson(
   }
 
   const summary: Record<string, unknown> = {};
+
   const textFields = ["summary", "result", "message", "error"] as const;
   for (const key of textFields) {
     const value = truncateSummaryText(resultJson[key]);
@@ -89,6 +132,11 @@ export function summarizeHeartbeatRunResultJson(
     }
   }
 
+  const errorCategoryCounts = buildErrorCategoryCounts(resultJson);
+  if (errorCategoryCounts && Object.keys(errorCategoryCounts).length > 0) {
+    summary.error_category_counts = errorCategoryCounts;
+  }
+
   return Object.keys(summary).length > 0 ? summary : null;
 }
 
@@ -98,11 +146,10 @@ export function buildHeartbeatRunIssueComment(
   if (!resultJson || typeof resultJson !== "object" || Array.isArray(resultJson)) {
     return null;
   }
-
   return (
-    readCommentText(resultJson.summary)
-    ?? readCommentText(resultJson.result)
-    ?? readCommentText(resultJson.message)
-    ?? null
+    readCommentText(resultJson.summary) ??
+    readCommentText(resultJson.result) ??
+    readCommentText(resultJson.message) ??
+    null
   );
 }


### PR DESCRIPTION
## What changed
- Added `error_category_counts` field to `summarizeHeartbeatRunResultJson()` in `server/src/services/heartbeat-run-summary.ts`
- New `buildErrorCategoryCounts()` helper counts errors by type/category from `resultJson.errors` array and `errorFamily` field
- New `classifyErrorText()` helper classifies plain string errors into categories (rate_limit, overloaded, authentication, permission, timeout, max_turns, not_found, process_lost, unknown)
- 8 new test cases covering typed errors, string errors, errorFamily, combined scenarios, edge cases
- All 16 tests pass, typecheck clean

## Why
The `error_category_counts` field in `run_summary.json` provides a quick aggregated view of error categories per heartbeat run, making it easier to identify patterns (e.g., rate limiting spikes, auth failures) without scanning the full errors array.

## How to test
```bash
npx vitest run server/src/__tests__/heartbeat-run-summary.test.ts
```

## Related
Closes PEP-1258