### PR TITLE
fix: preserve recovery workspace context

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -637,6 +637,9 @@ describe("renderPaperclipWakePrompt", () => {
   it("includes continuation and child issue summaries in structured wake context", () => {
     const payload = {
       reason: "issue_children_completed",
+      sourceIssueId: "source-issue-1",
+      recoveryActionId: "recovery-action-1",
+      strandedRunId: "run-stranded-1",
       issue: {
         id: "parent-1",
         identifier: "PAP-100",
@@ -671,6 +674,9 @@ describe("renderPaperclipWakePrompt", () => {
     };
 
     expect(JSON.parse(stringifyPaperclipWakePayload(payload) ?? "{}")).toMatchObject({
+      sourceIssueId: "source-issue-1",
+      recoveryActionId: "recovery-action-1",
+      strandedRunId: "run-stranded-1",
       continuationSummary: {
         body: expect.stringContaining("Continuation Summary"),
       },

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -381,6 +381,9 @@ type PaperclipWakeTreeHoldSummary = {
 
 type PaperclipWakePayload = {
   reason: string | null;
+  sourceIssueId: string | null;
+  recoveryActionId: string | null;
+  strandedRunId: string | null;
   issue: PaperclipWakeIssue | null;
   checkedOutByHarness: boolean;
   dependencyBlockedInteraction: boolean;
@@ -592,6 +595,9 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
 
   return {
     reason: asString(payload.reason, "").trim() || null,
+    sourceIssueId: asString(payload.sourceIssueId, "").trim() || null,
+    recoveryActionId: asString(payload.recoveryActionId, "").trim() || null,
+    strandedRunId: asString(payload.strandedRunId, "").trim() || null,
     issue: normalizePaperclipWakeIssue(payload.issue),
     checkedOutByHarness: asBoolean(payload.checkedOutByHarness, false),
     dependencyBlockedInteraction: asBoolean(payload.dependencyBlockedInteraction, false),

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -427,6 +427,8 @@ describe("codex execute", () => {
           wakeCommentId: "comment-2",
           paperclipWake: {
             reason: "issue_commented",
+            sourceIssueId: "source-issue-1",
+            strandedRunId: "run-stranded-1",
             issue: {
               id: "issue-1",
               identifier: "PAP-874",
@@ -475,6 +477,8 @@ describe("codex execute", () => {
       expect(capture.paperclipWakePayloadJson).not.toBeNull();
       expect(JSON.parse(capture.paperclipWakePayloadJson ?? "{}")).toMatchObject({
         reason: "issue_commented",
+        sourceIssueId: "source-issue-1",
+        strandedRunId: "run-stranded-1",
         latestCommentId: "comment-2",
         commentIds: ["comment-1", "comment-2"],
       });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2034,6 +2034,66 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
   });
 
+  it("inherits project id from a source issue's project workspace when the source project id is missing", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const sourceIssueId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspace project",
+      status: "in_progress",
+      executionWorkspacePolicy: {
+        enabled: true,
+        defaultMode: "isolated_workspace",
+        allowIssueOverride: true,
+        defaultProjectWorkspaceId: projectWorkspaceId,
+      },
+    });
+
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary workspace",
+      isPrimary: true,
+    });
+
+    await db.insert(issues).values({
+      id: sourceIssueId,
+      companyId,
+      projectId: null,
+      projectWorkspaceId,
+      title: "Source issue with workspace but missing project id",
+      status: "blocked",
+      priority: "high",
+    });
+
+    const recovery = await svc.create(companyId, {
+      parentId: sourceIssueId,
+      title: "Recover stalled issue",
+      status: "todo",
+      inheritExecutionWorkspaceFromIssueId: sourceIssueId,
+    });
+
+    expect(recovery.parentId).toBe(sourceIssueId);
+    expect(recovery.projectId).toBe(projectId);
+    expect(recovery.projectWorkspaceId).toBe(projectWorkspaceId);
+    expect(recovery.executionWorkspaceSettings).toEqual({
+      mode: "isolated_workspace",
+    });
+  });
+
   it("createChild applies parent defaults, acceptance criteria, workspace inheritance, and optional parent blocker chaining", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1998,6 +1998,9 @@ async function buildPaperclipWakePayload(input: {
 
   return {
     reason: readNonEmptyString(input.contextSnapshot.wakeReason),
+    sourceIssueId: readNonEmptyString(input.contextSnapshot.sourceIssueId),
+    recoveryActionId: readNonEmptyString(input.contextSnapshot.recoveryActionId),
+    strandedRunId: readNonEmptyString(input.contextSnapshot.strandedRunId),
     issue: issueSummary
       ? {
           id: issueSummary.id,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -483,6 +483,18 @@ async function getWorkspaceInheritanceIssue(
   return issue;
 }
 
+async function getProjectIdForProjectWorkspace(
+  db: DbReader,
+  companyId: string,
+  projectWorkspaceId: string,
+) {
+  return db
+    .select({ projectId: projectWorkspaces.projectId })
+    .from(projectWorkspaces)
+    .where(and(eq(projectWorkspaces.id, projectWorkspaceId), eq(projectWorkspaces.companyId, companyId)))
+    .then((rows) => rows[0]?.projectId ?? null);
+}
+
 function touchedByUserCondition(companyId: string, userId: string) {
   return sql<boolean>`
     (
@@ -4036,7 +4048,6 @@ export function issueService(db: Db) {
       }
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
-        const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         let projectWorkspaceId = issueData.projectWorkspaceId ?? null;
         let executionWorkspaceId = issueData.executionWorkspaceId ?? null;
         let executionWorkspacePreference = issueData.executionWorkspacePreference ?? null;
@@ -4049,6 +4060,20 @@ export function issueService(db: Db) {
           issueData.executionWorkspaceSettings !== undefined;
         if (workspaceInheritanceIssueId) {
           const workspaceSource = await getWorkspaceInheritanceIssue(tx, companyId, workspaceInheritanceIssueId);
+          if (
+            issueData.projectId == null &&
+            workspaceSource.projectId == null &&
+            workspaceSource.projectWorkspaceId
+          ) {
+            issueData.projectId = await getProjectIdForProjectWorkspace(
+              tx,
+              companyId,
+              workspaceSource.projectWorkspaceId,
+            );
+          }
+          if (issueData.projectId == null && workspaceSource.projectId) {
+            issueData.projectId = workspaceSource.projectId;
+          }
           if (projectWorkspaceId == null && workspaceSource.projectWorkspaceId) {
             projectWorkspaceId = workspaceSource.projectWorkspaceId;
           }
@@ -4137,6 +4162,7 @@ export function issueService(db: Db) {
             }
           }
         }
+        const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
         if (!projectWorkspaceId && issueData.projectId) {
           const project = await tx
             .select({


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Local issue execution needs isolated workspaces so recovery work does not fall back into an agent default checkout
> - Recovery and follow-up issues can be created from source issues that already have a project workspace but no direct project id
> - In that shape, the created recovery issue lost the execution workspace context and adapters could not see which source run/action was being recovered
> - This pull request preserves the recoverable workspace context while creating inherited issues
> - It also carries recovery source metadata into local adapter wake payloads
> - The benefit is recovery work can be dispatched with the same workspace continuity and enough metadata for the agent to act on the stranded run

## What Changed

- Inherit projectId from a source issue project workspace when the source issue itself has no projectId.
- Resolve projectGoalId after inherited project id resolution so created recovery/follow-up issues use the effective project context.
- Add recovery source metadata (sourceIssueId, recoveryActionId, strandedRunId) to the Paperclip wake payload.
- Preserve those recovery metadata fields through adapter-utils wake payload normalization so local adapters expose them in PAPERCLIP_WAKE_PAYLOAD_JSON.
- Added focused service and adapter tests for workspace inheritance and wake payload preservation.

## Verification

- `git diff --check`
- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts`
- `pnpm exec vitest run server/src/__tests__/codex-local-execute.test.ts packages/adapter-utils/src/server-utils.test.ts`

## Risks

- Low risk: the project inheritance path only applies when an issue explicitly inherits execution workspace context from a source issue and that source issue has a project workspace.
- Wake payload additions are additive fields, so existing adapters that ignore unknown metadata should keep working.
- The main behavioral risk is assigning a project context where one was previously missing; tests cover the COM-327-style fallback through the source project workspace.

## Model Used

- OpenAI GPT-5 / Codex, reasoning effort xhigh, tool use enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge