### PR TITLE
fix(issues): dedupe issue_children_completed wakes within 10-min window

### DIFF
--- a/server/src/__tests__/issue-children-completed-dedupe-service.test.ts
+++ b/server/src/__tests__/issue-children-completed-dedupe-service.test.ts
@@ -1,0 +1,283 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentWakeupRequests,
+  approvals,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issueApprovals,
+  issueRelations,
+  issueThreadInteractions,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { issueService } from "../services/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres issue_children_completed dedupe tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres(
+  "issueService.getWakeableParentAfterChildCompletion — 10-min issue_children_completed dedupe (PR #6120)",
+  () => {
+    let db!: ReturnType<typeof createDb>;
+    let svc!: ReturnType<typeof issueService>;
+    let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+    beforeAll(async () => {
+      tempDb = await startEmbeddedPostgresTestDatabase("paperclip-children-completed-dedupe-");
+      db = createDb(tempDb.connectionString);
+      svc = issueService(db);
+    }, 20_000);
+
+    afterEach(async () => {
+      await db.delete(issueThreadInteractions);
+      await db.delete(issueApprovals);
+      await db.delete(approvals);
+      await db.delete(activityLog);
+      await db.delete(heartbeatRuns);
+      await db.delete(agentWakeupRequests);
+      await db.delete(issueRelations);
+      await db.delete(issues);
+      await db.delete(agents);
+      await db.delete(companies);
+    });
+
+    afterAll(async () => {
+      await tempDb?.cleanup();
+    });
+
+    async function createCompany(prefix: string) {
+      const companyId = randomUUID();
+      const agentId = randomUUID();
+      await db.insert(companies).values({
+        id: companyId,
+        name: `Company ${prefix}`,
+        issuePrefix: prefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: `${prefix} Agent`,
+        role: "engineer",
+        status: "idle",
+      });
+      return { companyId, agentId };
+    }
+
+    async function insertIssue(input: {
+      companyId: string;
+      identifier: string;
+      title: string;
+      status: string;
+      parentId?: string | null;
+      assigneeAgentId?: string | null;
+    }) {
+      const id = randomUUID();
+      await db.insert(issues).values({
+        id,
+        companyId: input.companyId,
+        identifier: input.identifier,
+        title: input.title,
+        status: input.status,
+        priority: "medium",
+        parentId: input.parentId ?? null,
+        assigneeAgentId: input.assigneeAgentId ?? null,
+        originKind: "manual",
+        originFingerprint: "default",
+      });
+      return id;
+    }
+
+    async function insertWakeup(input: {
+      companyId: string;
+      agentId: string;
+      reason: string;
+      issueId: string;
+      offsetMs: number; // negative means in the past
+    }) {
+      const createdAt = new Date(Date.now() + input.offsetMs);
+      await db.insert(agentWakeupRequests).values({
+        id: randomUUID(),
+        companyId: input.companyId,
+        agentId: input.agentId,
+        source: "automation",
+        reason: input.reason,
+        payload: { issueId: input.issueId },
+        createdAt,
+      });
+    }
+
+    async function makeFamilyWithAllChildrenDone(prefix: string) {
+      const { companyId, agentId } = await createCompany(prefix);
+      const parentId = await insertIssue({
+        companyId,
+        identifier: `${prefix}-1`,
+        title: "parent",
+        status: "in_progress",
+        assigneeAgentId: agentId,
+      });
+      await insertIssue({
+        companyId,
+        identifier: `${prefix}-2`,
+        title: "child A",
+        status: "done",
+        parentId,
+        assigneeAgentId: agentId,
+      });
+      await insertIssue({
+        companyId,
+        identifier: `${prefix}-3`,
+        title: "child B",
+        status: "cancelled",
+        parentId,
+        assigneeAgentId: agentId,
+      });
+      return { companyId, agentId, parentId };
+    }
+
+    it("returns the wakeable parent when no recent issue_children_completed wake exists", async () => {
+      const { parentId } = await makeFamilyWithAllChildrenDone("DDA");
+      const result = await svc.getWakeableParentAfterChildCompletion(parentId);
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(parentId);
+    });
+
+    it("returns null when an issue_children_completed wake was enqueued in the last 10 minutes", async () => {
+      const { companyId, agentId, parentId } = await makeFamilyWithAllChildrenDone("DDB");
+      await insertWakeup({
+        companyId,
+        agentId,
+        reason: "issue_children_completed",
+        issueId: parentId,
+        offsetMs: -2 * 60 * 1000, // 2 minutes ago
+      });
+      const result = await svc.getWakeableParentAfterChildCompletion(parentId);
+      expect(result).toBeNull();
+    });
+
+    it("does not suppress a parent whose recent wake is older than the 10-min window", async () => {
+      const { companyId, agentId, parentId } = await makeFamilyWithAllChildrenDone("DDC");
+      await insertWakeup({
+        companyId,
+        agentId,
+        reason: "issue_children_completed",
+        issueId: parentId,
+        offsetMs: -20 * 60 * 1000, // 20 minutes ago
+      });
+      const result = await svc.getWakeableParentAfterChildCompletion(parentId);
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(parentId);
+    });
+
+    it("does not suppress a parent whose recent wake had a different reason", async () => {
+      const { companyId, agentId, parentId } = await makeFamilyWithAllChildrenDone("DDD");
+      await insertWakeup({
+        companyId,
+        agentId,
+        reason: "issue_commented",
+        issueId: parentId,
+        offsetMs: -1 * 60 * 1000,
+      });
+      const result = await svc.getWakeableParentAfterChildCompletion(parentId);
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(parentId);
+    });
+
+    it("does not suppress unrelated parents in the same company that share the same recent reason", async () => {
+      const { companyId, agentId } = await createCompany("DDE");
+      // Family 1 — recently woken
+      const parent1 = await insertIssue({
+        companyId,
+        identifier: "DDE-1",
+        title: "parent 1",
+        status: "in_progress",
+        assigneeAgentId: agentId,
+      });
+      await insertIssue({
+        companyId,
+        identifier: "DDE-2",
+        title: "child 1A",
+        status: "done",
+        parentId: parent1,
+        assigneeAgentId: agentId,
+      });
+      // Family 2 — never woken
+      const parent2 = await insertIssue({
+        companyId,
+        identifier: "DDE-3",
+        title: "parent 2",
+        status: "in_progress",
+        assigneeAgentId: agentId,
+      });
+      await insertIssue({
+        companyId,
+        identifier: "DDE-4",
+        title: "child 2A",
+        status: "done",
+        parentId: parent2,
+        assigneeAgentId: agentId,
+      });
+      // Wake parent 1 only
+      await insertWakeup({
+        companyId,
+        agentId,
+        reason: "issue_children_completed",
+        issueId: parent1,
+        offsetMs: -1 * 60 * 1000,
+      });
+
+      const blocked = await svc.getWakeableParentAfterChildCompletion(parent1);
+      const passes = await svc.getWakeableParentAfterChildCompletion(parent2);
+      expect(blocked).toBeNull();
+      expect(passes).not.toBeNull();
+      expect(passes?.id).toBe(parent2);
+    });
+
+    it("does not suppress a parent in a different company even with same reason+issueId payload shape", async () => {
+      const a = await createCompany("DDF");
+      const b = await createCompany("DDG");
+      // Family in company A with all-done children
+      const parentA = await insertIssue({
+        companyId: a.companyId,
+        identifier: "DDF-1",
+        title: "parent A",
+        status: "in_progress",
+        assigneeAgentId: a.agentId,
+      });
+      await insertIssue({
+        companyId: a.companyId,
+        identifier: "DDF-2",
+        title: "child A1",
+        status: "done",
+        parentId: parentA,
+        assigneeAgentId: a.agentId,
+      });
+      // Insert a recent wake in company B referencing the same parentA UUID via payload
+      // — the dedupe must scope on companyId, not just payload->>'issueId'.
+      await insertWakeup({
+        companyId: b.companyId,
+        agentId: b.agentId,
+        reason: "issue_children_completed",
+        issueId: parentA,
+        offsetMs: -1 * 60 * 1000,
+      });
+
+      const result = await svc.getWakeableParentAfterChildCompletion(parentA);
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(parentA);
+    });
+  },
+);

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3915,6 +3915,29 @@ export function issueService(db: Db) {
         return null;
       }
 
+      // Circuit breaker: skip if this parent was already woken with
+      // issue_children_completed in the last 10 minutes. Prevents
+      // child status flapping from compounding context burn — e.g.,
+      // FER-52 was observed reopening 273 times in succession because
+      // a parent with many children produces a wake on every child→done
+      // edge. Mirrors the dedupe pattern used in services/issues.ts:~870
+      // and services/issue-tree-control.ts.
+      const recentWake = await db
+        .select({ id: agentWakeupRequests.id })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, parent.companyId),
+            eq(agentWakeupRequests.reason, "issue_children_completed"),
+            sql`${agentWakeupRequests.payload} ->> 'issueId' = ${parent.id}`,
+            sql`${agentWakeupRequests.createdAt} > now() - interval '10 minutes'`,
+          ),
+        )
+        .limit(1);
+      if (recentWake.length > 0) {
+        return null;
+      }
+
       const childIdsForSummaries = children.slice(0, MAX_CHILD_COMPLETION_SUMMARIES).map((child) => child.id);
       const commentRows = childIdsForSummaries.length > 0
         ? await db

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3922,6 +3922,18 @@ export function issueService(db: Db) {
       // a parent with many children produces a wake on every child→done
       // edge. Mirrors the dedupe pattern used in services/issues.ts:~870
       // and services/issue-tree-control.ts.
+      //
+      // Soft TOCTOU: this is a query-only guard, not an atomic check-and-insert.
+      // Two concurrent child→done edges that both observe "no recent wake" can
+      // each enqueue a wake before either is visible to the other. That is
+      // acceptable here because (a) we tolerate up to one duplicate wake per
+      // 10-min window rather than zero — the circuit breaker still cuts the
+      // observed 273-wake storm down by ~99 % even with worst-case race
+      // doubling, and (b) the agentWakeupRequests insert path doesn't currently
+      // carry a unique constraint on (companyId, reason, payload->>'issueId',
+      // window) that would let us swap this for ON CONFLICT DO NOTHING without
+      // a migration. If the duplicate rate proves material in practice, the
+      // follow-up is a partial unique index plus an atomic upsert here.
       const recentWake = await db
         .select({ id: agentWakeupRequests.id })
         .from(agentWakeupRequests)


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issue lifecycle is the central control loop: status changes drive wakes, wakes drive agent runs, agent runs burn tokens
> - One specific edge — a child issue transitioning to `done` or `cancelled` while its siblings are already complete — fires `issue_children_completed` for the parent so the parent's assignee can act on the completed family
> - With no dedupe, that edge fires once per child status flap. A parent with N children that each flap once produces N back-to-back wakes carrying the same "your kids are done" context. We observed FER-52 reopen 273 times in succession before manual intervention, each round replaying ~40K tokens of bootstrap context against the model
> - This pull request adds a 10-minute query-only circuit breaker in `issueService.getWakeableParentAfterChildCompletion`: if the same parent already had an `issue_children_completed` wake in the company's recent window, skip the new one
> - The benefit is bounded amplification: a child flapping storm cuts from N wakes to 1 per 10-min window per parent, which in our deployment is the difference between a 273-wake storm and 1 wake; observed-week token burn against this lane drops by ~99 percent

## What Changed

- **`server/src/services/issues.ts`** (in `issueService.getWakeableParentAfterChildCompletion`, before the per-child summary fan-out): added a SELECT against `agentWakeupRequests` that asks "in this company, for this parent's `payload->>'issueId'`, with `reason='issue_children_completed'`, did we already enqueue a wake in the last 10 minutes?" If yes, return `null` and short-circuit before the summary join. The pattern mirrors the JSON-payload dedupe idioms already used at `services/issues.ts:~870` (`BLOCKER_ATTENTION_ACTIVE_WAKE_STATUSES`) and `services/issue-tree-control.ts:~60`. No new imports needed — `and`, `eq`, `sql`, `agentWakeupRequests` are all already in scope.
- **Same file, expanded code comment**: explicitly calls out the soft TOCTOU limitation (Greptile review). This is a query-only guard, not an atomic check-and-insert. Two concurrent `child→done` edges that both observe "no recent wake" can each enqueue a wake before either is visible to the other. The comment also documents why an atomic upsert isn't introduced here: `agent_wakeup_requests` has no unique constraint on `(companyId, reason, payload->>'issueId', window)` today, so a safe ON CONFLICT pattern would require a migration. Worst-case race-doubling still leaves the circuit breaker cutting the observed 273-wake storm by ~99 percent.
- **`server/src/__tests__/issue-children-completed-dedupe-service.test.ts`** (new file): six embedded-postgres service-level tests against the real `issueService(db)` covering exactly the dedupe behavior:
  - returns the wakeable parent when no recent `issue_children_completed` wake exists
  - returns `null` when a same-reason wake was enqueued within 10 minutes
  - **does not suppress** a parent whose recent wake is older than the window
  - **does not suppress** a parent whose recent wake had a different reason
  - **does not suppress** unrelated parents in the same company that share the same recent reason
  - **does not suppress** a parent in a different company even when the cross-company wake's `payload->>'issueId'` happens to match (verifies the dedupe is correctly scoped on `companyId`, not on payload alone)
- The original route-level coverage (`issue-dependency-wakeups-routes.test.ts`, `issue-comment-reopen-routes.test.ts`) is preserved unchanged and still passes.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-dependency-wakeups-routes.test.ts server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/issue-children-completed-dedupe-service.test.ts` — **39 tests passed** (2 + 31 + 6).
- `pnpm typecheck` — clean across all workspaces.
- `pnpm run preflight:workspace-links` — clean exit.
- `git diff --check` — clean (no whitespace errors).
- `git status` — only the intended two files (`services/issues.ts` modified, new test file added).
- `git diff --stat` — single touched source file plus the new dedicated test file.

## Risks

- **Low risk.** The change is additive — a single SELECT-then-`return null` guard inside an existing function. Path is purely additive on the early-return side: a parent that legitimately needs re-attention is delayed by up to 10 minutes; the parent's own heartbeat / status-change / comment / blocker-resolved wakes are not dedupable here and continue to fire normally.
- **Index coverage.** The dedupe SELECT joins on `companyId`, `reason`, `payload->>'issueId'`, `createdAt`. The sibling precedent queries at `services/issues.ts:~870` and `services/issue-tree-control.ts:~60` use the same query shape; whatever indexing situation applies to those is the same here. If maintainers want a partial index on `(companyId, reason, (payload->>'issueId')) WHERE created_at > now() - interval '10 minutes'`, that is a small follow-up rather than part of this circuit-breaker patch.
- **Soft TOCTOU.** Documented in the code comment. Worst case is one duplicate wake per 10-min window under concurrent flap; the observed 273-wake storm still drops by ~99 percent even with race doubling. If duplicate rate is measured to be material in production, the follow-up is a partial unique index plus an atomic upsert.
- **No breaking schema changes.** No migration. No new dependencies. `pnpm-lock.yaml` is not committed.

## Model Used

- **Claude (Opus 4.7, 1M context)** via Claude Code CLI for: code review of the existing patch, expansion of the TOCTOU comment, authoring of the new service-level regression test file, and PR-body authoring.
- **OpenAI Codex (gpt-5.4, medium reasoning)** via the `skill-codex` slash skill — used earlier in the same session for an unrelated adversarial workspace-trim review. The original patch shape (the 10-min query-only guard) was cross-reviewed by Codex (`gpt-5.4` high reasoning) before initial PR submission per the companion PR #6121 thread.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (39/39 in targeted runs; typecheck clean across all workspaces)
- [x] I have added or updated tests where applicable (six new embedded-postgres service-level regression tests, mapped to the exact behaviors a future reviewer would want to assert)
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [x] I have updated relevant documentation to reflect my changes (in-code comment expanded to explain the TOCTOU + follow-up path; PR body itself)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
