### PR TITLE
feat(core): auto-resolve stale request_confirmation interactions

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -707,7 +707,7 @@ export interface RequestConfirmationPayload {
 
 export interface RequestConfirmationResult {
   version: 1;
-  outcome: "accepted" | "rejected" | "superseded_by_comment" | "stale_target";
+  outcome: "accepted" | "rejected" | "superseded_by_comment" | "stale_target" | "superseded" | "issue_closed";
   reason?: string | null;
   commentId?: string | null;
   staleTarget?: RequestConfirmationTarget | null;

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -714,7 +714,7 @@ export const requestConfirmationPayloadSchema = z.object({
 
 export const requestConfirmationResultSchema = z.object({
   version: z.literal(1),
-  outcome: z.enum(["accepted", "rejected", "superseded_by_comment", "stale_target"]),
+  outcome: z.enum(["accepted", "rejected", "superseded_by_comment", "stale_target", "superseded", "issue_closed"]),
   reason: z.string().trim().max(4000).nullable().optional(),
   commentId: z.string().uuid().nullable().optional(),
   staleTarget: requestConfirmationTargetSchema.nullable().optional(),

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -972,4 +972,459 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       },
     });
   });
+
+  it("expires older pending request confirmations targeting the same document key when a newer one is created", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+    const documentId = randomUUID();
+    const revisionId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Target supersede",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+    await db.insert(documents).values({
+      id: documentId,
+      companyId,
+      title: "Plan",
+      format: "markdown",
+      latestBody: "v1",
+      latestRevisionId: revisionId,
+      latestRevisionNumber: 1,
+    });
+    await db.insert(issueDocuments).values({
+      companyId,
+      issueId,
+      documentId,
+      key: "plan",
+    });
+
+    const first = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "First?",
+        target: {
+          type: "issue_document",
+          issueId,
+          documentId,
+          key: "plan",
+          revisionId,
+          revisionNumber: 1,
+        },
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const second = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Second?",
+        target: {
+          type: "issue_document",
+          issueId,
+          documentId,
+          key: "plan",
+          revisionId,
+          revisionNumber: 1,
+        },
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const listed = await interactionsSvc.listForIssue(issueId);
+    const firstAfter = listed.find((i) => i.id === first.id);
+    const secondAfter = listed.find((i) => i.id === second.id);
+
+    expect(firstAfter?.status).toBe("expired");
+    expect(firstAfter?.result).toMatchObject({
+      version: 1,
+      outcome: "superseded",
+    });
+    expect(secondAfter?.status).toBe("pending");
+  });
+
+  it("expires older pending request confirmations with the same custom target key when a newer one is created", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Custom target supersede",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const first = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "First?",
+        target: {
+          type: "custom",
+          key: "deploy-prod",
+        },
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const second = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Second?",
+        target: {
+          type: "custom",
+          key: "deploy-prod",
+        },
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const listed = await interactionsSvc.listForIssue(issueId);
+    const firstAfter = listed.find((i) => i.id === first.id);
+    const secondAfter = listed.find((i) => i.id === second.id);
+
+    expect(firstAfter?.status).toBe("expired");
+    expect(firstAfter?.result).toMatchObject({ outcome: "superseded" });
+    expect(secondAfter?.status).toBe("pending");
+  });
+
+  it("expires older pending request confirmations with the same idempotency key prefix when a newer one is created", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Idempotency prefix supersede",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const first = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      idempotencyKey: "confirmation:plan:1",
+      payload: {
+        version: 1,
+        prompt: "First?",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const second = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      idempotencyKey: "confirmation:plan:2",
+      payload: {
+        version: 1,
+        prompt: "Second?",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const third = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      idempotencyKey: "confirmation:design:1",
+      payload: {
+        version: 1,
+        prompt: "Third?",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const listed = await interactionsSvc.listForIssue(issueId);
+    const firstAfter = listed.find((i) => i.id === first.id);
+    const secondAfter = listed.find((i) => i.id === second.id);
+    const thirdAfter = listed.find((i) => i.id === third.id);
+
+    expect(firstAfter?.status).toBe("expired");
+    expect(firstAfter?.result).toMatchObject({ outcome: "superseded" });
+    expect(secondAfter?.status).toBe("pending");
+    expect(thirdAfter?.status).toBe("pending");
+  });
+
+  it("does not expire request confirmations with different targets or idempotency prefixes", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "No supersede",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const first = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "First?",
+        target: { type: "custom", key: "a" },
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const second = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Second?",
+        target: { type: "custom", key: "b" },
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const listed = await interactionsSvc.listForIssue(issueId);
+    const firstAfter = listed.find((i) => i.id === first.id);
+    const secondAfter = listed.find((i) => i.id === second.id);
+
+    expect(firstAfter?.status).toBe("pending");
+    expect(secondAfter?.status).toBe("pending");
+  });
+
+  it("expires all pending request confirmations when an issue is closed", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Closure expiration",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const first = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "First?",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const second = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Second?",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    const expired = await interactionsSvc.expirePendingRequestConfirmationsOnIssueClosure(
+      { id: issueId, companyId },
+      { userId: "local-board" },
+    );
+
+    expect(expired).toHaveLength(2);
+    expect(expired.map((i) => i.id)).toEqual(expect.arrayContaining([first.id, second.id]));
+    for (const interaction of expired) {
+      expect(interaction.status).toBe("expired");
+      expect(interaction.result).toMatchObject({
+        version: 1,
+        outcome: "issue_closed",
+      });
+    }
+  });
+
+  it("defaults supersedeOnUserComment to true for agent-created request confirmations", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Default supersede",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Parent issue",
+      status: "in_progress",
+      priority: "medium",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "TestAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const agentCreated = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Agent?",
+      },
+    }, {
+      agentId,
+    });
+
+    const userCreated = await interactionsSvc.create({
+      id: issueId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "User?",
+      },
+    }, {
+      userId: "local-board",
+    });
+
+    expect((agentCreated as any).payload.supersedeOnUserComment).toBe(true);
+    expect((userCreated as any).payload.supersedeOnUserComment).toBeUndefined();
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3161,6 +3161,22 @@ export function issueRoutes(
       return;
     }
 
+    if (updateFields.status === "done" || updateFields.status === "cancelled") {
+      const expiredInteractions = await issueThreadInteractionService(db).expirePendingRequestConfirmationsOnIssueClosure(
+        issue,
+        {
+          agentId: actor.agentId,
+          userId: actor.actorType === "user" ? actor.actorId : null,
+        },
+      );
+      await logExpiredRequestConfirmations({
+        issue,
+        interactions: expiredInteractions,
+        actor,
+        source: "issue.status_closed",
+      });
+    }
+
     let cancelledStatusRunId: string | null = null;
     if (runToCancelForCancelledStatus) {
       try {

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -144,6 +144,13 @@ function isTerminalIssueStatus(status: string) {
   return status === "done" || status === "cancelled";
 }
 
+function idempotencyKeyPrefix(key: string | null | undefined): string | null {
+  if (!key) return null;
+  const lastColon = key.lastIndexOf(":");
+  if (lastColon <= 0) return key;
+  return key.slice(0, lastColon);
+}
+
 function shouldReturnAcceptedConfirmationToCreatorAgent(args: {
   issue: IssueResolutionContext;
   current: IssueThreadInteractionRow;
@@ -681,6 +688,13 @@ export function issueThreadInteractionService(db: Db) {
         });
       }
 
+      const payload = data.kind === "request_confirmation"
+        ? {
+            ...data.payload,
+            supersedeOnUserComment: data.payload.supersedeOnUserComment ?? (actor.agentId ? true : undefined),
+          }
+        : data.payload;
+
       let created: IssueThreadInteractionRow;
       try {
         [created] = await db
@@ -698,7 +712,7 @@ export function issueThreadInteractionService(db: Db) {
             summary: data.summary ?? null,
             createdByAgentId: actor.agentId ?? null,
             createdByUserId: actor.userId ?? null,
-            payload: data.payload,
+            payload,
           })
           .returning();
       } catch (error) {
@@ -720,7 +734,15 @@ export function issueThreadInteractionService(db: Db) {
       }
 
       await touchIssue(db, issue.id);
-      return hydrateInteraction(created);
+      const createdInteraction = hydrateInteraction(created);
+      if (createdInteraction.kind === "request_confirmation") {
+        await issueThreadInteractionService(db).expireSupersededRequestConfirmationsOnCreate(
+          issue,
+          createdInteraction,
+          actor,
+        );
+      }
+      return createdInteraction;
     },
 
     acceptInteraction: async (
@@ -1075,6 +1097,138 @@ export function issueThreadInteractionService(db: Db) {
               version: 1,
               outcome: "stale_target",
               staleTarget: target,
+            },
+            resolvedByAgentId: actor.agentId ?? null,
+            resolvedByUserId: actor.userId ?? null,
+            resolvedAt: now,
+            updatedAt: now,
+          })
+          .where(and(
+            eq(issueThreadInteractions.id, row.id),
+            eq(issueThreadInteractions.status, "pending"),
+          ))
+          .returning();
+        if (updated) expired.push(hydrateInteraction(updated));
+      }
+
+      if (expired.length > 0) {
+        await touchIssue(db, issue.id);
+      }
+      return expired;
+    },
+
+    expireSupersededRequestConfirmationsOnCreate: async (
+      issue: { id: string; companyId: string },
+      createdInteraction: IssueThreadInteraction,
+      actor: InteractionActor,
+    ) => {
+      if (createdInteraction.kind !== "request_confirmation" || createdInteraction.status !== "pending") {
+        return [];
+      }
+
+      const rows = await db
+        .select()
+        .from(issueThreadInteractions)
+        .where(and(
+          eq(issueThreadInteractions.companyId, issue.companyId),
+          eq(issueThreadInteractions.issueId, issue.id),
+          eq(issueThreadInteractions.kind, "request_confirmation"),
+          eq(issueThreadInteractions.status, "pending"),
+        ));
+
+      const createdPayload = (createdInteraction as RequestConfirmationInteraction).payload;
+      const createdTarget = createdPayload.target ?? null;
+      const createdPrefix = idempotencyKeyPrefix(createdInteraction.idempotencyKey);
+
+      const superseded = rows.filter((row) => {
+        if (row.id === createdInteraction.id) return false;
+        const interaction = hydrateInteraction(row) as RequestConfirmationInteraction;
+        const target = interaction.payload.target ?? null;
+
+        if (createdTarget && target) {
+          if (createdTarget.type === "issue_document" && target.type === "issue_document") {
+            const createdIssueId = createdTarget.issueId ?? issue.id;
+            const targetIssueId = target.issueId ?? issue.id;
+            if (createdIssueId === targetIssueId && createdTarget.key === target.key) {
+              if (createdTarget.documentId && target.documentId && createdTarget.documentId !== target.documentId) {
+                return false;
+              }
+              return true;
+            }
+          }
+          if (createdTarget.type === "custom" && target.type === "custom") {
+            if (createdTarget.key === target.key) return true;
+          }
+        }
+
+        const prefix = idempotencyKeyPrefix(interaction.idempotencyKey);
+        if (createdPrefix && prefix && prefix === createdPrefix) return true;
+
+        return false;
+      });
+
+      if (superseded.length === 0) return [];
+
+      const now = new Date();
+      const expired: IssueThreadInteraction[] = [];
+      for (const row of superseded) {
+        const interaction = hydrateInteraction(row) as RequestConfirmationInteraction;
+        const [updated] = await db
+          .update(issueThreadInteractions)
+          .set({
+            status: "expired",
+            result: {
+              version: 1,
+              outcome: "superseded",
+              staleTarget: interaction.payload.target ?? null,
+            },
+            resolvedByAgentId: actor.agentId ?? null,
+            resolvedByUserId: actor.userId ?? null,
+            resolvedAt: now,
+            updatedAt: now,
+          })
+          .where(and(
+            eq(issueThreadInteractions.id, row.id),
+            eq(issueThreadInteractions.status, "pending"),
+          ))
+          .returning();
+        if (updated) expired.push(hydrateInteraction(updated));
+      }
+
+      if (expired.length > 0) {
+        await touchIssue(db, issue.id);
+      }
+      return expired;
+    },
+
+    expirePendingRequestConfirmationsOnIssueClosure: async (
+      issue: { id: string; companyId: string },
+      actor: InteractionActor,
+    ) => {
+      const rows = await db
+        .select()
+        .from(issueThreadInteractions)
+        .where(and(
+          eq(issueThreadInteractions.companyId, issue.companyId),
+          eq(issueThreadInteractions.issueId, issue.id),
+          eq(issueThreadInteractions.kind, "request_confirmation"),
+          eq(issueThreadInteractions.status, "pending"),
+        ));
+
+      if (rows.length === 0) return [];
+
+      const now = new Date();
+      const expired: IssueThreadInteraction[] = [];
+      for (const row of rows) {
+        const interaction = hydrateInteraction(row) as RequestConfirmationInteraction;
+        const [updated] = await db
+          .update(issueThreadInteractions)
+          .set({
+            status: "expired",
+            result: {
+              version: 1,
+              outcome: "issue_closed",
+              staleTarget: interaction.payload.target ?? null,
             },
             resolvedByAgentId: actor.agentId ?? null,
             resolvedByUserId: actor.userId ?? null,

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -977,24 +977,47 @@ function RequestConfirmationResolution({
   }
 
   if (interaction.status === "expired") {
-    const expiredByComment = outcome === "superseded_by_comment";
-    const expiredByTargetChange = outcome === "stale_target";
+    let title: string;
+    let message: string;
+    let showCommentLink = false;
+    let showTargetChange = false;
+
+    switch (outcome) {
+      case "superseded_by_comment":
+        title = "Expired by comment";
+        message = "A board comment superseded this confirmation before it was resolved.";
+        showCommentLink = true;
+        break;
+      case "stale_target":
+        title = "Expired by target change";
+        message = "The requested target changed before this confirmation was resolved.";
+        showTargetChange = true;
+        break;
+      case "superseded":
+        title = "Superseded";
+        message = "A newer confirmation replaced this one before it was resolved.";
+        break;
+      case "issue_closed":
+        title = "Expired by issue closure";
+        message = "The issue was closed before this confirmation was resolved.";
+        break;
+      default:
+        title = "Expired";
+        message = "This confirmation expired before it was resolved.";
+    }
+
     return (
       <div className="space-y-3 rounded-sm border border-amber-500/60 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 dark:text-amber-100">
         <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-amber-700">
-          {expiredByComment ? "Expired by comment" : "Expired by target change"}
+          {title}
         </div>
-        <p className="leading-6">
-          {expiredByComment
-            ? "A board comment superseded this confirmation before it was resolved."
-            : "The requested target changed before this confirmation was resolved."}
-        </p>
-        {expiredByComment && interaction.result?.commentId ? (
+        <p className="leading-6">{message}</p>
+        {showCommentLink && interaction.result?.commentId ? (
           <Button asChild size="sm" variant="ghost" className="h-7 px-2 text-amber-950 hover:bg-amber-500/15 dark:text-amber-50">
             <a href={`#comment-${interaction.result.commentId}`}>Jump to comment</a>
           </Button>
         ) : null}
-        {expiredByTargetChange ? (
+        {showTargetChange ? (
           <div className="flex flex-wrap items-center gap-2">
             <RequestConfirmationTargetChip
               interaction={interaction}


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents interact with issues via thread interactions like `request_confirmation`
> - Pending `request_confirmation` interactions could remain visible indefinitely unless explicitly resolved
> - Only narrow expiration paths existed (opt-in comment superseding or document revision mismatch)
> - This PR adds automatic expiration: new confirmations supersede older ones targeting the same subject, and issue closure expires all pending confirmations
> - The benefit is reduced stale UI noise and less manual cleanup for board users and agents

## What Changed

- **Service**: Added `expireSupersededRequestConfirmationsOnCreate` to expire older pending confirmations with the same document/custom target or same idempotency-key prefix when a new `request_confirmation` is created.
- **Service**: Added `expirePendingRequestConfirmationsOnIssueClosure` to expire all pending confirmations when an issue transitions to `done` or `cancelled`.
- **Route**: Hooked issue-closure expiration into `PATCH /issues/:id`.
- **Payload default**: Agent-created `request_confirmation` interactions now default `supersedeOnUserComment` to `true`.
- **Schema**: Added `superseded` and `issue_closed` outcomes to `requestConfirmationResultSchema` and `RequestConfirmationResult` type.
- **UI**: Updated `IssueThreadInteractionCard` to gracefully render the new expired outcomes with appropriate labels and messages.
- **Tests**: Added 6 new tests covering superseding by document target, custom target, idempotency prefix, non-matching subjects, issue-closure expiration, and the agent default payload behavior.

## Verification

```bash
cd server
npx vitest run src/__tests__/issue-thread-interactions-service.test.ts
```

All 16 tests pass. Full `pnpm typecheck` and `pnpm build` also pass.

## Risks

- **Low risk**: The new expiration logic only touches `pending` `request_confirmation` rows and runs in the same transaction/flow as existing mutations.
- **UI fallback**: Unknown expired outcomes fall back to a generic "Expired" label, so future schema additions won't crash the card.
- **Behavioral shift**: Agent-created confirmations now auto-supersede on user comments by default. This aligns with intended behavior but changes the previous opt-in default.

## Model Used

- Provider: Anthropic
- Model: Claude (Opus 4.7, kimi-k2.5 via Claude Code harness)
- Capabilities: tool use, codebase search, edit, bash execution
- Context: full session with Paperclip core repo clone

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge