### PR TITLE
feat(cli): add `paperclipai issue document list|get|put` subcommands

### DIFF
--- a/cli/src/__tests__/issue-document.test.ts
+++ b/cli/src/__tests__/issue-document.test.ts
@@ -1,0 +1,230 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerIssueCommands } from "../commands/client/issue.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+function buildProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  registerIssueCommands(program);
+  return program;
+}
+
+function findDocument(program: Command): Command {
+  const issue = program.commands.find((command) => command.name() === "issue");
+  expect(issue).toBeDefined();
+  const document = issue!.commands.find((command) => command.name() === "document");
+  expect(document).toBeDefined();
+  return document!;
+}
+
+describe("registerIssueCommands document subcommands", () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it("registers `issue document list|get|put`", () => {
+    const program = buildProgram();
+    const document = findDocument(program);
+    expect(document.commands.map((c) => c.name()).sort()).toEqual(["get", "list", "put"]);
+  });
+
+  it("declares put body, body-file, title, format, and base-revision-id options", () => {
+    const program = buildProgram();
+    const document = findDocument(program);
+    const put = document.commands.find((c) => c.name() === "put");
+    expect(put).toBeDefined();
+    const longs = put!.options.map((o) => o.long);
+    for (const flag of [
+      "--body",
+      "--body-file",
+      "--title",
+      "--format",
+      "--base-revision-id",
+    ]) {
+      expect(longs).toContain(flag);
+    }
+  });
+
+  it("declares list --include-system option", () => {
+    const program = buildProgram();
+    const document = findDocument(program);
+    const list = document.commands.find((c) => c.name() === "list");
+    expect(list).toBeDefined();
+    expect(list!.options.map((o) => o.long)).toContain("--include-system");
+  });
+});
+
+class ExitInvoked extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe("issue document put — wire format", () => {
+  let tmpDir: string;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclipai-cli-doc-"));
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new ExitInvoked(code ?? 0);
+    }) as never);
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("PUTs the body from --body-file with auth and run-id headers, then GETs round-trip", async () => {
+    const issueId = "00000000-0000-0000-0000-0000000000aa";
+    const apiBase = "http://test:3100";
+    const body = "# Audit Table\n\n| Plugin | Status |\n| --- | --- |\n| facebook | review |\n";
+
+    const bodyFile = path.join(tmpDir, "audit-table.md");
+    fs.writeFileSync(bodyFile, body, "utf8");
+
+    process.env.PAPERCLIP_API_URL = apiBase;
+    process.env.PAPERCLIP_API_KEY = "token-xyz";
+    process.env.PAPERCLIP_RUN_ID = "run-9";
+    process.env.PAPERCLIP_COMPANY_ID = "company-1";
+
+    const docResponse = {
+      id: "doc-1",
+      companyId: "company-1",
+      issueId,
+      key: "audit-table",
+      title: "Audit Table",
+      format: "markdown",
+      body,
+      latestRevisionId: "rev-1",
+      latestRevisionNumber: 1,
+      createdByAgentId: null,
+      createdByUserId: null,
+      updatedByAgentId: null,
+      updatedByUserId: null,
+      createdAt: "2026-05-15T00:00:00.000Z",
+      updatedAt: "2026-05-15T00:00:00.000Z",
+    };
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify(docResponse), { status: 201 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(docResponse), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const program = buildProgram();
+    await program.parseAsync(
+      [
+        "issue",
+        "document",
+        "put",
+        issueId,
+        "audit-table",
+        "--body-file",
+        bodyFile,
+        "--title",
+        "Audit Table",
+        "--json",
+      ],
+      { from: "user" },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [putUrl, putInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(putUrl).toBe(`${apiBase}/api/issues/${issueId}/documents/audit-table`);
+    expect(putInit.method).toBe("PUT");
+    const putHeaders = putInit.headers as Record<string, string>;
+    expect(putHeaders.authorization).toBe("Bearer token-xyz");
+    expect(putHeaders["x-paperclip-run-id"]).toBe("run-9");
+    expect(putHeaders["content-type"]).toBe("application/json");
+    const putBody = JSON.parse(String(putInit.body));
+    expect(putBody).toEqual({
+      title: "Audit Table",
+      format: "markdown",
+      body,
+    });
+
+    await program.parseAsync(
+      ["issue", "document", "get", issueId, "audit-table", "--json"],
+      { from: "user" },
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [getUrl, getInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+    expect(getUrl).toBe(`${apiBase}/api/issues/${issueId}/documents/audit-table`);
+    expect(getInit.method).toBe("GET");
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects when neither --body nor --body-file is provided", async () => {
+    process.env.PAPERCLIP_API_URL = "http://test:3100";
+    process.env.PAPERCLIP_API_KEY = "token";
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const program = buildProgram();
+    await expect(
+      program.parseAsync(
+        ["issue", "document", "put", "issue-1", "audit-table"],
+        { from: "user" },
+      ),
+    ).rejects.toBeInstanceOf(ExitInvoked);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderr).toHaveBeenCalled();
+    stderr.mockRestore();
+  });
+
+  it("rejects when both --body and --body-file are provided", async () => {
+    process.env.PAPERCLIP_API_URL = "http://test:3100";
+    process.env.PAPERCLIP_API_KEY = "token";
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const bodyFile = path.join(tmpDir, "body.md");
+    fs.writeFileSync(bodyFile, "hi", "utf8");
+
+    const program = buildProgram();
+    await expect(
+      program.parseAsync(
+        [
+          "issue",
+          "document",
+          "put",
+          "issue-1",
+          "audit-table",
+          "--body",
+          "hi",
+          "--body-file",
+          bodyFile,
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toBeInstanceOf(ExitInvoked);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(stderr).toHaveBeenCalled();
+    stderr.mockRestore();
+  });
+});

--- a/cli/src/client/http.ts
+++ b/cli/src/client/http.ts
@@ -81,6 +81,13 @@ export class PaperclipApiClient {
     }, opts);
   }
 
+  put<T>(path: string, body?: unknown, opts?: RequestOptions): Promise<T | null> {
+    return this.request<T>(path, {
+      method: "PUT",
+      body: body === undefined ? undefined : JSON.stringify(body),
+    }, opts);
+  }
+
   delete<T>(path: string, opts?: RequestOptions): Promise<T | null> {
     return this.request<T>(path, { method: "DELETE" }, opts);
   }

--- a/cli/src/commands/client/common.ts
+++ b/cli/src/commands/client/common.ts
@@ -73,9 +73,12 @@ export function resolveCommandContext(
     );
   }
 
+  const runId = process.env.PAPERCLIP_RUN_ID?.trim() || undefined;
+
   const api = new PaperclipApiClient({
     apiBase,
     apiKey,
+    runId,
     recoverAuth: explicitApiKey || !canAttemptInteractiveBoardAuth()
       ? undefined
       : async ({ error }) => {

--- a/cli/src/commands/client/issue.ts
+++ b/cli/src/commands/client/issue.ts
@@ -1,11 +1,14 @@
 import { Command } from "commander";
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import {
   addIssueCommentSchema,
   checkoutIssueSchema,
   createIssueSchema,
   type FeedbackTrace,
+  type IssueDocument,
+  type IssueDocumentSummary,
   updateIssueSchema,
+  upsertIssueDocumentSchema,
   type Issue,
   type IssueComment,
 } from "@paperclipai/shared";
@@ -67,6 +70,19 @@ interface IssueCommentOptions extends BaseClientOptions {
 interface IssueCheckoutOptions extends BaseClientOptions {
   agentId: string;
   expectedStatuses?: string;
+}
+
+interface IssueDocumentPutOptions extends BaseClientOptions {
+  body?: string;
+  bodyFile?: string;
+  title?: string;
+  format?: string;
+  baseRevisionId?: string;
+  changeSummary?: string;
+}
+
+interface IssueDocumentListOptions extends BaseClientOptions {
+  includeSystem?: boolean;
 }
 
 interface IssueFeedbackOptions extends BaseClientOptions {
@@ -379,6 +395,113 @@ export function registerIssueCommands(program: Command): void {
         }
       }),
   );
+
+  const document = issue.command("document").description("Issue document operations");
+
+  addCommonClientOptions(
+    document
+      .command("list")
+      .description("List documents on an issue")
+      .argument("<issueId>", "Issue ID or identifier")
+      .option("--include-system", "Include system-managed documents")
+      .action(async (issueId: string, opts: IssueDocumentListOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const path =
+            `/api/issues/${issueId}/documents` +
+            (opts.includeSystem ? "?includeSystem=true" : "");
+          const docs = (await ctx.api.get<IssueDocumentSummary[]>(path)) ?? [];
+          if (ctx.json) {
+            printOutput(docs, { json: true });
+            return;
+          }
+          if (docs.length === 0) {
+            printOutput([], { json: false });
+            return;
+          }
+          for (const doc of docs) {
+            console.log(
+              formatInlineRecord({
+                key: doc.key,
+                id: doc.id,
+                title: doc.title,
+                format: doc.format,
+                revision: doc.latestRevisionNumber,
+                updatedAt: doc.updatedAt instanceof Date ? doc.updatedAt.toISOString() : String(doc.updatedAt),
+              }),
+            );
+          }
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+  );
+
+  addCommonClientOptions(
+    document
+      .command("get")
+      .description("Get an issue document by key")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<key>", "Document key (e.g. plan)")
+      .action(async (issueId: string, key: string, opts: BaseClientOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const doc = await ctx.api.get<IssueDocument>(`/api/issues/${issueId}/documents/${key}`);
+          printOutput(doc, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+  );
+
+  addCommonClientOptions(
+    document
+      .command("put")
+      .description("Create or update an issue document by key")
+      .argument("<issueId>", "Issue ID or identifier")
+      .argument("<key>", "Document key (e.g. plan)")
+      .option("--body <markdown>", "Document body (mutually exclusive with --body-file)")
+      .option("--body-file <path>", "Path to a file containing the document body")
+      .option("--title <title>", "Document title")
+      .option("--format <format>", "Document format", "markdown")
+      .option("--base-revision-id <id>", "Base revision ID for optimistic concurrency")
+      .option("--change-summary <text>", "Short summary of this change")
+      .action(async (issueId: string, key: string, opts: IssueDocumentPutOptions) => {
+        try {
+          const ctx = resolveCommandContext(opts);
+          const body = await resolveDocumentBody(opts);
+          const payload = upsertIssueDocumentSchema.parse({
+            title: opts.title,
+            format: opts.format ?? "markdown",
+            body,
+            changeSummary: opts.changeSummary,
+            baseRevisionId: opts.baseRevisionId,
+          });
+          const doc = await ctx.api.put<IssueDocument>(
+            `/api/issues/${issueId}/documents/${key}`,
+            payload,
+          );
+          printOutput(doc, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+  );
+}
+
+async function resolveDocumentBody(opts: IssueDocumentPutOptions): Promise<string> {
+  const hasBody = typeof opts.body === "string";
+  const hasBodyFile = typeof opts.bodyFile === "string" && opts.bodyFile.trim().length > 0;
+  if (hasBody && hasBodyFile) {
+    throw new Error("Pass either --body or --body-file, not both.");
+  }
+  if (!hasBody && !hasBodyFile) {
+    throw new Error("Document body is required. Pass --body <markdown> or --body-file <path>.");
+  }
+  if (hasBodyFile) {
+    return readFile(opts.bodyFile!, "utf8");
+  }
+  return opts.body ?? "";
 }
 
 function parseCsv(value: string | undefined): string[] {


### PR DESCRIPTION
## Summary

Adds three subcommands to `paperclipai issue` so agents on sandboxed adapters (e.g. `claude_local` static-analyzer profiles that block `curl`/`node`/`python3`) can produce keyed issue-document deliverables without shelling out:

- `paperclipai issue document list <issueId> [--include-system]`
- `paperclipai issue document get  <issueId> <key>`
- `paperclipai issue document put  <issueId> <key> [--body | --body-file] [--title] [--format markdown] [--base-revision-id] [--change-summary]`

These map directly to the existing API:

- `GET  /api/issues/:id/documents`
- `GET  /api/issues/:id/documents/:key`
- `PUT  /api/issues/:id/documents/:key` body `{ title, format, body, baseRevisionId, changeSummary }`

Multiline markdown bodies should use `--body-file <path>` — it side-steps the static-analyzer length limit that already trips long `--body` payloads on `issue comment`.

### Other touches in this PR

- `PaperclipApiClient` gets a `put<T>()` method (parallel to `post` / `patch`).
- `resolveCommandContext` now reads `PAPERCLIP_RUN_ID` from env and passes it into the API client, so all CLI writes (including the existing `issue comment` and the new `issue document` subcommands) audit-trail via the `X-Paperclip-Run-Id` header.

### Why

Unblocks the SHE-409 audit-table deliverable: LegalCounsel can now PUT a keyed `audit-table` issue document directly from its agent sandbox instead of waiting on a `curl` allowlist exception.

## Test plan

- [x] `pnpm --filter paperclipai exec vitest run src/__tests__/issue-document.test.ts` — 6 tests pass (registration, option declarations, PUT wire format with auth + run-id headers, GET round-trip, --body/--body-file mutual-exclusion validation).
- [x] Live PUT → GET → list round-trip against a local Paperclip instance using `paperclipai issue document put $ISSUE smoke-test --body-file …`, `… get`, `… list`.
- [x] Live re-PUT with `--base-revision-id` to confirm optimistic-concurrency hand-off works and conflict errors surface `details.currentRevisionId` cleanly.
- [x] `pnpm --filter paperclipai typecheck` clean.
- [x] Existing `http.test.ts` / `common.test.ts` still green.

Out of scope: `delete` (revisioned; agents do not need it), attachments (separate endpoint), web-fetch (separate sandbox ask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)