### PR TITLE
Add project sidebar status indicators

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -329,6 +329,7 @@ export type {
   ProjectCodebase,
   ProjectCodebaseOrigin,
   ProjectGoalRef,
+  ProjectIssueStatusSummary,
   ProjectManagedByPlugin,
   ProjectWorkspace,
   CompanySearchHighlight,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -89,7 +89,15 @@ export type {
   AdapterEnvironmentTestResult,
 } from "./agent.js";
 export type { AssetImage } from "./asset.js";
-export type { Project, ProjectCodebase, ProjectCodebaseOrigin, ProjectGoalRef, ProjectManagedByPlugin, ProjectWorkspace } from "./project.js";
+export type {
+  Project,
+  ProjectCodebase,
+  ProjectCodebaseOrigin,
+  ProjectGoalRef,
+  ProjectIssueStatusSummary,
+  ProjectManagedByPlugin,
+  ProjectWorkspace,
+} from "./project.js";
 export type {
   CompanySearchHighlight,
   CompanySearchIssueSummary,

--- a/packages/shared/src/types/project.ts
+++ b/packages/shared/src/types/project.ts
@@ -1,4 +1,4 @@
-import type { PauseReason, ProjectStatus } from "../constants.js";
+import type { IssueStatus, PauseReason, ProjectStatus } from "../constants.js";
 import type {
   ProjectExecutionWorkspacePolicy,
   ProjectWorkspaceRuntimeConfig,
@@ -64,6 +64,8 @@ export interface ProjectManagedByPlugin {
   updatedAt: Date;
 }
 
+export type ProjectIssueStatusSummary = Partial<Record<IssueStatus, number>>;
+
 export interface Project {
   id: string;
   companyId: string;
@@ -86,6 +88,7 @@ export interface Project {
   workspaces: ProjectWorkspace[];
   primaryWorkspace: ProjectWorkspace | null;
   managedByPlugin?: ProjectManagedByPlugin | null;
+  issueStatusSummary?: ProjectIssueStatusSummary;
   archivedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -1,6 +1,7 @@
-import { and, asc, desc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
+  issues,
   projects,
   projectGoals,
   goals,
@@ -10,6 +11,7 @@ import {
   workspaceRuntimeServices,
 } from "@paperclipai/db";
 import {
+  ISSUE_STATUSES,
   PROJECT_COLORS,
   deriveProjectUrlKey,
   hasNonAsciiContent,
@@ -18,6 +20,7 @@ import {
   type ProjectCodebase,
   type ProjectExecutionWorkspacePolicy,
   type ProjectGoalRef,
+  type ProjectIssueStatusSummary,
   type ProjectManagedByPlugin,
   type ProjectWorkspaceRuntimeConfig,
   type ProjectWorkspace,
@@ -62,6 +65,7 @@ interface ProjectWithGoals extends Omit<ProjectRow, "executionWorkspacePolicy"> 
   workspaces: ProjectWorkspace[];
   primaryWorkspace: ProjectWorkspace | null;
   managedByPlugin: ProjectManagedByPlugin | null;
+  issueStatusSummary: ProjectIssueStatusSummary;
 }
 
 interface ProjectShortnameRow {
@@ -315,6 +319,45 @@ async function attachWorkspaces(db: Db, rows: ProjectWithGoals[]): Promise<Proje
   });
 }
 
+function emptyProjectIssueStatusSummary(): ProjectIssueStatusSummary {
+  return Object.fromEntries(ISSUE_STATUSES.map((status) => [status, 0])) as ProjectIssueStatusSummary;
+}
+
+async function attachIssueStatusSummaries(db: Db, rows: ProjectWithGoals[]): Promise<ProjectWithGoals[]> {
+  if (rows.length === 0) return [];
+
+  const projectIds = rows.map((row) => row.id);
+  const summaries = new Map<string, ProjectIssueStatusSummary>(
+    projectIds.map((projectId) => [projectId, emptyProjectIssueStatusSummary()]),
+  );
+  const validStatuses = new Set<string>(ISSUE_STATUSES);
+
+  const counts = await db
+    .select({
+      projectId: issues.projectId,
+      status: issues.status,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(issues)
+    .where(and(
+      eq(issues.companyId, rows[0]!.companyId),
+      inArray(issues.projectId, projectIds),
+    ))
+    .groupBy(issues.projectId, issues.status);
+
+  for (const row of counts) {
+    if (!row.projectId || !validStatuses.has(row.status)) continue;
+    const summary = summaries.get(row.projectId);
+    if (!summary) continue;
+    summary[row.status as keyof ProjectIssueStatusSummary] = Number(row.count) || 0;
+  }
+
+  return rows.map((row) => ({
+    ...row,
+    issueStatusSummary: summaries.get(row.id) ?? emptyProjectIssueStatusSummary(),
+  }));
+}
+
 /** Sync the project_goals join table for a single project. */
 async function syncGoalLinks(db: Db, projectId: string, companyId: string, goalIds: string[]) {
   // Delete existing links
@@ -505,14 +548,17 @@ export function projectService(db: Db) {
     const [withGoals] = await attachGoals(db, [row]);
     if (!withGoals) return null;
     const [enriched] = await attachWorkspaces(db, [withGoals]);
-    return enriched ?? null;
+    if (!enriched) return null;
+    const [withIssueStatusSummary] = await attachIssueStatusSummaries(db, [enriched]);
+    return withIssueStatusSummary ?? null;
   };
 
   return {
     list: async (companyId: string): Promise<ProjectWithGoals[]> => {
       const rows = await db.select().from(projects).where(eq(projects.companyId, companyId));
       const withGoals = await attachGoals(db, rows);
-      return attachWorkspaces(db, withGoals);
+      const withWorkspaces = await attachWorkspaces(db, withGoals);
+      return attachIssueStatusSummaries(db, withWorkspaces);
     },
 
     listByIds: async (companyId: string, ids: string[]): Promise<ProjectWithGoals[]> => {
@@ -524,7 +570,8 @@ export function projectService(db: Db) {
         .where(and(eq(projects.companyId, companyId), inArray(projects.id, dedupedIds)));
       const withGoals = await attachGoals(db, rows);
       const withWorkspaces = await attachWorkspaces(db, withGoals);
-      const byId = new Map(withWorkspaces.map((project) => [project.id, project]));
+      const withIssueStatusSummaries = await attachIssueStatusSummaries(db, withWorkspaces);
+      const byId = new Map(withIssueStatusSummaries.map((project) => [project.id, project]));
       return dedupedIds.map((id) => byId.get(id)).filter((project): project is ProjectWithGoals => Boolean(project));
     },
 

--- a/ui/src/components/SidebarProjects.test.tsx
+++ b/ui/src/components/SidebarProjects.test.tsx
@@ -78,7 +78,7 @@ vi.mock("../api/auth", () => ({
 
 vi.mock("../hooks/useProjectOrder", () => ({
   useProjectOrder: ({ projects }: { projects: Project[] }) => {
-    const curatedOrder = ["project-b", "project-a", "project-c"];
+    const curatedOrder = ["project-b", "project-a", "project-c", "project-d"];
     return {
       orderedProjects: [...projects].sort(
         (left, right) => curatedOrder.indexOf(left.id) - curatedOrder.indexOf(right.id),
@@ -140,6 +140,19 @@ function makeProject(overrides: Partial<Project>): Project {
     archivedAt: null,
     createdAt: new Date("2026-01-01T00:00:00Z"),
     updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeIssueStatusSummary(overrides: NonNullable<Project["issueStatusSummary"]> = {}) {
+  return {
+    backlog: 0,
+    todo: 0,
+    in_progress: 0,
+    in_review: 0,
+    done: 0,
+    blocked: 0,
+    cancelled: 0,
     ...overrides,
   };
 }
@@ -254,6 +267,54 @@ describe("SidebarProjects", () => {
 
     expect(projectLinkLabels(container)).toEqual(["Bravo", "Alpha", "Charlie"]);
     expect(container.querySelector('[data-testid="project-slot-project-b"]')).toBeTruthy();
+  });
+
+  it("renders project status circles from issue and project state instead of project colors", async () => {
+    mockProjectsApi.list.mockResolvedValue([
+      makeProject({
+        id: "project-a",
+        urlKey: "alpha",
+        name: "Active",
+        status: "planned",
+        color: "#ef4444",
+        issueStatusSummary: makeIssueStatusSummary({ in_progress: 1 }),
+      }),
+      makeProject({
+        id: "project-b",
+        urlKey: "bravo",
+        name: "Waiting",
+        status: "in_progress",
+        color: "#22c55e",
+        issueStatusSummary: makeIssueStatusSummary({ blocked: 1 }),
+      }),
+      makeProject({
+        id: "project-c",
+        urlKey: "charlie",
+        name: "Inactive",
+        status: "completed",
+        color: "#3b82f6",
+        issueStatusSummary: makeIssueStatusSummary({ done: 2 }),
+      }),
+      makeProject({
+        id: "project-d",
+        urlKey: "delta",
+        name: "Unset",
+        status: "unknown" as Project["status"],
+        color: "#a855f7",
+      }),
+    ]);
+
+    await renderSidebarProjects();
+
+    expect(container.querySelector('[aria-label="Project status: blocked or pending"]')?.className)
+      .toContain("bg-amber-400");
+    expect(container.querySelector('[aria-label="Project status: active work"]')?.className)
+      .toContain("bg-emerald-500");
+    expect(container.querySelector('[aria-label="Project status: finished, empty, or inactive"]')?.className)
+      .toContain("bg-muted-foreground/45");
+    expect(container.querySelector('[aria-label="Project status: unset"]')?.className)
+      .toContain("bg-transparent");
+    expect(container.querySelector('[style*="background-color"]')).toBeNull();
   });
 
   it("uses the heading for section menu and the plus button for project creation", async () => {

--- a/ui/src/components/SidebarProjects.tsx
+++ b/ui/src/components/SidebarProjects.tsx
@@ -18,6 +18,11 @@ import { useSidebar } from "../context/SidebarContext";
 import { authApi } from "../api/auth";
 import { projectsApi } from "../api/projects";
 import { SIDEBAR_SCROLL_RESET_STATE } from "../lib/navigation-scroll";
+import {
+  getProjectSidebarStatusIndicator,
+  projectSidebarStatusIndicatorClass,
+  projectSidebarStatusIndicatorLabel,
+} from "../lib/project-status-indicator";
 import { queryKeys } from "../lib/queryKeys";
 import { cn, projectRouteRef } from "../lib/utils";
 import { useProjectOrder } from "../hooks/useProjectOrder";
@@ -85,6 +90,8 @@ function ProjectItem({
   isDragging = false,
 }: ProjectItemProps) {
   const routeRef = projectRouteRef(project);
+  const statusIndicator = getProjectSidebarStatusIndicator(project);
+  const statusIndicatorLabel = projectSidebarStatusIndicatorLabel[statusIndicator];
 
   return (
     <div className="flex flex-col gap-0.5">
@@ -106,8 +113,12 @@ function ProjectItem({
         )}
       >
         <span
-          className="shrink-0 h-3.5 w-3.5 rounded-sm"
-          style={{ backgroundColor: project.color ?? "#6366f1" }}
+          aria-label={statusIndicatorLabel}
+          title={statusIndicatorLabel}
+          className={cn(
+            "shrink-0 h-3.5 w-3.5 rounded-full border",
+            projectSidebarStatusIndicatorClass[statusIndicator],
+          )}
         />
         <span className="flex-1 truncate">{project.name}</span>
         {project.pauseReason === "budget" ? <BudgetSidebarMarker title="Project paused by budget" /> : null}

--- a/ui/src/lib/project-status-indicator.ts
+++ b/ui/src/lib/project-status-indicator.ts
@@ -1,0 +1,47 @@
+import type { Project } from "@paperclipai/shared";
+
+export type ProjectSidebarStatusIndicator = "default" | "active" | "waiting" | "inactive";
+
+type ProjectStatusInput = Pick<Project, "status" | "pauseReason" | "issueStatusSummary">;
+
+const WAITING_ISSUE_STATUSES = ["blocked", "in_review", "todo", "backlog"] as const;
+
+function issueStatusCount(project: ProjectStatusInput, status: keyof NonNullable<Project["issueStatusSummary"]>): number {
+  return project.issueStatusSummary?.[status] ?? 0;
+}
+
+function hasIssueStatusSummary(project: ProjectStatusInput): boolean {
+  return project.issueStatusSummary != null;
+}
+
+export function getProjectSidebarStatusIndicator(project: ProjectStatusInput): ProjectSidebarStatusIndicator {
+  // Sidebar status is derived from issue state first, then project state:
+  // blocked/in_review/todo/backlog issues -> waiting, in_progress issue/project -> active,
+  // completed/cancelled/empty projects -> inactive, unknown legacy state -> default outline.
+  const hasWaitingWork = WAITING_ISSUE_STATUSES.some((status) => issueStatusCount(project, status) > 0);
+  if (project.pauseReason || hasWaitingWork) return "waiting";
+
+  if (project.status === "in_progress" || issueStatusCount(project, "in_progress") > 0) return "active";
+
+  if (project.status === "completed" || project.status === "cancelled") return "inactive";
+
+  if (hasIssueStatusSummary(project)) return "inactive";
+
+  if (project.status === "backlog" || project.status === "planned") return "waiting";
+
+  return "default";
+}
+
+export const projectSidebarStatusIndicatorLabel: Record<ProjectSidebarStatusIndicator, string> = {
+  default: "Project status: unset",
+  active: "Project status: active work",
+  waiting: "Project status: blocked or pending",
+  inactive: "Project status: finished, empty, or inactive",
+};
+
+export const projectSidebarStatusIndicatorClass: Record<ProjectSidebarStatusIndicator, string> = {
+  default: "border-foreground bg-transparent",
+  active: "border-emerald-600 bg-emerald-500",
+  waiting: "border-amber-500 bg-amber-400",
+  inactive: "border-muted-foreground/55 bg-muted-foreground/45",
+};


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies through projects, issues, and execution state.
> - The left sidebar is one of the fastest operator surfaces for scanning which projects need attention.
> - Project sidebar markers were previously visual color swatches, so they did not communicate operational status.
> - Operators need those markers to show active work, waiting/blocked work, inactive work, and unset legacy states.
> - This pull request adds a code-only project status indicator path backed by project issue status summaries.
> - The benefit is a portable UI/API patch that another Paperclip install can apply without company, agent, runtime, or seed data.

## What Changed

- Adds `ProjectIssueStatusSummary` to shared project types and project API responses.
- Aggregates issue counts by status in `projectService.list`, `listByIds`, and detail lookup.
- Replaces sidebar project color swatches with status circles derived from issue state first, then project state.
- Adds a focused sidebar component test covering active, waiting, inactive, and unset indicators.

## Verification

- `pnpm exec vitest run ui/src/components/SidebarProjects.test.tsx` passed: 5 tests.
- `pnpm --filter @paperclipai/shared typecheck` passed.
- `pnpm --filter @paperclipai/ui typecheck` passed.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `git diff --check` passed.
- Secret scan over the patch for API/token/secret/private-key markers returned no matches.
- UI screenshot not attached for this branch handoff; the visible behavior is covered by the sidebar DOM assertions above.

## Risks

- Low data risk: this only adds read-side aggregation and response fields; it does not change schema or persisted project data.
- Query cost grows with the number of projects returned because the aggregation batches project IDs for the list/detail response. This should remain bounded by the existing project list surface.
- Sidebar indicator labels are currently English literals, matching the upstream code-only branch and keeping this separate from the Turkish UI patch.

## Model Used

- OpenAI Codex, GPT-5 family coding agent, with terminal/tool use and medium reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
