### PR TITLE
Add watchdog pause and cascade brakes

### DIFF
--- a/packages/db/src/migrations/0085_watchdog_brakes.sql
+++ b/packages/db/src/migrations/0085_watchdog_brakes.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "companies" ADD COLUMN IF NOT EXISTS "resumed_at" timestamp with time zone;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "issues_active_watchdog_rollup_uq"
+  ON "issues" USING btree ("company_id","origin_kind","origin_id")
+  WHERE "origin_kind" = 'watchdog_rollup'
+    AND "origin_id" IS NOT NULL
+    AND "hidden_at" IS NULL
+    AND "status" NOT IN ('done', 'cancelled');

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -596,6 +596,13 @@
       "when": 1778355326070,
       "tag": "0084_issue_recovery_actions",
       "breakpoints": true
+    },
+    {
+      "idx": 85,
+      "version": "7",
+      "when": 1778846515000,
+      "tag": "0085_watchdog_brakes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/companies.ts
+++ b/packages/db/src/schema/companies.ts
@@ -9,6 +9,7 @@ export const companies = pgTable(
     status: text("status").notNull().default("active"),
     pauseReason: text("pause_reason"),
     pausedAt: timestamp("paused_at", { withTimezone: true }),
+    resumedAt: timestamp("resumed_at", { withTimezone: true }),
     issuePrefix: text("issue_prefix").notNull().default("PAP"),
     issueCounter: integer("issue_counter").notNull().default(0),
     budgetMonthlyCents: integer("budget_monthly_cents").notNull().default(0),

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -139,5 +139,13 @@ export const issues = pgTable(
           and ${table.hiddenAt} is null
           and ${table.status} not in ('done', 'cancelled')`,
       ),
+    activeWatchdogRollupIdx: uniqueIndex("issues_active_watchdog_rollup_uq")
+      .on(table.companyId, table.originKind, table.originId)
+      .where(
+        sql`${table.originKind} = 'watchdog_rollup'
+          and ${table.originId} is not null
+          and ${table.hiddenAt} is null
+          and ${table.status} not in ('done', 'cancelled')`,
+      ),
   }),
 );

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -216,6 +216,69 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     expect(evaluations[0]?.description).not.toContain("sk-test-secret-value");
   });
 
+  it("creates one rollup instead of another evaluation above the cascade cap", async () => {
+    const previousCap = process.env.WATCHDOG_PER_AGENT_24H_CAP;
+    process.env.WATCHDOG_PER_AGENT_24H_CAP = "2";
+    try {
+      const now = new Date("2026-04-22T20:00:00.000Z");
+      const { companyId, managerId, runId, issuePrefix } = await seedRunningRun({
+        now,
+        ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+      });
+      await db.insert(issues).values([
+        {
+          id: randomUUID(),
+          companyId,
+          title: "Existing stale run evaluation",
+          status: "todo",
+          priority: "medium",
+          assigneeAgentId: managerId,
+          issueNumber: 30,
+          identifier: `${issuePrefix}-30`,
+          originKind: "stale_active_run_evaluation",
+          originId: randomUUID(),
+          originFingerprint: "existing-stale-1",
+          createdAt: new Date(now.getTime() - 60_000),
+        },
+        {
+          id: randomUUID(),
+          companyId,
+          title: "Existing productivity review",
+          status: "todo",
+          priority: "high",
+          assigneeAgentId: managerId,
+          issueNumber: 31,
+          identifier: `${issuePrefix}-31`,
+          originKind: "issue_productivity_review",
+          originId: randomUUID(),
+          originFingerprint: "existing-productivity-1",
+          createdAt: new Date(now.getTime() - 30_000),
+        },
+      ]);
+      const heartbeat = heartbeatService(db);
+
+      const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+      expect(result.created).toBe(0);
+      expect(result.skipped).toBe(1);
+      const evaluations = await db
+        .select()
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+      expect(evaluations.filter((issue) => issue.originId === runId)).toHaveLength(0);
+      const rollups = await db
+        .select()
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "watchdog_rollup")));
+      expect(rollups).toHaveLength(1);
+      expect(rollups[0]?.assigneeAgentId).toBe(managerId);
+      expect(rollups[0]?.description).toContain("cascade cap");
+    } finally {
+      if (previousCap === undefined) delete process.env.WATCHDOG_PER_AGENT_24H_CAP;
+      else process.env.WATCHDOG_PER_AGENT_24H_CAP = previousCap;
+    }
+  });
+
   it("redacts sensitive values from actual run-log evidence", async () => {
     const now = new Date("2026-04-22T20:00:00.000Z");
     const leakedJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";

--- a/server/src/__tests__/pause-aware-guard.test.ts
+++ b/server/src/__tests__/pause-aware-guard.test.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { companies, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  DEFAULT_WATCHDOG_RESUME_WARMUP_MS,
+  isCompanyWatchdogPaused,
+} from "../services/recovery/pause-aware-guard.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("pause-aware watchdog guard", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-pause-aware-guard-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("suppresses watchdogs while paused and during resume warm-up", async () => {
+    const companyId = randomUUID();
+    const now = new Date("2026-05-15T12:00:00.000Z");
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Pause Co",
+      issuePrefix: "PAU",
+      status: "paused",
+      pausedAt: new Date(now.getTime() - 60_000),
+    });
+
+    await expect(isCompanyWatchdogPaused(db, companyId, now)).resolves.toBe(true);
+
+    await db
+      .update(companies)
+      .set({
+        status: "active",
+        pausedAt: null,
+        resumedAt: new Date(now.getTime() - DEFAULT_WATCHDOG_RESUME_WARMUP_MS + 1_000),
+      })
+      .where(eq(companies.id, companyId));
+    await expect(isCompanyWatchdogPaused(db, companyId, now)).resolves.toBe(true);
+
+    await db
+      .update(companies)
+      .set({ resumedAt: new Date(now.getTime() - DEFAULT_WATCHDOG_RESUME_WARMUP_MS - 1_000) })
+      .where(eq(companies.id, companyId));
+    await expect(isCompanyWatchdogPaused(db, companyId, now)).resolves.toBe(false);
+  });
+});

--- a/server/src/__tests__/watchdog-self-exclusion.test.ts
+++ b/server/src/__tests__/watchdog-self-exclusion.test.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { companies, createDb, issues } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { RECOVERY_ORIGIN_KINDS } from "../services/recovery/origins.ts";
+import { isWatchdogFamilyDescendant } from "../services/recovery/watchdog-family.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("watchdog family self-exclusion", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-watchdog-self-exclusion-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("detects direct, ancestor, and origin-linked watchdog families", async () => {
+    const companyId = randomUUID();
+    const reviewId = randomUUID();
+    const childId = randomUUID();
+    const originLinkedId = randomUUID();
+    const manualId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Watchdog Family Co",
+      issuePrefix: "WDF",
+    });
+    await db.insert(issues).values([
+      {
+        id: reviewId,
+        companyId,
+        title: "Review productivity",
+        status: "todo",
+        priority: "high",
+        originKind: RECOVERY_ORIGIN_KINDS.issueProductivityReview,
+        originId: manualId,
+      },
+      {
+        id: childId,
+        companyId,
+        title: "Nested recovery child",
+        status: "todo",
+        priority: "medium",
+        parentId: reviewId,
+      },
+      {
+        id: originLinkedId,
+        companyId,
+        title: "Origin linked recovery child",
+        status: "todo",
+        priority: "medium",
+        originId: reviewId,
+      },
+      {
+        id: manualId,
+        companyId,
+        title: "Manual implementation",
+        status: "todo",
+        priority: "medium",
+      },
+    ]);
+
+    const rows = await db.select().from(issues);
+    const byId = new Map(rows.map((row) => [row.id, row]));
+    await expect(isWatchdogFamilyDescendant(db, byId.get(reviewId)!)).resolves.toBe(true);
+    await expect(isWatchdogFamilyDescendant(db, byId.get(childId)!)).resolves.toBe(true);
+    await expect(isWatchdogFamilyDescendant(db, byId.get(originLinkedId)!)).resolves.toBe(true);
+    await expect(isWatchdogFamilyDescendant(db, byId.get(manualId)!)).resolves.toBe(false);
+  });
+});

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -290,6 +290,7 @@ export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
         status: "active",
         pauseReason: null,
         pausedAt: null,
+        resumedAt: now,
         updatedAt: now,
       })
       .where(and(eq(companies.id, policy.scopeId), eq(companies.pauseReason, "budget")));

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -41,6 +41,9 @@ export function companyService(db: Db) {
     name: companies.name,
     description: companies.description,
     status: companies.status,
+    pauseReason: companies.pauseReason,
+    pausedAt: companies.pausedAt,
+    resumedAt: companies.resumedAt,
     issuePrefix: companies.issuePrefix,
     issueCounter: companies.issueCounter,
     budgetMonthlyCents: companies.budgetMonthlyCents,
@@ -194,6 +197,14 @@ export function companyService(db: Db) {
         if (!existing) return null;
 
         const { logoAssetId, ...companyPatch } = data;
+        const nextCompanyPatch = { ...companyPatch };
+        if (
+          nextCompanyPatch.status === "active" &&
+          (existing.status === "paused" || existing.pausedAt) &&
+          nextCompanyPatch.pausedAt === null
+        ) {
+          nextCompanyPatch.resumedAt = new Date();
+        }
 
         if (logoAssetId !== undefined && logoAssetId !== null) {
           const nextLogoAsset = await tx
@@ -209,7 +220,7 @@ export function companyService(db: Db) {
 
         const updated = await tx
           .update(companies)
-          .set({ ...companyPatch, updatedAt: new Date() })
+          .set({ ...nextCompanyPatch, updatedAt: new Date() })
           .where(eq(companies.id, id))
           .returning()
           .then((rows) => rows[0] ?? null);

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -19,6 +19,8 @@ import {
   withRecoveryModelProfileHint,
 } from "./recovery/model-profile-hint.js";
 import { RECOVERY_ORIGIN_KINDS } from "./recovery/origins.js";
+import { isCompanyWatchdogPaused } from "./recovery/pause-aware-guard.js";
+import { isWatchdogFamilyDescendant, WATCHDOG_FAMILY_ORIGIN_KINDS } from "./recovery/watchdog-family.js";
 
 export const PRODUCTIVITY_REVIEW_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.issueProductivityReview;
 export const DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS = 10;
@@ -30,6 +32,9 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS = 3;
 export const DEFAULT_PRODUCTIVITY_REVIEW_CREATION_WINDOW_MS = 24 * 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 3;
+export const DEFAULT_WATCHDOG_PER_AGENT_24H_CAP = 5;
+const WATCHDOG_CAP_WINDOW_MS = 24 * 60 * 60 * 1000;
+const WATCHDOG_ROLLUP_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.watchdogRollup;
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
@@ -94,6 +99,15 @@ type EnqueueWakeup = (
 
 function productivityReviewFingerprint(sourceIssueId: string) {
   return `productivity-review:${sourceIssueId}`;
+}
+
+function watchdogPerAgent24hCap() {
+  const raw = Number(process.env.WATCHDOG_PER_AGENT_24H_CAP ?? DEFAULT_WATCHDOG_PER_AGENT_24H_CAP);
+  return Math.max(1, Math.floor(Number.isFinite(raw) ? raw : DEFAULT_WATCHDOG_PER_AGENT_24H_CAP));
+}
+
+function watchdogRollupOriginId(agentId: string | null, familyKey: string) {
+  return `watchdog_rollup:${agentId ?? "unassigned"}:${familyKey}`;
 }
 
 function issueRunScopeSql(issueId: string) {
@@ -239,6 +253,81 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       depth += 1;
     }
     return false;
+  }
+
+  async function findOpenWatchdogRollup(companyId: string, originId: string) {
+    return db
+      .select()
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, companyId),
+        eq(issues.originKind, WATCHDOG_ROLLUP_ORIGIN_KIND),
+        eq(issues.originId, originId),
+        isNull(issues.hiddenAt),
+        notInArray(issues.status, ["done", "cancelled"]),
+      ))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function ensureWatchdogRollup(input: {
+    sourceIssue: IssueRow;
+    ownerAgentId: string | null;
+    prefix: string;
+    generatedAt: Date;
+  }) {
+    const originId = watchdogRollupOriginId(input.ownerAgentId, input.sourceIssue.id);
+    const existing = await findOpenWatchdogRollup(input.sourceIssue.companyId, originId);
+    if (existing) return existing;
+    return issuesSvc.create(input.sourceIssue.companyId, {
+      title: "Review watchdog cascade brake",
+      description: [
+        "Paperclip suppressed additional productivity-review watchdog creation because this owner/family exceeded the 24h cascade cap.",
+        "",
+        `- Source family root: ${issueUiLink(input.sourceIssue, input.prefix)}`,
+        `- Trigger origin: \`${PRODUCTIVITY_REVIEW_ORIGIN_KIND}\``,
+        `- Owner agent: \`${input.ownerAgentId ?? "unassigned"}\``,
+        `- Cap: ${watchdogPerAgent24hCap()} watchdog issues in 24h`,
+        `- Generated at: ${input.generatedAt.toISOString()}`,
+        "",
+        "Inspect the family and resolve the underlying stuck recovery loop before closing this rollup.",
+      ].join("\n"),
+      status: "todo",
+      priority: "high",
+      parentId: input.sourceIssue.id,
+      projectId: input.sourceIssue.projectId,
+      goalId: input.sourceIssue.goalId,
+      billingCode: input.sourceIssue.billingCode,
+      assigneeAgentId: input.ownerAgentId,
+      assigneeAdapterOverrides: recoveryAssigneeAdapterOverrides(),
+      originKind: WATCHDOG_ROLLUP_ORIGIN_KIND,
+      originId,
+      originFingerprint: originId,
+      requestDepth: clampIssueRequestDepth(input.sourceIssue.requestDepth + 1),
+    });
+  }
+
+  async function shouldBrakeWatchdogCascade(input: {
+    sourceIssue: IssueRow;
+    ownerAgentId: string | null;
+    prefix: string;
+    generatedAt: Date;
+  }) {
+    if (!input.ownerAgentId) return false;
+    const cutoff = new Date(input.generatedAt.getTime() - WATCHDOG_CAP_WINDOW_MS);
+    const [row] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, input.sourceIssue.companyId),
+        eq(issues.assigneeAgentId, input.ownerAgentId),
+        inArray(issues.originKind, [...WATCHDOG_FAMILY_ORIGIN_KINDS]),
+        isNull(issues.hiddenAt),
+        sql`${issues.createdAt} >= ${cutoff.toISOString()}::timestamptz`,
+        notInArray(issues.status, ["done", "cancelled"]),
+      ));
+    if (Number(row?.count ?? 0) < watchdogPerAgent24hCap()) return false;
+    await ensureWatchdogRollup(input);
+    return true;
   }
 
   async function findOpenProductivityReview(companyId: string, sourceIssueId: string) {
@@ -679,6 +768,14 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     }
 
     const ownerAgentId = await resolveReviewOwnerAgentId(evidence.sourceIssue, evidence.sourceAgent);
+    if (await shouldBrakeWatchdogCascade({
+      sourceIssue: evidence.sourceIssue,
+      ownerAgentId,
+      prefix: opts.prefix,
+      generatedAt: evidence.generatedAt,
+    })) {
+      return { kind: "creation_capped" as const, reviewIssueId: null };
+    }
     let review: Awaited<ReturnType<typeof issuesSvc.create>>;
     try {
       review = await issuesSvc.create(evidence.sourceIssue.companyId, {
@@ -796,11 +893,15 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
 
     const prefixCache = new Map<string, string>();
     for (const candidate of candidates) {
+      if (await isCompanyWatchdogPaused(db, candidate.companyId, now)) {
+        result.skipped += 1;
+        continue;
+      }
       if (!candidate.assigneeAgentId) {
         result.skipped += 1;
         continue;
       }
-      if (await isProductivityReviewDescendant(candidate)) {
+      if (await isProductivityReviewDescendant(candidate) || await isWatchdogFamilyDescendant(db, candidate)) {
         result.skipped += 1;
         continue;
       }

--- a/server/src/services/recovery/origins.ts
+++ b/server/src/services/recovery/origins.ts
@@ -3,6 +3,7 @@ export const RECOVERY_ORIGIN_KINDS = {
   issueProductivityReview: "issue_productivity_review",
   strandedIssueRecovery: "stranded_issue_recovery",
   staleActiveRunEvaluation: "stale_active_run_evaluation",
+  watchdogRollup: "watchdog_rollup",
 } as const;
 
 export const RECOVERY_REASON_KINDS = {

--- a/server/src/services/recovery/pause-aware-guard.ts
+++ b/server/src/services/recovery/pause-aware-guard.ts
@@ -1,0 +1,33 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { companies } from "@paperclipai/db";
+import { asNumber } from "../../adapters/utils.js";
+
+export const DEFAULT_WATCHDOG_RESUME_WARMUP_MS = 15 * 60 * 1000;
+
+export function watchdogResumeWarmupMs() {
+  return Math.max(
+    0,
+    asNumber(process.env.PAPERCLIP_WATCHDOG_RESUME_WARMUP_MS, DEFAULT_WATCHDOG_RESUME_WARMUP_MS),
+  );
+}
+
+export async function isCompanyWatchdogPaused(
+  db: Db,
+  companyId: string,
+  now = new Date(),
+) {
+  const row = await db
+    .select({
+      status: companies.status,
+      pausedAt: companies.pausedAt,
+      resumedAt: companies.resumedAt,
+    })
+    .from(companies)
+    .where(and(eq(companies.id, companyId)))
+    .then((rows) => rows[0] ?? null);
+  if (!row) return false;
+  if (row.status === "paused" || row.pausedAt) return true;
+  const warmupMs = watchdogResumeWarmupMs();
+  return Boolean(row.resumedAt && now.getTime() - row.resumedAt.getTime() < warmupMs);
+}

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -58,6 +58,8 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { isCompanyWatchdogPaused } from "./pause-aware-guard.js";
+import { isWatchdogFamilyDescendant, WATCHDOG_FAMILY_ORIGIN_KINDS } from "./watchdog-family.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
@@ -67,7 +69,10 @@ export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+const WATCHDOG_ROLLUP_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.watchdogRollup;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
+const DEFAULT_WATCHDOG_PER_AGENT_24H_CAP = 5;
+const WATCHDOG_CAP_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 type RecoveryWakeupOptions = {
   source?: "timer" | "assignment" | "on_demand" | "automation";
@@ -334,6 +339,21 @@ function isUniqueLivenessRecoveryConflict(error: unknown) {
           maybe.message.includes("issues_active_liveness_recovery_incident_uq") ||
           maybe.message.includes("issues_active_liveness_recovery_leaf_uq")
         )
+    );
+}
+
+function watchdogRollupOriginId(input: { agentId: string | null; familyKey: string }) {
+  return `watchdog_rollup:${input.agentId ?? "unassigned"}:${input.familyKey}`;
+}
+
+function isUniqueWatchdogRollupConflict(error: unknown) {
+  const maybe = unwrapDatabaseConflictError(error);
+  if (!maybe) return false;
+  return maybe.code === "23505" &&
+    (
+      maybe.constraint === "issues_active_watchdog_rollup_uq" ||
+      maybe.constraint_name === "issues_active_watchdog_rollup_uq" ||
+      typeof maybe.message === "string" && maybe.message.includes("issues_active_watchdog_rollup_uq")
     );
 }
 
@@ -667,6 +687,105 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .from(companies)
       .where(eq(companies.id, companyId))
       .then((rows) => rows[0]?.issuePrefix ?? "PAP");
+  }
+
+  function watchdogPerAgent24hCap() {
+    return Math.max(
+      1,
+      Math.floor(asNumber(process.env.WATCHDOG_PER_AGENT_24H_CAP, DEFAULT_WATCHDOG_PER_AGENT_24H_CAP)),
+    );
+  }
+
+  async function findOpenWatchdogRollup(companyId: string, originId: string) {
+    return db
+      .select()
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, companyId),
+        eq(issues.originKind, WATCHDOG_ROLLUP_ORIGIN_KIND),
+        eq(issues.originId, originId),
+        isNull(issues.hiddenAt),
+        notInArray(issues.status, ["done", "cancelled"]),
+      ))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function ensureWatchdogRollup(input: {
+    companyId: string;
+    ownerAgentId: string | null;
+    sourceIssue: typeof issues.$inferSelect | null;
+    familyKey: string;
+    triggerOriginKind: string;
+    now: Date;
+  }) {
+    const originId = watchdogRollupOriginId({ agentId: input.ownerAgentId, familyKey: input.familyKey });
+    const existing = await findOpenWatchdogRollup(input.companyId, originId);
+    if (existing) return existing;
+    const prefix = await getCompanyIssuePrefix(input.companyId);
+    const sourceLine = input.sourceIssue
+      ? `- Source family root: ${issueUiLink(input.sourceIssue, prefix)}`
+      : `- Source family root: \`${input.familyKey}\``;
+    try {
+      return await issuesSvc.create(input.companyId, {
+        title: "Review watchdog cascade brake",
+        description: [
+          "Paperclip suppressed additional watchdog ticket creation because this owner/family exceeded the 24h cascade cap.",
+          "",
+          sourceLine,
+          `- Trigger origin: \`${input.triggerOriginKind}\``,
+          `- Owner agent: \`${input.ownerAgentId ?? "unassigned"}\``,
+          `- Cap: ${watchdogPerAgent24hCap()} watchdog issues in 24h`,
+          `- Generated at: ${input.now.toISOString()}`,
+          "",
+          "Inspect the family and resolve the underlying stuck recovery loop before closing this rollup.",
+        ].join("\n"),
+        status: "todo",
+        priority: "high",
+        parentId: input.sourceIssue && !["done", "cancelled"].includes(input.sourceIssue.status)
+          ? input.sourceIssue.id
+          : null,
+        projectId: input.sourceIssue?.projectId ?? null,
+        goalId: input.sourceIssue?.goalId ?? null,
+        billingCode: input.sourceIssue?.billingCode ?? null,
+        assigneeAgentId: input.ownerAgentId,
+        assigneeAdapterOverrides: recoveryAssigneeAdapterOverrides(),
+        originKind: WATCHDOG_ROLLUP_ORIGIN_KIND,
+        originId,
+        originFingerprint: originId,
+      });
+    } catch (error) {
+      if (!isUniqueWatchdogRollupConflict(error)) throw error;
+      const raced = await findOpenWatchdogRollup(input.companyId, originId);
+      if (!raced) throw error;
+      return raced;
+    }
+  }
+
+  async function shouldBrakeWatchdogCascade(input: {
+    companyId: string;
+    ownerAgentId: string | null;
+    sourceIssue: typeof issues.$inferSelect | null;
+    familyKey: string;
+    triggerOriginKind: string;
+    now: Date;
+  }) {
+    if (!input.ownerAgentId) return false;
+    const cutoff = new Date(input.now.getTime() - WATCHDOG_CAP_WINDOW_MS);
+    const [row] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(issues)
+      .where(and(
+        eq(issues.companyId, input.companyId),
+        eq(issues.assigneeAgentId, input.ownerAgentId),
+        inArray(issues.originKind, [...WATCHDOG_FAMILY_ORIGIN_KINDS]),
+        isNull(issues.hiddenAt),
+        sql`${issues.createdAt} >= ${cutoff.toISOString()}::timestamptz`,
+        notInArray(issues.status, ["done", "cancelled"]),
+      ));
+    if (Number(row?.count ?? 0) < watchdogPerAgent24hCap()) return false;
+    await ensureWatchdogRollup(input);
+    return true;
   }
 
   function staleActiveRunOriginFingerprint(companyId: string, runId: string) {
@@ -1030,6 +1149,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
+    if (sourceIssue && await isWatchdogFamilyDescendant(db, sourceIssue)) return { kind: "skipped" as const };
     const prefix = await getCompanyIssuePrefix(input.run.companyId);
     const evidence = await collectStaleRunEvidence({
       run: input.run,
@@ -1070,6 +1190,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     const ownerAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });
+    if (await shouldBrakeWatchdogCascade({
+      companyId: input.run.companyId,
+      ownerAgentId,
+      sourceIssue,
+      familyKey: sourceIssue?.id ?? input.run.id,
+      triggerOriginKind: STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND,
+      now: input.now,
+    })) {
+      return { kind: "skipped" as const };
+    }
     const description = buildStaleRunEvaluationDescription({
       run: input.run,
       runningAgent,
@@ -1155,6 +1285,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function scanSilentActiveRuns(opts?: { now?: Date; companyId?: string }) {
     const now = opts?.now ?? new Date();
+    if (opts?.companyId && await isCompanyWatchdogPaused(db, opts.companyId, now)) {
+      return {
+        scanned: 0,
+        created: 0,
+        existing: 0,
+        escalated: 0,
+        snoozed: 0,
+        skipped: 0,
+        evaluationIssueIds: [] as string[],
+      };
+    }
     const suspicionBefore = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS);
     const candidates = await db
       .select()
@@ -1180,6 +1321,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     };
 
     for (const run of candidates) {
+      if (await isCompanyWatchdogPaused(db, run.companyId, now)) {
+        result.skipped += 1;
+        continue;
+      }
       if (await latestActiveOutputQuietUntilDecision(run.companyId, run.id, now)) {
         result.snoozed += 1;
         continue;
@@ -1493,12 +1638,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     if (isStrandedIssueRecoveryIssue(input.issue)) return null;
+    if (await isWatchdogFamilyDescendant(db, input.issue)) return null;
 
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;
 
     const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
     if (!ownerAgentId) return null;
+    if (await shouldBrakeWatchdogCascade({
+      companyId: input.issue.companyId,
+      ownerAgentId,
+      sourceIssue: input.issue,
+      familyKey: input.issue.id,
+      triggerOriginKind: STRANDED_ISSUE_RECOVERY_ORIGIN_KIND,
+      now: new Date(),
+    })) {
+      return null;
+    }
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
     const sourceAssignee = input.issue.assigneeAgentId ? await getAgent(input.issue.assigneeAgentId) : null;
@@ -1998,6 +2154,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     };
 
     for (const issue of candidates) {
+      if (await isCompanyWatchdogPaused(db, issue.companyId)) {
+        result.skipped += 1;
+        continue;
+      }
       const agentId = issue.assigneeAgentId;
       if (!agentId) {
         result.skipped += 1;
@@ -2016,6 +2176,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+        result.skipped += 1;
+        continue;
+      }
+      if (await isWatchdogFamilyDescendant(db, issue) && !isStrandedIssueRecoveryIssue(issue)) {
         result.skipped += 1;
         continue;
       }

--- a/server/src/services/recovery/watchdog-family.ts
+++ b/server/src/services/recovery/watchdog-family.ts
@@ -1,0 +1,63 @@
+import { and, eq, inArray, isNull } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issues } from "@paperclipai/db";
+import { RECOVERY_ORIGIN_KINDS } from "./origins.js";
+
+export const WATCHDOG_FAMILY_ORIGIN_KINDS = [
+  RECOVERY_ORIGIN_KINDS.issueProductivityReview,
+  RECOVERY_ORIGIN_KINDS.strandedIssueRecovery,
+  RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation,
+  RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation,
+  RECOVERY_ORIGIN_KINDS.watchdogRollup,
+] as const;
+
+type WatchdogFamilyOriginKind = (typeof WATCHDOG_FAMILY_ORIGIN_KINDS)[number];
+
+function isWatchdogOriginKind(originKind: string | null | undefined): originKind is WatchdogFamilyOriginKind {
+  return WATCHDOG_FAMILY_ORIGIN_KINDS.includes(originKind as WatchdogFamilyOriginKind);
+}
+
+export async function isWatchdogFamilyDescendant(
+  db: Db,
+  issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "parentId" | "originKind" | "originId">,
+  opts?: { maxDepth?: number },
+) {
+  if (isWatchdogOriginKind(issue.originKind)) return true;
+
+  const maxDepth = opts?.maxDepth ?? 25;
+  const seen = new Set<string>([issue.id]);
+  let parentId = issue.parentId;
+  let depth = 0;
+
+  while (parentId && depth < maxDepth) {
+    if (seen.has(parentId)) return false;
+    seen.add(parentId);
+    const parent = await db
+      .select({
+        id: issues.id,
+        parentId: issues.parentId,
+        originKind: issues.originKind,
+      })
+      .from(issues)
+      .where(and(eq(issues.companyId, issue.companyId), eq(issues.id, parentId), isNull(issues.hiddenAt)))
+      .then((rows) => rows[0] ?? null);
+    if (!parent) return false;
+    if (isWatchdogOriginKind(parent.originKind)) return true;
+    parentId = parent.parentId;
+    depth += 1;
+  }
+
+  const originId = typeof issue.originId === "string" && issue.originId.trim() ? issue.originId : null;
+  if (!originId || seen.has(originId)) return false;
+  const [originIssue] = await db
+    .select({ id: issues.id, originKind: issues.originKind })
+    .from(issues)
+    .where(and(
+      eq(issues.companyId, issue.companyId),
+      eq(issues.id, originId),
+      isNull(issues.hiddenAt),
+      inArray(issues.originKind, [...WATCHDOG_FAMILY_ORIGIN_KINDS]),
+    ))
+    .limit(1);
+  return Boolean(originIssue);
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The watchdog/recovery subsystem creates follow-up work when agent runs, issue assignments, or productivity patterns appear stuck.
> - Those watchdogs need to stay quiet during company pauses and immediately after resume so paused work does not generate recovery noise.
> - Watchdog-created issues also need to exclude their own families so productivity reviews, stranded recovery issues, stale-run evaluations, and liveness recoveries do not recursively trigger each other.
> - A runaway watchdog cascade should collapse into one explicit rollup instead of creating unlimited per-agent recovery work.
> - This pull request adds shared family self-exclusion, pause-aware guards, and a per-owner 24h cascade brake with a rollup origin.
> - The benefit is safer recovery automation that preserves operator visibility without multiplying recovery tickets during pause/resume and recursive failure modes.

## What Changed

- Added `companies.resumed_at` plus migration `0085_watchdog_brakes` and schema metadata.
- Added `pause-aware-guard.ts` with `PAPERCLIP_WATCHDOG_RESUME_WARMUP_MS` support, defaulting to 15 minutes.
- Added shared `isWatchdogFamilyDescendant` helper for watchdog-family self-exclusion.
- Wired pause and family guards into stale active-run scans, productivity review reconciliation, and stranded assigned issue reconciliation.
- Added `watchdog_rollup` recovery origin and a partial unique index for active rollups.
- Added per-owner 24h cascade brake using `WATCHDOG_PER_AGENT_24H_CAP`, defaulting to 5.
- Updated company/budget resume paths to persist `resumed_at`.
- Added/extended tests for pause-aware behavior, family exclusion, and cascade rollup creation.

## Verification

- `pnpm typecheck` passed locally.
- `pnpm exec vitest run server/src/__tests__/recovery-classifiers.test.ts` passed locally.
- `pnpm exec vitest run server/src/__tests__/pause-aware-guard.test.ts server/src/__tests__/watchdog-self-exclusion.test.ts server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts server/src/__tests__/productivity-review-service.test.ts` ran locally, but embedded-Postgres suites were skipped on this host because the embedded Postgres init script exited with code 1 before test execution.
- `git diff --check` passed locally.

## Risks

- Migration adds a nullable `companies.resumed_at` column and one partial unique index; expected rollout risk is low.
- The cascade brake currently counts active watchdog-family issues assigned to the same owner in the last 24h; this is intentionally conservative and may roll up noisy but distinct watchdog families for the same owner.
- Pause-aware suppression depends on resume paths setting `resumed_at`; this PR covers the existing company service update and budget resume paths.

## Model Used

- OpenAI Codex using GPT-5, tool-assisted coding session with shell, git, and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
