### PR TITLE
Coerce non-UUID X-Paperclip-Run-Id header to null at auth boundary

### DIFF
--- a/server/src/__tests__/auth-run-id-coercion.test.ts
+++ b/server/src/__tests__/auth-run-id-coercion.test.ts
@@ -1,0 +1,90 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { actorMiddleware, coerceRunId } from "../middleware/auth.js";
+
+function createDb() {
+  return {} as any;
+}
+
+function createApp() {
+  const app = express();
+  app.use(
+    actorMiddleware(createDb(), {
+      deploymentMode: "local_trusted",
+    }),
+  );
+  app.get("/actor", (req, res) => {
+    res.json({ runId: req.actor.runId ?? null });
+  });
+  return app;
+}
+
+describe("actorMiddleware X-Paperclip-Run-Id coercion (header path)", () => {
+  it("passes through a valid UUID run id unchanged", async () => {
+    const app = createApp();
+    const validUuid = "11111111-2222-4333-8444-555555555555";
+
+    const res = await request(app)
+      .get("/actor")
+      .set("x-paperclip-run-id", validUuid);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ runId: validUuid });
+  });
+
+  it("coerces a malformed run id header to null so downstream UUID columns receive null instead of 500ing", async () => {
+    const app = createApp();
+    // Real example seen in NOY-6892 forensics — agent constructed a slug-style id.
+    const malformed = "noy6809-monitor-1778938148";
+
+    const res = await request(app)
+      .get("/actor")
+      .set("x-paperclip-run-id", malformed);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ runId: null });
+  });
+
+  it("treats a missing run id header as null", async () => {
+    const app = createApp();
+
+    const res = await request(app).get("/actor");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ runId: null });
+  });
+
+  it("coerces an empty run id header to null", async () => {
+    const app = createApp();
+
+    const res = await request(app)
+      .get("/actor")
+      .set("x-paperclip-run-id", "");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ runId: null });
+  });
+});
+
+// Direct unit-test coverage of the JWT-claim branch. Building a fully-signed
+// agent JWT + stubbing the DB just to exercise the same helper as the header
+// path would add a lot of moving parts; the helper itself is the contract.
+describe("coerceRunId (JWT-claim path)", () => {
+  const fakeReq = { method: "POST", originalUrl: "/api/issues/abc/comments" };
+
+  it("passes through a valid UUID claims.run_id unchanged", () => {
+    const validUuid = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    expect(coerceRunId(validUuid, "jwt", fakeReq)).toBe(validUuid);
+  });
+
+  it("coerces a malformed claims.run_id to undefined", () => {
+    expect(coerceRunId("noy6809-monitor-1778938148", "jwt", fakeReq)).toBeUndefined();
+  });
+
+  it("treats a missing or empty claims.run_id as undefined", () => {
+    expect(coerceRunId(undefined, "jwt", fakeReq)).toBeUndefined();
+    expect(coerceRunId(null, "jwt", fakeReq)).toBeUndefined();
+    expect(coerceRunId("", "jwt", fakeReq)).toBeUndefined();
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -4,13 +4,43 @@ import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agentApiKeys, agents, authUsers, companies, companyMemberships, instanceUserRoles } from "@paperclipai/db";
 import { verifyLocalAgentJwt } from "../agent-auth-jwt.js";
-import type { DeploymentMode } from "@paperclipai/shared";
+import { isUuidLike, type DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
 
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Coerce an `X-Paperclip-Run-Id` header (or the JWT-embedded `run_id` claim)
+ * to a value safe to write into Postgres UUID columns. Three columns are
+ * affected today: `activity_log.run_id`, `issue_comments.created_by_run_id`,
+ * and `heartbeat_runs.id` (detached-run cleanup spam). Non-UUID strings are
+ * discarded with a warn-level log so callers can be tracked down and fixed,
+ * while the request itself is allowed to proceed unblocked.
+ *
+ * Exported only so unit tests can exercise both the header source and the
+ * JWT-claim source without spinning up the full middleware.
+ */
+export function coerceRunId(
+  value: string | null | undefined,
+  source: "header" | "jwt",
+  req: Pick<Request, "method" | "originalUrl">,
+): string | undefined {
+  if (value == null || value === "") return undefined;
+  if (isUuidLike(value)) return value;
+  logger.warn(
+    {
+      runIdSource: source,
+      runIdSample: value.length > 64 ? `${value.slice(0, 64)}…` : value,
+      method: req.method,
+      url: req.originalUrl,
+    },
+    "Discarded non-UUID run id; downstream activity log + comment writes will record null",
+  );
+  return undefined;
 }
 
 interface ActorMiddlewareOptions {
@@ -33,7 +63,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
           }
         : { type: "none", source: "none" };
 
-    const runIdHeader = req.header("x-paperclip-run-id");
+    const runIdHeader = coerceRunId(req.header("x-paperclip-run-id"), "header", req);
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {
@@ -163,7 +193,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         agentId: claims.sub,
         companyId: claims.company_id,
         keyId: undefined,
-        runId: runIdHeader || claims.run_id || undefined,
+        runId: runIdHeader || coerceRunId(claims.run_id, "jwt", req),
         source: "agent_jwt",
       };
       next();


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents send the `X-Paperclip-Run-Id` HTTP header to attribute their writes to a specific run, and that value flows into three Postgres UUID columns: `activity_log.run_id`, `issue_comments.created_by_run_id`, and `heartbeat_runs.id`
> - But the server trusts the incoming string and writes it straight through, so an agent that hand-rolls a slug-style id (e.g. `noy6809-monitor-1778938148` from a routine we hit in production this week) crashes the request with `invalid input syntax for type uuid: "..."`
> - The failure mode is confusing because the persistence semantics split per call path: `PATCH /api/issues/:id` 500s **after** the update commits (activity-log runs post-commit), while `POST /api/issues/:id/comments` 500s **inside** the same transaction and drops the comment — the caller can't tell from the response whether retry is safe
> - All three downstream write sites read `req.actor.runId`, which is assigned in exactly one place (the `actorMiddleware`), so the right boundary to fix is the assignment, not the downstream sites
> - This pull request adds an `isUuidLike`-gated coercion in `actorMiddleware`: valid UUIDs pass through, malformed strings are dropped to `undefined` with a single warn-level log line so the offending caller can be located, and the request continues unblocked
> - The benefit is that agent-side mistakes can no longer manifest as 500s with inconsistent split-persistence semantics on this header — they degrade to a null `run_id` and a server-side warning instead

## What Changed

- `server/src/middleware/auth.ts`: added `coerceRunId(value, source, req)` helper that returns the value if `isUuidLike(value)`, otherwise logs a warn-level message and returns `undefined`. Applied at the two boundaries where a run id enters the actor: the `x-paperclip-run-id` header read and the JWT `claims.run_id` fallback in the agent-jwt path.
- `server/src/__tests__/auth-run-id-coercion.test.ts`: new supertest suite that exercises `actorMiddleware` end-to-end with four cases — valid UUID passes through unchanged, malformed slug-style id coerces to null, missing header coerces to null, empty header coerces to null.

No call-site swaps were needed — every site that records `runId` already reads it from `req.actor.runId`, so coercion at the single assignment point fixes all three documented call paths transitively. References that were checked:

- `services/activity-log.ts:81` (`activity_log.run_id` insert) — reads from `input.runId` populated by callers in `routes/issues.ts` from `actor.runId`.
- `services/issues.ts:5096` (`issue_comments.created_by_run_id` insert) — reads from `actor.runId ?? null`.
- `routes/issues.ts:3245` and `:4612` (detached-run cleanup log spam) — reads `actor.runId` to call `heartbeat.reportRunActivity`.

## Verification

```bash
# From the repo root, after `pnpm install --frozen-lockfile && pnpm build`:
cd server
pnpm exec vitest run \
  src/__tests__/auth-run-id-coercion.test.ts \
  src/__tests__/auth-session-route.test.ts \
  src/__tests__/auth-routes.test.ts
# → 3 files, 11 tests, all green

pnpm exec tsc --noEmit
# → exit 0 (no new errors vs master)
```

Manual reproduction of the original failure mode (before this change, hits Postgres):

```bash
curl -i -X POST "$PAPERCLIP_API_URL/api/issues/<id>/comments" \
  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
  -H "X-Paperclip-Run-Id: noy6809-monitor-1778938148" \
  -H "Content-Type: application/json" \
  -d '{"body":"test"}'
# Before: HTTP 500, no comment row inserted, server.log shows
#   `invalid input syntax for type uuid: "noy6809-monitor-1778938148"`
# After:  HTTP 201, comment row inserted with `created_by_run_id = NULL`,
#   server.log shows one warn line:
#   `Discarded non-UUID run id; downstream activity log + comment writes will record null`
```

## Risks

- **Low risk.** The change is a narrow `isUuidLike`-gated drop applied at a single chokepoint, with downstream `?? null` semantics already in place at every consumer. The behavior on a valid UUID is byte-identical to before.
- **Observability impact:** a malformed header now produces one `warn` log line instead of a 500 + stack trace. Operators watching for the old error string in logs will need to switch to the new warn message to track agents that need fixing.
- **Auditing impact:** activity rows that previously failed to insert (PATCH case, post-commit logActivity) will now insert with `run_id = NULL`. Activity rows that previously dropped (POST comment case, in-txn) will now persist with `run_id = NULL`. Net effect is **more** audit data, not less; existing rows are unaffected.
- **JWT path:** the same coercion is also applied to `claims.run_id` from `verifyLocalAgentJwt`. JWTs are signed by us so this is defense-in-depth rather than a known attack vector, but it costs nothing.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`), 200k context, extended thinking off, tool use on. Authored from a Paperclip CTO seat as part of the Noya Motor Group CRM project (forensics on the upstream bug were captured on Noya issue NOY-6892; this PR is the upstream fix scoped per Noya issue NOY-6893).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — not applicable, server-only change
- [x] I have updated relevant documentation to reflect my changes — none required; the helper has a JSDoc comment naming the three protected columns
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge