### PR TITLE
fix(openclaw-gateway): surface wake_reason prominently in wake text

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -392,6 +392,11 @@ function buildWakeText(
 
   const lines = [
     "Paperclip wake event for a cloud adapter.",
+    `Wake reason: ${payload.wakeReason ?? "none"}`,
+    "",
+    "Note: your text output may be posted as a visible comment on the Paperclip issue.",
+    "If your workspace instructions define trigger-specific behavior for this wake_reason, follow those instructions instead of the generic workflow below.",
+    "",
     "",
     "Run this procedure now. Do not guess undocumented endpoints and do not ask for additional heartbeat docs.",
     "",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The openclaw-gateway adapter bridges Paperclip triggers to OpenClaw agents via WebSocket
> - OpenClaw agents receive a wake message containing trigger context (wake_reason, taskId, etc.)
> - But wake_reason is buried in the environment variable listing at line ~15 of the message
> - Agents with workspace-level trigger routing (e.g., bridge mentions to Discord vs execute assignments) cannot reliably differentiate trigger types because the reason appears too late
> - This causes agents to apply the generic "execute everything" workflow to bridge triggers, leading to incorrect behavior (full issue checkout on notification relays)
> - This PR surfaces wake_reason on line 2 of the wake text and adds a note about text output visibility
> - The benefit is agents can now reliably route by trigger type using their workspace instructions

## What Changed

- `packages/adapters/openclaw-gateway/src/server/execute.ts`: Added 5 lines to `buildWakeText()` that place `wake_reason` immediately after the "Paperclip wake event" header, before the generic workflow
- Added note: "your text output may be posted as a visible comment on the Paperclip issue"
- Added guidance: "if your workspace instructions define trigger-specific behavior for this wake_reason, follow those instead of the generic workflow below"

## Verification

1. Trigger an OpenClaw agent via `issue_comment_mentioned` wake reason
2. Observe that the wake message now starts with:
   ```
   Paperclip wake event for a cloud adapter.
   Wake reason: issue_comment_mentioned
   
   Note: your text output may be posted as a visible comment on the Paperclip issue.
   If your workspace instructions define trigger-specific behavior...
   ```
3. The generic workflow ("Run this procedure now...") still appears below, unchanged
4. Agents without workspace routing continue to follow the generic workflow (backward-compatible)
5. Agents WITH workspace routing can now match on wake_reason at the top of the message

## Risks

Low risk. Additive change only -- 5 lines prepended to the wake text array. The generic workflow remains intact and is not modified. Agents that do not check wake_reason will not notice the change. No config schema changes, no new dependencies, no migration needed.

## Model Used

Claude Opus 4.6 (1M context) -- extended reasoning mode, tool use for codebase analysis and implementation. Assisted with root cause analysis of the trigger-routing problem and implementation of the fix.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] Change is small and focused (Path 1: 5 lines, 1 file)
- [x] Backward-compatible (no behavioral change for agents without workspace routing)
- [x] PR template fully filled out