### PR TITLE
fix(BLU-7716): break productivity-review snooze-expiry loop

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -16,9 +16,13 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { MAX_ISSUE_REQUEST_DEPTH } from "@paperclipai/shared";
 import {
+  DEFAULT_PRODUCTIVITY_REVIEW_EXTENDED_SNOOZE_AFTER_CLOSES,
+  DEFAULT_PRODUCTIVITY_REVIEW_EXTENDED_SNOOZE_MS,
+  DEFAULT_PRODUCTIVITY_REVIEW_LONG_ACTIVE_HOURS,
   DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS,
   DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
   DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
+  DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS,
   PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,
   productivityReviewService,
@@ -286,9 +290,13 @@ describeEmbeddedPostgres("productivity review service", () => {
       }),
     );
 
+    // Disable snooze (resolved + extended) so this test exercises the creation-cap
+    // path directly. The default 24h resolved-snooze would otherwise short-circuit
+    // before the cap is consulted on these 8–10h-old historical closes (BLU-7716).
     const result = await productivityReviewService(db).reconcileProductivityReviews({
       now,
       companyId: seeded.companyId,
+      thresholds: { resolvedSnoozeMs: 1, extendedSnoozeMs: 1 },
     });
 
     expect(result.created).toBe(0);
@@ -495,6 +503,112 @@ describeEmbeddedPostgres("productivity review service", () => {
 
     expect(result.snoozed).toBe(1);
     expect(reviews).toHaveLength(1);
+  });
+
+  it("BLU-7716: default resolved-snooze must be materially larger than the long-active trigger", () => {
+    // Invariant: a snooze expiry must not immediately re-satisfy the long-active trigger,
+    // otherwise permanently-`in_progress` source issues (signal bus, routine_execution)
+    // produce a perpetual loop — observed at 4 cycles on BLU-7316 before this fix.
+    const longActiveMs = DEFAULT_PRODUCTIVITY_REVIEW_LONG_ACTIVE_HOURS * 60 * 60 * 1000;
+    expect(DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS).toBeGreaterThan(longActiveMs);
+    expect(DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS).toBeGreaterThanOrEqual(longActiveMs * 4);
+    expect(DEFAULT_PRODUCTIVITY_REVIEW_EXTENDED_SNOOZE_MS).toBeGreaterThan(DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS);
+  });
+
+  it("BLU-7716: extends the snooze window after N consecutive PRODUCTIVE closes on the same source", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+    // Three prior PRODUCTIVE closes — the most recent at 25h ago, just outside the
+    // default 24h snooze cutoff. Without the extended snooze the scanner would re-fire
+    // here (this is exactly the BLU-7316 loop pattern).
+    const closeHoursAgo = [36, 30, 25];
+    expect(closeHoursAgo.length).toBe(DEFAULT_PRODUCTIVITY_REVIEW_EXTENDED_SNOOZE_AFTER_CLOSES);
+    await db.insert(issues).values(
+      closeHoursAgo.map((hoursAgo, index) => {
+        const ts = new Date(now.getTime() - hoursAgo * 60 * 60 * 1000);
+        return {
+          id: randomUUID(),
+          companyId: seeded.companyId,
+          title: `Closed productivity review ${index + 1}`,
+          status: "done" as const,
+          priority: "medium" as const,
+          originKind: PRODUCTIVITY_REVIEW_ORIGIN_KIND,
+          originId: seeded.issueId,
+          originFingerprint: `productivity-review:${seeded.issueId}`,
+          parentId: seeded.issueId,
+          issueNumber: index + 2,
+          identifier: `${seeded.issuePrefix}-${index + 2}`,
+          createdAt: ts,
+          updatedAt: ts,
+        };
+      }),
+    );
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.snoozed).toBe(1);
+    expect(result.created).toBe(0);
+    // Three historical reviews + no new one.
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(3);
+  });
+
+  it("BLU-7716: a cancelled review resets the consecutive-close streak", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+    // History (oldest → newest): cancelled@36h, done@28h, done@25h.
+    // The cancelled review breaks the streak — only 2 consecutive `done` from newest,
+    // below the threshold. Latest done is 25h ago, outside the 24h default snooze
+    // window, so the scanner must re-fire.
+    const history: Array<{ hoursAgo: number; status: "done" | "cancelled" }> = [
+      { hoursAgo: 36, status: "cancelled" },
+      { hoursAgo: 28, status: "done" },
+      { hoursAgo: 25, status: "done" },
+    ];
+    await db.insert(issues).values(
+      history.map((entry, index) => {
+        const ts = new Date(now.getTime() - entry.hoursAgo * 60 * 60 * 1000);
+        return {
+          id: randomUUID(),
+          companyId: seeded.companyId,
+          title: `Historical productivity review ${index + 1}`,
+          status: entry.status,
+          priority: "medium" as const,
+          originKind: PRODUCTIVITY_REVIEW_ORIGIN_KIND,
+          originId: seeded.issueId,
+          originFingerprint: `productivity-review:${seeded.issueId}`,
+          parentId: seeded.issueId,
+          issueNumber: index + 2,
+          identifier: `${seeded.issuePrefix}-${index + 2}`,
+          createdAt: ts,
+          updatedAt: ts,
+        };
+      }),
+    );
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    expect(result.snoozed).toBe(0);
   });
 
   it("reports and logs soft-stop holds for open no-comment reviews", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -25,7 +25,20 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS = 10;
 export const DEFAULT_PRODUCTIVITY_REVIEW_LONG_ACTIVE_HOURS = 6;
 export const DEFAULT_PRODUCTIVITY_REVIEW_HIGH_CHURN_HOURLY = 10;
 export const DEFAULT_PRODUCTIVITY_REVIEW_HIGH_CHURN_SIX_HOURS = 30;
-export const DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS = 6 * 60 * 60 * 1000;
+// 24h. MUST be materially larger than `longActiveMs` (6h) — see invariant
+// in buildThresholds(). Otherwise permanently-`in_progress` source issues
+// (routine_execution, continuous signal bus) re-satisfy the long-active
+// trigger the instant the snooze expires, producing a perpetual loop.
+// BLU-7716: BLU-7316 cycled through 4 reviews in ~24h at the prior 6h value.
+export const DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS = 24 * 60 * 60 * 1000;
+// After this many consecutive PRODUCTIVE closes on the same source, apply the
+// extended snooze. A `cancelled` review breaks the streak.
+export const DEFAULT_PRODUCTIVITY_REVIEW_EXTENDED_SNOOZE_AFTER_CLOSES = 3;
+// 7d. Applied once consecutive PRODUCTIVE closes ≥ extendedSnoozeAfterCloses —
+// covers permanently-active sources (signal bus, weekly rollup) so the scanner
+// stops re-firing on a fixed cadence after the reviewer has confirmed the
+// pattern is expected.
+export const DEFAULT_PRODUCTIVITY_REVIEW_EXTENDED_SNOOZE_MS = 7 * 24 * 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS = 3;
 export const DEFAULT_PRODUCTIVITY_REVIEW_CREATION_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -49,6 +62,8 @@ type ProductivityReviewThresholds = {
   highChurnHourly: number;
   highChurnSixHours: number;
   resolvedSnoozeMs: number;
+  extendedSnoozeAfterCloses: number;
+  extendedSnoozeMs: number;
   refreshIntervalMs: number;
   maxRefreshComments: number;
   creationWindowMs: number;
@@ -160,6 +175,14 @@ function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): Pro
       overrides?.resolvedSnoozeMs ?? DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS,
       DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS,
     ),
+    extendedSnoozeAfterCloses: readPositiveInteger(
+      overrides?.extendedSnoozeAfterCloses ?? DEFAULT_PRODUCTIVITY_REVIEW_EXTENDED_SNOOZE_AFTER_CLOSES,
+      DEFAULT_PRODUCTIVITY_REVIEW_EXTENDED_SNOOZE_AFTER_CLOSES,
+    ),
+    extendedSnoozeMs: readPositiveInteger(
+      overrides?.extendedSnoozeMs ?? DEFAULT_PRODUCTIVITY_REVIEW_EXTENDED_SNOOZE_MS,
+      DEFAULT_PRODUCTIVITY_REVIEW_EXTENDED_SNOOZE_MS,
+    ),
     refreshIntervalMs: readPositiveInteger(
       overrides?.refreshIntervalMs ?? DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
       DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
@@ -259,13 +282,44 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       .then((rows) => rows[0] ?? null);
   }
 
+  async function countConsecutiveProductiveCloses(companyId: string, sourceIssueId: string) {
+    // Count consecutive `done` reviews from newest backwards. A `cancelled` review
+    // breaks the streak — cancellation signals the reviewer (or governance) rejected
+    // the productive pattern, so accumulated `done` history shouldn't keep extending
+    // the snooze after a reset.
+    const recent = await db
+      .select({ status: issues.status })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, PRODUCTIVITY_REVIEW_ORIGIN_KIND),
+          eq(issues.originId, sourceIssueId),
+          isNull(issues.hiddenAt),
+          inArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt))
+      .limit(10);
+    let count = 0;
+    for (const row of recent) {
+      if (row.status === "done") count += 1;
+      else break;
+    }
+    return count;
+  }
+
   async function findRecentResolvedProductivityReview(
     companyId: string,
     sourceIssueId: string,
     thresholds: ProductivityReviewThresholds,
     now: Date,
   ) {
-    const cutoff = new Date(now.getTime() - thresholds.resolvedSnoozeMs);
+    const consecutiveCloses = await countConsecutiveProductiveCloses(companyId, sourceIssueId);
+    const effectiveSnoozeMs = consecutiveCloses >= thresholds.extendedSnoozeAfterCloses
+      ? thresholds.extendedSnoozeMs
+      : thresholds.resolvedSnoozeMs;
+    const cutoff = new Date(now.getTime() - effectiveSnoozeMs);
     return db
       .select({ id: issues.id, identifier: issues.identifier, status: issues.status, updatedAt: issues.updatedAt })
       .from(issues)


### PR DESCRIPTION
## Summary

Resolves [BLU-7716](https://paperclip.blueorange.dev/BLU/issues/BLU-7716) — productivity-review snooze-expiry loop on permanently-active source issues.

Before this fix, `DEFAULT_PRODUCTIVITY_REVIEW_RESOLVED_SNOOZE_MS = 6h = DEFAULT_PRODUCTIVITY_REVIEW_LONG_ACTIVE_HOURS`. The snooze expiry instantly re-satisfied the long-active trigger for source issues that are `in_progress` by design (`routine_execution`, continuous signal bus). Observed at:

- **BLU-7316** (opm-event-bus execution child) — 4 consecutive review cycles in ~24h: BLU-7325 → BLU-7587 → BLU-7645 → BLU-7713, all closed PRODUCTIVE.
- **BLU-6381** (Ops Health Weekly Rollup) — 5+ false-positive review children.

Cost: $0.05–0.20/cycle × every standing-routine issue, indefinitely.

## Fix

Enforce invariant: `resolvedSnoozeMs > longActiveMs`.

- **Default `resolvedSnoozeMs`: 6h → 24h** (4× the 6h trigger threshold).
- **Extended snooze**: after 3 consecutive PRODUCTIVE closes on the same source, `findRecentResolvedProductivityReview` uses a **7d** cutoff instead of 24h. Covers signal-bus / weekly-rollup sources that will never stop being "long active."
- A `cancelled` review breaks the consecutive-close streak (manual reset semantics).

The original ticket directive ("status-only PATCH on close") was a no-op — agent-authored comments do not implicitly reopen `done` issues (`shouldImplicitlyMoveCommentedIssueToTodo` excludes them), and reviewer close-comments land on the review child, not the source parent. HoP redirected to the snooze-expiry fix on 2026-05-15 ([comment 1f62f36c](https://paperclip.blueorange.dev/BLU/issues/BLU-7716#comment-1f62f36c) on BLU-7716).

## Test plan

- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/productivity-review-service.test.ts` — 14/14 pass
- [x] Three new vitest cases:
  - `BLU-7716: default resolved-snooze must be materially larger than the long-active trigger` (asserts invariant on constants).
  - `BLU-7716: extends the snooze window after N consecutive PRODUCTIVE closes on the same source` (3 historical `done` reviews at 25/30/36h ago → snoozed; without extended-snooze logic this would re-fire).
  - `BLU-7716: a cancelled review resets the consecutive-close streak` (cancelled@36h, done@28h, done@25h → 2 consecutive, falls back to default 24h, 25h-old `done` outside snooze → re-fires).
- [x] One pre-existing creation-cap test (`caps productivity review creation per source issue in the rolling creation window`) now overrides `resolvedSnoozeMs` and `extendedSnoozeMs` to preserve its original creation-cap intent — with the new 24h default, snooze would otherwise short-circuit before the cap on the 8–10h-old historical closes.
- [x] Typecheck: pre-existing unrelated errors in `environment-runtime.ts` / `plugin-environment-driver.ts` (verified present on master); no new errors introduced by this change.

## Related

- BLU-7715 — prior context (this PR supersedes the proposed structural fix in the BLU-7715 description).
- BLU-7718 — runaway refresh-comment storm (separate bug, same code area, separate PR #6034).
- BLU-6155 — label-based exemption (complementary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)