### PR TITLE
fix: walk error.cause when detecting companies_issue_prefix_idx conflicts (#6088)

### DIFF
--- a/server/src/__tests__/issue-prefix-conflict.test.ts
+++ b/server/src/__tests__/issue-prefix-conflict.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { isIssuePrefixConflict } from "../services/companies.js";
+
+describe("isIssuePrefixConflict", () => {
+  it("recognises a bare postgres-js error (no wrapping)", () => {
+    const err = {
+      name: "PostgresError",
+      code: "23505",
+      constraint: "companies_issue_prefix_idx",
+      severity: "ERROR",
+      message: "duplicate key value violates unique constraint",
+    };
+    expect(isIssuePrefixConflict(err)).toBe(true);
+  });
+
+  it("recognises the same error after drizzle-orm wraps it in DrizzleQueryError", () => {
+    // Shape produced by drizzle-orm/postgres-js when an INSERT fails on a
+    // unique constraint: the underlying postgres error is nested at `cause`.
+    const err = {
+      name: "DrizzleQueryError",
+      message: 'Failed query: insert into "companies" ...',
+      cause: {
+        name: "PostgresError",
+        code: "23505",
+        constraint: "companies_issue_prefix_idx",
+        severity: "ERROR",
+      },
+    };
+    expect(isIssuePrefixConflict(err)).toBe(true);
+  });
+
+  it("recognises deeper nesting via the cause chain", () => {
+    const err = {
+      name: "OuterWrapper",
+      cause: {
+        name: "InnerWrapper",
+        cause: {
+          code: "23505",
+          constraint: "companies_issue_prefix_idx",
+        },
+      },
+    };
+    expect(isIssuePrefixConflict(err)).toBe(true);
+  });
+
+  it("accepts the alternative `constraint_name` field used by some drivers", () => {
+    const err = { code: "23505", constraint_name: "companies_issue_prefix_idx" };
+    expect(isIssuePrefixConflict(err)).toBe(true);
+  });
+
+  it("returns false for a different unique-constraint violation", () => {
+    const err = {
+      cause: { code: "23505", constraint: "companies_name_idx" },
+    };
+    expect(isIssuePrefixConflict(err)).toBe(false);
+  });
+
+  it("returns false for a non-conflict postgres error", () => {
+    const err = { cause: { code: "23502", constraint: "companies_issue_prefix_idx" } };
+    expect(isIssuePrefixConflict(err)).toBe(false);
+  });
+
+  it("returns false for null / undefined / primitives", () => {
+    expect(isIssuePrefixConflict(null)).toBe(false);
+    expect(isIssuePrefixConflict(undefined)).toBe(false);
+    expect(isIssuePrefixConflict("23505")).toBe(false);
+    expect(isIssuePrefixConflict(23505)).toBe(false);
+  });
+});

--- a/server/src/__tests__/issue-prefix-conflict.test.ts
+++ b/server/src/__tests__/issue-prefix-conflict.test.ts
@@ -66,4 +66,17 @@ describe("isIssuePrefixConflict", () => {
     expect(isIssuePrefixConflict("23505")).toBe(false);
     expect(isIssuePrefixConflict(23505)).toBe(false);
   });
+
+  it("terminates promptly on a circular cause graph (depth-cap regression)", () => {
+    // Construct a cycle a → b → a. A naive while(cause) traversal would spin
+    // forever. The MAX_DEPTH guard must short-circuit and return false.
+    const a: Record<string, unknown> = { code: "OTHER", constraint: "irrelevant" };
+    const b: Record<string, unknown> = { code: "OTHER", constraint: "irrelevant" };
+    a.cause = b;
+    b.cause = a;
+    const start = Date.now();
+    expect(isIssuePrefixConflict(a)).toBe(false);
+    // Sanity: a hung loop would never return; assert this finished quickly.
+    expect(Date.now() - start).toBeLessThan(100);
+  });
 });

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -42,8 +42,12 @@ import { environmentService } from "./environments.js";
  * surface). Exported for unit testing.
  */
 export function isIssuePrefixConflict(error: unknown): boolean {
+  // Bounded depth so a pathological (circular or pathologically deep) error
+  // graph cannot spin the loop. Real Postgres / Drizzle errors nest at most
+  // 1–2 levels; 10 leaves comfortable headroom without becoming a foot-gun.
+  const MAX_DEPTH = 10;
   let cursor: unknown = error;
-  while (cursor && typeof cursor === "object") {
+  for (let depth = 0; cursor && typeof cursor === "object" && depth < MAX_DEPTH; depth += 1) {
     const node = cursor as {
       code?: string;
       constraint?: string;

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -32,6 +32,33 @@ import {
 import { notFound, unprocessable } from "../errors.js";
 import { environmentService } from "./environments.js";
 
+/**
+ * Returns true if `error` is the unique-constraint violation that fires when
+ * two companies would end up with the same `issue_prefix`.
+ *
+ * Walks the `error.cause` chain so we recognise the conflict both when the
+ * postgres driver throws directly (older code paths) and when drizzle-orm wraps
+ * the postgres error in a `DrizzleQueryError` (current postgres-js driver
+ * surface). Exported for unit testing.
+ */
+export function isIssuePrefixConflict(error: unknown): boolean {
+  let cursor: unknown = error;
+  while (cursor && typeof cursor === "object") {
+    const node = cursor as {
+      code?: string;
+      constraint?: string;
+      constraint_name?: string;
+      cause?: unknown;
+    };
+    const constraint = node.constraint ?? node.constraint_name;
+    if (node.code === "23505" && constraint === "companies_issue_prefix_idx") {
+      return true;
+    }
+    cursor = node.cause;
+  }
+  return false;
+}
+
 export function companyService(db: Db) {
   const ISSUE_PREFIX_FALLBACK = "CMP";
   const environmentsSvc = environmentService(db);
@@ -122,19 +149,6 @@ export function companyService(db: Db) {
   function suffixForAttempt(attempt: number) {
     if (attempt <= 1) return "";
     return "A".repeat(attempt - 1);
-  }
-
-  function isIssuePrefixConflict(error: unknown) {
-    const constraint = typeof error === "object" && error !== null && "constraint" in error
-      ? (error as { constraint?: string }).constraint
-      : typeof error === "object" && error !== null && "constraint_name" in error
-        ? (error as { constraint_name?: string }).constraint_name
-        : undefined;
-    return typeof error === "object"
-      && error !== null
-      && "code" in error
-      && (error as { code?: string }).code === "23505"
-      && constraint === "companies_issue_prefix_idx";
   }
 
   async function createCompanyWithUniquePrefix(data: typeof companies.$inferInsert) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Companies are the top-level scoping primitive; creating one is a high-frequency op via API + UI
> - Issue prefixes are auto-derived from the first three letters of the company name and must be unique per instance — `createCompanyWithUniquePrefix` exists specifically to retry with suffixed prefixes (`DOG` → `DOGA` → `DOGAA` …) on collision
> - The retry loop relies on `isIssuePrefixConflict` to recognise the Postgres unique-violation; when drizzle-orm wraps the driver error in `DrizzleQueryError`, the detector misses it (`code` / `constraint` live at `error.cause`, not on the outer error)
> - Net effect: any second-and-onward create whose name shares a 3-letter base prefix surfaces as `HTTP 500 Internal server error` instead of getting a unique suffix
> - This pull request walks the `error.cause` chain so the detector recognises both the bare driver error and the wrapped form
> - The benefit is that the retry loop functions as intended — multi-company-create flows (provisioning new orgs, importing company sets) stop spuriously 500'ing

Closes #6088.

## What Changed

- `server/src/services/companies.ts`: rewrite `isIssuePrefixConflict` to traverse `error.cause` so it recognises `code: "23505"` + `constraint: "companies_issue_prefix_idx"` whether the postgres error is bare or wrapped in `DrizzleQueryError`. Hoist the helper to a module-level export (pure function, no `db` dependency) so it can be unit-tested without a database harness.
- `server/src/__tests__/issue-prefix-conflict.test.ts`: new unit tests covering the bare error, the drizzle-wrapped form, deeper nesting, the alternative `constraint_name` field used by some drivers, and negative cases (different constraint, different code, null/undefined/primitives).
- No behavior change for `createCompanyWithUniquePrefix` itself; the retry loop now actually retries instead of rethrowing.

## Verification

Reproduce on master (without this patch), against a fresh CEO-bootstrapped instance with any instance-admin board API key:

```bash
KEY=$(cat ~/.paperclip_admin_api_key)
for name in dogdevs dogcic dogjobagency; do
  curl -sS -X POST http://paperclip.home.arpa/api/companies \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    -d "{\"name\":\"$name\"}" -w "\n  status: %{http_code}\n"
done
# Expected on master: 201, 500, 500
# Expected on this PR: 201, 201, 201  (prefixes DOG, DOGA, DOGAA)
```

Unit-test the helper directly:

```bash
pnpm --filter @paperclipai/server test issue-prefix-conflict
```

All assertions cover the wrapping shapes drizzle-orm actually produces against postgres-js as of the version pinned by this repo.

## Risks

Very low. The only behavior change is that `isIssuePrefixConflict` now also matches errors wrapped in `DrizzleQueryError` and chains deeper. No call-sites changed; no schema migrations; pure recognition logic with positive unit-test coverage and explicit negative cases (different constraint name, different error code, non-Postgres errors, primitives).

The function is now a top-level export (was previously inside the `companyService(db)` closure). That's a public-surface addition rather than a removal, so no downstream import will break.

## Model Used

- Provider: Anthropic
- Model: Claude Opus 4.7 (`claude-opus-4-7`)
- Context window: 1M tokens
- Reasoning mode: high-effort thinking enabled
- Tool use: Bash, Read, Edit, Write
- Workflow: bug surfaced via direct repro against an `authenticated/private`-mode instance during a multi-company provisioning sequence; root-causing involved reading the compiled `node_modules/@paperclipai/server/dist/services/companies.js` against the live error trace in `journalctl -u paperclip.service` and tracing the wrapped error shape via Python `urllib` probes — then mapping the same line back to the source under `server/src/services/companies.ts` for the fix.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (purely a bug fix)
- [ ] I have run tests locally and they pass — *I do not have `pnpm` on the workstation I authored this from; the new unit-test file is self-contained vitest with no DB dependency; please defer to CI*
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — *N/A, server-only fix*
- [x] I have updated relevant documentation to reflect my changes — *no docs reference this helper*
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

🤖 Made with Claude Code (Opus 4.7, 1M context, high-effort thinking)