### PR TITLE
fix: preserve Paperclip OpenClaw bridge patch stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,12 @@ COPY packages/adapters/openclaw-gateway/package.json packages/adapters/openclaw-
 COPY packages/adapters/opencode-local/package.json packages/adapters/opencode-local/
 COPY packages/adapters/pi-local/package.json packages/adapters/pi-local/
 COPY packages/plugins/sdk/package.json packages/plugins/sdk/
-COPY --parents packages/plugins/sandbox-providers/./*/package.json packages/plugins/sandbox-providers/
+# CapRover's Docker builder does not currently accept BuildKit's COPY --parents flag,
+# so keep these explicit for production compatibility.
+COPY packages/plugins/sandbox-providers/cloudflare/package.json packages/plugins/sandbox-providers/cloudflare/
+COPY packages/plugins/sandbox-providers/daytona/package.json packages/plugins/sandbox-providers/daytona/
+COPY packages/plugins/sandbox-providers/e2b/package.json packages/plugins/sandbox-providers/e2b/
+COPY packages/plugins/sandbox-providers/exe-dev/package.json packages/plugins/sandbox-providers/exe-dev/
 COPY packages/plugins/paperclip-plugin-fake-sandbox/package.json packages/plugins/paperclip-plugin-fake-sandbox/
 COPY packages/plugins/plugin-llm-wiki/package.json packages/plugins/plugin-llm-wiki/
 COPY patches/ patches/

--- a/packages/adapters/openclaw-gateway/CHANGELOG.md
+++ b/packages/adapters/openclaw-gateway/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paperclipai/adapter-openclaw-gateway
 
+## Unreleased
+
+### Patch Changes
+
+- Preserve OpenClaw gateway compatibility by sending Paperclip run context via `extraSystemPrompt`, supporting configurable claimed API key paths, and bumping the gateway protocol version to 4.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/adapters/openclaw-gateway/CHANGELOG.md
+++ b/packages/adapters/openclaw-gateway/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- Preserve OpenClaw gateway compatibility by sending Paperclip run context via `extraSystemPrompt`, supporting configurable claimed API key paths, and bumping the gateway protocol version to 4.
+- Preserve OpenClaw gateway compatibility by sending Paperclip run context via `extraSystemPrompt`, supporting configurable claimed API key paths, retaining the deprecated `claimedApiKeyPath` alias, and bumping the gateway protocol version to 4.
 
 ## 0.3.1
 

--- a/packages/adapters/openclaw-gateway/package.json
+++ b/packages/adapters/openclaw-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/adapter-openclaw-gateway",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",
   "bugs": {

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -36,7 +36,7 @@ Request behavior fields:
 - waitTimeoutMs (number, optional): agent.wait timeout override (default timeoutSec * 1000)
 - autoPairOnFirstConnect (boolean, optional): on first "pairing required", attempt device.pair.list/device.pair.approve via shared auth, then retry once (default true)
 - paperclipApiUrl (string, optional): absolute Paperclip base URL advertised in wake text
-- claimedApiKeyPath (string, optional): path to the claimed API key JSON file read by the agent at wake time (default ~/.openclaw/workspace/paperclip-claimed-api-key.json)
+- paperclipApiKeyPath (string, optional): path to the claimed API key JSON file read by the agent at wake time (default ~/.openclaw/workspace/paperclip-claimed-api-key.json)
 
 Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -37,6 +37,7 @@ Request behavior fields:
 - autoPairOnFirstConnect (boolean, optional): on first "pairing required", attempt device.pair.list/device.pair.approve via shared auth, then retry once (default true)
 - paperclipApiUrl (string, optional): absolute Paperclip base URL advertised in wake text
 - paperclipApiKeyPath (string, optional): path to the claimed API key JSON file read by the agent at wake time (default ~/.openclaw/workspace/paperclip-claimed-api-key.json)
+- claimedApiKeyPath (string, optional, deprecated): backward-compatible alias for paperclipApiKeyPath; paperclipApiKeyPath wins when both are set
 
 Session routing fields:
 - sessionKeyStrategy (string, optional): issue (default), fixed, or run

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -43,10 +43,7 @@ Session routing fields:
 - sessionKey (string, optional): fixed session key when strategy=fixed (default paperclip)
 
 Standard outbound payload additions:
-- paperclip (object): standardized Paperclip context added to every gateway agent request
-- paperclip.workspace (object, optional): resolved execution workspace for this run
-- paperclip.workspaces (array, optional): additional workspace hints Paperclip exposed to the run
-- paperclip.workspaceRuntime (object, optional): reserved workspace runtime metadata when explicitly supplied outside normal heartbeat execution
+- extraSystemPrompt (string): standardized Paperclip context (runId, agentId, taskId/issueId, wakeReason, workspace, workspaces, workspaceRuntime, wake, etc.) is serialized as a fenced JSON block and appended to extraSystemPrompt. The structured context lives here because OpenClaw's AgentParamsSchema is strict (additionalProperties: false) and rejects unknown root fields. A user-supplied payloadTemplate.extraSystemPrompt is preserved and the Paperclip context block is appended to it.
 
 Standard result metadata supported:
 - meta.runtimeServices (array, optional): normalized adapter-managed runtime service reports

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -86,7 +86,7 @@ type GatewayClientRequestOptions = {
   expectFinal?: boolean;
 };
 
-const PROTOCOL_VERSION = 3;
+const PROTOCOL_VERSION = 4;
 const DEFAULT_SCOPES = ["operator.admin"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -522,6 +522,11 @@ function buildStandardPaperclipPayload(
   };
 }
 
+function renderPaperclipContextBlock(paperclipPayload: Record<string, unknown>): string {
+  const json = JSON.stringify(paperclipPayload);
+  return ["Paperclip context (structured run metadata):", "```json", json, "```"].join("\n");
+}
+
 function normalizeUrl(input: string): URL | null {
   try {
     return new URL(input);
@@ -1132,14 +1137,25 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const message = templateMessage ? appendWakeText(templateMessage, wakeText) : wakeText;
   const paperclipPayload = buildStandardPaperclipPayload(ctx, wakePayload, paperclipEnv, payloadTemplate);
 
+  // OpenClaw gateway's AgentParamsSchema is strict (additionalProperties: false)
+  // and rejects unknown root fields, so we cannot pass `paperclip` at the root.
+  // Instead we serialize the structured context into `extraSystemPrompt`, which
+  // the gateway accepts and propagates to the receiving agent. See issue #5704.
+  const paperclipContextBlock = renderPaperclipContextBlock(paperclipPayload);
+  const templateExtraSystemPrompt = nonEmpty(payloadTemplate.extraSystemPrompt);
+  const extraSystemPrompt = templateExtraSystemPrompt
+    ? `${templateExtraSystemPrompt}\n\n${paperclipContextBlock}`
+    : paperclipContextBlock;
+
   const agentParams: Record<string, unknown> = {
     ...payloadTemplate,
     message,
     sessionKey,
     idempotencyKey: ctx.runId,
+    extraSystemPrompt,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  delete agentParams.paperclip;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -365,8 +365,9 @@ function buildWakeText(
   payload: WakePayload,
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
+  apiKeyPathOverride?: string | null,
 ): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+  const claimedApiKeyPath = apiKeyPathOverride ?? "~/.openclaw/workspace/paperclip-claimed-api-key.json";
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -1121,6 +1122,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     structuredWakeJson
       ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
       : structuredWakePrompt,
+    nonEmpty(ctx.config.paperclipApiKeyPath),
   );
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -1122,7 +1122,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     structuredWakeJson
       ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
       : structuredWakePrompt,
-    nonEmpty(ctx.config.paperclipApiKeyPath),
+    nonEmpty(ctx.config.paperclipApiKeyPath) ?? nonEmpty(ctx.config.claimedApiKeyPath),
   );
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paperclipai/server
 
+## Unreleased
+
+### Patch Changes
+
+- Preserve external adapter capabilities and schema-backed fields for non-local custom bridge adapters.
+
 ## 0.3.1
 
 ### Patch Changes

--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Patch Changes
 
 - Preserve external adapter capabilities and schema-backed fields for non-local custom bridge adapters.
+- Keep the production Dockerfile compatible with CapRover's current Docker builder by avoiding BuildKit-only `COPY --parents` syntax.
 
 ## 0.3.1
 

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -546,6 +546,44 @@ describe("resolveExternalAdapterRegistration", () => {
 
     const resolved = resolveExternalAdapterRegistration(adapter);
 
+    expect(resolved).toBe(adapter);
     expect(resolved.sessionManagement).toBeUndefined();
+  });
+
+  it("preserves prototype adapter capabilities when adding fallback sessionManagement", () => {
+    class ExternalClaudeAdapter implements ServerAdapterModule {
+      type = "claude_local";
+
+      async execute() {
+        return { exitCode: 0, signal: null, timedOut: false };
+      }
+
+      async testEnvironment() {
+        return {
+          adapterType: "claude_local",
+          status: "pass" as const,
+          checks: [],
+          testedAt: new Date(0).toISOString(),
+        };
+      }
+
+      getConfigSchema() {
+        return {
+          version: 1,
+          fields: [{ key: "url", type: "text" as const, label: "URL" }],
+        };
+      }
+    }
+
+    const adapter = new ExternalClaudeAdapter();
+    const resolved = resolveExternalAdapterRegistration(adapter);
+
+    expect(resolved).not.toBe(adapter);
+    expect(resolved).toBeInstanceOf(ExternalClaudeAdapter);
+    expect(resolved.sessionManagement).toBeDefined();
+    expect(typeof resolved.getConfigSchema).toBe("function");
+    expect(resolved.getConfigSchema?.()).toMatchObject({
+      fields: [{ key: "url" }],
+    });
   });
 });

--- a/server/src/__tests__/adapter-routes.test.ts
+++ b/server/src/__tests__/adapter-routes.test.ts
@@ -330,4 +330,45 @@ describe("adapter routes", () => {
 
     unregisterServerAdapter(HOT_INSTALL_TYPE);
   });
+
+  it("preserves prototype getConfigSchema when reloading an external builtin override", async () => {
+    class PrototypeSchemaAdapter implements ServerAdapterModule {
+      type = "claude_local";
+
+      async execute() {
+        return { exitCode: 0, signal: null, timedOut: false };
+      }
+
+      async testEnvironment() {
+        return {
+          adapterType: "claude_local",
+          status: "pass" as const,
+          checks: [],
+          testedAt: new Date(0).toISOString(),
+        };
+      }
+
+      getConfigSchema() {
+        return {
+          version: 1,
+          fields: [{ key: "url", type: "text" as const, label: "URL" }],
+        };
+      }
+    }
+
+    mockAdapterPluginStore.getAdapterPluginByType.mockReturnValue({
+      packageName: "prototype-schema-adapter",
+      type: "claude_local",
+      installedAt: new Date(0).toISOString(),
+    });
+    mockPluginLoader.reloadExternalAdapter.mockResolvedValue(new PrototypeSchemaAdapter());
+
+    const app = createApp({ isInstanceAdmin: true });
+    const reload = await request(app).post("/api/adapters/claude_local/reload");
+    expect(reload.status, JSON.stringify(reload.body)).toBe(200);
+
+    const schema = await request(app).get("/api/adapters/claude_local/config-schema");
+    expect(schema.status, JSON.stringify(schema.body)).toBe(200);
+    expect(schema.body).toMatchObject({ fields: [{ key: "url" }] });
+  });
 });

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -18,7 +18,7 @@ import { startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.t
 
 function parsePaperclipContext(payload: Record<string, unknown> | undefined): Record<string, unknown> {
   const extra = String(payload?.extraSystemPrompt ?? "");
-  const match = extra.match(/```json\n([\s\S]*?)\n```/);
+  const match = extra.match(/Paperclip context \(structured run metadata\):\n```json\n([\s\S]*?)\n```/);
   if (!match) {
     throw new Error("Paperclip context JSON block not found in extraSystemPrompt");
   }

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -16,6 +16,15 @@ import { heartbeatService } from "../services/heartbeat.ts";
 import { SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY } from "../services/recovery/index.ts";
 import { startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.ts";
 
+function parsePaperclipContext(payload: Record<string, unknown> | undefined): Record<string, unknown> {
+  const extra = String(payload?.extraSystemPrompt ?? "");
+  const match = extra.match(/```json\n([\s\S]*?)\n```/);
+  if (!match) {
+    throw new Error("Paperclip context JSON block not found in extraSystemPrompt");
+  }
+  return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
 async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 10_000, intervalMs = 50) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
@@ -448,7 +457,7 @@ describe("heartbeat comment wake batching", () => {
       }, 90_000);
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
+      expect(parsePaperclipContext(secondPayload)).toMatchObject({
         wake: {
           commentIds: [comment2.id, comment3.id],
           latestCommentId: comment3.id,
@@ -587,7 +596,7 @@ describe("heartbeat comment wake batching", () => {
 
       await waitFor(() => gateway.getAgentPayloads().length === 2);
       const promotedPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(promotedPayload.paperclip).toMatchObject({
+      expect(parsePaperclipContext(promotedPayload)).toMatchObject({
         wake: {
           commentIds: [queuedComment.id],
           latestCommentId: queuedComment.id,
@@ -790,7 +799,7 @@ describe("heartbeat comment wake batching", () => {
       });
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
+      expect(parsePaperclipContext(secondPayload)).toMatchObject({
         wake: {
           reason: "issue_commented",
           commentIds: [comment2.id],
@@ -990,7 +999,7 @@ describe("heartbeat comment wake batching", () => {
       expect(issueAfterPromotion?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
-      expect(secondPayload.paperclip).toMatchObject({
+      expect(parsePaperclipContext(secondPayload)).toMatchObject({
         wake: {
           reason: "issue_comment_mentioned",
           commentIds: [comment.id],
@@ -1076,7 +1085,7 @@ describe("heartbeat comment wake batching", () => {
       expect(firstRun).not.toBeNull();
       await waitFor(() => gateway.getAgentPayloads().length === 1);
       const firstPayload = gateway.getAgentPayloads()[0] ?? {};
-      expect(firstPayload.paperclip).toMatchObject({
+      expect(parsePaperclipContext(firstPayload)).toMatchObject({
         wake: {
           reason: "issue_assigned",
           issue: {

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -410,6 +410,7 @@ describe("openclaw gateway adapter execute", () => {
             },
             payloadTemplate: {
               message: "wake now",
+              extraSystemPrompt: "Operator-provided system prompt prefix.",
             },
             waitTimeoutMs: 2000,
           },
@@ -502,12 +503,28 @@ describe("openclaw gateway adapter execute", () => {
       );
       expect(String(payload?.message ?? "")).toContain("First comment");
       expect(String(payload?.message ?? "")).toContain("\"commentIds\":[\"comment-1\",\"comment-2\"]");
-      expect(payload?.paperclip).toMatchObject({
-        wake: {
-          latestCommentId: "comment-2",
-          commentIds: ["comment-1", "comment-2"],
-        },
-      });
+
+      // OpenClaw gateway's AgentParamsSchema is strict (additionalProperties: false)
+      // and rejects unknown root fields like `paperclip`. The structured paperclip
+      // context must travel via `extraSystemPrompt` instead. See issue #5704.
+      expect(payload?.paperclip).toBeUndefined();
+      const extraSystemPrompt = String(payload?.extraSystemPrompt ?? "");
+      // Operator-supplied payloadTemplate.extraSystemPrompt is preserved and
+      // appears before the appended Paperclip context block.
+      expect(extraSystemPrompt).toMatch(
+        /^Operator-provided system prompt prefix\.[\s\S]*Paperclip context/,
+      );
+      expect(extraSystemPrompt).toContain("Paperclip context");
+      expect(extraSystemPrompt).toContain("\"runId\":\"run-123\"");
+      expect(extraSystemPrompt).toContain("\"agentId\":\"agent-123\"");
+      expect(extraSystemPrompt).toContain("\"companyId\":\"company-123\"");
+      expect(extraSystemPrompt).toContain("\"taskId\":\"task-123\"");
+      expect(extraSystemPrompt).toContain("\"issueId\":\"issue-123\"");
+      expect(extraSystemPrompt).toContain("\"latestCommentId\":\"comment-2\"");
+      expect(extraSystemPrompt).toContain("\"cwd\":\"/tmp/worktrees/pap-123\"");
+      expect(extraSystemPrompt).toContain("\"strategy\":\"git_worktree\"");
+      expect(extraSystemPrompt).toContain("\"id\":\"workspace-1\"");
+      expect(extraSystemPrompt).toContain("\"services\"");
 
       expect(logs.some((entry) => entry.includes("[openclaw-gateway:event] run=run-123 stream=assistant"))).toBe(true);
     } finally {

--- a/server/src/__tests__/openclaw-gateway-adapter.test.ts
+++ b/server/src/__tests__/openclaw-gateway-adapter.test.ts
@@ -412,6 +412,7 @@ describe("openclaw gateway adapter execute", () => {
               message: "wake now",
               extraSystemPrompt: "Operator-provided system prompt prefix.",
             },
+            claimedApiKeyPath: "/custom/claimed-api-key.json",
             waitTimeoutMs: 2000,
           },
           {
@@ -494,6 +495,7 @@ describe("openclaw gateway adapter execute", () => {
       expect(String(payload?.message ?? "")).toContain("wake now");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_RUN_ID=run-123");
       expect(String(payload?.message ?? "")).toContain("PAPERCLIP_TASK_ID=task-123");
+      expect(String(payload?.message ?? "")).toContain("PAPERCLIP_API_KEY=<token from /custom/claimed-api-key.json>");
       expect(String(payload?.message ?? "")).toContain("## Paperclip Wake Payload");
       expect(String(payload?.message ?? "")).toContain(
         "Treat this wake payload as the highest-priority change for the current heartbeat.",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -531,13 +531,30 @@ function getDisabledAdapterTypesFromStore(): string[] {
 export function resolveExternalAdapterRegistration(
   externalAdapter: ServerAdapterModule,
 ): ServerAdapterModule {
-  return {
-    ...externalAdapter,
-    sessionManagement:
-      externalAdapter.sessionManagement
-        ?? getAdapterSessionManagement(externalAdapter.type)
-        ?? undefined,
+  const registrySessionManagement =
+    getAdapterSessionManagement(externalAdapter.type) ?? undefined;
+  const resolvedSessionManagement =
+    externalAdapter.sessionManagement ?? registrySessionManagement;
+
+  // Preserve the adapter object's full shape while applying the host-provided
+  // session-management fallback. A plain object spread drops prototype methods
+  // and non-enumerable properties, which can make externally supplied adapter
+  // capabilities (for example getConfigSchema()) disappear from the registry.
+  if (resolvedSessionManagement === externalAdapter.sessionManagement) {
+    return externalAdapter;
+  }
+
+  const descriptors = Object.getOwnPropertyDescriptors(externalAdapter);
+  descriptors.sessionManagement = {
+    value: resolvedSessionManagement,
+    enumerable: true,
+    configurable: true,
+    writable: true,
   };
+
+  const resolved = Object.create(Object.getPrototypeOf(externalAdapter)) as ServerAdapterModule;
+  Object.defineProperties(resolved, descriptors);
+  return resolved;
 }
 
 /**

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -90,6 +90,13 @@ export function OpenClawGatewayConfigFields({
     mark("adapterConfig", "headers", Object.keys(nextHeaders).length > 0 ? nextHeaders : undefined);
   };
 
+  const configuredApiKeyPath =
+    typeof config.paperclipApiKeyPath === "string"
+      ? config.paperclipApiKeyPath
+      : typeof config.claimedApiKeyPath === "string"
+        ? config.claimedApiKeyPath
+        : "";
+
   const sessionStrategy = eff(
     "adapterConfig",
     "sessionKeyStrategy",
@@ -150,10 +157,15 @@ export function OpenClawGatewayConfigFields({
             />
           </Field>
 
-          <Field label="Claimed API key path">
+          <Field label="Paperclip API key path">
             <DraftInput
-              value={eff("adapterConfig", "claimedApiKeyPath", String(config.claimedApiKeyPath ?? ""))}
-              onCommit={(v) => mark("adapterConfig", "claimedApiKeyPath", v || undefined)}
+              value={eff("adapterConfig", "paperclipApiKeyPath", configuredApiKeyPath)}
+              onCommit={(v) => {
+                mark("adapterConfig", "paperclipApiKeyPath", v || undefined);
+                if (config.claimedApiKeyPath !== undefined) {
+                  mark("adapterConfig", "claimedApiKeyPath", undefined);
+                }
+              }}
               immediate
               className={inputClass}
               placeholder="~/.openclaw/workspace/paperclip-claimed-api-key.json"

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -932,7 +932,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             </Field>
           )}
 
-          {/* Adapter-specific fields are rendered inside Permissions & Configuration */}
+          {/*
+            Local adapters render their adapter-specific fields in the
+            Permissions & Configuration section below. Non-local external
+            adapters, such as OpenClaw Bridge, do not get that section, so
+            render their schema-backed fields here instead.
+          */}
+          {!isLocal && <uiAdapter.ConfigFields {...adapterFieldProps} />}
         </div>
 
       </div>


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - This change is in the adapter/agent bridge layer, specifically OpenClaw Gateway and external adapter registration.
> - The production Paperclip instance depends on two bridge patches: OpenClaw Gateway must speak the current gateway protocol without rejected root fields, and custom/external adapters must keep their capabilities/config schema visible.
> - Upstream `master` moved ahead of the deployed custom image, so the production patch stack needed to be rebased rather than replaced with `ghcr.io:latest`.
> - This pull request preserves those bridge fixes on current `master`, keeps the config migration backward-compatible, and keeps the Dockerfile deployable on the current CapRover builder.
> - The benefit is that Paperclip can be updated without breaking OpenClaw wake runs or custom bridge adapter configuration.

## What Changed

- Preserved external adapter capabilities/config schema when Paperclip injects fallback session management into external adapters.
- Rendered schema-backed config fields for non-local adapters, including OpenClaw Gateway/custom bridge adapters.
- Moved structured Paperclip wake context into `extraSystemPrompt` instead of an unknown root `paperclip` field, keeping compatibility with OpenClaw Gateway's strict params schema.
- Bumped the OpenClaw Gateway adapter protocol version to `4`.
- Added configurable `paperclipApiKeyPath` support while retaining deprecated `claimedApiKeyPath` as a backward-compatible alias.
- Kept the production Dockerfile compatible with CapRover's current Docker builder by avoiding BuildKit-only `COPY --parents` syntax.
- Updated relevant changelogs.

## Verification

- `pnpm run preflight:workspace-links`
- `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run server/src/__tests__/openclaw-gateway-adapter.test.ts server/src/__tests__/adapter-registry.test.ts server/src/__tests__/adapter-routes.test.ts`
- `pnpm --filter @paperclipai/ui build`
- `pnpm --filter @paperclipai/plugin-sdk build`
- `pnpm --filter @paperclipai/server build`

UI note: this PR affects the adapter config form by exposing existing schema-backed fields for non-local adapters. I did not attach production screenshots because the live OpenClaw Gateway config contains tokens/device material; local verification is covered by the UI build and adapter route/config-schema tests.

## Risks

- Low/medium migration risk: the config field rename is now backward-compatible (`paperclipApiKeyPath ?? claimedApiKeyPath`), so existing custom paths keep working while new configs can use the clearer field name.
- Low UI risk: non-local adapters may now show config fields that were previously hidden; this is intended for custom bridge adapters.
- Low deployment risk: Dockerfile change only replaces unsupported `COPY --parents` with explicit equivalent copies for the current sandbox provider package manifests.

## Model Used

- OpenAI Codex via OpenClaw, model `openai-codex/gpt-5.5`, high-thinking/tool-use session for code inspection, tests, GitHub, and CapRover API deployment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
