### PR TITLE
feat(skills): lazy-load skill catalog to reduce per-wake token cost

### DIFF
--- a/server/src/__tests__/company-skills-routes.test.ts
+++ b/server/src/__tests__/company-skills-routes.test.ts
@@ -14,6 +14,8 @@ const mockAccessService = vi.hoisted(() => ({
 const mockCompanySkillService = vi.hoisted(() => ({
   importFromSource: vi.fn(),
   deleteSkill: vi.fn(),
+  list: vi.fn(),
+  searchSkills: vi.fn(),
 }));
 
 const mockLogActivity = vi.hoisted(() => vi.fn());
@@ -320,5 +322,43 @@ describe("company skill mutation permissions", () => {
     });
     expect(mockCompanySkillService.deleteSkill).toHaveBeenCalledWith("company-1", "skill-1");
     expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("calls searchSkills when ?q is provided on GET /skills", async () => {
+    const fakeResults = [{ id: "skill-1", key: "my-skill", slug: "my-skill", name: "My Skill" }];
+    mockCompanySkillService.searchSkills.mockResolvedValue(fakeResults);
+
+    const res = await request(await createApp({
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    }))
+      .get("/api/companies/company-1/skills?q=my");
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toEqual(fakeResults);
+    expect(mockCompanySkillService.searchSkills).toHaveBeenCalledWith("company-1", "my");
+    expect(mockCompanySkillService.list).not.toHaveBeenCalled();
+  });
+
+  it("calls list when no ?q is provided on GET /skills", async () => {
+    const fakeResults = [{ id: "skill-1", key: "my-skill", slug: "my-skill", name: "My Skill" }];
+    mockCompanySkillService.list.mockResolvedValue(fakeResults);
+
+    const res = await request(await createApp({
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    }))
+      .get("/api/companies/company-1/skills");
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toEqual(fakeResults);
+    expect(mockCompanySkillService.list).toHaveBeenCalledWith("company-1");
+    expect(mockCompanySkillService.searchSkills).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/company-skills.test.ts
+++ b/server/src/__tests__/company-skills.test.ts
@@ -268,6 +268,17 @@ describe("truncateSkillDescription", () => {
     expect(descValue.length).toBeLessThanOrEqual(120);
   });
 
+  it("hard-slices at 120 chars when the first sentence has no word boundary within 120 chars", () => {
+    const longToken = "a".repeat(150);
+    const input = `---\nname: my-skill\ndescription: ${longToken}\n---\n\n# Body`;
+    const output = truncateSkillDescription(input);
+    const match = output.match(/^description:\s*(.+)$/m);
+    expect(match).not.toBeNull();
+    const descValue = match![1].replace(/^"(.*)"$/, "$1").trim();
+    expect(descValue).not.toBe("");
+    expect(descValue).toBe(longToken.slice(0, 120));
+  });
+
   it("unwraps quoted description values before truncating", () => {
     const input = `---\nname: my-skill\ndescription: "Does one thing. Then another."\n---\n# Body`;
     const output = truncateSkillDescription(input);
@@ -282,6 +293,13 @@ describe("truncateSkillDescription", () => {
     expect(match).not.toBeNull();
     const descValue = match![1].trim();
     expect(descValue.startsWith('"') && descValue.endsWith('"')).toBe(true);
+  });
+
+  it("unescapes YAML single-quoted apostrophes ('' -> ') before re-quoting", () => {
+    const input = `---\nname: my-skill\ndescription: 'It''s a skill that does things.'\n---\n# Body`;
+    const output = truncateSkillDescription(input);
+    expect(output).toContain("It's a skill");
+    expect(output).not.toContain("It''s");
   });
 
   it("passes block scalar descriptions (> |) through unchanged", () => {

--- a/server/src/__tests__/company-skills.test.ts
+++ b/server/src/__tests__/company-skills.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeGitHubSkillDirectory,
   parseSkillImportSourceInput,
   readLocalSkillImportFromDirectory,
+  truncateSkillDescription,
 } from "../services/company-skills.js";
 
 const cleanupDirs = new Set<string>();
@@ -225,5 +226,74 @@ describe("missing local skill reconciliation", () => {
     ]);
 
     expect(missingIds).toEqual(["skill-1"]);
+  });
+});
+
+describe("truncateSkillDescription", () => {
+  it("returns content unchanged when no YAML frontmatter", () => {
+    const content = "# My Skill\n\nSome body.";
+    expect(truncateSkillDescription(content)).toBe(content);
+  });
+
+  it("returns content unchanged when frontmatter has no closing ---", () => {
+    const content = "---\nname: my-skill\ndescription: A skill.";
+    expect(truncateSkillDescription(content)).toBe(content);
+  });
+
+  it("returns content unchanged when description field is absent", () => {
+    const content = "---\nname: my-skill\n---\n\n# Body";
+    expect(truncateSkillDescription(content)).toBe(content);
+  });
+
+  it("keeps a short single-sentence description unchanged", () => {
+    const input = "---\nname: my-skill\ndescription: Does one thing well.\n---\n\n# Body";
+    const output = truncateSkillDescription(input);
+    expect(output).toContain("description: Does one thing well.");
+  });
+
+  it("truncates to the first sentence when there are multiple sentences", () => {
+    const input = "---\nname: my-skill\ndescription: Does one thing well. Then it does another. And more.\n---\n\n# Body";
+    const output = truncateSkillDescription(input);
+    expect(output).toContain("description: Does one thing well.");
+    expect(output).not.toContain("Then it does another");
+  });
+
+  it("truncates descriptions longer than 120 chars at a word boundary", () => {
+    const longWord = "word ".repeat(30); // 150 chars
+    const input = `---\nname: my-skill\ndescription: ${longWord.trim()}\n---\n\n# Body`;
+    const output = truncateSkillDescription(input);
+    const match = output.match(/^description:\s*(.+)$/m);
+    expect(match).not.toBeNull();
+    const descValue = match![1].trim();
+    expect(descValue.length).toBeLessThanOrEqual(120);
+  });
+
+  it("unwraps quoted description values before truncating", () => {
+    const input = `---\nname: my-skill\ndescription: "Does one thing. Then another."\n---\n# Body`;
+    const output = truncateSkillDescription(input);
+    expect(output).toContain("Does one thing.");
+    expect(output).not.toContain("Then another");
+  });
+
+  it("quotes the truncated value when it contains YAML-special characters", () => {
+    const input = `---\nname: my-skill\ndescription: "Calls the API: does stuff. Then more."\n---\n# Body`;
+    const output = truncateSkillDescription(input);
+    const match = output.match(/^description:\s*(.+)$/m);
+    expect(match).not.toBeNull();
+    const descValue = match![1].trim();
+    expect(descValue.startsWith('"') && descValue.endsWith('"')).toBe(true);
+  });
+
+  it("passes block scalar descriptions (> |) through unchanged", () => {
+    const input = `---\nname: my-skill\ndescription: >\n  Long description here.\n  Spans multiple lines.\n---\n# Body`;
+    const output = truncateSkillDescription(input);
+    expect(output).toBe(input);
+  });
+
+  it("preserves all content after the closing --- delimiter", () => {
+    const body = "\n\n# My Skill\n\nSome body text.\n";
+    const input = `---\nname: my-skill\ndescription: First sentence. Second sentence.\n---${body}`;
+    const output = truncateSkillDescription(input);
+    expect(output.endsWith(body)).toBe(true);
   });
 });

--- a/server/src/routes/company-skills.ts
+++ b/server/src/routes/company-skills.ts
@@ -84,6 +84,12 @@ export function companySkillRoutes(db: Db) {
   router.get("/companies/:companyId/skills", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
+    const q = asString(req.query.q as string | undefined);
+    if (q !== null) {
+      const result = await svc.searchSkills(companyId, q);
+      res.json(result);
+      return;
+    }
     const result = await svc.list(companyId);
     res.json(result);
   });

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -151,6 +151,48 @@ type RuntimeSkillEntryOptions = {
 
 const skillInventoryRefreshPromises = new Map<string, Promise<void>>();
 
+export function truncateSkillDescription(content: string): string {
+  if (!content.startsWith("---\n")) return content;
+  const frontmatterEnd = content.indexOf("\n---", 4);
+  if (frontmatterEnd === -1) return content;
+
+  const frontmatter = content.slice(4, frontmatterEnd);
+  const rest = content.slice(frontmatterEnd);
+
+  const newFrontmatter = frontmatter.replace(
+    /^(description:[ \t]*)(.*)$/m,
+    (_match, prefix, rawValue) => {
+      const stripped = rawValue.trim();
+      let value: string;
+      if (
+        (stripped.startsWith('"') && stripped.endsWith('"')) ||
+        (stripped.startsWith("'") && stripped.endsWith("'"))
+      ) {
+        value = stripped.slice(1, -1);
+      } else if (stripped.startsWith(">") || stripped.startsWith("|")) {
+        return `${prefix}${rawValue}`;
+      } else {
+        value = stripped;
+      }
+
+      const firstNewline = value.indexOf("\\n");
+      const oneLine = firstNewline >= 0 ? value.slice(0, firstNewline) : value;
+      const sentenceEnd = oneLine.search(/\.\s/);
+      const firstSentence = sentenceEnd >= 0 ? oneLine.slice(0, sentenceEnd + 1) : oneLine;
+      const truncated =
+        firstSentence.length > 120
+          ? firstSentence.slice(0, firstSentence.lastIndexOf(" ", 120) + 1).trimEnd()
+          : firstSentence;
+
+      const needsQuotes =
+        /[:"'{}[\],|>&*!%@`]/.test(truncated) || /^\s|\s$/.test(truncated);
+      return `${prefix}${needsQuotes ? `"${truncated.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"` : truncated}`;
+    },
+  );
+
+  return `---\n${newFrontmatter}${rest}`;
+}
+
 function selectCompanySkillColumns() {
   return {
     id: companySkills.id,
@@ -1676,6 +1718,19 @@ export function companySkillService(db: Db) {
     return rows.map((row) => toCompanySkill(row));
   }
 
+  async function searchSkills(companyId: string, query: string): Promise<CompanySkillListItem[]> {
+    const all = await list(companyId);
+    if (!query.trim()) return all;
+    const q = query.toLowerCase();
+    return all.filter((skill) => {
+      return (
+        skill.key.toLowerCase().includes(q) ||
+        (skill.name ?? "").toLowerCase().includes(q) ||
+        (skill.description ?? "").toLowerCase().includes(q)
+      );
+    });
+  }
+
   async function listReferenceTargets(companyId: string): Promise<SkillReferenceTarget[]> {
     const rows = await db
       .select({
@@ -2115,6 +2170,65 @@ export function companySkillService(db: Db) {
     };
   }
 
+  function resolveLazyRuntimeSkillPath(companyId: string, skill: Pick<CompanySkill, "key" | "slug">) {
+    const lazyRoot = path.resolve(resolveManagedSkillsRoot(companyId), "__runtime-lazy__");
+    return path.resolve(lazyRoot, buildSkillRuntimeName(skill.key, skill.slug));
+  }
+
+  async function materializeLazyRuntimeSkillFiles(companyId: string, skill: CompanySkill): Promise<string> {
+    const lazyRoot = path.resolve(resolveManagedSkillsRoot(companyId), "__runtime-lazy__");
+    const lazyDir = path.resolve(lazyRoot, buildSkillRuntimeName(skill.key, skill.slug));
+    await fs.rm(lazyDir, { recursive: true, force: true });
+    await fs.mkdir(lazyDir, { recursive: true });
+
+    for (const entry of skill.fileInventory) {
+      const detail = await readFile(companyId, skill.id, entry.path).catch(() => null);
+      if (!detail) continue;
+      const targetPath = path.resolve(lazyDir, entry.path);
+      await fs.mkdir(path.dirname(targetPath), { recursive: true });
+      const outputContent =
+        entry.path === "SKILL.md" ? truncateSkillDescription(detail.content) : detail.content;
+      await fs.writeFile(targetPath, outputContent, "utf8");
+    }
+
+    return lazyDir;
+  }
+
+  async function materializeLazyLocalSkillFiles(companyId: string, skill: CompanySkill, sourceDir: string): Promise<string> {
+    const lazyRoot = path.resolve(resolveManagedSkillsRoot(companyId), "__runtime-lazy__");
+    const lazyDir = path.resolve(lazyRoot, buildSkillRuntimeName(skill.key, skill.slug));
+
+    const skillMdPath = path.join(sourceDir, "SKILL.md");
+    const skillMdStat = await fs.stat(skillMdPath).catch(() => null);
+    const sourceMtime = skillMdStat?.mtimeMs ?? 0;
+
+    const lazySkillMdPath = path.join(lazyDir, "SKILL.md");
+    const lazyStat = await fs.stat(lazySkillMdPath).catch(() => null);
+
+    if (lazyStat && lazyStat.mtimeMs >= sourceMtime) {
+      return lazyDir;
+    }
+
+    await fs.rm(lazyDir, { recursive: true, force: true });
+    await fs.mkdir(lazyDir, { recursive: true });
+
+    const sourceEntries = await fs.readdir(sourceDir, { withFileTypes: true }).catch(() => []);
+    for (const entry of sourceEntries) {
+      const src = path.join(sourceDir, entry.name);
+      const target = path.join(lazyDir, entry.name);
+      if (entry.name === "SKILL.md") {
+        const raw = await fs.readFile(src, "utf8").catch(() => null);
+        if (raw !== null) {
+          await fs.writeFile(target, truncateSkillDescription(raw), "utf8");
+        }
+      } else {
+        await fs.symlink(src, target).catch(() => {});
+      }
+    }
+
+    return lazyDir;
+  }
+
   async function materializeCatalogSkillFiles(
     companyId: string,
     skill: ImportedSkill,
@@ -2163,6 +2277,10 @@ export function companySkillService(db: Db) {
     return path.resolve(runtimeRoot, buildSkillRuntimeName(skill.key, skill.slug));
   }
 
+  function resolveLazySkillMaterializedPath(companyId: string, skill: Pick<CompanySkill, "key" | "slug">) {
+    return resolveLazyRuntimeSkillPath(companyId, skill);
+  }
+
   async function listRuntimeSkillEntries(
     companyId: string,
     options: RuntimeSkillEntryOptions = {},
@@ -2172,11 +2290,17 @@ export function companySkillService(db: Db) {
     const out: PaperclipSkillEntry[] = [];
     for (const skill of skills) {
       const sourceKind = asString(getSkillMeta(skill).sourceKind);
-      let source = normalizeSkillDirectory(skill);
-      if (!source) {
+      const localSourceDir = normalizeSkillDirectory(skill);
+
+      let source: string | null;
+      if (localSourceDir) {
         source = options.materializeMissing === false
-          ? resolveRuntimeSkillMaterializedPath(companyId, skill)
-          : await materializeRuntimeSkillFiles(companyId, skill).catch(() => null);
+          ? resolveLazySkillMaterializedPath(companyId, skill)
+          : await materializeLazyLocalSkillFiles(companyId, skill, localSourceDir).catch(() => localSourceDir);
+      } else {
+        source = options.materializeMissing === false
+          ? resolveLazySkillMaterializedPath(companyId, skill)
+          : await materializeLazyRuntimeSkillFiles(companyId, skill).catch(() => null);
       }
       if (!source) continue;
 
@@ -2474,5 +2598,6 @@ export function companySkillService(db: Db) {
     importPackageFiles,
     installUpdate,
     listRuntimeSkillEntries,
+    searchSkills,
   };
 }

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -164,11 +164,10 @@ export function truncateSkillDescription(content: string): string {
     (_match, prefix, rawValue) => {
       const stripped = rawValue.trim();
       let value: string;
-      if (
-        (stripped.startsWith('"') && stripped.endsWith('"')) ||
-        (stripped.startsWith("'") && stripped.endsWith("'"))
-      ) {
+      if (stripped.startsWith('"') && stripped.endsWith('"')) {
         value = stripped.slice(1, -1);
+      } else if (stripped.startsWith("'") && stripped.endsWith("'")) {
+        value = stripped.slice(1, -1).replace(/''/g, "'");
       } else if (stripped.startsWith(">") || stripped.startsWith("|")) {
         return `${prefix}${rawValue}`;
       } else {
@@ -181,7 +180,10 @@ export function truncateSkillDescription(content: string): string {
       const firstSentence = sentenceEnd >= 0 ? oneLine.slice(0, sentenceEnd + 1) : oneLine;
       const truncated =
         firstSentence.length > 120
-          ? firstSentence.slice(0, firstSentence.lastIndexOf(" ", 120) + 1).trimEnd()
+          ? (() => {
+              const boundary = firstSentence.lastIndexOf(" ", 120);
+              return (boundary > 0 ? firstSentence.slice(0, boundary) : firstSentence.slice(0, 120)).trimEnd();
+            })()
           : firstSentence;
 
       const needsQuotes =
@@ -2222,7 +2224,7 @@ export function companySkillService(db: Db) {
           await fs.writeFile(target, truncateSkillDescription(raw), "utf8");
         }
       } else {
-        await fs.symlink(src, target).catch(() => {});
+        await fs.symlink(src, target);
       }
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents via short heartbeat execution windows; each wake injects a system-reminder listing the full skill catalog
> - The skill catalog subsystem materializes SKILL.md files into the Claude prompt bundle, which Claude Code reads and displays in `<system-reminder>` as name + full description per skill
> - With 87 ContentCow skills averaging 200–300 char descriptions, the catalog dumps an estimated 4,000–5,000 tokens per wake as inline description text — wasted on skills not used in that heartbeat
> - The lazy-load pattern (analogous to `ToolSearch` deferred tools) reduces descriptions to 1-line / first sentence at materialization time while keeping full bodies available on-demand via the skills API
> - This PR introduces `truncateSkillDescription()`, `__runtime-lazy__/` materialization, and a `?q=` search endpoint so agents can pull full skill content when needed
> - The benefit is ~57% reduction in per-wake description tokens (~2,700 tokens saved per wake for the ContentCow catalog) with no change to skill authoring or the `Skill` tool invocation path

## What Changed

- **`server/src/services/company-skills.ts`**
  - Export `truncateSkillDescription(content)` at module level: strips SKILL.md YAML `description` to first sentence ≤ 120 chars; preserves block scalars (`>`, `|`) unchanged; re-quotes when the truncated value contains YAML-special characters
  - Add `materializeLazyRuntimeSkillFiles()`: writes truncated SKILL.md + full other files to `__runtime-lazy__/{name}/` (DB-backed skills)
  - Add `materializeLazyLocalSkillFiles()`: same for `local_path` skills; symlinks non-SKILL.md files to source; skips re-write when source SKILL.md hasn't changed (mtime check)
  - Wire `listRuntimeSkillEntries()` to use lazy paths — the Claude prompt bundle now symlinks to `__runtime-lazy__/` instead of `__runtime__/`
  - Add `searchSkills(companyId, query)`: filters `list()` results by name, key, and description match (case-insensitive)
  - Export `searchSkills` from service object

- **`server/src/routes/company-skills.ts`**
  - `GET /companies/:companyId/skills?q=<query>` dispatches to `searchSkills` when `q` is a non-empty string; falls back to `list` when absent

## Verification

```bash
# Type-check
pnpm typecheck          # passes

# Build
pnpm build              # passes

# Tests (31 pass)
pnpm exec vitest run server/src/__tests__/company-skills.test.ts \
                        server/src/__tests__/company-skills-routes.test.ts
```

Token measurement (sampled from 6 representative ContentCow skills):
- Description chars: 1,311 → 564 (57% reduction)
- Tokens: ~328 → ~141 per sample set
- Scaled to 87-skill catalog: ~4,752 → ~2,045 description tokens per wake

## Risks

- **Stale lazy dirs**: `__runtime-lazy__/` is fully rebuilt on every skill materialization call (DB skills) or when source SKILL.md mtime changes (local_path skills). Stale lazy content should not persist across runs. Low blast radius — worst case: agent sees a description that's one heartbeat behind.
- **Block scalar pass-through**: descriptions in `>` or `|` block scalar style are passed through unchanged to preserve correctness; these agents continue to see full block descriptions (typically short anyway).
- **`__runtime__/` preserved**: the original full-content `__runtime__/` directory is no longer written by `listRuntimeSkillEntries()` but the `materializeRuntimeSkillFiles()` function remains for any callers that need it.
- **Sentence detection heuristic**: `oneLine.search(/\.\s/)` truncates at `. ` (period + space); descriptions that end sentences without a trailing space (end of string) fall back to 120-char word-boundary truncation. Could leave some descriptions mid-sentence — acceptable for catalog browsing.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Tool use: enabled (Read, Edit, Write, Bash, Grep, Glob)
- Context: standard context window, multi-turn heartbeat session

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (no UI changes)
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge