### PR TITLE
Fix secret rotation fingerprint and error body logging

### DIFF
--- a/server/src/__tests__/error-handler.test.ts
+++ b/server/src/__tests__/error-handler.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 import { HttpError } from "../errors.js";
 import { errorHandler } from "../middleware/error-handler.js";
 
-function makeReq(): Request {
+function makeReq(method = "GET"): Request {
   return {
-    method: "GET",
+    method,
     originalUrl: "/api/test",
     body: { a: 1 },
     params: { id: "123" },
@@ -49,5 +49,27 @@ describe("errorHandler", () => {
     expect(res.json).toHaveBeenCalledWith({ error: "db exploded" });
     expect(res.err).toBe(err);
     expect(res.__errorContext?.error?.message).toBe("db exploded");
+  });
+
+  it("omits write request bodies from persisted error context", () => {
+    const req = makeReq("POST");
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+
+    errorHandler(new Error("boom"), req, res, next);
+
+    expect(res.__errorContext?.reqBody).toBeUndefined();
+    expect(res.__errorContext?.reqParams).toEqual({ id: "123" });
+    expect(res.__errorContext?.reqQuery).toEqual({ q: "x" });
+  });
+
+  it("keeps non-write request bodies in persisted error context", () => {
+    const req = makeReq("GET");
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+
+    errorHandler(new Error("boom"), req, res, next);
+
+    expect(res.__errorContext?.reqBody).toEqual({ a: 1 });
   });
 });

--- a/server/src/__tests__/secrets-routes.test.ts
+++ b/server/src/__tests__/secrets-routes.test.ts
@@ -17,6 +17,7 @@ const mockSecretService = vi.hoisted(() => ({
   checkProviderConfigHealth: vi.fn(),
   getById: vi.fn(),
   create: vi.fn(),
+  rotate: vi.fn(),
   update: vi.fn(),
   remove: vi.fn(),
   previewRemoteImport: vi.fn(),
@@ -102,6 +103,60 @@ describe("secret routes", () => {
 
     expect(res.status).toBe(403);
     expect(mockSecretService.listProviderConfigs).not.toHaveBeenCalled();
+  });
+
+  it("rotates a secret and logs only the new version", async () => {
+    const createdAt = new Date("2026-05-15T10:00:00.000Z");
+    const existing = {
+      id: "11111111-1111-4111-8111-111111111111",
+      companyId: "company-1",
+      key: "runtime-token",
+      name: "Runtime token",
+      provider: "local_encrypted",
+      status: "active",
+      managedMode: "paperclip_managed",
+      externalRef: null,
+      providerConfigId: null,
+      providerMetadata: null,
+      latestVersion: 1,
+      description: null,
+      lastResolvedAt: null,
+      lastRotatedAt: createdAt,
+      deletedAt: null,
+      createdByAgentId: null,
+      createdByUserId: "user-1",
+      createdAt,
+      updatedAt: createdAt,
+    };
+    const rotated = { ...existing, latestVersion: 2, updatedAt: createdAt };
+    mockSecretService.getById.mockResolvedValue(existing);
+    mockSecretService.rotate.mockResolvedValue(rotated);
+
+    const res = await request(createApp()).post(`/api/secrets/${existing.id}/rotate`).send({
+      value: "new-runtime-value",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: existing.id, latestVersion: 2 });
+    expect(mockSecretService.rotate).toHaveBeenCalledWith(
+      existing.id,
+      {
+        value: "new-runtime-value",
+        externalRef: undefined,
+        providerVersionRef: undefined,
+        providerConfigId: undefined,
+      },
+      { userId: "user-1", agentId: null },
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "secret.rotated",
+        entityId: existing.id,
+        details: { version: 2 },
+      }),
+    );
+    expect(JSON.stringify(mockLogActivity.mock.calls)).not.toContain("new-runtime-value");
   });
 
   it("rejects provider vault cross-company access before calling the service", async () => {

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import {
   agents,
   companies,
@@ -655,8 +655,20 @@ describeEmbeddedPostgres("secretService", () => {
     });
     const rotated = await svc.rotate(secret.id, { value: "rotated-runtime-secret" });
     const resolved = await svc.resolveSecretValue(companyId, rotated.id, "latest");
+    const rotatedVersion = await db
+      .select()
+      .from(companySecretVersions)
+      .where(and(
+        eq(companySecretVersions.secretId, secret.id),
+        eq(companySecretVersions.version, 2),
+      ))
+      .then((rows) => rows[0] ?? null);
 
     expect(resolved).toBe("resolved-secret");
+    expect(rotatedVersion).toMatchObject({
+      status: "current",
+      fingerprintSha256: "fingerprint-sha-2",
+    });
     expect(createSpy).toHaveBeenCalledWith(expect.objectContaining({
       providerConfig: expect.objectContaining({
         id: awsVault.id,

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -13,6 +13,10 @@ export interface ErrorContext {
   reqQuery?: unknown;
 }
 
+export function shouldPersistErrorRequestBody(method: string): boolean {
+  return !["POST", "PUT", "PATCH", "DELETE"].includes(method.toUpperCase());
+}
+
 function attachErrorContext(
   req: Request,
   res: Response,
@@ -23,7 +27,7 @@ function attachErrorContext(
     error: payload,
     method: req.method,
     url: req.originalUrl,
-    reqBody: req.body,
+    reqBody: shouldPersistErrorRequestBody(req.method) ? req.body : undefined,
     reqParams: req.params,
     reqQuery: req.query,
   } satisfies ErrorContext;

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -5,6 +5,7 @@ import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
 import { shouldSilenceHttpSuccessLog } from "./http-log-policy.js";
+import { shouldPersistErrorRequestBody } from "./error-handler.js";
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -76,7 +77,12 @@ export const httpLogger = pinoHttp({
       }
       const props: Record<string, unknown> = {};
       const { body, params, query } = req as any;
-      if (body && typeof body === "object" && Object.keys(body).length > 0) {
+      if (
+        shouldPersistErrorRequestBody(req.method ?? "") &&
+        body &&
+        typeof body === "object" &&
+        Object.keys(body).length > 0
+      ) {
         props.reqBody = body;
       }
       if (params && typeof params === "object" && Object.keys(params).length > 0) {

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -253,6 +253,14 @@ function assertSelectableProviderConfig(config: {
   }
 }
 
+function preparedFingerprintSha256(prepared: PreparedSecretVersion): string {
+  const fingerprint = (prepared.fingerprintSha256 ?? prepared.valueSha256).trim();
+  if (!fingerprint) {
+    throw unprocessable("Secret provider returned an invalid version fingerprint");
+  }
+  return fingerprint;
+}
+
 export function secretService(db: Db) {
   type NormalizeEnvOptions = {
     strictMode?: boolean;
@@ -1395,7 +1403,7 @@ export function secretService(db: Db) {
               version: 1,
               material: preparedSecret.material,
               valueSha256: preparedSecret.valueSha256,
-              fingerprintSha256: preparedSecret.fingerprintSha256 ?? preparedSecret.valueSha256,
+              fingerprintSha256: preparedFingerprintSha256(preparedSecret),
               providerVersionRef: preparedSecret.providerVersionRef ?? null,
               status: "current",
               createdByAgentId: actor?.agentId ?? null,
@@ -1558,7 +1566,7 @@ export function secretService(db: Db) {
           version: 1,
           material: prepared.material,
           valueSha256: prepared.valueSha256,
-          fingerprintSha256: prepared.fingerprintSha256 ?? prepared.valueSha256,
+          fingerprintSha256: preparedFingerprintSha256(prepared),
           providerVersionRef: prepared.providerVersionRef ?? null,
           status: "disabled",
           createdByAgentId: actor?.agentId ?? null,
@@ -1688,7 +1696,7 @@ export function secretService(db: Db) {
           version: nextVersion,
           material: prepared.material,
           valueSha256: prepared.valueSha256,
-          fingerprintSha256: prepared.fingerprintSha256 ?? prepared.valueSha256,
+          fingerprintSha256: preparedFingerprintSha256(prepared),
           providerVersionRef: prepared.providerVersionRef ?? null,
           status: "disabled",
           createdByAgentId: actor?.agentId ?? null,


### PR DESCRIPTION
Linked ITO ticket: ITO-390

Summary:
- Hardens secret version persistence so create/rotate/import paths only write a non-empty `fingerprintSha256`.
- Stops failed write requests from persisting `reqBody` into server log error context, including validation failures before route handlers run.
- Adds focused regressions for `POST /api/secrets/{id}/rotate`, persisted rotate fingerprint, and write-request error body omission.

Diff stat:
```text
 server/src/__tests__/error-handler.test.ts   | 26 ++++++++++++-
 server/src/__tests__/secrets-routes.test.ts  | 55 ++++++++++++++++++++++++++++
 server/src/__tests__/secrets-service.test.ts | 14 ++++++-
 server/src/middleware/error-handler.ts       |  6 ++-
 server/src/middleware/logger.ts              |  8 +++-
 server/src/services/secrets.ts               | 14 +++++--
 6 files changed, 115 insertions(+), 8 deletions(-)
```

Verification:
```text
pnpm exec vitest run server/src/__tests__/error-handler.test.ts server/src/__tests__/secrets-routes.test.ts server/src/__tests__/secrets-service.test.ts
# 3 files passed, 61 tests passed

pnpm --filter @paperclipai/server typecheck
# passed
```

Relevant raw diff excerpts:
```diff
+export function shouldPersistErrorRequestBody(method: string): boolean {
+  return !["POST", "PUT", "PATCH", "DELETE"].includes(method.toUpperCase());
+}
...
-    reqBody: req.body,
+    reqBody: shouldPersistErrorRequestBody(req.method) ? req.body : undefined,
```

```diff
-      if (body && typeof body === "object" && Object.keys(body).length > 0) {
+      if (
+        shouldPersistErrorRequestBody(req.method ?? "") &&
+        body &&
+        typeof body === "object" &&
+        Object.keys(body).length > 0
+      ) {
         props.reqBody = body;
       }
```

```diff
+function preparedFingerprintSha256(prepared: PreparedSecretVersion): string {
+  const fingerprint = (prepared.fingerprintSha256 ?? prepared.valueSha256).trim();
+  if (!fingerprint) {
+    throw unprocessable("Secret provider returned an invalid version fingerprint");
+  }
+  return fingerprint;
+}
...
-          fingerprintSha256: prepared.fingerprintSha256 ?? prepared.valueSha256,
+          fingerprintSha256: preparedFingerprintSha256(prepared),
```

Review checklist:
- Functional correctness vs ITO-390 acceptance criteria
- Tests/CI green
- No secret values in diff, logs, PR body, or screenshots
- No architecture drift in middleware/service boundaries
- Branch naming convention acceptable for ITO work

Expected outcome: Approve / Request changes / Block.
