### PR TITLE
feat(KEN-4172): persist originKind/originId/originFingerprint on POST /issues

### DIFF
--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { MAX_ISSUE_REQUEST_DEPTH } from "../index.js";
 import {
+  SYSTEM_RESERVED_ORIGIN_KINDS,
   addIssueCommentSchema,
   createIssueSchema,
+  isSystemReservedOriginKind,
   issueBlockedInboxAttentionSchema,
   resolveIssueRecoveryActionSchema,
   respondIssueThreadInteractionSchema,
@@ -361,5 +363,110 @@ describe("issue validators", () => {
     });
 
     expect(parsed.success).toBe(false);
+  });
+
+  describe("origin fields on createIssueSchema", () => {
+    it("preserves namespaced origin fields supplied by external integrations", () => {
+      const parsed = createIssueSchema.parse({
+        title: "Linear webhook sync",
+        originKind: "linear",
+        originId: "LIN-123",
+        originFingerprint: "webhook",
+      });
+
+      expect(parsed.originKind).toBe("linear");
+      expect(parsed.originId).toBe("LIN-123");
+      expect(parsed.originFingerprint).toBe("webhook");
+    });
+
+    it("remains backwards compatible when origin fields are omitted", () => {
+      const parsed = createIssueSchema.parse({ title: "No origin info" });
+
+      expect(parsed.originKind).toBeUndefined();
+      expect(parsed.originId).toBeUndefined();
+      expect(parsed.originFingerprint).toBeUndefined();
+    });
+
+    it.each(SYSTEM_RESERVED_ORIGIN_KINDS)(
+      "rejects the system-reserved originKind %s",
+      (reserved) => {
+        const result = createIssueSchema.safeParse({
+          title: "external attempt",
+          originKind: reserved,
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          const message = result.error.issues
+            .map((issue) => issue.message)
+            .join(" | ");
+          expect(message).toContain("reserved");
+          expect(message).toContain(reserved);
+        }
+      },
+    );
+
+    it("rejects originKind values matching the plugin operation namespace", () => {
+      const result = createIssueSchema.safeParse({
+        title: "external attempt",
+        originKind: "plugin:foo:operation",
+      });
+
+      expect(result.success).toBe(false);
+
+      const scopedResult = createIssueSchema.safeParse({
+        title: "external attempt",
+        originKind: "plugin:foo:operation:bar",
+      });
+
+      expect(scopedResult.success).toBe(false);
+    });
+
+    it("accepts namespaced plugin originKind values that are not the reserved operation form", () => {
+      const result = createIssueSchema.safeParse({
+        title: "plugin feature",
+        originKind: "plugin:paperclip.missions:feature",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("trims and applies length limits to origin fields", () => {
+      const parsed = createIssueSchema.parse({
+        title: "trim",
+        originKind: "  linear  ",
+        originId: " LIN-1 ",
+        originFingerprint: "  webhook  ",
+      });
+      expect(parsed.originKind).toBe("linear");
+      expect(parsed.originId).toBe("LIN-1");
+      expect(parsed.originFingerprint).toBe("webhook");
+
+      const overflow = createIssueSchema.safeParse({
+        title: "too long",
+        originKind: "x".repeat(121),
+      });
+      expect(overflow.success).toBe(false);
+    });
+
+    it("blocks reserved originKind values on updateIssueSchema by omitting the field", () => {
+      // updateIssueSchema intentionally omits origin fields; they are immutable
+      // after creation. Strict-stripping silently drops unknown keys, but the
+      // resulting parsed object should not contain originKind.
+      const parsed = updateIssueSchema.parse({
+        title: "rename",
+        originKind: "routine_execution",
+      } as Record<string, unknown>);
+
+      expect((parsed as Record<string, unknown>).originKind).toBeUndefined();
+    });
+
+    it("exposes a shared isSystemReservedOriginKind helper", () => {
+      expect(isSystemReservedOriginKind("routine_execution")).toBe(true);
+      expect(isSystemReservedOriginKind("plugin:x:operation")).toBe(true);
+      expect(isSystemReservedOriginKind("plugin:x:operation:y")).toBe(true);
+      expect(isSystemReservedOriginKind("linear")).toBe(false);
+      expect(isSystemReservedOriginKind("plugin:x:feature")).toBe(false);
+    });
   });
 });

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -364,6 +364,40 @@ function withCreateIssueStatusDefault<T extends z.ZodRawShape>(schema: z.ZodObje
   }, schema);
 }
 
+export const SYSTEM_RESERVED_ORIGIN_KINDS = [
+  "routine_execution",
+  "harness_liveness_escalation",
+  "stale_active_run_evaluation",
+  "issue_productivity_review",
+  "stranded_issue_recovery",
+  "blocker_attention_open_recovery",
+] as const;
+
+export type SystemReservedOriginKind = typeof SYSTEM_RESERVED_ORIGIN_KINDS[number];
+
+const SYSTEM_RESERVED_ORIGIN_KIND_SET: ReadonlySet<string> = new Set(SYSTEM_RESERVED_ORIGIN_KINDS);
+
+export function isSystemReservedOriginKind(value: string): boolean {
+  if (SYSTEM_RESERVED_ORIGIN_KIND_SET.has(value)) return true;
+  // Plugin operation origins are reserved for internal plugin orchestration.
+  // External callers may use namespaced values like "plugin:foo" but not the
+  // operation-level forms reserved for the orchestrator.
+  if (/^plugin:[^:]+:operation(?::.+)?$/.test(value)) return true;
+  return false;
+}
+
+function applyOriginKindReservationGuard<Schema extends z.ZodTypeAny>(schema: Schema): Schema {
+  return schema.superRefine((value: { originKind?: string | null }, ctx) => {
+    if (typeof value.originKind === "string" && isSystemReservedOriginKind(value.originKind)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `originKind "${value.originKind}" is reserved for internal use; external callers must use a namespaced value (e.g. "linear", "sentry", "plugin:<id>")`,
+        path: ["originKind"],
+      });
+    }
+  }) as unknown as Schema;
+}
+
 const createIssueBaseSchema = z.object({
   projectId: z.string().uuid().optional().nullable(),
   projectWorkspaceId: z.string().uuid().optional().nullable(),
@@ -386,25 +420,34 @@ const createIssueBaseSchema = z.object({
   executionWorkspacePreference: z.enum(ISSUE_EXECUTION_WORKSPACE_PREFERENCES).optional().nullable(),
   executionWorkspaceSettings: issueExecutionWorkspaceSettingsSchema.optional().nullable(),
   labelIds: z.array(z.string().uuid()).optional(),
+  originKind: z.string().trim().min(1).max(120).optional(),
+  originId: z.string().trim().min(1).max(500).optional().nullable(),
+  originFingerprint: z.string().trim().min(1).max(120).optional(),
 });
 
-export const createIssueInputSchema = createIssueBaseSchema.extend({
-  status: createIssueBaseSchema.shape.status.optional(),
-});
+export const createIssueInputSchema = applyOriginKindReservationGuard(
+  createIssueBaseSchema.extend({
+    status: createIssueBaseSchema.shape.status.optional(),
+  }),
+);
 
-export const createIssueSchema = withCreateIssueStatusDefault(createIssueBaseSchema);
+export const createIssueSchema = applyOriginKindReservationGuard(
+  withCreateIssueStatusDefault(createIssueBaseSchema),
+);
 
 export type CreateIssue = z.infer<typeof createIssueSchema>;
 
-export const createChildIssueSchema = withCreateIssueStatusDefault(createIssueBaseSchema
-  .omit({
-    parentId: true,
-    inheritExecutionWorkspaceFromIssueId: true,
-  })
-  .extend({
-    acceptanceCriteria: z.array(z.string().trim().min(1).max(500)).max(20).optional(),
-    blockParentUntilDone: z.boolean().optional().default(false),
-  }));
+export const createChildIssueSchema = applyOriginKindReservationGuard(
+  withCreateIssueStatusDefault(createIssueBaseSchema
+    .omit({
+      parentId: true,
+      inheritExecutionWorkspaceFromIssueId: true,
+    })
+    .extend({
+      acceptanceCriteria: z.array(z.string().trim().min(1).max(500)).max(20).optional(),
+      blockParentUntilDone: z.boolean().optional().default(false),
+    })),
+);
 
 export type CreateChildIssue = z.infer<typeof createChildIssueSchema>;
 
@@ -415,16 +458,19 @@ export const createIssueLabelSchema = z.object({
 
 export type CreateIssueLabel = z.infer<typeof createIssueLabelSchema>;
 
-export const updateIssueSchema = createIssueBaseSchema.partial().extend({
-  requestDepth: issueRequestDepthInputSchema.optional(),
-  assigneeAgentId: z.string().trim().min(1).optional().nullable(),
-  comment: multilineTextSchema.pipe(z.string().min(1)).optional(),
-  reviewRequest: issueReviewRequestSchema.optional().nullable(),
-  reopen: z.boolean().optional(),
-  resume: z.boolean().optional(),
-  interrupt: z.boolean().optional(),
-  hiddenAt: z.string().datetime().nullable().optional(),
-});
+export const updateIssueSchema = createIssueBaseSchema
+  .omit({ originKind: true, originId: true, originFingerprint: true })
+  .partial()
+  .extend({
+    requestDepth: issueRequestDepthInputSchema.optional(),
+    assigneeAgentId: z.string().trim().min(1).optional().nullable(),
+    comment: multilineTextSchema.pipe(z.string().min(1)).optional(),
+    reviewRequest: issueReviewRequestSchema.optional().nullable(),
+    reopen: z.boolean().optional(),
+    resume: z.boolean().optional(),
+    interrupt: z.boolean().optional(),
+    hiddenAt: z.string().datetime().nullable().optional(),
+  });
 
 export type UpdateIssue = z.infer<typeof updateIssueSchema>;
 export type IssueExecutionWorkspaceSettings = z.infer<typeof issueExecutionWorkspaceSettingsSchema>;

--- a/server/src/__tests__/issue-create-origin-fields.test.ts
+++ b/server/src/__tests__/issue-create-origin-fields.test.ts
@@ -1,0 +1,284 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Verifies KEN-4172: POST /api/companies/:id/issues must accept and forward
+// originKind, originId, and originFingerprint to the service layer, while
+// rejecting system-reserved originKind values from external callers.
+
+const mockIssueService = vi.hoisted(() => ({
+  addComment: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+  create: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  getByIdentifier: vi.fn(),
+  getById: vi.fn(),
+  getRelationSummaries: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockExecutionWorkspaceService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockFeedbackService = vi.hoisted(() => ({
+  listIssueVotesForUser: vi.fn(),
+  saveIssueVote: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(),
+  reportRunActivity: vi.fn(),
+  getRun: vi.fn(),
+  getActiveRunForAgent: vi.fn(),
+  cancelRun: vi.fn(),
+}));
+
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  get: vi.fn(),
+  listCompanyIds: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+const mockRoutineService = vi.hoisted(() => ({
+  syncRunStatusForIssue: vi.fn(),
+}));
+
+function registerRouteMocks() {
+  vi.doMock("../services/access.js", () => ({
+    accessService: () => mockAccessService,
+  }));
+  vi.doMock("../services/activity-log.js", () => ({
+    logActivity: mockLogActivity,
+  }));
+  vi.doMock("../services/agents.js", () => ({
+    agentService: () => mockAgentService,
+  }));
+  vi.doMock("../services/execution-workspaces.js", () => ({
+    executionWorkspaceService: () => mockExecutionWorkspaceService,
+  }));
+  vi.doMock("../services/feedback.js", () => ({
+    feedbackService: () => mockFeedbackService,
+  }));
+  vi.doMock("../services/heartbeat.js", () => ({
+    heartbeatService: () => mockHeartbeatService,
+  }));
+  vi.doMock("../services/instance-settings.js", () => ({
+    instanceSettingsService: () => mockInstanceSettingsService,
+  }));
+  vi.doMock("../services/issues.js", () => ({
+    issueService: () => mockIssueService,
+  }));
+  vi.doMock("../services/routines.js", () => ({
+    routineService: () => mockRoutineService,
+  }));
+  vi.doMock("../services/index.js", () => ({
+    companyService: () => ({
+      getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+    }),
+    accessService: () => mockAccessService,
+    agentService: () => mockAgentService,
+    documentService: () => ({}),
+    executionWorkspaceService: () => mockExecutionWorkspaceService,
+    feedbackService: () => mockFeedbackService,
+    goalService: () => ({}),
+    heartbeatService: () => mockHeartbeatService,
+    instanceSettingsService: () => mockInstanceSettingsService,
+    issueApprovalService: () => ({}),
+    issueReferenceService: () => ({
+      deleteDocumentSource: async () => undefined,
+      diffIssueReferenceSummary: () => ({
+        addedReferencedIssues: [],
+        removedReferencedIssues: [],
+        currentReferencedIssues: [],
+      }),
+      emptySummary: () => ({ outbound: [], inbound: [] }),
+      listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+      syncComment: async () => undefined,
+      syncDocument: async () => undefined,
+      syncIssue: async () => undefined,
+    }),
+    issueRecoveryActionService: () => ({
+      getActiveForIssue: vi.fn(async () => null),
+      listActiveForIssues: vi.fn(async () => new Map()),
+    }),
+    issueService: () => mockIssueService,
+    logActivity: mockLogActivity,
+    projectService: () => ({}),
+    routineService: () => mockRoutineService,
+    workProductService: () => ({}),
+  }));
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const [{ errorHandler }, { issueRoutes }] = await Promise.all([
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = actor;
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "issue-1",
+    companyId: "company-1",
+    status: "todo",
+    priority: "medium",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    createdByUserId: "board-user",
+    identifier: "PAP-1000",
+    title: "Linear webhook sync",
+    originKind: "linear",
+    originId: "LIN-1",
+    originFingerprint: "webhook",
+    executionPolicy: null,
+    executionState: null,
+    executionWorkspaceId: null,
+    hiddenAt: null,
+    ...overrides,
+  };
+}
+
+describe("POST /issues persists origin fields (KEN-4172)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/access.js");
+    vi.doUnmock("../services/activity-log.js");
+    vi.doUnmock("../services/agents.js");
+    vi.doUnmock("../services/execution-workspaces.js");
+    vi.doUnmock("../services/feedback.js");
+    vi.doUnmock("../services/heartbeat.js");
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../services/instance-settings.js");
+    vi.doUnmock("../services/issues.js");
+    vi.doUnmock("../services/routines.js");
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerRouteMocks();
+    vi.clearAllMocks();
+    mockIssueService.addComment.mockResolvedValue(null);
+    mockIssueService.create.mockResolvedValue(makeIssue());
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.getById.mockResolvedValue(makeIssue());
+    mockIssueService.getByIdentifier.mockResolvedValue(null);
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.update.mockResolvedValue(makeIssue());
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAgentService.getById.mockResolvedValue(null);
+    mockExecutionWorkspaceService.getById.mockResolvedValue(null);
+    mockFeedbackService.listIssueVotesForUser.mockResolvedValue([]);
+    mockFeedbackService.saveIssueVote.mockResolvedValue({
+      vote: null,
+      consentEnabledNow: false,
+      sharingEnabled: false,
+    });
+    mockHeartbeatService.wakeup.mockResolvedValue(undefined);
+    mockHeartbeatService.reportRunActivity.mockResolvedValue(undefined);
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+    mockHeartbeatService.getActiveRunForAgent.mockResolvedValue(null);
+    mockHeartbeatService.cancelRun.mockResolvedValue(null);
+    mockInstanceSettingsService.get.mockResolvedValue({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    });
+    mockInstanceSettingsService.listCompanyIds.mockResolvedValue(["company-1"]);
+    mockLogActivity.mockResolvedValue(undefined);
+    mockRoutineService.syncRunStatusForIssue.mockResolvedValue(undefined);
+  });
+
+  it("forwards namespaced origin fields to the service layer", async () => {
+    const app = await createApp({
+      type: "user",
+      actorId: "board-user",
+      companyId: "company-1",
+    });
+
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Linear webhook sync",
+        originKind: "linear",
+        originId: "LIN-1",
+        originFingerprint: "webhook",
+      });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalledTimes(1);
+    const [, payload] = mockIssueService.create.mock.calls[0];
+    expect(payload.originKind).toBe("linear");
+    expect(payload.originId).toBe("LIN-1");
+    expect(payload.originFingerprint).toBe("webhook");
+    expect(res.body.originKind).toBe("linear");
+    expect(res.body.originId).toBe("LIN-1");
+    expect(res.body.originFingerprint).toBe("webhook");
+  });
+
+  it("rejects external requests using a system-reserved originKind", async () => {
+    const app = await createApp({
+      type: "user",
+      actorId: "board-user",
+      companyId: "company-1",
+    });
+
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Sneaky",
+        originKind: "routine_execution",
+      });
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/reserved/i);
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects external requests using the plugin operation originKind namespace", async () => {
+    const app = await createApp({
+      type: "user",
+      actorId: "board-user",
+      companyId: "company-1",
+    });
+
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "Pretend orchestrator",
+        originKind: "plugin:foo:operation",
+      });
+
+    expect(res.status).toBe(400);
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes KEN-4172.

## Summary
Extends `createIssueBaseSchema` in `@paperclipai/shared` to accept `originKind`, `originId`, and `originFingerprint` on POST `/api/companies/:companyId/issues`, so external integrations (Linear, Sentry, manual scripts) can persist namespaced origin metadata instead of all falling back to `originKind="manual"`.

## Changes
- `packages/shared/src/validators/issue.ts`
  - Adds optional `originKind` / `originId` / `originFingerprint` fields to `createIssueBaseSchema` (with trim + length caps).
  - Exports `SYSTEM_RESERVED_ORIGIN_KINDS` and `isSystemReservedOriginKind` helper.
  - Wraps `createIssueInputSchema`, `createIssueSchema`, and `createChildIssueSchema` with a `superRefine` guard that rejects system-reserved values (`routine_execution`, `harness_liveness_escalation`, `stale_active_run_evaluation`, `issue_productivity_review`, `stranded_issue_recovery`, `blocker_attention_open_recovery`, and the `plugin:*:operation[:*]` namespace).
  - Strips origin fields from `updateIssueSchema` so PATCH semantics are unchanged.
- `packages/shared/src/validators/issue.test.ts` — 7 new tests covering happy path, back-compat, each reserved kind, plugin operation namespace, allowed plugin sub-namespaces, trim/length, and that PATCH ignores the new fields.
- `server/src/__tests__/issue-create-origin-fields.test.ts` — new integration test: forwards fields to service layer, rejects reserved `originKind`, rejects plugin-operation `originKind`.

## Notes
- No DB schema change. Existing `originKind` (default `manual`), `originId`, and `originFingerprint` columns are already present in `packages/db/src/schema/issues.ts`.
- Internal callers (recovery service, routines, productivity review) bypass the HTTP schema and continue to call `issueService.create()` directly with their reserved values — only external HTTP requests are guarded.

## Test plan
- [x] `pnpm --filter @paperclipai/shared test` (36/36 pass)
- [x] `pnpm --filter @paperclipai/server vitest run issue-create-origin-fields` (3/3 pass)
- [x] Typecheck clean on `@paperclipai/shared` and `@paperclipai/server`