### PR TITLE
feat(done-gate): write-time PATCH gate for status=done transitions (STAA-4122/STAA-4128)

### DIFF
--- a/server/src/__tests__/done-gate.test.ts
+++ b/server/src/__tests__/done-gate.test.ts
@@ -8,6 +8,12 @@ vi.mock("../middleware/logger.js", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+// Mock node:child_process so execFileAsync in done-gate is controllable per test.
+// vitest hoists vi.mock() calls, so this runs before the module is imported.
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
 // Stub the DB — done-gate only uses it for project workspace lookup
 const mockDb = {
   select: vi.fn().mockReturnThis(),
@@ -28,6 +34,7 @@ function makeDbWithRepoUrl(repoUrl: string | null) {
   } as unknown as import("@paperclipai/db").Db;
 }
 
+import { execFile } from "node:child_process";
 import { validateDoneGate } from "../services/done-gate.js";
 
 // Helper: build a close comment body for Path A
@@ -281,20 +288,217 @@ describe("done-gate Path A structural validation", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Shadow mode
+// Path A — SHA verification via GitHub API (mocked fetch)
+// Use distinct SHAs per test to avoid hitting the module-level SHA cache.
 // ---------------------------------------------------------------------------
 
-describe("done-gate shadow mode", () => {
-  beforeEach(() => {
-    // Temporarily override the module-level constant via env
-    // (module is already loaded; test shadow mode by testing the behaviour inline)
+const GITHUB_REPO_URL = "https://github.com/paperclipai/paperclip";
+
+describe("done-gate Path A — SHA verification via GitHub API", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
   });
 
-  it("returns null (no rejection) when DONE_GATE_SHADOW_MODE=true regardless of missing block", async () => {
-    // We can't easily toggle the module constant after import, so test via
-    // the exported flag value being respected in the logic by patching the
-    // module. For now verify the flag is exported for external control.
-    const gateModule = await import("../services/done-gate.js");
-    expect(typeof gateModule.DONE_GATE_SHADOW_MODE).toBe("boolean");
+  it("accepts Path A when GitHub API returns 200 (SHA exists on main)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 200 }));
+
+    const result = await validateDoneGate({
+      commentBody: pathABody({ sha: "b".repeat(40) }),
+      issueId: "issue-sha-200",
+      projectId: "proj-1",
+      companyId: "co-1",
+      db: makeDbWithRepoUrl(GITHUB_REPO_URL),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("rejects with path_a_sha_not_found when GitHub API returns 404 (phantom SHA)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 404 }));
+
+    const result = await validateDoneGate({
+      commentBody: pathABody({ sha: "c".repeat(40) }),
+      issueId: "issue-sha-404",
+      projectId: "proj-1",
+      companyId: "co-1",
+      db: makeDbWithRepoUrl(GITHUB_REPO_URL),
+    });
+    expect(result?.reason).toBe("path_a_sha_not_found");
+    expect(result?.details).toMatchObject({ verifiedSha: expect.stringContaining("404") });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Path A — SHA verification fallback paths (fetch unavailable → ls-remote)
+// ---------------------------------------------------------------------------
+
+describe("done-gate Path A — ls-remote fallback", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("accepts when GitHub API times out but ls-remote confirms SHA as main HEAD", async () => {
+    const sha = "e".repeat(40);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network timeout")));
+    // promisify(execFile) calls execFile(file, args, opts, callback); callback(err, value)
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1];
+      cb(null, { stdout: `${sha}\trefs/heads/main\n`, stderr: "" });
+      return {} as any;
+    });
+
+    const result = await validateDoneGate({
+      commentBody: pathABody({ sha }),
+      issueId: "issue-sha-ls-ok",
+      projectId: "proj-1",
+      companyId: "co-1",
+      db: makeDbWithRepoUrl(GITHUB_REPO_URL),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("rejects with path_a_sha_infra_unavailable when both GitHub API and ls-remote fail", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network timeout")));
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1];
+      cb(new Error("git ls-remote failed"));
+      return {} as any;
+    });
+
+    const result = await validateDoneGate({
+      commentBody: pathABody({ sha: "d".repeat(40) }),
+      issueId: "issue-sha-double-fail",
+      projectId: "proj-1",
+      companyId: "co-1",
+      db: makeDbWithRepoUrl(GITHUB_REPO_URL),
+    });
+    expect(result?.reason).toBe("path_a_sha_infra_unavailable");
+  });
+
+  it("accepts via ls-remote directly for non-GitHub repo URLs when SHA matches main HEAD", async () => {
+    const sha = "4".repeat(40);
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1];
+      cb(null, { stdout: `${sha}\trefs/heads/main\n`, stderr: "" });
+      return {} as any;
+    });
+
+    const result = await validateDoneGate({
+      commentBody: pathABody({ sha }),
+      issueId: "issue-sha-non-gh-ok",
+      projectId: "proj-1",
+      companyId: "co-1",
+      db: makeDbWithRepoUrl("https://gitea.example.com/org/repo"),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("rejects with path_a_sha_infra_unavailable when ls-remote fails for non-GitHub repo", async () => {
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1];
+      cb(new Error("git ls-remote: connection refused"));
+      return {} as any;
+    });
+
+    const result = await validateDoneGate({
+      commentBody: pathABody({ sha: "5".repeat(40) }),
+      issueId: "issue-sha-non-gh-fail",
+      projectId: "proj-1",
+      companyId: "co-1",
+      db: makeDbWithRepoUrl("https://gitea.example.com/org/repo"),
+    });
+    expect(result?.reason).toBe("path_a_sha_infra_unavailable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shadow mode — behavioral tests
+// DONE_GATE_SHADOW_MODE is a module-level constant evaluated at import time.
+// Use vi.resetModules() + dynamic import to load a fresh module instance with
+// the env var set to "true", then restore after each test.
+// ---------------------------------------------------------------------------
+
+describe("done-gate shadow mode (behavioral)", () => {
+  afterEach(async () => {
+    process.env.DONE_GATE_SHADOW_MODE = "false";
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  async function loadShadowGate() {
+    process.env.DONE_GATE_SHADOW_MODE = "true";
+    vi.resetModules();
+    const mod = await import("../services/done-gate.js");
+    expect(mod.DONE_GATE_SHADOW_MODE).toBe(true);
+    return mod.validateDoneGate;
+  }
+
+  it("suppresses missing_close_block — returns null instead of 422", async () => {
+    const shadowValidate = await loadShadowGate();
+    const result = await shadowValidate({
+      commentBody: "no valid close block here",
+      issueId: "issue-shadow-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("suppresses path_b_reason_not_allowed — returns null instead of 422", async () => {
+    const shadowValidate = await loadShadowGate();
+    const result = await shadowValidate({
+      commentBody: "non-shippable: completely-random-not-in-allowlist",
+      issueId: "issue-shadow-2",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("suppresses path_a_sha_not_found — returns null instead of 422", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 404 }));
+    const shadowValidate = await loadShadowGate();
+    const result = await shadowValidate({
+      commentBody: pathABody({ sha: "0".repeat(40) }),
+      issueId: "issue-shadow-3",
+      projectId: "proj-1",
+      companyId: "co-1",
+      db: makeDbWithRepoUrl(GITHUB_REPO_URL),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("suppresses path_a_sha_infra_unavailable — returns null instead of 422", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("timeout")));
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      const cb = args[args.length - 1];
+      cb(new Error("ls-remote failed"));
+      return {} as any;
+    });
+    const shadowValidate = await loadShadowGate();
+    const result = await shadowValidate({
+      commentBody: pathABody({ sha: "1".repeat(40) }),
+      issueId: "issue-shadow-4",
+      projectId: "proj-1",
+      companyId: "co-1",
+      db: makeDbWithRepoUrl(GITHUB_REPO_URL),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("suppresses close_override_path_not_yet_enabled — returns null instead of 422", async () => {
+    const shadowValidate = await loadShadowGate();
+    const result = await shadowValidate({
+      commentBody: "close-override: approval-abc",
+      issueId: "issue-shadow-5",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result).toBeNull();
   });
 });

--- a/server/src/__tests__/done-gate.test.ts
+++ b/server/src/__tests__/done-gate.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// Shadow mode must be off for these tests
+process.env.DONE_GATE_SHADOW_MODE = "false";
+
+// Mock the logger to avoid file I/O in tests
+vi.mock("../middleware/logger.js", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Stub the DB — done-gate only uses it for project workspace lookup
+const mockDb = {
+  select: vi.fn().mockReturnThis(),
+  from: vi.fn().mockReturnThis(),
+  where: vi.fn().mockReturnThis(),
+  then: vi.fn().mockResolvedValue([]),
+} as unknown as import("@paperclipai/db").Db;
+
+// We need to control the DB query result; override the chain
+function makeDbWithRepoUrl(repoUrl: string | null) {
+  const row = repoUrl ? [{ repoUrl }] : [];
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({ then: (fn: (r: typeof row) => unknown) => Promise.resolve(fn(row)) }),
+      }),
+    }),
+  } as unknown as import("@paperclipai/db").Db;
+}
+
+import { validateDoneGate } from "../services/done-gate.js";
+
+// Helper: build a close comment body for Path A
+function pathABody(
+  opts: { url?: string; at?: string; sha?: string } = {},
+) {
+  const url = opts.url ?? "https://formationfx.vercel.app";
+  const at = opts.at ?? new Date().toISOString();
+  const sha = opts.sha ?? "a".repeat(40);
+  return `verified_live_url: ${url}\nverified_at: ${at}\nverified_sha: ${sha}`;
+}
+
+// ---------------------------------------------------------------------------
+// Path B tests (no external calls needed)
+// ---------------------------------------------------------------------------
+
+describe("done-gate Path B", () => {
+  it("accepts non-shippable: audit", async () => {
+    const result = await validateDoneGate({
+      commentBody: "non-shippable: audit",
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts non-shippable anywhere in body", async () => {
+    const result = await validateDoneGate({
+      commentBody: "## Done\n\nSome prose.\n\nnon-shippable: governance\n\nMore prose.",
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts non-shippable with free-text qualifier", async () => {
+    const result = await validateDoneGate({
+      commentBody: "non-shippable: routine weekly sync",
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts legal-action-carrier", async () => {
+    const result = await validateDoneGate({
+      commentBody: "non-shippable: legal-action-carrier",
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("accepts non-shippable case-insensitively", async () => {
+    const result = await validateDoneGate({
+      commentBody: "non-shippable: Audit",
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("rejects unknown non-shippable reason", async () => {
+    const result = await validateDoneGate({
+      commentBody: "non-shippable: random thing",
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.reason).toBe("path_b_reason_not_allowed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Path C tests
+// ---------------------------------------------------------------------------
+
+describe("done-gate Path C", () => {
+  it("rejects close-override with placeholder reason", async () => {
+    const result = await validateDoneGate({
+      commentBody: "close-override: some-approval-id",
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("close_override_path_not_yet_enabled");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing close block
+// ---------------------------------------------------------------------------
+
+describe("done-gate missing block", () => {
+  it("rejects when comment has no valid close block", async () => {
+    const result = await validateDoneGate({
+      commentBody: "Done! Fixed the bug.",
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("missing_close_block");
+  });
+
+  it("rejects when comment is empty", async () => {
+    const result = await validateDoneGate({
+      commentBody: "",
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("missing_close_block");
+  });
+
+  it("rejects when comment is null", async () => {
+    const result = await validateDoneGate({
+      commentBody: null,
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("missing_close_block");
+  });
+
+  it("includes copy-pasteable example in rejection", async () => {
+    const result = await validateDoneGate({
+      commentBody: null,
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.example).toBeDefined();
+    const ex = result?.example as Record<string, string>;
+    expect(ex["Path A (shippable)"]).toContain("verified_live_url");
+    expect(ex["Path B (non-shippable)"]).toContain("non-shippable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Path A structural validation (no GitHub calls — SHA verification falls
+// through to infra_unavailable when no repoUrl)
+// ---------------------------------------------------------------------------
+
+describe("done-gate Path A structural validation", () => {
+  it("rejects when verified_live_url is missing https", async () => {
+    const result = await validateDoneGate({
+      commentBody: pathABody({ url: "http://not-secure.com" }),
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("path_a_invalid_live_url");
+  });
+
+  it("rejects missing verified_at", async () => {
+    const result = await validateDoneGate({
+      commentBody: "verified_live_url: https://example.com\nverified_sha: " + "a".repeat(40),
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("path_a_missing_verified_at");
+  });
+
+  it("rejects invalid verified_at", async () => {
+    const result = await validateDoneGate({
+      commentBody: pathABody({ at: "not-a-date" }),
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("path_a_invalid_verified_at");
+  });
+
+  it("rejects verified_at older than 60 min", async () => {
+    const oldDate = new Date(Date.now() - 65 * 60 * 1000).toISOString();
+    const result = await validateDoneGate({
+      commentBody: pathABody({ at: oldDate }),
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("path_a_verified_at_too_old");
+  });
+
+  it("rejects missing verified_sha", async () => {
+    const result = await validateDoneGate({
+      commentBody: `verified_live_url: https://example.com\nverified_at: ${new Date().toISOString()}`,
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("path_a_missing_verified_sha");
+  });
+
+  it("rejects short sha", async () => {
+    const result = await validateDoneGate({
+      commentBody: pathABody({ sha: "abc123" }),
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("path_a_invalid_verified_sha_format");
+  });
+
+  it("rejects sha with uppercase hex", async () => {
+    const result = await validateDoneGate({
+      commentBody: pathABody({ sha: "A".repeat(40) }),
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: mockDb,
+    });
+    expect(result?.reason).toBe("path_a_invalid_verified_sha_format");
+  });
+
+  it("rejects when no project repoUrl (infra_unavailable → fail closed)", async () => {
+    // No project → SHA verification can't proceed → infra_unavailable → reject
+    const result = await validateDoneGate({
+      commentBody: pathABody(),
+      issueId: "issue-1",
+      projectId: null,
+      companyId: "co-1",
+      db: makeDbWithRepoUrl(null),
+    });
+    expect(result?.reason).toBe("path_a_sha_infra_unavailable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shadow mode
+// ---------------------------------------------------------------------------
+
+describe("done-gate shadow mode", () => {
+  beforeEach(() => {
+    // Temporarily override the module-level constant via env
+    // (module is already loaded; test shadow mode by testing the behaviour inline)
+  });
+
+  it("returns null (no rejection) when DONE_GATE_SHADOW_MODE=true regardless of missing block", async () => {
+    // We can't easily toggle the module constant after import, so test via
+    // the exported flag value being respected in the logic by patching the
+    // module. For now verify the flag is exported for external control.
+    const gateModule = await import("../services/done-gate.js");
+    expect(typeof gateModule.DONE_GATE_SHADOW_MODE).toBe("boolean");
+  });
+});

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -17,6 +17,11 @@ const mockTrackAgentTaskCompleted = vi.hoisted(() => vi.fn());
 const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
 
 function registerModuleMocks() {
+  vi.doMock("../services/done-gate.js", () => ({
+    validateDoneGate: vi.fn(async () => null),
+    DONE_GATE_SHADOW_MODE: false,
+  }));
+
   vi.doMock("@paperclipai/shared/telemetry", () => ({
     trackAgentTaskCompleted: mockTrackAgentTaskCompleted,
     trackErrorHandlerCrash: vi.fn(),

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -109,6 +109,7 @@ import {
 } from "../services/issue-execution-policy.js";
 import { parseIssueExecutionWorkspaceSettings } from "../services/execution-workspace-policy.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { validateDoneGate } from "../services/done-gate.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -2949,6 +2950,21 @@ export function issueRoutes(
     if (assigneeWillChange && !transition.workflowControlledAssignment) {
       if (!isAgentReturningIssueToCreator) {
         await assertCanAssignTasks(req, existing.companyId);
+      }
+    }
+
+    // Write-time done gate (STAA-4122)
+    if (updateFields.status === "done" && existing.status !== "done") {
+      const gateRejection = await validateDoneGate({
+        commentBody,
+        issueId: existing.id,
+        projectId: existing.projectId ?? null,
+        companyId: existing.companyId,
+        db,
+      });
+      if (gateRejection) {
+        res.status(422).json(gateRejection);
+        return;
       }
     }
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2953,8 +2953,15 @@ export function issueRoutes(
       }
     }
 
-    // Write-time done gate (STAA-4122)
-    if (updateFields.status === "done" && existing.status !== "done") {
+    // Write-time done gate (STAA-4122). Agent-only — board/user closes are not
+    // subject to close-block doctrine. Also skipped for execution-policy decisions
+    // (approval/review stage outcomes are already governance-gated).
+    if (
+      updateFields.status === "done" &&
+      existing.status !== "done" &&
+      actor.actorType === "agent" &&
+      !transition.decision
+    ) {
       const gateRejection = await validateDoneGate({
         commentBody,
         issueId: existing.id,

--- a/server/src/services/done-gate.ts
+++ b/server/src/services/done-gate.ts
@@ -1,0 +1,412 @@
+/**
+ * Write-time PATCH gate for status=done transitions (STAA-4122).
+ *
+ * Rejects a close PATCH with HTTP 422 unless the closing comment contains
+ * a valid Path A (shippable), Path B (non-shippable), or Path C (close-override)
+ * block. Path C is a placeholder (rejected with close_override_path_not_yet_enabled).
+ *
+ * Shadow mode: set env DONE_GATE_SHADOW_MODE=true to log rejections without
+ * returning 422. Used during P1 dry-run before P2 hard enforcement.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { Db } from "@paperclipai/db";
+import { projectWorkspaces } from "@paperclipai/db";
+import { eq } from "drizzle-orm";
+import { logger } from "../middleware/logger.js";
+
+const execFileAsync = promisify(execFile);
+
+export const DONE_GATE_SHADOW_MODE = process.env.DONE_GATE_SHADOW_MODE === "true";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VERIFIED_AT_MAX_AGE_MS = 60 * 60 * 1000; // 60 minutes
+
+const PATH_B_ALLOWLIST = new Set([
+  "audit",
+  "governance",
+  "planning",
+  "routine",
+  "code review",
+  "process",
+  "triage",
+  "legal-action-carrier",
+]);
+
+// ---------------------------------------------------------------------------
+// SHA verification cache (in-process LRU with 5-min TTL)
+// ---------------------------------------------------------------------------
+
+interface ShaCacheEntry {
+  exists: boolean;
+  fetchedAt: number;
+}
+
+const SHA_CACHE_TTL_MS = 5 * 60 * 1000;
+const shaCache = new Map<string, ShaCacheEntry>();
+
+function cacheLookup(cacheKey: string): boolean | null {
+  const entry = shaCache.get(cacheKey);
+  if (!entry) return null;
+  if (Date.now() - entry.fetchedAt > SHA_CACHE_TTL_MS) {
+    shaCache.delete(cacheKey);
+    return null;
+  }
+  return entry.exists;
+}
+
+function cacheSet(cacheKey: string, exists: boolean) {
+  shaCache.set(cacheKey, { exists, fetchedAt: Date.now() });
+}
+
+// ---------------------------------------------------------------------------
+// Path parsing
+// ---------------------------------------------------------------------------
+
+const PATH_A_REGEX = /^verified_live_url:\s*(.+)$/im;
+const PATH_A_AT_REGEX = /^verified_at:\s*(.+)$/im;
+const PATH_A_SHA_REGEX = /^verified_sha:\s*([0-9a-f]+)$/im;
+
+const PATH_B_REGEX = /^non-shippable:\s*(.+)$/im;
+
+const PATH_C_REGEX = /^close-override:\s*(.+)$/im;
+
+function parsePathA(body: string) {
+  const urlMatch = PATH_A_REGEX.exec(body);
+  const atMatch = PATH_A_AT_REGEX.exec(body);
+  const shaMatch = PATH_A_SHA_REGEX.exec(body);
+  if (!urlMatch && !atMatch && !shaMatch) return null;
+  return {
+    verifiedLiveUrl: urlMatch?.[1]?.trim() ?? null,
+    verifiedAt: atMatch?.[1]?.trim() ?? null,
+    verifiedSha: shaMatch?.[1]?.trim() ?? null,
+  };
+}
+
+function parsePathB(body: string) {
+  const match = PATH_B_REGEX.exec(body);
+  if (!match) return null;
+  return { reason: match[1].trim() };
+}
+
+function parsePathC(body: string) {
+  const match = PATH_C_REGEX.exec(body);
+  if (!match) return null;
+  return { approvalId: match[1].trim() };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const GITHUB_HTTPS_RE = /^https?:\/\/github\.com\/([^/]+)\/([^/.]+?)(?:\.git)?\/?$/;
+
+function extractGitHubOwnerRepo(repoUrl: string): { owner: string; repo: string } | null {
+  const m = GITHUB_HTTPS_RE.exec(repoUrl);
+  if (!m) return null;
+  return { owner: m[1], repo: m[2] };
+}
+
+async function shaExistsOnMainViaGitHub(
+  owner: string,
+  repo: string,
+  sha: string,
+): Promise<boolean | "infra_unavailable"> {
+  const cacheKey = `gh:${owner}/${repo}:${sha}`;
+  const cached = cacheLookup(cacheKey);
+  if (cached !== null) return cached;
+
+  const token = process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = { Accept: "application/vnd.github.v3+json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  try {
+    const url = `https://api.github.com/repos/${owner}/${repo}/commits/${sha}`;
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(8000) });
+    const exists = res.status === 200;
+    cacheSet(cacheKey, exists);
+    return exists;
+  } catch {
+    return "infra_unavailable";
+  }
+}
+
+async function shaExistsOnMainViaGitLsRemote(
+  repoUrl: string,
+  sha: string,
+): Promise<boolean | "infra_unavailable"> {
+  const cacheKey = `ls:${repoUrl}:${sha}`;
+  const cached = cacheLookup(cacheKey);
+  if (cached !== null) return cached;
+
+  try {
+    const { stdout } = await execFileAsync("git", ["ls-remote", repoUrl, "refs/heads/main"], {
+      timeout: 8000,
+    });
+    // stdout format: "<sha>\trefs/heads/main\n"
+    const mainSha = stdout.trim().split("\t")[0]?.trim() ?? "";
+    // We can only check if verified_sha equals HEAD of main. For merged commits
+    // that are not HEAD, fall through to GitHub API.
+    if (mainSha.startsWith(sha) || sha.startsWith(mainSha)) {
+      cacheSet(cacheKey, true);
+      return true;
+    }
+    // ls-remote only gives HEAD; can't confirm arbitrary ancestors without full fetch
+    return "infra_unavailable";
+  } catch {
+    return "infra_unavailable";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SHA verification orchestration
+// ---------------------------------------------------------------------------
+
+async function verifySha(
+  sha: string,
+  repoUrl: string | null,
+): Promise<"ok" | "not_found" | "infra_unavailable"> {
+  if (!repoUrl) return "infra_unavailable";
+
+  const ownerRepo = extractGitHubOwnerRepo(repoUrl);
+  if (ownerRepo) {
+    // Try GitHub API first (can verify any SHA on the repo, not just HEAD)
+    const result = await shaExistsOnMainViaGitHub(ownerRepo.owner, ownerRepo.repo, sha);
+    if (result === "infra_unavailable") {
+      // GitHub API unavailable — try git ls-remote as last resort
+      const lsResult = await shaExistsOnMainViaGitLsRemote(repoUrl, sha);
+      if (lsResult === true) return "ok";
+      return "infra_unavailable";
+    }
+    return result ? "ok" : "not_found";
+  }
+
+  // Non-GitHub repo: try git ls-remote
+  const lsResult = await shaExistsOnMainViaGitLsRemote(repoUrl, sha);
+  if (lsResult === true) return "ok";
+  return lsResult === false ? "not_found" : "infra_unavailable";
+}
+
+// ---------------------------------------------------------------------------
+// 422 error payloads
+// ---------------------------------------------------------------------------
+
+function makeRejectionPayload(reason: string, details: Record<string, unknown>) {
+  return {
+    error: "done_gate_rejected",
+    reason,
+    details,
+    example: {
+      "Path A (shippable)": [
+        "verified_live_url: https://your-deploy-url.vercel.app",
+        "verified_at: 2026-05-13T12:00:00.000Z",
+        "verified_sha: <40-char git sha that exists on origin/main>",
+      ].join("\n"),
+      "Path B (non-shippable)": "non-shippable: audit",
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface DoneGateParams {
+  commentBody: string | null | undefined;
+  issueId: string;
+  projectId: string | null;
+  companyId: string;
+  db: Db;
+}
+
+export interface DoneGateRejection {
+  error: string;
+  reason: string;
+  details: Record<string, unknown>;
+  example: unknown;
+}
+
+/**
+ * Returns a rejection payload if the close should be blocked, or null to allow.
+ * In shadow mode always returns null (rejection is logged only).
+ */
+export async function validateDoneGate(params: DoneGateParams): Promise<DoneGateRejection | null> {
+  const { commentBody, issueId, projectId, companyId, db } = params;
+
+  // --- Resolve project repoUrl for SHA verification ---
+  let repoUrl: string | null = null;
+  if (projectId) {
+    const workspace = await db
+      .select({ repoUrl: projectWorkspaces.repoUrl })
+      .from(projectWorkspaces)
+      .where(eq(projectWorkspaces.projectId, projectId))
+      .then((rows) => rows.find((r) => r.repoUrl) ?? null);
+    repoUrl = workspace?.repoUrl ?? null;
+  }
+
+  const body = commentBody ?? "";
+
+  // --- Path C: placeholder ---
+  const pathC = parsePathC(body);
+  if (pathC) {
+    const rejection = makeRejectionPayload("close_override_path_not_yet_enabled", {
+      approvalId: pathC.approvalId,
+      note: "Path C (close-override) is not yet enabled. Use Path A or Path B.",
+    });
+    if (DONE_GATE_SHADOW_MODE) {
+      logger.warn({ issueId, companyId, reason: rejection.reason }, "done-gate shadow: would reject");
+      return null;
+    }
+    return rejection;
+  }
+
+  // --- Path B: non-shippable ---
+  const pathB = parsePathB(body);
+  if (pathB) {
+    const raw = pathB.reason.toLowerCase();
+    // Allow if reason starts with an allowlisted word (free-text qualifier permitted after)
+    const allowed = Array.from(PATH_B_ALLOWLIST).some((term) => raw === term || raw.startsWith(term + " ") || raw.startsWith(term + ":") || raw.startsWith(term + ","));
+    if (!allowed) {
+      const rejection = makeRejectionPayload("path_b_reason_not_allowed", {
+        reason: pathB.reason,
+        allowed: Array.from(PATH_B_ALLOWLIST),
+      });
+      if (DONE_GATE_SHADOW_MODE) {
+        logger.warn({ issueId, companyId, reason: rejection.reason }, "done-gate shadow: would reject");
+        return null;
+      }
+      return rejection;
+    }
+    // Valid Path B
+    logger.info({ issueId, companyId, path: "B", reason: pathB.reason }, "done-gate: accepted via Path B");
+    return null;
+  }
+
+  // --- Path A: shippable ---
+  const pathA = parsePathA(body);
+  if (pathA) {
+    // Validate verified_live_url
+    if (!pathA.verifiedLiveUrl || !pathA.verifiedLiveUrl.startsWith("https://")) {
+      const rejection = makeRejectionPayload("path_a_invalid_live_url", {
+        verifiedLiveUrl: pathA.verifiedLiveUrl,
+        note: "verified_live_url must be a https:// URL",
+      });
+      if (DONE_GATE_SHADOW_MODE) {
+        logger.warn({ issueId, companyId, reason: rejection.reason }, "done-gate shadow: would reject");
+        return null;
+      }
+      return rejection;
+    }
+
+    // Validate verified_at
+    if (!pathA.verifiedAt) {
+      const rejection = makeRejectionPayload("path_a_missing_verified_at", {
+        note: "verified_at is required (ISO-8601 timestamp within 60 min of now)",
+      });
+      if (DONE_GATE_SHADOW_MODE) {
+        logger.warn({ issueId, companyId, reason: rejection.reason }, "done-gate shadow: would reject");
+        return null;
+      }
+      return rejection;
+    }
+    const verifiedAtMs = new Date(pathA.verifiedAt).getTime();
+    if (Number.isNaN(verifiedAtMs)) {
+      const rejection = makeRejectionPayload("path_a_invalid_verified_at", {
+        verifiedAt: pathA.verifiedAt,
+        note: "verified_at must be a valid ISO-8601 timestamp",
+      });
+      if (DONE_GATE_SHADOW_MODE) {
+        logger.warn({ issueId, companyId, reason: rejection.reason }, "done-gate shadow: would reject");
+        return null;
+      }
+      return rejection;
+    }
+    const ageMs = Date.now() - verifiedAtMs;
+    if (ageMs > VERIFIED_AT_MAX_AGE_MS || ageMs < -5 * 60 * 1000) {
+      const rejection = makeRejectionPayload("path_a_verified_at_too_old", {
+        verifiedAt: pathA.verifiedAt,
+        ageMinutes: Math.round(ageMs / 60_000),
+        maxAgeMinutes: 60,
+        note: "verified_at must be within the last 60 minutes",
+      });
+      if (DONE_GATE_SHADOW_MODE) {
+        logger.warn({ issueId, companyId, reason: rejection.reason }, "done-gate shadow: would reject");
+        return null;
+      }
+      return rejection;
+    }
+
+    // Validate verified_sha
+    if (!pathA.verifiedSha) {
+      const rejection = makeRejectionPayload("path_a_missing_verified_sha", {
+        note: "verified_sha is required (40-char hex git SHA that exists on origin/main)",
+      });
+      if (DONE_GATE_SHADOW_MODE) {
+        logger.warn({ issueId, companyId, reason: rejection.reason }, "done-gate shadow: would reject");
+        return null;
+      }
+      return rejection;
+    }
+    if (!/^[0-9a-f]{40}$/.test(pathA.verifiedSha)) {
+      const rejection = makeRejectionPayload("path_a_invalid_verified_sha_format", {
+        verifiedSha: pathA.verifiedSha,
+        note: "verified_sha must be exactly 40 lowercase hex characters",
+      });
+      if (DONE_GATE_SHADOW_MODE) {
+        logger.warn({ issueId, companyId, reason: rejection.reason }, "done-gate shadow: would reject");
+        return null;
+      }
+      return rejection;
+    }
+
+    // SHA existence check
+    const shaResult = await verifySha(pathA.verifiedSha, repoUrl);
+    if (shaResult === "not_found") {
+      const rejection = makeRejectionPayload("path_a_sha_not_found", {
+        verifiedSha: `${pathA.verifiedSha} → 404`,
+        note: "verified_sha does not exist on origin/main",
+      });
+      if (DONE_GATE_SHADOW_MODE) {
+        logger.warn({ issueId, companyId, reason: rejection.reason, sha: pathA.verifiedSha }, "done-gate shadow: would reject");
+        return null;
+      }
+      return rejection;
+    }
+    if (shaResult === "infra_unavailable") {
+      logger.warn(
+        { issueId, companyId, sha: pathA.verifiedSha, repoUrl },
+        "done-gate: SHA verification unavailable (no repoUrl or infra error) — passing in shadow mode",
+      );
+      if (!DONE_GATE_SHADOW_MODE) {
+        // Hard enforcement: fail closed when infra is unavailable
+        const rejection = makeRejectionPayload("path_a_sha_infra_unavailable", {
+          verifiedSha: `${pathA.verifiedSha} → infra_unavailable`,
+          note: "SHA verification infrastructure unavailable. Park the close and retry, or contact platform support.",
+        });
+        return rejection;
+      }
+      return null;
+    }
+
+    // Valid Path A
+    logger.info(
+      { issueId, companyId, path: "A", sha: pathA.verifiedSha, url: pathA.verifiedLiveUrl },
+      "done-gate: accepted via Path A",
+    );
+    return null;
+  }
+
+  // --- No valid path found ---
+  const rejection = makeRejectionPayload("missing_close_block", {
+    note: "A status=done PATCH requires a valid close block in the comment. Include Path A (verified_live_url / verified_at / verified_sha) for shippable work or Path B (non-shippable: <reason>) for non-shippable work.",
+  });
+  if (DONE_GATE_SHADOW_MODE) {
+    logger.warn({ issueId, companyId, reason: rejection.reason }, "done-gate shadow: would reject");
+    return null;
+  }
+  return rejection;
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -20,5 +20,10 @@ export default defineConfig({
       hooks: "list",
     },
     setupFiles: ["./src/__tests__/setup-supertest.ts"],
+    // Ensure shadow-mode env is always off in tests; the done-gate test suite
+    // re-enables it explicitly per-test via vi.resetModules() + dynamic import.
+    env: {
+      DONE_GATE_SHADOW_MODE: "false",
+    },
   },
 });


### PR DESCRIPTION
## Summary

Adds a write-time gate on `status=done` transitions for agent-authored PATCHes.

- **Path A (shippable):** must include `verified_live_url`, `verified_at`, `verified_sha` with server-side SHA verification against origin/main
- **Path B (non-shippable):** must include `non-shippable: <allowlisted-reason>`
- **Board/user actors:** bypassed entirely
- **Shadow mode (`DONE_GATE_SHADOW_MODE=true`):** logs rejections, returns 200 — safe for P1 rollout

## Files changed

- `server/src/services/done-gate.ts` — core gate service with SHA verification (GitHub API + git ls-remote fallback), 5-min in-process LRU cache, fail-closed on infra error
- `server/src/routes/issues.ts` — middleware on PATCH /api/issues/:id
- `server/src/__tests__/done-gate.test.ts` — 30 unit tests covering Path A/B/C, SHA verification (200/404/timeout/ls-remote/double-fail), and shadow mode behavioral tests
- `server/vitest.config.ts` — adds `env: { DONE_GATE_SHADOW_MODE: "false" }` to prevent ESM import-order flakiness in tests

## Tickets

- [STAA-4122](/STAA/issues/STAA-4122) (doctrine)
- [STAA-4128](/STAA/issues/STAA-4128) (implementation)
- [STAA-4206](/STAA/issues/STAA-4206) (code review)

## Rollout plan

1. Board approves server restart with `DONE_GATE_SHADOW_MODE=true`
2. 24h shadow observation vs QUORUM sweep rate
3. Flip to hard enforcement if sweep rate holds

Supersedes PR #5896 (same commits, branch renamed to comply with STAA-491 naming convention).