### PR TITLE
fix(recovery): skip handoff loop for stale_active_run_evaluation issues

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4027,6 +4027,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeUserId: issues.assigneeUserId,
         executionState: issues.executionState,
         projectId: issues.projectId,
+        originKind: issues.originKind,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))

--- a/server/src/services/recovery/origins.ts
+++ b/server/src/services/recovery/origins.ts
@@ -22,6 +22,10 @@ export function isStrandedIssueRecoveryOriginKind(originKind: string | null | un
   return originKind === RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 }
 
+export function isReviewOriginKind(originKind: string | null | undefined) {
+  return originKind === RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+}
+
 export function buildIssueGraphLivenessIncidentKey(input: {
   companyId: string;
   issueId: string;

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -292,6 +292,15 @@ describe("successful run handoff decision", () => {
     expect(noticeMetadataReferencesRecoveryAction(notice.metadata, "88888888-8888-4888-8888-888888888888")).toBe(false);
   });
 
+  it("does not queue for stale_active_run_evaluation review-origin issues", () => {
+    expect(
+      decide({ issue: { ...issue, originKind: "stale_active_run_evaluation" } }),
+    ).toEqual({
+      kind: "skip",
+      reason: "review-origin issue is disposed of by analysis alone",
+    });
+  });
+
   it("recognizes new notices and legacy markdown headings for fallback deduplication", () => {
     expect(isSuccessfulRunHandoffRequiredNoticeBody(SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY)).toBe(true);
     expect(isSuccessfulRunHandoffRequiredNoticeBody("## Successful run missing issue disposition\n\nold body")).toBe(true);

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -3,6 +3,7 @@ import type { Db } from "@paperclipai/db";
 import { agentWakeupRequests, agents, heartbeatRuns, issues } from "@paperclipai/db";
 import type { IssueCommentMetadata, IssueCommentPresentation, RunLivenessState } from "@paperclipai/shared";
 import { withRecoveryModelProfileHint } from "./model-profile-hint.js";
+import { isReviewOriginKind } from "./origins.js";
 
 export const FINISH_SUCCESSFUL_RUN_HANDOFF_REASON = "finish_successful_run_handoff";
 export const SUCCESSFUL_RUN_MISSING_STATE_REASON = "successful_run_missing_state";
@@ -45,7 +46,15 @@ export function isIdempotentFinishSuccessfulRunHandoffWakeStatus(status: string)
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
 type IssueRow = Pick<
   typeof issues.$inferSelect,
-  "id" | "companyId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId" | "executionState"
+  | "id"
+  | "companyId"
+  | "identifier"
+  | "title"
+  | "status"
+  | "assigneeAgentId"
+  | "assigneeUserId"
+  | "executionState"
+  | "originKind"
 >;
 type AgentRow = Pick<typeof agents.$inferSelect, "id" | "companyId" | "status">;
 type NoticeIssue = Pick<typeof issues.$inferSelect, "id" | "identifier" | "title" | "status">;
@@ -364,6 +373,9 @@ export function decideSuccessfulRunHandoff(input: {
   if (issue.assigneeUserId) return { kind: "skip", reason: "issue is human-owned" };
   if (issue.status !== "in_progress") return { kind: "skip", reason: `issue status ${issue.status} is a valid disposition` };
   if (issue.executionState) return { kind: "skip", reason: "issue has execution policy state" };
+  if (isReviewOriginKind(issue.originKind)) {
+    return { kind: "skip", reason: "review-origin issue is disposed of by analysis alone" };
+  }
   if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
     return { kind: "skip", reason: `agent status ${agent.status} is not invokable` };
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies and manages their issue lifecycle
> - The recovery subsystem's `finish_successful_run_handoff` path detects successful runs that leave issues without a clear next-step disposition
> - `stale_active_run_evaluation` issues are diagnostic review tasks — agents close them by posting analysis and marking `done`, with no code or state mutation required
> - The liveness heuristic (`isProductiveSuccessfulRun`) treats any run with a progress signal (e.g. `livenessReason` or a result summary) as needing explicit disposition evidence before skipping the corrective handoff
> - For review-origin issues this is wrong: the agent correctly marks `done`, but the handoff fires anyway because the evaluation window may see `in_progress` before the status write is committed, OR because the heuristic sees progress but not the disposition
> - The loop: agent marks done → harness queues handoff → checkout resets to `in_progress` → agent re-closes → repeat (observed 6+ times on CLI-362)
> - This PR adds `isReviewOriginKind()` and gates the handoff skip on `stale_active_run_evaluation` origins — the cleanest Option 1 fix from the issue spec

## Linked Issues or Issue Description

Refs #8146 — `finish_successful_run_handoff` wakes bypass terminal-status check, causing re-close loops for `stale_active_run_evaluation` issues.

When an agent closes a review-origin issue by posting analysis, the recovery subsystem's `finish_successful_run_handoff` path re-opens it, causing observed loops of 6+ checkout/re-close cycles. The fix adds `isReviewOriginKind()` to skip the handoff for issues already disposed of by analysis.
## What Changed

- `server/src/services/recovery/origins.ts` — add `isReviewOriginKind()` helper (parallel to `isStrandedIssueRecoveryOriginKind`)
- `server/src/services/recovery/successful-run-handoff.ts` — add `originKind` to `IssueRow` type; add skip check for review origins after the `executionState` check in `decideSuccessfulRunHandoff`
- `server/src/services/heartbeat.ts` — select `originKind: issues.originKind` in the `handleSuccessfulRunHandoff` issue query so the field is available at decision time
- `server/src/services/recovery/successful-run-handoff.test.ts` — add test asserting `stale_active_run_evaluation` issues skip with `"review-origin issue is disposed of by analysis alone"`

## Verification

```sh
pnpm test  # or: node <path-to-vitest> run server/src/services/recovery/successful-run-handoff.test.ts
```

All 15 tests pass including the new one. The new test directly exercises the skip path:

```
✓ does not queue for stale_active_run_evaluation review-origin issues
```

To verify end-to-end: create a `stale_active_run_evaluation` issue, have an agent post a comment and mark `done`, confirm no `finish_successful_run_handoff` wake is queued.

## Risks

- Low risk. The change only adds a new early-exit skip path; all existing skip paths and the enqueue path are unchanged.
- No database migration needed — `originKind` is an existing column read into a local variable, not written.
- The new `isReviewOriginKind` function currently covers only `stale_active_run_evaluation`; other review-like origins (`issue_productivity_review`, `harness_liveness_escalation`) are NOT included and will continue to go through the standard liveness check.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context: standard, no extended thinking
- Tool use: file read/write, bash, grep

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI changes)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge