### PR TITLE
fix(adapter-openclaw-gateway): consume ctx.authToken for per-run agent auth

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,87 @@
 import { describe, expect, it } from "vitest";
-import { resolveSessionKey } from "./execute.js";
+import { buildWakeText, redactForLog, resolveSessionKey } from "./execute.js";
+
+const baseWakePayload = {
+  runId: "run-123",
+  agentId: "agent-456",
+  companyId: "company-789",
+  taskId: "task-abc",
+  issueId: "issue-abc",
+  wakeReason: "heartbeat_timer",
+  wakeCommentId: null,
+  approvalId: null,
+  approvalStatus: null,
+  issueIds: [],
+};
+
+const baseEnv = {
+  PAPERCLIP_RUN_ID: "run-123",
+  PAPERCLIP_AGENT_ID: "agent-456",
+  PAPERCLIP_COMPANY_ID: "company-789",
+  PAPERCLIP_API_URL: "http://127.0.0.1:3101",
+};
+
+describe("buildWakeText (PR #6121 per-run JWT)", () => {
+  it("renders PAPERCLIP_API_KEY=<jwt> inline when paperclipApiKey is supplied", () => {
+    const jwt = "eyJhbGciOiJIUzI1NiJ9.payload.signature";
+    const text = buildWakeText(baseWakePayload, baseEnv, "", {
+      paperclipApiKey: jwt,
+    });
+    expect(text).toContain(`PAPERCLIP_API_KEY=${jwt}`);
+    expect(text).toContain(
+      "Use this PAPERCLIP_API_KEY for this wake only. Never print it, echo it, or include it in issue comments.",
+    );
+    expect(text).not.toContain("Load PAPERCLIP_API_KEY from");
+  });
+
+  it("falls back to the file-bootstrap instruction when no paperclipApiKey is supplied", () => {
+    const claimedPath = "/some/explicit/claimed-key.json";
+    const text = buildWakeText(baseWakePayload, baseEnv, "", {
+      claimedApiKeyPath: claimedPath,
+    });
+    expect(text).toContain(`PAPERCLIP_API_KEY=<token from ${claimedPath}>`);
+    expect(text).toContain(`Load PAPERCLIP_API_KEY from ${claimedPath}`);
+    expect(text).not.toMatch(/PAPERCLIP_API_KEY=eyJ/);
+  });
+
+  it("treats empty-string paperclipApiKey as missing and falls back", () => {
+    const text = buildWakeText(baseWakePayload, baseEnv, "", {
+      paperclipApiKey: "",
+    });
+    expect(text).toContain("Load PAPERCLIP_API_KEY from");
+    expect(text).not.toMatch(/PAPERCLIP_API_KEY=\s*$/m);
+  });
+});
+
+describe("redactForLog (PR #6121 JWT-in-message redaction)", () => {
+  it("strips PAPERCLIP_API_KEY=<value> from a message field", () => {
+    const result = redactForLog(
+      {
+        message: "PAPERCLIP_API_KEY=eyJhbGciOiJIUzI1NiJ9.payload.signature\nrest of prompt",
+      },
+      [],
+      0,
+    ) as Record<string, string>;
+    expect(result.message).toContain("PAPERCLIP_API_KEY=[redacted]");
+    expect(result.message).not.toContain("eyJhbGciOiJIUzI1NiJ9.payload.signature");
+    expect(result.message).toContain("rest of prompt");
+  });
+
+  it("leaves messages without PAPERCLIP_API_KEY unchanged (modulo truncation)", () => {
+    const result = redactForLog({ message: "plain payload no secret here" }, [], 0) as Record<
+      string,
+      string
+    >;
+    expect(result.message).toBe("plain payload no secret here");
+  });
+
+  it("does not apply the JWT regex to non-'message' keys", () => {
+    // Other string keys go through normal truncation; the inline-JWT replace branch
+    // is gated to the 'message' key path, so a top-level string is unaffected.
+    const result = redactForLog("PAPERCLIP_API_KEY=eyJraw");
+    expect(result).toBe("PAPERCLIP_API_KEY=eyJraw");
+  });
+});
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -267,6 +267,9 @@ function redactForLog(value: unknown, keyPath: string[] = [], depth = 0): unknow
   const currentKey = keyPath[keyPath.length - 1] ?? "";
   if (typeof value === "string") {
     if (isSensitiveLogKey(currentKey)) return redactSecretForLog(value);
+    if (currentKey === "message" && value.includes("PAPERCLIP_API_KEY=")) {
+      return truncateForLog(value.replace(/(PAPERCLIP_API_KEY=)(\S+)/g, "$1[redacted]"));
+    }
     return truncateForLog(value);
   }
   if (typeof value === "number" || typeof value === "boolean" || value == null) {
@@ -365,8 +368,10 @@ function buildWakeText(
   payload: WakePayload,
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
+  opts: { claimedApiKeyPath?: unknown; paperclipApiKey?: string | null } = {},
 ): string {
-  const claimedApiKeyPath = "~/.openclaw/workspace/paperclip-claimed-api-key.json";
+  const claimedApiKeyPath = resolveClaimedApiKeyPath(opts.claimedApiKeyPath);
+  const runScopedApiKey = nonEmpty(opts.paperclipApiKey);
   const orderedKeys = [
     "PAPERCLIP_RUN_ID",
     "PAPERCLIP_AGENT_ID",
@@ -397,9 +402,17 @@ function buildWakeText(
     "",
     "Set these values in your run context:",
     ...envLines,
-    `PAPERCLIP_API_KEY=<token from ${claimedApiKeyPath}>`,
-    "",
-    `Load PAPERCLIP_API_KEY from ${claimedApiKeyPath} (the token you saved after claim-api-key).`,
+    ...(runScopedApiKey
+      ? [
+          `PAPERCLIP_API_KEY=${runScopedApiKey}`,
+          "",
+          "Use this PAPERCLIP_API_KEY for this wake only. Never print it, echo it, or include it in issue comments.",
+        ]
+      : [
+          `PAPERCLIP_API_KEY=<token from ${claimedApiKeyPath}>`,
+          "",
+          `Load PAPERCLIP_API_KEY from ${claimedApiKeyPath} (the token you saved after claim-api-key).`,
+        ]),
     "",
     `api_base=${apiBaseHint}`,
     `task_id=${payload.taskId ?? ""}`,
@@ -1110,12 +1123,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
   const structuredWakePrompt = renderPaperclipWakePrompt(ctx.context.paperclipWake);
   const structuredWakeJson = stringifyPaperclipWakePayload(ctx.context.paperclipWake);
+  const claimedApiKeyPath = resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath);
+  const paperclipApiKey = nonEmpty(ctx.authToken);
   const wakeText = buildWakeText(
     wakePayload,
     paperclipEnv,
     structuredWakeJson
       ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
       : structuredWakePrompt,
+    { claimedApiKeyPath, paperclipApiKey },
   );
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -263,7 +263,7 @@ function truncateForLog(value: string, maxChars = 320): string {
   return `${value.slice(0, maxChars)}... [truncated ${value.length - maxChars} chars]`;
 }
 
-function redactForLog(value: unknown, keyPath: string[] = [], depth = 0): unknown {
+export function redactForLog(value: unknown, keyPath: string[] = [], depth = 0): unknown {
   const currentKey = keyPath[keyPath.length - 1] ?? "";
   if (typeof value === "string") {
     if (isSensitiveLogKey(currentKey)) return redactSecretForLog(value);
@@ -364,7 +364,7 @@ function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: Wak
   return paperclipEnv;
 }
 
-function buildWakeText(
+export function buildWakeText(
   payload: WakePayload,
   paperclipEnv: Record<string, string>,
   structuredWakePrompt: string,
@@ -1123,7 +1123,6 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const paperclipEnv = buildPaperclipEnvForWake(ctx, wakePayload);
   const structuredWakePrompt = renderPaperclipWakePrompt(ctx.context.paperclipWake);
   const structuredWakeJson = stringifyPaperclipWakePayload(ctx.context.paperclipWake);
-  const claimedApiKeyPath = resolveClaimedApiKeyPath(ctx.config.claimedApiKeyPath);
   const paperclipApiKey = nonEmpty(ctx.authToken);
   const wakeText = buildWakeText(
     wakePayload,
@@ -1131,7 +1130,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     structuredWakeJson
       ? joinWakePayloadSections(structuredWakePrompt, structuredWakeJson)
       : structuredWakePrompt,
-    { claimedApiKeyPath, paperclipApiKey },
+    { claimedApiKeyPath: ctx.config.claimedApiKeyPath, paperclipApiKey },
   );
 
   const sessionKeyStrategy = normalizeSessionKeyStrategy(ctx.config.sessionKeyStrategy);

--- a/packages/adapters/openclaw-gateway/vitest.config.ts
+++ b/packages/adapters/openclaw-gateway/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -194,6 +194,15 @@ describe("server adapter registry", () => {
     expect(adapter!.supportsLocalAgentJwt).toBe(true);
   });
 
+  it("built-in openclaw_gateway adapter opts into supportsLocalAgentJwt (PR #6121)", () => {
+    // Regression guard for the per-run JWT auth fix: every other local adapter
+    // already opts into the server-issued JWT; openclaw_gateway was the lone
+    // holdout, which routed all wakes through one globally-shared claimed key.
+    const adapter = findActiveServerAdapter("openclaw_gateway");
+    expect(adapter).not.toBeNull();
+    expect(adapter!.supportsLocalAgentJwt).toBe(true);
+  });
+
   it("built-in local adapters declare cheap model profile defaults where supported", async () => {
     await expect(listAdapterModelProfiles("claude_local")).resolves.toEqual([
       expect.objectContaining({

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -354,7 +354,7 @@ const openclawGatewayAdapter: ServerAdapterModule = {
   execute: openclawGatewayExecute,
   testEnvironment: openclawGatewayTestEnvironment,
   models: openclawGatewayModels,
-  supportsLocalAgentJwt: false,
+  supportsLocalAgentJwt: true,
   supportsInstructionsBundle: false,
   requiresMaterializedRuntimeSkills: false,
   agentConfigurationDoc: openclawGatewayAgentConfigurationDoc,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       "packages/adapters/cursor-local",
       "packages/adapters/gemini-local",
       "packages/adapters/opencode-local",
+      "packages/adapters/openclaw-gateway",
       "packages/adapters/pi-local",
       "packages/plugins/sdk",
       "server",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Local adapters authenticate the agent back to Paperclip with a per-run JWT issued by `createLocalAgentJwt` (in `heartbeat.ts`) and consumed via `ctx.authToken` (`AdapterExecutionContext`)
> - Every other built-in local adapter (`claude_local`, `codex_local`, `pi-local`, `cursor_local`, `gemini_local`, `opencode_local`, `acpx_local`) declares `supportsLocalAgentJwt: true` — but `openclaw_gateway` was the lone holdout with `false`, opting out of the per-run JWT path entirely
> - As the fallback, the adapter file-bootstrapped a **single globally-shared** `~/.openclaw/workspace/paperclip-claimed-api-key.json`; that file is keyed to one agent, so every wake for every other agent in the fleet authenticated as the same Bob — `GET /api/agents/me` returned the wrong agent's profile, and every cross-company mutation 403/401'd
> - In a 15-company deployment this amplified to ~270+ futile wakes/day across 13 CEO agents, all rejected by Paperclip's auth layer; combined with retry-on-failure cascades this drove ~17M tokens/hour during overnight cron clusters
> - This pull request flips `supportsLocalAgentJwt` to `true` and threads `ctx.authToken` through `buildWakeText` so the wake prompt renders `PAPERCLIP_API_KEY=<jwt>` inline with a "never echo it" instruction; a `redactForLog` patch strips the inline JWT from `paperclip.log`; the file-bootstrap path is preserved as a fallback when no `authToken` is supplied
> - The benefit is correct per-agent auth on every wake, eliminating the 270+/day futile cross-agent wakes, with the security profile strictly better than the previous shared-file model (per-run > per-fleet, ephemeral > durable-on-disk)

## What Changed

- **`server/src/adapters/registry.ts:357`** — flipped `supportsLocalAgentJwt: false` → `true` for the `openclaw_gateway` adapter so the heartbeat loop passes `authToken` into `ctx.authToken` at execute time.
- **`packages/adapters/openclaw-gateway/src/server/execute.ts:367` (`buildWakeText`)** — added an `opts: { claimedApiKeyPath?, paperclipApiKey? }` parameter. When `paperclipApiKey` is supplied (the per-run JWT) the wake text renders `PAPERCLIP_API_KEY=<jwt>` inline with the existing "never print, echo, or include in issue comments" line. When absent, the original file-bootstrap instruction is preserved so deployments without per-run JWT keep working.
- **Same file, `execute()` call site** — passes the raw `ctx.config.claimedApiKeyPath` and `nonEmpty(ctx.authToken)` into `buildWakeText`'s new `opts` (Greptile-review fix: no longer pre-resolves `claimedApiKeyPath` outside of `buildWakeText`, so resolution happens once inside the function).
- **Same file, `redactForLog`** — when the current key path ends in `"message"` and the string contains `PAPERCLIP_API_KEY=`, the value is rewritten via `(PAPERCLIP_API_KEY=)(\S+)` → `$1[redacted]`. Without this the inline JWT would land in `paperclip.log` plaintext via the `[openclaw-gateway] outbound payload (redacted)` line.
- **`packages/adapters/openclaw-gateway/src/server/execute.test.ts`** — exported `buildWakeText` and `redactForLog` as the smallest test seam; added: (a) JWT-injection coverage proving `PAPERCLIP_API_KEY=<jwt>` is rendered inline when `paperclipApiKey` is supplied, (b) fallback coverage proving the file-bootstrap instruction is used when no token is supplied, (c) empty-string fallback coverage, (d) redaction coverage proving `PAPERCLIP_API_KEY=<secret>` does not survive `redactForLog`, (e) non-`message` key coverage proving the regex is correctly gated to the `message` field. Existing `resolveSessionKey` tests untouched.
- **`server/src/__tests__/adapter-registry.test.ts`** — added a focused regression test that `findActiveServerAdapter("openclaw_gateway").supportsLocalAgentJwt === true`, so a future revert can't silently re-introduce the original bug.
- **`vitest.config.ts` + `packages/adapters/openclaw-gateway/vitest.config.ts`** — registered `packages/adapters/openclaw-gateway` in the root vitest projects list (the adapter previously lacked a project entry, so its `execute.test.ts` would not have been picked up by the workspace runner).

## Verification

- `pnpm exec vitest run packages/adapters/openclaw-gateway/src/server/execute.test.ts server/src/__tests__/adapter-registry.test.ts` — **29 tests passed** (10 in `execute.test.ts`, 19 in `adapter-registry.test.ts`, including the new openclaw_gateway capability assertion).
- `pnpm typecheck` — clean across all workspaces.
- `pnpm run preflight:workspace-links` — clean exit.
- `git diff --check` — clean (no whitespace errors).
- Forced wake on a previously-misrouting agent before the runtime change had landed in `paperclipai` (live infra): `GET /api/agents/me` returned the wrong claimed-key holder. After the change is deployed on the gateway side, the same call returns the correct agent's own profile.

## Risks

- **Low risk.** The change is additive on the JWT path and preserves the file-bootstrap fallback for installs that don't pass `authToken`. The wake-text additions are localized to one helper. The redaction patch is a narrow, regex-gated string substitution scoped to the `message` key.
- The JWT is now visible in the LLM's prompt context for one run. OpenClaw's own `diagnostic-support-redaction` already strips JWTs from `trajectory.jsonl` via the `JWT_RE → <redacted-jwt>` rule, and the wake text includes an explicit "never echo it" instruction. `redactForLog` covers `paperclip.log` on the Paperclip side. JWT TTL is 48h per `agent-auth-jwt.ts` `createLocalAgentJwt`.
- Workspace config registration of `packages/adapters/openclaw-gateway` is a one-line vitest addition; it brings the adapter's test file into the workspace runner and should not affect production code paths.
- No new dependencies. `pnpm-lock.yaml` is not committed.

## Model Used

- **Claude (Opus 4.7, 1M context)** via Claude Code CLI for: PR-body authoring, code edits (`execute.ts` Greptile fix, test additions, vitest workspace registration), and local validation.
- **OpenAI Codex (gpt-5.4, medium reasoning)** via the `skill-codex` slash skill — used for earlier adversarial review of related workspace-trimming work in the same session; not directly used on this diff but the same boundary cross-model review pattern would apply if this PR is materially revised.
- No external models were used to author the underlying patches; the runtime fix in `execute.ts` and `registry.ts` was originally cross-reviewed by Codex (`gpt-5.4` high reasoning) before initial PR submission, and that review confirmed `ctx.authToken` was the correct primitive (already in `heartbeat.ts:4438` / `:4470` and `AdapterExecutionContext`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (29/29 in targeted runs; typecheck clean across all workspaces)
- [x] I have added or updated tests where applicable (JWT injection, file-bootstrap fallback, log redaction, registry capability)
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [x] I have updated relevant documentation to reflect my changes (PR body itself; no code-comment doc changes needed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
