### PR TITLE
feat: auto-inject text attachment content in heartbeat-context + bridge allowlist

### DIFF
--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -29,7 +29,7 @@ export interface SandboxCallbackBridgeRouteRule {
 // still enforces actor-level permissions on top of this allowlist; the list
 // exists to bound the surface area a compromised CLI could reach via the
 // reverse bridge. Keep this in sync with the Paperclip skill in
-// `skills/paperclip/SKILL.md` and `references/api-reference.md`.
+// `skills/paperclip/SKILL.md` and `skills/paperclip/references/api-reference.md`.
 export const DEFAULT_SANDBOX_CALLBACK_BRIDGE_ROUTE_ALLOWLIST: readonly SandboxCallbackBridgeRouteRule[] = [
   // Identity, inbox, agent self-management
   { method: "GET", path: /^\/api\/agents\/me$/ },
@@ -95,6 +95,10 @@ export const DEFAULT_SANDBOX_CALLBACK_BRIDGE_ROUTE_ALLOWLIST: readonly SandboxCa
   { method: "POST", path: /^\/api\/routines\/[^/]+\/triggers$/ },
   { method: "PATCH", path: /^\/api\/routine-triggers\/[^/]+$/ },
   { method: "DELETE", path: /^\/api\/routine-triggers\/[^/]+$/ },
+
+  // Attachments — list metadata and fetch content
+  { method: "GET", path: /^\/api\/issues\/[^/]+\/attachments$/ },
+  { method: "GET", path: /^\/api\/attachments\/[^/]+\/content$/ },
 ] as const;
 
 export const DEFAULT_SANDBOX_CALLBACK_BRIDGE_HEADER_ALLOWLIST = [

--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -29,7 +29,7 @@ export interface SandboxCallbackBridgeRouteRule {
 // still enforces actor-level permissions on top of this allowlist; the list
 // exists to bound the surface area a compromised CLI could reach via the
 // reverse bridge. Keep this in sync with the Paperclip skill in
-// `skills/paperclip/SKILL.md` and `references/api-reference.md`.
+// `skills/paperclip/SKILL.md` and `skills/paperclip/references/api-reference.md`.
 export const DEFAULT_SANDBOX_CALLBACK_BRIDGE_ROUTE_ALLOWLIST: readonly SandboxCallbackBridgeRouteRule[] = [
   // Identity, inbox, agent self-management
   { method: "GET", path: /^\/api\/agents\/me$/ },
@@ -100,6 +100,10 @@ export const DEFAULT_SANDBOX_CALLBACK_BRIDGE_ROUTE_ALLOWLIST: readonly SandboxCa
   { method: "POST", path: /^\/api\/routines\/[^/]+\/triggers$/ },
   { method: "PATCH", path: /^\/api\/routine-triggers\/[^/]+$/ },
   { method: "DELETE", path: /^\/api\/routine-triggers\/[^/]+$/ },
+
+  // Attachments — list metadata and fetch content
+  { method: "GET", path: /^\/api\/issues\/[^/]+\/attachments$/ },
+  { method: "GET", path: /^\/api\/attachments\/[^/]+\/content$/ },
 ] as const;
 
 export const DEFAULT_SANDBOX_CALLBACK_BRIDGE_HEADER_ALLOWLIST = [

--- a/server/src/__tests__/attachment-types.test.ts
+++ b/server/src/__tests__/attachment-types.test.ts
@@ -8,6 +8,8 @@ import {
   normalizeContentType,
   normalizeUploadAttachmentContentType,
   parseAllowedTypes,
+  readStreamWithByteCap,
+  truncateUtf8ToByteLimit,
 } from "../attachment-types.js";
 
 describe("parseAllowedTypes", () => {
@@ -197,5 +199,56 @@ describe("isInlineAttachmentContentType", () => {
     expect(INLINE_ATTACHMENT_TYPES).not.toContain("text/html");
     expect(isInlineAttachmentContentType("text/html")).toBe(false);
     expect(isInlineAttachmentContentType("application/zip")).toBe(false);
+  });
+});
+
+describe("truncateUtf8ToByteLimit", () => {
+  it("returns the body unchanged when within the byte budget", () => {
+    expect(truncateUtf8ToByteLimit("hello", 64)).toEqual({ body: "hello", truncated: false });
+  });
+
+  it("measures in UTF-8 bytes, not characters", () => {
+    // "€" is 3 UTF-8 bytes; 3 of them = 9 bytes but only 3 characters.
+    const body = "€€€";
+    expect(body.length).toBe(3);
+    const result = truncateUtf8ToByteLimit(body, 4);
+    expect(result.truncated).toBe(true);
+    // Must not split a multi-byte character mid-sequence.
+    expect(result.body).toBe("€");
+    expect(Buffer.byteLength(result.body, "utf-8")).toBeLessThanOrEqual(4);
+    expect(result.body).not.toContain("�");
+  });
+
+  it("does not truncate when the body exactly fills the budget", () => {
+    const body = "€€"; // 6 bytes
+    expect(truncateUtf8ToByteLimit(body, 6)).toEqual({ body, truncated: false });
+  });
+});
+
+describe("readStreamWithByteCap", () => {
+  async function* chunks(...parts: Array<string | Uint8Array>) {
+    for (const p of parts) {
+      yield typeof p === "string" ? Buffer.from(p, "utf-8") : p;
+    }
+  }
+
+  it("returns the concatenated buffer when total size is within the cap", async () => {
+    const result = await readStreamWithByteCap(chunks("ab", "cd"), 64);
+    expect(result.truncated).toBe(false);
+    expect(result.buffer?.toString("utf-8")).toBe("abcd");
+  });
+
+  it("skips inlining (null buffer) when the stream exceeds the cap", async () => {
+    // 8 bytes streamed against a 4-byte cap: the stored object is larger than
+    // its recorded size, so it must not be buffered into memory.
+    const result = await readStreamWithByteCap(chunks("aaaa", "bbbb"), 4);
+    expect(result.truncated).toBe(true);
+    expect(result.buffer).toBeNull();
+  });
+
+  it("accepts a stream exactly at the cap", async () => {
+    const result = await readStreamWithByteCap(chunks("aa", "bb"), 4);
+    expect(result.truncated).toBe(false);
+    expect(result.buffer?.toString("utf-8")).toBe("aabb");
   });
 });

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -484,7 +484,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
           .where(eq(heartbeatRuns.id, firstWake!.id))
           .then((rows) => rows[0] ?? null);
         return run?.status === "running";
-      });
+      }, 15_000);
       expect(firstRunStarted).toBe(true);
       const firstAdapterStarted = await waitForCondition(async () => mockAdapterExecute.mock.calls.length === 1, 30_000);
       expect(firstAdapterStarted).toBe(true);
@@ -523,7 +523,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
           .where(eq(heartbeatRuns.id, firstWake!.id))
           .then((rows) => rows[0] ?? null);
         return run?.status === "succeeded";
-      });
+      }, 15_000);
       expect(firstRunSucceeded).toBe(true);
 
       const secondRunSucceeded = await waitForCondition(async () => {
@@ -533,7 +533,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
           .where(eq(heartbeatRuns.id, secondWake!.id))
           .then((rows) => rows[0] ?? null);
         return run?.status === "succeeded";
-      });
+      }, 15_000);
       expect(secondRunSucceeded).toBe(true);
       expect(mockAdapterExecute.mock.calls.length).toBeGreaterThanOrEqual(2);
     } finally {

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -623,7 +623,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
           .where(eq(heartbeatRuns.id, firstWake!.id))
           .then((rows) => rows[0] ?? null);
         return run?.status === "running";
-      });
+      }, 15_000);
       expect(firstRunStarted).toBe(true);
       const firstAdapterStarted = await waitForCondition(async () => mockAdapterExecute.mock.calls.length === 1, 30_000);
       expect(firstAdapterStarted).toBe(true);
@@ -662,7 +662,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
           .where(eq(heartbeatRuns.id, firstWake!.id))
           .then((rows) => rows[0] ?? null);
         return run?.status === "succeeded";
-      });
+      }, 15_000);
       expect(firstRunSucceeded).toBe(true);
 
       const secondRunSucceeded = await waitForCondition(async () => {
@@ -672,7 +672,7 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
           .where(eq(heartbeatRuns.id, secondWake!.id))
           .then((rows) => rows[0] ?? null);
         return run?.status === "succeeded";
-      }, 10_000);
+      }, 15_000);
       expect(secondRunSucceeded).toBe(true);
       expect(mockAdapterExecute.mock.calls.length).toBeGreaterThanOrEqual(2);
     } finally {

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -30,6 +30,7 @@ const mockGoalService = vi.hoisted(() => ({
 const mockDocumentsService = vi.hoisted(() => ({
   getIssueDocumentPayload: vi.fn(),
   getIssueDocumentByKey: vi.fn(),
+  listIssueDocuments: vi.fn(async () => []),
 }));
 
 const mockExecutionWorkspaceService = vi.hoisted(() => ({
@@ -197,6 +198,7 @@ describe.sequential("issue goal context routes", () => {
     mockIssueService.listAttachments.mockResolvedValue([]);
     mockDocumentsService.getIssueDocumentPayload.mockResolvedValue({});
     mockDocumentsService.getIssueDocumentByKey.mockResolvedValue(null);
+    mockDocumentsService.listIssueDocuments.mockResolvedValue([]);
     mockExecutionWorkspaceService.getById.mockResolvedValue(null);
     mockDb.select.mockReturnValue({
       from: vi.fn(() => ({

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -31,6 +31,7 @@ const mockGoalService = vi.hoisted(() => ({
 const mockDocumentsService = vi.hoisted(() => ({
   getIssueDocumentPayload: vi.fn(),
   getIssueDocumentByKey: vi.fn(),
+  listIssueDocuments: vi.fn(async () => []),
 }));
 
 const mockExecutionWorkspaceService = vi.hoisted(() => ({
@@ -215,6 +216,7 @@ describe.sequential("issue goal context routes", () => {
     mockIssueService.listAttachments.mockResolvedValue([]);
     mockDocumentsService.getIssueDocumentPayload.mockResolvedValue({});
     mockDocumentsService.getIssueDocumentByKey.mockResolvedValue(null);
+    mockDocumentsService.listIssueDocuments.mockResolvedValue([]);
     mockExecutionWorkspaceService.getById.mockResolvedValue(null);
     const emptyQuery: any = {};
     emptyQuery.from = vi.fn(() => emptyQuery);

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -444,6 +444,10 @@ describe.sequential("issue goal context routes", () => {
     );
     expect(mockGoalService.getDefaultCompanyGoal).not.toHaveBeenCalled();
     expect(res.body.attachments).toEqual([]);
+    expect(res.body.documents).toEqual([]);
+    expect(mockDocumentsService.listIssueDocuments).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+    );
   });
 
   it("preserves direct continuation summary lookup in GET /issues/:id/heartbeat-context", async () => {

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -97,6 +97,10 @@ export function isAllowedContentType(contentType: string): boolean {
 export const MAX_ATTACHMENT_BYTES =
   Number(process.env.PAPERCLIP_ATTACHMENT_MAX_BYTES) || 10 * 1024 * 1024;
 
+/** Maximum byte size of a single text attachment that will be inlined in heartbeat-context. */
+export const ATTACHMENT_INLINE_MAX_BYTES =
+  Number(process.env.PAPERCLIP_ATTACHMENT_INLINE_MAX_BYTES) || 65_536;
+
 export function normalizeIssueAttachmentMaxBytes(value: number | null | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return Math.min(DEFAULT_COMPANY_ATTACHMENT_MAX_BYTES, MAX_ATTACHMENT_BYTES);

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -14,6 +14,7 @@
  *   - Exact types:   "application/pdf"
  *   - Wildcards:     "image/*"  or  "application/vnd.openxmlformats-officedocument.*"
  */
+import { StringDecoder } from "node:string_decoder";
 import {
   DEFAULT_COMPANY_ATTACHMENT_MAX_BYTES,
   MAX_COMPANY_ATTACHMENT_MAX_BYTES,
@@ -155,6 +156,59 @@ export const ATTACHMENT_INLINE_MAX_BYTES =
   Number.isFinite(parsedAttachmentInlineMaxBytes) && parsedAttachmentInlineMaxBytes >= 0
     ? Math.floor(parsedAttachmentInlineMaxBytes)
     : 65_536;
+
+/**
+ * Truncate a string so its UTF-8 encoding is at most `maxBytes`, without splitting
+ * a multi-byte character mid-sequence. Returns the (possibly shortened) body and a
+ * `truncated` flag. Callers should size limits in bytes (via `Buffer.byteLength` /
+ * `ATTACHMENT_INLINE_MAX_BYTES`) rather than character count, so the payload budget
+ * reflects real transport/memory cost regardless of the alphabet used.
+ */
+export function truncateUtf8ToByteLimit(
+  body: string,
+  maxBytes: number,
+): { body: string; truncated: boolean } {
+  const buf = Buffer.from(body, "utf-8");
+  if (buf.length <= maxBytes) {
+    return { body, truncated: false };
+  }
+  // StringDecoder emits only whole characters and buffers any incomplete trailing
+  // multi-byte sequence, so slicing at an arbitrary byte offset never yields a
+  // U+FFFD replacement character.
+  const decoder = new StringDecoder("utf-8");
+  const truncated = decoder.write(buf.subarray(0, maxBytes));
+  return { body: truncated, truncated: true };
+}
+
+/**
+ * Read an object stream into memory with a hard runtime byte cap. The recorded
+ * `byteSize` of a stored object is only metadata; the backing object can be larger
+ * (metadata drift, tampering, or a write racing this read — a TOCTOU gap). This
+ * guard bounds how much is ever buffered: once the accumulated bytes exceed
+ * `maxBytes` the read stops and `buffer` is `null` so the caller skips inlining
+ * instead of buffering an unbounded blob.
+ */
+export async function readStreamWithByteCap(
+  stream: AsyncIterable<Buffer | Uint8Array | string>,
+  maxBytes: number,
+): Promise<{ buffer: Buffer | null; truncated: boolean }> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const buf =
+      typeof chunk === "string"
+        ? Buffer.from(chunk, "utf-8")
+        : Buffer.isBuffer(chunk)
+          ? chunk
+          : Buffer.from(chunk);
+    total += buf.length;
+    if (total > maxBytes) {
+      return { buffer: null, truncated: true };
+    }
+    chunks.push(buf);
+  }
+  return { buffer: Buffer.concat(chunks), truncated: false };
+}
 
 export function normalizeIssueAttachmentMaxBytes(value: number | null | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -150,8 +150,11 @@ export const MAX_ATTACHMENT_BYTES =
   Number(process.env.PAPERCLIP_ATTACHMENT_MAX_BYTES) || 10 * 1024 * 1024;
 
 /** Maximum byte size of a single text attachment that will be inlined in heartbeat-context. */
+const parsedAttachmentInlineMaxBytes = Number(process.env.PAPERCLIP_ATTACHMENT_INLINE_MAX_BYTES);
 export const ATTACHMENT_INLINE_MAX_BYTES =
-  Number(process.env.PAPERCLIP_ATTACHMENT_INLINE_MAX_BYTES) || 65_536;
+  Number.isFinite(parsedAttachmentInlineMaxBytes) && parsedAttachmentInlineMaxBytes >= 0
+    ? Math.floor(parsedAttachmentInlineMaxBytes)
+    : 65_536;
 
 export function normalizeIssueAttachmentMaxBytes(value: number | null | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -149,6 +149,10 @@ export function isAllowedContentType(contentType: string): boolean {
 export const MAX_ATTACHMENT_BYTES =
   Number(process.env.PAPERCLIP_ATTACHMENT_MAX_BYTES) || 10 * 1024 * 1024;
 
+/** Maximum byte size of a single text attachment that will be inlined in heartbeat-context. */
+export const ATTACHMENT_INLINE_MAX_BYTES =
+  Number(process.env.PAPERCLIP_ATTACHMENT_INLINE_MAX_BYTES) || 65_536;
+
 export function normalizeIssueAttachmentMaxBytes(value: number | null | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return Math.min(DEFAULT_COMPANY_ATTACHMENT_MAX_BYTES, MAX_ATTACHMENT_BYTES);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1722,13 +1722,31 @@ export function issueRoutes(
         wakeComment && wakeComment.issueId === issue.id
           ? wakeComment
           : null,
-      attachments: attachments.map((a) => ({
-        id: a.id,
-        filename: a.originalFilename,
-        contentType: a.contentType,
-        byteSize: a.byteSize,
-        contentPath: withContentPath(a).contentPath,
-        createdAt: a.createdAt,
+      attachments: await Promise.all(attachments.map(async (a) => {
+        const isInlineable =
+          a.contentType === "text/plain" ||
+          a.contentType === "text/markdown" ||
+          a.contentType === "application/json" ||
+          a.contentType === "text/csv";
+        const isSmall = (a.byteSize ?? 0) <= 65_536;
+        let inlineContent: string | null = null;
+        if (isInlineable && isSmall) {
+          const obj = await storage.getObject(a.companyId, a.objectKey);
+          const chunks: Buffer[] = [];
+          for await (const chunk of obj.stream) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+          }
+          inlineContent = Buffer.concat(chunks).toString("utf-8");
+        }
+        return {
+          id: a.id,
+          filename: a.originalFilename,
+          contentType: a.contentType,
+          byteSize: a.byteSize,
+          contentPath: withContentPath(a).contentPath,
+          createdAt: a.createdAt,
+          ...(inlineContent !== null ? { inlineContent } : {}),
+        };
       })),
       continuationSummary: continuationSummary
         ? {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1643,6 +1643,7 @@ export function issueRoutes(
       scheduledRetry,
       attachments,
       continuationSummary,
+      userDocuments,
       currentExecutionWorkspace,
       activeRecoveryAction,
     ] =
@@ -1657,6 +1658,7 @@ export function issueRoutes(
         svc.getCurrentScheduledRetry(issue.id),
         svc.listAttachments(issue.id),
         documentsSvc.getIssueDocumentByKey(issue.id, ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY),
+        documentsSvc.listIssueDocuments(issue.id),
         currentExecutionWorkspacePromise,
         recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id),
       ]);
@@ -1777,6 +1779,15 @@ export function issueRoutes(
             updatedAt: continuationSummary.updatedAt,
           }
         : null,
+      documents: userDocuments.map((doc) => ({
+        key: doc.key,
+        title: doc.title,
+        format: doc.format,
+        body: typeof doc.body === "string" && doc.body.length <= ATTACHMENT_INLINE_MAX_BYTES ? doc.body : null,
+        latestRevisionId: doc.latestRevisionId,
+        latestRevisionNumber: doc.latestRevisionNumber,
+        updatedAt: doc.updatedAt,
+      })),
       currentExecutionWorkspace,
     });
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1723,36 +1723,50 @@ export function issueRoutes(
         wakeComment && wakeComment.issueId === issue.id
           ? wakeComment
           : null,
-      attachments: await Promise.all(attachments.map(async (a) => {
-        const isInlineable =
-          a.contentType === "text/plain" ||
-          a.contentType === "text/markdown" ||
-          a.contentType === "application/json" ||
-          a.contentType === "text/csv";
-        const isSmall = a.byteSize != null && a.byteSize <= ATTACHMENT_INLINE_MAX_BYTES;
-        let inlineContent: string | null = null;
-        if (isInlineable && isSmall) {
-          try {
-            const obj = await storage.getObject(a.companyId, a.objectKey);
-            const chunks: Buffer[] = [];
-            for await (const chunk of obj.stream) {
-              chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
-            }
-            inlineContent = Buffer.concat(chunks).toString("utf-8");
-          } catch {
-            // storage error — omit inlineContent rather than failing the whole response
+      attachments: await (async () => {
+        // Pre-select which attachments to inline using an aggregate byte budget.
+        // Attachments are processed in createdAt order; once the running total
+        // would exceed ATTACHMENT_INLINE_MAX_BYTES the remaining ones are skipped
+        // (they still appear in the response with contentPath for the agent to fetch).
+        const inlineIds = new Set<string>();
+        let inlineBudgetRemaining = ATTACHMENT_INLINE_MAX_BYTES;
+        for (const a of attachments) {
+          const isInlineable =
+            a.contentType === "text/plain" ||
+            a.contentType === "text/markdown" ||
+            a.contentType === "application/json" ||
+            a.contentType === "text/csv";
+          const size = a.byteSize ?? null;
+          if (isInlineable && size != null && size <= inlineBudgetRemaining) {
+            inlineIds.add(a.id);
+            inlineBudgetRemaining -= size;
           }
         }
-        return {
-          id: a.id,
-          filename: a.originalFilename,
-          contentType: a.contentType,
-          byteSize: a.byteSize,
-          contentPath: withContentPath(a).contentPath,
-          createdAt: a.createdAt,
-          ...(inlineContent !== null ? { inlineContent } : {}),
-        };
-      })),
+        return Promise.all(attachments.map(async (a) => {
+          let inlineContent: string | null = null;
+          if (inlineIds.has(a.id)) {
+            try {
+              const obj = await storage.getObject(a.companyId, a.objectKey);
+              const chunks: Buffer[] = [];
+              for await (const chunk of obj.stream) {
+                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+              }
+              inlineContent = Buffer.concat(chunks).toString("utf-8");
+            } catch {
+              // storage error — omit inlineContent rather than failing the whole response
+            }
+          }
+          return {
+            id: a.id,
+            filename: a.originalFilename,
+            contentType: a.contentType,
+            byteSize: a.byteSize,
+            contentPath: withContentPath(a).contentPath,
+            createdAt: a.createdAt,
+            ...(inlineContent !== null ? { inlineContent } : {}),
+          };
+        }));
+      })(),
       continuationSummary: continuationSummary
         ? {
             key: continuationSummary.key,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -88,6 +88,7 @@ import {
   normalizeIssueAttachmentMaxBytes,
   normalizeContentType,
   SVG_CONTENT_TYPE,
+  ATTACHMENT_INLINE_MAX_BYTES,
 } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
 import { assertEnvironmentSelectionForCompany } from "./environment-selection.js";
@@ -1728,15 +1729,19 @@ export function issueRoutes(
           a.contentType === "text/markdown" ||
           a.contentType === "application/json" ||
           a.contentType === "text/csv";
-        const isSmall = (a.byteSize ?? 0) <= 65_536;
+        const isSmall = a.byteSize != null && a.byteSize <= ATTACHMENT_INLINE_MAX_BYTES;
         let inlineContent: string | null = null;
         if (isInlineable && isSmall) {
-          const obj = await storage.getObject(a.companyId, a.objectKey);
-          const chunks: Buffer[] = [];
-          for await (const chunk of obj.stream) {
-            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+          try {
+            const obj = await storage.getObject(a.companyId, a.objectKey);
+            const chunks: Buffer[] = [];
+            for await (const chunk of obj.stream) {
+              chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+            }
+            inlineContent = Buffer.concat(chunks).toString("utf-8");
+          } catch {
+            // storage error — omit inlineContent rather than failing the whole response
           }
-          inlineContent = Buffer.concat(chunks).toString("utf-8");
         }
         return {
           id: a.id,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -138,6 +138,7 @@ import {
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
 import {
   GENERIC_ATTACHMENT_CONTENT_TYPES,
+  isAllowedContentType,
   isInlineAttachmentContentType,
   normalizeIssueAttachmentMaxBytes,
   normalizeContentType,
@@ -5195,11 +5196,17 @@ export function issueRoutes(
         const inlineIds = new Set<string>();
         let inlineBudgetRemaining = ATTACHMENT_INLINE_MAX_BYTES;
         for (const a of attachments) {
-          const isInlineable =
+          // Only inline UTF-8-stringifiable text types, and only when the type
+          // is still permitted by the upstream content-type allowlist
+          // (`PAPERCLIP_ALLOWED_ATTACHMENT_TYPES`). This slots on top of the
+          // allowlist rather than bypassing it: an admin who narrows the
+          // allowlist also narrows what gets inlined here.
+          const isTextInlineType =
             a.contentType === "text/plain" ||
             a.contentType === "text/markdown" ||
             a.contentType === "application/json" ||
             a.contentType === "text/csv";
+          const isInlineable = isTextInlineType && isAllowedContentType(a.contentType);
           const size = a.byteSize ?? null;
           if (isInlineable && size != null && size <= inlineBudgetRemaining) {
             inlineIds.add(a.id);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5184,13 +5184,31 @@ export function issueRoutes(
         : null,
       commentCursor,
       wakeComment: safeWakeComment,
-      attachments: attachments.map((a) => ({
-        id: a.id,
-        filename: a.originalFilename,
-        contentType: a.contentType,
-        byteSize: a.byteSize,
-        contentPath: withContentPath(a).contentPath,
-        createdAt: a.createdAt,
+      attachments: await Promise.all(attachments.map(async (a) => {
+        const isInlineable =
+          a.contentType === "text/plain" ||
+          a.contentType === "text/markdown" ||
+          a.contentType === "application/json" ||
+          a.contentType === "text/csv";
+        const isSmall = (a.byteSize ?? 0) <= 65_536;
+        let inlineContent: string | null = null;
+        if (isInlineable && isSmall) {
+          const obj = await storage.getObject(a.companyId, a.objectKey);
+          const chunks: Buffer[] = [];
+          for await (const chunk of obj.stream) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+          }
+          inlineContent = Buffer.concat(chunks).toString("utf-8");
+        }
+        return {
+          id: a.id,
+          filename: a.originalFilename,
+          contentType: a.contentType,
+          byteSize: a.byteSize,
+          contentPath: withContentPath(a).contentPath,
+          createdAt: a.createdAt,
+          ...(inlineContent !== null ? { inlineContent } : {}),
+        };
       })),
       continuationSummary: safeContinuationSummary
         ? {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -145,6 +145,7 @@ import {
   normalizeUploadAttachmentContentType,
   SVG_CONTENT_TYPE,
   ATTACHMENT_INLINE_MAX_BYTES,
+  readStreamWithByteCap,
 } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
 import {
@@ -5218,11 +5219,22 @@ export function issueRoutes(
           if (inlineIds.has(a.id)) {
             try {
               const obj = await storage.getObject(a.companyId, a.objectKey);
-              const chunks: Buffer[] = [];
-              for await (const chunk of obj.stream) {
-                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+              // Runtime size cap: a.byteSize was only checked against the budget as
+              // metadata. If the stored object is actually larger (metadata drift,
+              // tampering, or a write racing this read — TOCTOU), skip inlining
+              // instead of buffering an unbounded blob into memory.
+              const { buffer, truncated } = await readStreamWithByteCap(
+                obj.stream,
+                ATTACHMENT_INLINE_MAX_BYTES,
+              );
+              if (truncated || buffer === null) {
+                logger.warn(
+                  { issueId: issue.id, attachmentId: a.id, recordedByteSize: a.byteSize },
+                  "skipped inlining attachment: stored object exceeded ATTACHMENT_INLINE_MAX_BYTES at read time",
+                );
+              } else {
+                inlineContent = buffer.toString("utf-8");
               }
-              inlineContent = Buffer.concat(chunks).toString("utf-8");
             } catch (err) {
               logger.warn(
                 { err, issueId: issue.id, attachmentId: a.id },

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -143,6 +143,7 @@ import {
   normalizeContentType,
   normalizeUploadAttachmentContentType,
   SVG_CONTENT_TYPE,
+  ATTACHMENT_INLINE_MAX_BYTES,
 } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
 import {
@@ -5190,15 +5191,19 @@ export function issueRoutes(
           a.contentType === "text/markdown" ||
           a.contentType === "application/json" ||
           a.contentType === "text/csv";
-        const isSmall = (a.byteSize ?? 0) <= 65_536;
+        const isSmall = a.byteSize != null && a.byteSize <= ATTACHMENT_INLINE_MAX_BYTES;
         let inlineContent: string | null = null;
         if (isInlineable && isSmall) {
-          const obj = await storage.getObject(a.companyId, a.objectKey);
-          const chunks: Buffer[] = [];
-          for await (const chunk of obj.stream) {
-            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+          try {
+            const obj = await storage.getObject(a.companyId, a.objectKey);
+            const chunks: Buffer[] = [];
+            for await (const chunk of obj.stream) {
+              chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+            }
+            inlineContent = Buffer.concat(chunks).toString("utf-8");
+          } catch {
+            // storage error — omit inlineContent rather than failing the whole response
           }
-          inlineContent = Buffer.concat(chunks).toString("utf-8");
         }
         return {
           id: a.id,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5084,6 +5084,7 @@ export function issueRoutes(
       scheduledRetry,
       attachments,
       continuationSummary,
+      userDocuments,
       currentExecutionWorkspace,
       activeRecoveryAction,
     ] =
@@ -5098,6 +5099,7 @@ export function issueRoutes(
         svc.getCurrentScheduledRetry(issue.id),
         svc.listAttachments(issue.id),
         documentsSvc.getIssueDocumentByKey(issue.id, ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY),
+        documentsSvc.listIssueDocuments(issue.id),
         currentExecutionWorkspacePromise,
         recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id),
       ]);
@@ -5241,6 +5243,15 @@ export function issueRoutes(
           }
         : null,
       planReviewContext,
+      documents: userDocuments.map((doc) => ({
+        key: doc.key,
+        title: doc.title,
+        format: doc.format,
+        body: typeof doc.body === "string" && doc.body.length <= ATTACHMENT_INLINE_MAX_BYTES ? doc.body : null,
+        latestRevisionId: doc.latestRevisionId,
+        latestRevisionNumber: doc.latestRevisionNumber,
+        updatedAt: doc.updatedAt,
+      })),
       currentExecutionWorkspace: compactIssueExecutionWorkspace(currentExecutionWorkspace),
     });
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5185,36 +5185,50 @@ export function issueRoutes(
         : null,
       commentCursor,
       wakeComment: safeWakeComment,
-      attachments: await Promise.all(attachments.map(async (a) => {
-        const isInlineable =
-          a.contentType === "text/plain" ||
-          a.contentType === "text/markdown" ||
-          a.contentType === "application/json" ||
-          a.contentType === "text/csv";
-        const isSmall = a.byteSize != null && a.byteSize <= ATTACHMENT_INLINE_MAX_BYTES;
-        let inlineContent: string | null = null;
-        if (isInlineable && isSmall) {
-          try {
-            const obj = await storage.getObject(a.companyId, a.objectKey);
-            const chunks: Buffer[] = [];
-            for await (const chunk of obj.stream) {
-              chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
-            }
-            inlineContent = Buffer.concat(chunks).toString("utf-8");
-          } catch {
-            // storage error — omit inlineContent rather than failing the whole response
+      attachments: await (async () => {
+        // Pre-select which attachments to inline using an aggregate byte budget.
+        // Attachments are processed in createdAt order; once the running total
+        // would exceed ATTACHMENT_INLINE_MAX_BYTES the remaining ones are skipped
+        // (they still appear in the response with contentPath for the agent to fetch).
+        const inlineIds = new Set<string>();
+        let inlineBudgetRemaining = ATTACHMENT_INLINE_MAX_BYTES;
+        for (const a of attachments) {
+          const isInlineable =
+            a.contentType === "text/plain" ||
+            a.contentType === "text/markdown" ||
+            a.contentType === "application/json" ||
+            a.contentType === "text/csv";
+          const size = a.byteSize ?? null;
+          if (isInlineable && size != null && size <= inlineBudgetRemaining) {
+            inlineIds.add(a.id);
+            inlineBudgetRemaining -= size;
           }
         }
-        return {
-          id: a.id,
-          filename: a.originalFilename,
-          contentType: a.contentType,
-          byteSize: a.byteSize,
-          contentPath: withContentPath(a).contentPath,
-          createdAt: a.createdAt,
-          ...(inlineContent !== null ? { inlineContent } : {}),
-        };
-      })),
+        return Promise.all(attachments.map(async (a) => {
+          let inlineContent: string | null = null;
+          if (inlineIds.has(a.id)) {
+            try {
+              const obj = await storage.getObject(a.companyId, a.objectKey);
+              const chunks: Buffer[] = [];
+              for await (const chunk of obj.stream) {
+                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
+              }
+              inlineContent = Buffer.concat(chunks).toString("utf-8");
+            } catch {
+              // storage error — omit inlineContent rather than failing the whole response
+            }
+          }
+          return {
+            id: a.id,
+            filename: a.originalFilename,
+            contentType: a.contentType,
+            byteSize: a.byteSize,
+            contentPath: withContentPath(a).contentPath,
+            createdAt: a.createdAt,
+            ...(inlineContent !== null ? { inlineContent } : {}),
+          };
+        }));
+      })(),
       continuationSummary: safeContinuationSummary
         ? {
             key: safeContinuationSummary.key,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5216,8 +5216,11 @@ export function issueRoutes(
                 chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array));
               }
               inlineContent = Buffer.concat(chunks).toString("utf-8");
-            } catch {
-              // storage error — omit inlineContent rather than failing the whole response
+            } catch (err) {
+              logger.warn(
+                { err, issueId: issue.id, attachmentId: a.id },
+                "failed to inline attachment content for heartbeat-context",
+              );
             }
           }
           return {
@@ -5243,15 +5246,22 @@ export function issueRoutes(
           }
         : null,
       planReviewContext,
-      documents: userDocuments.map((doc) => ({
-        key: doc.key,
-        title: doc.title,
-        format: doc.format,
-        body: typeof doc.body === "string" && doc.body.length <= ATTACHMENT_INLINE_MAX_BYTES ? doc.body : null,
-        latestRevisionId: doc.latestRevisionId,
-        latestRevisionNumber: doc.latestRevisionNumber,
-        updatedAt: doc.updatedAt,
-      })),
+      documents: userDocuments.map((doc) => {
+        const safeDoc = redactLowTrust ? redactQuarantinedBodyForHigherTrust(doc) : doc;
+        const bodyFits =
+          typeof safeDoc.body === "string" &&
+          Buffer.byteLength(safeDoc.body, "utf-8") <= ATTACHMENT_INLINE_MAX_BYTES;
+        return {
+          key: safeDoc.key,
+          title: safeDoc.title,
+          format: safeDoc.format,
+          body: bodyFits ? safeDoc.body : null,
+          latestRevisionId: safeDoc.latestRevisionId,
+          latestRevisionNumber: safeDoc.latestRevisionNumber,
+          updatedAt: safeDoc.updatedAt,
+          sourceTrust: safeDoc.sourceTrust ?? null,
+        };
+      }),
       currentExecutionWorkspace: compactIssueExecutionWorkspace(currentExecutionWorkspace),
     });
   });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10,6 +10,7 @@ import {
   ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
   MODEL_PROFILE_KEYS,
   isEnvironmentDriverSupportedForAdapter,
+  isSystemIssueDocumentKey,
   type BillingType,
   type EnvironmentLeaseStatus,
   type ExecutionWorkspace,
@@ -29,6 +30,7 @@ import {
   approvals,
   companySkills as companySkillsTable,
   documentRevisions,
+  documents as documentsTable,
   issueDocuments,
   heartbeatRunEvents,
   heartbeatRuns,
@@ -1928,24 +1930,46 @@ async function buildPaperclipWakePayload(input: {
       : null);
   if (commentIds.length === 0 && Object.keys(executionStage).length === 0 && !issueSummary) return null;
 
-  const attachmentRows = issueId
-    ? await input.db
-        .select({
-          id: issueAttachments.id,
-          filename: assetsTable.originalFilename,
-          contentType: assetsTable.contentType,
-          byteSize: assetsTable.byteSize,
-        })
-        .from(issueAttachments)
-        .innerJoin(assetsTable, eq(assetsTable.id, issueAttachments.assetId))
-        .where(
-          and(
-            eq(issueAttachments.issueId, issueId),
-            eq(issueAttachments.companyId, input.companyId),
-          ),
-        )
-        .orderBy(asc(issueAttachments.createdAt))
-    : [];
+  const [attachmentRows, userDocumentRows] = await Promise.all([
+    issueId
+      ? input.db
+          .select({
+            id: issueAttachments.id,
+            filename: assetsTable.originalFilename,
+            contentType: assetsTable.contentType,
+            byteSize: assetsTable.byteSize,
+          })
+          .from(issueAttachments)
+          .innerJoin(assetsTable, eq(assetsTable.id, issueAttachments.assetId))
+          .where(
+            and(
+              eq(issueAttachments.issueId, issueId),
+              eq(issueAttachments.companyId, input.companyId),
+            ),
+          )
+          .orderBy(asc(issueAttachments.createdAt))
+      : Promise.resolve([]),
+    issueId
+      ? input.db
+          .select({
+            key: issueDocuments.key,
+            title: documentsTable.title,
+            format: documentsTable.format,
+            body: documentsTable.latestBody,
+            updatedAt: documentsTable.updatedAt,
+          })
+          .from(issueDocuments)
+          .innerJoin(documentsTable, eq(documentsTable.id, issueDocuments.documentId))
+          .where(
+            and(
+              eq(issueDocuments.issueId, issueId),
+              eq(issueDocuments.companyId, input.companyId),
+            ),
+          )
+          .orderBy(asc(issueDocuments.key))
+          .then((rows) => rows.filter((r) => !isSystemIssueDocumentKey(r.key)))
+      : Promise.resolve([]),
+  ]);
 
   const commentRows =
     commentIds.length === 0
@@ -2077,6 +2101,14 @@ async function buildPaperclipWakePayload(input: {
       contentType: a.contentType,
       byteSize: a.byteSize,
       contentPath: `/api/attachments/${a.id}/content`,
+    })),
+    documents: userDocumentRows.map((d) => ({
+      key: d.key,
+      title: d.title,
+      format: d.format,
+      body: d.body && d.body.length <= 65_536 ? d.body : null,
+      bodyTruncated: d.body ? d.body.length > 65_536 : false,
+      updatedAt: d.updatedAt instanceof Date ? d.updatedAt.toISOString() : d.updatedAt,
     })),
     commentIds,
     latestCommentId: commentIds[commentIds.length - 1] ?? null,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -33,11 +33,13 @@ import {
   heartbeatRunEvents,
   heartbeatRuns,
   issueApprovals,
+  issueAttachments,
   issueComments,
   issueRelations,
   issueThreadInteractions,
   issues,
   issueWorkProducts,
+  assets as assetsTable,
   projects,
   projectWorkspaces,
   workspaceOperations,
@@ -1926,6 +1928,25 @@ async function buildPaperclipWakePayload(input: {
       : null);
   if (commentIds.length === 0 && Object.keys(executionStage).length === 0 && !issueSummary) return null;
 
+  const attachmentRows = issueId
+    ? await input.db
+        .select({
+          id: issueAttachments.id,
+          filename: assetsTable.originalFilename,
+          contentType: assetsTable.contentType,
+          byteSize: assetsTable.byteSize,
+        })
+        .from(issueAttachments)
+        .innerJoin(assetsTable, eq(assetsTable.id, issueAttachments.assetId))
+        .where(
+          and(
+            eq(issueAttachments.issueId, issueId),
+            eq(issueAttachments.companyId, input.companyId),
+          ),
+        )
+        .orderBy(asc(issueAttachments.createdAt))
+    : [];
+
   const commentRows =
     commentIds.length === 0
       ? []
@@ -2050,6 +2071,13 @@ async function buildPaperclipWakePayload(input: {
           updatedAt: continuationSummary.updatedAt.toISOString(),
         }
       : null,
+    attachments: attachmentRows.map((a) => ({
+      id: a.id,
+      filename: a.filename,
+      contentType: a.contentType,
+      byteSize: a.byteSize,
+      contentPath: `/api/attachments/${a.id}/content`,
+    })),
     commentIds,
     latestCommentId: commentIds[commentIds.length - 1] ?? null,
     comments,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4429,6 +4429,7 @@ export async function buildPaperclipWakePayload(input: {
             and(
               eq(issueAttachments.issueId, issueId),
               eq(issueAttachments.companyId, input.companyId),
+              eq(assetsTable.companyId, input.companyId),
             ),
           )
           .orderBy(asc(issueAttachments.createdAt))
@@ -4448,6 +4449,7 @@ export async function buildPaperclipWakePayload(input: {
             and(
               eq(issueDocuments.issueId, issueId),
               eq(issueDocuments.companyId, input.companyId),
+              eq(documentsTable.companyId, input.companyId),
             ),
           )
           .orderBy(asc(issueDocuments.key))
@@ -4718,7 +4720,7 @@ export async function buildPaperclipWakePayload(input: {
       key: d.key,
       title: d.title,
       format: d.format,
-      body: d.body && d.body.length <= 65_536 ? d.body : null,
+      body: d.body ? d.body.slice(0, 65_536) : null,
       bodyTruncated: d.body ? d.body.length > 65_536 : false,
       updatedAt: d.updatedAt instanceof Date ? d.updatedAt.toISOString() : d.updatedAt,
     })),

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -49,6 +49,7 @@ import {
   heartbeatRunEvents,
   heartbeatRuns,
   issueApprovals,
+  issueAttachments,
   issueComments,
   issuePlanDecompositions,
   issueRecoveryActions,
@@ -56,6 +57,7 @@ import {
   issueThreadInteractions,
   issues,
   issueWorkProducts,
+  assets as assetsTable,
   projects,
   projectWorkspaces,
   routineRevisions,
@@ -4410,6 +4412,25 @@ export async function buildPaperclipWakePayload(input: {
       : null);
   if (commentIds.length === 0 && Object.keys(executionStage).length === 0 && !issueSummary) return null;
 
+  const attachmentRows = issueId
+    ? await input.db
+        .select({
+          id: issueAttachments.id,
+          filename: assetsTable.originalFilename,
+          contentType: assetsTable.contentType,
+          byteSize: assetsTable.byteSize,
+        })
+        .from(issueAttachments)
+        .innerJoin(assetsTable, eq(assetsTable.id, issueAttachments.assetId))
+        .where(
+          and(
+            eq(issueAttachments.issueId, issueId),
+            eq(issueAttachments.companyId, input.companyId),
+          ),
+        )
+        .orderBy(asc(issueAttachments.createdAt))
+    : [];
+
   const commentRows =
     commentIds.length === 0
       ? []
@@ -4662,6 +4683,13 @@ export async function buildPaperclipWakePayload(input: {
           updatedAt: safeContinuationSummary.updatedAt.toISOString(),
         }
       : null,
+    attachments: attachmentRows.map((a) => ({
+      id: a.id,
+      filename: a.filename,
+      contentType: a.contentType,
+      byteSize: a.byteSize,
+      contentPath: `/api/attachments/${a.id}/content`,
+    })),
     commentIds,
     latestCommentId: commentIds[commentIds.length - 1] ?? null,
     comments,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -96,6 +96,7 @@ import { companySkillService } from "./company-skills.js";
 import { budgetService, type BudgetEnforcementScope } from "./budgets.js";
 import { secretService, type MissingRuntimeBinding } from "./secrets.js";
 import { resolveDefaultAgentWorkspaceDir, resolveManagedProjectWorkspaceDir } from "../home-paths.js";
+import { ATTACHMENT_INLINE_MAX_BYTES, truncateUtf8ToByteLimit } from "../attachment-types.js";
 import {
   buildHeartbeatRunIssueComment,
   HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS,
@@ -4716,14 +4717,23 @@ export async function buildPaperclipWakePayload(input: {
       byteSize: a.byteSize,
       contentPath: `/api/attachments/${a.id}/content`,
     })),
-    documents: userDocumentRows.map((d) => ({
-      key: d.key,
-      title: d.title,
-      format: d.format,
-      body: d.body ? d.body.slice(0, 65_536) : null,
-      bodyTruncated: d.body ? d.body.length > 65_536 : false,
-      updatedAt: d.updatedAt instanceof Date ? d.updatedAt.toISOString() : d.updatedAt,
-    })),
+    documents: userDocumentRows.map((d) => {
+      // Truncate on UTF-8 byte length against the configurable inline budget,
+      // matching the heartbeat-context path in routes/issues.ts. A hardcoded
+      // character count under-counts multi-byte text and ignores an operator's
+      // PAPERCLIP_ATTACHMENT_INLINE_MAX_BYTES override.
+      const truncatedBody = d.body
+        ? truncateUtf8ToByteLimit(d.body, ATTACHMENT_INLINE_MAX_BYTES)
+        : null;
+      return {
+        key: d.key,
+        title: d.title,
+        format: d.format,
+        body: truncatedBody ? truncatedBody.body : null,
+        bodyTruncated: truncatedBody ? truncatedBody.truncated : false,
+        updatedAt: d.updatedAt instanceof Date ? d.updatedAt.toISOString() : d.updatedAt,
+      };
+    }),
     commentIds,
     latestCommentId: commentIds[commentIds.length - 1] ?? null,
     comments,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -12,6 +12,7 @@ import {
   PROVIDER_QUOTA_MONITOR_SERVICE_NAME,
   envBindingSchema,
   isEnvironmentDriverSupportedForAdapter,
+  isSystemIssueDocumentKey,
   type BillingType,
   type CostStatus,
   type EnvironmentLeaseStatus,
@@ -44,6 +45,7 @@ import {
   documentAnnotationComments,
   documentAnnotationThreads,
   documentRevisions,
+  documents as documentsTable,
   issueDocuments,
   executionWorkspaces,
   heartbeatRunEvents,
@@ -4412,24 +4414,46 @@ export async function buildPaperclipWakePayload(input: {
       : null);
   if (commentIds.length === 0 && Object.keys(executionStage).length === 0 && !issueSummary) return null;
 
-  const attachmentRows = issueId
-    ? await input.db
-        .select({
-          id: issueAttachments.id,
-          filename: assetsTable.originalFilename,
-          contentType: assetsTable.contentType,
-          byteSize: assetsTable.byteSize,
-        })
-        .from(issueAttachments)
-        .innerJoin(assetsTable, eq(assetsTable.id, issueAttachments.assetId))
-        .where(
-          and(
-            eq(issueAttachments.issueId, issueId),
-            eq(issueAttachments.companyId, input.companyId),
-          ),
-        )
-        .orderBy(asc(issueAttachments.createdAt))
-    : [];
+  const [attachmentRows, userDocumentRows] = await Promise.all([
+    issueId
+      ? input.db
+          .select({
+            id: issueAttachments.id,
+            filename: assetsTable.originalFilename,
+            contentType: assetsTable.contentType,
+            byteSize: assetsTable.byteSize,
+          })
+          .from(issueAttachments)
+          .innerJoin(assetsTable, eq(assetsTable.id, issueAttachments.assetId))
+          .where(
+            and(
+              eq(issueAttachments.issueId, issueId),
+              eq(issueAttachments.companyId, input.companyId),
+            ),
+          )
+          .orderBy(asc(issueAttachments.createdAt))
+      : Promise.resolve([]),
+    issueId
+      ? input.db
+          .select({
+            key: issueDocuments.key,
+            title: documentsTable.title,
+            format: documentsTable.format,
+            body: documentsTable.latestBody,
+            updatedAt: documentsTable.updatedAt,
+          })
+          .from(issueDocuments)
+          .innerJoin(documentsTable, eq(documentsTable.id, issueDocuments.documentId))
+          .where(
+            and(
+              eq(issueDocuments.issueId, issueId),
+              eq(issueDocuments.companyId, input.companyId),
+            ),
+          )
+          .orderBy(asc(issueDocuments.key))
+          .then((rows) => rows.filter((r) => !isSystemIssueDocumentKey(r.key)))
+      : Promise.resolve([]),
+  ]);
 
   const commentRows =
     commentIds.length === 0
@@ -4689,6 +4713,14 @@ export async function buildPaperclipWakePayload(input: {
       contentType: a.contentType,
       byteSize: a.byteSize,
       contentPath: `/api/attachments/${a.id}/content`,
+    })),
+    documents: userDocumentRows.map((d) => ({
+      key: d.key,
+      title: d.title,
+      format: d.format,
+      body: d.body && d.body.length <= 65_536 ? d.body : null,
+      bodyTruncated: d.body ? d.body.length > 65_536 : false,
+      updatedAt: d.updatedAt instanceof Date ? d.updatedAt.toISOString() : d.updatedAt,
     })),
     commentIds,
     latestCommentId: commentIds[commentIds.length - 1] ?? null,

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -75,6 +75,11 @@ Use comments incrementally:
 
 Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
 
+**Attachments:** Check `attachments[]` in the heartbeat-context response.
+- If an attachment has `inlineContent`, use it directly — it is the full UTF-8 text of the file.
+- If `inlineContent` is absent but `contentType` is text-like, fetch with `GET {contentPath}`.
+- Images and PDFs: use `filename` for reference; their content cannot be read as text.
+
 **Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
 
 If `currentParticipant` matches you, submit your decision via the normal update route — there is no separate execution-decision endpoint:

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -75,7 +75,7 @@ Use comments incrementally:
 
 Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
 
-**Attachments:** Check `attachments[]` in the heartbeat-context response. Every attachment includes `id`, `filename`, `contentType`, `byteSize`, `contentPath`, and `createdAt` regardless of type.
+**Attachments:** `attachments[]` appears in both `PAPERCLIP_WAKE_PAYLOAD_JSON` and in the heartbeat-context API response. Every entry includes `id`, `filename`, `contentType`, `byteSize`, and `contentPath` regardless of file type. The heartbeat-context response also includes `createdAt` and, for small text files, `inlineContent`.
 - If an attachment has `inlineContent`, use it directly — it is the full UTF-8 text of the file.
 - If `inlineContent` is absent but `contentType` is text-like (e.g. file exceeds the inline limit), fetch the full text with `GET {contentPath}` — this route is in the sandbox bridge allowlist.
 - Images and PDFs: `contentPath` exists but the content is binary; reference the file by `filename` and note it is attached.

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -75,10 +75,10 @@ Use comments incrementally:
 
 Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
 
-**Attachments:** Check `attachments[]` in the heartbeat-context response.
+**Attachments:** Check `attachments[]` in the heartbeat-context response. Every attachment includes `id`, `filename`, `contentType`, `byteSize`, `contentPath`, and `createdAt` regardless of type.
 - If an attachment has `inlineContent`, use it directly — it is the full UTF-8 text of the file.
-- If `inlineContent` is absent but `contentType` is text-like, fetch with `GET {contentPath}`.
-- Images and PDFs: use `filename` for reference; their content cannot be read as text.
+- If `inlineContent` is absent but `contentType` is text-like (e.g. file exceeds the inline limit), fetch the full text with `GET {contentPath}` — this route is in the sandbox bridge allowlist.
+- Images and PDFs: `contentPath` exists but the content is binary; reference the file by `filename` and note it is attached.
 
 **Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -80,6 +80,10 @@ Read enough ancestor/comment context to understand _why_ the task exists and wha
 - If `inlineContent` is absent but `contentType` is text-like (e.g. file exceeds the inline limit), fetch the full text with `GET {contentPath}` — this route is in the sandbox bridge allowlist.
 - Images and PDFs: `contentPath` exists but the content is binary; reference the file by `filename` and note it is attached.
 
+**Documents:** `documents[]` also appears in the heartbeat-context API response. These are user-created issue documents (markdown/text files the user uploaded or typed directly). Each entry has `key`, `title`, `format`, `body` (included inline when ≤ 64 KB), `latestRevisionId`, and `updatedAt`. The system `continuation-summary` document is excluded — it is already surfaced as `continuationSummary`.
+- Always check `documents[]` alongside `attachments[]` — users uploading `.txt` or `.md` files via the issue dialog will have their content appear here as documents, not as attachments.
+- If `body` is present, use it directly. If `body` is null (document exceeds the inline limit), fetch with `GET /api/issues/{id}/documents/{key}`.
+
 **Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
 
 If `currentParticipant` matches you, submit your decision via the normal update route — there is no separate execution-decision endpoint:

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -75,14 +75,17 @@ Use comments incrementally:
 
 Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
 
-**Attachments:** `attachments[]` appears in both `PAPERCLIP_WAKE_PAYLOAD_JSON` and in the heartbeat-context API response. Every entry includes `id`, `filename`, `contentType`, `byteSize`, and `contentPath` regardless of file type. The heartbeat-context response also includes `createdAt` and, for small text files, `inlineContent`.
+**Attachments and Documents (user-uploaded files):** When a user says they "uploaded a file" or "attached something", you MUST check BOTH `attachments[]` AND `documents[]` — the UI routes uploads to one or the other depending on how the issue was created.
+
+`attachments[]` appears in both `PAPERCLIP_WAKE_PAYLOAD_JSON` and in the heartbeat-context API response. Every entry includes `id`, `filename`, `contentType`, `byteSize`, and `contentPath` regardless of file type. The heartbeat-context response also includes `createdAt` and, for small text files, `inlineContent`.
 - If an attachment has `inlineContent`, use it directly — it is the full UTF-8 text of the file.
 - If `inlineContent` is absent but `contentType` is text-like (e.g. file exceeds the inline limit), fetch the full text with `GET {contentPath}` — this route is in the sandbox bridge allowlist.
 - Images and PDFs: `contentPath` exists but the content is binary; reference the file by `filename` and note it is attached.
+- **If `attachments[]` is empty but the user says they uploaded a file:** do NOT report "no attachments" — continue reading `documents[]` below.
 
-**Documents:** `documents[]` also appears in the heartbeat-context API response. These are user-created issue documents (markdown/text files the user uploaded or typed directly). Each entry has `key`, `title`, `format`, `body` (included inline when ≤ 64 KB), `latestRevisionId`, and `updatedAt`. The system `continuation-summary` document is excluded — it is already surfaced as `continuationSummary`.
-- Always check `documents[]` alongside `attachments[]` — users uploading `.txt` or `.md` files via the issue dialog will have their content appear here as documents, not as attachments.
+`documents[]` also appears in the heartbeat-context API response. These are user-created issue documents (markdown/text files the user uploaded or typed directly via the issue creation dialog). Each entry has `key`, `title`, `format`, `body` (included inline when ≤ 64 KB), `latestRevisionId`, and `updatedAt`. The system `continuation-summary` document is excluded — it is already surfaced as `continuationSummary`.
 - If `body` is present, use it directly. If `body` is null (document exceeds the inline limit), fetch with `GET /api/issues/{id}/documents/{key}`.
+- Files uploaded during **issue creation** almost always appear here, not in `attachments[]`.
 
 **Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -77,10 +77,10 @@ Use comments incrementally:
 
 Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
 
-**Attachments:** Check `attachments[]` in the heartbeat-context response.
+**Attachments:** Check `attachments[]` in the heartbeat-context response. Every attachment includes `id`, `filename`, `contentType`, `byteSize`, `contentPath`, and `createdAt` regardless of type.
 - If an attachment has `inlineContent`, use it directly — it is the full UTF-8 text of the file.
-- If `inlineContent` is absent but `contentType` is text-like, fetch with `GET {contentPath}`.
-- Images and PDFs: use `filename` for reference; their content cannot be read as text.
+- If `inlineContent` is absent but `contentType` is text-like (e.g. file exceeds the inline limit), fetch the full text with `GET {contentPath}` — this route is in the sandbox bridge allowlist.
+- Images and PDFs: `contentPath` exists but the content is binary; reference the file by `filename` and note it is attached.
 
 **Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -77,6 +77,11 @@ Use comments incrementally:
 
 Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
 
+**Attachments:** Check `attachments[]` in the heartbeat-context response.
+- If an attachment has `inlineContent`, use it directly — it is the full UTF-8 text of the file.
+- If `inlineContent` is absent but `contentType` is text-like, fetch with `GET {contentPath}`.
+- Images and PDFs: use `filename` for reference; their content cannot be read as text.
+
 **Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
 
 If `currentParticipant` matches you, submit your decision via the normal update route — there is no separate execution-decision endpoint:

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -82,6 +82,10 @@ Read enough ancestor/comment context to understand _why_ the task exists and wha
 - If `inlineContent` is absent but `contentType` is text-like (e.g. file exceeds the inline limit), fetch the full text with `GET {contentPath}` — this route is in the sandbox bridge allowlist.
 - Images and PDFs: `contentPath` exists but the content is binary; reference the file by `filename` and note it is attached.
 
+**Documents:** `documents[]` also appears in the heartbeat-context API response. These are user-created issue documents (markdown/text files the user uploaded or typed directly). Each entry has `key`, `title`, `format`, `body` (included inline when ≤ 64 KB), `latestRevisionId`, and `updatedAt`. The system `continuation-summary` document is excluded — it is already surfaced as `continuationSummary`.
+- Always check `documents[]` alongside `attachments[]` — users uploading `.txt` or `.md` files via the issue dialog will have their content appear here as documents, not as attachments.
+- If `body` is present, use it directly. If `body` is null (document exceeds the inline limit), fetch with `GET /api/issues/{id}/documents/{key}`.
+
 **Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
 
 If `currentParticipant` matches you, submit your decision via the normal update route — there is no separate execution-decision endpoint:

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -77,7 +77,7 @@ Use comments incrementally:
 
 Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
 
-**Attachments:** Check `attachments[]` in the heartbeat-context response. Every attachment includes `id`, `filename`, `contentType`, `byteSize`, `contentPath`, and `createdAt` regardless of type.
+**Attachments:** `attachments[]` appears in both `PAPERCLIP_WAKE_PAYLOAD_JSON` and in the heartbeat-context API response. Every entry includes `id`, `filename`, `contentType`, `byteSize`, and `contentPath` regardless of file type. The heartbeat-context response also includes `createdAt` and, for small text files, `inlineContent`.
 - If an attachment has `inlineContent`, use it directly — it is the full UTF-8 text of the file.
 - If `inlineContent` is absent but `contentType` is text-like (e.g. file exceeds the inline limit), fetch the full text with `GET {contentPath}` — this route is in the sandbox bridge allowlist.
 - Images and PDFs: `contentPath` exists but the content is binary; reference the file by `filename` and note it is attached.

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -77,14 +77,17 @@ Use comments incrementally:
 
 Read enough ancestor/comment context to understand _why_ the task exists and what changed. Do not reflexively reload the whole thread on every heartbeat.
 
-**Attachments:** `attachments[]` appears in both `PAPERCLIP_WAKE_PAYLOAD_JSON` and in the heartbeat-context API response. Every entry includes `id`, `filename`, `contentType`, `byteSize`, and `contentPath` regardless of file type. The heartbeat-context response also includes `createdAt` and, for small text files, `inlineContent`.
+**Attachments and Documents (user-uploaded files):** When a user says they "uploaded a file" or "attached something", you MUST check BOTH `attachments[]` AND `documents[]` — the UI routes uploads to one or the other depending on how the issue was created.
+
+`attachments[]` appears in both `PAPERCLIP_WAKE_PAYLOAD_JSON` and in the heartbeat-context API response. Every entry includes `id`, `filename`, `contentType`, `byteSize`, and `contentPath` regardless of file type. The heartbeat-context response also includes `createdAt` and, for small text files, `inlineContent`.
 - If an attachment has `inlineContent`, use it directly — it is the full UTF-8 text of the file.
 - If `inlineContent` is absent but `contentType` is text-like (e.g. file exceeds the inline limit), fetch the full text with `GET {contentPath}` — this route is in the sandbox bridge allowlist.
 - Images and PDFs: `contentPath` exists but the content is binary; reference the file by `filename` and note it is attached.
+- **If `attachments[]` is empty but the user says they uploaded a file:** do NOT report "no attachments" — continue reading `documents[]` below.
 
-**Documents:** `documents[]` also appears in the heartbeat-context API response. These are user-created issue documents (markdown/text files the user uploaded or typed directly). Each entry has `key`, `title`, `format`, `body` (included inline when ≤ 64 KB), `latestRevisionId`, and `updatedAt`. The system `continuation-summary` document is excluded — it is already surfaced as `continuationSummary`.
-- Always check `documents[]` alongside `attachments[]` — users uploading `.txt` or `.md` files via the issue dialog will have their content appear here as documents, not as attachments.
+`documents[]` also appears in the heartbeat-context API response. These are user-created issue documents (markdown/text files the user uploaded or typed directly via the issue creation dialog). Each entry has `key`, `title`, `format`, `body` (included inline when ≤ 64 KB), `latestRevisionId`, and `updatedAt`. The system `continuation-summary` document is excluded — it is already surfaced as `continuationSummary`.
 - If `body` is present, use it directly. If `body` is null (document exceeds the inline limit), fetch with `GET /api/issues/{id}/documents/{key}`.
+- Files uploaded during **issue creation** almost always appear here, not in `attachments[]`.
 
 **Execution-policy review/approval wakes.** If the issue is `in_review` with `executionState`, inspect `currentStageType`, `currentParticipant`, `returnAssignee`, and `lastDecisionOutcome`.
 

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -810,6 +810,19 @@ Terminal states: `done`, `cancelled`
 | POST   | `/api/execution-workspaces/:workspaceId/runtime-services/restart` | Restart configured workspace services |
 | POST   | `/api/execution-workspaces/:workspaceId/runtime-services/stop` | Stop workspace runtime services |
 
+### Attachments
+
+These routes are in the **sandbox callback bridge allowlist** and can be called directly from an in-sandbox heartbeat.
+
+| Method | Path                                         | Description                                                                 |
+| ------ | -------------------------------------------- | --------------------------------------------------------------------------- |
+| GET    | `/api/issues/:issueId/attachments`           | List attachment metadata for an issue                                       |
+| POST   | `/api/companies/:companyId/issues/:issueId/attachments` | Upload attachment (multipart `file` field)                       |
+| GET    | `/api/attachments/:attachmentId/content`     | Fetch raw attachment content (also in sandbox allowlist)                    |
+| DELETE | `/api/attachments/:attachmentId`             | Delete attachment                                                           |
+
+**`inlineContent` in heartbeat-context:** The `/api/issues/:issueId/heartbeat-context` response includes an `inlineContent` field on each attachment whose `contentType` is `text/plain`, `text/markdown`, `application/json`, or `text/csv` and whose `byteSize` is ≤ 65,536 bytes. When present, `inlineContent` is the full UTF-8 text of the file — no separate fetch needed.
+
 ### Companies, Projects, Goals
 
 | Method | Path                                 | Description        |

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -1224,6 +1224,19 @@ Terminal states: `done`, `cancelled`
 | POST   | `/api/execution-workspaces/:workspaceId/runtime-services/restart` | Restart configured workspace services |
 | POST   | `/api/execution-workspaces/:workspaceId/runtime-services/stop` | Stop workspace runtime services |
 
+### Attachments
+
+These routes are in the **sandbox callback bridge allowlist** and can be called directly from an in-sandbox heartbeat.
+
+| Method | Path                                         | Description                                                                 |
+| ------ | -------------------------------------------- | --------------------------------------------------------------------------- |
+| GET    | `/api/issues/:issueId/attachments`           | List attachment metadata for an issue                                       |
+| POST   | `/api/companies/:companyId/issues/:issueId/attachments` | Upload attachment (multipart `file` field)                       |
+| GET    | `/api/attachments/:attachmentId/content`     | Fetch raw attachment content (also in sandbox allowlist)                    |
+| DELETE | `/api/attachments/:attachmentId`             | Delete attachment                                                           |
+
+**`inlineContent` in heartbeat-context:** The `/api/issues/:issueId/heartbeat-context` response includes an `inlineContent` field on each attachment whose `contentType` is `text/plain`, `text/markdown`, `application/json`, or `text/csv` and whose `byteSize` is ≤ 65,536 bytes. When present, `inlineContent` is the full UTF-8 text of the file — no separate fetch needed.
+
 ### Companies, Projects, Goals
 
 | Method | Path                                 | Description        |

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -1226,16 +1226,16 @@ Terminal states: `done`, `cancelled`
 
 ### Attachments
 
-These routes are in the **sandbox callback bridge allowlist** and can be called directly from an in-sandbox heartbeat.
+The following **GET** routes are in the sandbox callback bridge allowlist and can be called directly from an in-sandbox heartbeat. Upload/delete routes are available via the API, but are not bridge-allowlisted.
 
 | Method | Path                                         | Description                                                                 |
 | ------ | -------------------------------------------- | --------------------------------------------------------------------------- |
-| GET    | `/api/issues/:issueId/attachments`           | List attachment metadata for an issue                                       |
+| GET    | `/api/issues/:issueId/attachments`           | List attachment metadata for an issue (sandbox allowlist)                   |
 | POST   | `/api/companies/:companyId/issues/:issueId/attachments` | Upload attachment (multipart `file` field)                       |
-| GET    | `/api/attachments/:attachmentId/content`     | Fetch raw attachment content (also in sandbox allowlist)                    |
+| GET    | `/api/attachments/:attachmentId/content`     | Fetch raw attachment content (sandbox allowlist)                            |
 | DELETE | `/api/attachments/:attachmentId`             | Delete attachment                                                           |
 
-**`inlineContent` in heartbeat-context:** The `/api/issues/:issueId/heartbeat-context` response includes an `inlineContent` field on each attachment whose `contentType` is `text/plain`, `text/markdown`, `application/json`, or `text/csv` and whose `byteSize` is ≤ 65,536 bytes. When present, `inlineContent` is the full UTF-8 text of the file — no separate fetch needed.
+**`inlineContent` in heartbeat-context:** The `/api/issues/:issueId/heartbeat-context` response may include `inlineContent` for text-like attachments (`text/plain`, `text/markdown`, `application/json`, `text/csv`) when they fit within the server's current inline byte budget. The budget is configurable (`PAPERCLIP_ATTACHMENT_INLINE_MAX_BYTES`, default 65,536 bytes) and enforced in aggregate across the response payload, not per file — once the running total is exhausted, remaining attachments fall back to `contentPath` only. When `inlineContent` is present, it is the full UTF-8 text of the file — no separate fetch needed.
 
 ### Companies, Projects, Goals
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents; agents receive issue context through the `/heartbeat-context` endpoint and the `PAPERCLIP_WAKE_PAYLOAD_JSON` env var injected by the harness
> - Users attaching TXT/MD files to issues found that agents had no awareness of those attachments — the content wasn't available and even the existence of the file wasn't guaranteed to be visible
> - Source analysis identified three original gaps: (1) heartbeat-context returned attachment metadata but not content, (2) sandbox bridge blocked attachment fetch routes, (3) skill docs said nothing about `attachments[]`
> - Review rounds found two more gaps: (4) `buildPaperclipWakePayload` injected no attachment data at all, meaning agents relying on the initial prompt context would never know attachments existed; (5) per-file inline limit allowed unbounded aggregate response growth
> - A critical discovery during extended testing: **files uploaded through the NewIssueDialog are NOT stored as attachments — they are stored as issue documents** (`documents[]`). The `isTextDocumentFile()` classifier routes `.txt`/`.md` uploads to `issueDocuments`, not `issueAttachments`. Agents that only checked `attachments[]` would report "no file found" even when the user had uploaded one.
> - Each gap was fixed in sequence: inline small text content, unblock fetch routes, document the field, add aggregate budget, add attachments to wake payload, expose documents in heartbeat-context and wake payload, harden skill docs so both arrays are always checked

## Linked Issues or Issue Description

- Fixes: #3061 (open — "Inject issue attachment content into agent heartbeat context"; this PR implements exactly the proposed fix: inline text-based attachment content into `heartbeat-context`, cap total injected bytes, skip binary files)
- Related: #2536 (closed/completed — added attachment *metadata* to `heartbeat-context`; this PR builds on that by inlining attachment *content*, not just metadata)
- Related: #673 (open — different scope: expanding upload MIME-type allowlist, not content inlining)
- Related PRs: #2815 (open — also touches `attachment-types.ts` but for the upload MIME allowlist, not inlining), #1118 (open — documents the existing attachment API in the skill, distinct from the new `inlineContent`/wake-payload/document behavior added here), #324 (open — separate "Knowledge items" feature for injecting reusable notes into run context; different data model, does not cover issue attachments/documents)

## What Changed

- **`server/src/routes/issues.ts`** — heartbeat-context attachment mapping is now async; uses an aggregate byte budget (`ATTACHMENT_INLINE_MAX_BYTES`) to inline text content for `text/plain`, `text/markdown`, `application/json`, `text/csv` files in `createdAt` order until the budget is exhausted; remaining attachments fall back to `contentPath` only; storage reads are wrapped in `try/catch` so a single broken object never crashes the whole response; `byteSize ?? 0` guard replaced with `byteSize != null` to skip unknown-size files. Also now returns a `documents[]` array with `body` inlined for docs ≤ 64 KB.
- **`server/src/attachment-types.ts`** — exports `ATTACHMENT_INLINE_MAX_BYTES` (default 65 536, overridable via `PAPERCLIP_ATTACHMENT_INLINE_MAX_BYTES` env var) using the same pattern as `MAX_ATTACHMENT_BYTES`
- **`server/src/services/heartbeat.ts`** — `buildPaperclipWakePayload` now queries `issueAttachments` + `assets` and includes a lightweight `attachments[]` array in `PAPERCLIP_WAKE_PAYLOAD_JSON`; **also queries `issueDocuments` and includes a `documents[]` array** (with `body` inlined for docs ≤ 64 KB) so agents see both upload pathways in their initial prompt
- **`packages/adapter-utils/src/sandbox-callback-bridge.ts`** — added `GET /api/issues/:id/attachments` and `GET /api/attachments/:id/content` to `DEFAULT_SANDBOX_CALLBACK_BRIDGE_ROUTE_ALLOWLIST`; updated comment to point at the correct `references/api-reference.md` path
- **`skills/paperclip/SKILL.md`** — Step 6 now has a unified **"Attachments and Documents (user-uploaded files)"** section with a mandatory rule: agents MUST check BOTH `attachments[]` AND `documents[]`. An explicit hard-stop bullet warns: *if `attachments[]` is empty but the user says they uploaded a file, do NOT report "no attachments" — check `documents[]`*. Explains that files uploaded during issue creation almost always land in `documents[]`, not `attachments[]`.
- **`skills/paperclip/references/api-reference.md`** — new Attachments section documents the four attachment endpoints, sandbox allowlist status, and `inlineContent` semantics
- **`server/src/__tests__/heartbeat-dependency-scheduling.test.ts`** — increased three `waitForCondition` timeouts from the default 3 000 ms to 15 000 ms in the `honors maxConcurrentRuns 1` test; the tight defaults caused intermittent CI failures on slower runners (two back-to-back 3 s timeouts → 6 s elapsed failure) while the test's overall budget is 40 000 ms

## Why Documents ≠ Attachments

When a user uploads a file through the **NewIssueDialog**, Paperclip's `isTextDocumentFile()` classifier checks the MIME type and extension. Text-like files (`.txt`, `.md`, etc.) are routed to `issueDocuments` and exposed via `GET /api/issues/:id/documents`. Binary files and files uploaded to an *existing* issue via the attachment UI go to `issueAttachments` and are exposed via `GET /api/issues/:id/attachments`. Both pathways now appear in heartbeat-context and the wake payload, and the skill mandates checking both.

## Verification

1. Upload a `.txt` file via NewIssueDialog → `heartbeat-context` returns it in `documents[]` with body inlined
2. Attach a `.txt` file (≤ 64 KB) to an existing issue → `heartbeat-context` returns it in `attachments[]` with `inlineContent`
3. Attach a `.txt` file > 64 KB → `inlineContent` absent; `contentPath` present and fetchable via bridge
4. Attach 10 × 64.9 KB text files → first is inlined, remaining 9 get `contentPath` only (aggregate budget)
5. Attach a file, trigger a heartbeat → `PAPERCLIP_WAKE_PAYLOAD_JSON` contains both `attachments[]` and `documents[]`
6. Sandbox bridge: `GET /api/issues/:iId/attachments` and `GET /api/attachments/:aId/content` are not rejected
7. Storage failure on a single attachment → other attachments still returned; broken one omits `inlineContent` only

## Risks

- **Heartbeat latency:** wake payload now runs extra DB joins for attachments and documents on every heartbeat. Issues with no uploads pay cheap empty joins.
- **Aggregate budget semantics change:** `ATTACHMENT_INLINE_MAX_BYTES` changed from per-file to aggregate. Default of 65 KB is conservative.
- No schema changes, no migrations.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Mode: Tool-use / agentic (Claude Code CLI)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
