### PR TITLE
feat(interactions): timeout auto-accept and CEO escalation for request_confirmation

### DIFF
--- a/packages/db/src/migrations/0086_interaction_timeout_escalation.sql
+++ b/packages/db/src/migrations/0086_interaction_timeout_escalation.sql
@@ -1,0 +1,9 @@
+-- Add timeout/escalation support to request_confirmation interactions.
+-- When an interaction is created with timeoutMinutes set, scheduled_escalation_at
+-- is populated and a background job auto-accepts the interaction when the deadline passes.
+
+ALTER TABLE "issue_thread_interactions"
+  ADD COLUMN "scheduled_escalation_at" timestamp with time zone;
+
+CREATE INDEX "issue_thread_interactions_scheduled_escalation_idx"
+  ON "issue_thread_interactions" ("scheduled_escalation_at");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -603,6 +603,13 @@
       "when": 1778787362162,
       "tag": "0085_tranquil_the_executioner",
       "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "7",
+      "when": 1747400000000,
+      "tag": "0086_interaction_timeout_escalation",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issue_thread_interactions.ts
+++ b/packages/db/src/schema/issue_thread_interactions.ts
@@ -30,6 +30,7 @@ export const issueThreadInteractions = pgTable(
     resolvedByUserId: text("resolved_by_user_id"),
     payload: jsonb("payload").$type<IssueThreadInteractionPayload>().notNull(),
     result: jsonb("result").$type<IssueThreadInteractionResult>(),
+    scheduledEscalationAt: timestamp("scheduled_escalation_at", { withTimezone: true }),
     resolvedAt: timestamp("resolved_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
@@ -50,5 +51,6 @@ export const issueThreadInteractions = pgTable(
       .on(table.companyId, table.issueId, table.idempotencyKey)
       .where(sql`${table.idempotencyKey} IS NOT NULL`),
     sourceCommentIdx: index("issue_thread_interactions_source_comment_idx").on(table.sourceCommentId),
+    scheduledEscalationIdx: index("issue_thread_interactions_scheduled_escalation_idx").on(table.scheduledEscalationAt),
   }),
 );

--- a/packages/shared/src/issue-thread-interactions.test.ts
+++ b/packages/shared/src/issue-thread-interactions.test.ts
@@ -92,6 +92,66 @@ describe("issue thread interaction schemas", () => {
     });
   });
 
+  it("accepts auto_accept timeout configuration", () => {
+    const parsed = createIssueThreadInteractionSchema.parse({
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Proceed with deployment?",
+        timeoutMinutes: 60,
+        timeoutAction: "auto_accept",
+      },
+    });
+
+    expect(parsed.kind).toBe("request_confirmation");
+    if (parsed.kind !== "request_confirmation") return;
+    expect(parsed.payload.timeoutMinutes).toBe(60);
+    expect(parsed.payload.timeoutAction).toBe("auto_accept");
+    expect(parsed.payload.escalationAgentId).toBeUndefined();
+  });
+
+  it("accepts escalate_to_ceo timeout configuration", () => {
+    const parsed = createIssueThreadInteractionSchema.parse({
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Proceed with deployment?",
+        timeoutMinutes: 30,
+        timeoutAction: "escalate_to_ceo",
+        escalationAgentId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      },
+    });
+
+    expect(parsed.kind).toBe("request_confirmation");
+    if (parsed.kind !== "request_confirmation") return;
+    expect(parsed.payload.timeoutMinutes).toBe(30);
+    expect(parsed.payload.timeoutAction).toBe("escalate_to_ceo");
+    expect(parsed.payload.escalationAgentId).toBe("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+  });
+
+  it("rejects escalate_to_ceo without escalationAgentId", () => {
+    expect(() => createIssueThreadInteractionSchema.parse({
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Proceed?",
+        timeoutMinutes: 30,
+        timeoutAction: "escalate_to_ceo",
+      },
+    })).toThrow("escalationAgentId is required when timeoutAction is escalate_to_ceo");
+  });
+
+  it("rejects timeoutAction without timeoutMinutes", () => {
+    expect(() => createIssueThreadInteractionSchema.parse({
+      kind: "request_confirmation",
+      payload: {
+        version: 1,
+        prompt: "Proceed?",
+        timeoutAction: "auto_accept",
+      },
+    })).toThrow("timeoutMinutes is required when timeoutAction is set");
+  });
+
   it("rejects unsafe request_confirmation target hrefs", () => {
     const base = {
       kind: "request_confirmation",

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -703,11 +703,17 @@ export interface RequestConfirmationPayload {
   detailsMarkdown?: string | null;
   supersedeOnUserComment?: boolean;
   target?: RequestConfirmationTarget | null;
+  /** Minutes to wait for board response before firing timeoutAction. Must be >= 1. */
+  timeoutMinutes?: number | null;
+  /** Action to take when timeoutMinutes elapses with no board response. */
+  timeoutAction?: "auto_accept" | "escalate_to_ceo" | null;
+  /** Agent ID to attribute the auto-acceptance to when timeoutAction is "escalate_to_ceo". */
+  escalationAgentId?: string | null;
 }
 
 export interface RequestConfirmationResult {
   version: 1;
-  outcome: "accepted" | "rejected" | "superseded_by_comment" | "stale_target";
+  outcome: "accepted" | "rejected" | "superseded_by_comment" | "stale_target" | "timed_out";
   reason?: string | null;
   commentId?: string | null;
   staleTarget?: RequestConfirmationTarget | null;

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -710,11 +710,29 @@ export const requestConfirmationPayloadSchema = z.object({
   detailsMarkdown: z.string().max(20000).nullable().optional(),
   supersedeOnUserComment: z.boolean().optional(),
   target: requestConfirmationTargetSchema.nullable().optional(),
+  timeoutMinutes: z.number().int().min(1).max(1440).nullable().optional(),
+  timeoutAction: z.enum(["auto_accept", "escalate_to_ceo"]).nullable().optional(),
+  escalationAgentId: z.string().uuid().nullable().optional(),
+}).superRefine((val, ctx) => {
+  if (val.timeoutAction != null && val.timeoutMinutes == null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "timeoutMinutes is required when timeoutAction is set",
+      path: ["timeoutMinutes"],
+    });
+  }
+  if (val.timeoutAction === "escalate_to_ceo" && val.escalationAgentId == null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "escalationAgentId is required when timeoutAction is escalate_to_ceo",
+      path: ["escalationAgentId"],
+    });
+  }
 });
 
 export const requestConfirmationResultSchema = z.object({
   version: z.literal(1),
-  outcome: z.enum(["accepted", "rejected", "superseded_by_comment", "stale_target"]),
+  outcome: z.enum(["accepted", "rejected", "superseded_by_comment", "stale_target", "timed_out"]),
   reason: z.string().trim().max(4000).nullable().optional(),
   commentId: z.string().uuid().nullable().optional(),
   staleTarget: requestConfirmationTargetSchema.nullable().optional(),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,6 +32,7 @@ import {
   feedbackService,
   heartbeatService,
   instanceSettingsService,
+  issueThreadInteractionService,
   reconcilePersistedRuntimeServicesOnStartup,
   routineService,
 } from "./services/index.js";
@@ -738,7 +739,40 @@ export async function startServer(): Promise<StartedServer> {
         .catch((err) => {
           logger.error({ err }, "routine scheduler tick failed");
         });
-  
+
+      const interactionTickNow = new Date();
+      void issueThreadInteractionService(db as any)
+        .tickTimeouts(interactionTickNow)
+        .then((result) => {
+          if (result.autoAccepted > 0 || result.errors > 0) {
+            logger.info({ ...result }, "interaction timeout tick auto-accepted confirmations");
+          }
+          for (const target of result.wakeTargets) {
+            if (target.agentId) {
+              void heartbeat.wakeup(target.agentId, {
+                source: "automation",
+                triggerDetail: "system",
+                reason: "issue_commented",
+                payload: {
+                  issueId: target.issueId,
+                  mutation: "interaction_timeout",
+                },
+                requestedByActorType: "system",
+                requestedByActorId: "interaction_timeout_scheduler",
+                contextSnapshot: {
+                  issueId: target.issueId,
+                  taskId: target.issueId,
+                  wakeReason: "issue_commented",
+                  source: "interaction_timeout",
+                },
+              }).catch((err) => logger.warn({ err, issueId: target.issueId, agentId: target.agentId }, "failed to wake agent after interaction timeout"));
+            }
+          }
+        })
+        .catch((err) => {
+          logger.error({ err }, "interaction timeout tick failed");
+        });
+
       // Periodically reap orphaned runs (5-min staleness threshold) and make sure
       // persisted queued work is still being driven forward.
       void heartbeat

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1,5 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, lte } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   documents,
@@ -681,6 +681,14 @@ export function issueThreadInteractionService(db: Db) {
         });
       }
 
+      let scheduledEscalationAt: Date | null = null;
+      if (data.kind === "request_confirmation") {
+        const confirmPayload = data.payload as { timeoutMinutes?: number | null };
+        if (confirmPayload.timeoutMinutes != null && confirmPayload.timeoutMinutes > 0) {
+          scheduledEscalationAt = new Date(Date.now() + confirmPayload.timeoutMinutes * 60 * 1000);
+        }
+      }
+
       let created: IssueThreadInteractionRow;
       try {
         [created] = await db
@@ -699,6 +707,7 @@ export function issueThreadInteractionService(db: Db) {
             createdByAgentId: actor.agentId ?? null,
             createdByUserId: actor.userId ?? null,
             payload: data.payload,
+            scheduledEscalationAt,
           })
           .returning();
       } catch (error) {
@@ -1205,6 +1214,97 @@ export function issueThreadInteractionService(db: Db) {
 
       await touchIssue(db, issue.id);
       return hydrateInteraction(updated);
+    },
+
+    tickTimeouts: async (now: Date): Promise<{
+      processed: number;
+      autoAccepted: number;
+      errors: number;
+      wakeTargets: Array<{ issueId: string; agentId: string | null; status: string }>;
+    }> => {
+      const dueRows = await db
+        .select()
+        .from(issueThreadInteractions)
+        .where(and(
+          eq(issueThreadInteractions.kind, "request_confirmation"),
+          eq(issueThreadInteractions.status, "pending"),
+          isNotNull(issueThreadInteractions.scheduledEscalationAt),
+          lte(issueThreadInteractions.scheduledEscalationAt, now),
+        ));
+
+      let processed = 0;
+      let autoAccepted = 0;
+      let errors = 0;
+      const wakeTargets: Array<{ issueId: string; agentId: string | null; status: string }> = [];
+
+      for (const row of dueRows) {
+        processed += 1;
+        try {
+          const interaction = hydrateInteraction(row) as RequestConfirmationInteraction;
+          const { timeoutAction, escalationAgentId } = interaction.payload;
+          if (!timeoutAction) continue;
+
+          const resolvedByAgentId =
+            timeoutAction === "escalate_to_ceo" ? (escalationAgentId ?? null) : null;
+
+          const [updated] = await db
+            .update(issueThreadInteractions)
+            .set({
+              status: "accepted",
+              result: {
+                version: 1,
+                outcome: "timed_out",
+              },
+              resolvedByAgentId,
+              resolvedAt: now,
+              updatedAt: now,
+            })
+            .where(and(
+              eq(issueThreadInteractions.id, row.id),
+              eq(issueThreadInteractions.status, "pending"),
+            ))
+            .returning();
+
+          if (!updated) continue;
+
+          // Return the issue to the creator agent so the workflow continues.
+          const creatorAgentId = row.createdByAgentId ?? null;
+          if (creatorAgentId) {
+            const issueRows = await db
+              .select({ id: issues.id, status: issues.status, assigneeAgentId: issues.assigneeAgentId })
+              .from(issues)
+              .where(eq(issues.id, row.issueId));
+            const issueRow = issueRows[0] ?? null;
+
+            if (issueRow && !isTerminalIssueStatus(issueRow.status)) {
+              await db
+                .update(issues)
+                .set({
+                  assigneeAgentId: creatorAgentId,
+                  assigneeUserId: null,
+                  updatedAt: now,
+                })
+                .where(eq(issues.id, row.issueId));
+
+              wakeTargets.push({
+                issueId: row.issueId,
+                agentId: creatorAgentId,
+                status: issueRow.status,
+              });
+            } else {
+              await touchIssue(db, row.issueId);
+            }
+          } else {
+            await touchIssue(db, row.issueId);
+          }
+
+          autoAccepted += 1;
+        } catch {
+          errors += 1;
+        }
+      }
+
+      return { processed, autoAccepted, errors, wakeTargets };
     },
   };
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agent teams for zero-human companies, where agents interact with a human board through structured "interactions" such as `request_confirmation` gates.
> - The `request_confirmation` kind is gated behind `assertBoard` — only human board members can accept or reject it.
> - When the board is unavailable (e.g., offline for hours), any `request_confirmation` gate permanently freezes the agent workflow with no automated fallback.
> - This gap was observed in a 6-hour incident (MBD-1132/MBD-1083) where 4 escalation cycles were needed because the CEO could not technically accept the interaction through the normal board path.
> - The fix adds opt-in `timeoutMinutes`, `timeoutAction`, and `escalationAgentId` fields to `request_confirmation` payloads, plus a background scheduler tick that auto-accepts due interactions.
> - The benefit is that agent workflows are never permanently frozen by board non-response, while the board's ability to respond normally is unchanged for interactions without a timeout.

## What Changed

- **`packages/shared/src/types/issue.ts`**: Added `timeoutMinutes`, `timeoutAction`, `escalationAgentId` optional fields to `RequestConfirmationPayload`; added `"timed_out"` to `RequestConfirmationResult.outcome`
- **`packages/shared/src/validators/issue.ts`**: Added Zod schema for the three new payload fields with cross-field validation (`timeoutAction` requires `timeoutMinutes`; `escalate_to_ceo` requires `escalationAgentId`)
- **`packages/shared/src/issue-thread-interactions.test.ts`**: Added 4 tests covering valid auto_accept, valid escalate_to_ceo, and two invalid validation cases
- **`packages/db/src/schema/issue_thread_interactions.ts`**: Added `scheduledEscalationAt` column and index
- **`packages/db/src/migrations/0086_interaction_timeout_escalation.sql`**: Migration adding `scheduled_escalation_at` column + index
- **`server/src/services/issue-thread-interactions.ts`**: Set `scheduledEscalationAt` from `createdAt + timeoutMinutes` on interaction creation; added `tickTimeouts(now)` method that auto-accepts due interactions and returns a list of wake targets
- **`server/src/index.ts`**: Wire `issueThreadInteractionService(db).tickTimeouts(now)` into the existing `setInterval` scheduler; queue agent wakeups for the issue creator after auto-acceptance

## Verification

```sh
# Typecheck passes
pnpm typecheck

# Unit tests pass
cd packages/shared && npx vitest run src/issue-thread-interactions.test.ts
```

Manual smoke:
1. Create a `request_confirmation` interaction with `timeoutMinutes: 1, timeoutAction: "auto_accept"` via the API
2. Wait 1+ minute
3. The next scheduler tick (governed by `heartbeatSchedulerIntervalMs`) auto-accepts the interaction with outcome `"timed_out"` and wakes the issue's creator agent

## Risks

- **Backward compatible**: All new fields are optional; existing `request_confirmation` interactions without `timeoutMinutes` are completely unaffected.
- **Timer granularity**: Auto-acceptance is bounded by `heartbeatSchedulerIntervalMs` (default 60s), so actual timeout latency can be up to `timeoutMinutes + 1 minute`.
- **Migration safety**: `ALTER TABLE ... ADD COLUMN` with no default is safe for the existing zero-null rows; the column is nullable.
- **Agent reassignment**: `tickTimeouts` reassigns the issue to `createdByAgentId` directly in the DB (bypassing the issues service layer). This is intentional to match what `acceptRequestConfirmation` does when a user accepts on behalf of an agent, but does skip any execution-policy side effects. Low risk: these interactions are board-gated gates, which are not inside execution-policy flows.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Capabilities: tool use, code editing, agentic reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge

Closes #6134