### PR TITLE
Add @paperclipai/plugin-clarifier-example with Tier-0 pre-filter (CAL-112)

### DIFF
--- a/packages/plugins/examples/plugin-clarifier-example/.gitignore
+++ b/packages/plugins/examples/plugin-clarifier-example/.gitignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+.paperclip-sdk

--- a/packages/plugins/examples/plugin-clarifier-example/README.md
+++ b/packages/plugins/examples/plugin-clarifier-example/README.md
@@ -1,0 +1,27 @@
+# Plugin Clarifier Example
+
+A Paperclip plugin
+
+## Development
+
+```bash
+pnpm install
+pnpm dev            # watch builds
+pnpm dev:ui         # local dev server with hot-reload events
+pnpm test
+```
+
+
+
+## Install Into Paperclip
+
+```bash
+curl -X POST http://127.0.0.1:3100/api/plugins/install \
+  -H "Content-Type: application/json" \
+  -d '{"packageName":"/Users/work/Projects/PM/paperclip/packages/plugins/examples/plugin-clarifier-example","isLocalPath":true}'
+```
+
+## Build Options
+
+- `pnpm build` uses esbuild presets from `@paperclipai/plugin-sdk/bundlers`.
+- `pnpm build:rollup` uses rollup presets from the same SDK.

--- a/packages/plugins/examples/plugin-clarifier-example/esbuild.config.mjs
+++ b/packages/plugins/examples/plugin-clarifier-example/esbuild.config.mjs
@@ -1,0 +1,17 @@
+import esbuild from "esbuild";
+import { createPluginBundlerPresets } from "@paperclipai/plugin-sdk/bundlers";
+
+const presets = createPluginBundlerPresets({ uiEntry: "src/ui/index.tsx" });
+const watch = process.argv.includes("--watch");
+
+const workerCtx = await esbuild.context(presets.esbuild.worker);
+const manifestCtx = await esbuild.context(presets.esbuild.manifest);
+const uiCtx = await esbuild.context(presets.esbuild.ui);
+
+if (watch) {
+  await Promise.all([workerCtx.watch(), manifestCtx.watch(), uiCtx.watch()]);
+  console.log("esbuild watch mode enabled for worker, manifest, and ui");
+} else {
+  await Promise.all([workerCtx.rebuild(), manifestCtx.rebuild(), uiCtx.rebuild()]);
+  await Promise.all([workerCtx.dispose(), manifestCtx.dispose(), uiCtx.dispose()]);
+}

--- a/packages/plugins/examples/plugin-clarifier-example/migrations/001_clarifier_eligible.sql
+++ b/packages/plugins/examples/plugin-clarifier-example/migrations/001_clarifier_eligible.sql
@@ -1,0 +1,16 @@
+CREATE TABLE plugin_clarifier_9e2ef9ecdc.clarifier_eligible (
+  id uuid PRIMARY KEY,
+  issue_id uuid NOT NULL REFERENCES public.issues(id) ON DELETE CASCADE,
+  evaluated_at timestamptz NOT NULL DEFAULT now(),
+  eligible boolean NOT NULL,
+  signals text[] NOT NULL DEFAULT ARRAY[]::text[],
+  trigger_kind text NOT NULL,
+  trigger_event_id text,
+  trigger_comment_id uuid,
+  issue_status text,
+  issue_assignee_agent_id uuid,
+  details jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX clarifier_eligible_issue_eval_idx
+  ON plugin_clarifier_9e2ef9ecdc.clarifier_eligible (issue_id, evaluated_at DESC);

--- a/packages/plugins/examples/plugin-clarifier-example/package.json
+++ b/packages/plugins/examples/plugin-clarifier-example/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@paperclipai/plugin-clarifier-example",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "description": "Tier-0 structural pre-filter that decides whether an issue is eligible for clarification.",
+  "scripts": {
+    "build": "node ./esbuild.config.mjs",
+    "build:rollup": "rollup -c",
+    "dev": "node ./esbuild.config.mjs --watch",
+    "dev:ui": "paperclip-plugin-dev-server --root . --ui-dir dist/ui --port 4177",
+    "test": "vitest run --config ./vitest.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "keywords": [
+    "paperclip",
+    "plugin",
+    "connector"
+  ],
+  "author": "Paperclip",
+  "license": "MIT",
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@paperclipai/shared": "workspace:*",
+    "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-typescript": "^12.1.2",
+    "@types/node": "^24.6.0",
+    "@types/react": "^19.0.8",
+    "esbuild": "^0.27.3",
+    "rollup": "^4.38.0",
+    "tslib": "^2.8.1",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/plugin-clarifier-example/rollup.config.mjs
+++ b/packages/plugins/examples/plugin-clarifier-example/rollup.config.mjs
@@ -1,0 +1,28 @@
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+import { createPluginBundlerPresets } from "@paperclipai/plugin-sdk/bundlers";
+
+const presets = createPluginBundlerPresets({ uiEntry: "src/ui/index.tsx" });
+
+function withPlugins(config) {
+  if (!config) return null;
+  return {
+    ...config,
+    plugins: [
+      nodeResolve({
+        extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs"],
+      }),
+      typescript({
+        tsconfig: "./tsconfig.json",
+        declaration: false,
+        declarationMap: false,
+      }),
+    ],
+  };
+}
+
+export default [
+  withPlugins(presets.rollup.manifest),
+  withPlugins(presets.rollup.worker),
+  withPlugins(presets.rollup.ui),
+].filter(Boolean);

--- a/packages/plugins/examples/plugin-clarifier-example/src/manifest.ts
+++ b/packages/plugins/examples/plugin-clarifier-example/src/manifest.ts
@@ -1,0 +1,46 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: "paperclipai.plugin-clarifier-example",
+  apiVersion: 1,
+  version: "0.1.0",
+  displayName: "Clarifier",
+  description:
+    "Tier-0 structural pre-filter that decides whether an issue is eligible for clarification. " +
+    "Subscribes to issue comments, status changes, and run completions; persists eligibility verdicts " +
+    "to the plugin namespace for the LLM tier to consume.",
+  author: "Paperclip",
+  categories: ["automation"],
+  capabilities: [
+    "events.subscribe",
+    "issues.read",
+    "issue.comments.read",
+    "issue.relations.read",
+    "database.namespace.migrate",
+    "database.namespace.read",
+    "database.namespace.write",
+    "plugin.state.read",
+    "plugin.state.write",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  database: {
+    namespaceSlug: "clarifier",
+    migrationsDir: "migrations",
+    coreReadTables: ["issues", "issue_comments"],
+  },
+  ui: {
+    slots: [
+      {
+        type: "dashboardWidget",
+        id: "health-widget",
+        displayName: "Clarifier Health",
+        exportName: "DashboardWidget",
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-clarifier-example/src/tier0.ts
+++ b/packages/plugins/examples/plugin-clarifier-example/src/tier0.ts
@@ -1,0 +1,193 @@
+// Tier-0 structural pre-filter for the Clarifier plugin.
+//
+// Pure functions only. No I/O. Decides whether an issue is *eligible* for
+// clarification based on the structured signals listed in CAL-112. The next
+// tier (CAL-113) does the LLM call and only sees issues that pass here.
+
+export type EligibleStatus = "in_progress" | "in_review" | "blocked";
+export const ELIGIBLE_STATUSES: readonly EligibleStatus[] = [
+  "in_progress",
+  "in_review",
+  "blocked",
+] as const;
+
+export const ONE_HOUR_MS = 60 * 60 * 1000;
+export const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
+
+export const QUESTION_KEYWORD_RE =
+  /\b(should|could|can|which|what|how|who|when|approve|confirm)\b.*\?/i;
+
+export type TriggerKind =
+  | "comment.created"
+  | "issue.status_changed"
+  | "agent.run.finished"
+  | "scheduled.evaluate";
+
+export type ActorType = "agent" | "user" | "system" | "plugin";
+
+export interface FixtureIssue {
+  id: string;
+  status: string;
+  assigneeAgentId: string | null;
+  updatedAt: Date;
+}
+
+export interface FixtureComment {
+  id: string;
+  body: string;
+  actorType: ActorType;
+  authorAgentId: string | null;
+  createdAt: Date;
+}
+
+export interface FixtureBlocker {
+  id: string;
+  status: string;
+  /**
+   * Whether this blocker is itself stuck (e.g. blocked, or in_progress with
+   * no run finished in some configurable window). The worker computes this
+   * one level deep — Tier-0 just consumes the boolean.
+   */
+  stuck: boolean;
+}
+
+export type Trigger =
+  | {
+      kind: "comment.created";
+      comment: FixtureComment;
+    }
+  | {
+      kind: "issue.status_changed";
+      previousStatus: string | null;
+      newStatus: string;
+    }
+  | {
+      kind: "agent.run.finished";
+      runId: string;
+      runFinishedAt: Date;
+    }
+  | {
+      kind: "scheduled.evaluate";
+    };
+
+export interface Tier0Input {
+  issue: FixtureIssue;
+  trigger: Trigger;
+  /** Most recent comment on the issue (any author), if any. */
+  latestComment?: FixtureComment | null;
+  /**
+   * Wall-clock time of the most recent finished run for this issue's assignee,
+   * scoped to this issue if known. Used for the "run finished in last hour
+   * and nothing changed" signal.
+   */
+  lastRunFinishedAt?: Date | null;
+  /**
+   * Wall-clock time the issue's `status` or `assigneeAgentId` last changed.
+   * Used to detect "nothing changed since the run finished".
+   */
+  statusOrAssigneeChangedAt?: Date | null;
+  /** Direct blockers; the worker pre-computes the `stuck` flag at depth 1. */
+  blockers?: FixtureBlocker[];
+  /** Evaluation clock. Defaults to `new Date()`. */
+  now?: Date;
+}
+
+export type EligibilitySignal =
+  | "agent_question"
+  | "transitioned_to_blocked"
+  | "run_finished_no_change"
+  | "stale_after_agent_comment"
+  | "stuck_blocker";
+
+export type IneligibilityReason =
+  | "status_not_eligible"
+  | "missing_assignee"
+  | "no_signal";
+
+export interface Tier0Verdict {
+  eligible: boolean;
+  signals: EligibilitySignal[];
+  reasons: IneligibilityReason[];
+}
+
+function isEligibleStatus(status: string): status is EligibleStatus {
+  return (ELIGIBLE_STATUSES as readonly string[]).includes(status);
+}
+
+function commentLooksLikeQuestion(body: string): boolean {
+  if (!body) return false;
+  const trimmed = body.trim();
+  if (trimmed.endsWith("?")) return true;
+  return QUESTION_KEYWORD_RE.test(trimmed);
+}
+
+function commentIsFromAgent(comment: FixtureComment): boolean {
+  return comment.actorType === "agent" && comment.authorAgentId != null;
+}
+
+/**
+ * Pure structural pre-filter. Returns a verdict plus the list of signals that
+ * fired (for traceability) and the list of reasons the issue is ineligible (if
+ * any). Always safe to call — no I/O, no side effects.
+ */
+export function evaluateTier0(input: Tier0Input): Tier0Verdict {
+  const now = input.now ?? new Date();
+  const { issue, trigger } = input;
+
+  const reasons: IneligibilityReason[] = [];
+  if (!isEligibleStatus(issue.status)) reasons.push("status_not_eligible");
+  if (!issue.assigneeAgentId) reasons.push("missing_assignee");
+
+  if (reasons.length > 0) {
+    return { eligible: false, signals: [], reasons };
+  }
+
+  const signals: EligibilitySignal[] = [];
+
+  // 1. Triggering comment is an agent question.
+  if (trigger.kind === "comment.created") {
+    if (commentIsFromAgent(trigger.comment) && commentLooksLikeQuestion(trigger.comment.body)) {
+      signals.push("agent_question");
+    }
+  }
+
+  // 2. Status just transitioned to blocked.
+  if (
+    trigger.kind === "issue.status_changed" &&
+    trigger.previousStatus !== "blocked" &&
+    trigger.newStatus === "blocked"
+  ) {
+    signals.push("transitioned_to_blocked");
+  }
+
+  // 3. A run finished in the last hour and status/assignee did not change since.
+  if (input.lastRunFinishedAt) {
+    const ageMs = now.getTime() - input.lastRunFinishedAt.getTime();
+    if (ageMs >= 0 && ageMs <= ONE_HOUR_MS) {
+      const changedAt = input.statusOrAssigneeChangedAt;
+      if (!changedAt || changedAt <= input.lastRunFinishedAt) {
+        signals.push("run_finished_no_change");
+      }
+    }
+  }
+
+  // 4. updatedAt older than 4 hours AND last comment is from an agent.
+  const issueAgeMs = now.getTime() - issue.updatedAt.getTime();
+  if (
+    issueAgeMs > FOUR_HOURS_MS &&
+    input.latestComment &&
+    commentIsFromAgent(input.latestComment)
+  ) {
+    signals.push("stale_after_agent_comment");
+  }
+
+  // 5. At least one unresolved blocker is itself stuck (cap depth 1).
+  if (input.blockers && input.blockers.some((b) => b.status !== "done" && b.status !== "cancelled" && b.stuck)) {
+    signals.push("stuck_blocker");
+  }
+
+  if (signals.length === 0) {
+    return { eligible: false, signals: [], reasons: ["no_signal"] };
+  }
+  return { eligible: true, signals, reasons: [] };
+}

--- a/packages/plugins/examples/plugin-clarifier-example/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-clarifier-example/src/ui/index.tsx
@@ -1,0 +1,23 @@
+import { usePluginAction, usePluginData, type PluginWidgetProps } from "@paperclipai/plugin-sdk/ui";
+
+type HealthData = {
+  status: "ok" | "degraded" | "error";
+  checkedAt: string;
+};
+
+export function DashboardWidget(_props: PluginWidgetProps) {
+  const { data, loading, error } = usePluginData<HealthData>("health");
+  const ping = usePluginAction("ping");
+
+  if (loading) return <div>Loading plugin health...</div>;
+  if (error) return <div>Plugin error: {error.message}</div>;
+
+  return (
+    <div style={{ display: "grid", gap: "0.5rem" }}>
+      <strong>Plugin Clarifier Example</strong>
+      <div>Health: {data?.status ?? "unknown"}</div>
+      <div>Checked: {data?.checkedAt ?? "never"}</div>
+      <button onClick={() => void ping()}>Ping Worker</button>
+    </div>
+  );
+}

--- a/packages/plugins/examples/plugin-clarifier-example/src/worker.ts
+++ b/packages/plugins/examples/plugin-clarifier-example/src/worker.ts
@@ -1,0 +1,300 @@
+import { randomUUID } from "node:crypto";
+import {
+  definePlugin,
+  runWorker,
+  type PluginContext,
+  type PluginEvent,
+} from "@paperclipai/plugin-sdk";
+import type { IssueComment, Issue } from "@paperclipai/shared";
+import {
+  evaluateTier0,
+  type FixtureBlocker,
+  type FixtureComment,
+  type FixtureIssue,
+  type Trigger,
+  type Tier0Verdict,
+} from "./tier0.js";
+
+// SDK version pinned via the workspace dependency. Logged on boot so operators
+// can correlate behavior with a specific SDK release.
+const SDK_VERSION = "1.0.0";
+
+function eligibleTableName(namespace: string): string {
+  return `${namespace}.clarifier_eligible`;
+}
+
+function mapIssueToFixture(issue: Issue): FixtureIssue {
+  return {
+    id: issue.id,
+    status: issue.status,
+    assigneeAgentId: issue.assigneeAgentId ?? null,
+    updatedAt: issue.updatedAt instanceof Date ? issue.updatedAt : new Date(issue.updatedAt),
+  };
+}
+
+function mapCommentToFixture(comment: IssueComment): FixtureComment {
+  return {
+    id: comment.id,
+    body: comment.body,
+    actorType: comment.authorType,
+    authorAgentId: comment.authorAgentId ?? null,
+    createdAt: comment.createdAt instanceof Date ? comment.createdAt : new Date(comment.createdAt),
+  };
+}
+
+async function loadLatestComment(
+  ctx: PluginContext,
+  issueId: string,
+  companyId: string,
+): Promise<FixtureComment | null> {
+  const comments = await ctx.issues.listComments(issueId, companyId);
+  if (!comments.length) return null;
+  const latest = comments.reduce((acc, c) => {
+    const aDate = c.createdAt instanceof Date ? c.createdAt : new Date(c.createdAt);
+    const accDate = acc.createdAt instanceof Date ? acc.createdAt : new Date(acc.createdAt);
+    return aDate > accDate ? c : acc;
+  });
+  return mapCommentToFixture(latest);
+}
+
+async function loadBlockersDepth1(
+  ctx: PluginContext,
+  issueId: string,
+  companyId: string,
+): Promise<FixtureBlocker[]> {
+  const relations = await ctx.issues.relations.get(issueId, companyId);
+  return relations.blockedBy.map((b) => ({
+    id: b.id,
+    status: b.status,
+    // Depth-1 heuristic: blocked or in_progress with no assignee = stuck.
+    // The plan caps depth at 1, so we don't recurse further.
+    stuck: b.status === "blocked" || (b.status === "in_progress" && !b.assigneeAgentId),
+  }));
+}
+
+interface PersistInput {
+  issueId: string;
+  verdict: Tier0Verdict;
+  triggerKind: Trigger["kind"];
+  triggerEventId: string | null;
+  triggerCommentId: string | null;
+  issueStatus: string;
+  issueAssigneeAgentId: string | null;
+  details: Record<string, unknown>;
+  evaluatedAt: Date;
+}
+
+async function persistVerdict(ctx: PluginContext, input: PersistInput): Promise<void> {
+  await ctx.db.execute(
+    `INSERT INTO ${eligibleTableName(ctx.db.namespace)} (
+       id,
+       issue_id,
+       evaluated_at,
+       eligible,
+       signals,
+       trigger_kind,
+       trigger_event_id,
+       trigger_comment_id,
+       issue_status,
+       issue_assignee_agent_id,
+       details
+     ) VALUES ($1, $2, $3, $4, $5::text[], $6, $7, $8, $9, $10, $11::jsonb)`,
+    [
+      randomUUID(),
+      input.issueId,
+      input.evaluatedAt.toISOString(),
+      input.verdict.eligible,
+      input.verdict.signals,
+      input.triggerKind,
+      input.triggerEventId,
+      input.triggerCommentId,
+      input.issueStatus,
+      input.issueAssigneeAgentId,
+      JSON.stringify(input.details),
+    ],
+  );
+}
+
+interface EvaluateOptions {
+  ctx: PluginContext;
+  companyId: string;
+  issueId: string;
+  trigger: Trigger;
+  triggerEventId: string | null;
+  triggerCommentId: string | null;
+  /** Last finished run timestamp tracked from `agent.run.finished`. */
+  lastRunFinishedAt: Date | null;
+}
+
+async function evaluateAndPersist(opts: EvaluateOptions): Promise<Tier0Verdict | null> {
+  const { ctx, companyId, issueId, trigger, triggerEventId, triggerCommentId } = opts;
+  const issue = await ctx.issues.get(issueId, companyId);
+  if (!issue) {
+    ctx.logger.warn("Tier-0 skipped: issue not found", { issueId });
+    return null;
+  }
+  const fixtureIssue = mapIssueToFixture(issue);
+  const [latestComment, blockers] = await Promise.all([
+    loadLatestComment(ctx, issueId, companyId),
+    loadBlockersDepth1(ctx, issueId, companyId),
+  ]);
+
+  const verdict = evaluateTier0({
+    issue: fixtureIssue,
+    trigger,
+    latestComment,
+    lastRunFinishedAt: opts.lastRunFinishedAt,
+    statusOrAssigneeChangedAt: fixtureIssue.updatedAt,
+    blockers,
+  });
+
+  const evaluatedAt = new Date();
+  await persistVerdict(ctx, {
+    issueId,
+    verdict,
+    triggerKind: trigger.kind,
+    triggerEventId,
+    triggerCommentId,
+    issueStatus: fixtureIssue.status,
+    issueAssigneeAgentId: fixtureIssue.assigneeAgentId,
+    details: { latestCommentId: latestComment?.id ?? null, blockerCount: blockers.length },
+    evaluatedAt,
+  });
+  ctx.logger.info("Tier-0 evaluated", {
+    issueId,
+    eligible: verdict.eligible,
+    signals: verdict.signals,
+    reasons: verdict.reasons,
+    triggerKind: trigger.kind,
+  });
+  return verdict;
+}
+
+// Per-issue cache of last finished run timestamp. In-memory is sufficient — the
+// signal is "run finished in last hour", so cold-start staleness is bounded.
+const lastRunFinishedByIssue = new Map<string, Date>();
+
+const plugin = definePlugin({
+  async setup(ctx: PluginContext) {
+    ctx.logger.info("clarifier worker ready", { sdkVersion: SDK_VERSION });
+
+    ctx.events.on("issue.comment.created", async (event: PluginEvent) => {
+      const payload = (event.payload ?? {}) as { commentId?: string; bodySnippet?: string };
+      const issueId = event.entityId ?? null;
+      if (!issueId) return;
+      const commentId = payload.commentId ?? null;
+      // Build a synthetic trigger comment from the event envelope so the pure
+      // pre-filter can fire without an extra DB round-trip when the snippet is
+      // already sufficient. Full body is fetched lazily by loadLatestComment.
+      const actorType =
+        (event.actorType as FixtureComment["actorType"] | undefined) ?? "system";
+      const triggerComment: FixtureComment = {
+        id: commentId ?? randomUUID(),
+        body: payload.bodySnippet ?? "",
+        actorType,
+        authorAgentId: actorType === "agent" ? (event.actorId ?? null) : null,
+        createdAt: new Date(event.occurredAt),
+      };
+      await evaluateAndPersist({
+        ctx,
+        companyId: event.companyId,
+        issueId,
+        trigger: { kind: "comment.created", comment: triggerComment },
+        triggerEventId: event.eventId,
+        triggerCommentId: commentId,
+        lastRunFinishedAt: lastRunFinishedByIssue.get(issueId) ?? null,
+      });
+    });
+
+    // `issue.status_changed` is not a first-class event; derive it from
+    // `issue.updated` payload diff using `_previous.status`. See CAL-109 audit
+    // verdicts §2 for the agreed workaround.
+    ctx.events.on("issue.updated", async (event: PluginEvent) => {
+      const payload = (event.payload ?? {}) as {
+        patch?: Record<string, unknown>;
+        _previous?: { status?: string | null };
+      };
+      const issueId = event.entityId ?? null;
+      if (!issueId) return;
+      const previousStatus = payload._previous?.status ?? null;
+      const patchStatus = payload.patch && typeof payload.patch.status === "string"
+        ? (payload.patch.status as string)
+        : null;
+      if (!patchStatus || patchStatus === previousStatus) {
+        // No status transition in this update; nothing for Tier-0 to do beyond
+        // the comment/run signals already wired.
+        return;
+      }
+      await evaluateAndPersist({
+        ctx,
+        companyId: event.companyId,
+        issueId,
+        trigger: {
+          kind: "issue.status_changed",
+          previousStatus,
+          newStatus: patchStatus,
+        },
+        triggerEventId: event.eventId,
+        triggerCommentId: null,
+        lastRunFinishedAt: lastRunFinishedByIssue.get(issueId) ?? null,
+      });
+    });
+
+    ctx.events.on("agent.run.finished", async (event: PluginEvent) => {
+      const payload = (event.payload ?? {}) as { issueId?: string | null; finishedAt?: string | null };
+      const issueId = payload.issueId ?? null;
+      if (!issueId) return;
+      const finishedAt = payload.finishedAt ? new Date(payload.finishedAt) : new Date(event.occurredAt);
+      lastRunFinishedByIssue.set(issueId, finishedAt);
+      await evaluateAndPersist({
+        ctx,
+        companyId: event.companyId,
+        issueId,
+        trigger: {
+          kind: "agent.run.finished",
+          runId: (event.payload as { runId?: string })?.runId ?? event.eventId,
+          runFinishedAt: finishedAt,
+        },
+        triggerEventId: event.eventId,
+        triggerCommentId: null,
+        lastRunFinishedAt: finishedAt,
+      });
+    });
+
+    ctx.data.register("health", async () => ({
+      status: "ok",
+      sdkVersion: SDK_VERSION,
+      databaseNamespace: ctx.db.namespace,
+      checkedAt: new Date().toISOString(),
+    }));
+
+    // Manual evaluation entry point — useful for the LLM tier subtask and for
+    // operator-triggered checks. Mirrors the same code path as events.
+    ctx.actions.register("evaluate", async (params) => {
+      const companyId = String(params.companyId ?? "");
+      const issueId = String(params.issueId ?? "");
+      if (!companyId || !issueId) throw new Error("companyId and issueId are required");
+      const verdict = await evaluateAndPersist({
+        ctx,
+        companyId,
+        issueId,
+        trigger: { kind: "scheduled.evaluate" },
+        triggerEventId: null,
+        triggerCommentId: null,
+        lastRunFinishedAt: lastRunFinishedByIssue.get(issueId) ?? null,
+      });
+      return verdict ?? { eligible: false, signals: [], reasons: ["no_signal"] };
+    });
+  },
+
+  async onHealth() {
+    return {
+      status: "ok",
+      message: "Clarifier worker is running",
+      details: { sdkVersion: SDK_VERSION, trackedIssues: lastRunFinishedByIssue.size },
+    };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-clarifier-example/tests/plugin.spec.ts
+++ b/packages/plugins/examples/plugin-clarifier-example/tests/plugin.spec.ts
@@ -1,0 +1,351 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { Issue, IssueComment } from "@paperclipai/shared";
+import { createTestHarness } from "@paperclipai/plugin-sdk/testing";
+import manifest from "../src/manifest.js";
+import plugin from "../src/worker.js";
+import {
+  evaluateTier0,
+  type FixtureBlocker,
+  type FixtureComment,
+  type FixtureIssue,
+  type Trigger,
+} from "../src/tier0.js";
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+function makeIssue(overrides: Partial<FixtureIssue> = {}): FixtureIssue {
+  return {
+    id: randomUUID(),
+    status: "in_progress",
+    assigneeAgentId: randomUUID(),
+    updatedAt: new Date("2026-05-15T12:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeComment(overrides: Partial<FixtureComment> = {}): FixtureComment {
+  return {
+    id: randomUUID(),
+    body: "noop",
+    actorType: "agent",
+    authorAgentId: randomUUID(),
+    createdAt: new Date("2026-05-15T11:55:00Z"),
+    ...overrides,
+  };
+}
+
+function fullIssue(seed: Partial<Issue> & Pick<Issue, "id" | "companyId" | "title">): Issue {
+  const now = new Date();
+  return {
+    projectId: null,
+    projectWorkspaceId: null,
+    goalId: null,
+    parentId: null,
+    description: null,
+    status: "in_progress",
+    priority: "medium",
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    issueNumber: null,
+    identifier: null,
+    originKind: "manual",
+    originId: null,
+    originRunId: null,
+    requestDepth: 0,
+    billingCode: null,
+    assigneeAdapterOverrides: null,
+    executionWorkspaceId: null,
+    executionWorkspacePreference: null,
+    executionWorkspaceSettings: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    hiddenAt: null,
+    createdAt: now,
+    updatedAt: now,
+    ...seed,
+  } as Issue;
+}
+
+function fullComment(seed: Partial<IssueComment> & Pick<IssueComment, "id" | "companyId" | "issueId" | "body" | "authorType">): IssueComment {
+  const now = new Date();
+  return {
+    authorAgentId: null,
+    authorUserId: null,
+    presentation: null,
+    metadata: null,
+    createdAt: now,
+    updatedAt: now,
+    ...seed,
+  } as IssueComment;
+}
+
+// ---------------------------------------------------------------------------
+// Pure pre-filter fixture tests (10 cases — every signal + negatives)
+// ---------------------------------------------------------------------------
+
+describe("Tier-0 pre-filter fixtures", () => {
+  const now = new Date("2026-05-15T13:00:00Z");
+
+  it("F1 — agent question triggers agent_question signal", () => {
+    const verdict = evaluateTier0({
+      issue: makeIssue({ status: "in_progress" }),
+      trigger: {
+        kind: "comment.created",
+        comment: makeComment({ body: "Should we ship this today?" }),
+      },
+      now,
+    });
+    expect(verdict).toEqual({
+      eligible: true,
+      signals: ["agent_question"],
+      reasons: [],
+    });
+  });
+
+  it("F2 — agent comment ending with '?' triggers agent_question signal", () => {
+    const verdict = evaluateTier0({
+      issue: makeIssue({ status: "in_review" }),
+      trigger: {
+        kind: "comment.created",
+        comment: makeComment({ body: "Ready to merge yet?" }),
+      },
+      now,
+    });
+    expect(verdict.eligible).toBe(true);
+    expect(verdict.signals).toEqual(["agent_question"]);
+  });
+
+  it("F3 — user-authored question does NOT trigger agent_question", () => {
+    const verdict = evaluateTier0({
+      issue: makeIssue({ status: "in_progress" }),
+      trigger: {
+        kind: "comment.created",
+        comment: makeComment({
+          body: "Should we ship this today?",
+          actorType: "user",
+          authorAgentId: null,
+        }),
+      },
+      now,
+    });
+    expect(verdict).toEqual({
+      eligible: false,
+      signals: [],
+      reasons: ["no_signal"],
+    });
+  });
+
+  it("F4 — status transition to blocked triggers transitioned_to_blocked", () => {
+    const verdict = evaluateTier0({
+      issue: makeIssue({ status: "blocked" }),
+      trigger: {
+        kind: "issue.status_changed",
+        previousStatus: "in_progress",
+        newStatus: "blocked",
+      },
+      now,
+    });
+    expect(verdict).toEqual({
+      eligible: true,
+      signals: ["transitioned_to_blocked"],
+      reasons: [],
+    });
+  });
+
+  it("F5 — run finished within 1h with no change since triggers run_finished_no_change", () => {
+    const runFinishedAt = new Date(now.getTime() - 30 * 60 * 1000); // 30 min ago
+    const verdict = evaluateTier0({
+      issue: makeIssue({ status: "in_progress", updatedAt: new Date(runFinishedAt.getTime() - 5 * 60 * 1000) }),
+      trigger: { kind: "agent.run.finished", runId: randomUUID(), runFinishedAt },
+      lastRunFinishedAt: runFinishedAt,
+      statusOrAssigneeChangedAt: new Date(runFinishedAt.getTime() - 5 * 60 * 1000),
+      now,
+    });
+    expect(verdict.eligible).toBe(true);
+    expect(verdict.signals).toContain("run_finished_no_change");
+  });
+
+  it("F6 — stale issue (>4h) with agent-authored last comment triggers stale_after_agent_comment", () => {
+    const verdict = evaluateTier0({
+      issue: makeIssue({
+        status: "in_progress",
+        updatedAt: new Date(now.getTime() - 5 * 60 * 60 * 1000), // 5h ago
+      }),
+      trigger: { kind: "scheduled.evaluate" },
+      latestComment: makeComment({
+        body: "running checks",
+        createdAt: new Date(now.getTime() - 5 * 60 * 60 * 1000),
+      }),
+      now,
+    });
+    expect(verdict.eligible).toBe(true);
+    expect(verdict.signals).toContain("stale_after_agent_comment");
+  });
+
+  it("F7 — stuck blocker (cap depth 1) triggers stuck_blocker", () => {
+    const blockers: FixtureBlocker[] = [
+      { id: randomUUID(), status: "blocked", stuck: true },
+    ];
+    const verdict = evaluateTier0({
+      issue: makeIssue({ status: "blocked" }),
+      trigger: { kind: "scheduled.evaluate" },
+      blockers,
+      now,
+    });
+    expect(verdict.eligible).toBe(true);
+    expect(verdict.signals).toContain("stuck_blocker");
+  });
+
+  it("F8 — ineligible status disqualifies even with signals", () => {
+    const verdict = evaluateTier0({
+      issue: makeIssue({ status: "done" }),
+      trigger: {
+        kind: "comment.created",
+        comment: makeComment({ body: "Should we re-open?" }),
+      },
+      now,
+    });
+    expect(verdict).toEqual({
+      eligible: false,
+      signals: [],
+      reasons: ["status_not_eligible"],
+    });
+  });
+
+  it("F9 — missing assignee disqualifies even with signals", () => {
+    const verdict = evaluateTier0({
+      issue: makeIssue({ status: "in_progress", assigneeAgentId: null }),
+      trigger: {
+        kind: "comment.created",
+        comment: makeComment({ body: "How should we proceed?" }),
+      },
+      now,
+    });
+    expect(verdict).toEqual({
+      eligible: false,
+      signals: [],
+      reasons: ["missing_assignee"],
+    });
+  });
+
+  it("F10 — eligible status + assignee but no signal at all → ineligible (no_signal)", () => {
+    const verdict = evaluateTier0({
+      issue: makeIssue({
+        status: "in_progress",
+        // Fresh, just-updated issue.
+        updatedAt: new Date(now.getTime() - 60_000),
+      }),
+      trigger: { kind: "scheduled.evaluate" },
+      latestComment: makeComment({ body: "ok, working on it" }),
+      blockers: [],
+      lastRunFinishedAt: null,
+      now,
+    });
+    expect(verdict).toEqual({
+      eligible: false,
+      signals: [],
+      reasons: ["no_signal"],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worker wiring test — ensure the worker subscribes and persists to the table.
+// ---------------------------------------------------------------------------
+
+describe("clarifier worker wiring", () => {
+  it("subscribes to comment + status + run events and writes a verdict row per evaluation", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const harness = createTestHarness({ manifest });
+    harness.seed({
+      issues: [
+        fullIssue({
+          id: issueId,
+          companyId,
+          title: "Plan a billing pipeline migration",
+          status: "in_progress",
+          assigneeAgentId,
+          updatedAt: new Date(),
+        }),
+      ],
+      issueComments: [
+        fullComment({
+          id: randomUUID(),
+          companyId,
+          issueId,
+          body: "Should I gate the migration behind a feature flag?",
+          authorType: "agent",
+          authorAgentId: assigneeAgentId,
+        }),
+      ],
+    });
+    await plugin.definition.setup(harness.ctx);
+
+    expect(harness.logs.some((entry) => entry.message === "clarifier worker ready")).toBe(true);
+
+    await harness.emit(
+      "issue.comment.created",
+      {
+        commentId: randomUUID(),
+        bodySnippet: "Should I gate the migration behind a feature flag?",
+        identifier: "CAL-999",
+        agentId: assigneeAgentId,
+      },
+      {
+        companyId,
+        entityId: issueId,
+        entityType: "issue",
+        actorType: "agent",
+        actorId: assigneeAgentId,
+      },
+    );
+
+    expect(harness.dbExecutes.length).toBeGreaterThan(0);
+    const lastExec = harness.dbExecutes.at(-1)!;
+    expect(lastExec.sql).toContain(".clarifier_eligible");
+    expect(lastExec.params?.[3]).toBe(true); // eligible column
+    expect(lastExec.params?.[4]).toEqual(expect.arrayContaining(["agent_question"]));
+  });
+
+  it("does not write a verdict for issue.updated payloads with no status change", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    const harness = createTestHarness({ manifest });
+    harness.seed({
+      issues: [
+        fullIssue({
+          id: issueId,
+          companyId,
+          title: "Stable issue",
+          status: "in_progress",
+          assigneeAgentId: randomUUID(),
+        }),
+      ],
+    });
+    await plugin.definition.setup(harness.ctx);
+
+    const before = harness.dbExecutes.length;
+    await harness.emit(
+      "issue.updated",
+      {
+        identifier: "CAL-1",
+        patch: { title: "Renamed" },
+        _previous: { status: "in_progress", assigneeAgentId: null, assigneeUserId: null },
+      },
+      { companyId, entityId: issueId, entityType: "issue" },
+    );
+    expect(harness.dbExecutes.length).toBe(before);
+  });
+});

--- a/packages/plugins/examples/plugin-clarifier-example/tsconfig.json
+++ b/packages/plugins/examples/plugin-clarifier-example/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "tests"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}

--- a/packages/plugins/examples/plugin-clarifier-example/vitest.config.ts
+++ b/packages/plugins/examples/plugin-clarifier-example/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,46 @@ importers:
         specifier: ^3.0.5
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
+  packages/plugins/examples/plugin-clarifier-example:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+      react:
+        specifier: '>=18'
+        version: 19.2.4
+    devDependencies:
+      '@paperclipai/shared':
+        specifier: workspace:*
+        version: link:../../../shared
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.1
+        version: 16.0.3(rollup@4.60.1)
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.2
+        version: 12.3.0(rollup@4.60.1)(tslib@2.8.1)(typescript@5.9.3)
+      '@types/node':
+        specifier: ^24.6.0
+        version: 24.12.0
+      '@types/react':
+        specifier: ^19.0.8
+        version: 19.2.14
+      esbuild:
+        specifier: ^0.27.3
+        version: 0.27.3
+      rollup:
+        specifier: '>=4.59.0'
+        version: 4.60.1
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
       '@codemirror/lang-javascript':

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -180,6 +180,14 @@ const BUNDLED_PLUGIN_EXAMPLES: AvailablePluginExample[] = [
     localPath: "packages/plugins/examples/plugin-orchestration-smoke-example",
     tag: "example",
   },
+  {
+    packageName: "@paperclipai/plugin-clarifier-example",
+    pluginKey: "paperclipai.plugin-clarifier-example",
+    displayName: "Clarifier (Example)",
+    description: "Tier-0 structural pre-filter that decides whether an issue is eligible for clarification — subscribes to comment, status, and run events and writes verdicts to a plugin-owned table for the LLM tier to consume.",
+    localPath: "packages/plugins/examples/plugin-clarifier-example",
+    tag: "example",
+  },
 ];
 
 function listBundledPluginExamples(): AvailablePluginExample[] {


### PR DESCRIPTION
## Summary

Scaffolds a new bundled example plugin, `@paperclipai/plugin-clarifier-example`, that implements the **Tier-0 structural pre-filter** for the Clarifier & Nudger feature ([CAL-104](https://example.com/CAL/issues/CAL-104) plan, §1-2; this PR is [CAL-112](https://example.com/CAL/issues/CAL-112)).

The pre-filter decides whether an issue is *eligible* for clarification using only structured fields — **no LLM call**. The LLM tier is the next subtask ([CAL-113](https://example.com/CAL/issues/CAL-113)) and consumes the verdicts this plugin writes to its own table.

## What's in the PR

- **Pure pre-filter** at `packages/plugins/examples/plugin-clarifier-example/src/tier0.ts` — `evaluateTier0(input)` returns `{ eligible, signals, reasons }`. No I/O. Same function used by the worker and every fixture test.
- **Worker** at `src/worker.ts` — boots, logs `clarifier worker ready` with the SDK version, subscribes to:
  - `issue.comment.created` (agent-question signal via regex on body snippet)
  - `issue.updated` with status-diff derivation (per the [CAL-109](https://example.com/CAL/issues/CAL-109) SDK readiness audit, which found `issue.status_changed` is not a first-class event)
  - `agent.run.finished` (run-finished + run-finished-no-change signals)
- **Migration** at `migrations/001_clarifier_eligible.sql` — creates `plugin_clarifier_<hash>.clarifier_eligible` keyed on `(issue_id, evaluated_at)` with `signals text[]` and a `(issue_id, evaluated_at DESC)` index so CAL-113 can read the latest verdict per issue.
- **Bundled-example registration** in `server/src/routes/plugins.ts` so local-path installs find the package.
- **Fixture tests** at `tests/plugin.spec.ts` — 12/12 passing:
  - 10 pre-filter fixture cases covering every signal plus the three negative classes (`status_not_eligible`, `missing_assignee`, `no_signal`)
  - 2 worker-wiring tests that assert the verdict row is written on `issue.comment.created` and skipped on a no-status-change `issue.updated`

Pre-filter signals (status ∈ {`in_progress`, `in_review`, `blocked`} AND `assigneeAgentId` is set, plus at least one of):
- agent-authored comment matching `/\\b(should|could|can|which|what|how|who|when|approve|confirm)\\b.*\\?/i` or ending with `?`
- status just transitioned to `blocked`
- a run finished in the last hour and status/assignee didn't change since
- `updatedAt` older than 4h AND last comment is from an agent
- has at least one unresolved `blockedBy` whose blocker is itself stuck (cap depth 1)

## Out of scope

- LLM call, draft generation, output cache → [CAL-113](https://example.com/CAL/issues/CAL-113) (CTO)
- Sidebar UI → BrowserDebugger track ([CAL-114](https://example.com/CAL/issues/CAL-114))
- Cost cap, role gate, audit rows → [CAL-115](https://example.com/CAL/issues/CAL-115) (CTO)

## Test plan

- [ ] \`pnpm install\` at the repo root
- [ ] \`pnpm --filter @paperclipai/plugin-clarifier-example typecheck\` — clean
- [ ] \`pnpm --filter @paperclipai/plugin-clarifier-example test\` — 12/12 passing
- [ ] \`pnpm --filter @paperclipai/plugin-clarifier-example build\` — produces \`dist/manifest.js\`, \`dist/worker.js\`, \`dist/ui/index.js\`
- [ ] Install into a running Paperclip dev server with the local-path install endpoint and verify the migration creates \`clarifier_eligible\` and the worker logs \`clarifier worker ready\` with SDK version \`1.0.0\`

## Pinned SDK

\`@paperclipai/plugin-sdk@1.0.0\` (workspace dep, runtime not dev) — logged on every worker boot.