### PR TITLE
Resolve stale missing disposition recovery actions

### DIFF
--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -545,6 +545,125 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     );
   });
 
+  it("auto-resolves active missing-disposition recovery when an ordinary update closes the source issue", async () => {
+    const { companyId, managerId, sourceIssueId } = await seedCompany();
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "missing_disposition",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "successful_run_missing_state",
+      fingerprint: "missing-disposition:closed-source",
+      evidence: { sourceRunId: "run-1" },
+      nextAction: "Choose a valid issue disposition.",
+      wakePolicy: { type: "wake_owner" },
+    });
+    const app = createApp();
+
+    await request(app)
+      .patch(`/api/issues/${sourceIssueId}`)
+      .send({ status: "done" })
+      .expect(200);
+
+    expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toBeNull();
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({
+      status: "resolved",
+      outcome: "restored",
+      resolutionNote: "Auto-resolved missing-disposition recovery: source issue is done.",
+    });
+
+    const activityRows = await db.select().from(activityLog).where(eq(activityLog.entityId, sourceIssueId));
+    expect(activityRows.some((row) =>
+      row.action === "issue.recovery_action_resolved" &&
+      (row.details as Record<string, unknown> | null)?.source === "missing_disposition_auto_disposition" &&
+      (row.details as Record<string, unknown> | null)?.resolutionReason === "source_closed_done"
+    )).toBe(true);
+  });
+
+  it("auto-resolves active missing-disposition recovery when rolling work returns to an assigned todo owner", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    await db.update(issues).set({ status: "blocked", assigneeAgentId: managerId }).where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "missing_disposition",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+      cause: "successful_run_missing_state",
+      fingerprint: "missing-disposition:rolling-continuation",
+      evidence: { sourceRunId: "run-1" },
+      nextAction: "Choose a valid issue disposition.",
+      wakePolicy: { type: "wake_owner" },
+    });
+    const app = createApp();
+
+    await request(app)
+      .patch(`/api/issues/${sourceIssueId}`)
+      .send({ status: "todo", assigneeAgentId: coderId })
+      .expect(200);
+
+    expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toBeNull();
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({
+      status: "resolved",
+      outcome: "delegated",
+      resolutionNote: "Auto-resolved missing-disposition recovery: source issue is queued for an assigned continuation owner.",
+    });
+  });
+
+  it("sweeps stale active missing-disposition recovery actions on already-disposed source issues", async () => {
+    const { companyId, managerId, sourceIssueId } = await seedCompany();
+    await db.update(issues).set({ status: "done" }).where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "missing_disposition",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      cause: "successful_run_missing_state",
+      fingerprint: "missing-disposition:stale-done",
+      evidence: { sourceRunId: "run-1" },
+      nextAction: "Choose a valid issue disposition.",
+      wakePolicy: { type: "wake_owner" },
+    });
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+    const result = await recovery.reconcileStrandedAssignedIssues();
+
+    expect(result.missingDispositionRecoveryResolved).toBe(1);
+    expect(result.issueIds).toContain(sourceIssueId);
+    expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toBeNull();
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, action.id));
+    expect(actionRow).toMatchObject({
+      status: "resolved",
+      outcome: "restored",
+      resolutionNote: "Auto-resolved missing-disposition recovery: source issue is done.",
+    });
+
+    const activityRows = await db.select().from(activityLog).where(eq(activityLog.entityId, sourceIssueId));
+    expect(activityRows.some((row) =>
+      row.action === "issue.recovery_action_resolved" &&
+      (row.details as Record<string, unknown> | null)?.source === "missing_disposition_recovery_sweep" &&
+      (row.details as Record<string, unknown> | null)?.resolutionReason === "source_closed_done"
+    )).toBe(true);
+  });
+
   it("rejects blocked recovery resolution when the source issue has no first-class blockers", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     const recoveryActionSvc = issueRecoveryActionService(db);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -686,6 +686,7 @@ export async function startServer(): Promise<StartedServer> {
           reconciled.assignmentDispatched > 0 ||
           reconciled.dispatchRequeued > 0 ||
           reconciled.continuationRequeued > 0 ||
+          reconciled.missingDispositionRecoveryResolved > 0 ||
           reconciled.successfulRunHandoffEscalated > 0 ||
           reconciled.escalated > 0
         ) {
@@ -752,6 +753,7 @@ export async function startServer(): Promise<StartedServer> {
             reconciled.assignmentDispatched > 0 ||
             reconciled.dispatchRequeued > 0 ||
             reconciled.continuationRequeued > 0 ||
+            reconciled.missingDispositionRecoveryResolved > 0 ||
             reconciled.successfulRunHandoffEscalated > 0 ||
             reconciled.escalated > 0
           ) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3221,6 +3221,34 @@ export function issueRoutes(
     }
     await routinesSvc.syncRunStatusForIssue(issue.id);
 
+    const autoResolvedMissingDisposition =
+      await recoveryActionsSvc.resolveActiveMissingDispositionIfSourceDisposed({
+        companyId: issue.companyId,
+        sourceIssueId: issue.id,
+      });
+    if (autoResolvedMissingDisposition) {
+      await logActivity(db, {
+        companyId: issue.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "issue.recovery_action_resolved",
+        entityType: "issue",
+        entityId: issue.id,
+        details: {
+          identifier: issue.identifier,
+          recoveryActionId: autoResolvedMissingDisposition.recoveryAction.id,
+          recoveryActionStatus: autoResolvedMissingDisposition.recoveryAction.status,
+          outcome: autoResolvedMissingDisposition.recoveryAction.outcome,
+          sourceIssueStatus: issue.status,
+          resolutionNote: autoResolvedMissingDisposition.recoveryAction.resolutionNote,
+          resolutionReason: autoResolvedMissingDisposition.reason,
+          source: "missing_disposition_auto_disposition",
+        },
+      });
+    }
+
     if (actor.runId) {
       await heartbeat.reportRunActivity(actor.runId).catch((err) =>
         logger.warn({ err, runId: actor.runId }, "failed to clear detached run warning after issue activity"));

--- a/server/src/services/issue-recovery-actions.ts
+++ b/server/src/services/issue-recovery-actions.ts
@@ -1,6 +1,15 @@
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { issueRecoveryActions } from "@paperclipai/db";
+import {
+  agentWakeupRequests,
+  approvals,
+  heartbeatRuns,
+  issueApprovals,
+  issueRecoveryActions,
+  issueRelations,
+  issueThreadInteractions,
+  issues,
+} from "@paperclipai/db";
 import type {
   IssueRecoveryAction,
   IssueRecoveryActionKind,
@@ -8,13 +17,50 @@ import type {
   IssueRecoveryActionOutcome,
   IssueRecoveryActionStatus,
 } from "@paperclipai/shared";
+import { parseIssueExecutionState } from "./issue-execution-policy.js";
 
 const ACTIVE_RECOVERY_ACTION_STATUSES = ["active", "escalated"] as const satisfies readonly IssueRecoveryActionStatus[];
+const ACTIVE_EXECUTION_PATH_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+const ACTIVE_WAKE_STATUSES = ["queued", "deferred_issue_execution"] as const;
+const PENDING_INTERACTION_STATUSES = ["pending"] as const;
+const PENDING_APPROVAL_STATUSES = ["pending", "revision_requested"] as const;
+const TERMINAL_ISSUE_STATUSES = ["done", "cancelled"] as const;
+const MISSING_DISPOSITION_KIND = "missing_disposition" as const satisfies IssueRecoveryActionKind;
 const MAX_UPSERT_RETRIES = 3;
 
 type IssueRecoveryActionRow = typeof issueRecoveryActions.$inferSelect;
 type DbTransaction = Parameters<Parameters<Db["transaction"]>[0]>[0];
 type DbOrTransaction = Db | DbTransaction;
+type SourceIssueRow = Pick<
+  typeof issues.$inferSelect,
+  | "id"
+  | "companyId"
+  | "identifier"
+  | "status"
+  | "assigneeAgentId"
+  | "assigneeUserId"
+  | "executionState"
+  | "monitorNextCheckAt"
+>;
+
+type MissingDispositionResolutionReason =
+  | "source_closed_done"
+  | "source_closed_cancelled"
+  | "queued_continuation_owner"
+  | "review_human_owner"
+  | "review_execution_participant"
+  | "blocked_human_owner"
+  | "blocked_first_class_blocker"
+  | "scheduled_monitor"
+  | "pending_issue_thread_interaction"
+  | "pending_approval"
+  | "live_execution_path";
+
+type MissingDispositionResolution = {
+  outcome: IssueRecoveryActionOutcome;
+  reason: MissingDispositionResolutionReason;
+  note: string;
+};
 
 export type UpsertIssueRecoveryActionInput = {
   companyId: string;
@@ -75,6 +121,47 @@ function toReadModel(row: IssueRecoveryActionRow): IssueRecoveryAction {
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
+}
+
+function hasFutureDate(value: Date | null, now: Date) {
+  return value instanceof Date && value.getTime() > now.getTime();
+}
+
+function hasExecutionParticipant(value: unknown) {
+  const state = parseIssueExecutionState(value);
+  if (!state || state.status !== "pending") return false;
+  const participant = state.currentParticipant;
+  if (!participant) return false;
+  if (participant.type === "agent") return Boolean(participant.agentId);
+  if (participant.type === "user") return Boolean(participant.userId);
+  return false;
+}
+
+function missingDispositionResolutionNote(reason: MissingDispositionResolutionReason) {
+  switch (reason) {
+    case "source_closed_done":
+      return "Auto-resolved missing-disposition recovery: source issue is done.";
+    case "source_closed_cancelled":
+      return "Auto-resolved missing-disposition recovery: source issue is cancelled.";
+    case "queued_continuation_owner":
+      return "Auto-resolved missing-disposition recovery: source issue is queued for an assigned continuation owner.";
+    case "review_human_owner":
+      return "Auto-resolved missing-disposition recovery: source issue is in review with a human owner.";
+    case "review_execution_participant":
+      return "Auto-resolved missing-disposition recovery: source issue is in review with an execution participant.";
+    case "blocked_human_owner":
+      return "Auto-resolved missing-disposition recovery: source issue is blocked with a human owner action.";
+    case "blocked_first_class_blocker":
+      return "Auto-resolved missing-disposition recovery: source issue is blocked by an unresolved first-class blocker.";
+    case "scheduled_monitor":
+      return "Auto-resolved missing-disposition recovery: source issue has a live scheduled monitor.";
+    case "pending_issue_thread_interaction":
+      return "Auto-resolved missing-disposition recovery: source issue has a pending issue-thread interaction.";
+    case "pending_approval":
+      return "Auto-resolved missing-disposition recovery: source issue has a pending approval.";
+    case "live_execution_path":
+      return "Auto-resolved missing-disposition recovery: source issue has a non-recovery live execution path.";
+  }
 }
 
 function isUniqueRecoveryActionConflict(error: unknown) {
@@ -286,10 +373,269 @@ export function issueRecoveryActionService(db: Db) {
     return updated ? toReadModel(updated) : null;
   }
 
+  async function hasUnresolvedFirstClassBlocker(
+    dbOrTx: DbOrTransaction,
+    sourceIssue: SourceIssueRow,
+  ) {
+    const rows = await dbOrTx
+      .select({ id: issues.id })
+      .from(issueRelations)
+      .innerJoin(
+        issues,
+        and(
+          eq(issues.companyId, issueRelations.companyId),
+          eq(issues.id, issueRelations.issueId),
+        ),
+      )
+      .where(
+        and(
+          eq(issueRelations.companyId, sourceIssue.companyId),
+          eq(issueRelations.relatedIssueId, sourceIssue.id),
+          eq(issueRelations.type, "blocks"),
+          notInArray(issues.status, [...TERMINAL_ISSUE_STATUSES]),
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  async function hasPendingInteraction(dbOrTx: DbOrTransaction, sourceIssue: SourceIssueRow) {
+    const rows = await dbOrTx
+      .select({ id: issueThreadInteractions.id })
+      .from(issueThreadInteractions)
+      .where(
+        and(
+          eq(issueThreadInteractions.companyId, sourceIssue.companyId),
+          eq(issueThreadInteractions.issueId, sourceIssue.id),
+          inArray(issueThreadInteractions.status, [...PENDING_INTERACTION_STATUSES]),
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  async function hasPendingApproval(dbOrTx: DbOrTransaction, sourceIssue: SourceIssueRow) {
+    const rows = await dbOrTx
+      .select({ id: approvals.id })
+      .from(issueApprovals)
+      .innerJoin(
+        approvals,
+        and(
+          eq(approvals.companyId, issueApprovals.companyId),
+          eq(approvals.id, issueApprovals.approvalId),
+        ),
+      )
+      .where(
+        and(
+          eq(issueApprovals.companyId, sourceIssue.companyId),
+          eq(issueApprovals.issueId, sourceIssue.id),
+          inArray(approvals.status, [...PENDING_APPROVAL_STATUSES]),
+        ),
+      )
+      .limit(1);
+    return rows.length > 0;
+  }
+
+  async function hasNonRecoveryLiveExecutionPath(
+    dbOrTx: DbOrTransaction,
+    action: IssueRecoveryActionRow,
+    sourceIssue: SourceIssueRow,
+  ) {
+    const activeRuns = await dbOrTx
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, sourceIssue.companyId),
+          inArray(heartbeatRuns.status, [...ACTIVE_EXECUTION_PATH_RUN_STATUSES]),
+          or(
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${sourceIssue.id}`,
+            sql`${heartbeatRuns.contextSnapshot} ->> 'taskId' = ${sourceIssue.id}`,
+          ),
+          sql`coalesce(${heartbeatRuns.contextSnapshot} ->> 'recoveryActionId', '') <> ${action.id}`,
+          sql`coalesce(${heartbeatRuns.contextSnapshot} ->> 'source', '') <> 'issue_recovery_action'`,
+        ),
+      )
+      .limit(1);
+    if (activeRuns.length > 0) return true;
+
+    const queuedWakeups = await dbOrTx
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, sourceIssue.companyId),
+          inArray(agentWakeupRequests.status, [...ACTIVE_WAKE_STATUSES]),
+          or(
+            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${sourceIssue.id}`,
+            sql`${agentWakeupRequests.payload} ->> 'taskId' = ${sourceIssue.id}`,
+          ),
+          sql`coalesce(${agentWakeupRequests.payload} ->> 'recoveryActionId', '') <> ${action.id}`,
+          sql`coalesce(${agentWakeupRequests.reason}, '') <> 'source_scoped_recovery_action'`,
+        ),
+      )
+      .limit(1);
+    return queuedWakeups.length > 0;
+  }
+
+  async function missingDispositionResolutionForSource(
+    dbOrTx: DbOrTransaction,
+    action: IssueRecoveryActionRow,
+    sourceIssue: SourceIssueRow,
+    now = new Date(),
+  ): Promise<MissingDispositionResolution | null> {
+    const resolution = (
+      outcome: IssueRecoveryActionOutcome,
+      reason: MissingDispositionResolutionReason,
+    ): MissingDispositionResolution => ({
+      outcome,
+      reason,
+      note: missingDispositionResolutionNote(reason),
+    });
+
+    if (sourceIssue.status === "done") return resolution("restored", "source_closed_done");
+    if (sourceIssue.status === "cancelled") return resolution("cancelled", "source_closed_cancelled");
+    if (sourceIssue.status === "todo" && (sourceIssue.assigneeAgentId || sourceIssue.assigneeUserId)) {
+      return resolution("delegated", "queued_continuation_owner");
+    }
+
+    if (hasFutureDate(sourceIssue.monitorNextCheckAt, now)) return resolution("restored", "scheduled_monitor");
+    if (await hasPendingInteraction(dbOrTx, sourceIssue)) {
+      return resolution("restored", "pending_issue_thread_interaction");
+    }
+    if (await hasPendingApproval(dbOrTx, sourceIssue)) return resolution("restored", "pending_approval");
+    if (await hasNonRecoveryLiveExecutionPath(dbOrTx, action, sourceIssue)) {
+      return resolution("restored", "live_execution_path");
+    }
+
+    if (sourceIssue.status === "in_review") {
+      if (sourceIssue.assigneeUserId) return resolution("restored", "review_human_owner");
+      if (hasExecutionParticipant(sourceIssue.executionState)) {
+        return resolution("restored", "review_execution_participant");
+      }
+    }
+
+    if (sourceIssue.status === "blocked") {
+      if (sourceIssue.assigneeUserId) return resolution("blocked", "blocked_human_owner");
+      if (await hasUnresolvedFirstClassBlocker(dbOrTx, sourceIssue)) {
+        return resolution("blocked", "blocked_first_class_blocker");
+      }
+    }
+
+    return null;
+  }
+
+  async function resolveActiveMissingDispositionIfSourceDisposed(
+    input: {
+      companyId: string;
+      sourceIssueId: string;
+      actionId?: string | null;
+    },
+    dbOrTx: DbOrTransaction = db,
+  ): Promise<{
+    recoveryAction: IssueRecoveryAction;
+    sourceIssue: SourceIssueRow;
+    reason: MissingDispositionResolutionReason;
+  } | null> {
+    const actionPredicates = [
+      eq(issueRecoveryActions.companyId, input.companyId),
+      eq(issueRecoveryActions.sourceIssueId, input.sourceIssueId),
+      eq(issueRecoveryActions.kind, MISSING_DISPOSITION_KIND),
+      inArray(issueRecoveryActions.status, [...ACTIVE_RECOVERY_ACTION_STATUSES]),
+    ];
+    if (input.actionId) {
+      actionPredicates.push(eq(issueRecoveryActions.id, input.actionId));
+    }
+
+    const action = await dbOrTx
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(...actionPredicates))
+      .orderBy(desc(issueRecoveryActions.updatedAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!action) return null;
+
+    const sourceIssue = await dbOrTx
+      .select({
+        id: issues.id,
+        companyId: issues.companyId,
+        identifier: issues.identifier,
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+        executionState: issues.executionState,
+        monitorNextCheckAt: issues.monitorNextCheckAt,
+      })
+      .from(issues)
+      .where(and(eq(issues.companyId, input.companyId), eq(issues.id, input.sourceIssueId)))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!sourceIssue) return null;
+
+    const disposition = await missingDispositionResolutionForSource(dbOrTx, action, sourceIssue);
+    if (!disposition) return null;
+
+    const recoveryAction = await resolveActiveForIssue(
+      {
+        companyId: input.companyId,
+        sourceIssueId: input.sourceIssueId,
+        actionId: action.id,
+        status: "resolved",
+        outcome: disposition.outcome,
+        resolutionNote: disposition.note,
+      },
+      dbOrTx,
+    );
+    if (!recoveryAction) return null;
+    return { recoveryAction, sourceIssue, reason: disposition.reason };
+  }
+
+  async function resolveStaleMissingDispositionActions(input: {
+    companyId?: string | null;
+    limit?: number;
+  } = {}) {
+    const predicates = [
+      eq(issueRecoveryActions.kind, MISSING_DISPOSITION_KIND),
+      inArray(issueRecoveryActions.status, [...ACTIVE_RECOVERY_ACTION_STATUSES]),
+    ];
+    if (input.companyId) {
+      predicates.push(eq(issueRecoveryActions.companyId, input.companyId));
+    }
+
+    const rows = await db
+      .select({
+        id: issueRecoveryActions.id,
+        companyId: issueRecoveryActions.companyId,
+        sourceIssueId: issueRecoveryActions.sourceIssueId,
+      })
+      .from(issueRecoveryActions)
+      .where(and(...predicates))
+      .orderBy(desc(issueRecoveryActions.updatedAt))
+      .limit(input.limit ?? 100);
+
+    const resolved: Array<{
+      recoveryAction: IssueRecoveryAction;
+      sourceIssue: SourceIssueRow;
+      reason: MissingDispositionResolutionReason;
+    }> = [];
+    for (const row of rows) {
+      const result = await resolveActiveMissingDispositionIfSourceDisposed({
+        companyId: row.companyId,
+        sourceIssueId: row.sourceIssueId,
+        actionId: row.id,
+      });
+      if (result) resolved.push(result);
+    }
+    return resolved;
+  }
+
   return {
     getActiveForIssue,
     listActiveForIssues,
+    resolveActiveMissingDispositionIfSourceDisposed,
     resolveActiveForIssue,
+    resolveStaleMissingDispositionActions,
     upsertSourceScoped,
   };
 }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1991,11 +1991,40 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       productiveContinuationObserved: 0,
       successfulContinuationObserved: 0,
       orphanBlockersAssigned: 0,
+      missingDispositionRecoveryResolved: 0,
       successfulRunHandoffEscalated: 0,
       escalated: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
+
+    const resolvedMissingDispositionActions = await recoveryActionsSvc.resolveStaleMissingDispositionActions({
+      limit: 250,
+    });
+    for (const resolved of resolvedMissingDispositionActions) {
+      result.missingDispositionRecoveryResolved += 1;
+      result.issueIds.push(resolved.sourceIssue.id);
+      await logActivity(db, {
+        companyId: resolved.sourceIssue.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: null,
+        action: "issue.recovery_action_resolved",
+        entityType: "issue",
+        entityId: resolved.sourceIssue.id,
+        details: {
+          identifier: resolved.sourceIssue.identifier,
+          recoveryActionId: resolved.recoveryAction.id,
+          recoveryActionStatus: resolved.recoveryAction.status,
+          outcome: resolved.recoveryAction.outcome,
+          sourceIssueStatus: resolved.sourceIssue.status,
+          resolutionNote: resolved.recoveryAction.resolutionNote,
+          resolutionReason: resolved.reason,
+          source: "missing_disposition_recovery_sweep",
+        },
+      });
+    }
 
     for (const issue of candidates) {
       const agentId = issue.assigneeAgentId;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for autonomous companies.
> - The issue/recovery subsystem turns ambiguous agent run endings into explicit operator-visible recovery actions.
> - `missing_disposition` recovery actions were staying active after the source issue later had a valid disposition.
> - That made already-resolved or intentionally-continued work still show Recovery Needed cards, confusing the board about whether the issue was blocked.
> - This pull request adds a narrow lifecycle cleanup path for `missing_disposition` actions only.
> - The benefit is that source issues stop showing stale recovery cards once they are closed, returned to assigned todo continuation, sent to a real review path, blocked by real blockers, or otherwise have a live waiting/execution path.

## What Changed

- Added missing-disposition disposition detection to `issueRecoveryActionService`, including closed issues, assigned `todo` continuation, review participants/human owners, first-class blockers, pending interactions/approvals, scheduled monitors, and non-recovery live execution paths.
- Auto-resolves active `missing_disposition` actions after ordinary issue updates when the source now has a valid disposition.
- Runs the same stale-action cleanup during stranded-assigned-issue reconciliation so already-disposed source issues are migrated safely on startup/periodic recovery sweeps.
- Added focused route/service tests for closed source issues, rolling assigned-`todo` continuation, and stale already-done source cleanup.

## Verification

- `pnpm run preflight:workspace-links && pnpm exec vitest run --project @paperclipai/server server/src/__tests__/issue-recovery-actions.test.ts --pool=forks --poolOptions.forks.isolate=true`
- `pnpm run preflight:workspace-links && pnpm --filter @paperclipai/server typecheck`
- `pnpm install --frozen-lockfile`
- `pnpm build`
- Manual live cleanup: resolved stale active `missing_disposition` action `9a9f5c8a-3146-4727-a7df-38ef98e616c5` on done issue DAT-4340 through the existing recovery resolution endpoint.

## Risks

- Low-to-medium risk: this only auto-resolves `missing_disposition` actions, but it changes when recovery cards disappear.
- The cleanup intentionally excludes the recovery action's own wake/run from "live execution path" so freshly-created recovery actions do not immediately resolve themselves.
- Assigned `todo` is treated as a valid continuation disposition; that matches Paperclip's assignment recovery model, which can enqueue assigned `todo` work.

## Model Used

- OpenAI Codex, GPT-5-based coding agent, with repository tool use and shell/test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
