### PR TITLE
fix(BLU-7718): atomic refresh-cap reservation in productivity-review

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -255,6 +255,40 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(await listRefreshComments(review!.id)).toHaveLength(DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS);
   });
 
+  it("holds the refresh-interval guard under concurrent reconciliation (BLU-7718)", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const [review] = await listProductivityReviews(seeded.companyId);
+
+    // Multiple server processes fire reconcile concurrently in the same window
+    // (simulated here with Promise.all over a shared pool). Without atomic
+    // check-then-act around the cap+interval check, each racer sees the same
+    // pre-burst count and all racers insert. The empirical BLU-7325 burst on
+    // 2026-05-14 showed three refresh comments committed inside 27ms — the
+    // failure mode this test pins.
+    const refreshAt = new Date(now.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS);
+    const concurrent = 5;
+    const results = await Promise.all(
+      Array.from({ length: concurrent }, () =>
+        service.reconcileProductivityReviews({ now: refreshAt, companyId: seeded.companyId }),
+      ),
+    );
+
+    const totalUpdates = results.reduce((acc, r) => acc + r.updated, 0);
+    expect(totalUpdates).toBe(1);
+    expect(await listRefreshComments(review!.id)).toHaveLength(1);
+  });
+
   it("caps productivity review creation per source issue in the rolling creation window", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -255,6 +255,40 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(await listRefreshComments(review!.id)).toHaveLength(DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS);
   });
 
+  it("holds the refresh-interval guard under concurrent reconciliation (BLU-7718)", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const service = productivityReviewService(db);
+    await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    const [review] = await listProductivityReviews(seeded.companyId);
+
+    // Multiple server processes fire reconcile concurrently in the same window
+    // (simulated here with Promise.all over a shared pool). Without atomic
+    // check-then-act around the cap+interval check, each racer sees the same
+    // pre-burst count and all racers insert. The empirical BLU-7325 burst on
+    // 2026-05-14 showed three refresh comments committed inside 27ms — the
+    // failure mode this test pins.
+    const refreshAt = new Date(now.getTime() + DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS);
+    const concurrent = 5;
+    const results = await Promise.all(
+      Array.from({ length: concurrent }, () =>
+        service.reconcileProductivityReviews({ now: refreshAt, companyId: seeded.companyId }),
+      ),
+    );
+
+    const totalUpdates = results.reduce((acc, r) => acc + r.updated, 0);
+    expect(totalUpdates).toBe(1);
+    expect(await listRefreshComments(review!.id)).toHaveLength(1);
+  });
+
   it("allows only one productivity review per source issue in 24 hours", async () => {
     const now = new Date("2026-04-28T12:00:00.000Z");
     const seeded = await seedAssignedIssue();

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -639,33 +639,44 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   ) {
     const existing = await findOpenProductivityReview(evidence.sourceIssue.companyId, evidence.sourceIssue.id);
     if (existing) {
-      const refreshState = await getRefreshCommentState(evidence.sourceIssue.companyId, existing.id);
-      const lastRefreshOrCreationAt = refreshState.latestCreatedAt ?? existing.createdAt;
-      if (
-        refreshState.count >= opts.thresholds.maxRefreshComments ||
-        evidence.generatedAt.getTime() - lastRefreshOrCreationAt.getTime() < opts.thresholds.refreshIntervalMs
-      ) {
-        return { kind: "existing" as const, reviewIssueId: existing.id };
-      }
-      await addRefreshComment(existing.id, buildRefreshComment(evidence, opts.prefix), evidence.generatedAt);
-      await logActivity(db, {
-        companyId: evidence.sourceIssue.companyId,
-        actorType: "system",
-        actorId: "system",
-        action: "issue.productivity_review_updated",
-        entityType: "issue",
-        entityId: existing.id,
-        agentId: existing.assigneeAgentId,
-        details: {
-          source: "productivity_review.reconcile",
-          sourceIssueId: evidence.sourceIssue.id,
-          trigger: evidence.trigger,
-          noCommentStreak: evidence.noCommentStreak,
-          runCountLastHour: evidence.runCountLastHour,
-          commentCountLastHour: evidence.commentCountLastHour,
-        },
+      // Serialize cap + interval evaluation per review issue. The SELECT-then-INSERT
+      // pattern below would otherwise race across concurrent reconcile runs (each
+      // server process fires reconcileProductivityReviews on a 30s setInterval),
+      // letting every racer see the same pre-burst count and all racers insert.
+      // BLU-7718: BLU-7325 accumulated 3,754 refresh comments through this race.
+      // pg_advisory_xact_lock auto-releases when the transaction commits.
+      return db.transaction(async (tx) => {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${`productivity_review_refresh:${existing.id}`}, 0))`,
+        );
+        const refreshState = await getRefreshCommentState(evidence.sourceIssue.companyId, existing.id);
+        const lastRefreshOrCreationAt = refreshState.latestCreatedAt ?? existing.createdAt;
+        if (
+          refreshState.count >= opts.thresholds.maxRefreshComments ||
+          evidence.generatedAt.getTime() - lastRefreshOrCreationAt.getTime() < opts.thresholds.refreshIntervalMs
+        ) {
+          return { kind: "existing" as const, reviewIssueId: existing.id };
+        }
+        await addRefreshComment(existing.id, buildRefreshComment(evidence, opts.prefix), evidence.generatedAt);
+        await logActivity(db, {
+          companyId: evidence.sourceIssue.companyId,
+          actorType: "system",
+          actorId: "system",
+          action: "issue.productivity_review_updated",
+          entityType: "issue",
+          entityId: existing.id,
+          agentId: existing.assigneeAgentId,
+          details: {
+            source: "productivity_review.reconcile",
+            sourceIssueId: evidence.sourceIssue.id,
+            trigger: evidence.trigger,
+            noCommentStreak: evidence.noCommentStreak,
+            runCountLastHour: evidence.runCountLastHour,
+            commentCountLastHour: evidence.commentCountLastHour,
+          },
+        });
+        return { kind: "updated" as const, reviewIssueId: existing.id };
       });
-      return { kind: "updated" as const, reviewIssueId: existing.id };
     }
 
     const recentCreationCount = await countRecentProductivityReviews(

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -696,33 +696,44 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
   ) {
     const existing = await findOpenProductivityReview(evidence.sourceIssue.companyId, evidence.sourceIssue.id);
     if (existing) {
-      const refreshState = await getRefreshCommentState(evidence.sourceIssue.companyId, existing.id);
-      const lastRefreshOrCreationAt = refreshState.latestCreatedAt ?? existing.createdAt;
-      if (
-        refreshState.count >= opts.thresholds.maxRefreshComments ||
-        evidence.generatedAt.getTime() - lastRefreshOrCreationAt.getTime() < opts.thresholds.refreshIntervalMs
-      ) {
-        return { kind: "existing" as const, reviewIssueId: existing.id };
-      }
-      await addRefreshComment(existing.id, buildRefreshComment(evidence, opts.prefix), evidence.generatedAt);
-      await logActivity(db, {
-        companyId: evidence.sourceIssue.companyId,
-        actorType: "system",
-        actorId: "system",
-        action: "issue.productivity_review_updated",
-        entityType: "issue",
-        entityId: existing.id,
-        agentId: existing.assigneeAgentId,
-        details: {
-          source: "productivity_review.reconcile",
-          sourceIssueId: evidence.sourceIssue.id,
-          trigger: evidence.trigger,
-          noCommentStreak: evidence.noCommentStreak,
-          runCountLastHour: evidence.runCountLastHour,
-          commentCountLastHour: evidence.commentCountLastHour,
-        },
+      // Serialize cap + interval evaluation per review issue. The SELECT-then-INSERT
+      // pattern below would otherwise race across concurrent reconcile runs (each
+      // server process fires reconcileProductivityReviews on a 30s setInterval),
+      // letting every racer see the same pre-burst count and all racers insert.
+      // BLU-7718: BLU-7325 accumulated 3,754 refresh comments through this race.
+      // pg_advisory_xact_lock auto-releases when the transaction commits.
+      return db.transaction(async (tx) => {
+        await tx.execute(
+          sql`select pg_advisory_xact_lock(hashtextextended(${`productivity_review_refresh:${existing.id}`}, 0))`,
+        );
+        const refreshState = await getRefreshCommentState(evidence.sourceIssue.companyId, existing.id);
+        const lastRefreshOrCreationAt = refreshState.latestCreatedAt ?? existing.createdAt;
+        if (
+          refreshState.count >= opts.thresholds.maxRefreshComments ||
+          evidence.generatedAt.getTime() - lastRefreshOrCreationAt.getTime() < opts.thresholds.refreshIntervalMs
+        ) {
+          return { kind: "existing" as const, reviewIssueId: existing.id };
+        }
+        await addRefreshComment(existing.id, buildRefreshComment(evidence, opts.prefix), evidence.generatedAt);
+        await logActivity(db, {
+          companyId: evidence.sourceIssue.companyId,
+          actorType: "system",
+          actorId: "system",
+          action: "issue.productivity_review_updated",
+          entityType: "issue",
+          entityId: existing.id,
+          agentId: existing.assigneeAgentId,
+          details: {
+            source: "productivity_review.reconcile",
+            sourceIssueId: evidence.sourceIssue.id,
+            trigger: evidence.trigger,
+            noCommentStreak: evidence.noCommentStreak,
+            runCountLastHour: evidence.runCountLastHour,
+            commentCountLastHour: evidence.commentCountLastHour,
+          },
+        });
+        return { kind: "updated" as const, reviewIssueId: existing.id };
       });
-      return { kind: "updated" as const, reviewIssueId: existing.id };
     }
 
     const recentCreationCount = await countRecentProductivityReviews(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The **productivity-review** subsystem watches open issues and, when an agent looks stuck, opens a review issue and periodically refreshes it with fresh evidence comments — gated by a refresh-comment **cap** and a **refresh-interval**.
> - The cap + interval guard was implemented as a non-atomic **SELECT-then-INSERT** against `issue_comments`. Each server process fires `reconcileProductivityReviews` on a 30s `setInterval`, so multiple racers read the same pre-burst count, all pass the guard, and all insert.
> - This produced **3,754** `Productivity review evidence refreshed.` comments on one review issue (BLU-7325) — sampling shows three inserts inside **27 ms**, which a serial loop with a `>= 3` cap cannot produce.
> - This pull request serializes the cap+interval evaluation per review issue with `pg_advisory_xact_lock`, keyed on the review issue id and scoped to a transaction so it auto-releases on commit.
> - The benefit is that the documented cap is actually enforced under concurrency, stopping the comment-flooding without a schema migration or API change.

## Linked Issues or Issue Description

No public GitHub issue exists (tracked internally as BLU-7718). Describing the underlying bug in-PR following `bug_report.yml`:

**What happened?** Open productivity-review issues accumulate far more `Productivity review evidence refreshed.` comments than the configured cap allows. One review issue reached 3,754 refresh comments; thread sampling shows 3 inserts within 27 ms.

**Expected behavior:** With a `maxRefreshComments` cap (e.g. `>= 3`) and a `refreshIntervalMs` guard, an open review should receive at most one refresh comment per interval and never exceed the cap.

**Steps to reproduce:** Run more than one server process (or any concurrency) firing the 30s `reconcileProductivityReviews` interval against the same open review issue. Concurrent racers each read the same pre-burst count via SELECT, all pass the guard, and all INSERT — the cap is silently exceeded.

**Root cause:** The cap + interval check is a non-atomic SELECT-then-INSERT with no serialization across concurrent reconcile runs.

**Component:** `server/src/services/productivity-review.ts` (`createOrUpdateReview`). Not adapter-specific — core bug.

**Related (searched, distinct mechanism):** #5574, #5363, #5383, #5121 address refresh flooding via content-dedup / skip-on-unchanged / cap introduction. This PR is the **atomicity** fix for the cap itself; #4948 added the cap but not the serialization, so the race still fires post-#4948. These are complementary, not duplicates.

## What Changed

- `server/src/services/productivity-review.ts`: wrap the existing-review cap+interval evaluation and refresh-comment insert in a `db.transaction`, taking `pg_advisory_xact_lock(hashtextextended('productivity_review_refresh:<reviewIssueId>', 0))` first so the SELECT-then-INSERT is serialized per review issue. Lock auto-releases on commit.
- `server/src/__tests__/productivity-review-service.test.ts`: added a concurrency reproducer — 5 concurrent reconcile calls against one open review; exactly 1 commits an update (without the lock, 4–5 commit).
- No schema migration. No API change. No new dependencies. Lock granularity is per-review-issue, so other reviews are not blocked.

## Verification

- [x] `pnpm vitest run server/src/__tests__/productivity-review-service.test.ts` — all tests pass, including the existing serial cap/interval test and the new concurrency test `holds the refresh-interval guard under concurrent reconciliation (BLU-7718)`.
- [x] Without the fix, the new test fails with `expected 4 to be 1`, demonstrating the race reproduces deterministically in CI.
- [x] Typecheck shows no new errors from this change (pre-existing master errors in `environment-runtime.ts` / `plugin-environment-driver.ts` are unrelated).
- [x] Rebased on current `master` (2026-06-07) — clean, no conflicts.

## Risks

Low risk. The change is surgical and additive: one advisory lock + transaction wrapping logic that already existed. `pg_advisory_xact_lock` auto-releases on transaction commit/rollback, so there is no leaked-lock failure mode. The lock key is per review issue (`hashtextextended` of `productivity_review_refresh:<id>`), so reconcile work on other reviews proceeds concurrently. No migration, no API surface change, no behavioral change to the serial (single-process) path.

## Model Used

Claude — `claude-opus-4-8` (Opus 4.8), extended thinking, with tool use / code execution via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-only)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — pending (CI running on the rebased head)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — pending re-run on rebased head
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
