### PR TITLE
fix(create-paperclip-plugin): move bin to dedicated entry to prevent CLI side-effects

### DIFF
--- a/packages/plugins/create-paperclip-plugin/package.json
+++ b/packages/plugins/create-paperclip-plugin/package.json
@@ -13,7 +13,7 @@
   },
   "type": "module",
   "bin": {
-    "create-paperclip-plugin": "./dist/index.js"
+    "create-paperclip-plugin": "./dist/cli.js"
   },
   "exports": {
     ".": "./src/index.ts"
@@ -21,7 +21,7 @@
   "publishConfig": {
     "access": "public",
     "bin": {
-      "create-paperclip-plugin": "./dist/index.js"
+      "create-paperclip-plugin": "./dist/cli.js"
     },
     "exports": {
       ".": {

--- a/packages/plugins/create-paperclip-plugin/src/cli.ts
+++ b/packages/plugins/create-paperclip-plugin/src/cli.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runCli } from "./index.js";
+
+runCli();

--- a/packages/plugins/create-paperclip-plugin/src/index.ts
+++ b/packages/plugins/create-paperclip-plugin/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -707,7 +706,7 @@ function parseArg(name: string): string | undefined {
 }
 
 /** CLI wrapper for `scaffoldPluginProject`. */
-function runCli() {
+export function runCli() {
   const pluginName = process.argv[2];
   if (!pluginName) {
     // eslint-disable-next-line no-console
@@ -732,8 +731,4 @@ function runCli() {
 
   // eslint-disable-next-line no-console
   console.log(`Created plugin scaffold at ${out}`);
-}
-
-if (import.meta.url === `file://${process.argv[1]}`) {
-  runCli();
 }


### PR DESCRIPTION
## Summary

The `paperclipai` CLI bundle (master, post-v2026.512.0) accidentally executes the `create-paperclip-plugin` scaffolder on **every** invocation. It scaffolds a directory in CWD named after `process.argv[2]` (e.g. `./--version`, `./issue`, `./list`) and logs `Created plugin scaffold at <path>`.

## Root cause

`packages/plugins/create-paperclip-plugin/src/index.ts` had a top-level module-entrypoint guard:

```ts
if (import.meta.url === `file://${process.argv[1]}`) {
  runCli();
}
```

`cli/src/commands/client/plugin.ts` imports `scaffoldPluginProject` from that file. esbuild inlines the guard into the CLI bundle. At runtime in the bundle, `import.meta.url` matches `file://<bundle-path>` and `process.argv[1]` is the bundle path, so the guard fires — and `runCli()` is the `create-paperclip-plugin` scaffolder entrypoint.

## Fix

- Drop the top-level guard from `src/index.ts`. Export `runCli` instead.
- Add `src/cli.ts` as the dedicated bin entry script — a 3-line shim that imports `runCli` and calls it.
- Point `bin.create-paperclip-plugin` in `package.json` (and `publishConfig.bin`) to `./dist/cli.js`.

Bundlers can't inline the entry script because nothing imports it. Library consumers (the CLI) keep importing `scaffoldPluginProject` and `shellQuote` from `src/index.ts` with no behavior change.

## Verification

Rebuilt the CLI bundle on master vs. this branch and compared:

|                                                  | master | fix |
| ------------------------------------------------ | -----: | --: |
| `Created plugin scaffold` literal in bundle      |      2 |   1 |
| `import.meta.url ===` entrypoint guard in bundle |      1 |   0 |
| `runCli` references in bundle                    |      2 |   0 |

The remaining `Created plugin scaffold` match in the fixed bundle is the styled `pc.green` line emitted by the `paperclipai plugin init` command path, which is the correct behavior.

## Test plan

- [x] Typecheck `packages/plugins/create-paperclip-plugin` (`pnpm typecheck`)
- [x] Typecheck `cli` (`pnpm typecheck`)
- [x] Run `cli/src/__tests__/plugin-init.test.ts` (6 passed)
- [x] Diff master vs. fix CLI bundle: guard gone, scaffold side-effect gone, `scaffoldPluginProject` still bundled for the proper `plugin init` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)