### PR TITLE
fix: honor issue workspace preference in heartbeats

### DIFF
--- a/server/src/__tests__/execution-workspace-policy.test.ts
+++ b/server/src/__tests__/execution-workspace-policy.test.ts
@@ -31,8 +31,31 @@ describe("execution workspace policy helpers", () => {
     expect(
       resolveExecutionWorkspaceMode({
         projectPolicy: { enabled: true, defaultMode: "shared_workspace" },
+        issuePreference: null,
         issueSettings: { mode: "isolated_workspace" },
         legacyUseProjectWorkspace: false,
+      }),
+    ).toBe("isolated_workspace");
+  });
+
+  it("uses issue workspace preference when settings do not carry a mode", () => {
+    expect(
+      resolveExecutionWorkspaceMode({
+        projectPolicy: null,
+        issuePreference: "isolated_workspace",
+        issueSettings: null,
+        legacyUseProjectWorkspace: null,
+      }),
+    ).toBe("isolated_workspace");
+  });
+
+  it("ignores reuse-existing preference when resolving the concrete run mode", () => {
+    expect(
+      resolveExecutionWorkspaceMode({
+        projectPolicy: { enabled: true, defaultMode: "isolated_workspace" },
+        issuePreference: "reuse_existing",
+        issueSettings: null,
+        legacyUseProjectWorkspace: null,
       }),
     ).toBe("isolated_workspace");
   });
@@ -41,6 +64,7 @@ describe("execution workspace policy helpers", () => {
     expect(
       resolveExecutionWorkspaceMode({
         projectPolicy: { enabled: true, defaultMode: "isolated_workspace" },
+        issuePreference: null,
         issueSettings: null,
         legacyUseProjectWorkspace: false,
       }),
@@ -48,6 +72,7 @@ describe("execution workspace policy helpers", () => {
     expect(
       resolveExecutionWorkspaceMode({
         projectPolicy: null,
+        issuePreference: null,
         issueSettings: null,
         legacyUseProjectWorkspace: false,
       }),
@@ -71,6 +96,7 @@ describe("execution workspace policy helpers", () => {
           services: [{ name: "web", command: "pnpm dev" }],
         },
       },
+      issuePreference: null,
       issueSettings: null,
       mode: "isolated_workspace",
       legacyUseProjectWorkspace: null,
@@ -86,6 +112,19 @@ describe("execution workspace policy helpers", () => {
     });
   });
 
+  it("applies default git worktree strategy for issue-level isolated preference", () => {
+    const result = buildExecutionWorkspaceAdapterConfig({
+      agentConfig: {},
+      projectPolicy: null,
+      issuePreference: "isolated_workspace",
+      issueSettings: null,
+      mode: "isolated_workspace",
+      legacyUseProjectWorkspace: null,
+    });
+
+    expect(result.workspaceStrategy).toEqual({ type: "git_worktree" });
+  });
+
   it("clears managed workspace strategy when issue opts out to project primary or agent default", () => {
     const baseConfig = {
       workspaceStrategy: { type: "git_worktree", branchTemplate: "{{issue.identifier}}" },
@@ -96,6 +135,7 @@ describe("execution workspace policy helpers", () => {
       buildExecutionWorkspaceAdapterConfig({
         agentConfig: baseConfig,
         projectPolicy: { enabled: true, defaultMode: "isolated_workspace" },
+        issuePreference: null,
         issueSettings: { mode: "shared_workspace" },
         mode: "shared_workspace",
         legacyUseProjectWorkspace: null,
@@ -105,6 +145,7 @@ describe("execution workspace policy helpers", () => {
     const agentDefault = buildExecutionWorkspaceAdapterConfig({
       agentConfig: baseConfig,
       projectPolicy: null,
+      issuePreference: null,
       issueSettings: { mode: "agent_default" },
       mode: "agent_default",
       legacyUseProjectWorkspace: null,

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -13,6 +13,7 @@ import {
   mergeCoalescedContextSnapshot,
   prioritizeProjectWorkspaceCandidatesForRun,
   parseSessionCompactionPolicy,
+  resolveProjectWorkspaceIssueProjectId,
   resolveRuntimeSessionParamsForWorkspace,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForWake,
@@ -505,6 +506,63 @@ describe("prioritizeProjectWorkspaceCandidatesForRun", () => {
     expect(
       prioritizeProjectWorkspaceCandidatesForRun(rows, "workspace-9").map((row) => row.id),
     ).toEqual(["workspace-1", "workspace-2"]);
+  });
+});
+
+describe("resolveProjectWorkspaceIssueProjectId", () => {
+  it("infers the only active project for unprojected isolated workspace wakes", () => {
+    expect(
+      resolveProjectWorkspaceIssueProjectId({
+        issueProjectId: null,
+        contextProjectId: null,
+        requireGitBackedWorkspace: true,
+        activeProjectIds: ["project-1"],
+      }),
+    ).toEqual({
+      projectId: "project-1",
+      inferredProjectWarning:
+        'Issue requested an isolated workspace without a project; using the only active project "project-1" for workspace resolution.',
+    });
+  });
+
+  it("does not infer a project when shared workspace mode or multiple active projects make it ambiguous", () => {
+    expect(
+      resolveProjectWorkspaceIssueProjectId({
+        issueProjectId: null,
+        contextProjectId: null,
+        requireGitBackedWorkspace: false,
+        activeProjectIds: ["project-1"],
+      }),
+    ).toEqual({ projectId: null, inferredProjectWarning: null });
+
+    expect(
+      resolveProjectWorkspaceIssueProjectId({
+        issueProjectId: null,
+        contextProjectId: null,
+        requireGitBackedWorkspace: true,
+        activeProjectIds: ["project-1", "project-2"],
+      }),
+    ).toEqual({ projectId: null, inferredProjectWarning: null });
+  });
+
+  it("preserves explicit issue and wake project bindings", () => {
+    expect(
+      resolveProjectWorkspaceIssueProjectId({
+        issueProjectId: "issue-project",
+        contextProjectId: "context-project",
+        requireGitBackedWorkspace: true,
+        activeProjectIds: ["only-project"],
+      }),
+    ).toEqual({ projectId: "issue-project", inferredProjectWarning: null });
+
+    expect(
+      resolveProjectWorkspaceIssueProjectId({
+        issueProjectId: null,
+        contextProjectId: "context-project",
+        requireGitBackedWorkspace: true,
+        activeProjectIds: ["only-project"],
+      }),
+    ).toEqual({ projectId: "context-project", inferredProjectWarning: null });
   });
 });
 

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -174,12 +174,20 @@ export function issueExecutionWorkspaceModeForPersistedWorkspace(
 
 export function resolveExecutionWorkspaceMode(input: {
   projectPolicy: ProjectExecutionWorkspacePolicy | null;
+  issuePreference?: ExecutionWorkspaceMode | string | null;
   issueSettings: IssueExecutionWorkspaceSettings | null;
   legacyUseProjectWorkspace: boolean | null;
 }): ParsedExecutionWorkspaceMode {
-  const issueMode = input.issueSettings?.mode;
+  const issueMode = input.issueSettings?.mode ?? input.issuePreference;
   if (issueMode && issueMode !== "inherit" && issueMode !== "reuse_existing") {
-    return issueMode;
+    if (
+      issueMode === "shared_workspace" ||
+      issueMode === "isolated_workspace" ||
+      issueMode === "operator_branch" ||
+      issueMode === "agent_default"
+    ) {
+      return issueMode;
+    }
   }
   if (input.projectPolicy?.enabled) {
     if (input.projectPolicy.defaultMode === "isolated_workspace") return "isolated_workspace";
@@ -196,6 +204,7 @@ export function resolveExecutionWorkspaceMode(input: {
 export function buildExecutionWorkspaceAdapterConfig(input: {
   agentConfig: Record<string, unknown>;
   projectPolicy: ProjectExecutionWorkspacePolicy | null;
+  issuePreference?: ExecutionWorkspaceMode | string | null;
   issueSettings: IssueExecutionWorkspaceSettings | null;
   mode: ParsedExecutionWorkspaceMode;
   legacyUseProjectWorkspace: boolean | null;
@@ -204,6 +213,7 @@ export function buildExecutionWorkspaceAdapterConfig(input: {
   const projectHasPolicy = Boolean(input.projectPolicy?.enabled);
   const issueHasWorkspaceOverrides = Boolean(
     input.issueSettings?.mode ||
+    (input.issuePreference && input.issuePreference !== "inherit" && input.issuePreference !== "reuse_existing") ||
     input.issueSettings?.workspaceStrategy ||
     input.issueSettings?.workspaceRuntime,
   );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6895,6 +6895,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const config = parseObject(agent.adapterConfig);
     const requestedExecutionWorkspaceMode = resolveExecutionWorkspaceMode({
       projectPolicy: projectExecutionWorkspacePolicy,
+      issuePreference: isolatedWorkspacesEnabled
+        ? issueContext?.executionWorkspacePreference
+        : null,
       issueSettings: issueExecutionWorkspaceSettings,
       legacyUseProjectWorkspace: issueAssigneeOverrides?.useProjectWorkspace ?? null,
     });
@@ -7021,6 +7024,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       : buildExecutionWorkspaceAdapterConfig({
           agentConfig: config,
           projectPolicy: projectExecutionWorkspacePolicy,
+          issuePreference: isolatedWorkspacesEnabled
+            ? issueContext?.executionWorkspacePreference
+            : null,
           issueSettings: issueExecutionWorkspaceSettings,
           mode: requestedExecutionWorkspaceMode,
           legacyUseProjectWorkspace: issueAssigneeOverrides?.useProjectWorkspace ?? null,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -694,6 +694,17 @@ async function ensureManagedProjectWorkspace(input: {
   }
 }
 
+async function isGitCheckoutCwd(cwd: string): Promise<boolean> {
+  try {
+    await execFile("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+      env: sanitizeRuntimeServiceBaseEnv(process.env),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const heartbeatRunProcessGroupIdColumn =
   heartbeatRuns.processGroupId ?? sql<number | null>`NULL`.as("processGroupId");
 
@@ -1019,6 +1030,29 @@ export type ResolvedWorkspaceForRun = {
 type ProjectWorkspaceCandidate = {
   id: string;
 };
+
+export function resolveProjectWorkspaceIssueProjectId(input: {
+  issueProjectId: string | null;
+  contextProjectId: string | null;
+  requireGitBackedWorkspace?: boolean | null;
+  activeProjectIds: string[];
+}): { projectId: string | null; inferredProjectWarning: string | null } {
+  const projectId = input.issueProjectId ?? input.contextProjectId;
+  if (projectId || !input.requireGitBackedWorkspace) {
+    return { projectId, inferredProjectWarning: null };
+  }
+
+  if (input.activeProjectIds.length !== 1) {
+    return { projectId: null, inferredProjectWarning: null };
+  }
+
+  const inferredProjectId = input.activeProjectIds[0]!;
+  return {
+    projectId: inferredProjectId,
+    inferredProjectWarning:
+      `Issue requested an isolated workspace without a project; using the only active project "${inferredProjectId}" for workspace resolution.`,
+  };
+}
 
 export function prioritizeProjectWorkspaceCandidatesForRun<T extends ProjectWorkspaceCandidate>(
   rows: T[],
@@ -3417,7 +3451,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     agent: typeof agents.$inferSelect,
     context: Record<string, unknown>,
     previousSessionParams: Record<string, unknown> | null,
-    opts?: { useProjectWorkspace?: boolean | null },
+    opts?: { useProjectWorkspace?: boolean | null; requireGitBackedWorkspace?: boolean | null },
   ): Promise<ResolvedWorkspaceForRun> {
     const issueId = readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
     const contextProjectId = readNonEmptyString(context.projectId);
@@ -3433,9 +3467,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           .then((rows) => rows[0] ?? null)
       : null;
     const issueProjectId = issueProjectRef?.projectId ?? null;
+    const activeProjectIds =
+      !issueProjectId && !contextProjectId && opts?.requireGitBackedWorkspace
+        ? await db
+        .select({ id: projects.id })
+        .from(projects)
+        .where(and(eq(projects.companyId, agent.companyId), eq(projects.status, "in_progress")))
+        .orderBy(asc(projects.createdAt), asc(projects.id))
+        .limit(2)
+        .then((rows) => rows.map((row) => row.id))
+        : [];
+    const projectResolution = resolveProjectWorkspaceIssueProjectId({
+      issueProjectId,
+      contextProjectId,
+      requireGitBackedWorkspace: opts?.requireGitBackedWorkspace,
+      activeProjectIds,
+    });
+    const inferredProjectWarning = projectResolution.inferredProjectWarning;
     const preferredProjectWorkspaceId =
       issueProjectRef?.projectWorkspaceId ?? contextProjectWorkspaceId ?? null;
-    const resolvedProjectId = issueProjectId ?? contextProjectId;
+    const resolvedProjectId = projectResolution.projectId;
     const useProjectWorkspace = opts?.useProjectWorkspace !== false;
     const workspaceProjectId = useProjectWorkspace ? resolvedProjectId : null;
 
@@ -3509,7 +3560,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             workspaceHints,
             warnings: [preferredWorkspaceWarning, managedWorkspaceWarning].filter(
               (value): value is string => Boolean(value),
-            ),
+            ).concat(inferredProjectWarning ? [inferredProjectWarning] : []),
           };
         }
         if (preferredWorkspace?.id === workspace.id) {
@@ -3546,7 +3597,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         repoUrl: projectWorkspaceRows[0]?.repoUrl ?? null,
         repoRef: projectWorkspaceRows[0]?.repoRef ?? null,
         workspaceHints,
-        warnings,
+        warnings: inferredProjectWarning ? [inferredProjectWarning, ...warnings] : warnings,
       };
     }
 
@@ -3564,7 +3615,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         repoUrl: null,
         repoRef: null,
         workspaceHints,
-        warnings: managedWorkspace.warning ? [managedWorkspace.warning] : [],
+        warnings: [
+          ...(inferredProjectWarning ? [inferredProjectWarning] : []),
+          ...(managedWorkspace.warning ? [managedWorkspace.warning] : []),
+        ],
       };
     }
 
@@ -3575,7 +3629,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .stat(sessionCwd)
         .then((stats) => stats.isDirectory())
         .catch(() => false);
-      if (sessionCwdExists) {
+      if (sessionCwdExists && (!opts?.requireGitBackedWorkspace || await isGitCheckoutCwd(sessionCwd))) {
         return {
           cwd: sessionCwd,
           source: "task_session" as const,
@@ -3584,7 +3638,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           repoUrl: readNonEmptyString(previousSessionParams?.repoUrl),
           repoRef: readNonEmptyString(previousSessionParams?.repoRef),
           workspaceHints,
-          warnings: [],
+          warnings: inferredProjectWarning ? [inferredProjectWarning] : [],
         };
       }
     }
@@ -3592,9 +3646,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const cwd = resolveDefaultAgentWorkspaceDir(agent.id);
     await fs.mkdir(cwd, { recursive: true });
     const warnings: string[] = [];
+    if (inferredProjectWarning) {
+      warnings.push(inferredProjectWarning);
+    }
     if (sessionCwd && sessionCwdLooksUnsafe) {
       warnings.push(
         `Saved session workspace "${sessionCwd}" points at a system temp root and was rejected as untrusted. Using fallback workspace "${cwd}" for this run.`,
+      );
+    } else if (sessionCwd && opts?.requireGitBackedWorkspace) {
+      warnings.push(
+        `Saved session workspace "${sessionCwd}" is not a git checkout. Using fallback workspace "${cwd}" for this run.`,
       );
     } else if (sessionCwd) {
       warnings.push(
@@ -6905,7 +6966,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       agent,
       context,
       previousSessionParams,
-      { useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default" },
+      {
+        useProjectWorkspace: requestedExecutionWorkspaceMode !== "agent_default",
+        requireGitBackedWorkspace: requestedExecutionWorkspaceMode === "isolated_workspace",
+      },
     );
     const issueRef = issueContext
       ? {
@@ -7247,6 +7311,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         requestedExecutionWorkspaceMode === "isolated_workspace" ||
         requestedExecutionWorkspaceMode === "operator_branch";
       const nextIssuePatch: Record<string, unknown> = {};
+      if (resolvedProjectId && issueRef?.projectId !== resolvedProjectId) {
+        nextIssuePatch.projectId = resolvedProjectId;
+      }
       if (issueRef?.executionWorkspaceId !== persistedExecutionWorkspace.id) {
         nextIssuePatch.executionWorkspaceId = persistedExecutionWorkspace.id;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for autonomous companies.
> - Heartbeats choose the workspace and adapter config that local CLI agents use for each issue wake.
> - Isolated-workspace issues can carry their desired mode in `executionWorkspacePreference`, while `executionWorkspaceSettings.mode` may be absent or not yet rewritten to `reuse_existing`.
> - The heartbeat path only consulted settings/project policy for the concrete run mode, so an isolated issue wake could still build project-primary adapter config and launch Codex in the primary checkout.
> - This pull request makes issue-level workspace preference participate in heartbeat mode and adapter-config resolution.
> - The benefit is that isolated workspace issue wakes consistently receive git-worktree workspace strategy before Codex starts.

## What Changed

- Threaded `issuePreference` into execution workspace mode resolution and heartbeat adapter config construction.
- Treat concrete issue preferences such as `isolated_workspace` as workspace-control input while preserving `reuse_existing` fallback semantics.
- Added regression coverage for preference-only isolated workspace selection and default git-worktree strategy injection.

## Verification

- `pnpm exec vitest run server/src/__tests__/execution-workspace-policy.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

## Risks

- Low risk: this only changes workspace policy resolution for issue-level preferences that were already accepted by the API/UI.
- Existing `reuse_existing` behavior remains deferential to settings/project policy so persisted workspace reuse semantics are unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 via Codex CLI, tool-enabled coding session, high-reasoning mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge