### PR TITLE
feat(gemini-local): support cross-agent session handoff via shared company storage

### DIFF
--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -156,6 +156,73 @@ async function ensureGeminiSkillsInjected(
   }
 }
 
+/**
+ * Ensure that Gemini chat sessions are shared across agents within the same company.
+ * This works by symlinking `~/.gemini/tmp/${agentId}/chats` to a shared company-scoped directory.
+ */
+async function ensureGeminiChatsShared(
+  onLog: AdapterExecutionContext["onLog"],
+  companyId: string,
+  agentId: string,
+): Promise<void> {
+  const sharedDir = path.join(os.homedir(), ".gemini", "companies", companyId, "chats");
+  const agentTmpDir = path.join(os.homedir(), ".gemini", "tmp", agentId);
+  const agentChatsDir = path.join(agentTmpDir, "chats");
+
+  try {
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.mkdir(agentTmpDir, { recursive: true });
+
+    let shouldLink = true;
+    try {
+      const stats = await fs.lstat(agentChatsDir);
+      if (stats.isSymbolicLink()) {
+        const target = await fs.readlink(agentChatsDir);
+        if (path.resolve(target) === path.resolve(sharedDir)) {
+          shouldLink = false;
+        } else {
+          await fs.unlink(agentChatsDir);
+        }
+      } else if (stats.isDirectory()) {
+        // Move existing chats to shared dir
+        const entries = await fs.readdir(agentChatsDir);
+        if (entries.length > 0) {
+          await onLog(
+            "stdout",
+            `[paperclip] Migrating existing Gemini chats from agent ${agentId} to shared company storage.\n`,
+          );
+          for (const entry of entries) {
+            const src = path.join(agentChatsDir, entry);
+            const dest = path.join(sharedDir, entry);
+            try {
+              // Copy then remove to be safe across possible (though unlikely) filesystem boundaries
+              await fs.cp(src, dest, { recursive: true });
+            } catch (copyErr) {
+              await onLog(
+                "stderr",
+                `[paperclip] Warning: failed to copy chat entry ${entry}: ${copyErr instanceof Error ? copyErr.message : String(copyErr)}\n`,
+              );
+            }
+          }
+        }
+        await fs.rm(agentChatsDir, { recursive: true, force: true });
+      }
+    } catch (err) {
+      // Doesn't exist, fine
+    }
+
+    if (shouldLink) {
+      await fs.symlink(sharedDir, agentChatsDir);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await onLog(
+      "stdout",
+      `[paperclip] Warning: failed to set up shared Gemini chat storage: ${message}\n`,
+    );
+  }
+}
+
 async function buildGeminiSkillsDir(
   config: Record<string, unknown>,
 ): Promise<string> {
@@ -209,6 +276,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const desiredGeminiSkillNames = resolvePaperclipDesiredSkillNames(config, geminiSkillEntries);
   if (!executionTargetIsRemote) {
     await ensureGeminiSkillsInjected(onLog, geminiSkillEntries, desiredGeminiSkillNames);
+    await ensureGeminiChatsShared(onLog, agent.companyId, agent.id);
   }
 
   const envConfig = parseObject(config.env);

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -191,24 +191,42 @@ async function ensureGeminiChatsShared(
             "stdout",
             `[paperclip] Migrating existing Gemini chats from agent ${agentId} to shared company storage.\n`,
           );
+          let migrationFailed = false;
           for (const entry of entries) {
             const src = path.join(agentChatsDir, entry);
             const dest = path.join(sharedDir, entry);
             try {
-              // Copy then remove to be safe across possible (though unlikely) filesystem boundaries
+              // Copy to shared storage
               await fs.cp(src, dest, { recursive: true });
             } catch (copyErr) {
+              migrationFailed = true;
               await onLog(
                 "stderr",
                 `[paperclip] Warning: failed to copy chat entry ${entry}: ${copyErr instanceof Error ? copyErr.message : String(copyErr)}\n`,
               );
             }
           }
+
+          if (migrationFailed) {
+            await onLog(
+              "stderr",
+              `[paperclip] Warning: migration of some chats failed; skipping removal of original directory to prevent data loss. Cross-agent handoff may be unreliable for this agent until resolved.\n`,
+            );
+            shouldLink = false;
+          } else {
+            await fs.rm(agentChatsDir, { recursive: true, force: true });
+          }
+        } else {
+          // Empty directory, just remove it to make way for the symlink
+          await fs.rm(agentChatsDir, { recursive: true, force: true });
         }
-        await fs.rm(agentChatsDir, { recursive: true, force: true });
       }
     } catch (err) {
-      // Doesn't exist, fine
+      if (err instanceof Error && (err as any).code === "ENOENT") {
+        // Doesn't exist, fine
+      } else {
+        throw err;
+      }
     }
 
     if (shouldLink) {

--- a/packages/adapters/gemini-local/src/server/shared-chats.test.ts
+++ b/packages/adapters/gemini-local/src/server/shared-chats.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -40,6 +40,7 @@ describe("gemini shared chats", () => {
   afterEach(async () => {
     process.env.HOME = previousHome;
     await fs.rm(root, { recursive: true, force: true });
+    vi.restoreAllMocks();
   });
 
   it("sets up shared company chat storage and migrates existing chats", async () => {
@@ -109,5 +110,40 @@ describe("gemini shared chats", () => {
     const agentChatsDir = path.join(root, ".gemini", "tmp", agentId, "chats");
     const agentFiles = await fs.readdir(agentChatsDir);
     expect(agentFiles).toContain("existing.jsonl");
+  });
+
+  it("does not remove agent directory if migration fails", async () => {
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "gemini");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeGeminiCommand(commandPath);
+
+    const agentId = "agent-3";
+    const companyId = "company-3";
+    const agentTmpDir = path.join(root, ".gemini", "tmp", agentId);
+    const agentChatsDir = path.join(agentTmpDir, "chats");
+
+    // 1. Pre-create chats
+    await fs.mkdir(agentChatsDir, { recursive: true });
+    await fs.writeFile(path.join(agentChatsDir, "chat-1.jsonl"), "data");
+
+    // 2. Mock fs.cp to fail
+    vi.spyOn(fs, "cp").mockRejectedValue(new Error("Copy failed"));
+
+    // 3. Execute
+    await execute({
+      runId: "run-3",
+      agent: { id: agentId, companyId, name: "G", adapterType: "gemini_local", adapterConfig: {} },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: { command: commandPath, cwd: workspace },
+      context: {},
+      authToken: "t",
+      onLog: async () => {},
+    });
+
+    // 4. Verify agent directory STILL EXISTS and is a directory (not a symlink)
+    const stats = await fs.lstat(agentChatsDir);
+    expect(stats.isDirectory()).toBe(true);
+    expect(stats.isSymbolicLink()).toBe(false);
   });
 });

--- a/packages/adapters/gemini-local/src/server/shared-chats.test.ts
+++ b/packages/adapters/gemini-local/src/server/shared-chats.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "@paperclipai/adapter-gemini-local/server";
+
+async function writeFakeGeminiCommand(commandPath: string): Promise<void> {
+  const script = `#!/usr/bin/env node
+console.log(JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "test-session",
+  model: "gemini-2.5-pro",
+}));
+console.log(JSON.stringify({
+  type: "assistant",
+  message: { content: [{ type: "output_text", text: "hello" }] },
+}));
+console.log(JSON.stringify({
+  type: "result",
+  subtype: "success",
+  session_id: "test-session",
+  result: "ok",
+}));
+`;
+  await fs.writeFile(commandPath, script, "utf8");
+  await fs.chmod(commandPath, 0o755);
+}
+
+describe("gemini shared chats", () => {
+  let root: string;
+  let previousHome: string | undefined;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-gemini-shared-"));
+    previousHome = process.env.HOME;
+    process.env.HOME = root;
+  });
+
+  afterEach(async () => {
+    process.env.HOME = previousHome;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("sets up shared company chat storage and migrates existing chats", async () => {
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "gemini");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeGeminiCommand(commandPath);
+
+    const agentId = "agent-1";
+    const companyId = "company-1";
+    const agentTmpDir = path.join(root, ".gemini", "tmp", agentId);
+    const agentChatsDir = path.join(agentTmpDir, "chats");
+    const sharedDir = path.join(root, ".gemini", "companies", companyId, "chats");
+
+    // 1. Pre-create some chats in the agent's directory
+    await fs.mkdir(agentChatsDir, { recursive: true });
+    await fs.writeFile(path.join(agentChatsDir, "old-session.jsonl"), "data");
+
+    // 2. Execute
+    await execute({
+      runId: "run-1",
+      agent: { id: agentId, companyId, name: "G", adapterType: "gemini_local", adapterConfig: {} },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: { command: commandPath, cwd: workspace },
+      context: {},
+      authToken: "t",
+      onLog: async () => {},
+    });
+
+    // 3. Verify migration
+    const sharedFiles = await fs.readdir(sharedDir);
+    expect(sharedFiles).toContain("old-session.jsonl");
+
+    // 4. Verify symlink
+    const stats = await fs.lstat(agentChatsDir);
+    expect(stats.isSymbolicLink()).toBe(true);
+    const target = await fs.readlink(agentChatsDir);
+    expect(path.resolve(root, target)).toBe(path.resolve(sharedDir));
+  });
+
+  it("reuses existing shared storage", async () => {
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "gemini");
+    await fs.mkdir(workspace, { recursive: true });
+    await writeFakeGeminiCommand(commandPath);
+
+    const agentId = "agent-2";
+    const companyId = "company-2";
+    const sharedDir = path.join(root, ".gemini", "companies", companyId, "chats");
+    
+    // 1. Pre-create shared storage
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "existing.jsonl"), "data");
+
+    // 2. Execute
+    await execute({
+      runId: "run-2",
+      agent: { id: agentId, companyId, name: "G", adapterType: "gemini_local", adapterConfig: {} },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: { command: commandPath, cwd: workspace },
+      context: {},
+      authToken: "t",
+      onLog: async () => {},
+    });
+
+    // 3. Verify agent now points to it
+    const agentChatsDir = path.join(root, ".gemini", "tmp", agentId, "chats");
+    const agentFiles = await fs.readdir(agentChatsDir);
+    expect(agentFiles).toContain("existing.jsonl");
+  });
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The `gemini_local` adapter uses the Gemini CLI for autonomous software engineering.
> - Gemini CLI uses agent-scoped temporary directories for session storage (derived from the JWT `sub` claim).
> - When a task is reassigned from one agent to another, the new agent cannot find the previous agent's session files, leading to "Invalid session identifier" errors.
> - This PR implements shared Gemini chat storage for agents within the same company by symlinking agent-specific chat directories to a shared company-scoped directory.
> - The benefit is seamless session handoff across agents within a company, improving collaboration and task resumption reliability.

## What Changed

- Added `ensureGeminiChatsShared` utility to `packages/adapters/gemini-local/src/server/execute.ts`.
- This utility ensures `~/.gemini/tmp/${agentId}/chats` is a symlink to `~/.gemini/companies/${companyId}/chats`.
- Implemented migration logic to move existing chats to the shared directory on first use.
- Added unit tests in `packages/adapters/gemini-local/src/server/shared-chats.test.ts` to verify migration and symlink creation.

## Verification

- Added `packages/adapters/gemini-local/src/server/shared-chats.test.ts` and ran it with `vitest`.
- Verified that existing chats are migrated to the shared directory.
- Verified that the agent directory is correctly symlinked.
- Ran existing `gemini-local-execute.test.ts` to ensure no regressions.

## Risks

- Low risk. The change is limited to the `gemini_local` adapter and only affects local process execution.
- Migration logic is "best effort" and uses `fs.cp` followed by `fs.rm` to be safe across filesystems.

## Model Used

- Provider: Google
- Model: Gemini 2.5 Flash Lite
- Context window: 1M tokens
- Capabilities: Tool use, code execution, chain-of-thought reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge