### PR TITLE
Fix root-level SKILL.md file inventory across all import paths (#2037)

### DIFF
--- a/server/src/__tests__/company-skills.test.ts
+++ b/server/src/__tests__/company-skills.test.ts
@@ -255,10 +255,13 @@ describe("local directory skill imports", () => {
     const rootPaths = new Set(rootSkill.fileInventory.map((e) => e.path));
     expect(rootPaths).toContain("SKILL.md");
     expect(rootPaths).toContain("references/root-ref.md");
+    expect(rootPaths).not.toContain("sub-skill/SKILL.md");
+    expect(rootPaths).not.toContain("sub-skill/scripts/sub.sh");
 
     const subPaths = new Set(subSkill.fileInventory.map((e) => e.path));
     expect(subPaths).toContain("SKILL.md");
     expect(subPaths).toContain("scripts/sub.sh");
+    expect(subPaths).not.toContain("references/root-ref.md");
   });
 });
 

--- a/server/src/__tests__/company-skills.test.ts
+++ b/server/src/__tests__/company-skills.test.ts
@@ -7,6 +7,7 @@ import {
   findMissingLocalSkillIds,
   normalizeGitHubSkillDirectory,
   parseSkillImportSourceInput,
+  readInlineSkillImports,
   readLocalSkillImportFromDirectory,
   readLocalSkillImports,
 } from "../services/company-skills.js";
@@ -258,6 +259,61 @@ describe("local directory skill imports", () => {
     const subPaths = new Set(subSkill.fileInventory.map((e) => e.path));
     expect(subPaths).toContain("SKILL.md");
     expect(subPaths).toContain("scripts/sub.sh");
+  });
+});
+
+describe("inline skill imports (covers GitHub/skills.sh inventory pattern)", () => {
+  const COMPANY_ID = "55555555-5555-5555-5555-555555555555";
+
+  it("includes all files for root-level SKILL.md in inline imports", () => {
+    const files: Record<string, string> = {
+      "SKILL.md": "---\nname: inline-skill\n---\n\n# Inline Skill\n",
+      "scripts/deploy.sh": "echo deploy\n",
+      "references/checklist.md": "# Checklist\n",
+      "assets/logo.png": "fake-png",
+    };
+
+    const imported = readInlineSkillImports(COMPANY_ID, files);
+
+    expect(imported).toHaveLength(1);
+    const paths = new Set(imported[0]!.fileInventory.map((e) => e.path));
+    expect(paths).toContain("SKILL.md");
+    expect(paths).toContain("scripts/deploy.sh");
+    expect(paths).toContain("references/checklist.md");
+    expect(paths).toContain("assets/logo.png");
+  });
+
+  it("classifies kinds correctly for root-level inline imports", () => {
+    const files: Record<string, string> = {
+      "SKILL.md": "---\nname: typed-inline\n---\n\n# Typed\n",
+      "scripts/run.sh": "echo ok\n",
+      "references/notes.md": "# Notes\n",
+      "assets/icon.svg": "<svg/>",
+    };
+
+    const imported = readInlineSkillImports(COMPANY_ID, files);
+
+    const byPath = new Map(imported[0]!.fileInventory.map((e) => [e.path, e.kind]));
+    expect(byPath.get("SKILL.md")).toBe("skill");
+    expect(byPath.get("scripts/run.sh")).toBe("script");
+    expect(byPath.get("references/notes.md")).toBe("reference");
+    expect(byPath.get("assets/icon.svg")).toBe("asset");
+  });
+
+  it("scopes files correctly for nested SKILL.md in inline imports", () => {
+    const files: Record<string, string> = {
+      "my-skill/SKILL.md": "---\nname: nested-skill\n---\n\n# Nested\n",
+      "my-skill/references/guide.md": "# Guide\n",
+      "other-file.txt": "unrelated\n",
+    };
+
+    const imported = readInlineSkillImports(COMPANY_ID, files);
+
+    expect(imported).toHaveLength(1);
+    const paths = new Set(imported[0]!.fileInventory.map((e) => e.path));
+    expect(paths).toContain("SKILL.md");
+    expect(paths).toContain("references/guide.md");
+    expect(paths).not.toContain("other-file.txt");
   });
 });
 

--- a/server/src/__tests__/company-skills.test.ts
+++ b/server/src/__tests__/company-skills.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeGitHubSkillDirectory,
   parseSkillImportSourceInput,
   readLocalSkillImportFromDirectory,
+  readLocalSkillImports,
 } from "../services/company-skills.js";
 
 const cleanupDirs = new Set<string>();
@@ -184,6 +185,79 @@ describe("project workspace skill discovery", () => {
         },
       ],
     });
+  });
+});
+
+describe("local directory skill imports", () => {
+  it("includes scripts and references in inventory for root-level SKILL.md", async () => {
+    const skillDir = await makeTempDir("paperclip-local-import-root-");
+    await writeSkillDir(skillDir, "My Local Skill");
+    await fs.mkdir(path.join(skillDir, "scripts"), { recursive: true });
+    await fs.mkdir(path.join(skillDir, "references"), { recursive: true });
+    await fs.writeFile(path.join(skillDir, "scripts", "setup.sh"), "#!/bin/sh\necho ok\n", "utf8");
+    await fs.writeFile(path.join(skillDir, "references", "guide.md"), "# Guide\n", "utf8");
+
+    const imported = await readLocalSkillImports(
+      "44444444-4444-4444-4444-444444444444",
+      skillDir,
+    );
+
+    expect(imported).toHaveLength(1);
+    const paths = new Set(imported[0]!.fileInventory.map((entry) => entry.path));
+    expect(paths).toContain("SKILL.md");
+    expect(paths).toContain("scripts/setup.sh");
+    expect(paths).toContain("references/guide.md");
+  });
+
+  it("classifies inventory kinds correctly for root-level imports", async () => {
+    const skillDir = await makeTempDir("paperclip-local-import-kinds-");
+    await writeSkillDir(skillDir, "Typed Skill");
+    await fs.mkdir(path.join(skillDir, "scripts"), { recursive: true });
+    await fs.mkdir(path.join(skillDir, "references"), { recursive: true });
+    await fs.mkdir(path.join(skillDir, "assets"), { recursive: true });
+    await fs.writeFile(path.join(skillDir, "scripts", "run.sh"), "echo hi\n", "utf8");
+    await fs.writeFile(path.join(skillDir, "references", "notes.md"), "# Notes\n", "utf8");
+    await fs.writeFile(path.join(skillDir, "assets", "icon.png"), "fake-png", "utf8");
+
+    const imported = await readLocalSkillImports(
+      "44444444-4444-4444-4444-444444444444",
+      skillDir,
+    );
+
+    const byPath = new Map(imported[0]!.fileInventory.map((e) => [e.path, e.kind]));
+    expect(byPath.get("SKILL.md")).toBe("skill");
+    expect(byPath.get("scripts/run.sh")).toBe("script");
+    expect(byPath.get("references/notes.md")).toBe("reference");
+    expect(byPath.get("assets/icon.png")).toBe("asset");
+  });
+
+  it("handles nested skills alongside a root SKILL.md", async () => {
+    const root = await makeTempDir("paperclip-local-import-nested-");
+    await writeSkillDir(root, "Root Skill");
+    await fs.mkdir(path.join(root, "references"), { recursive: true });
+    await fs.writeFile(path.join(root, "references", "root-ref.md"), "# Root Ref\n", "utf8");
+    await writeSkillDir(path.join(root, "sub-skill"), "Sub Skill");
+    await fs.mkdir(path.join(root, "sub-skill", "scripts"), { recursive: true });
+    await fs.writeFile(path.join(root, "sub-skill", "scripts", "sub.sh"), "echo sub\n", "utf8");
+
+    const imported = await readLocalSkillImports(
+      "44444444-4444-4444-4444-444444444444",
+      root,
+    );
+
+    expect(imported.length).toBeGreaterThanOrEqual(2);
+    const rootSkill = imported.find((s) => s.name === "Root Skill")!;
+    const subSkill = imported.find((s) => s.name === "Sub Skill")!;
+    expect(rootSkill).toBeDefined();
+    expect(subSkill).toBeDefined();
+
+    const rootPaths = new Set(rootSkill.fileInventory.map((e) => e.path));
+    expect(rootPaths).toContain("SKILL.md");
+    expect(rootPaths).toContain("references/root-ref.md");
+
+    const subPaths = new Set(subSkill.fileInventory.map((e) => e.path));
+    expect(subPaths).toContain("SKILL.md");
+    expect(subPaths).toContain("scripts/sub.sh");
   });
 });
 

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -796,7 +796,7 @@ function deriveImportedSkillSource(
   };
 }
 
-function readInlineSkillImports(companyId: string, files: Record<string, string>): ImportedSkill[] {
+export function readInlineSkillImports(companyId: string, files: Record<string, string>): ImportedSkill[] {
   const normalizedFiles = normalizePackageFileMap(files);
   const skillPaths = Object.keys(normalizedFiles).filter(
     (entry) => path.posix.basename(entry).toLowerCase() === "skill.md",
@@ -812,9 +812,9 @@ function readInlineSkillImports(companyId: string, files: Record<string, string>
     const slug = deriveImportedSkillSlug(parsed.frontmatter, slugFallback);
     const source = deriveImportedSkillSource(parsed.frontmatter, slug);
     const inventory = Object.keys(normalizedFiles)
-      .filter((entry) => entry === skillPath || (skillDir ? entry.startsWith(`${skillDir}/`) : false))
+      .filter((entry) => entry === skillPath || (!skillDir || entry.startsWith(`${skillDir}/`)))
       .map((entry) => {
-        const relative = entry === skillPath ? "SKILL.md" : entry.slice(skillDir.length + 1);
+        const relative = entry === skillPath ? "SKILL.md" : (skillDir ? entry.slice(skillDir.length + 1) : entry);
         return {
           path: normalizePortablePath(relative),
           kind: classifyInventoryKind(relative),
@@ -1119,12 +1119,16 @@ async function readUrlSkillImports(
           slug,
         ),
       };
+      const isRootSkill = skillDir === ".";
       const inventory = filteredPaths
-        .filter((entry) => entry === relativeSkillPath || entry.startsWith(`${skillDir}/`))
-        .map((entry) => ({
-          path: entry === relativeSkillPath ? "SKILL.md" : entry.slice(skillDir.length + 1),
-          kind: classifyInventoryKind(entry === relativeSkillPath ? "SKILL.md" : entry.slice(skillDir.length + 1)),
-        }))
+        .filter((entry) => entry === relativeSkillPath || (isRootSkill ? true : entry.startsWith(`${skillDir}/`)))
+        .map((entry) => {
+          const relative = entry === relativeSkillPath ? "SKILL.md" : (isRootSkill ? entry : entry.slice(skillDir.length + 1));
+          return {
+            path: relative,
+            kind: classifyInventoryKind(relative),
+          };
+        })
         .sort((left, right) => left.path.localeCompare(right.path));
       skills.push({
         key: deriveCanonicalSkillKey(companyId, {

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -973,7 +973,7 @@ export async function discoverProjectWorkspaceSkillDirectories(target: ProjectSk
     .sort((left, right) => left.skillDir.localeCompare(right.skillDir));
 }
 
-async function readLocalSkillImports(companyId: string, sourcePath: string): Promise<ImportedSkill[]> {
+export async function readLocalSkillImports(companyId: string, sourcePath: string): Promise<ImportedSkill[]> {
   const resolvedPath = path.resolve(sourcePath);
   const stat = await fs.stat(resolvedPath).catch(() => null);
   if (!stat) {
@@ -1027,10 +1027,11 @@ async function readLocalSkillImports(companyId: string, sourcePath: string): Pro
   const imports: ImportedSkill[] = [];
   for (const skillPath of skillPaths) {
     const skillDir = path.posix.dirname(skillPath);
+    const isRootSkill = skillDir === ".";
     const inventory = allFiles
-      .filter((entry) => entry === skillPath || entry.startsWith(`${skillDir}/`))
+      .filter((entry) => entry === skillPath || (isRootSkill ? true : entry.startsWith(`${skillDir}/`)))
       .map((entry) => {
-        const relative = entry === skillPath ? "SKILL.md" : entry.slice(skillDir.length + 1);
+        const relative = entry === skillPath ? "SKILL.md" : (isRootSkill ? entry : entry.slice(skillDir.length + 1));
         return {
           path: normalizePortablePath(relative),
           kind: classifyInventoryKind(relative),

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -801,6 +801,7 @@ export function readInlineSkillImports(companyId: string, files: Record<string, 
   const skillPaths = Object.keys(normalizedFiles).filter(
     (entry) => path.posix.basename(entry).toLowerCase() === "skill.md",
   );
+  const siblingSkillDirs = skillPaths.map((p) => path.posix.dirname(p)).filter((d) => d !== ".");
   const imports: ImportedSkill[] = [];
 
   for (const skillPath of skillPaths) {
@@ -812,7 +813,7 @@ export function readInlineSkillImports(companyId: string, files: Record<string, 
     const slug = deriveImportedSkillSlug(parsed.frontmatter, slugFallback);
     const source = deriveImportedSkillSource(parsed.frontmatter, slug);
     const inventory = Object.keys(normalizedFiles)
-      .filter((entry) => entry === skillPath || (!skillDir || entry.startsWith(`${skillDir}/`)))
+      .filter((entry) => entry === skillPath || (!skillDir ? !siblingSkillDirs.some((d) => entry.startsWith(`${d}/`) || entry === `${d}/SKILL.md`) : entry.startsWith(`${skillDir}/`)))
       .map((entry) => {
         const relative = entry === skillPath ? "SKILL.md" : (skillDir ? entry.slice(skillDir.length + 1) : entry);
         return {
@@ -1024,12 +1025,13 @@ export async function readLocalSkillImports(companyId: string, sourcePath: strin
     throw unprocessable("No SKILL.md files were found in the provided path.");
   }
 
+  const siblingSkillDirs = skillPaths.map((p) => path.posix.dirname(p)).filter((d) => d !== ".");
   const imports: ImportedSkill[] = [];
   for (const skillPath of skillPaths) {
     const skillDir = path.posix.dirname(skillPath);
     const isRootSkill = skillDir === ".";
     const inventory = allFiles
-      .filter((entry) => entry === skillPath || (isRootSkill ? true : entry.startsWith(`${skillDir}/`)))
+      .filter((entry) => entry === skillPath || (isRootSkill ? !siblingSkillDirs.some((d) => entry.startsWith(`${d}/`) || entry === `${d}/SKILL.md`) : entry.startsWith(`${skillDir}/`)))
       .map((entry) => {
         const relative = entry === skillPath ? "SKILL.md" : (isRootSkill ? entry : entry.slice(skillDir.length + 1));
         return {
@@ -1092,6 +1094,7 @@ async function readUrlSkillImports(
         "No SKILL.md files were found in the provided GitHub source.",
       );
     }
+    const siblingSkillDirs = skillPaths.map((p) => path.posix.dirname(p)).filter((d) => d !== ".");
     const skills: ImportedSkill[] = [];
     for (const relativeSkillPath of skillPaths) {
       const repoSkillPath = basePrefix ? `${basePrefix}${relativeSkillPath}` : relativeSkillPath;
@@ -1121,7 +1124,7 @@ async function readUrlSkillImports(
       };
       const isRootSkill = skillDir === ".";
       const inventory = filteredPaths
-        .filter((entry) => entry === relativeSkillPath || (isRootSkill ? true : entry.startsWith(`${skillDir}/`)))
+        .filter((entry) => entry === relativeSkillPath || (isRootSkill ? !siblingSkillDirs.some((d) => entry.startsWith(`${d}/`) || entry === `${d}/SKILL.md`) : entry.startsWith(`${skillDir}/`)))
         .map((entry) => {
           const relative = entry === relativeSkillPath ? "SKILL.md" : (isRootSkill ? entry : entry.slice(skillDir.length + 1));
           return {


### PR DESCRIPTION
Fixes #2037

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Companies import skills from local directories, GitHub URLs, and inline packages
> - Each imported skill exposes a file inventory (SKILL.md, references/, scripts/, and any other files/folders) so agents can access skill resources at runtime
> - When a skill's SKILL.md lives at the root of its source (not in a subdirectory), `path.posix.dirname("SKILL.md")` returns `"."`
> - The inventory filter used `entry.startsWith("./")` which fails because relative paths like `references/foo.md` don't start with `"./"`
> - This caused root-level skills to expose only SKILL.md in their file inventory, silently dropping all other files and folders
> - This PR fixes the root-level skill inventory filter across all three import paths
> - The benefit is that skills imported from any source now correctly expose their full file tree to agents

## What Changed

- Fixed `readLocalSkillImports` to detect root-level skills (`skillDir === "."`) and include all files and folders instead of filtering with a broken prefix match that excluded everything
- Applied the same fix to `readInlineSkillImports` (package imports) and `readUrlSkillImports` (GitHub/URL imports) which had the identical bug
- Exported `readLocalSkillImports` and `readInlineSkillImports` for direct unit testing
- Added 130 lines of test coverage verifying root-level skill inventory across all import paths (18 tests total)

## Verification

- `npx vitest run server/src/__tests__/company-skills.test.ts` — all 18 tests pass
- `pnpm -w run typecheck` — all packages pass cleanly
- Full test suite (`pnpm -w run test`) passes with only pre-existing failures in `cursor-local-execute.test.ts` (unrelated `ERR_MODULE_NOT_FOUND` on master)
- Manual: import a skill repo with SKILL.md at root → verify all files/folders (not just SKILL.md) appear in the file inventory

## Risks

- Low risk. The fix only changes behavior for the `skillDir === "."` case (root-level skills). Skills in subdirectories are unaffected — their existing `startsWith("subdir/")` filter path is unchanged.
- Two previously-private functions are now exported for testability; no API contract change since `company-skills.ts` is an internal service module.

## Model Used

Anthropic Claude Opus 4.6 (`claude-opus-4-6`). Extended thinking enabled, tool use (Bash, Read, Edit), via Claude Code CLI. ~200k context window.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
