### PR TITLE
fix: exempt pulse (workMode=pulse) issues from recovery-action loop

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -147,7 +147,7 @@ export const INBOX_MINE_ISSUE_STATUS_FILTER = INBOX_MINE_ISSUE_STATUSES.join(","
 
 export const ISSUE_PRIORITIES = ["critical", "high", "medium", "low"] as const;
 export type IssuePriority = (typeof ISSUE_PRIORITIES)[number];
-export const ISSUE_WORK_MODES = ["standard", "planning"] as const;
+export const ISSUE_WORK_MODES = ["standard", "planning", "pulse"] as const;
 export type IssueWorkMode = (typeof ISSUE_WORK_MODES)[number];
 export const MAX_ISSUE_REQUEST_DEPTH = 1024;
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -213,7 +213,7 @@ export const INBOX_MINE_ISSUE_STATUS_FILTER = INBOX_MINE_ISSUE_STATUSES.join(","
 
 export const ISSUE_PRIORITIES = ["critical", "high", "medium", "low"] as const;
 export type IssuePriority = (typeof ISSUE_PRIORITIES)[number];
-export const ISSUE_WORK_MODES = ["standard", "ask", "planning", "skill_test"] as const;
+export const ISSUE_WORK_MODES = ["standard", "ask", "planning", "skill_test", "pulse"] as const;
 export type IssueWorkMode = (typeof ISSUE_WORK_MODES)[number];
 export const ISSUE_HARNESS_KINDS = ["skill_test"] as const;
 export type IssueHarnessKind = (typeof ISSUE_HARNESS_KINDS)[number];

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7821,6 +7821,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         identifier: issues.identifier,
         title: issues.title,
         status: issues.status,
+        workMode: issues.workMode,
         assigneeAgentId: issues.assigneeAgentId,
         assigneeUserId: issues.assigneeUserId,
         executionState: issues.executionState,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4023,6 +4023,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         identifier: issues.identifier,
         title: issues.title,
         status: issues.status,
+        workMode: issues.workMode,
         assigneeAgentId: issues.assigneeAgentId,
         assigneeUserId: issues.assigneeUserId,
         executionState: issues.executionState,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3237,6 +3237,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     };
 
     for (const issue of candidates) {
+      if (issue.workMode === "pulse") {
+        result.skipped += 1;
+        continue;
+      }
+
       const executionState = issue.status === "in_review"
         ? parseIssueExecutionState(issue.executionState)
         : null;
@@ -3277,11 +3282,6 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
-        result.skipped += 1;
-        continue;
-      }
-
-      if (issue.workMode === "pulse") {
         result.skipped += 1;
         continue;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3281,6 +3281,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
+      if (issue.workMode === "pulse") {
+        result.skipped += 1;
+        continue;
+      }
+
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
       if (latestRun?.status === "succeeded" && await hasPersistedDurableWaitPath(issue)) {
         result.skipped += 1;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2020,6 +2020,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
+      if (issue.workMode === "pulse") {
+        result.skipped += 1;
+        continue;
+      }
+
       const latestRun = await getLatestIssueRun(issue.companyId, issue.id);
       if (isStrandedIssueRecoveryIssue(issue) && isUnsuccessfulTerminalIssueRun(latestRun)) {
         const updated = await escalateStrandedRecoveryIssueInPlace({

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -94,6 +94,13 @@ describe("successful run handoff decision", () => {
     });
   });
 
+  it("does not queue for pulse issues that are intentionally permanent", () => {
+    expect(decide({ issue: { ...issue, workMode: "pulse" } as any })).toEqual({
+      kind: "skip",
+      reason: "pulse issue is intentionally permanent",
+    });
+  });
+
   it("does not queue when a successful run records an accepted next-action path", () => {
     expect(decide({ issue: { ...issue, status: "in_review" } as any })).toEqual({
       kind: "skip",

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -107,6 +107,13 @@ describe("successful run handoff decision", () => {
     });
   });
 
+  it("does not queue for pulse issues that are intentionally permanent", () => {
+    expect(decide({ issue: { ...issue, workMode: "pulse" } as any })).toEqual({
+      kind: "skip",
+      reason: "pulse issue is intentionally permanent",
+    });
+  });
+
   it("does not queue when a successful run records an accepted next-action path", () => {
     expect(decide({ issue: { ...issue, status: "in_review" } as any })).toEqual({
       kind: "skip",

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -45,7 +45,7 @@ export function isIdempotentFinishSuccessfulRunHandoffWakeStatus(status: string)
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
 type IssueRow = Pick<
   typeof issues.$inferSelect,
-  "id" | "companyId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId" | "executionState"
+  "id" | "companyId" | "identifier" | "title" | "status" | "workMode" | "assigneeAgentId" | "assigneeUserId" | "executionState"
 >;
 type AgentRow = Pick<typeof agents.$inferSelect, "id" | "companyId" | "status">;
 type NoticeIssue = Pick<typeof issues.$inferSelect, "id" | "identifier" | "title" | "status">;
@@ -362,6 +362,7 @@ export function decideSuccessfulRunHandoff(input: {
     return { kind: "skip", reason: "issue is no longer assigned to the source run agent" };
   }
   if (issue.assigneeUserId) return { kind: "skip", reason: "issue is human-owned" };
+  if (issue.workMode === "pulse") return { kind: "skip", reason: "pulse issue is intentionally permanent" };
   if (issue.status !== "in_progress") return { kind: "skip", reason: `issue status ${issue.status} is a valid disposition` };
   if (issue.executionState) return { kind: "skip", reason: "issue has execution policy state" };
   if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -45,7 +45,7 @@ export function isIdempotentFinishSuccessfulRunHandoffWakeStatus(status: string)
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
 type IssueRow = Pick<
   typeof issues.$inferSelect,
-  "id" | "companyId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId" | "executionState"
+  "id" | "companyId" | "identifier" | "title" | "status" | "workMode" | "assigneeAgentId" | "assigneeUserId" | "executionState"
 >;
 type AgentRow = Pick<typeof agents.$inferSelect, "id" | "companyId" | "status">;
 type NoticeIssue = Pick<typeof issues.$inferSelect, "id" | "identifier" | "title" | "status">;
@@ -376,6 +376,7 @@ export function decideSuccessfulRunHandoff(input: {
     return { kind: "skip", reason: "issue is no longer assigned to the source run agent" };
   }
   if (issue.assigneeUserId) return { kind: "skip", reason: "issue is human-owned" };
+  if (issue.workMode === "pulse") return { kind: "skip", reason: "pulse issue is intentionally permanent" };
   if (issue.status !== "in_progress") return { kind: "skip", reason: `issue status ${issue.status} is a valid disposition` };
   if (issue.executionState) return { kind: "skip", reason: "issue has execution policy state" };
   if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The recovery subsystem (`source_scoped_recovery_action`) detects when a run succeeds but its issue is still `in_progress` and treats that as a missing disposition, enqueuing a corrective handoff wake
> - Some issues are intentionally permanent — department "pulse" heartbeats and long-running monitors succeed every cycle and by design never reach a terminal status
> - For these issues the "succeeded but still in_progress" condition is structural, not an error, so the recovery chain fires on every reconciler cycle in an infinite no-op loop that burns budget
> - This pull request adds a `workMode === "pulse"` early-exit guard at both recovery entry points and extends the shared `ISSUE_WORK_MODES` enum so the API accepts `workMode=pulse`
> - The benefit is that an operator can explicitly mark an intentionally-permanent issue and stop the recovery loop without disabling recovery for normal issues

## Linked Issues or Issue Description

No public GitHub issue exists. Describing the bug inline per the `bug_report.yml` template (CONTRIBUTING.md → "Link Issues or Describe Them In-PR"), using the same fields a filed bug would provide.

### What happened?

An issue that is intentionally permanent — a pulse/heartbeat issue that produces a `succeeded` run every cycle but is meant to stay `in_progress` forever — gets caught by the successful-run recovery chain. Each successful run is read as a missing disposition, so `decideSuccessfulRunHandoff` enqueues a corrective handoff wake; that corrective run also succeeds without changing status; `reconcileStrandedAssignedIssues` then reads an exhausted handoff and escalates, creating an `activeRecoveryAction` with `wakePolicy: wake_owner`. That action re-fires on every reconciler cycle — an infinite corrective loop that consumes budget with no state change.

### Expected behavior

An issue explicitly marked as intentionally permanent should be skipped by the recovery chain — no corrective handoff wake, no stranded-issue escalation — while normal (`standard` / `planning` / `ask` / `skill_test`) issues keep full recovery behavior.

### Steps to reproduce

1. Assign an issue to an agent and keep it `in_progress`.
2. Have that issue produce a `succeeded` run every heartbeat (e.g. a pulse/monitor issue that reports and re-arms without reaching a terminal status).
3. Observe `activeRecoveryAction` become non-null and re-wake each reconciler cycle, burning budget on no-op corrective runs.
4. With this change, `PATCH /api/issues/:id` with `workMode=pulse` makes both recovery entry points skip the issue and the loop stops.

### Paperclip version or commit

Reproducible on current `master` (branch refreshed onto `master` @ `f44a002b`, 2026-07-16).

### Deployment mode

Not deployment-specific — the loop is in the core recovery service (`server/src/services/recovery/*`) and reproduces in any mode running the reconciler. Not adapter-specific.

## What Changed

- `packages/shared/src/constants.ts`: Appended `"pulse"` to `ISSUE_WORK_MODES` (now `["standard", "ask", "planning", "skill_test", "pulse"]`) so `PATCH /api/issues/:id` accepts `workMode=pulse` without a validation error
- `server/src/services/recovery/successful-run-handoff.ts`: Added `workMode` to the `IssueRow` Pick; added early skip `if (issue.workMode === "pulse")` in `decideSuccessfulRunHandoff` (after the human-owned check) to prevent the initial corrective handoff wake from being enqueued
- `server/src/services/recovery/service.ts`: Added a matching `issue.workMode === "pulse"` skip in the stranded-issue reconciliation loop so exhausted-handoff escalation cannot fire on pulse issues
- `server/src/services/heartbeat.ts`: Added `workMode: issues.workMode` to the issue projection feeding `decideSuccessfulRunHandoff`
- `server/src/services/recovery/successful-run-handoff.test.ts`: Added test `"does not queue for pulse issues that are intentionally permanent"`

## Verification

1. Targeted unit test: `npx vitest run server/src/services/recovery/successful-run-handoff.test.ts` (pulse issue is skipped by `decideSuccessfulRunHandoff`)
2. Typechecks: `pnpm --filter @paperclipai/server run typecheck` and `pnpm --filter @paperclipai/shared run typecheck`
3. Scope review after refresh onto current `master`: the enum has no exhaustive `switch`/`Record<IssueWorkMode>` consumers, so `"pulse"` is purely additive; the recovery-loop candidates use a full-row `db.select().from(issues)`, so `issue.workMode` is in scope; the `heartbeat.ts` projection feeds the exact `IssueRow` Pick used by `decideSuccessfulRunHandoff`.

## Risks

- Low risk: every change is an additive early-exit guard; existing `standard` / `planning` / `ask` / `skill_test` paths are unaffected.
- `workMode` is already a `text` column — no migration required.
- The suppression is opt-in: an operator must explicitly `PATCH workMode=pulse`, so legitimate recovery cannot be suppressed by accident.

## Model Used

- Original authorship (2026-05-15): Anthropic Claude (`claude-sonnet-4-6`), tool use + multi-file editing.
- Refresh onto current `master` (2026-07-16): Anthropic Claude Opus 4.8 (1M context), extended reasoning + tool use — rebuilt the two commits on top of `master` (648 commits of drift) and resolved the `ISSUE_WORK_MODES` enum conflict.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and found none (searched open/closed PRs for "pulse", "workMode", "recovery loop", "source_scoped_recovery")
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub references)
- [x] My branch name describes the change (`fix/pulse-issue-recovery-loop-exemption`) and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — N/A (no doc surface for this internal recovery guard)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — CI re-running on the refreshed commits
- [ ] Greptile is 5/5 with no open P2s — currently 4/5 ("Safe to merge"; only nit is an optional DB round-trip micro-optimization)
- [x] I will address all Greptile and reviewer comments before requesting merge
