### PR TITLE
docs(skill): clarify 409 lock disposition — long ≠ stale, escalate on evidence

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -61,7 +61,19 @@ Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLI
 { "agentId": "{your-agent-id}", "expectedStatuses": ["todo", "backlog", "blocked", "in_review"] }
 ```
 
-If already checked out by you, returns normally. If owned by another agent: `409 Conflict` — stop, pick a different task. **Never retry a 409.**
+If already checked out by you, returns normally. If owned by another agent: `409 Conflict` — **never retry the same 409**. The task belongs to someone else *right now*, but their run may finish before your next heartbeat.
+
+**409 lock disposition (do not infer staleness from wall-clock age).** Long-running heartbeats are normal — cold-cache builds, large refactors, multi-tool flows can legitimately exceed 60 minutes. A lock that looks "old" is almost always live work in progress, not an orphan. Decision tree when you 409:
+
+1. **Pick a different task this heartbeat.** Always safe. Skip back to Step 4.
+2. **If the issue you 409'd on is your highest-priority assignment** (e.g. you were woken specifically because the issue was reassigned to you mid-run), post one short comment acknowledging the 409 and stating you'll resume on your next wake. Do NOT request a force-release on this heartbeat. Move on.
+3. **Only escalate ("please release lock on /<prefix>/issues/<id>") when ALL of the following hold:**
+   - You have observed the same lock across at least **2 of your own subsequent heartbeats**.
+   - **No new commits, comments, status changes, or document revisions from the lock owner** have appeared between those heartbeats (verify with `GET /api/issues/{id}/heartbeat-context` and the issue's comment cursor).
+   - You have a concrete *substantive* reason the work cannot wait (e.g. the new assignment supersedes the in-flight direction, deadline pressure on a downstream dependency).
+4. **When you do escalate, cite evidence — never elapsed time alone.** Acceptable: *"Lock held across my last 2 heartbeats with no new commits/comments/status changes since {timestamp}; my new assignment changes the work direction."* Not acceptable: *"Lock is N minutes old, looks stale."*
+
+**Long ≠ stale.** This rule replaces any earlier wall-clock heuristic. It is forward-compatible: when the platform exposes per-run liveness (e.g. `GET /api/runs/{runId}`), step 3's three-condition check collapses to a single terminal-state API call, but the "long ≠ stale" principle remains the agent-side default.
 
 **Step 6 — Understand context.** Prefer `GET /api/issues/{issueId}/heartbeat-context` first. It gives you compact issue state, ancestor summaries, goal/project info, and comment cursor metadata without forcing a full thread replay.
 
@@ -225,7 +237,7 @@ For commands, response fields, and MCP tools, read:
 
 ## Critical Rules
 
-- **Never retry a 409.** The task belongs to someone else.
+- **Never retry a 409.** The task belongs to someone else right now. Wall-clock age is **not** a staleness signal — long heartbeats are normal. See Step 5 ("409 lock disposition") for the escalation rules.
 - **Never look for unassigned work.** No assignments = exit.
 - **Self-assign only for explicit @-mention handoff.** Requires a mention-triggered wake with `PAPERCLIP_WAKE_COMMENT_ID` and a comment that clearly directs you to do the task. Use checkout (never direct assignee patch).
 - **Honor "send it back to me" requests from board users.** If a board/user asks for review handoff (e.g. "let me review it", "assign it back to me"), reassign to them with `assigneeAgentId: null` and `assigneeUserId: "<requesting-user-id>"`, typically setting status to `in_review` instead of `done`. Resolve the user id from the triggering comment's `authorUserId` when available, else the issue's `createdByUserId` if it matches the requester context.

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -887,7 +887,8 @@ Terminal states: `done`, `cancelled`
 | Mistake                                     | Why it's wrong                                        | What to do instead                                      |
 | ------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------- |
 | Start work without checkout                 | Another agent may claim it simultaneously             | Always `POST /issues/:id/checkout` first                |
-| Retry a `409` checkout                      | The task belongs to someone else                      | Pick a different task                                   |
+| Retry a `409` checkout                      | The task belongs to someone else right now            | Pick a different task; never retry on the same heartbeat |
+| Treat an "old" lock as stale                | Long heartbeats are normal — wall-clock age is not a liveness signal | Use the Step 5 "409 lock disposition" rules — escalate only with evidence (≥2 heartbeats with no progress from the owner), never on elapsed time alone |
 | Look for unassigned work                    | You're overstepping; managers assign work             | If you have no assignments, exit, except explicit mention handoff |
 | Exit without commenting on in-progress work | Your manager can't see progress; work appears stalled | Leave a comment explaining where you are                |
 | Create tasks without `parentId`             | Breaks the task hierarchy; work becomes untraceable   | Link every subtask to its parent                        |


### PR DESCRIPTION
## Why

The current `Never retry a 409` rule is correct but underspecified. In practice, agents that 409 against a *long-running* checkout often inferred staleness from wall-clock age — "lock is 60+ minutes old, must be orphaned" — and chased force-releases or filed escalation comments. Long heartbeats are normal in agent fleets: cold-cache builds, large refactors, multi-tool flows, and IDE/build-server warmups can legitimately exceed 60 minutes, so the implicit wall-clock heuristic produced **false-positive escalations** even though the platform's lock was working as intended.

Concrete failure mode we hit:

- 10:34 — Agent A checks out an issue and starts a long, productive heartbeat.
- 11:24 — A manager reassigns the issue to Agent B mid-flight (legitimate cross-agent reassign).
- 11:37 — Agent B wakes, attempts checkout, 409s. Heuristic in use: *"lock is 61 minutes old, therefore stale."* Posts a `WIP on disk, blocked by stale run-lock` comment, asks the manager to release.
- 12:09 — Agent A's run finishes and ships a real commit. The lock was never stale — it was a long, productive heartbeat.

Both agents did the right thing given the rules they had. The fix is on the **agent-side decision rule**, not the platform: replace the implicit wall-clock rule with an explicit, evidence-based decision tree.

## What changes

Three small, scoped edits — all rule clarifications, no API surface changes.

### 1. `skills/paperclip/SKILL.md` — Step 5 (Checkout)

Replaces the single-sentence 409 paragraph with a four-branch decision tree:

1. Pick a different task this heartbeat (always safe).
2. If the issue is your highest-priority assignment, post one ack comment and resume on the next wake — don't request a force-release this heartbeat.
3. Only escalate when **all** of: same lock observed across ≥2 of your own subsequent heartbeats, **no new commits/comments/status changes/document revisions from the lock owner** between those heartbeats (verified with `GET /api/issues/{id}/heartbeat-context` and the comment cursor), and a concrete substantive reason the work cannot wait.
4. When you escalate, **cite evidence — never elapsed time alone**.

Adds a closing **Long ≠ stale** principle that's forward-compatible: if/when the platform exposes per-run liveness (e.g. `GET /api/runs/{runId}`), step 3's three-condition check collapses to a single terminal-state API call, but the agent-side default holds.

### 2. `skills/paperclip/SKILL.md` — Critical Rules

The bullet stays, but now points readers at Step 5 and explicitly calls out that wall-clock age is **not** a staleness signal.

### 3. `skills/paperclip/references/api-reference.md` — Common Mistakes table

The original row conflated two distinct anti-patterns:

- "Retry a `409` checkout" → task belongs to someone else *right now*.
- "Treat an old lock as stale" → long heartbeats are normal; wall-clock age is not a liveness signal.

Splits them into two rows and points the second at the Step 5 decision tree.

## Why this scope

- **No new API surface.** A platform-side change (e.g. `GET /api/runs/{runId}` for liveness, or enriching the 409 body with `{ ownerRunStatus, ownerRunStartedAt, ownerAgentId }`) would also close this gap, but it's a larger commitment to maintain. The skill-side fix closes the failure mode today and stays valid even after a future runs-API ships.
- **Forward-compatible.** The decision tree is written against semantics ("did the lock owner make any progress?"), not against today's API surface. A future runs-API drop-in replaces step 3's three-condition check with a single call, without rewriting the rule.
- **Backwards-compatible.** Existing "never retry a 409" behavior is preserved verbatim — branches (1) and (2) of the new tree match what disciplined agents already do. Only the escalation branch becomes stricter, which is the intended effect.

## Verification

- Diffs apply cleanly against `master` at `4c47eb46`. Diff anchors verified verbatim before edits (`SKILL.md:64`, `SKILL.md:228`, `references/api-reference.md:890`).
- `+14/−2` in `SKILL.md`, `+2/−1` in `references/api-reference.md`.
- Re-applied the new rule to the failure mode above: Agent B's 11:37 wake lands in branch (2) — post one ack comment, move on. Agent A's run finishes at 12:09; Agent B's next heartbeat sees the new commit + status change and proceeds normally. No force-release request, no lost time.

## Out of scope

- Adding `GET /api/runs/{runId}` or enriching 409 response bodies. Mentioned as forward-compat anchors only; happy to file a separate issue if the maintainers want to scope that.
- Auto-release of long-running runs. Different problem, different blast radius.

Filed under engineering identity from a downstream operator (multi-product workspaces platform, agent-driven engineering). Happy to iterate on wording, table formatting, or scope.