### PR TITLE
Fix generated skill YAML descriptions

### DIFF
--- a/server/src/__tests__/company-skills.test.ts
+++ b/server/src/__tests__/company-skills.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { promises as fs } from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  buildLocalSkillMarkdown,
   discoverProjectWorkspaceSkillDirectories,
   findMissingLocalSkillIds,
   normalizeGitHubSkillDirectory,
@@ -87,6 +88,29 @@ describe("company skill import source parsing", () => {
 });
 
 describe("project workspace skill discovery", () => {
+  it("YAML-quotes generated local skill descriptions", async () => {
+    const workspace = await makeTempDir("paperclip-generated-skill-yaml-");
+    const skillDir = path.join(workspace, "skills", "design-consultation");
+    const description = "Design consultation: client's \"editor\" workflow";
+    const markdown = buildLocalSkillMarkdown({
+      name: "Design Consultation",
+      description,
+    });
+
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), markdown, "utf8");
+
+    expect(markdown).toContain(`description: ${JSON.stringify(description)}`);
+
+    const imported = await readLocalSkillImportFromDirectory(
+      "33333333-3333-4333-8333-333333333333",
+      skillDir,
+      { inventoryMode: "full" },
+    );
+
+    expect(imported.description).toBe(description);
+  });
+
   it("normalizes GitHub skill directories for blob imports and legacy metadata", () => {
     expect(normalizeGitHubSkillDirectory("retro/.", "retro")).toBe("retro");
     expect(normalizeGitHubSkillDirectory("retro/SKILL.md", "retro")).toBe("retro");

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -436,6 +436,29 @@ function parseYamlScalar(rawValue: string): unknown {
   return trimmed;
 }
 
+function renderYamlScalar(value: string) {
+  return JSON.stringify(value);
+}
+
+export function buildLocalSkillMarkdown(input: Pick<CompanySkillCreateRequest, "name" | "description" | "markdown">) {
+  if (input.markdown?.trim().length) {
+    return input.markdown;
+  }
+
+  const description = input.description?.trim();
+  return [
+    "---",
+    `name: ${renderYamlScalar(input.name)}`,
+    ...(description ? [`description: ${renderYamlScalar(description)}`] : []),
+    "---",
+    "",
+    `# ${input.name}`,
+    "",
+    description ? description : "Describe what this skill does.",
+    "",
+  ].join("\n");
+}
+
 function parseYamlBlock(
   lines: Array<{ indent: number; content: string }>,
   startIndex: number,
@@ -1840,19 +1863,7 @@ export function companySkillService(db: Db) {
 
     await fs.mkdir(skillDir, { recursive: true });
 
-    const markdown = (input.markdown?.trim().length
-      ? input.markdown
-      : [
-        "---",
-        `name: ${input.name}`,
-        ...(input.description?.trim() ? [`description: ${input.description.trim()}`] : []),
-        "---",
-        "",
-        `# ${input.name}`,
-        "",
-        input.description?.trim() ? input.description.trim() : "Describe what this skill does.",
-        "",
-      ].join("\n"));
+    const markdown = buildLocalSkillMarkdown(input);
 
     await fs.writeFile(skillFilePath, markdown, "utf8");
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Company skills are installed and synced as `SKILL.md` files with YAML frontmatter.
> - Some generated local skill descriptions contain YAML-sensitive text like `: `, apostrophes, and double quotes.
> - Raw string interpolation made regenerated `SKILL.md` files invalid for strict YAML parsers, which broke `codex_local` skill loading.
> - This pull request makes generated local skill frontmatter quote scalar values before writing them.
> - The benefit is that skill sync can no longer regenerate invalid YAML for ordinary human-readable descriptions.

## What Changed

- Added a `buildLocalSkillMarkdown` helper for generated local skill markdown.
- YAML/JSON-quotes generated `name` and `description` frontmatter scalars instead of interpolating them raw.
- Preserved custom `markdown` passthrough behavior for callers that supply full skill markdown.
- Added a regression test for a generated description with colon-space, apostrophe, and double quotes, then re-imports the generated `SKILL.md` to verify the description round-trips.

## Verification

- `pnpm exec vitest run server/src/__tests__/company-skills.test.ts` — 13/13 passed.
- `git diff --check upstream/master` — passed.
- Ruby/libyaml sanity check against the exact JSON-quoted scalar shape — passed.
- Eliot QA review on [LEV-495](/LEV/issues/LEV-495) approved the change with no findings.

## Risks

- Low risk. This only changes generated local skill markdown when Paperclip creates a default `SKILL.md`; full custom markdown remains unchanged.
- Generated `name` values are now quoted too, which is valid YAML and parsed by the existing scalar parser.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5.5 via Codex local, with shell/tool use for code inspection, editing, tests, git, and Paperclip issue coordination.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
