### PR TITLE
fix(issues): cancel orphaned runs on admin force-release

### DIFF
--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -8,6 +8,7 @@ import {
   agents,
   companies,
   createDb,
+  heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
   issueRelations,
@@ -45,6 +46,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     await db.delete(issueRelations);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
@@ -211,6 +213,37 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       executionRunId: null,
       executionLockedAt: null,
     });
+  });
+
+  it("cancels active runs on force-release so the silence monitor does not generate false-positive alerts", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Force release run cancellation",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(boardActor(companyId)))
+      .post(`/api/issues/${issueId}/admin/force-release`)
+      .send();
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    // The running run must be cancelled so it leaves the "running" pool the silence monitor queries
+    const run = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, currentRunId))
+      .then((rows) => rows[0]);
+    expect(run?.status).toBe("cancelled");
   });
 
   it("restricts admin force-release to board users with company access and writes an audit event", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3833,6 +3833,18 @@ export function issueRoutes(
       return;
     }
 
+    // Cancel orphaned runs so the Silence-Monitor doesn't generate false-positive alerts.
+    // Force-release means we gave up on the run; mark it terminal so it leaves the "running" pool.
+    const orphanedRunIds = [
+      result.previous.checkoutRunId,
+      result.previous.executionRunId,
+    ].filter((runId): runId is string => runId != null);
+    await Promise.all(
+      [...new Set(orphanedRunIds)].map((runId) =>
+        heartbeat.cancelRun(runId).catch(() => undefined),
+      ),
+    );
+
     const actor = getActorInfo(req);
     await logActivity(db, {
       companyId: result.issue.companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents; runs are tracked in `heartbeat_runs` with statuses like `running`, `cancelled`, `failed`
> - The Silence-Monitor (`scanSilentActiveRuns`) queries all runs with `status = 'running'` silent longer than 1 h and creates watchdog evaluation issues
> - When a run is killed at the OS level without a clean shutdown, its status stays `running` in the database — no terminal event is written
> - A board user can call `POST /issues/:id/admin/force-release` to clear the execution lock on the issue, but this only NULLs `checkoutRunId`/`executionRunId` on the issue row; it does not touch the `heartbeat_runs` table
> - The orphaned run therefore remains `running` indefinitely and triggers repeated Silence-Monitor false-positive alerts (50+ ghost issues per incident, as in POE-686)
> - This PR calls `heartbeat.cancelRun()` on both orphaned run IDs immediately after the lock is cleared, moving them to `cancelled` and removing them from the Silence-Monitor's query pool
> - The benefit is that force-release now closes the run lifecycle gap at the source, with no changes required to the Silence-Monitor itself

## What Changed

- `server/src/routes/issues.ts`: after `adminForceRelease` succeeds, best-effort cancel both `checkoutRunId` and `executionRunId` runs (deduplicated). Errors are swallowed — the force-release itself must always succeed even if the run is already terminal.
- `server/src/__tests__/issue-stale-execution-lock-routes.test.ts`:
  - Added regression test verifying that a `running` run is set to `cancelled` after force-release
  - Added `heartbeatRunEvents` to `afterEach` teardown (required once `cancelRun` writes run events, which creates FK-constrained rows)

## Verification

```sh
pnpm test
# or targeted:
node_modules/.bin/vitest run server/src/__tests__/issue-stale-execution-lock-routes.test.ts
# Expected: 4 passed
```

Manual: call `POST /api/issues/:id/admin/force-release` on an issue with an active run, then check `SELECT status FROM heartbeat_runs WHERE id = '<run-id>'` → should be `cancelled`.

## Risks

- `cancelRun` also calls `releaseIssueExecutionAndPromote`, which tries to promote deferred wakeups. Since `executionRunId` is already NULL on the issue by the time `cancelRun` runs, the function finds no matching issue and exits early — no double-clear or unintended promotion.
- Best-effort cancel (`.catch(() => undefined)`) means a failed cancel is silent; the force-release still succeeds. Monitoring for the orphaned run would need to be done separately if the cancel itself fails (rare: only if the run record is missing).
- Low overall risk: this is additive behavior triggered only by board-level force-release, which is already an exceptional admin operation.

## Model Used

- Provider: Anthropic  
- Model ID: `claude-sonnet-4-6`  
- Context window: 200k  
- Tool use enabled (read, edit, grep, bash, subagents)  
- No extended thinking mode

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge