### PR TITLE
Improve routines cleanup UX

### DIFF
--- a/ui/src/components/RoutineList.tsx
+++ b/ui/src/components/RoutineList.tsx
@@ -130,6 +130,7 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   disableRunNow = false,
   disableToggle = false,
   hideArchiveAction = false,
+  divider = true,
   onRunNow,
   onToggleEnabled,
   onToggleArchived,
@@ -149,6 +150,8 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   disableRunNow?: boolean;
   disableToggle?: boolean;
   hideArchiveAction?: boolean;
+  /** Render a bottom divider between consecutive rows. Off when the group is its own card. */
+  divider?: boolean;
   onRunNow: (routine: TRoutine) => void;
   onToggleEnabled: (routine: TRoutine, enabled: boolean) => void;
   onToggleArchived?: (routine: TRoutine) => void;
@@ -169,7 +172,11 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   const activeIssue = routine.activeIssue ?? null;
 
   return (
-    <div className="flex flex-col gap-3 border-b border-border px-3 py-3 last:border-b-0 sm:flex-row sm:items-center">
+    <div
+      className={`flex flex-col gap-3 px-3 py-3 sm:flex-row sm:items-center${
+        divider ? " border-b border-border last:border-b-0" : ""
+      }`}
+    >
       <div className="min-w-0 flex-1 space-y-1.5">
         <div className="flex flex-wrap items-center gap-2">
           <Link to={href} className="truncate text-sm font-medium text-inherit no-underline hover:underline">

--- a/ui/src/components/RoutineList.tsx
+++ b/ui/src/components/RoutineList.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { MoreHorizontal, Play } from "lucide-react";
 import { Link } from "@/lib/router";
 import { AgentIcon } from "@/components/AgentIconPicker";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -11,10 +12,15 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
+import { cn } from "@/lib/utils";
 
 export type RoutineListProjectSummary = {
   name: string;
   color?: string | null;
+};
+
+export type RoutineListGoalSummary = {
+  title: string;
 };
 
 export type RoutineListAgentSummary = {
@@ -22,16 +28,41 @@ export type RoutineListAgentSummary = {
   icon?: string | null;
 };
 
+export type RoutineListHealthBadge = {
+  key: string;
+  label: string;
+  tone: "warning" | "danger";
+};
+
+type RoutineListIssueSummary = {
+  id: string;
+  identifier: string | null;
+  status: string;
+};
+
+type RoutineListTriggerSummary = {
+  id: string;
+  kind: string;
+  label: string | null;
+  enabled: boolean;
+  nextRunAt?: Date | string | null;
+};
+
 export type RoutineListRowItem = {
   id: string;
   title: string;
   status: string;
   projectId: string | null;
+  goalId?: string | null;
   assigneeAgentId: string | null;
+  triggers?: RoutineListTriggerSummary[];
   lastRun?: {
     triggeredAt?: Date | string | null;
     status?: string | null;
+    linkedIssue?: RoutineListIssueSummary | null;
+    trigger?: Pick<RoutineListTriggerSummary, "id" | "kind" | "label"> | null;
   } | null;
+  activeIssue?: RoutineListIssueSummary | null;
 };
 
 export function formatLastRunTimestamp(value: Date | string | null | undefined) {
@@ -44,6 +75,40 @@ export function formatRoutineRunStatus(value: string | null | undefined) {
   return value.replaceAll("_", " ");
 }
 
+function formatTriggerKind(value: string | null | undefined) {
+  if (!value) return "Trigger";
+  return value.replaceAll("_", " ");
+}
+
+function formatTriggerLabel(trigger: RoutineListTriggerSummary | Pick<RoutineListTriggerSummary, "kind" | "label"> | null | undefined) {
+  if (!trigger) return null;
+  return trigger.label?.trim() || formatTriggerKind(trigger.kind);
+}
+
+function formatIssueStatus(value: string | null | undefined) {
+  if (!value) return null;
+  return value.replaceAll("_", " ");
+}
+
+function findPrimaryTrigger(triggers: RoutineListTriggerSummary[]) {
+  return triggers.find((trigger) => trigger.enabled) ?? triggers[0] ?? null;
+}
+
+function findNextRunAt(triggers: RoutineListTriggerSummary[]) {
+  return triggers
+    .filter((trigger) => trigger.enabled && trigger.nextRunAt)
+    .map((trigger) => trigger.nextRunAt!)
+    .sort((left, right) => new Date(left).getTime() - new Date(right).getTime())[0] ?? null;
+}
+
+function issueHref(issue: RoutineListIssueSummary) {
+  return `/issues/${issue.identifier ?? issue.id}`;
+}
+
+function issueLabel(issue: RoutineListIssueSummary) {
+  return issue.identifier ?? issue.id.slice(0, 8);
+}
+
 export function nextRoutineStatus(currentStatus: string, enabled: boolean) {
   if (currentStatus === "archived" && enabled) return "active";
   return enabled ? "active" : "paused";
@@ -52,6 +117,7 @@ export function nextRoutineStatus(currentStatus: string, enabled: boolean) {
 export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   routine,
   projectById,
+  goalById,
   agentById,
   runningRoutineId,
   statusMutationRoutineId,
@@ -59,17 +125,18 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   configureLabel = "Edit",
   managedByLabel,
   secondaryDetails,
+  healthBadges = [],
   runNowButton = false,
   disableRunNow = false,
   disableToggle = false,
   hideArchiveAction = false,
-  divider = true,
   onRunNow,
   onToggleEnabled,
   onToggleArchived,
 }: {
   routine: TRoutine;
   projectById: Map<string, RoutineListProjectSummary>;
+  goalById?: Map<string, RoutineListGoalSummary>;
   agentById: Map<string, RoutineListAgentSummary>;
   runningRoutineId: string | null;
   statusMutationRoutineId: string | null;
@@ -77,12 +144,11 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   configureLabel?: string;
   managedByLabel?: string | null;
   secondaryDetails?: ReactNode;
+  healthBadges?: RoutineListHealthBadge[];
   runNowButton?: boolean;
   disableRunNow?: boolean;
   disableToggle?: boolean;
   hideArchiveAction?: boolean;
-  /** Render a bottom divider between consecutive rows. Off when the group is its own card. */
-  divider?: boolean;
   onRunNow: (routine: TRoutine) => void;
   onToggleEnabled: (routine: TRoutine, enabled: boolean) => void;
   onToggleArchived?: (routine: TRoutine) => void;
@@ -91,20 +157,24 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   const isArchived = routine.status === "archived";
   const isStatusPending = statusMutationRoutineId === routine.id;
   const project = routine.projectId ? projectById.get(routine.projectId) ?? null : null;
+  const goal = routine.goalId ? goalById?.get(routine.goalId) ?? null : null;
   const agent = routine.assigneeAgentId ? agentById.get(routine.assigneeAgentId) ?? null : null;
   const isDraft = !isArchived && !routine.assigneeAgentId;
   const runDisabled = runningRoutineId === routine.id || isArchived || disableRunNow;
+  const triggers = routine.triggers ?? [];
+  const primaryTrigger = findPrimaryTrigger(triggers);
+  const nextRunAt = findNextRunAt(triggers);
+  const triggerCountSuffix = triggers.length > 1 ? ` +${triggers.length - 1}` : "";
+  const lastRunLinkedIssue = routine.lastRun?.linkedIssue ?? null;
+  const activeIssue = routine.activeIssue ?? null;
 
   return (
-    <Link
-      to={href}
-      className={`group flex flex-col gap-3 px-3 py-3 transition-colors hover:bg-accent/50 sm:flex-row sm:items-center no-underline text-inherit${
-        divider ? " border-b border-border last:border-b-0" : ""
-      }`}
-    >
+    <div className="flex flex-col gap-3 border-b border-border px-3 py-3 last:border-b-0 sm:flex-row sm:items-center">
       <div className="min-w-0 flex-1 space-y-1.5">
         <div className="flex flex-wrap items-center gap-2">
-          <span className="truncate text-sm font-medium">{routine.title}</span>
+          <Link to={href} className="truncate text-sm font-medium text-inherit no-underline hover:underline">
+            {routine.title}
+          </Link>
           {(isArchived || routine.status === "paused" || isDraft) ? (
             <span className="text-xs text-muted-foreground">
               {isArchived ? "archived" : isDraft ? "draft" : "paused"}
@@ -113,6 +183,18 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
           {managedByLabel ? (
             <span className="text-xs text-muted-foreground">{managedByLabel}</span>
           ) : null}
+          {healthBadges.map((badge) => (
+            <Badge
+              key={badge.key}
+              variant={badge.tone === "danger" ? "destructive" : "outline"}
+              className={cn(
+                "h-5 px-1.5 text-xs font-medium",
+                badge.tone === "warning" && "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200",
+              )}
+            >
+              {badge.label}
+            </Badge>
+          ))}
         </div>
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
           <span className="flex items-center gap-2">
@@ -122,14 +204,39 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
             />
             <span>{routine.projectId ? (project?.name ?? "Unknown project") : "No project"}</span>
           </span>
+          <span className="min-w-0 truncate">
+            Goal: {routine.goalId ? (goal?.title ?? "Unknown goal") : "No goal"}
+          </span>
           <span className="flex items-center gap-2">
             {agent?.icon ? <AgentIcon icon={agent.icon} className="h-3.5 w-3.5 shrink-0" /> : null}
             <span>{routine.assigneeAgentId ? (agent?.name ?? "Unknown agent") : "No default agent"}</span>
           </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
           <span>
-            {formatLastRunTimestamp(routine.lastRun?.triggeredAt)}
-            {routine.lastRun ? ` · ${formatRoutineRunStatus(routine.lastRun.status)}` : ""}
+            Trigger: {formatTriggerLabel(primaryTrigger) ?? "No triggers"}{triggerCountSuffix}
+            {primaryTrigger && !primaryTrigger.enabled ? " (disabled)" : ""}
           </span>
+          <span>Next: {formatLastRunTimestamp(nextRunAt)}</span>
+          <span>
+            Last: {formatLastRunTimestamp(routine.lastRun?.triggeredAt)}
+            {routine.lastRun ? ` · ${formatRoutineRunStatus(routine.lastRun.status)}` : ""}
+            {routine.lastRun?.trigger ? ` · ${formatTriggerLabel(routine.lastRun.trigger)}` : ""}
+          </span>
+          {lastRunLinkedIssue ? (
+            <Link to={issueHref(lastRunLinkedIssue)} className="text-muted-foreground underline-offset-2 hover:underline">
+              Last issue: {issueLabel(lastRunLinkedIssue)} · {formatIssueStatus(lastRunLinkedIssue.status)}
+            </Link>
+          ) : (
+            <span>Last issue: none</span>
+          )}
+          {activeIssue ? (
+            <Link to={issueHref(activeIssue)} className="text-muted-foreground underline-offset-2 hover:underline">
+              Active: {issueLabel(activeIssue)} · {formatIssueStatus(activeIssue.status)}
+            </Link>
+          ) : (
+            <span>Active: none</span>
+          )}
         </div>
         {secondaryDetails ? (
           <div className="text-xs text-muted-foreground">{secondaryDetails}</div>
@@ -139,7 +246,7 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
       <div className="flex items-center gap-3" onClick={(event) => { event.preventDefault(); event.stopPropagation(); }}>
         {runNowButton ? (
           <Button
-            variant="outline"
+            variant="ghost"
             size="sm"
             disabled={runDisabled}
             onClick={() => onRunNow(routine)}
@@ -196,6 +303,6 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/ui/src/components/RoutineList.tsx
+++ b/ui/src/components/RoutineList.tsx
@@ -169,7 +169,7 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   const activeIssue = routine.activeIssue ?? null;
 
   return (
-    <div className="group flex flex-col gap-3 border-b border-border px-3 py-3 transition-colors hover:bg-accent/50 last:border-b-0 sm:flex-row sm:items-center">
+    <div className="flex flex-col gap-3 border-b border-border px-3 py-3 last:border-b-0 sm:flex-row sm:items-center">
       <div className="min-w-0 flex-1 space-y-1.5">
         <div className="flex flex-wrap items-center gap-2">
           <Link to={href} className="truncate text-sm font-medium text-inherit no-underline hover:underline">

--- a/ui/src/components/RoutineList.tsx
+++ b/ui/src/components/RoutineList.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { MoreHorizontal, Play } from "lucide-react";
 import { Link } from "@/lib/router";
 import { AgentIcon } from "@/components/AgentIconPicker";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -11,10 +12,15 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
+import { cn } from "@/lib/utils";
 
 export type RoutineListProjectSummary = {
   name: string;
   color?: string | null;
+};
+
+export type RoutineListGoalSummary = {
+  title: string;
 };
 
 export type RoutineListAgentSummary = {
@@ -22,16 +28,41 @@ export type RoutineListAgentSummary = {
   icon?: string | null;
 };
 
+export type RoutineListHealthBadge = {
+  key: string;
+  label: string;
+  tone: "warning" | "danger";
+};
+
+type RoutineListIssueSummary = {
+  id: string;
+  identifier: string | null;
+  status: string;
+};
+
+type RoutineListTriggerSummary = {
+  id: string;
+  kind: string;
+  label: string | null;
+  enabled: boolean;
+  nextRunAt?: Date | string | null;
+};
+
 export type RoutineListRowItem = {
   id: string;
   title: string;
   status: string;
   projectId: string | null;
+  goalId?: string | null;
   assigneeAgentId: string | null;
+  triggers?: RoutineListTriggerSummary[];
   lastRun?: {
     triggeredAt?: Date | string | null;
     status?: string | null;
+    linkedIssue?: RoutineListIssueSummary | null;
+    trigger?: Pick<RoutineListTriggerSummary, "id" | "kind" | "label"> | null;
   } | null;
+  activeIssue?: RoutineListIssueSummary | null;
 };
 
 export function formatLastRunTimestamp(value: Date | string | null | undefined) {
@@ -44,6 +75,40 @@ export function formatRoutineRunStatus(value: string | null | undefined) {
   return value.replaceAll("_", " ");
 }
 
+function formatTriggerKind(value: string | null | undefined) {
+  if (!value) return "Trigger";
+  return value.replaceAll("_", " ");
+}
+
+function formatTriggerLabel(trigger: RoutineListTriggerSummary | Pick<RoutineListTriggerSummary, "kind" | "label"> | null | undefined) {
+  if (!trigger) return null;
+  return trigger.label?.trim() || formatTriggerKind(trigger.kind);
+}
+
+function formatIssueStatus(value: string | null | undefined) {
+  if (!value) return null;
+  return value.replaceAll("_", " ");
+}
+
+function findPrimaryTrigger(triggers: RoutineListTriggerSummary[]) {
+  return triggers.find((trigger) => trigger.enabled) ?? triggers[0] ?? null;
+}
+
+function findNextRunAt(triggers: RoutineListTriggerSummary[]) {
+  return triggers
+    .filter((trigger) => trigger.enabled && trigger.nextRunAt)
+    .map((trigger) => trigger.nextRunAt!)
+    .sort((left, right) => new Date(left).getTime() - new Date(right).getTime())[0] ?? null;
+}
+
+function issueHref(issue: RoutineListIssueSummary) {
+  return `/issues/${issue.identifier ?? issue.id}`;
+}
+
+function issueLabel(issue: RoutineListIssueSummary) {
+  return issue.identifier ?? issue.id.slice(0, 8);
+}
+
 export function nextRoutineStatus(currentStatus: string, enabled: boolean) {
   if (currentStatus === "archived" && enabled) return "active";
   return enabled ? "active" : "paused";
@@ -52,6 +117,7 @@ export function nextRoutineStatus(currentStatus: string, enabled: boolean) {
 export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   routine,
   projectById,
+  goalById,
   agentById,
   runningRoutineId,
   statusMutationRoutineId,
@@ -59,6 +125,7 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   configureLabel = "Edit",
   managedByLabel,
   secondaryDetails,
+  healthBadges = [],
   runNowButton = false,
   disableRunNow = false,
   disableToggle = false,
@@ -69,6 +136,7 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
 }: {
   routine: TRoutine;
   projectById: Map<string, RoutineListProjectSummary>;
+  goalById?: Map<string, RoutineListGoalSummary>;
   agentById: Map<string, RoutineListAgentSummary>;
   runningRoutineId: string | null;
   statusMutationRoutineId: string | null;
@@ -76,6 +144,7 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   configureLabel?: string;
   managedByLabel?: string | null;
   secondaryDetails?: ReactNode;
+  healthBadges?: RoutineListHealthBadge[];
   runNowButton?: boolean;
   disableRunNow?: boolean;
   disableToggle?: boolean;
@@ -88,18 +157,24 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
   const isArchived = routine.status === "archived";
   const isStatusPending = statusMutationRoutineId === routine.id;
   const project = routine.projectId ? projectById.get(routine.projectId) ?? null : null;
+  const goal = routine.goalId ? goalById?.get(routine.goalId) ?? null : null;
   const agent = routine.assigneeAgentId ? agentById.get(routine.assigneeAgentId) ?? null : null;
   const isDraft = !isArchived && !routine.assigneeAgentId;
   const runDisabled = runningRoutineId === routine.id || isArchived || disableRunNow;
+  const triggers = routine.triggers ?? [];
+  const primaryTrigger = findPrimaryTrigger(triggers);
+  const nextRunAt = findNextRunAt(triggers);
+  const triggerCountSuffix = triggers.length > 1 ? ` +${triggers.length - 1}` : "";
+  const lastRunLinkedIssue = routine.lastRun?.linkedIssue ?? null;
+  const activeIssue = routine.activeIssue ?? null;
 
   return (
-    <Link
-      to={href}
-      className="group flex flex-col gap-3 border-b border-border px-3 py-3 transition-colors hover:bg-accent/50 last:border-b-0 sm:flex-row sm:items-center no-underline text-inherit"
-    >
+    <div className="group flex flex-col gap-3 border-b border-border px-3 py-3 transition-colors hover:bg-accent/50 last:border-b-0 sm:flex-row sm:items-center">
       <div className="min-w-0 flex-1 space-y-1.5">
         <div className="flex flex-wrap items-center gap-2">
-          <span className="truncate text-sm font-medium">{routine.title}</span>
+          <Link to={href} className="truncate text-sm font-medium text-inherit no-underline hover:underline">
+            {routine.title}
+          </Link>
           {(isArchived || routine.status === "paused" || isDraft) ? (
             <span className="text-xs text-muted-foreground">
               {isArchived ? "archived" : isDraft ? "draft" : "paused"}
@@ -108,6 +183,18 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
           {managedByLabel ? (
             <span className="text-xs text-muted-foreground">{managedByLabel}</span>
           ) : null}
+          {healthBadges.map((badge) => (
+            <Badge
+              key={badge.key}
+              variant={badge.tone === "danger" ? "destructive" : "outline"}
+              className={cn(
+                "h-5 px-1.5 text-xs font-medium",
+                badge.tone === "warning" && "border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200",
+              )}
+            >
+              {badge.label}
+            </Badge>
+          ))}
         </div>
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
           <span className="flex items-center gap-2">
@@ -117,14 +204,39 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
             />
             <span>{routine.projectId ? (project?.name ?? "Unknown project") : "No project"}</span>
           </span>
+          <span className="min-w-0 truncate">
+            Goal: {routine.goalId ? (goal?.title ?? "Unknown goal") : "No goal"}
+          </span>
           <span className="flex items-center gap-2">
             {agent?.icon ? <AgentIcon icon={agent.icon} className="h-3.5 w-3.5 shrink-0" /> : null}
             <span>{routine.assigneeAgentId ? (agent?.name ?? "Unknown agent") : "No default agent"}</span>
           </span>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
           <span>
-            {formatLastRunTimestamp(routine.lastRun?.triggeredAt)}
-            {routine.lastRun ? ` · ${formatRoutineRunStatus(routine.lastRun.status)}` : ""}
+            Trigger: {formatTriggerLabel(primaryTrigger) ?? "No triggers"}{triggerCountSuffix}
+            {primaryTrigger && !primaryTrigger.enabled ? " (disabled)" : ""}
           </span>
+          <span>Next: {formatLastRunTimestamp(nextRunAt)}</span>
+          <span>
+            Last: {formatLastRunTimestamp(routine.lastRun?.triggeredAt)}
+            {routine.lastRun ? ` · ${formatRoutineRunStatus(routine.lastRun.status)}` : ""}
+            {routine.lastRun?.trigger ? ` · ${formatTriggerLabel(routine.lastRun.trigger)}` : ""}
+          </span>
+          {lastRunLinkedIssue ? (
+            <Link to={issueHref(lastRunLinkedIssue)} className="text-muted-foreground underline-offset-2 hover:underline">
+              Last issue: {issueLabel(lastRunLinkedIssue)} · {formatIssueStatus(lastRunLinkedIssue.status)}
+            </Link>
+          ) : (
+            <span>Last issue: none</span>
+          )}
+          {activeIssue ? (
+            <Link to={issueHref(activeIssue)} className="text-muted-foreground underline-offset-2 hover:underline">
+              Active: {issueLabel(activeIssue)} · {formatIssueStatus(activeIssue.status)}
+            </Link>
+          ) : (
+            <span>Active: none</span>
+          )}
         </div>
         {secondaryDetails ? (
           <div className="text-xs text-muted-foreground">{secondaryDetails}</div>
@@ -191,6 +303,6 @@ export function RoutineListRow<TRoutine extends RoutineListRowItem>({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -654,11 +654,26 @@ describe("Routines page", () => {
     });
   });
 
-  it("defaults the routines list to project groups sorted by title", async () => {
+  it("defaults the routines list to ungrouped rows sorted by updated descending", async () => {
     routinesListMock.mockResolvedValue([
-      createRoutine({ id: "routine-1", title: "Weekly digest", projectId: "project-1" }),
-      createRoutine({ id: "routine-2", title: "Morning sync", projectId: "project-1" }),
-      createRoutine({ id: "routine-3", title: "Agent review", projectId: "project-2" }),
+      createRoutine({
+        id: "routine-1",
+        title: "Weekly digest",
+        projectId: "project-1",
+        updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+      }),
+      createRoutine({
+        id: "routine-2",
+        title: "Morning sync",
+        projectId: "project-1",
+        updatedAt: new Date("2026-04-03T00:00:00.000Z"),
+      }),
+      createRoutine({
+        id: "routine-3",
+        title: "Agent review",
+        projectId: "project-2",
+        updatedAt: new Date("2026-04-02T00:00:00.000Z"),
+      }),
     ]);
     issuesListMock.mockResolvedValue([]);
 
@@ -678,24 +693,23 @@ describe("Routines page", () => {
       await flush();
     });
 
-    for (let attempts = 0; attempts < 5 && !container.textContent?.includes("Project Alpha"); attempts += 1) {
+    for (let attempts = 0; attempts < 5 && !container.textContent?.includes("Morning sync"); attempts += 1) {
       await act(async () => {
         await flush();
       });
     }
 
     const text = container.textContent ?? "";
-    expect(text.indexOf("Project Alpha")).toBeLessThan(text.indexOf("Project Beta"));
-    expect(text.indexOf("Morning sync")).toBeLessThan(text.indexOf("Weekly digest"));
-    expect(text.indexOf("Project Alpha")).toBeLessThan(text.indexOf("Morning sync"));
-    expect(text.indexOf("Weekly digest")).toBeLessThan(text.indexOf("Project Beta"));
+    expect(text).not.toContain("PROJECT ALPHA");
+    expect(text.indexOf("Morning sync")).toBeLessThan(text.indexOf("Agent review"));
+    expect(text.indexOf("Agent review")).toBeLessThan(text.indexOf("Weekly digest"));
 
     await act(async () => {
       root.unmount();
     });
   });
 
-  it("hides archived routines from the routines list", async () => {
+  it("shows only active routines by default with archived available in filters", async () => {
     routinesListMock.mockResolvedValue([
       createRoutine({ id: "routine-1", title: "Morning sync", status: "active" }),
       createRoutine({ id: "routine-2", title: "Archived cleanup", status: "archived" }),
@@ -725,7 +739,8 @@ describe("Routines page", () => {
     }
 
     const text = container.textContent ?? "";
-    expect(text).toContain("1 routine");
+    expect(text).toContain("1 shown");
+    expect(text).toContain("Archived");
     expect(text).toContain("Morning sync");
     expect(text).not.toContain("Archived cleanup");
 
@@ -734,7 +749,7 @@ describe("Routines page", () => {
     });
   });
 
-  it("shows an outlined row-level run now button on the routines table", async () => {
+  it("shows a row-level run now button on the routines table", async () => {
     routinesListMock.mockResolvedValue([createRoutine({ id: "routine-1", title: "Morning sync" })]);
     issuesListMock.mockResolvedValue([]);
 
@@ -755,19 +770,18 @@ describe("Routines page", () => {
     });
 
     let runNowButton = Array.from(container.querySelectorAll("button")).find((button) =>
-      button.textContent?.includes("Run now"),
+      button.textContent?.includes("Run now") && button.getAttribute("data-variant") === "ghost",
     );
     for (let attempts = 0; attempts < 5 && !runNowButton; attempts += 1) {
       await act(async () => {
         await flush();
       });
       runNowButton = Array.from(container.querySelectorAll("button")).find((button) =>
-        button.textContent?.includes("Run now"),
+        button.textContent?.includes("Run now") && button.getAttribute("data-variant") === "ghost",
       );
     }
 
     expect(runNowButton).toBeTruthy();
-    expect(runNowButton?.getAttribute("data-variant")).toBe("outline");
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -8,6 +8,7 @@ import type { Issue, RoutineListItem } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Routines,
+  buildRoutinesTabHref,
   buildRoutineGroups,
   countRoutinesByStatus,
   deriveRoutineHealthBadges,
@@ -487,6 +488,14 @@ describe("Routines page", () => {
     expect(filterRoutinesByStatus(routines, "active").map((routine) => routine.id)).toEqual(["routine-active"]);
     expect(filterRoutinesByStatus(routines, "paused").map((routine) => routine.id)).toEqual(["routine-paused"]);
     expect(filterRoutinesByStatus(routines, "archived").map((routine) => routine.id)).toEqual(["routine-archived"]);
+  });
+
+  it("preserves routine status filters when building tab navigation URLs", () => {
+    expect(buildRoutinesTabHref("routines", "active")).toBe("/routines");
+    expect(buildRoutinesTabHref("routines", "archived")).toBe("/routines?status=archived");
+    expect(buildRoutinesTabHref("runs", "active")).toBe("/routines?tab=runs");
+    expect(buildRoutinesTabHref("runs", "paused")).toBe("/routines?tab=runs&status=paused");
+    expect(buildRoutinesTabHref("runs", "archived")).toBe("/routines?tab=runs&status=archived");
   });
 
   it("derives routine health badges for trigger and stale last-run states", () => {

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -6,7 +6,15 @@ import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue, RoutineListItem } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Routines, buildRoutineGroups, sortRoutines } from "./Routines";
+import {
+  Routines,
+  buildRoutineGroups,
+  countRoutinesByStatus,
+  deriveRoutineHealthBadges,
+  filterRoutinesByStatus,
+  findDuplicateTitleScheduleRoutineIds,
+  sortRoutines,
+} from "./Routines";
 
 let currentSearch = "";
 
@@ -173,6 +181,24 @@ vi.mock("../api/projects", () => ({
   },
 }));
 
+vi.mock("../api/goals", () => ({
+  goalsApi: {
+    list: vi.fn(async () => [
+      {
+        id: "goal-1",
+        companyId: "company-1",
+        title: "Company growth",
+        description: null,
+        level: "company",
+        status: "active",
+        parentId: null,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+      },
+    ]),
+  },
+}));
+
 vi.mock("../api/access", () => ({
   accessApi: {
     listUserDirectory: vi.fn(async () => ({
@@ -326,6 +352,30 @@ function createIssue(overrides: Partial<Issue> = {}): Issue {
   };
 }
 
+function createRun(overrides: Partial<NonNullable<RoutineListItem["lastRun"]>> = {}): NonNullable<RoutineListItem["lastRun"]> {
+  return {
+    id: "run-1",
+    companyId: "company-1",
+    routineId: "routine-1",
+    triggerId: null,
+    source: "manual",
+    status: "succeeded",
+    triggeredAt: new Date("2026-04-02T00:00:00.000Z"),
+    idempotencyKey: null,
+    triggerPayload: null,
+    dispatchFingerprint: null,
+    linkedIssueId: null,
+    coalescedIntoRunId: null,
+    failureReason: null,
+    completedAt: null,
+    createdAt: new Date("2026-04-02T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-02T00:00:00.000Z"),
+    linkedIssue: null,
+    trigger: null,
+    ...overrides,
+  };
+}
+
 async function flush() {
   await Promise.resolve();
   await Promise.resolve();
@@ -424,6 +474,136 @@ describe("Routines page", () => {
       "routine-2",
     ]);
     expect(routines.map((routine) => routine.id)).toEqual(["routine-1", "routine-2"]);
+  });
+
+  it("counts and filters routines by active, paused, and archived state", () => {
+    const routines = [
+      createRoutine({ id: "routine-active", status: "active" }),
+      createRoutine({ id: "routine-paused", status: "paused" }),
+      createRoutine({ id: "routine-archived", status: "archived" }),
+    ];
+
+    expect(countRoutinesByStatus(routines)).toEqual({ active: 1, paused: 1, archived: 1 });
+    expect(filterRoutinesByStatus(routines, "active").map((routine) => routine.id)).toEqual(["routine-active"]);
+    expect(filterRoutinesByStatus(routines, "paused").map((routine) => routine.id)).toEqual(["routine-paused"]);
+    expect(filterRoutinesByStatus(routines, "archived").map((routine) => routine.id)).toEqual(["routine-archived"]);
+  });
+
+  it("derives routine health badges for trigger and stale last-run states", () => {
+    const routines = [
+      createRoutine({
+        id: "routine-1",
+        title: "Weekly cleanup",
+        triggers: [
+          {
+            id: "trigger-1",
+            kind: "schedule",
+            label: "Weekday morning",
+            enabled: true,
+            cronExpression: "0 9 * * 1-5",
+            timezone: "UTC",
+            nextRunAt: null,
+            lastFiredAt: null,
+            lastResult: null,
+          },
+          {
+            id: "trigger-2",
+            kind: "schedule",
+            label: "Weekday morning duplicate",
+            enabled: false,
+            cronExpression: "0 9 * * 1-5",
+            timezone: "UTC",
+            nextRunAt: null,
+            lastFiredAt: null,
+            lastResult: null,
+          },
+        ],
+        lastRun: createRun({
+          linkedIssueId: "issue-1",
+          linkedIssue: {
+            id: "issue-1",
+            identifier: "PAP-1",
+            title: "Review cleanup",
+            status: "in_review",
+            priority: "medium",
+            updatedAt: new Date("2026-04-10T00:00:00.000Z"),
+          },
+        }),
+      }),
+      createRoutine({
+        id: "routine-2",
+        title: "Weekly cleanup",
+        triggers: [
+          {
+            id: "trigger-3",
+            kind: "schedule",
+            label: "Weekday morning",
+            enabled: true,
+            cronExpression: "0 9 * * 1-5",
+            timezone: "UTC",
+            nextRunAt: null,
+            lastFiredAt: null,
+            lastResult: null,
+          },
+        ],
+      }),
+    ];
+
+    const duplicateIds = findDuplicateTitleScheduleRoutineIds(routines);
+    const badges = deriveRoutineHealthBadges(
+      routines[0]!,
+      duplicateIds,
+      new Date("2026-04-13T01:00:00.000Z").getTime(),
+    ).map((badge) => badge.key);
+
+    expect(badges).toEqual([
+      "disabled-triggers",
+      "duplicate-triggers",
+      "duplicate-title-schedule",
+      "stale-in-review",
+    ]);
+  });
+
+  it("derives no-trigger and cancelled or blocked last-run health badges", () => {
+    const blocked = deriveRoutineHealthBadges(
+      createRoutine({
+        id: "routine-blocked",
+        triggers: [],
+        lastRun: createRun({
+          linkedIssueId: "issue-1",
+          linkedIssue: {
+            id: "issue-1",
+            identifier: "PAP-1",
+            title: "Blocked run",
+            status: "blocked",
+            priority: "medium",
+            updatedAt: new Date("2026-04-10T00:00:00.000Z"),
+          },
+        }),
+      }),
+      new Set(),
+    ).map((badge) => badge.key);
+    const cancelled = deriveRoutineHealthBadges(
+      createRoutine({
+        id: "routine-cancelled",
+        triggers: [],
+        lastRun: createRun({
+          linkedIssueId: "issue-2",
+          linkedIssue: {
+            id: "issue-2",
+            identifier: "PAP-2",
+            title: "Cancelled run",
+            status: "cancelled",
+            priority: "medium",
+            updatedAt: new Date("2026-04-10T00:00:00.000Z"),
+          },
+        }),
+      }),
+      new Set(),
+    ).map((badge) => badge.key);
+
+    expect(blocked).toEqual(["no-triggers", "last-run-blocked"]);
+    expect(cancelled).toEqual(["no-triggers", "last-run-cancelled"]);
   });
 
   it("renders the routines sort control before the group control", async () => {

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -7,6 +7,7 @@ import type { Issue, RoutineListItem } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   Routines,
+  buildRoutinesTabHref,
   buildRoutineGroups,
   countRoutinesByStatus,
   deriveRoutineHealthBadges,
@@ -478,6 +479,14 @@ describe("Routines page", () => {
     expect(filterRoutinesByStatus(routines, "active").map((routine) => routine.id)).toEqual(["routine-active"]);
     expect(filterRoutinesByStatus(routines, "paused").map((routine) => routine.id)).toEqual(["routine-paused"]);
     expect(filterRoutinesByStatus(routines, "archived").map((routine) => routine.id)).toEqual(["routine-archived"]);
+  });
+
+  it("preserves routine status filters when building tab navigation URLs", () => {
+    expect(buildRoutinesTabHref("routines", "active")).toBe("/routines");
+    expect(buildRoutinesTabHref("routines", "archived")).toBe("/routines?status=archived");
+    expect(buildRoutinesTabHref("runs", "active")).toBe("/routines?tab=runs");
+    expect(buildRoutinesTabHref("runs", "paused")).toBe("/routines?tab=runs&status=paused");
+    expect(buildRoutinesTabHref("runs", "archived")).toBe("/routines?tab=runs&status=archived");
   });
 
   it("derives routine health badges for trigger and stale last-run states", () => {

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -5,7 +5,15 @@ import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { Issue, RoutineListItem } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Routines, buildRoutineGroups, sortRoutines } from "./Routines";
+import {
+  Routines,
+  buildRoutineGroups,
+  countRoutinesByStatus,
+  deriveRoutineHealthBadges,
+  filterRoutinesByStatus,
+  findDuplicateTitleScheduleRoutineIds,
+  sortRoutines,
+} from "./Routines";
 
 let currentSearch = "";
 
@@ -157,6 +165,24 @@ vi.mock("../api/projects", () => ({
         codebase: null,
         workspaces: [],
         primaryWorkspace: null,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+      },
+    ]),
+  },
+}));
+
+vi.mock("../api/goals", () => ({
+  goalsApi: {
+    list: vi.fn(async () => [
+      {
+        id: "goal-1",
+        companyId: "company-1",
+        title: "Company growth",
+        description: null,
+        level: "company",
+        status: "active",
+        parentId: null,
         createdAt: new Date("2026-04-01T00:00:00.000Z"),
         updatedAt: new Date("2026-04-01T00:00:00.000Z"),
       },
@@ -317,6 +343,30 @@ function createIssue(overrides: Partial<Issue> = {}): Issue {
   };
 }
 
+function createRun(overrides: Partial<NonNullable<RoutineListItem["lastRun"]>> = {}): NonNullable<RoutineListItem["lastRun"]> {
+  return {
+    id: "run-1",
+    companyId: "company-1",
+    routineId: "routine-1",
+    triggerId: null,
+    source: "manual",
+    status: "succeeded",
+    triggeredAt: new Date("2026-04-02T00:00:00.000Z"),
+    idempotencyKey: null,
+    triggerPayload: null,
+    dispatchFingerprint: null,
+    linkedIssueId: null,
+    coalescedIntoRunId: null,
+    failureReason: null,
+    completedAt: null,
+    createdAt: new Date("2026-04-02T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-02T00:00:00.000Z"),
+    linkedIssue: null,
+    trigger: null,
+    ...overrides,
+  };
+}
+
 async function flush() {
   await Promise.resolve();
   await Promise.resolve();
@@ -415,6 +465,136 @@ describe("Routines page", () => {
       "routine-2",
     ]);
     expect(routines.map((routine) => routine.id)).toEqual(["routine-1", "routine-2"]);
+  });
+
+  it("counts and filters routines by active, paused, and archived state", () => {
+    const routines = [
+      createRoutine({ id: "routine-active", status: "active" }),
+      createRoutine({ id: "routine-paused", status: "paused" }),
+      createRoutine({ id: "routine-archived", status: "archived" }),
+    ];
+
+    expect(countRoutinesByStatus(routines)).toEqual({ active: 1, paused: 1, archived: 1 });
+    expect(filterRoutinesByStatus(routines, "active").map((routine) => routine.id)).toEqual(["routine-active"]);
+    expect(filterRoutinesByStatus(routines, "paused").map((routine) => routine.id)).toEqual(["routine-paused"]);
+    expect(filterRoutinesByStatus(routines, "archived").map((routine) => routine.id)).toEqual(["routine-archived"]);
+  });
+
+  it("derives routine health badges for trigger and stale last-run states", () => {
+    const routines = [
+      createRoutine({
+        id: "routine-1",
+        title: "Weekly cleanup",
+        triggers: [
+          {
+            id: "trigger-1",
+            kind: "schedule",
+            label: "Weekday morning",
+            enabled: true,
+            cronExpression: "0 9 * * 1-5",
+            timezone: "UTC",
+            nextRunAt: null,
+            lastFiredAt: null,
+            lastResult: null,
+          },
+          {
+            id: "trigger-2",
+            kind: "schedule",
+            label: "Weekday morning duplicate",
+            enabled: false,
+            cronExpression: "0 9 * * 1-5",
+            timezone: "UTC",
+            nextRunAt: null,
+            lastFiredAt: null,
+            lastResult: null,
+          },
+        ],
+        lastRun: createRun({
+          linkedIssueId: "issue-1",
+          linkedIssue: {
+            id: "issue-1",
+            identifier: "PAP-1",
+            title: "Review cleanup",
+            status: "in_review",
+            priority: "medium",
+            updatedAt: new Date("2026-04-10T00:00:00.000Z"),
+          },
+        }),
+      }),
+      createRoutine({
+        id: "routine-2",
+        title: "Weekly cleanup",
+        triggers: [
+          {
+            id: "trigger-3",
+            kind: "schedule",
+            label: "Weekday morning",
+            enabled: true,
+            cronExpression: "0 9 * * 1-5",
+            timezone: "UTC",
+            nextRunAt: null,
+            lastFiredAt: null,
+            lastResult: null,
+          },
+        ],
+      }),
+    ];
+
+    const duplicateIds = findDuplicateTitleScheduleRoutineIds(routines);
+    const badges = deriveRoutineHealthBadges(
+      routines[0]!,
+      duplicateIds,
+      new Date("2026-04-13T01:00:00.000Z").getTime(),
+    ).map((badge) => badge.key);
+
+    expect(badges).toEqual([
+      "disabled-triggers",
+      "duplicate-triggers",
+      "duplicate-title-schedule",
+      "stale-in-review",
+    ]);
+  });
+
+  it("derives no-trigger and cancelled or blocked last-run health badges", () => {
+    const blocked = deriveRoutineHealthBadges(
+      createRoutine({
+        id: "routine-blocked",
+        triggers: [],
+        lastRun: createRun({
+          linkedIssueId: "issue-1",
+          linkedIssue: {
+            id: "issue-1",
+            identifier: "PAP-1",
+            title: "Blocked run",
+            status: "blocked",
+            priority: "medium",
+            updatedAt: new Date("2026-04-10T00:00:00.000Z"),
+          },
+        }),
+      }),
+      new Set(),
+    ).map((badge) => badge.key);
+    const cancelled = deriveRoutineHealthBadges(
+      createRoutine({
+        id: "routine-cancelled",
+        triggers: [],
+        lastRun: createRun({
+          linkedIssueId: "issue-2",
+          linkedIssue: {
+            id: "issue-2",
+            identifier: "PAP-2",
+            title: "Cancelled run",
+            status: "cancelled",
+            priority: "medium",
+            updatedAt: new Date("2026-04-10T00:00:00.000Z"),
+          },
+        }),
+      }),
+      new Set(),
+    ).map((badge) => badge.key);
+
+    expect(blocked).toEqual(["no-triggers", "last-run-blocked"]);
+    expect(cancelled).toEqual(["no-triggers", "last-run-cancelled"]);
   });
 
   it("renders the routines sort control before the group control", async () => {

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -5,6 +5,7 @@ import { ArrowUpDown, Check, ChevronDown, ChevronRight, Layers, Plus, Repeat } f
 import { routinesApi } from "../api/routines";
 import { agentsApi } from "../api/agents";
 import { projectsApi } from "../api/projects";
+import { goalsApi } from "../api/goals";
 import { issuesApi } from "../api/issues";
 import { heartbeatsApi } from "../api/heartbeats";
 import { accessApi } from "../api/access";
@@ -25,7 +26,7 @@ import { PageTabBar } from "../components/PageTabBar";
 import { AgentIcon } from "../components/AgentIconPicker";
 import { InlineEntitySelector, type InlineEntityOption } from "../components/InlineEntitySelector";
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "../components/MarkdownEditor";
-import { RoutineListRow, nextRoutineStatus } from "../components/RoutineList";
+import { RoutineListRow, nextRoutineStatus, type RoutineListHealthBadge } from "../components/RoutineList";
 import {
   RoutineRunVariablesDialog,
   type RoutineRunDialogSubmitData,
@@ -34,7 +35,7 @@ import { RoutineVariablesEditor, RoutineVariablesHint } from "../components/Rout
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Select,
@@ -44,7 +45,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
-import type { RoutineListItem, RoutineVariable } from "@paperclipai/shared";
+import type { Goal, RoutineListItem, RoutineVariable } from "@paperclipai/shared";
 
 const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active"];
 const catchUpPolicies = ["skip_missed", "enqueue_missed_with_cap"];
@@ -57,6 +58,12 @@ const catchUpPolicyDescriptions: Record<string, string> = {
   skip_missed: "Ignore windows that were missed while the scheduler or routine was paused.",
   enqueue_missed_with_cap: "Catch up missed schedule windows in capped batches after recovery.",
 };
+const routineStatusFilters: Array<{ value: RoutineStatusFilter; label: string }> = [
+  { value: "active", label: "Active" },
+  { value: "paused", label: "Paused" },
+  { value: "archived", label: "Archived" },
+];
+const staleInReviewLastRunMs = 48 * 60 * 60 * 1000;
 
 function autoResizeTextarea(element: HTMLTextAreaElement | null) {
   if (!element) return;
@@ -68,6 +75,7 @@ type RoutinesTab = "routines" | "runs";
 type RoutineGroupBy = "none" | "project" | "assignee";
 type RoutineSortField = "updated" | "created" | "title" | "lastRun";
 type RoutineSortDir = "asc" | "desc";
+type RoutineStatusFilter = "active" | "paused" | "archived";
 
 type RoutineViewState = {
   sortField: RoutineSortField;
@@ -83,9 +91,9 @@ type RoutineGroup = {
 };
 
 const defaultRoutineViewState: RoutineViewState = {
-  sortField: "title",
-  sortDir: "asc",
-  groupBy: "project",
+  sortField: "updated",
+  sortDir: "desc",
+  groupBy: "none",
   collapsedGroups: [],
 };
 
@@ -129,6 +137,115 @@ function buildRoutineMutationPayload(input: {
     projectId: input.projectId || null,
     assigneeAgentId: input.assigneeAgentId || null,
   };
+}
+
+function isRoutineStatusFilter(value: string | null): value is RoutineStatusFilter {
+  return value === "active" || value === "paused" || value === "archived";
+}
+
+function getRoutineStatusFilter(searchParams: URLSearchParams): RoutineStatusFilter {
+  const status = searchParams.get("status");
+  return isRoutineStatusFilter(status) ? status : "active";
+}
+
+export function countRoutinesByStatus(routines: RoutineListItem[]) {
+  return routines.reduce(
+    (counts, routine) => {
+      if (routine.status === "archived") counts.archived += 1;
+      else if (routine.status === "paused") counts.paused += 1;
+      else counts.active += 1;
+      return counts;
+    },
+    { active: 0, paused: 0, archived: 0 },
+  );
+}
+
+export function filterRoutinesByStatus(routines: RoutineListItem[], filter: RoutineStatusFilter): RoutineListItem[] {
+  return routines.filter((routine) => {
+    if (filter === "archived") return routine.status === "archived";
+    if (filter === "paused") return routine.status === "paused";
+    return routine.status !== "archived" && routine.status !== "paused";
+  });
+}
+
+function normalizeDuplicateText(value: string | null | undefined) {
+  return (value ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function scheduleTriggerKey(trigger: RoutineListItem["triggers"][number]) {
+  if (trigger.kind !== "schedule" || !trigger.cronExpression) return null;
+  return `${trigger.cronExpression.trim()}|${trigger.timezone?.trim() || "local"}`;
+}
+
+function triggerIdentity(trigger: RoutineListItem["triggers"][number]) {
+  if (trigger.kind === "schedule") return `schedule:${scheduleTriggerKey(trigger) ?? "__missing"}`;
+  return `${trigger.kind}:${normalizeDuplicateText(trigger.label) || trigger.id}`;
+}
+
+export function findDuplicateTitleScheduleRoutineIds(routines: RoutineListItem[]): Set<string> {
+  const idsByKey = new Map<string, Set<string>>();
+  for (const routine of routines) {
+    const titleKey = normalizeDuplicateText(routine.title);
+    if (!titleKey) continue;
+    for (const trigger of routine.triggers) {
+      const key = scheduleTriggerKey(trigger);
+      if (!key) continue;
+      const routineIds = idsByKey.get(`${titleKey}|${key}`) ?? new Set<string>();
+      routineIds.add(routine.id);
+      idsByKey.set(`${titleKey}|${key}`, routineIds);
+    }
+  }
+
+  const duplicates = new Set<string>();
+  for (const routineIds of idsByKey.values()) {
+    if (routineIds.size < 2) continue;
+    for (const id of routineIds) duplicates.add(id);
+  }
+  return duplicates;
+}
+
+export function deriveRoutineHealthBadges(
+  routine: RoutineListItem,
+  duplicateTitleScheduleRoutineIds: Set<string>,
+  now: number = Date.now(),
+): RoutineListHealthBadge[] {
+  const badges: RoutineListHealthBadge[] = [];
+  if (routine.triggers.length === 0) {
+    badges.push({ key: "no-triggers", label: "No triggers", tone: "warning" });
+  }
+  if (routine.triggers.some((trigger) => !trigger.enabled)) {
+    badges.push({ key: "disabled-triggers", label: "Disabled triggers", tone: "warning" });
+  }
+
+  const seenTriggerKeys = new Set<string>();
+  const hasDuplicateTrigger = routine.triggers.some((trigger) => {
+    const key = triggerIdentity(trigger);
+    if (seenTriggerKeys.has(key)) return true;
+    seenTriggerKeys.add(key);
+    return false;
+  });
+  if (hasDuplicateTrigger) {
+    badges.push({ key: "duplicate-triggers", label: "Duplicate triggers", tone: "warning" });
+  }
+  if (duplicateTitleScheduleRoutineIds.has(routine.id)) {
+    badges.push({ key: "duplicate-title-schedule", label: "Duplicate title/schedule", tone: "warning" });
+  }
+
+  const linkedIssue = routine.lastRun?.linkedIssue ?? null;
+  if (linkedIssue?.status === "in_review") {
+    const updatedAt = new Date(linkedIssue.updatedAt).getTime();
+    if (Number.isFinite(updatedAt) && now - updatedAt > staleInReviewLastRunMs) {
+      badges.push({ key: "stale-in-review", label: "Stale review", tone: "warning" });
+    }
+  }
+  if (linkedIssue?.status === "blocked" || linkedIssue?.status === "cancelled") {
+    badges.push({
+      key: `last-run-${linkedIssue.status}`,
+      label: `Last run ${linkedIssue.status}`,
+      tone: "danger",
+    });
+  }
+  return badges;
 }
 
 export function buildRoutineGroups(
@@ -195,8 +312,13 @@ export function sortRoutines(
   });
 }
 
-function buildRoutinesTabHref(tab: RoutinesTab) {
-  return tab === "runs" ? "/routines?tab=runs" : "/routines";
+export function buildRoutinesTabHref(tab: RoutinesTab, statusFilter: RoutineStatusFilter = "active") {
+  if (tab === "runs") {
+    const params = new URLSearchParams({ tab: "runs" });
+    if (statusFilter !== "active") params.set("status", statusFilter);
+    return `/routines?${params.toString()}`;
+  }
+  return statusFilter === "active" ? "/routines" : `/routines?status=${statusFilter}`;
 }
 
 export function Routines() {
@@ -216,6 +338,7 @@ export function Routines() {
   const [composerOpen, setComposerOpen] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const activeTab: RoutinesTab = searchParams.get("tab") === "runs" ? "runs" : "routines";
+  const routineStatusFilter = getRoutineStatusFilter(searchParams);
   const [draft, setDraft] = useState<{
     title: string;
     description: string;
@@ -261,6 +384,11 @@ export function Routines() {
   const { data: projects } = useQuery({
     queryKey: queryKeys.projects.list(selectedCompanyId!),
     queryFn: () => projectsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+  const { data: goals } = useQuery({
+    queryKey: queryKeys.goals.list(selectedCompanyId!),
+    queryFn: () => goalsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId,
   });
   const { data: companyMembers } = useQuery({
@@ -416,14 +544,26 @@ export function Routines() {
     () => new Map((projects ?? []).map((project) => [project.id, project])),
     [projects],
   );
+  const goalById = useMemo(
+    () => new Map((goals ?? []).map((goal) => [goal.id, goal] satisfies [string, Goal])),
+    [goals],
+  );
   const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
-  const visibleRoutines = useMemo(
-    () => (routines ?? []).filter((routine) => routine.status !== "archived"),
+  const routineStatusCounts = useMemo(
+    () => countRoutinesByStatus(routines ?? []),
+    [routines],
+  );
+  const duplicateTitleScheduleRoutineIds = useMemo(
+    () => findDuplicateTitleScheduleRoutineIds(routines ?? []),
     [routines],
   );
   const sortedRoutines = useMemo(
-    () => sortRoutines(visibleRoutines, routineViewState.sortField, routineViewState.sortDir),
-    [routineViewState.sortDir, routineViewState.sortField, visibleRoutines],
+    () => sortRoutines(
+      filterRoutinesByStatus(routines ?? [], routineStatusFilter),
+      routineViewState.sortField,
+      routineViewState.sortDir,
+    ),
+    [routineStatusFilter, routineViewState.sortDir, routineViewState.sortField, routines],
   );
   const routineGroups = useMemo(
     () => buildRoutineGroups(sortedRoutines, routineViewState.groupBy, projectById, agentById),
@@ -452,7 +592,7 @@ export function Routines() {
   function handleTabChange(tab: string) {
     const nextTab = tab === "runs" ? "runs" : "routines";
     startTransition(() => {
-      navigate(buildRoutinesTabHref(nextTab));
+      navigate(buildRoutinesTabHref(nextTab, routineStatusFilter));
     });
   }
 
@@ -498,7 +638,7 @@ export function Routines() {
             Routines
           </h1>
           <p className="text-sm text-muted-foreground">
-            Recurring work definitions that materialize into auditable execution tasks.
+            Recurring work definitions that materialize into auditable execution issues.
           </p>
         </div>
         <Button onClick={() => setComposerOpen(true)}>
@@ -518,14 +658,41 @@ export function Routines() {
           ]}
         />
         <TabsContent value="routines" className="space-y-4">
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-sm text-muted-foreground">
-              {visibleRoutines.length} routine{visibleRoutines.length === 1 ? "" : "s"}
-            </p>
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-wrap items-center gap-2">
+              {routineStatusFilters.map((filter) => {
+                const count = routineStatusCounts[filter.value];
+                const selected = routineStatusFilter === filter.value;
+                return (
+                  <Button
+                    key={filter.value}
+                    variant={selected ? "secondary" : "ghost"}
+                    size="sm"
+                    className="h-8 gap-2 px-2.5 text-xs"
+                    aria-pressed={selected}
+                    onClick={() => {
+                      if (!selected) {
+                        startTransition(() => {
+                          navigate(buildRoutinesTabHref("routines", filter.value));
+                        });
+                      }
+                    }}
+                  >
+                    <span>{filter.label}</span>
+                    <span className="rounded-full bg-background/70 px-1.5 py-0.5 text-xs text-muted-foreground">
+                      {count}
+                    </span>
+                  </Button>
+                );
+              })}
+              <span className="text-sm text-muted-foreground">
+                {sortedRoutines.length} shown
+              </span>
+            </div>
             <div className="flex items-center gap-1">
               <Popover>
                 <PopoverTrigger asChild>
-                  <Button variant="ghost" size="sm" className="text-xs" title="Sort">
+                  <Button variant="ghost" size="sm" className="text-xs" title="Sort" aria-label="Sort routines">
                     <ArrowUpDown className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
                     <span className="hidden sm:inline">Sort</span>
                   </Button>
@@ -566,7 +733,7 @@ export function Routines() {
               </Popover>
               <Popover>
                 <PopoverTrigger asChild>
-                  <Button variant="ghost" size="sm" className="text-xs" title="Group">
+                  <Button variant="ghost" size="sm" className="text-xs" title="Group" aria-label="Group routines">
                     <Layers className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
                     <span className="hidden sm:inline">Group</span>
                   </Button>
@@ -596,6 +763,11 @@ export function Routines() {
               </Popover>
             </div>
           </div>
+          {routineStatusFilter === "archived" ? (
+            <p className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+              Archived routines are retained so historical runs and linked issues stay auditable. Restore a routine to use it again; permanent purge is intentionally unavailable until Paperclip has a retention policy.
+            </p>
+          ) : null}
         </TabsContent>
         <TabsContent value="runs">
           <IssuesList
@@ -626,10 +798,10 @@ export function Routines() {
         >
           <div className="shrink-0 flex flex-wrap items-center justify-between gap-3 border-b border-border/60 px-5 py-3">
             <div>
-              <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">New routine</p>
-              <p className="text-sm text-muted-foreground">
+              <DialogTitle className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">New routine</DialogTitle>
+              <DialogDescription className="text-sm text-muted-foreground">
                 Define the recurring work first. Default project and agent are optional for draft routines.
-              </p>
+              </DialogDescription>
             </div>
             <Button
               variant="ghost"
@@ -877,67 +1049,65 @@ export function Routines() {
 
       {activeTab === "routines" ? (
         <div>
-          {visibleRoutines.length === 0 ? (
+          {sortedRoutines.length === 0 ? (
             <div className="py-12">
               <EmptyState
                 icon={Repeat}
-                message="No active routines. Use Create routine to define the first recurring workflow."
+                message={
+                  (routines ?? []).length === 0
+                    ? "No routines yet. Use Create routine to define the first recurring workflow."
+                    : `No ${routineStatusFilter} routines. Use the filters above to inspect another state.`
+                }
               />
             </div>
           ) : (
-            <div className="flex flex-col gap-3">
-              {routineGroups.map((group) => {
-                const isOpen = !routineViewState.collapsedGroups.includes(group.key);
-                return (
-                  <Collapsible
-                    key={group.key}
-                    open={isOpen}
-                    onOpenChange={(open) => {
-                      updateRoutineView({
-                        collapsedGroups: open
-                          ? routineViewState.collapsedGroups.filter((item) => item !== group.key)
-                          : [...routineViewState.collapsedGroups, group.key],
-                      });
-                    }}
-                  >
-                    {group.label ? (
-                      <div
-                        className={`flex items-center gap-2 rounded-lg border border-border px-3 py-2${
-                          isOpen ? " mb-1" : ""
-                        }`}
-                      >
-                        <CollapsibleTrigger className="flex items-center gap-1.5">
-                          <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform [[data-state=open]>&]:rotate-90" />
-                          <span className="text-sm font-semibold uppercase tracking-wide">
-                            {group.label}
-                          </span>
-                        </CollapsibleTrigger>
-                        <span className="text-xs text-muted-foreground">
-                          {group.items.length}
+            <div className="rounded-lg border border-border">
+              {routineGroups.map((group) => (
+                <Collapsible
+                  key={group.key}
+                  open={!routineViewState.collapsedGroups.includes(group.key)}
+                  onOpenChange={(open) => {
+                    updateRoutineView({
+                      collapsedGroups: open
+                        ? routineViewState.collapsedGroups.filter((item) => item !== group.key)
+                        : [...routineViewState.collapsedGroups, group.key],
+                    });
+                  }}
+                >
+                  {group.label ? (
+                    <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+                      <CollapsibleTrigger className="flex items-center gap-1.5">
+                        <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform [[data-state=open]>&]:rotate-90" />
+                        <span className="text-sm font-semibold uppercase tracking-wide">
+                          {group.label}
                         </span>
-                      </div>
-                    ) : null}
-                    <CollapsibleContent>
-                      {group.items.map((routine) => (
-                        <RoutineListRow
-                          key={routine.id}
-                          routine={routine}
-                          projectById={projectById}
-                          agentById={agentById}
-                          runningRoutineId={runningRoutineId}
-                          statusMutationRoutineId={statusMutationRoutineId}
-                          href={`/routines/${routine.id}`}
-                          runNowButton
-                          divider={false}
-                          onRunNow={handleRunNow}
-                          onToggleEnabled={handleToggleEnabled}
-                          onToggleArchived={handleToggleArchived}
-                        />
-                      ))}
-                    </CollapsibleContent>
-                  </Collapsible>
-                );
-              })}
+                      </CollapsibleTrigger>
+                      <span className="text-xs text-muted-foreground">
+                        {group.items.length}
+                      </span>
+                    </div>
+                  ) : null}
+                  <CollapsibleContent>
+                    {group.items.map((routine) => (
+                      <RoutineListRow
+                        key={routine.id}
+                        routine={routine}
+                        projectById={projectById}
+                        goalById={goalById}
+                        agentById={agentById}
+                        healthBadges={deriveRoutineHealthBadges(routine, duplicateTitleScheduleRoutineIds)}
+                        runningRoutineId={runningRoutineId}
+                        statusMutationRoutineId={statusMutationRoutineId}
+                        href={`/routines/${routine.id}`}
+                        runNowButton
+                        onRunNow={handleRunNow}
+                        onToggleEnabled={handleToggleEnabled}
+                        onToggleArchived={handleToggleArchived}
+                      />
+                    ))}
+                  </CollapsibleContent>
+                </Collapsible>
+              ))}
             </div>
           )}
         </div>

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -5,6 +5,7 @@ import { ArrowUpDown, Check, ChevronDown, ChevronRight, Layers, Plus, Repeat } f
 import { routinesApi } from "../api/routines";
 import { agentsApi } from "../api/agents";
 import { projectsApi } from "../api/projects";
+import { goalsApi } from "../api/goals";
 import { issuesApi } from "../api/issues";
 import { heartbeatsApi } from "../api/heartbeats";
 import { accessApi } from "../api/access";
@@ -25,7 +26,7 @@ import { PageTabBar } from "../components/PageTabBar";
 import { AgentIcon } from "../components/AgentIconPicker";
 import { InlineEntitySelector, type InlineEntityOption } from "../components/InlineEntitySelector";
 import { MarkdownEditor, type MarkdownEditorRef, type MentionOption } from "../components/MarkdownEditor";
-import { RoutineListRow, nextRoutineStatus } from "../components/RoutineList";
+import { RoutineListRow, nextRoutineStatus, type RoutineListHealthBadge } from "../components/RoutineList";
 import {
   RoutineRunVariablesDialog,
   type RoutineRunDialogSubmitData,
@@ -34,7 +35,7 @@ import { RoutineVariablesEditor, RoutineVariablesHint } from "../components/Rout
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Select,
@@ -44,7 +45,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
-import type { RoutineListItem, RoutineVariable } from "@paperclipai/shared";
+import type { Goal, RoutineListItem, RoutineVariable } from "@paperclipai/shared";
 
 const concurrencyPolicies = ["coalesce_if_active", "always_enqueue", "skip_if_active"];
 const catchUpPolicies = ["skip_missed", "enqueue_missed_with_cap"];
@@ -57,6 +58,12 @@ const catchUpPolicyDescriptions: Record<string, string> = {
   skip_missed: "Ignore windows that were missed while the scheduler or routine was paused.",
   enqueue_missed_with_cap: "Catch up missed schedule windows in capped batches after recovery.",
 };
+const routineStatusFilters: Array<{ value: RoutineStatusFilter; label: string }> = [
+  { value: "active", label: "Active" },
+  { value: "paused", label: "Paused" },
+  { value: "archived", label: "Archived" },
+];
+const staleInReviewLastRunMs = 48 * 60 * 60 * 1000;
 
 function autoResizeTextarea(element: HTMLTextAreaElement | null) {
   if (!element) return;
@@ -68,6 +75,7 @@ type RoutinesTab = "routines" | "runs";
 type RoutineGroupBy = "none" | "project" | "assignee";
 type RoutineSortField = "updated" | "created" | "title" | "lastRun";
 type RoutineSortDir = "asc" | "desc";
+type RoutineStatusFilter = "active" | "paused" | "archived";
 
 type RoutineViewState = {
   sortField: RoutineSortField;
@@ -129,6 +137,115 @@ function buildRoutineMutationPayload(input: {
     projectId: input.projectId || null,
     assigneeAgentId: input.assigneeAgentId || null,
   };
+}
+
+function isRoutineStatusFilter(value: string | null): value is RoutineStatusFilter {
+  return value === "active" || value === "paused" || value === "archived";
+}
+
+function getRoutineStatusFilter(searchParams: URLSearchParams): RoutineStatusFilter {
+  const status = searchParams.get("status");
+  return isRoutineStatusFilter(status) ? status : "active";
+}
+
+export function countRoutinesByStatus(routines: RoutineListItem[]) {
+  return routines.reduce(
+    (counts, routine) => {
+      if (routine.status === "archived") counts.archived += 1;
+      else if (routine.status === "paused") counts.paused += 1;
+      else counts.active += 1;
+      return counts;
+    },
+    { active: 0, paused: 0, archived: 0 },
+  );
+}
+
+export function filterRoutinesByStatus(routines: RoutineListItem[], filter: RoutineStatusFilter): RoutineListItem[] {
+  return routines.filter((routine) => {
+    if (filter === "archived") return routine.status === "archived";
+    if (filter === "paused") return routine.status === "paused";
+    return routine.status !== "archived" && routine.status !== "paused";
+  });
+}
+
+function normalizeDuplicateText(value: string | null | undefined) {
+  return (value ?? "").trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function scheduleTriggerKey(trigger: RoutineListItem["triggers"][number]) {
+  if (trigger.kind !== "schedule" || !trigger.cronExpression) return null;
+  return `${trigger.cronExpression.trim()}|${trigger.timezone?.trim() || "local"}`;
+}
+
+function triggerIdentity(trigger: RoutineListItem["triggers"][number]) {
+  if (trigger.kind === "schedule") return `schedule:${scheduleTriggerKey(trigger) ?? "__missing"}`;
+  return `${trigger.kind}:${normalizeDuplicateText(trigger.label) || trigger.id}`;
+}
+
+export function findDuplicateTitleScheduleRoutineIds(routines: RoutineListItem[]): Set<string> {
+  const idsByKey = new Map<string, Set<string>>();
+  for (const routine of routines) {
+    const titleKey = normalizeDuplicateText(routine.title);
+    if (!titleKey) continue;
+    for (const trigger of routine.triggers) {
+      const key = scheduleTriggerKey(trigger);
+      if (!key) continue;
+      const routineIds = idsByKey.get(`${titleKey}|${key}`) ?? new Set<string>();
+      routineIds.add(routine.id);
+      idsByKey.set(`${titleKey}|${key}`, routineIds);
+    }
+  }
+
+  const duplicates = new Set<string>();
+  for (const routineIds of idsByKey.values()) {
+    if (routineIds.size < 2) continue;
+    for (const id of routineIds) duplicates.add(id);
+  }
+  return duplicates;
+}
+
+export function deriveRoutineHealthBadges(
+  routine: RoutineListItem,
+  duplicateTitleScheduleRoutineIds: Set<string>,
+  now: number = Date.now(),
+): RoutineListHealthBadge[] {
+  const badges: RoutineListHealthBadge[] = [];
+  if (routine.triggers.length === 0) {
+    badges.push({ key: "no-triggers", label: "No triggers", tone: "warning" });
+  }
+  if (routine.triggers.some((trigger) => !trigger.enabled)) {
+    badges.push({ key: "disabled-triggers", label: "Disabled triggers", tone: "warning" });
+  }
+
+  const seenTriggerKeys = new Set<string>();
+  const hasDuplicateTrigger = routine.triggers.some((trigger) => {
+    const key = triggerIdentity(trigger);
+    if (seenTriggerKeys.has(key)) return true;
+    seenTriggerKeys.add(key);
+    return false;
+  });
+  if (hasDuplicateTrigger) {
+    badges.push({ key: "duplicate-triggers", label: "Duplicate triggers", tone: "warning" });
+  }
+  if (duplicateTitleScheduleRoutineIds.has(routine.id)) {
+    badges.push({ key: "duplicate-title-schedule", label: "Duplicate title/schedule", tone: "warning" });
+  }
+
+  const linkedIssue = routine.lastRun?.linkedIssue ?? null;
+  if (linkedIssue?.status === "in_review") {
+    const updatedAt = new Date(linkedIssue.updatedAt).getTime();
+    if (Number.isFinite(updatedAt) && now - updatedAt > staleInReviewLastRunMs) {
+      badges.push({ key: "stale-in-review", label: "Stale review", tone: "warning" });
+    }
+  }
+  if (linkedIssue?.status === "blocked" || linkedIssue?.status === "cancelled") {
+    badges.push({
+      key: `last-run-${linkedIssue.status}`,
+      label: `Last run ${linkedIssue.status}`,
+      tone: "danger",
+    });
+  }
+  return badges;
 }
 
 export function buildRoutineGroups(
@@ -195,8 +312,9 @@ export function sortRoutines(
   });
 }
 
-function buildRoutinesTabHref(tab: RoutinesTab) {
-  return tab === "runs" ? "/routines?tab=runs" : "/routines";
+function buildRoutinesTabHref(tab: RoutinesTab, statusFilter: RoutineStatusFilter = "active") {
+  if (tab === "runs") return "/routines?tab=runs";
+  return statusFilter === "active" ? "/routines" : `/routines?status=${statusFilter}`;
 }
 
 export function Routines() {
@@ -216,6 +334,7 @@ export function Routines() {
   const [composerOpen, setComposerOpen] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const activeTab: RoutinesTab = searchParams.get("tab") === "runs" ? "runs" : "routines";
+  const routineStatusFilter = getRoutineStatusFilter(searchParams);
   const [draft, setDraft] = useState<{
     title: string;
     description: string;
@@ -261,6 +380,11 @@ export function Routines() {
   const { data: projects } = useQuery({
     queryKey: queryKeys.projects.list(selectedCompanyId!),
     queryFn: () => projectsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+  const { data: goals } = useQuery({
+    queryKey: queryKeys.goals.list(selectedCompanyId!),
+    queryFn: () => goalsApi.list(selectedCompanyId!),
     enabled: !!selectedCompanyId,
   });
   const { data: companyMembers } = useQuery({
@@ -416,10 +540,26 @@ export function Routines() {
     () => new Map((projects ?? []).map((project) => [project.id, project])),
     [projects],
   );
+  const goalById = useMemo(
+    () => new Map((goals ?? []).map((goal) => [goal.id, goal] satisfies [string, Goal])),
+    [goals],
+  );
   const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
+  const routineStatusCounts = useMemo(
+    () => countRoutinesByStatus(routines ?? []),
+    [routines],
+  );
+  const duplicateTitleScheduleRoutineIds = useMemo(
+    () => findDuplicateTitleScheduleRoutineIds(routines ?? []),
+    [routines],
+  );
   const sortedRoutines = useMemo(
-    () => sortRoutines(routines ?? [], routineViewState.sortField, routineViewState.sortDir),
-    [routineViewState.sortDir, routineViewState.sortField, routines],
+    () => sortRoutines(
+      filterRoutinesByStatus(routines ?? [], routineStatusFilter),
+      routineViewState.sortField,
+      routineViewState.sortDir,
+    ),
+    [routineStatusFilter, routineViewState.sortDir, routineViewState.sortField, routines],
   );
   const routineGroups = useMemo(
     () => buildRoutineGroups(sortedRoutines, routineViewState.groupBy, projectById, agentById),
@@ -448,7 +588,7 @@ export function Routines() {
   function handleTabChange(tab: string) {
     const nextTab = tab === "runs" ? "runs" : "routines";
     startTransition(() => {
-      navigate(buildRoutinesTabHref(nextTab));
+      navigate(buildRoutinesTabHref(nextTab, routineStatusFilter));
     });
   }
 
@@ -514,14 +654,41 @@ export function Routines() {
           ]}
         />
         <TabsContent value="routines" className="space-y-4">
-          <div className="flex items-center justify-between gap-3">
-            <p className="text-sm text-muted-foreground">
-              {(routines ?? []).length} routine{(routines ?? []).length === 1 ? "" : "s"}
-            </p>
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-wrap items-center gap-2">
+              {routineStatusFilters.map((filter) => {
+                const count = routineStatusCounts[filter.value];
+                const selected = routineStatusFilter === filter.value;
+                return (
+                  <Button
+                    key={filter.value}
+                    variant={selected ? "secondary" : "ghost"}
+                    size="sm"
+                    className="h-8 gap-2 px-2.5 text-xs"
+                    aria-pressed={selected}
+                    onClick={() => {
+                      if (!selected) {
+                        startTransition(() => {
+                          navigate(buildRoutinesTabHref("routines", filter.value));
+                        });
+                      }
+                    }}
+                  >
+                    <span>{filter.label}</span>
+                    <span className="rounded-full bg-background/70 px-1.5 py-0.5 text-xs text-muted-foreground">
+                      {count}
+                    </span>
+                  </Button>
+                );
+              })}
+              <span className="text-sm text-muted-foreground">
+                {sortedRoutines.length} shown
+              </span>
+            </div>
             <div className="flex items-center gap-1">
               <Popover>
                 <PopoverTrigger asChild>
-                  <Button variant="ghost" size="sm" className="text-xs" title="Sort">
+                  <Button variant="ghost" size="sm" className="text-xs" title="Sort" aria-label="Sort routines">
                     <ArrowUpDown className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
                     <span className="hidden sm:inline">Sort</span>
                   </Button>
@@ -562,7 +729,7 @@ export function Routines() {
               </Popover>
               <Popover>
                 <PopoverTrigger asChild>
-                  <Button variant="ghost" size="sm" className="text-xs" title="Group">
+                  <Button variant="ghost" size="sm" className="text-xs" title="Group" aria-label="Group routines">
                     <Layers className="h-3.5 w-3.5 sm:h-3 sm:w-3 sm:mr-1" />
                     <span className="hidden sm:inline">Group</span>
                   </Button>
@@ -592,6 +759,11 @@ export function Routines() {
               </Popover>
             </div>
           </div>
+          {routineStatusFilter === "archived" ? (
+            <p className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+              Archived routines are retained so historical runs and linked issues stay auditable. Restore a routine to use it again; permanent purge is intentionally unavailable until Paperclip has a retention policy.
+            </p>
+          ) : null}
         </TabsContent>
         <TabsContent value="runs">
           <IssuesList
@@ -622,10 +794,10 @@ export function Routines() {
         >
           <div className="shrink-0 flex flex-wrap items-center justify-between gap-3 border-b border-border/60 px-5 py-3">
             <div>
-              <p className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">New routine</p>
-              <p className="text-sm text-muted-foreground">
+              <DialogTitle className="text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">New routine</DialogTitle>
+              <DialogDescription className="text-sm text-muted-foreground">
                 Define the recurring work first. Default project and agent are optional for draft routines.
-              </p>
+              </DialogDescription>
             </div>
             <Button
               variant="ghost"
@@ -873,11 +1045,15 @@ export function Routines() {
 
       {activeTab === "routines" ? (
         <div>
-          {(routines ?? []).length === 0 ? (
+          {sortedRoutines.length === 0 ? (
             <div className="py-12">
               <EmptyState
                 icon={Repeat}
-                message="No routines yet. Use Create routine to define the first recurring workflow."
+                message={
+                  (routines ?? []).length === 0
+                    ? "No routines yet. Use Create routine to define the first recurring workflow."
+                    : `No ${routineStatusFilter} routines. Use the filters above to inspect another state.`
+                }
               />
             </div>
           ) : (
@@ -913,7 +1089,9 @@ export function Routines() {
                         key={routine.id}
                         routine={routine}
                         projectById={projectById}
+                        goalById={goalById}
                         agentById={agentById}
+                        healthBadges={deriveRoutineHealthBadges(routine, duplicateTitleScheduleRoutineIds)}
                         runningRoutineId={runningRoutineId}
                         statusMutationRoutineId={statusMutationRoutineId}
                         href={`/routines/${routine.id}`}

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -312,8 +312,12 @@ export function sortRoutines(
   });
 }
 
-function buildRoutinesTabHref(tab: RoutinesTab, statusFilter: RoutineStatusFilter = "active") {
-  if (tab === "runs") return "/routines?tab=runs";
+export function buildRoutinesTabHref(tab: RoutinesTab, statusFilter: RoutineStatusFilter = "active") {
+  if (tab === "runs") {
+    const params = new URLSearchParams({ tab: "runs" });
+    if (statusFilter !== "active") params.set("status", statusFilter);
+    return `/routines?${params.toString()}`;
+  }
   return statusFilter === "active" ? "/routines" : `/routines?status=${statusFilter}`;
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the operational system for managing AI agents, their tasks, and recurring work.
> - The Routines surface is where operators inspect and maintain recurring automation.
> - Disabled and archived routines were mixed into the default list, making the page noisy and cleanup decisions harder.
> - Existing rows did not expose enough operational context to know who owns a routine, what it runs, when it last ran, or whether it is healthy.
> - Deleting routines also was not an intentional product path because historical runs and issues need retention semantics.
> - This pull request adds a cleanup-oriented routines list that defaults to active work, exposes paused and archived counts, and surfaces routine health signals.
> - The benefit is faster routine triage without deleting historical records or turning the page into a one-off admin script.

## Linked Issues or Issue Description

No public GitHub issue tracks this internal Paperclip operations request. Internal reference: [DAT-4412](/DAT/issues/DAT-4412).

## Problem or motivation

- Archived routines clutter the default Routines page.
- Routine labels and rows do not explain enough about ownership, trigger configuration, linked work, or health.
- `DELETE /api/routines/:id` currently returns 404, so the UI should not imply that deletion is supported without a deliberate retention policy.

## Proposed solution

- Hide archived routines from the default list.
- Add visible Active, Paused, and Archived filters with counts.
- Enrich routine rows with assignee, goal/project, trigger label, next run, last linked issue/status, and active issue.
- Add health badges for no triggers, disabled triggers, duplicate triggers, duplicate title/schedule, stale `in_review` last run, and cancelled/blocked last run.
- Explain archive retention instead of deleting historical run/issues.

## Alternatives considered

- Deleting disabled routines outright — rejected because historical runs and linked issues need retention semantics.
- Leaving the default list unfiltered — rejected because archived routines make routine triage noisy and slow.

## What Changed

- Added Active/Paused/Archived routine filters with counts and default active filtering.
- Enriched routine rows with operational metadata: goal/project, assignee, trigger summary, next run, last linked issue/status, and active issue.
- Added routine health badge derivation for trigger, duplicate, stale, cancelled, and blocked-run states.
- Added archived-retention copy instead of implementing unsafe deletion/purge behavior.
- Added focused tests for filtering, counts, duplicate schedule detection, and health-badge derivation.
- Rebased the PR onto current `master`, resolved routine-list merge conflicts, and kept the CTO-approved row hover/click affordance and status-filter preservation fixes.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/pages/Routines.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm build`
- PR branch was refreshed at commit `0d136e5da4e06a9e794554c1b3f054fcb5c84085`.
- Local trusted dev screenshots were captured for `/DAT/routines`, `/DAT/routines?status=archived`, and mobile; those screenshots are attached to internal issue [DAT-4412](/DAT/issues/DAT-4412).

## Risks

- Medium UI risk: operators may need to use filters to find archived routines that were previously visible by default.
- Low data risk: this PR does not delete routines, runs, or linked issues.
- Low performance risk: the duplicate scan is memoized; per-row health derivation is bounded for this operational list.
- Merge risk was addressed by rebasing onto current `master` and rerunning focused tests.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent with shell, GitHub, and Paperclip API tool use for implementation review and CTO coordination.
- Cursor cloud agent assisted with the final rebase/conflict-resolution pass on commit `0d136e5da4e06a9e794554c1b3f054fcb5c84085`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
