### PR TITLE
ui: relax live-run / log polling intervals to reduce CPU pressure

### DIFF
--- a/ui/src/components/LiveRunWidget.tsx
+++ b/ui/src/components/LiveRunWidget.tsx
@@ -32,14 +32,14 @@ export function LiveRunWidget({ issueId, companyId }: LiveRunWidgetProps) {
     queryKey: queryKeys.issues.liveRuns(issueId),
     queryFn: () => heartbeatsApi.liveRunsForIssue(issueId),
     enabled: !!issueId,
-    refetchInterval: 3000,
+    refetchInterval: 10_000,
   });
 
   const { data: activeRun } = useQuery({
     queryKey: queryKeys.issues.activeRun(issueId),
     queryFn: () => heartbeatsApi.activeRunForIssue(issueId),
     enabled: !!issueId,
-    refetchInterval: 3000,
+    refetchInterval: 10_000,
   });
 
   const runs = useMemo(() => {

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -3507,7 +3507,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
   const { data: workspaceOperations = [] } = useQuery({
     queryKey: queryKeys.runWorkspaceOperations(run.id),
     queryFn: () => heartbeatsApi.workspaceOperations(run.id),
-    refetchInterval: isLive ? 2000 : false,
+    refetchInterval: isLive ? 5000 : false,
   });
 
   function isRunLogUnavailable(err: unknown): boolean {
@@ -3715,7 +3715,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
       } catch {
         // ignore polling errors
       }
-    }, 2000);
+    }, 5000);
     return () => clearInterval(interval);
   }, [run.id, isLive, isStreamingConnected, events]);
 
@@ -3737,7 +3737,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
         if (isRunLogUnavailable(err)) return;
         // ignore polling errors
       }
-    }, 2000);
+    }, 5000);
     return () => clearInterval(interval);
   }, [run.id, isLive, isStreamingConnected, logOffset]);
 

--- a/ui/src/pages/Inbox.tsx
+++ b/ui/src/pages/Inbox.tsx
@@ -842,7 +842,7 @@ export function Inbox() {
     queryKey: queryKeys.liveRuns(selectedCompanyId!),
     queryFn: () => heartbeatsApi.liveRunsForCompany(selectedCompanyId!),
     enabled: !!selectedCompanyId,
-    refetchInterval: 5000,
+    refetchInterval: 15_000,
   });
   const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns), [liveRuns]);
   const { data: companyMembers } = useQuery({

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -744,7 +744,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   const { data: liveRuns } = useQuery({
     queryKey: queryKeys.issues.liveRuns(issueId),
     queryFn: () => heartbeatsApi.liveRunsForIssue(issueId),
-    refetchInterval: 3000,
+    refetchInterval: 10_000,
     placeholderData: keepPreviousDataForSameQueryTail<LiveRunForIssue[]>(issueId),
   });
   const resolvedLiveRuns = liveRuns ?? [];
@@ -753,7 +753,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
     queryKey: queryKeys.issues.activeRun(issueId),
     queryFn: () => heartbeatsApi.activeRunForIssue(issueId),
     enabled: !!executionRunId || issueStatus === "in_progress",
-    refetchInterval: liveRunCount > 0 ? false : 3000,
+    refetchInterval: liveRunCount > 0 ? false : 10_000,
     placeholderData: keepPreviousDataForSameQueryTail<ActiveRunForIssue | null>(issueId),
   });
   const resolvedActiveRun = useMemo(
@@ -764,7 +764,7 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   const { data: linkedRuns } = useQuery({
     queryKey: queryKeys.issues.runs(issueId),
     queryFn: () => activityApi.runsForIssue(issueId),
-    refetchInterval: hasLiveRuns ? 5000 : false,
+    refetchInterval: hasLiveRuns ? 15_000 : false,
     placeholderData: keepPreviousDataForSameQueryTail<RunForIssue[]>(issueId),
   });
   const resolvedActivity = activity ?? [];
@@ -1338,7 +1338,7 @@ export function IssueDetail() {
     queryKey: queryKeys.issues.liveRuns(issueId!),
     queryFn: () => heartbeatsApi.liveRunsForIssue(issueId!),
     enabled: !!issueId,
-    refetchInterval: 3000,
+    refetchInterval: 10_000,
     select: (runs) => runs.length,
     placeholderData: keepPreviousDataForSameQueryTail<LiveRunForIssue[]>(issueId ?? "pending"),
   });
@@ -1347,7 +1347,7 @@ export function IssueDetail() {
     queryKey: queryKeys.issues.activeRun(issueId!),
     queryFn: () => heartbeatsApi.activeRunForIssue(issueId!),
     enabled: !!issueId && (!!issue?.executionRunId || issue?.status === "in_progress"),
-    refetchInterval: liveRunCount > 0 ? false : 3000,
+    refetchInterval: liveRunCount > 0 ? false : 10_000,
     select: (run) => !!run,
     placeholderData: keepPreviousDataForSameQueryTail<ActiveRunForIssue | null>(issueId ?? "pending"),
   });
@@ -1388,7 +1388,7 @@ export function IssueDetail() {
     queryKey: resolvedCompanyId ? queryKeys.liveRuns(resolvedCompanyId) : ["live-runs", "pending"],
     queryFn: () => heartbeatsApi.liveRunsForCompany(resolvedCompanyId!),
     enabled: !!resolvedCompanyId,
-    refetchInterval: 5000,
+    refetchInterval: 15_000,
     placeholderData: keepPreviousDataForSameQueryTail<LiveRunForIssue[]>(resolvedCompanyId ?? "pending"),
   });
 


### PR DESCRIPTION
## Summary

Reduces refetch cadence on the hottest UI queries that hit the API/DB. WebSocket via `LiveUpdatesProvider` remains the primary push path; these polls are a safety net.

## Why

Observed on a 2-vCPU droplet (3.8 GiB RAM, no swap) hosting a default Paperclip install with 3 concurrent claude_local agents:

- Load average 5.66 / 6.61 / 8.12 — 280-400% saturation on 2 cores.
- 9-10 embedded-postgres backends each at 18-25% CPU, summed ~190% (95% of total user CPU).
- Last 5 minutes of `paperclip.service` log showed `GET /companies/{id}/live-runs` 13x and `GET /heartbeat-runs/{id}/log?offset=…&limitBytes=256000` 9x, fan-out from issue-detail polls at 2-3s tick rates.

## Changes

| Surface | Query | Before | After |
|---|---|---|---|
| `LiveRunWidget` | `issues.liveRuns`, `issues.activeRun` | 3000 | 10_000 |
| `IssueDetail` (chat tab) | `issues.liveRuns`, `issues.activeRun` | 3000 | 10_000 |
| `IssueDetail` (chat tab) | `issues.runs` (linked) | 5000 | 15_000 |
| `IssueDetail` (top-level) | `issues.liveRuns`, `issues.activeRun` | 3000 | 10_000 |
| `IssueDetail` (top-level) | `liveRuns(companyId)` | 5000 | 15_000 |
| `AgentDetail` LogViewer | workspaceOperations | 2000 | 5000 |
| `AgentDetail` LogViewer | events `setInterval` | 2000 | 5000 |
| `AgentDetail` LogViewer | log `setInterval` | 2000 | 5000 |
| `Inbox` | `liveRuns(companyId)` | 5000 | 15_000 |

No semantic change; WS-driven invalidation in `LiveUpdatesProvider` still delivers near-instant updates in the foreground.

## Test plan

- [ ] `pnpm -F ui test` (existing tests should pass — none assert on these literal intervals)
- [ ] Manual: open Issue Detail with a running agent — log tail still updates from WS; if WS drops, polling at 5s confirms the log keeps tailing
- [ ] Manual: Inbox `live-runs` badge updates within ~15s after a run flips state with WS suppressed (e.g., backgrounded tab + reconnect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)