### PR TITLE
Add plugin private-network HTTP capability

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -773,6 +773,7 @@ The host enforces capabilities in the SDK layer and refuses calls outside the gr
 - `jobs.schedule`
 - `webhooks.receive`
 - `http.outbound`
+- `http.private-network` — permits `http.outbound` requests to loopback, private LAN, link-local, and other reserved address ranges.
 - `secrets.read-ref`
 
 ### Agent Tools

--- a/packages/plugins/sdk/README.md
+++ b/packages/plugins/sdk/README.md
@@ -343,6 +343,7 @@ Declare in `manifest.capabilities`. Grouped by scope:
 | | `webhooks.receive` |
 | | `api.routes.register` |
 | | `http.outbound` |
+| | `http.private-network` |
 | | `secrets.read-ref` |
 | | `environment.drivers.register` |
 | | `local.folders` |

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -560,7 +560,9 @@ export interface PluginDatabaseClient {
 /**
  * `ctx.http` — make outbound HTTP requests.
  *
- * Requires `http.outbound` capability.
+ * Requires `http.outbound` capability. Requests to loopback, private LAN,
+ * link-local, or other reserved address ranges also require the
+ * `http.private-network` capability.
  *
  * @see PLUGIN_SPEC.md §15.1 — Capabilities: Runtime/Integration
  */
@@ -569,6 +571,7 @@ export interface PluginHttpClient {
    * Perform an outbound HTTP request.
    *
    * The host enforces `http.outbound` capability before allowing the call.
+   * Private-network targets also require `http.private-network`.
    * Plugins may also use standard Node `fetch` or other libraries directly —
    * this client exists for host-managed tracing and audit logging.
    *
@@ -1624,7 +1627,7 @@ export interface PluginContext {
   /** Restricted plugin-owned database namespace. Requires database namespace capabilities. */
   db: PluginDatabaseClient;
 
-  /** Make outbound HTTP requests. Requires `http.outbound`. */
+  /** Make outbound HTTP requests. Requires `http.outbound`; private targets also require `http.private-network`. */
   http: PluginHttpClient;
 
   /** Resolve secret references. Requires `secrets.read-ref`. */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -774,6 +774,7 @@ export const PLUGIN_CAPABILITIES = [
   "webhooks.receive",
   "api.routes.register",
   "http.outbound",
+  "http.private-network",
   "secrets.read-ref",
   "environment.drivers.register",
   "local.folders",

--- a/server/src/__tests__/plugin-http-private-network.test.ts
+++ b/server/src/__tests__/plugin-http-private-network.test.ts
@@ -1,0 +1,76 @@
+import { createServer, type Server } from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { createHostClientHandlers } from "../../../packages/plugins/sdk/src/host-client-factory.js";
+import { buildHostServices } from "../services/plugin-host-services.js";
+
+function createEventBusStub() {
+  return {
+    forPlugin() {
+      return { emit: async () => {}, subscribe: () => {} };
+    },
+  } as any;
+}
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) =>
+    new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve());
+    })
+  ));
+});
+
+async function startLoopbackServer() {
+  const responseBody = JSON.stringify({ ok: true });
+  const server = await new Promise<Server>((resolve) => {
+    const srv = createServer((req, res) => {
+      expect(req.headers.host).toMatch(/^127\.0\.0\.1:/);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(responseBody);
+    });
+    srv.listen(0, "127.0.0.1", () => resolve(srv));
+  });
+  servers.push(server);
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not expose a TCP port");
+  return { url: `http://127.0.0.1:${address.port}/health`, responseBody };
+}
+
+function handlersForCapabilities(capabilities: string[]) {
+  const services = buildHostServices({} as never, "plugin-record-id", "test.plugin", createEventBusStub(), undefined, {
+    manifest: { id: "test.plugin", capabilities } as any,
+  });
+  return createHostClientHandlers({
+    pluginId: "test.plugin",
+    capabilities,
+    services,
+  });
+}
+
+describe("plugin http.fetch private-network capability", () => {
+  it("blocks private-network targets when the plugin has only http.outbound", async () => {
+    const { url } = await startLoopbackServer();
+    const handlers = handlersForCapabilities(["http.outbound"]);
+
+    await expect(handlers["http.fetch"]({ url })).rejects.toThrow(/http\.private-network/);
+  });
+
+  it("allows private-network targets when the plugin declares http.private-network", async () => {
+    const { url, responseBody } = await startLoopbackServer();
+    const handlers = handlersForCapabilities(["http.outbound", "http.private-network"]);
+
+    await expect(handlers["http.fetch"]({ url })).resolves.toMatchObject({
+      status: 200,
+      body: responseBody,
+    });
+  });
+
+  it("still rejects non-http protocols", async () => {
+    const handlers = handlersForCapabilities(["http.outbound", "http.private-network"]);
+
+    await expect(handlers["http.fetch"]({ url: "file:///etc/passwd" })).rejects.toThrow(
+      /only http: and https: are permitted/,
+    );
+  });
+});

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -142,7 +142,7 @@ interface ValidatedFetchTarget {
   useTls: boolean;
 }
 
-async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedFetchTarget> {
+async function validateAndResolveFetchUrl(urlString: string, allowPrivateNetwork = false): Promise<ValidatedFetchTarget> {
   let parsed: URL;
   try {
     parsed = new URL(urlString);
@@ -181,10 +181,12 @@ async function validateAndResolveFetchUrl(urlString: string): Promise<ValidatedF
     // Filter to only non-private IPs instead of rejecting the entire request
     // when some IPs are private. This handles multi-homed hosts that resolve
     // to both private and public addresses.
-    const safeResults = results.filter((entry) => !isPrivateIP(entry.address));
+    const safeResults = allowPrivateNetwork
+      ? results
+      : results.filter((entry) => !isPrivateIP(entry.address));
     if (safeResults.length === 0) {
       throw new Error(
-        `All resolved IPs for ${originalHostname} are in private/reserved ranges`,
+        `All resolved IPs for ${originalHostname} are in private/reserved ranges; plugin requires http.private-network capability`,
       );
     }
 
@@ -972,7 +974,8 @@ export function buildHostServices(
       async fetch(params) {
         // SSRF protection: validate protocol whitelist + block private IPs.
         // Resolve once, then connect directly to that IP to prevent DNS rebinding.
-        const target = await validateAndResolveFetchUrl(params.url);
+        const allowPrivateNetwork = options.manifest?.capabilities.includes("http.private-network") ?? false;
+        const target = await validateAndResolveFetchUrl(params.url, allowPrivateNetwork);
 
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), PLUGIN_FETCH_TIMEOUT_MS);


### PR DESCRIPTION
## Thinking Path

Paperclip plugins already have an outbound HTTP capability, but the host currently treats all resolved private or reserved addresses as blocked. That is a good default for untrusted plugins, but it prevents trusted plugins from calling operator-managed internal services such as private webhooks or sidecars. The narrow fix is to keep private-network blocking as the default and require a separate explicit plugin capability before those targets are allowed.

## What Changed

- Added `http.private-network` to the supported plugin capability list.
- Kept private/reserved IP rejection enabled by default for `ctx.http.fetch`.
- Allowed private/reserved resolved addresses only when a plugin declares `http.private-network` in addition to `http.outbound`.
- Preserved protocol validation and DNS resolution/pinning behavior for both trusted and untrusted plugin fetches.
- Documented the new capability in the plugin SDK types, SDK README, and plugin spec.
- Added server tests for default rejection, explicit allowance, and protocol rejection.

## Verification

- `pnpm exec vitest run server/src/__tests__/plugin-http-private-network.test.ts`
- `pnpm exec vitest run packages/shared/src/validators/plugin.test.ts`
- `pnpm --filter @paperclipai/shared typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/plugin-sdk typecheck`
- `git diff --check`

## Risks

- Trusted plugins can reach internal network resources once they declare the new capability and are installed by an operator.
- Existing plugins remain blocked from private/reserved network targets unless they opt in to the new capability.
- Operators will need to review this capability carefully because it intentionally grants access to local/private infrastructure.

## Model Used

OpenAI GPT-5 Codex via Codex CLI.

## Checklist

- [x] I read and filled in every section of the pull request template.
- [x] I kept the change narrow and aligned with Paperclip's plugin capability model.
- [x] I updated documentation for changed plugin capability behavior.
- [x] I ran targeted tests and typechecks.
- [x] Screenshots are not applicable; this is a server/plugin capability change with no UI surface.