### PR TITLE
fix(scripts): enforce LF shebang for issue update helper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/cli/src/__tests__/paperclip-issue-update-script.test.ts
+++ b/cli/src/__tests__/paperclip-issue-update-script.test.ts
@@ -1,0 +1,23 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+describe("paperclip issue update helper", () => {
+  it("keeps the executable shebang LF-only", async () => {
+    const helper = await readFile(
+      path.join(repoRoot, "scripts/paperclip-issue-update.sh"),
+    );
+    const firstLineEnd = helper.indexOf(0x0a);
+
+    expect(firstLineEnd).toBeGreaterThan(0);
+    expect(helper.subarray(0, firstLineEnd + 1).toString("utf8")).toBe(
+      "#!/usr/bin/env bash\n",
+    );
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Operators use shell helpers to update issue state and preserve multiline comments from agent runs.
> - `scripts/paperclip-issue-update.sh` is meant to execute directly on Unix-like systems through its shebang.
> - A CRLF checkout can turn that shebang into `/usr/bin/env bash\r`, making the helper fail before it can send updates.
> - This pull request pins shell scripts to LF in Git attributes and adds a byte-level regression test for the helper shebang.
> - The benefit is that the issue update helper stays executable across Windows-influenced checkouts without changing its API behavior.

## What Changed

- Added `.gitattributes` so `*.sh` files are checked out with LF line endings.
- Added a focused CLI regression test that verifies `scripts/paperclip-issue-update.sh` starts with `#!/usr/bin/env bash\n`.

## Verification

- `git ls-files --eol scripts/paperclip-issue-update.sh .gitattributes`
- `xxd -g 1 -l 32 scripts/paperclip-issue-update.sh`
- `scripts/paperclip-issue-update.sh --issue-id test-issue --status done --dry-run <<'MD' ...`
- `pnpm exec vitest run cli/src/__tests__/paperclip-issue-update-script.test.ts --config cli/vitest.config.ts`

## Risks

- Low risk. The attributes rule affects shell scripts only and standardizes the line ending they already need for portable direct execution.
- Existing Windows-specific PowerShell scripts are unaffected.

## Model Used

- OpenAI GPT-5.5 via Codex CLI, `model_reasoning_effort=xhigh`, with shell/tool execution in a local isolated worktree.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge