### PR TITLE
fix: canonicalize pending request confirmations

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -386,6 +386,7 @@ export type {
   IssueExecutionMonitorState,
   IssueRelation,
   IssueRelationIssueSummary,
+  IssueCanonicalUnblockTuple,
   IssueExecutionPolicy,
   IssueExecutionState,
   IssueExecutionStage,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -162,6 +162,7 @@ export type {
   IssueRelatedWorkSummary,
   IssueRelation,
   IssueRelationIssueSummary,
+  IssueCanonicalUnblockTuple,
   IssueExecutionMonitorPolicy,
   IssueExecutionMonitorState,
   IssueExecutionPolicy,

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -130,7 +130,22 @@ export interface IssueRelationIssueSummary {
   priority: IssuePriority;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
+  canonicalUnblockTuple?: IssueCanonicalUnblockTuple | null;
   terminalBlockers?: IssueRelationIssueSummary[];
+}
+
+export interface IssueCanonicalUnblockTuple {
+  kind: "request_confirmation";
+  interactionId: string;
+  interactionStatus: Extract<IssueThreadInteractionStatus, "pending">;
+  continuationPolicy: IssueThreadInteractionContinuationPolicy;
+  unblockOwnerType: "user";
+  unblockAction: "resolve_pending_request_confirmation";
+  pendingInteractionCount: number;
+  targetIssueId?: string | null;
+  targetDocumentId?: string | null;
+  targetDocumentKey?: string | null;
+  targetRevisionId?: string | null;
 }
 
 export type IssueBlockerAttentionState = "none" | "covered" | "stalled" | "needs_attention";

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -1187,6 +1187,176 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
+  it("auto-approves a reviewer comment with the APPROVED review marker", async () => {
+    const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+    const policy = await normalizePolicy({
+      stages: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "review",
+          participants: [{ type: "agent", agentId: reviewerAgentId }],
+        },
+      ],
+    })!;
+    const issue = {
+      ...makeIssue("todo"),
+      status: "in_review",
+      assigneeAgentId: reviewerAgentId,
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0].id,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: reviewerAgentId },
+        returnAssignee: { type: "agent", agentId: "22222222-2222-4222-8222-222222222222" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    };
+    const reviewBody = "## Review: PAP-580 - APPROVED\n\nLooks good.";
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-review-1",
+      issueId: issue.id,
+      companyId: issue.companyId,
+      body: reviewBody,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: reviewerAgentId,
+      authorUserId: null,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>, tx?: unknown) => ({
+      ...issue,
+      ...patch,
+      executionState: patch.executionState,
+      status: "done",
+      completedAt: new Date(),
+      updatedAt: new Date(),
+      _tx: tx,
+    }));
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: reviewerAgentId,
+        companyId: "company-1",
+        source: "agent_key",
+        runId: "run-review-1",
+      }),
+    )
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: reviewBody });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      id: "comment-review-1",
+      issueId: issue.id,
+      body: reviewBody,
+    });
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        status: "done",
+        actorAgentId: reviewerAgentId,
+        actorUserId: null,
+        executionState: expect.objectContaining({
+          status: "completed",
+          lastDecisionId: expect.any(String),
+          lastDecisionOutcome: "approved",
+        }),
+      }),
+      mockTx,
+    );
+  });
+
+  it("auto-approves a reviewer comment with structured review metadata", async () => {
+    const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+    const policy = await normalizePolicy({
+      stages: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "review",
+          participants: [{ type: "agent", agentId: reviewerAgentId }],
+        },
+      ],
+    })!;
+    const issue = {
+      ...makeIssue("todo"),
+      status: "in_review",
+      assigneeAgentId: reviewerAgentId,
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0].id,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: reviewerAgentId },
+        returnAssignee: { type: "agent", agentId: "22222222-2222-4222-8222-222222222222" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    };
+    const reviewBody = "kind: review\ndecision: approved\nsummary: ship it";
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-review-2",
+      issueId: issue.id,
+      companyId: issue.companyId,
+      body: reviewBody,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: reviewerAgentId,
+      authorUserId: null,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>, tx?: unknown) => ({
+      ...issue,
+      ...patch,
+      executionState: patch.executionState,
+      status: "done",
+      completedAt: new Date(),
+      updatedAt: new Date(),
+      _tx: tx,
+    }));
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: reviewerAgentId,
+        companyId: "company-1",
+        source: "agent_key",
+        runId: "run-review-2",
+      }),
+    )
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: reviewBody });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      id: "comment-review-2",
+      issueId: issue.id,
+      body: reviewBody,
+    });
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        status: "done",
+        actorAgentId: reviewerAgentId,
+        actorUserId: null,
+        executionState: expect.objectContaining({
+          status: "completed",
+          lastDecisionId: expect.any(String),
+          lastDecisionOutcome: "approved",
+        }),
+      }),
+      mockTx,
+    );
+  });
+
   it("coerces executor handoff patches into workflow-controlled review wakes", async () => {
     const policy = await normalizePolicy({
       stages: [

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -701,6 +701,75 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     })).rejects.toThrow("A decline reason is required for this confirmation");
   });
 
+  it("rejects a second pending request_confirmation on the same issue with a canonical unblock tuple", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Confirm a request",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_review",
+      priority: "medium",
+      assigneeUserId: "local-board",
+    });
+
+    const first = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Approve revision one?",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    await expect(interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Approve revision two?",
+      },
+    }, {
+      userId: "local-board",
+    })).rejects.toMatchObject({
+      status: 409,
+      details: expect.objectContaining({
+        issueId,
+        interactionId: first.id,
+        interactionKind: "request_confirmation",
+        interactionStatus: "pending",
+        pendingInteractionCount: 1,
+        unblockOwnerType: "user",
+        unblockAction: "resolve_pending_request_confirmation",
+      }),
+    });
+  });
+
   it("returns agent-authored request confirmations to the creating agent when a board user accepts", async () => {
     const companyId = randomUUID();
     const goalId = randomUUID();

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -770,6 +770,85 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     });
   });
 
+  it("reports the oldest pending request_confirmation as canonical when legacy duplicates already exist", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+    const firstId = randomUUID();
+    const secondId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Confirm a request",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_review",
+      priority: "medium",
+      assigneeUserId: "local-board",
+    });
+    await db.insert(issueThreadInteractions).values([
+      {
+        id: firstId,
+        companyId,
+        issueId,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        payload: { version: 1, prompt: "Approve revision one?" },
+        createdByUserId: "local-board",
+        createdAt: new Date("2026-05-15T11:00:00.000Z"),
+        updatedAt: new Date("2026-05-15T11:00:00.000Z"),
+      },
+      {
+        id: secondId,
+        companyId,
+        issueId,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        payload: { version: 1, prompt: "Approve revision two?" },
+        createdByUserId: "local-board",
+        createdAt: new Date("2026-05-15T11:05:00.000Z"),
+        updatedAt: new Date("2026-05-15T11:05:00.000Z"),
+      },
+    ]);
+
+    await expect(interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Approve revision three?",
+      },
+    }, {
+      userId: "local-board",
+    })).rejects.toMatchObject({
+      status: 409,
+      details: expect.objectContaining({
+        issueId,
+        interactionId: firstId,
+        pendingInteractionCount: 2,
+      }),
+    });
+  });
+
   it("returns agent-authored request confirmations to the creating agent when a board user accepts", async () => {
     const companyId = randomUUID();
     const goalId = randomUUID();

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -310,10 +310,23 @@ describe.sequential("issue goal context routes", () => {
           id: "55555555-5555-4555-8555-555555555555",
           identifier: "PAP-580",
           title: "Finish wakeup plumbing",
-          status: "done",
+          status: "in_review",
           priority: "medium",
           assigneeAgentId: null,
-          assigneeUserId: null,
+          assigneeUserId: "local-board",
+          canonicalUnblockTuple: {
+            kind: "request_confirmation",
+            interactionId: "interaction-1",
+            interactionStatus: "pending",
+            continuationPolicy: "wake_assignee",
+            unblockOwnerType: "user",
+            unblockAction: "resolve_pending_request_confirmation",
+            pendingInteractionCount: 1,
+            targetIssueId: null,
+            targetDocumentId: null,
+            targetDocumentKey: null,
+            targetRevisionId: null,
+          },
         },
       ],
       blocks: [],
@@ -328,6 +341,10 @@ describe.sequential("issue goal context routes", () => {
       expect.objectContaining({
         id: "55555555-5555-4555-8555-555555555555",
         identifier: "PAP-580",
+        canonicalUnblockTuple: expect.objectContaining({
+          interactionId: "interaction-1",
+          unblockAction: "resolve_pending_request_confirmation",
+        }),
       }),
     ]);
   });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -15,6 +15,7 @@ import {
   issueComments,
   issueInboxArchives,
   issueRelations,
+  issueThreadInteractions,
   issues,
   projectWorkspaces,
   projects,
@@ -141,6 +142,7 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(issueRelations);
     await db.delete(issueInboxArchives);
@@ -1296,6 +1298,7 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(issueRelations);
     await db.delete(issueInboxArchives);
@@ -2067,6 +2070,7 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
   }, 20_000);
 
   afterEach(async () => {
+    await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(issueRelations);
     await db.delete(issueInboxArchives);
@@ -2164,6 +2168,75 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
         }),
       ],
     });
+  });
+
+  it("surfaces a blocker's canonical pending request_confirmation unblock tuple", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockedId = randomUUID();
+    const blockerId = randomUUID();
+    const interactionId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        identifier: "PAP-11",
+        title: "Approval blocker",
+        status: "in_review",
+        priority: "high",
+        assigneeUserId: "local-board",
+      },
+      {
+        id: blockedId,
+        companyId,
+        identifier: "PAP-12",
+        title: "Blocked issue",
+        status: "blocked",
+        priority: "medium",
+      },
+    ]);
+    await svc.update(blockedId, { blockedByIssueIds: [blockerId] });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: blockerId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Approve this plan?",
+      },
+      createdByUserId: "local-board",
+    });
+
+    const relations = await svc.getRelationSummaries(blockedId);
+
+    expect(relations.blockedBy).toEqual([
+      expect.objectContaining({
+        id: blockerId,
+        identifier: "PAP-11",
+        canonicalUnblockTuple: {
+          kind: "request_confirmation",
+          interactionId,
+          interactionStatus: "pending",
+          continuationPolicy: "wake_assignee",
+          unblockOwnerType: "user",
+          unblockAction: "resolve_pending_request_confirmation",
+          pendingInteractionCount: 1,
+          targetIssueId: null,
+          targetDocumentId: null,
+          targetDocumentKey: null,
+          targetRevisionId: null,
+        },
+      }),
+    ]);
   });
 
   it("rejects blocking cycles", async () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2239,6 +2239,85 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     ]);
   });
 
+  it("surfaces the oldest pending request_confirmation as canonical when legacy duplicates exist", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const blockedId = randomUUID();
+    const blockerId = randomUUID();
+    const firstInteractionId = randomUUID();
+    const secondInteractionId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        identifier: "PAP-21",
+        title: "Approval blocker",
+        status: "in_review",
+        priority: "high",
+        assigneeUserId: "local-board",
+      },
+      {
+        id: blockedId,
+        companyId,
+        identifier: "PAP-22",
+        title: "Blocked issue",
+        status: "blocked",
+        priority: "medium",
+      },
+    ]);
+    await svc.update(blockedId, { blockedByIssueIds: [blockerId] });
+    await db.insert(issueThreadInteractions).values([
+      {
+        id: firstInteractionId,
+        companyId,
+        issueId: blockerId,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        payload: {
+          version: 1,
+          prompt: "Approve this first plan?",
+        },
+        createdByUserId: "local-board",
+        createdAt: new Date("2026-05-15T11:00:00.000Z"),
+        updatedAt: new Date("2026-05-15T11:00:00.000Z"),
+      },
+      {
+        id: secondInteractionId,
+        companyId,
+        issueId: blockerId,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        payload: {
+          version: 1,
+          prompt: "Approve this second plan?",
+        },
+        createdByUserId: "local-board",
+        createdAt: new Date("2026-05-15T11:05:00.000Z"),
+        updatedAt: new Date("2026-05-15T11:05:00.000Z"),
+      },
+    ]);
+
+    const relations = await svc.getRelationSummaries(blockedId);
+
+    expect(relations.blockedBy).toEqual([
+      expect.objectContaining({
+        id: blockerId,
+        canonicalUnblockTuple: expect.objectContaining({
+          interactionId: firstInteractionId,
+          pendingInteractionCount: 2,
+        }),
+      }),
+    ]);
+  });
+
   it("rejects blocking cycles", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -422,6 +422,20 @@ function executionPrincipalsEqual(
   return left.type === "agent" ? left.agentId === right.agentId : left.userId === right.userId;
 }
 
+function actorMatchesExecutionParticipant(
+  actor: { actorType: "user" | "agent"; actorId: string },
+  participant: ParsedExecutionState["currentParticipant"] | null,
+) {
+  if (!participant) return false;
+  return participant.type === "agent" ? participant.agentId === actor.actorId : participant.userId === actor.actorId;
+}
+
+function isApprovalReviewComment(body: string) {
+  const normalized = body.replace(/\r\n?/g, "\n");
+  if (/(^|\n)##\s*Review:.*\bAPPROVED\b/im.test(normalized)) return true;
+  return /^\s*kind\s*:\s*review\s*$/im.test(normalized) && /^\s*decision\s*:\s*approved\s*$/im.test(normalized);
+}
+
 function buildExecutionStageWakeContext(input: {
   state: ParsedExecutionState;
   wakeRole: ExecutionStageWakeContext["wakeRole"];
@@ -4149,6 +4163,8 @@ export function issueRoutes(
     let reopenFromStatus: string | null = null;
     let interruptedRunId: string | null = null;
     let currentIssue = issue;
+    let issueBeforeCommentDecision = issue;
+    let commentDecisionStageWakeup: ReturnType<typeof buildExecutionStageWakeup> | null = null;
     const commentReferenceSummaryBefore = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
 
     if (effectiveMoveToTodoRequested && (isClosed || (isBlocked && !hasUnresolvedFirstClassBlockers))) {
@@ -4216,6 +4232,82 @@ export function issueRoutes(
       presentation: req.body.presentation ?? null,
       metadata: req.body.metadata ?? null,
     });
+
+    const currentExecutionState = parseIssueExecutionState(currentIssue.executionState);
+    const currentExecutionPolicy = normalizeIssueExecutionPolicy(currentIssue.executionPolicy ?? null);
+    const shouldAutoApproveReviewComment =
+      currentIssue.status === "in_review" &&
+      currentExecutionState?.status === "pending" &&
+      actorMatchesExecutionParticipant(actor, currentExecutionState.currentParticipant ?? null) &&
+      isApprovalReviewComment(req.body.body);
+    if (shouldAutoApproveReviewComment) {
+      const transition = applyIssueExecutionPolicyTransition({
+        issue: currentIssue,
+        policy: currentExecutionPolicy,
+        requestedStatus: "done",
+        requestedAssigneePatch: {},
+        actor: {
+          agentId: actor.agentId ?? null,
+          userId: actor.actorType === "user" ? actor.actorId : null,
+        },
+        commentBody: req.body.body,
+      });
+      const decisionId = transition.decision ? randomUUID() : null;
+      if (decisionId) {
+        const nextExecutionState = transition.patch.executionState;
+        if (!nextExecutionState || typeof nextExecutionState !== "object") {
+          throw new Error("Execution policy decision patch is missing executionState");
+        }
+        transition.patch.executionState = {
+          ...nextExecutionState,
+          lastDecisionId: decisionId,
+        };
+      }
+
+      issueBeforeCommentDecision = currentIssue;
+      const updatePatch = {
+        ...transition.patch,
+        status: typeof transition.patch.status === "string" ? transition.patch.status : "done",
+        actorAgentId: actor.agentId ?? null,
+        actorUserId: actor.actorType === "user" ? actor.actorId : null,
+      };
+
+      const updatedIssue = transition.decision && decisionId
+        ? await db.transaction(async (tx) => {
+          const updated = await svc.update(id, updatePatch, tx);
+          if (!updated) return null;
+
+          await tx.insert(issueExecutionDecisions).values({
+            id: decisionId,
+            companyId: updated.companyId,
+            issueId: updated.id,
+            stageId: transition.decision!.stageId,
+            stageType: transition.decision!.stageType,
+            actorAgentId: actor.agentId ?? null,
+            actorUserId: actor.actorType === "user" ? actor.actorId : null,
+            outcome: transition.decision!.outcome,
+            body: transition.decision!.body,
+            createdByRunId: actor.runId ?? null,
+          });
+
+          return updated;
+        })
+        : await svc.update(id, updatePatch);
+      if (!updatedIssue) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+      currentIssue = updatedIssue;
+      commentDecisionStageWakeup = buildExecutionStageWakeup({
+        issueId: currentIssue.id,
+        previousState: currentExecutionState,
+        nextState: parseIssueExecutionState(currentIssue.executionState),
+        interruptedRunId,
+        requestedByActorType: actor.actorType,
+        requestedByActorId: actor.actorId,
+      });
+    }
+
     await issueReferencesSvc.syncComment(comment.id);
     const commentReferenceSummaryAfter = await issueReferencesSvc.listIssueReferenceSummary(currentIssue.id);
     const commentReferenceDiff = issueReferencesSvc.diffIssueReferenceSummary(
@@ -4270,14 +4362,29 @@ export function issueRoutes(
 
     // Merge all wakeups from this comment into one enqueue per agent to avoid duplicate runs.
     void (async () => {
-      const wakeups = new Map<string, Parameters<typeof heartbeat.wakeup>[1]>();
+      type WakeupRequest = NonNullable<Parameters<typeof heartbeat.wakeup>[1]>;
+      const wakeups = new Map<string, { agentId: string; wakeup: WakeupRequest }>();
+      const addWakeup = (agentId: string, wakeup: WakeupRequest) => {
+        const wakeIssueId =
+          wakeup.payload && typeof wakeup.payload === "object" && typeof wakeup.payload.issueId === "string"
+            ? wakeup.payload.issueId
+            : currentIssue.id;
+        const key = `${agentId}:${wakeIssueId}`;
+        if (wakeups.has(key)) return;
+        wakeups.set(key, { agentId, wakeup });
+      };
+
+      if (commentDecisionStageWakeup) {
+        addWakeup(commentDecisionStageWakeup.agentId, commentDecisionStageWakeup.wakeup);
+      }
+
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
       const skipWake = selfComment || isClosed;
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
-          wakeups.set(assigneeId, {
+          addWakeup(assigneeId, {
             source: "automation",
             triggerDetail: "system",
             reason: "issue_reopened_via_comment",
@@ -4304,7 +4411,7 @@ export function issueRoutes(
             },
           });
         } else {
-          wakeups.set(assigneeId, {
+          addWakeup(assigneeId, {
             source: "automation",
             triggerDetail: "system",
             reason: "issue_commented",
@@ -4339,9 +4446,8 @@ export function issueRoutes(
       }
 
       for (const mentionedId of mentionedIds) {
-        if (wakeups.has(mentionedId)) continue;
         if (actorIsAgent && actor.actorId === mentionedId) continue;
-        wakeups.set(mentionedId, {
+        addWakeup(mentionedId, {
           source: "automation",
           triggerDetail: "system",
           reason: "issue_comment_mentioned",
@@ -4359,7 +4465,67 @@ export function issueRoutes(
         });
       }
 
-      for (const [agentId, wakeup] of wakeups.entries()) {
+      const becameDone = issueBeforeCommentDecision.status !== "done" && currentIssue.status === "done";
+      if (becameDone) {
+        const dependents = await svc.listWakeableBlockedDependents(currentIssue.id);
+        for (const dependent of dependents) {
+          addWakeup(dependent.assigneeAgentId, {
+            source: "automation",
+            triggerDetail: "system",
+            reason: "issue_blockers_resolved",
+            payload: {
+              issueId: dependent.id,
+              resolvedBlockerIssueId: currentIssue.id,
+              blockerIssueIds: dependent.blockerIssueIds,
+            },
+            requestedByActorType: actor.actorType,
+            requestedByActorId: actor.actorId,
+            contextSnapshot: {
+              issueId: dependent.id,
+              taskId: dependent.id,
+              wakeReason: "issue_blockers_resolved",
+              source: "issue.blockers_resolved",
+              resolvedBlockerIssueId: currentIssue.id,
+              blockerIssueIds: dependent.blockerIssueIds,
+            },
+          });
+        }
+      }
+
+      const becameTerminal =
+        !["done", "cancelled"].includes(issueBeforeCommentDecision.status) &&
+        ["done", "cancelled"].includes(currentIssue.status);
+      if (becameTerminal && currentIssue.parentId) {
+        const parent = await svc.getWakeableParentAfterChildCompletion(currentIssue.parentId);
+        if (parent) {
+          addWakeup(parent.assigneeAgentId, {
+            source: "automation",
+            triggerDetail: "system",
+            reason: "issue_children_completed",
+            payload: {
+              issueId: parent.id,
+              completedChildIssueId: currentIssue.id,
+              childIssueIds: parent.childIssueIds,
+              childIssueSummaries: parent.childIssueSummaries,
+              childIssueSummaryTruncated: parent.childIssueSummaryTruncated,
+            },
+            requestedByActorType: actor.actorType,
+            requestedByActorId: actor.actorId,
+            contextSnapshot: {
+              issueId: parent.id,
+              taskId: parent.id,
+              wakeReason: "issue_children_completed",
+              source: "issue.children_completed",
+              completedChildIssueId: currentIssue.id,
+              childIssueIds: parent.childIssueIds,
+              childIssueSummaries: parent.childIssueSummaries,
+              childIssueSummaryTruncated: parent.childIssueSummaryTruncated,
+            },
+          });
+        }
+      }
+
+      for (const { agentId, wakeup } of wakeups.values()) {
         heartbeat
           .wakeup(agentId, wakeup)
           .catch((err) => logger.warn({ err, issueId: currentIssue.id, agentId }, "failed to wake agent on issue comment"));

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1,5 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   documents,
@@ -383,6 +383,18 @@ async function listPendingRequestConfirmationRows(
     .orderBy(asc(issueThreadInteractions.createdAt), asc(issueThreadInteractions.id));
 }
 
+async function lockIssueRowForRequestConfirmationCreate(
+  db: Db | any,
+  args: { companyId: string; issueId: string },
+) {
+  await db.execute(
+    sql`select ${issues.id} from ${issues}
+        where ${issues.companyId} = ${args.companyId}
+          and ${issues.id} = ${args.issueId}
+        for update`,
+  );
+}
+
 async function expireStaleRequestConfirmationTarget(db: Db | any, args: {
   row: IssueThreadInteractionRow;
   actor: InteractionActor;
@@ -689,59 +701,67 @@ export function issueThreadInteractionService(db: Db) {
         }
       }
 
-      if (data.kind === "request_confirmation") {
-        await assertRequestConfirmationTargetIsCurrent(db, {
-          companyId: issue.companyId,
-          issueId: issue.id,
-          target: data.payload.target ?? null,
-        });
-
-        const pendingRows = await listPendingRequestConfirmationRows(db, {
-          companyId: issue.companyId,
-          issueId: issue.id,
-        });
-        const stillPending: IssueThreadInteractionRow[] = [];
-        for (const row of pendingRows) {
-          const expired = await expireStaleRequestConfirmationTarget(db, {
-            row,
-            actor,
-          });
-          if (!expired) stillPending.push(row);
-        }
-        if (stillPending.length > 0) {
-          const canonical = stillPending[stillPending.length - 1];
-          throw conflict("Issue already has a canonical pending request_confirmation interaction", {
-            issueId: issue.id,
-            interactionId: canonical?.id ?? null,
-            interactionKind: "request_confirmation",
-            interactionStatus: "pending",
-            pendingInteractionCount: stillPending.length,
-            unblockOwnerType: "user",
-            unblockAction: "resolve_pending_request_confirmation",
-          });
-        }
-      }
-
       let created: IssueThreadInteractionRow;
       try {
-        [created] = await db
-          .insert(issueThreadInteractions)
-          .values({
-            companyId: issue.companyId,
-            issueId: issue.id,
-            kind: data.kind,
-            status: "pending",
-            continuationPolicy: data.continuationPolicy,
-            idempotencyKey: data.idempotencyKey ?? null,
-            sourceCommentId: data.sourceCommentId ?? null,
-            sourceRunId: data.sourceRunId ?? null,
-            title: data.title ?? null,
-            summary: data.summary ?? null,
-            createdByAgentId: actor.agentId ?? null,
-            createdByUserId: actor.userId ?? null,
-            payload: data.payload,
-          })
-          .returning();
+        created = await db.transaction(async (tx) => {
+          if (data.kind === "request_confirmation") {
+            await lockIssueRowForRequestConfirmationCreate(tx, {
+              companyId: issue.companyId,
+              issueId: issue.id,
+            });
+
+            await assertRequestConfirmationTargetIsCurrent(tx, {
+              companyId: issue.companyId,
+              issueId: issue.id,
+              target: data.payload.target ?? null,
+            });
+
+            const pendingRows = await listPendingRequestConfirmationRows(tx, {
+              companyId: issue.companyId,
+              issueId: issue.id,
+            });
+            const stillPending: IssueThreadInteractionRow[] = [];
+            for (const row of pendingRows) {
+              const expired = await expireStaleRequestConfirmationTarget(tx, {
+                row,
+                actor,
+              });
+              if (!expired) stillPending.push(row);
+            }
+            if (stillPending.length > 0) {
+              const canonical = stillPending[0];
+              throw conflict("Issue already has a canonical pending request_confirmation interaction", {
+                issueId: issue.id,
+                interactionId: canonical?.id ?? null,
+                interactionKind: "request_confirmation",
+                interactionStatus: "pending",
+                pendingInteractionCount: stillPending.length,
+                unblockOwnerType: "user",
+                unblockAction: "resolve_pending_request_confirmation",
+              });
+            }
+          }
+
+          const [inserted] = await tx
+            .insert(issueThreadInteractions)
+            .values({
+              companyId: issue.companyId,
+              issueId: issue.id,
+              kind: data.kind,
+              status: "pending",
+              continuationPolicy: data.continuationPolicy,
+              idempotencyKey: data.idempotencyKey ?? null,
+              sourceCommentId: data.sourceCommentId ?? null,
+              sourceRunId: data.sourceRunId ?? null,
+              title: data.title ?? null,
+              summary: data.summary ?? null,
+              createdByAgentId: actor.agentId ?? null,
+              createdByUserId: actor.userId ?? null,
+              payload: data.payload,
+            })
+            .returning();
+          return inserted;
+        });
       } catch (error) {
         if (!data.idempotencyKey || !isIssueThreadInteractionIdempotencyConflict(error)) {
           throw error;

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -367,6 +367,22 @@ async function assertRequestConfirmationTargetIsCurrent(db: Db | any, args: {
   }
 }
 
+async function listPendingRequestConfirmationRows(
+  db: Db | any,
+  args: { companyId: string; issueId: string },
+) {
+  return db
+    .select()
+    .from(issueThreadInteractions)
+    .where(and(
+      eq(issueThreadInteractions.companyId, args.companyId),
+      eq(issueThreadInteractions.issueId, args.issueId),
+      eq(issueThreadInteractions.kind, "request_confirmation"),
+      eq(issueThreadInteractions.status, "pending"),
+    ))
+    .orderBy(asc(issueThreadInteractions.createdAt), asc(issueThreadInteractions.id));
+}
+
 async function expireStaleRequestConfirmationTarget(db: Db | any, args: {
   row: IssueThreadInteractionRow;
   actor: InteractionActor;
@@ -679,6 +695,31 @@ export function issueThreadInteractionService(db: Db) {
           issueId: issue.id,
           target: data.payload.target ?? null,
         });
+
+        const pendingRows = await listPendingRequestConfirmationRows(db, {
+          companyId: issue.companyId,
+          issueId: issue.id,
+        });
+        const stillPending: IssueThreadInteractionRow[] = [];
+        for (const row of pendingRows) {
+          const expired = await expireStaleRequestConfirmationTarget(db, {
+            row,
+            actor,
+          });
+          if (!expired) stillPending.push(row);
+        }
+        if (stillPending.length > 0) {
+          const canonical = stillPending[stillPending.length - 1];
+          throw conflict("Issue already has a canonical pending request_confirmation interaction", {
+            issueId: issue.id,
+            interactionId: canonical?.id ?? null,
+            interactionKind: "request_confirmation",
+            interactionStatus: "pending",
+            pendingInteractionCount: stillPending.length,
+            unblockOwnerType: "user",
+            unblockAction: "resolve_pending_request_confirmation",
+          });
+        }
       }
 
       let created: IssueThreadInteractionRow;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -29,6 +29,7 @@ import {
 } from "@paperclipai/db";
 import type {
   IssueCommentAuthorType,
+  IssueCanonicalUnblockTuple,
   IssueCommentMetadata,
   IssueCommentPresentation,
   IssueBlockerAttention,
@@ -45,6 +46,7 @@ import {
   issueCommentPresentationSchema,
   isUuidLike,
   normalizeIssueIdentifier as normalizeIssueReferenceIdentifier,
+  requestConfirmationPayloadSchema,
 } from "@paperclipai/shared";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import { parseObject } from "../adapters/utils.js";
@@ -950,6 +952,76 @@ function summarizeIssueRelationRow(row: IssueRelationSummaryRow): IssueRelationI
     assigneeAgentId: row.assigneeAgentId,
     assigneeUserId: row.assigneeUserId,
   };
+}
+
+async function canonicalUnblockTuplesByIssueId(
+  companyId: string,
+  issueIds: string[],
+  dbOrTx: DbReader = db,
+): Promise<Map<string, IssueCanonicalUnblockTuple>> {
+  const uniqueIssueIds = [...new Set(issueIds.filter(Boolean))];
+  const tuplesByIssueId = new Map<string, IssueCanonicalUnblockTuple>();
+  if (uniqueIssueIds.length === 0) return tuplesByIssueId;
+
+  const rows = await dbOrTx
+    .select({
+      issueId: issueThreadInteractions.issueId,
+      interactionId: issueThreadInteractions.id,
+      continuationPolicy: issueThreadInteractions.continuationPolicy,
+      payload: issueThreadInteractions.payload,
+      createdAt: issueThreadInteractions.createdAt,
+    })
+    .from(issueThreadInteractions)
+    .where(
+      and(
+        eq(issueThreadInteractions.companyId, companyId),
+        eq(issueThreadInteractions.kind, "request_confirmation"),
+        eq(issueThreadInteractions.status, "pending"),
+        inArray(issueThreadInteractions.issueId, uniqueIssueIds),
+      ),
+    )
+    .orderBy(desc(issueThreadInteractions.createdAt), desc(issueThreadInteractions.id));
+
+  const grouped = new Map<string, typeof rows>();
+  for (const row of rows) {
+    const list = grouped.get(row.issueId) ?? [];
+    list.push(row);
+    grouped.set(row.issueId, list);
+  }
+
+  for (const [issueId, interactionRows] of grouped.entries()) {
+    const canonical = interactionRows[0];
+    if (!canonical) continue;
+    const payload = requestConfirmationPayloadSchema.safeParse(canonical.payload);
+    const target = payload.success ? payload.data.target ?? null : null;
+    tuplesByIssueId.set(issueId, {
+      kind: "request_confirmation",
+      interactionId: canonical.interactionId,
+      interactionStatus: "pending",
+      continuationPolicy: canonical.continuationPolicy as IssueCanonicalUnblockTuple["continuationPolicy"],
+      unblockOwnerType: "user",
+      unblockAction: "resolve_pending_request_confirmation",
+      pendingInteractionCount: interactionRows.length,
+      targetIssueId: target?.type === "issue_document" ? (target.issueId ?? issueId) : null,
+      targetDocumentId: target?.type === "issue_document" ? target.documentId : null,
+      targetDocumentKey: target?.type === "issue_document" ? target.key : null,
+      targetRevisionId: target?.type === "issue_document" ? target.revisionId : null,
+    });
+  }
+
+  return tuplesByIssueId;
+}
+
+function attachCanonicalUnblockTuples(
+  summaries: IssueRelationIssueSummary[],
+  tuplesByIssueId: Map<string, IssueCanonicalUnblockTuple>,
+) {
+  for (const summary of summaries) {
+    summary.canonicalUnblockTuple = tuplesByIssueId.get(summary.id) ?? null;
+    if (summary.terminalBlockers && summary.terminalBlockers.length > 0) {
+      attachCanonicalUnblockTuples(summary.terminalBlockers, tuplesByIssueId);
+    }
+  }
 }
 
 async function terminalExplicitBlockersByRoot(
@@ -2187,9 +2259,14 @@ export function issueService(db: Db) {
       empty.get(row.currentIssueId)?.blocks.push(summarizeIssueRelationRow(row));
     }
 
-    const terminalByRoot = await terminalExplicitBlockersByRoot(
+    const directBlockedBy = [...empty.values()].flatMap((relations) => relations.blockedBy);
+    const terminalByRoot = await terminalExplicitBlockersByRoot(companyId, directBlockedBy, dbOrTx);
+    const tuplesByIssueId = await canonicalUnblockTuplesByIssueId(
       companyId,
-      [...empty.values()].flatMap((relations) => relations.blockedBy),
+      [
+        ...directBlockedBy.map((relation) => relation.id),
+        ...[...terminalByRoot.values()].flatMap((relations) => relations.map((relation) => relation.id)),
+      ],
       dbOrTx,
     );
 
@@ -2201,6 +2278,7 @@ export function issueService(db: Db) {
           blocker.terminalBlockers = terminalBlockers;
         }
       }
+      attachCanonicalUnblockTuples(relations.blockedBy, tuplesByIssueId);
       relations.blocks.sort((a, b) => a.title.localeCompare(b.title));
     }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -957,7 +957,7 @@ function summarizeIssueRelationRow(row: IssueRelationSummaryRow): IssueRelationI
 async function canonicalUnblockTuplesByIssueId(
   companyId: string,
   issueIds: string[],
-  dbOrTx: DbReader = db,
+  dbOrTx: DbReader,
 ): Promise<Map<string, IssueCanonicalUnblockTuple>> {
   const uniqueIssueIds = [...new Set(issueIds.filter(Boolean))];
   const tuplesByIssueId = new Map<string, IssueCanonicalUnblockTuple>();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -980,7 +980,7 @@ async function canonicalUnblockTuplesByIssueId(
         inArray(issueThreadInteractions.issueId, uniqueIssueIds),
       ),
     )
-    .orderBy(desc(issueThreadInteractions.createdAt), desc(issueThreadInteractions.id));
+    .orderBy(asc(issueThreadInteractions.createdAt), asc(issueThreadInteractions.id));
 
   const grouped = new Map<string, typeof rows>();
   for (const row of rows) {

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -119,7 +119,28 @@ The response also includes `blockedBy` and `blocks` arrays showing first-class d
   "projectId": "proj-1",
   "goalId": null,
   "blockedBy": [
-    { "id": "issue-80", "identifier": "PAP-80", "title": "Design auth schema", "status": "in_progress", "priority": "high", "assigneeAgentId": "agent-55", "assigneeUserId": null }
+    {
+      "id": "issue-80",
+      "identifier": "PAP-80",
+      "title": "Design auth schema",
+      "status": "in_review",
+      "priority": "high",
+      "assigneeAgentId": null,
+      "assigneeUserId": "local-board",
+      "canonicalUnblockTuple": {
+        "kind": "request_confirmation",
+        "interactionId": "interaction-123",
+        "interactionStatus": "pending",
+        "continuationPolicy": "wake_assignee",
+        "unblockOwnerType": "user",
+        "unblockAction": "resolve_pending_request_confirmation",
+        "pendingInteractionCount": 1,
+        "targetIssueId": "issue-80",
+        "targetDocumentId": "document-1",
+        "targetDocumentKey": "plan",
+        "targetRevisionId": "revision-7"
+      }
+    }
   ],
   "blocks": [],
   "project": {
@@ -682,9 +703,11 @@ Rules:
 - `continuationPolicy: "wake_assignee"` wakes the assignee only after a `request_confirmation` is accepted.
 - Rejection does not wake the assignee by default. The board/user can add a normal comment when revisions are needed.
 - Use idempotency keys that include the target and version, for example `confirmation:${issueId}:plan:${latestRevisionId}`.
+- Only one pending `request_confirmation` may exist on an issue at a time. A second create attempt returns `409 Conflict` with the canonical pending interaction id and unblock tuple in the error details.
 - Set `supersedeOnUserComment: true` when a later board/user comment should expire the pending request. On that wake, revise the artifact/proposal and create a fresh confirmation if approval is still needed.
 - A pending interaction is an explicit waiting path. Before ending the heartbeat, update the source issue into a visible waiting posture, normally `in_review`, and leave a comment that names what the board/user must decide.
 - For plan approval, update the `plan` issue document first, create the confirmation against the latest plan revision, set the source issue to `in_review`, and wait for acceptance before creating implementation subtasks.
+- When another issue is blocked by a confirmation-gated issue, `GET /api/issues/:issueId` and `GET /api/issues/:issueId/heartbeat-context` surface the blocker's canonical unblock path on `blockedBy[].canonicalUnblockTuple`.
 
 ### Checking approval status
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Issue-thread interactions and blocker relationships are part of the control plane that keeps work moving through approvals and reviews.
> - `request_confirmation` is the structured waiting path for board/user yes-no decisions, especially plan approvals.
> - A single issue could still accumulate multiple pending confirmations, which made the unblock path ambiguous and allowed silent deadlocks in blocked parent/child trees.
> - Blocked issue summaries also did not expose one machine-visible confirmation tuple that a caller could use as the canonical unblock path.
> - This pull request makes pending confirmations single-canonical per issue, expires stale document-target confirmations before re-create, and exposes a canonical unblock tuple on blocker summaries.
> - The benefit is that confirmation-gated waits stay auditable while agents and tooling see one deterministic unblock path instead of multiple equally-pending cards.

## What Changed

- Rejected a second pending `request_confirmation` on the same issue with a `409 Conflict` that includes the canonical pending interaction id and unblock tuple details.
- Expired stale document-target confirmations before the duplicate check so a fresh request can replace an out-of-date pending card without hiding history.
- Added `canonicalUnblockTuple` to issue blocker summaries and populated it from the canonical pending confirmation on the blocking issue.
- Surfaced the new unblock tuple contract through issue relation summaries, heartbeat-context route coverage, and the Paperclip API reference.
- Added focused backend tests for duplicate pending confirmations and blocker-summary exposure.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-thread-interactions-service.test.ts server/src/__tests__/issues-service.test.ts server/src/__tests__/issues-goal-context-routes.test.ts`
- Confirm the new service test rejects a second pending confirmation with `409` details naming the canonical interaction.
- Confirm the blocker summary tests show `blockedBy[].canonicalUnblockTuple` for confirmation-gated blockers.

## Risks

- Low risk. The main behavior change is stricter creation semantics for pending `request_confirmation` interactions; any caller that relied on opening multiple pending confirmations on one issue will now get an explicit `409` and must resolve the canonical one first.

## Model Used

- OpenAI GPT-5 Codex via Codex local adapter in high-reasoning coding mode with tool use, shell execution, and patch application.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
