### PR TITLE
fix(openclaw-gateway): use protocol 4

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -85,7 +85,7 @@ type GatewayClientRequestOptions = {
   expectFinal?: boolean;
 };
 
-const PROTOCOL_VERSION = 3;
+const PROTOCOL_VERSION = 4;
 const DEFAULT_SCOPES = ["operator.admin"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";

--- a/packages/adapters/openclaw-gateway/src/server/test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/test.ts
@@ -145,8 +145,8 @@ async function probeGateway(input: {
             id: connectId,
             method: "connect",
             params: {
-              minProtocol: 3,
-              maxProtocol: 3,
+              minProtocol: 4,
+              maxProtocol: 4,
               client: {
                 id: "gateway-client",
                 version: "paperclip-probe",


### PR DESCRIPTION
## Summary
- update the OpenClaw gateway adapter handshake to advertise protocol 4
- update the gateway probe to use the same protocol range

## Why
OpenClaw 2026.5.12 accepts protocol 4 for the authenticated gateway handshake. Paperclip's bundled OpenClaw gateway adapter was still advertising protocol 3, which required a local post-update patch after upgrading Paperclip/OpenClaw.

## Verification
- pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck
- pnpm --filter @paperclipai/adapter-openclaw-gateway build

Note: pnpm exec vitest run packages/adapters/openclaw-gateway/src/server/test.ts does not run in this repo because that file is an adapter environment probe, not a Vitest-matched test file.