### PR TITLE
Feat/Add atomic_agent_http adapter for OpenAI-compatible local operators 

### DIFF
--- a/cli/src/adapters/atomic-agent-http/format-event.ts
+++ b/cli/src/adapters/atomic-agent-http/format-event.ts
@@ -1,0 +1,4 @@
+export function printAtomicAgentHttpStdoutEvent(raw: string, _debug: boolean): void {
+  const line = raw.trim();
+  if (line) console.log(line);
+}

--- a/cli/src/adapters/atomic-agent-http/index.ts
+++ b/cli/src/adapters/atomic-agent-http/index.ts
@@ -1,0 +1,7 @@
+import type { CLIAdapterModule } from "@paperclipai/adapter-utils";
+import { printAtomicAgentHttpStdoutEvent } from "./format-event.js";
+
+export const atomicAgentHttpCLIAdapter: CLIAdapterModule = {
+  type: "atomic_agent_http",
+  formatStdoutEvent: printAtomicAgentHttpStdoutEvent,
+};

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -10,6 +10,7 @@ import { printPiStreamEvent } from "@paperclipai/adapter-pi-local/cli";
 import { printOpenClawGatewayStreamEvent } from "@paperclipai/adapter-openclaw-gateway/cli";
 import { processCLIAdapter } from "./process/index.js";
 import { httpCLIAdapter } from "./http/index.js";
+import { atomicAgentHttpCLIAdapter } from "./atomic-agent-http/index.js";
 
 const claudeLocalCLIAdapter: CLIAdapterModule = {
   type: "claude_local",
@@ -69,6 +70,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     openclawGatewayCLIAdapter,
     processCLIAdapter,
     httpCLIAdapter,
+    atomicAgentHttpCLIAdapter,
   ].map((a) => [a.type, a]),
 );
 

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -489,6 +489,8 @@ export interface CreateConfigValues {
   envVars: string;
   envBindings: Record<string, unknown>;
   url: string;
+  /** Optional API key for adapters that speak HTTP to a local serve endpoint (e.g. atomic_agent_http). */
+  atomicAgentApiKey?: string;
   bootstrapPrompt: string;
   payloadTemplateJson?: string;
   workspaceStrategyType?: string;

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -39,6 +39,7 @@ export const AGENT_ADAPTER_TYPES = [
   "pi_local",
   "cursor",
   "openclaw_gateway",
+  "atomic_agent_http",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number] | (string & {});
 

--- a/server/src/adapters/atomic-agent-http/execute.test.ts
+++ b/server/src/adapters/atomic-agent-http/execute.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { execute } from "./execute.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("atomic_agent_http execute", () => {
+  it("returns assistant text and usage on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: "Shipped fix for login." } }],
+            usage: { prompt_tokens: 10, completion_tokens: 20 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+
+    const result = await execute({
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Atomic",
+        adapterType: "atomic_agent_http",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        baseUrl: "http://127.0.0.1:1337",
+        model: "gemma-4-E4B-it-IQ4_XS",
+        timeoutMs: 30_000,
+      },
+      context: { paperclipWake: null },
+      onLog: async () => {},
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.summary).toBe("Shipped fix for login.");
+    expect(result.resultJson?.summary).toBe("Shipped fix for login.");
+    expect(result.usage).toMatchObject({
+      inputTokens: 10,
+      outputTokens: 20,
+    });
+    expect(result.model).toBe("gemma-4-E4B-it-IQ4_XS");
+  });
+
+  it("reports timeout", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url: string, init?: RequestInit) => new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      })),
+    );
+
+    const result = await execute({
+      runId: "run-1",
+      agent: {
+        id: "agent-1",
+        companyId: "company-1",
+        name: "Atomic",
+        adapterType: "atomic_agent_http",
+        adapterConfig: {},
+      },
+      runtime: {
+        sessionId: null,
+        sessionParams: null,
+        sessionDisplayId: null,
+        taskKey: null,
+      },
+      config: {
+        baseUrl: "http://127.0.0.1:1337",
+        model: "m",
+        timeoutMs: 1,
+      },
+      context: {},
+      onLog: async () => {},
+    });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorCode).toBe("timeout");
+  });
+});

--- a/server/src/adapters/atomic-agent-http/execute.ts
+++ b/server/src/adapters/atomic-agent-http/execute.ts
@@ -1,0 +1,233 @@
+import type { AdapterExecutionContext, AdapterExecutionResult } from "../types.js";
+import { asString, asNumber, parseObject } from "../utils.js";
+import {
+  renderPaperclipWakePrompt,
+  stringifyPaperclipWakePayload,
+} from "@paperclipai/adapter-utils/server-utils";
+
+export function normalizeAtomicAgentBaseUrl(raw: string): string {
+  let s = raw.trim().replace(/\/+$/, "");
+  if (s.endsWith("/v1")) {
+    s = s.slice(0, -3).replace(/\/+$/, "");
+  }
+  return s;
+}
+
+function readOpenAiMessageContent(message: Record<string, unknown> | null): string {
+  if (!message) return "";
+  const content = message.content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => {
+        if (typeof part !== "object" || part === null) return "";
+        const rec = part as Record<string, unknown>;
+        if (rec.type === "text" && typeof rec.text === "string") return rec.text;
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+async function fetchFirstModelId(
+  baseUrl: string,
+  headers: Record<string, string>,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const url = `${baseUrl}/v1/models`;
+  const res = await fetch(url, { method: "GET", headers, signal });
+  if (!res.ok) return null;
+  const body = (await res.json()) as { data?: Array<{ id?: string }> };
+  const first = body.data?.find((m) => typeof m.id === "string" && m.id.trim().length > 0);
+  return first?.id?.trim() ?? null;
+}
+
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const baseUrl = normalizeAtomicAgentBaseUrl(asString(ctx.config.baseUrl, ""));
+  if (!baseUrl) {
+    throw new Error("atomic_agent_http adapter missing baseUrl (e.g. http://127.0.0.1:8787)");
+  }
+
+  const apiKey = asString(ctx.config.apiKey, "").trim();
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+  };
+
+  const configuredTimeout = asNumber(ctx.config.timeoutMs, 0);
+  const timeoutMs = configuredTimeout > 0 ? configuredTimeout : 600_000;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  let model = asString(ctx.config.model, "").trim();
+  if (!model) {
+    try {
+      model = (await fetchFirstModelId(baseUrl, headers, controller.signal)) ?? "";
+    } catch {
+      model = "";
+    }
+  }
+  if (!model) {
+    clearTimeout(timer);
+    throw new Error(
+      "atomic_agent_http: set adapterConfig.model to an id from `atomic-agent serve` (GET /v1/models), or ensure /v1/models is reachable.",
+    );
+  }
+
+  const maxTokens = asNumber(ctx.config.maxTokens, 0);
+  const systemExtra = asString(ctx.config.systemPromptAppend, "").trim();
+  const defaultSystem = [
+    "You are a Paperclip agent: you receive wake payloads for a single issue and should act as the assigned operator.",
+    "Follow the execution contract in the user message. When you finish, reply with a concise summary suitable as an issue comment (plain text, no JSON wrapper).",
+    ...(systemExtra ? [systemExtra] : []),
+  ].join("\n");
+
+  const structuredWakePrompt = renderPaperclipWakePrompt(ctx.context.paperclipWake);
+  const structuredWakeJson = stringifyPaperclipWakePayload(ctx.context.paperclipWake);
+  const wakeLines = [
+    structuredWakePrompt.trim() || "(empty structured wake; use JSON below if present.)",
+    structuredWakeJson ? `\n## paperclipWake JSON\n${structuredWakeJson}` : "",
+    `\n## Paperclip run\n- runId: ${ctx.runId}\n- agentId: ${ctx.agent.id}\n- agentName: ${ctx.agent.name}`,
+  ];
+  const userContent = wakeLines.join("\n");
+
+  const url = `${baseUrl}/v1/chat/completions`;
+  const body: Record<string, unknown> = {
+    model,
+    messages: [
+      { role: "system", content: defaultSystem },
+      { role: "user", content: userContent },
+    ],
+  };
+  if (maxTokens > 0) {
+    body.max_tokens = maxTokens;
+  }
+
+  await ctx.onMeta?.({
+    adapterType: "atomic_agent_http",
+    command: "fetch",
+    commandArgs: [url],
+    context: ctx.context,
+  });
+
+  await ctx.onLog("stdout", `[paperclip] atomic_agent_http POST ${url} model=${model}\n`);
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    const rawText = await res.text();
+    if (!res.ok) {
+      const detail = rawText.length > 800 ? `${rawText.slice(0, 800)}…` : rawText;
+      await ctx.onLog("stderr", `[paperclip] atomic_agent_http HTTP ${res.status}: ${detail}\n`);
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: `atomic_agent_http: HTTP ${res.status}`,
+        errorCode: "adapter_failed",
+        provider: "atomic-agent",
+        biller: "llama_local",
+        model,
+        billingType: "fixed",
+      };
+    }
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(rawText) as Record<string, unknown>;
+    } catch {
+      await ctx.onLog("stderr", "[paperclip] atomic_agent_http: response was not JSON\n");
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: "atomic_agent_http: invalid JSON from /v1/chat/completions",
+        errorCode: "adapter_failed",
+        provider: "atomic-agent",
+        biller: "llama_local",
+        model,
+        billingType: "fixed",
+      };
+    }
+
+    const choices = parsed.choices;
+    const first =
+      Array.isArray(choices) && choices.length > 0 && typeof choices[0] === "object" && choices[0] !== null
+        ? (choices[0] as Record<string, unknown>)
+        : null;
+    const message =
+      first && typeof first.message === "object" && first.message !== null
+        ? (first.message as Record<string, unknown>)
+        : null;
+    const assistantText = readOpenAiMessageContent(message).trim();
+
+    if (!assistantText) {
+      await ctx.onLog("stderr", "[paperclip] atomic_agent_http: empty assistant message\n");
+      return {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        errorMessage: "atomic_agent_http: model returned no assistant text",
+        errorCode: "adapter_failed",
+        provider: "atomic-agent",
+        biller: "llama_local",
+        model,
+        billingType: "fixed",
+      };
+    }
+
+    const usageRaw = parsed.usage && typeof parsed.usage === "object" ? (parsed.usage as Record<string, unknown>) : null;
+    const usage =
+      usageRaw
+        ? {
+            inputTokens: asNumber(usageRaw.prompt_tokens, 0) || asNumber(usageRaw.input_tokens, 0),
+            outputTokens: asNumber(usageRaw.completion_tokens, 0) || asNumber(usageRaw.output_tokens, 0),
+            cachedInputTokens: asNumber(usageRaw.cached_prompt_tokens, 0) || undefined,
+          }
+        : undefined;
+
+    await ctx.onLog("stdout", `${assistantText}\n`);
+
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: assistantText,
+      resultJson: {
+        summary: assistantText,
+        result: assistantText,
+      },
+      usage,
+      provider: "atomic-agent",
+      biller: "llama_local",
+      model,
+      billingType: "fixed",
+      costUsd: null,
+    };
+  } catch (err) {
+    if (err instanceof Error && err.name === "AbortError") {
+      return {
+        exitCode: null,
+        signal: null,
+        timedOut: true,
+        errorMessage: `atomic_agent_http: timed out after ${timeoutMs}ms`,
+        errorCode: "timeout",
+        provider: "atomic-agent",
+        biller: "llama_local",
+        model,
+        billingType: "fixed",
+      };
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/server/src/adapters/atomic-agent-http/index.ts
+++ b/server/src/adapters/atomic-agent-http/index.ts
@@ -1,0 +1,35 @@
+import type { ServerAdapterModule } from "../types.js";
+import { execute } from "./execute.js";
+import { testEnvironment } from "./test.js";
+
+const agentConfigurationDoc = `# atomic_agent_http
+
+Paperclip → [atomic-agent](https://github.com/AtomicBot-ai/atomic-agent) via OpenAI-compatible \`POST /v1/chat/completions\` (one macro-turn per heartbeat).
+
+## Prerequisites
+
+1. Run llama.cpp \`llama-server\` (or \`atomic-agent models start\`).
+2. Run \`atomic-agent serve --host 127.0.0.1 --port 8787 --cwd /path/to/work\` (add \`--api-key\` if you lock the HTTP API).
+
+## adapterConfig
+
+- **baseUrl** (string, required): e.g. \`http://127.0.0.1:8787\` (no trailing \`/v1\` required).
+- **model** (string, optional): model id as reported by \`GET {baseUrl}/v1/models\`. If omitted, the adapter uses the first id returned by that endpoint when the heartbeat runs.
+- **apiKey** (string, optional): Bearer token for \`atomic-agent serve\` when \`--api-key\` is set.
+- **timeoutMs** (number, optional): HTTP timeout; default 600000 (10 minutes) because a single completion may include many tool steps.
+- **maxTokens** (number, optional): maps to \`max_tokens\` on the chat request.
+- **systemPromptAppend** (string, optional): extra system instructions after the default Paperclip operator preamble.
+
+## Notes
+
+- Approvals and browser tools run inside atomic-agent on the machine where \`serve\` listens, not inside Paperclip.
+- Token/cost reporting follows \`usage\` from the chat completion when present; billing is treated as local (\`fixed\` / \`llama_local\`).
+`;
+
+export const atomicAgentHttpAdapter: ServerAdapterModule = {
+  type: "atomic_agent_http",
+  execute,
+  testEnvironment,
+  models: [],
+  agentConfigurationDoc,
+};

--- a/server/src/adapters/atomic-agent-http/test.ts
+++ b/server/src/adapters/atomic-agent-http/test.ts
@@ -1,0 +1,109 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "../types.js";
+import { asString, parseObject } from "../utils.js";
+import { normalizeAtomicAgentBaseUrl } from "./execute.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const rawBase = asString(config.baseUrl, "");
+  if (!rawBase.trim()) {
+    checks.push({
+      code: "atomic_agent_http_base_url_missing",
+      level: "error",
+      message: "atomic_agent_http requires baseUrl.",
+      hint: "Point baseUrl at `atomic-agent serve` (e.g. http://127.0.0.1:8787).",
+    });
+    return {
+      adapterType: ctx.adapterType,
+      status: summarizeStatus(checks),
+      checks,
+      testedAt: new Date().toISOString(),
+    };
+  }
+
+  const baseUrl = normalizeAtomicAgentBaseUrl(rawBase);
+  let origin: URL | null = null;
+  try {
+    origin = new URL(baseUrl);
+  } catch {
+    checks.push({
+      code: "atomic_agent_http_base_url_invalid",
+      level: "error",
+      message: `Invalid baseUrl: ${rawBase}`,
+    });
+  }
+
+  if (origin && origin.protocol !== "http:" && origin.protocol !== "https:") {
+    checks.push({
+      code: "atomic_agent_http_protocol_invalid",
+      level: "error",
+      message: `Unsupported URL protocol: ${origin.protocol}`,
+    });
+  }
+
+  if (origin && (origin.protocol === "http:" || origin.protocol === "https:")) {
+    checks.push({
+      code: "atomic_agent_http_base_normalized",
+      level: "info",
+      message: `Normalized base: ${baseUrl}`,
+    });
+
+    const apiKey = asString(config.apiKey, "").trim();
+    const headers: Record<string, string> = {
+      ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+    };
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    try {
+      const modelsUrl = `${baseUrl}/v1/models`;
+      const response = await fetch(modelsUrl, {
+        method: "GET",
+        headers,
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        checks.push({
+          code: "atomic_agent_http_models_probe_failed",
+          level: "warn",
+          message: `GET /v1/models returned HTTP ${response.status}.`,
+          hint: "Start `atomic-agent serve` and verify ATOMIC_AGENT_API_KEY if configured.",
+        });
+      } else {
+        checks.push({
+          code: "atomic_agent_http_models_probe_ok",
+          level: "info",
+          message: "GET /v1/models succeeded.",
+        });
+      }
+    } catch (err) {
+      checks.push({
+        code: "atomic_agent_http_models_probe_error",
+        level: "warn",
+        message: err instanceof Error ? err.message : "Models probe failed",
+        hint: "Ensure atomic-agent is listening and reachable from the Paperclip server.",
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -14,4 +14,5 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "hermes_local",
   "process",
   "http",
+  "atomic_agent_http",
 ]);

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -130,6 +130,7 @@ import { buildExternalAdapters } from "./plugin-loader.js";
 import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
 import { processAdapter } from "./process/index.js";
 import { httpAdapter } from "./http/index.js";
+import { atomicAgentHttpAdapter } from "./atomic-agent-http/index.js";
 
 function readConfiguredCommand(config: Record<string, unknown>, fallback: string): string {
   const value = typeof config.command === "string" ? config.command.trim() : "";
@@ -490,6 +491,7 @@ function registerBuiltInAdapters() {
     hermesLocalAdapter,
     processAdapter,
     httpAdapter,
+    atomicAgentHttpAdapter,
   ]) {
     adaptersByType.set(adapter.type, adapter);
   }
@@ -592,7 +594,7 @@ export function registerServerAdapter(adapter: ServerAdapterModule): void {
 }
 
 export function unregisterServerAdapter(type: string): void {
-  if (type === processAdapter.type || type === httpAdapter.type) return;
+  if (type === processAdapter.type || type === httpAdapter.type || type === atomicAgentHttpAdapter.type) return;
   if (builtinFallbacks.has(type)) {
     pausedOverrides.delete(type);
     const fallback = builtinFallbacks.get(type);

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -125,7 +125,7 @@ const DEFAULT_INCLUDE: CompanyPortabilityInclude = {
 };
 
 const DEFAULT_COLLISION_STRATEGY: CompanyPortabilityCollisionStrategy = "rename";
-const IMPORT_FORBIDDEN_ADAPTER_TYPES = new Set(["process", "http"]);
+const IMPORT_FORBIDDEN_ADAPTER_TYPES = new Set(["process", "http", "atomic_agent_http"]);
 const execFileAsync = promisify(execFile);
 let bundledSkillsCommitPromise: Promise<string | null> | null = null;
 

--- a/server/src/services/heartbeat-stop-metadata.ts
+++ b/server/src/services/heartbeat-stop-metadata.ts
@@ -53,7 +53,7 @@ export function resolveHeartbeatRunTimeoutPolicy(
 ): HeartbeatRunTimeoutPolicy {
   const config = adapterConfig ?? {};
 
-  if (adapterType === "http") {
+  if (adapterType === "http" || adapterType === "atomic_agent_http") {
     const hasTimeoutMs = hasOwn(config, "timeoutMs");
     const rawTimeoutMs = hasTimeoutMs ? readFiniteNumber(config.timeoutMs) : 0;
     const timeoutMs = Math.max(0, Math.floor(rawTimeoutMs ?? 0));

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -51,6 +51,8 @@ export interface AdapterDisplayInfo {
   disabledLabel?: string;
   experimental?: boolean;
   hideFromVisualSelection?: boolean;
+  /** Lower values appear earlier in visual pickers (e.g. “More Agent Adapter Types”). */
+  visualRank?: number;
 }
 
 const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
@@ -77,31 +79,37 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     label: "Gemini CLI",
     description: "Local Gemini agent",
     icon: Gem,
+    visualRank: 20,
   },
   opencode_local: {
     label: "OpenCode",
     description: "Local multi-provider agent",
     icon: OpenCodeLogoIcon,
+    visualRank: 40,
   },
   hermes_local: {
     label: "Hermes Agent",
     description: "Local Hermes CLI agent",
     icon: HermesIcon,
+    visualRank: 30,
   },
   pi_local: {
     label: "Pi",
     description: "Local Pi agent",
     icon: Terminal,
+    visualRank: 50,
   },
   cursor: {
     label: "Cursor",
     description: "Local Cursor agent",
     icon: MousePointer2,
+    visualRank: 60,
   },
   cursor_cloud: {
     label: "Cursor Cloud",
     description: "Managed remote Cursor agent",
     icon: MousePointer2,
+    visualRank: 10,
   },
   openclaw_gateway: {
     label: "OpenClaw Gateway",
@@ -121,6 +129,12 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     description: "Internal HTTP adapter",
     icon: Cpu,
     comingSoon: true,
+  },
+  atomic_agent_http: {
+    label: "Atomic Agent",
+    description: "Local atomic-agent operator (llama.cpp, HTTP)",
+    icon: Bot,
+    visualRank: 35,
   },
 };
 

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -132,7 +132,7 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
   },
   atomic_agent_http: {
     label: "Atomic Agent",
-    description: "Local atomic-agent operator (llama.cpp, HTTP)",
+    description: "Local Atomic HTTP agent",
     icon: Bot,
     visualRank: 35,
   },

--- a/ui/src/adapters/atomic-agent-http/build-config.ts
+++ b/ui/src/adapters/atomic-agent-http/build-config.ts
@@ -1,0 +1,11 @@
+import type { CreateConfigValues } from "../../components/AgentConfigForm";
+
+export function buildAtomicAgentHttpConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+  if (v.url?.trim()) ac.baseUrl = v.url.trim();
+  if (v.model?.trim()) ac.model = v.model.trim();
+  const key = v.atomicAgentApiKey?.trim();
+  if (key) ac.apiKey = key;
+  ac.timeoutMs = 600_000;
+  return ac;
+}

--- a/ui/src/adapters/atomic-agent-http/config-fields.tsx
+++ b/ui/src/adapters/atomic-agent-http/config-fields.tsx
@@ -19,8 +19,8 @@ export function AtomicAgentHttpConfigFields({
   return (
     <>
       <Field
-        label="atomic-agent serve URL"
-        hint="Root URL of `atomic-agent serve` (no /v1 suffix). Example: http://127.0.0.1:8787"
+        label="API base URL"
+        hint="Atomic Chat or atomic-agent serve (no /v1 suffix). Examples: http://127.0.0.1:1337 or http://127.0.0.1:8787"
       >
         <DraftInput
           value={
@@ -35,7 +35,7 @@ export function AtomicAgentHttpConfigFields({
           }
           immediate
           className={inputClass}
-          placeholder="http://127.0.0.1:8787"
+          placeholder="http://127.0.0.1:1337"
         />
       </Field>
       <Field label="Model id" hint={help.model}>
@@ -57,7 +57,7 @@ export function AtomicAgentHttpConfigFields({
       </Field>
       <Field
         label="HTTP API key"
-        hint="Only if you started serve with --api-key. Stored in adapter config."
+        hint="Only if your Atomic serve endpoint requires --api-key. Stored in adapter config."
       >
         <DraftInput
           value={
@@ -73,7 +73,7 @@ export function AtomicAgentHttpConfigFields({
           immediate
           className={inputClass}
           type="password"
-          placeholder="Bearer token for atomic-agent serve"
+          placeholder="Optional Bearer token"
         />
       </Field>
     </>

--- a/ui/src/adapters/atomic-agent-http/config-fields.tsx
+++ b/ui/src/adapters/atomic-agent-http/config-fields.tsx
@@ -1,0 +1,81 @@
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  Field,
+  DraftInput,
+  help,
+} from "../../components/agent-config-primitives";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+
+export function AtomicAgentHttpConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <Field
+        label="atomic-agent serve URL"
+        hint="Root URL of `atomic-agent serve` (no /v1 suffix). Example: http://127.0.0.1:8787"
+      >
+        <DraftInput
+          value={
+            isCreate
+              ? values!.url
+              : eff("adapterConfig", "baseUrl", String(config.baseUrl ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ url: v })
+              : mark("adapterConfig", "baseUrl", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="http://127.0.0.1:8787"
+        />
+      </Field>
+      <Field label="Model id" hint={help.model}>
+        <DraftInput
+          value={
+            isCreate
+              ? values!.model
+              : eff("adapterConfig", "model", String(config.model ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ model: v })
+              : mark("adapterConfig", "model", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="From GET /v1/models (optional if only one model)"
+        />
+      </Field>
+      <Field
+        label="HTTP API key"
+        hint="Only if you started serve with --api-key. Stored in adapter config."
+      >
+        <DraftInput
+          value={
+            isCreate
+              ? values!.atomicAgentApiKey ?? ""
+              : eff("adapterConfig", "apiKey", String(config.apiKey ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ atomicAgentApiKey: v })
+              : mark("adapterConfig", "apiKey", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          type="password"
+          placeholder="Bearer token for atomic-agent serve"
+        />
+      </Field>
+    </>
+  );
+}

--- a/ui/src/adapters/atomic-agent-http/index.ts
+++ b/ui/src/adapters/atomic-agent-http/index.ts
@@ -5,7 +5,7 @@ import { buildAtomicAgentHttpConfig } from "./build-config";
 
 export const atomicAgentHttpUIAdapter: UIAdapterModule = {
   type: "atomic_agent_http",
-  label: "Atomic Agent (HTTP)",
+  label: "Local Atomic agent",
   parseStdoutLine: parseAtomicAgentHttpStdoutLine,
   ConfigFields: AtomicAgentHttpConfigFields,
   buildAdapterConfig: buildAtomicAgentHttpConfig,

--- a/ui/src/adapters/atomic-agent-http/index.ts
+++ b/ui/src/adapters/atomic-agent-http/index.ts
@@ -1,0 +1,12 @@
+import type { UIAdapterModule } from "../types";
+import { parseAtomicAgentHttpStdoutLine } from "./parse-stdout";
+import { AtomicAgentHttpConfigFields } from "./config-fields";
+import { buildAtomicAgentHttpConfig } from "./build-config";
+
+export const atomicAgentHttpUIAdapter: UIAdapterModule = {
+  type: "atomic_agent_http",
+  label: "Atomic Agent (HTTP)",
+  parseStdoutLine: parseAtomicAgentHttpStdoutLine,
+  ConfigFields: AtomicAgentHttpConfigFields,
+  buildAdapterConfig: buildAtomicAgentHttpConfig,
+};

--- a/ui/src/adapters/atomic-agent-http/parse-stdout.ts
+++ b/ui/src/adapters/atomic-agent-http/parse-stdout.ts
@@ -1,0 +1,5 @@
+import type { TranscriptEntry } from "../types";
+
+export function parseAtomicAgentHttpStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/ui/src/adapters/metadata.test.ts
+++ b/ui/src/adapters/metadata.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  compareAdapterVisualOrder,
   isEnabledAdapterType,
   isValidAdapterType,
   isVisualAdapterChoice,
@@ -35,6 +36,12 @@ describe("adapter metadata", () => {
   it("keeps intentionally withheld built-in adapters marked as coming soon", () => {
     expect(isEnabledAdapterType("process")).toBe(false);
     expect(isEnabledAdapterType("http")).toBe(false);
+  });
+
+  it("orders atomic_agent_http immediately after hermes_local in visual pickers", () => {
+    expect(compareAdapterVisualOrder("hermes_local", "atomic_agent_http")).toBeLessThan(0);
+    expect(compareAdapterVisualOrder("atomic_agent_http", "opencode_local")).toBeLessThan(0);
+    expect(compareAdapterVisualOrder("gemini_local", "hermes_local")).toBeLessThan(0);
   });
 
   it("keeps ACPX selectable from explicit configuration but out of visual pickers", () => {

--- a/ui/src/adapters/metadata.ts
+++ b/ui/src/adapters/metadata.ts
@@ -53,6 +53,16 @@ export function isVisualAdapterChoice(type: string): boolean {
   return !getAdapterDisplay(type).hideFromVisualSelection;
 }
 
+const DEFAULT_ADAPTER_VISUAL_RANK = 1000;
+
+/** Sort key for card pickers and adapter-type dropdowns. */
+export function compareAdapterVisualOrder(typeA: string, typeB: string): number {
+  const rankA = getAdapterDisplay(typeA).visualRank ?? DEFAULT_ADAPTER_VISUAL_RANK;
+  const rankB = getAdapterDisplay(typeB).visualRank ?? DEFAULT_ADAPTER_VISUAL_RANK;
+  if (rankA !== rankB) return rankA - rankB;
+  return getAdapterLabel(typeA).localeCompare(getAdapterLabel(typeB));
+}
+
 /**
  * Build option metadata for a list of adapters (for dropdowns).
  * `labelFor` callback allows callers to override labels; defaults to display registry.
@@ -62,13 +72,15 @@ export function listAdapterOptions(
   adapters: UIAdapterModule[] = listUIAdapters(),
 ): AdapterOptionMetadata[] {
   const getLabel = labelFor ?? getAdapterLabel;
-  return adapters.map((adapter) => ({
-    value: adapter.type,
-    label: getLabel(adapter.type),
-    comingSoon: !!getAdapterDisplay(adapter.type).comingSoon,
-    hidden: isAdapterTypeHidden(adapter.type),
-    experimental: !!getAdapterDisplay(adapter.type).experimental,
-  }));
+  return adapters
+    .map((adapter) => ({
+      value: adapter.type,
+      label: getLabel(adapter.type),
+      comingSoon: !!getAdapterDisplay(adapter.type).comingSoon,
+      hidden: isAdapterTypeHidden(adapter.type),
+      experimental: !!getAdapterDisplay(adapter.type).experimental,
+    }))
+    .sort((a, b) => compareAdapterVisualOrder(a.value, b.value));
 }
 
 /**

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -11,6 +11,7 @@ import { openClawGatewayUIAdapter } from "./openclaw-gateway";
 import { hermesLocalUIAdapter } from "./hermes-local";
 import { processUIAdapter } from "./process";
 import { httpUIAdapter } from "./http";
+import { atomicAgentHttpUIAdapter } from "./atomic-agent-http";
 import { loadDynamicParser, invalidateDynamicParser, setDynamicParserResultNotifier } from "./dynamic-loader";
 import { SchemaConfigFields, buildSchemaAdapterConfig } from "./schema-config-fields";
 
@@ -57,6 +58,7 @@ function registerBuiltInUIAdapters() {
     cursorCloudUIAdapter,
     geminiLocalUIAdapter,
     hermesLocalUIAdapter,
+    atomicAgentHttpUIAdapter,
     openCodeLocalUIAdapter,
     piLocalUIAdapter,
     cursorLocalUIAdapter,
@@ -82,7 +84,7 @@ export function registerUIAdapter(adapter: UIAdapterModule): void {
 }
 
 export function unregisterUIAdapter(type: string): void {
-  if (type === processUIAdapter.type || type === httpUIAdapter.type) return;
+  if (type === processUIAdapter.type || type === httpUIAdapter.type || type === atomicAgentHttpUIAdapter.type) return;
   const existingIndex = uiAdapters.findIndex((entry) => entry.type === type);
   if (existingIndex >= 0) {
     uiAdapters.splice(existingIndex, 1);

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -858,7 +858,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     } else if (t === "opencode_local") {
                       nextValues.model = DEFAULT_OPENCODE_LOCAL_MODEL;
                     } else if (t === "atomic_agent_http") {
-                      nextValues.url = "http://127.0.0.1:8787";
+                      nextValues.url = "http://127.0.0.1:1337";
                     }
                     set!(nextValues);
                   } else {

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -857,6 +857,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
                     } else if (t === "opencode_local") {
                       nextValues.model = DEFAULT_OPENCODE_LOCAL_MODEL;
+                    } else if (t === "atomic_agent_http") {
+                      nextValues.url = "http://127.0.0.1:8787";
                     }
                     set!(nextValues);
                   } else {

--- a/ui/src/components/NewAgentDialog.tsx
+++ b/ui/src/components/NewAgentDialog.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { listUIAdapters } from "../adapters";
-import { isVisualAdapterChoice } from "../adapters/metadata";
+import { compareAdapterVisualOrder, isVisualAdapterChoice } from "../adapters/metadata";
 import { getAdapterDisplay } from "../adapters/adapter-display-registry";
 import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 
@@ -81,7 +81,7 @@ export function NewAgentDialog() {
       .sort((a, b) => {
         if (a.recommended && !b.recommended) return -1;
         if (!a.recommended && b.recommended) return 1;
-        return a.label.localeCompare(b.label);
+        return compareAdapterVisualOrder(a.value, b.value);
       });
   }, [disabledTypes, serverAdapters]);
 

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -1116,18 +1116,14 @@ export function OnboardingWizard() {
                       <label className="text-xs text-muted-foreground mb-1 block">
                         {adapterType === "openclaw_gateway"
                           ? "Gateway URL"
-                          : adapterType === "atomic_agent_http"
-                            ? "Atomic Chat API URL"
-                            : "Webhook URL"}
+                          : "Webhook URL"}
                       </label>
                       <input
                         className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
                         placeholder={
                           adapterType === "openclaw_gateway"
                             ? "ws://127.0.0.1:18789"
-                            : adapterType === "atomic_agent_http"
-                              ? "http://127.0.0.1:1337"
-                              : "https://..."
+                            : "https://..."
                         }
                         value={url}
                         onChange={(e) => setUrl(e.target.value)}

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -202,6 +202,9 @@ export function OnboardingWizard() {
   const getCapabilities = useAdapterCapabilities();
   const adapterCaps = getCapabilities(adapterType);
   const isLocalAdapter = adapterCaps.supportsInstructionsBundle || adapterCaps.supportsSkills || adapterCaps.supportsLocalAgentJwt;
+  const isAtomicAgentHttp = adapterType === "atomic_agent_http";
+  const needsAdapterEnvironmentProbe = isLocalAdapter || isAtomicAgentHttp;
+  const showAdapterModelField = isLocalAdapter || isAtomicAgentHttp;
 
   // Build adapter grids dynamically from the UI registry + display metadata.
   // External/plugin adapters automatically appear with generic defaults.
@@ -437,7 +440,14 @@ export function OnboardingWizard() {
         }
       }
 
-      if (isLocalAdapter) {
+      if (adapterType === "atomic_agent_http" && !url.trim()) {
+        setError(
+          "Enter your Atomic Chat API URL (e.g. http://127.0.0.1:1337).",
+        );
+        return;
+      }
+
+      if (needsAdapterEnvironmentProbe) {
         const result = adapterEnvResult ?? (await runAdapterEnvironmentTest());
         if (!result) return;
       }
@@ -826,8 +836,10 @@ export function OnboardingWizard() {
                                 return;
                               }
                               if (nextType === "atomic_agent_http") {
-                                setUrl("http://127.0.0.1:8787");
-                                setModel("");
+                                setUrl("http://127.0.0.1:1337");
+                                setModel("gemma-4-E4B-it-IQ4_XS");
+                                setAdapterEnvResult(null);
+                                setAdapterEnvError(null);
                                 return;
                               }
                               setModel("");
@@ -847,7 +859,37 @@ export function OnboardingWizard() {
                   </div>
 
                   {/* Conditional adapter fields */}
-                  {isLocalAdapter && (
+                  {isAtomicAgentHttp && (
+                    <div className="space-y-3">
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          Atomic Chat API URL
+                        </label>
+                        <input
+                          className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                          placeholder="http://127.0.0.1:1337"
+                          value={url}
+                          onChange={(e) => setUrl(e.target.value)}
+                        />
+                      </div>
+                      <div>
+                        <label className="text-xs text-muted-foreground mb-1 block">
+                          Model id
+                        </label>
+                        <input
+                          className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                          placeholder="gemma-4-E4B-it-IQ4_XS"
+                          value={model}
+                          onChange={(e) => setModel(e.target.value)}
+                        />
+                        <p className="mt-1 text-[11px] text-muted-foreground">
+                          Must match an id from <span className="font-mono">GET /v1/models</span> on your Chat server.
+                        </p>
+                      </div>
+                    </div>
+                  )}
+
+                  {showAdapterModelField && !isAtomicAgentHttp && (
                     <div className="space-y-3">
                       <div>
                         <label className="text-xs text-muted-foreground mb-1 block">
@@ -949,7 +991,7 @@ export function OnboardingWizard() {
                     </div>
                   )}
 
-                  {isLocalAdapter && (
+                  {needsAdapterEnvironmentProbe && (
                     <div className="space-y-2 rounded-md border border-border p-3">
                       <div className="flex items-center justify-between gap-2">
                         <div>
@@ -957,8 +999,9 @@ export function OnboardingWizard() {
                             Adapter environment check
                           </p>
                           <p className="text-[11px] text-muted-foreground">
-                            Runs a live probe that asks the adapter CLI to
-                            respond with hello.
+                            {isAtomicAgentHttp
+                              ? "Probes GET /v1/models on your Atomic Chat server."
+                              : "Runs a live probe that asks the adapter CLI to respond with hello."}
                           </p>
                         </div>
                         <Button
@@ -1068,14 +1111,13 @@ export function OnboardingWizard() {
                   )}
 
                   {(adapterType === "http" ||
-                    adapterType === "openclaw_gateway" ||
-                    adapterType === "atomic_agent_http") && (
+                    adapterType === "openclaw_gateway") && (
                     <div>
                       <label className="text-xs text-muted-foreground mb-1 block">
                         {adapterType === "openclaw_gateway"
                           ? "Gateway URL"
                           : adapterType === "atomic_agent_http"
-                            ? "atomic-agent serve URL"
+                            ? "Atomic Chat API URL"
                             : "Webhook URL"}
                       </label>
                       <input
@@ -1084,7 +1126,7 @@ export function OnboardingWizard() {
                           adapterType === "openclaw_gateway"
                             ? "ws://127.0.0.1:18789"
                             : adapterType === "atomic_agent_http"
-                              ? "http://127.0.0.1:8787"
+                              ? "http://127.0.0.1:1337"
                               : "https://..."
                         }
                         value={url}
@@ -1228,7 +1270,10 @@ export function OnboardingWizard() {
                     <Button
                       size="sm"
                       disabled={
-                        !agentName.trim() || loading || adapterEnvLoading
+                        !agentName.trim() ||
+                        loading ||
+                        adapterEnvLoading ||
+                        (isAtomicAgentHttp && !url.trim())
                       }
                       onClick={handleStep2Next}
                     >

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -25,7 +25,7 @@ import {
 } from "../lib/model-utils";
 import { getUIAdapter } from "../adapters";
 import { listUIAdapters } from "../adapters";
-import { isVisualAdapterChoice } from "../adapters/metadata";
+import { compareAdapterVisualOrder, isVisualAdapterChoice } from "../adapters/metadata";
 import { useDisabledAdaptersSync } from "../adapters/use-disabled-adapters";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
 import { getAdapterDisplay } from "../adapters/adapter-display-registry";
@@ -215,9 +215,11 @@ export function OnboardingWizard() {
       )
       .map((a) => ({ ...getAdapterDisplay(a.type), type: a.type }));
 
+    const more = all.filter((a) => !a.recommended);
+    more.sort((a, b) => compareAdapterVisualOrder(a.type, b.type));
     return {
       recommendedAdapters: all.filter((a) => a.recommended),
-      moreAdapters: all.filter((a) => !a.recommended),
+      moreAdapters: more,
     };
   }, [disabledTypes]);
   const COMMAND_PLACEHOLDERS: Record<string, string> = {
@@ -823,6 +825,11 @@ export function OnboardingWizard() {
                                 setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
                                 return;
                               }
+                              if (nextType === "atomic_agent_http") {
+                                setUrl("http://127.0.0.1:8787");
+                                setModel("");
+                                return;
+                              }
                               setModel("");
                             }}
                           >
@@ -1061,19 +1068,24 @@ export function OnboardingWizard() {
                   )}
 
                   {(adapterType === "http" ||
-                    adapterType === "openclaw_gateway") && (
+                    adapterType === "openclaw_gateway" ||
+                    adapterType === "atomic_agent_http") && (
                     <div>
                       <label className="text-xs text-muted-foreground mb-1 block">
                         {adapterType === "openclaw_gateway"
                           ? "Gateway URL"
-                          : "Webhook URL"}
+                          : adapterType === "atomic_agent_http"
+                            ? "atomic-agent serve URL"
+                            : "Webhook URL"}
                       </label>
                       <input
                         className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
                         placeholder={
                           adapterType === "openclaw_gateway"
                             ? "ws://127.0.0.1:18789"
-                            : "https://..."
+                            : adapterType === "atomic_agent_http"
+                              ? "http://127.0.0.1:8787"
+                              : "https://..."
                         }
                         value={url}
                         onChange={(e) => setUrl(e.target.value)}

--- a/ui/src/components/agent-config-defaults.ts
+++ b/ui/src/components/agent-config-defaults.ts
@@ -18,6 +18,7 @@ export const defaultCreateValues: CreateConfigValues = {
   envVars: "",
   envBindings: {},
   url: "",
+  atomicAgentApiKey: "",
   bootstrapPrompt: "",
   payloadTemplateJson: "",
   workspaceStrategyType: "project_primary",

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -51,6 +51,8 @@ function createValuesForAdapterType(
     nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
   } else if (adapterType === "opencode_local") {
     nextValues.model = DEFAULT_OPENCODE_LOCAL_MODEL;
+  } else if (adapterType === "atomic_agent_http") {
+    nextValues.url = "http://127.0.0.1:8787";
   }
   return nextValues;
 }

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -52,7 +52,7 @@ function createValuesForAdapterType(
   } else if (adapterType === "opencode_local") {
     nextValues.model = DEFAULT_OPENCODE_LOCAL_MODEL;
   } else if (adapterType === "atomic_agent_http") {
-    nextValues.url = "http://127.0.0.1:8787";
+    nextValues.url = "http://127.0.0.1:1337";
   }
   return nextValues;
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies: goals, issues, heartbeats, budgets, and governance stay in the control plane while agents bring their own runtimes.
> - Built-in adapters cover CLI tools (Claude Code, Codex, OpenCode, Hermes) and generic HTTP webhooks, but there is no first-class path for local operator stacks that expose an OpenAI-compatible chat API.
> - [atomic-agent](https://github.com/AtomicBot-ai/atomic-agent) and compatible servers such as Atomic Chat (`llama.cpp` on `http://127.0.0.1:1337/v1`) fit that model: one HTTP completion can represent a full operator macro-turn with tools on the host.
> - Users running local inference need Paperclip to send wake payloads and record run outcomes without treating the integration as an opaque webhook.
> - This pull request adds a built-in `atomic_agent_http` adapter (server, UI, CLI) plus onboarding UX for Atomic Chat defaults (URL, model id, environment probe).
> - The benefit is a BYOA path for local OpenAI-compatible operators: Paperclip keeps orchestration; the runtime keeps browser/shell/tools and approvals on the machine where `serve` or Chat listens.

## What Changed

- Server adapter `atomic_agent_http` (`server/src/adapters/atomic-agent-http/`):
  - `POST {baseUrl}/v1/chat/completions` with Paperclip wake prompt and optional `paperclipWake` JSON
  - `GET {baseUrl}/v1/models` in `testEnvironment`
  - Config: `baseUrl`, `model`, `apiKey`, `timeoutMs` (default 10m), `maxTokens`, `systemPromptAppend`
  - Auto-selects first model from `/v1/models` when `model` is omitted
  - Maps assistant text to `resultJson.summary`; local billing (`llama_local` / `fixed`)
- Unit tests: `server/src/adapters/atomic-agent-http/execute.test.ts`
- Registered in server/CLI registries, `AGENT_ADAPTER_TYPES`, and builtin adapter types; heartbeat `timeoutMs` aligned with the `http` adapter
- Excluded `atomic_agent_http` from company portability import (same policy as `process` / `http`)
- UI adapter (`ui/src/adapters/atomic-agent-http/`): URL, model id, optional API key
- Display registry: **Atomic Agent** with `visualRank` after Hermes; `compareAdapterVisualOrder()` for picker/onboarding ordering
- Onboarding: Atomic Chat URL + model fields, defaults `http://127.0.0.1:1337`, `GET /v1/models` probe, block **Next** when URL is empty
- `agentConfigurationDoc` on the adapter module

**Commits:** `728fec4`, `4a6e172`, `c7beecd`

## Verification

### Prerequisites

Atomic Chat (or compatible API) at `http://127.0.0.1:1337/v1`:

```bash
curl -s http://127.0.0.1:1337/v1/models
```
## Manual

1. Onboarding or Agents → New → Atomic Agent (under “More Agent Adapter Types”, after Hermes)
2. Set URL http://127.0.0.1:1337 and model id (e.g. gemma-4-E4B-it-IQ4_XS)
3. Run Test environment — probe should pass
4. Trigger a heartbeat — logs should show atomic_agent_http POST .../v1/chat/completions; issue should receive a summary comment on success

## Automated
`pnpm exec vitest run server/src/adapters/atomic-agent-http/`
Targeted adapter tests pass (2 tests). Full pnpm test on macOS may hit unrelated flakes in adapter-utils / server integration tests not introduced by this PR.

## Risks
Low–medium.

-One heartbeat = one HTTP completion; long runs depend on timeoutMs (default 10m)
-Tooling, approvals, and browser state live in the operator process; Paperclip only sees the final assistant message
-No sessionId from Paperclip; continuity depends on the operator runtime
-Atomic Chat is inference-only; full desktop operator features require atomic-agent serve
-Company import excludes this adapter type (intentional)

> For core feature work, check [ROADMAP.md](vscode-file://vscode-app/Volumes/Cursor%20Installer/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/ROADMAP.md) first and discuss it in #dev before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See CONTRIBUTING.md.


## Model Used
Cursor AI assistant (Claude Sonnet family) with human direction. Used for implementation design, TypeScript across server/UI, onboarding, and PR text. Human reviewed requirements (Atomic Chat on port 1337, placement next to Hermes Agent).

Checklist
 
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x]  I will address all Greptile and reviewer comments before requesting merge

After:

<img width="619" height="654" alt="Снимок экрана 2026-05-15 в 15 40 24" src="https://github.com/user-attachments/assets/5d98fc49-13d6-4228-8fdf-2fdcea09d35b" />


