### PR TITLE
feat(interactions): support free-text ask_user_questions answers

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -636,6 +636,7 @@ export interface AskUserQuestionsQuestionOption {
   id: string;
   label: string;
   description?: string | null;
+  allowFreeText?: boolean;
 }
 
 export interface AskUserQuestionsQuestion {
@@ -657,6 +658,7 @@ export interface AskUserQuestionsPayload {
 export interface AskUserQuestionsAnswer {
   questionId: string;
   optionIds: string[];
+  freeText?: string | null;
 }
 
 export interface AskUserQuestionsResult {

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -610,6 +610,7 @@ export const askUserQuestionsQuestionOptionSchema = z.object({
   id: z.string().trim().min(1).max(120),
   label: z.string().trim().min(1).max(120),
   description: z.string().trim().max(500).nullable().optional(),
+  allowFreeText: z.boolean().optional(),
 });
 
 export const askUserQuestionsQuestionSchema = z.object({
@@ -655,6 +656,7 @@ export const askUserQuestionsPayloadSchema = z.object({
 export const askUserQuestionsAnswerSchema = z.object({
   questionId: z.string().trim().min(1).max(120),
   optionIds: z.array(z.string().trim().min(1).max(120)).max(20),
+  freeText: z.string().max(4000).nullable().optional(),
 });
 
 export const askUserQuestionsResultSchema = z.object({

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -389,7 +389,7 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
             required: true,
             options: [
               { id: "phase-1", label: "Phase 1" },
-              { id: "phase-2", label: "Phase 2" },
+              { id: "phase-2", label: "Phase 2", allowFreeText: true },
             ],
           },
           {
@@ -412,7 +412,7 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       companyId,
     }, created.id, {
       answers: [
-        { questionId: "scope", optionIds: ["phase-1"] },
+        { questionId: "scope", optionIds: ["phase-2"], freeText: "  Via rollout controlado  " },
         { questionId: "extras", optionIds: ["docs", "tests", "docs"] },
       ],
       summaryMarkdown: "Ship Phase 1 with tests and docs.",
@@ -424,11 +424,22 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     expect(answered.result).toEqual({
       version: 1,
       answers: [
-        { questionId: "scope", optionIds: ["phase-1"] },
+        { questionId: "scope", optionIds: ["phase-2"], freeText: "Via rollout controlado" },
         { questionId: "extras", optionIds: ["docs", "tests"] },
       ],
       summaryMarkdown: "Ship Phase 1 with tests and docs.",
     });
+
+    await expect(interactionsSvc.answerQuestions({
+      id: issueId,
+      companyId,
+    }, created.id, {
+      answers: [
+        { questionId: "scope", optionIds: ["phase-1"], freeText: "Texto inválido para opção sem flag" },
+      ],
+    }, {
+      userId: "local-board",
+    })).rejects.toThrow("does not allow free text");
 
     await expect(interactionsSvc.answerQuestions({
       id: issueId,

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -407,6 +407,17 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       userId: "local-board",
     });
 
+    await expect(interactionsSvc.answerQuestions({
+      id: issueId,
+      companyId,
+    }, created.id, {
+      answers: [
+        { questionId: "scope", optionIds: ["phase-1"], freeText: "Texto inválido para opção sem flag" },
+      ],
+    }, {
+      userId: "local-board",
+    })).rejects.toThrow("does not allow free text");
+
     const answered = await interactionsSvc.answerQuestions({
       id: issueId,
       companyId,
@@ -429,17 +440,6 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       ],
       summaryMarkdown: "Ship Phase 1 with tests and docs.",
     });
-
-    await expect(interactionsSvc.answerQuestions({
-      id: issueId,
-      companyId,
-    }, created.id, {
-      answers: [
-        { questionId: "scope", optionIds: ["phase-1"], freeText: "Texto inválido para opção sem flag" },
-      ],
-    }, {
-      userId: "local-board",
-    })).rejects.toThrow("does not allow free text");
 
     await expect(interactionsSvc.answerQuestions({
       id: issueId,

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -258,9 +258,24 @@ function normalizeQuestionAnswers(args: {
       throw unprocessable(`Question ${answer.questionId} only allows one answer`);
     }
 
+    const trimmedFreeText = answer.freeText?.trim() ?? "";
+    const hasFreeText = trimmedFreeText.length > 0;
+    if (hasFreeText) {
+      const selectedOptionSet = new Set(uniqueOptionIds);
+      const freeTextAllowed = question.options.some(
+        (option) => selectedOptionSet.has(option.id) && option.allowFreeText === true,
+      );
+      if (!freeTextAllowed) {
+        throw unprocessable(
+          `Question ${answer.questionId} does not allow free text for selected options`,
+        );
+      }
+    }
+
     answerByQuestionId.set(answer.questionId, {
       questionId: answer.questionId,
       optionIds: uniqueOptionIds,
+      freeText: hasFreeText ? trimmedFreeText : null,
     });
   }
 

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -275,7 +275,7 @@ function normalizeQuestionAnswers(args: {
     answerByQuestionId.set(answer.questionId, {
       questionId: answer.questionId,
       optionIds: uniqueOptionIds,
-      freeText: hasFreeText ? trimmedFreeText : null,
+      ...(hasFreeText ? { freeText: trimmedFreeText } : {}),
     });
   }
 

--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -110,6 +110,59 @@ describe("IssueThreadInteractionCard", () => {
     expect(withHandler.textContent).toContain("Cancel question");
   });
 
+  it("shows free-text textarea for selected options that allow it and submits the value", async () => {
+    const onSubmitInteractionAnswers = vi.fn(async () => undefined);
+    const host = renderCard({
+      interaction: pendingAskUserQuestionsInteraction,
+      onSubmitInteractionAnswers,
+    });
+
+    const radios = [...host.querySelectorAll('[role="radio"]')];
+    expect(radios).toHaveLength(3);
+
+    await act(async () => {
+      (radios[2] as HTMLButtonElement).click();
+    });
+
+    const textarea = host.querySelector(
+      "#interaction-questions-default-collapse-depth-free-text",
+    ) as HTMLTextAreaElement | null;
+    expect(textarea).toBeTruthy();
+
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      valueSetter?.call(textarea, "Detalhar regra operacional");
+      textarea!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const checkboxes = [...host.querySelectorAll('[role="checkbox"]')];
+    await act(async () => {
+      (checkboxes[0] as HTMLButtonElement).click();
+    });
+
+    const submitButton = Array.from(host.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Send answers"),
+    );
+    expect(submitButton).toBeTruthy();
+    await act(async () => {
+      submitButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onSubmitInteractionAnswers).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "ask_user_questions" }),
+      expect.arrayContaining([
+        expect.objectContaining({
+          questionId: "collapse-depth",
+          optionIds: ["other-mode"],
+          freeText: "Detalhar regra operacional",
+        }),
+      ]),
+    );
+  });
+
   it("makes child tasks explicit in suggested task trees", () => {
     const host = renderCard({
       interaction: pendingSuggestedTasksInteraction,

--- a/ui/src/components/IssueThreadInteractionCard.test.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.test.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "../context/ThemeContext";
 import { TooltipProvider } from "./ui/tooltip";
 import {
   pendingAskUserQuestionsInteraction,
+  pendingAskUserQuestionsWithFreeTextInteraction,
   commentExpiredRequestConfirmationInteraction,
   disabledDeclineReasonRequestConfirmationInteraction,
   failedRequestConfirmationInteraction,
@@ -113,7 +114,7 @@ describe("IssueThreadInteractionCard", () => {
   it("shows free-text textarea for selected options that allow it and submits the value", async () => {
     const onSubmitInteractionAnswers = vi.fn(async () => undefined);
     const host = renderCard({
-      interaction: pendingAskUserQuestionsInteraction,
+      interaction: pendingAskUserQuestionsWithFreeTextInteraction,
       onSubmitInteractionAnswers,
     });
 

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -717,11 +717,21 @@ function AskUserQuestionsCard({
     try {
       await onSubmitInteractionAnswers(
         interaction,
-        questions.map((question) => ({
-          questionId: question.id,
-          optionIds: draftAnswers[question.id] ?? [],
-          freeText: draftFreeTextByQuestionId[question.id] ?? "",
-        })),
+        questions.map((question) => {
+          const optionIds = draftAnswers[question.id] ?? [];
+          const trimmedFreeText = (draftFreeTextByQuestionId[question.id] ?? "").trim();
+          const hasSelectedFreeTextOption = optionIds.some((optionId) => {
+            const option = question.options.find((item) => item.id === optionId);
+            return option?.allowFreeText === true;
+          });
+          return {
+            questionId: question.id,
+            optionIds,
+            ...(hasSelectedFreeTextOption && trimmedFreeText.length > 0
+              ? { freeText: trimmedFreeText }
+              : {}),
+          };
+        }),
       );
     } finally {
       setWorking(false);

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -810,7 +810,7 @@ function AskUserQuestionsCard({
                     htmlFor={`${interaction.id}-${question.id}-free-text`}
                     className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground"
                   >
-                    Resposta livre
+                    Free response
                   </label>
                   <Textarea
                     id={`${interaction.id}-${question.id}-free-text`}
@@ -821,7 +821,7 @@ function AskUserQuestionsCard({
                         ...current,
                         [question.id]: event.target.value,
                       }))}
-                    placeholder="Digite uma resposta opcional"
+                    placeholder="Enter an optional response"
                   />
                 </div>
               ) : null}

--- a/ui/src/components/IssueThreadInteractionCard.tsx
+++ b/ui/src/components/IssueThreadInteractionCard.tsx
@@ -662,6 +662,14 @@ function AskUserQuestionsCard({
       ]),
     ),
   );
+  const [draftFreeTextByQuestionId, setDraftFreeTextByQuestionId] = useState<Record<string, string>>(
+    () => Object.fromEntries(
+      (interaction.result?.answers ?? []).map((answer) => [
+        answer.questionId,
+        answer.freeText ?? "",
+      ]),
+    ),
+  );
   const [working, setWorking] = useState(false);
   const [cancelling, setCancelling] = useState(false);
 
@@ -671,6 +679,14 @@ function AskUserQuestionsCard({
         (interaction.result?.answers ?? []).map((answer) => [
           answer.questionId,
           [...answer.optionIds],
+        ]),
+      ),
+    );
+    setDraftFreeTextByQuestionId(
+      Object.fromEntries(
+        (interaction.result?.answers ?? []).map((answer) => [
+          answer.questionId,
+          answer.freeText ?? "",
         ]),
       ),
     );
@@ -704,6 +720,7 @@ function AskUserQuestionsCard({
         questions.map((question) => ({
           questionId: question.id,
           optionIds: draftAnswers[question.id] ?? [],
+          freeText: draftFreeTextByQuestionId[question.id] ?? "",
         })),
       );
     } finally {
@@ -784,6 +801,30 @@ function AskUserQuestionsCard({
                   />
                 ))}
               </div>
+              {(draftAnswers[question.id] ?? []).some((optionId) => {
+                const option = question.options.find((item) => item.id === optionId);
+                return option?.allowFreeText === true;
+              }) ? (
+                <div className="mt-3">
+                  <label
+                    htmlFor={`${interaction.id}-${question.id}-free-text`}
+                    className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground"
+                  >
+                    Resposta livre
+                  </label>
+                  <Textarea
+                    id={`${interaction.id}-${question.id}-free-text`}
+                    className="mt-1"
+                    value={draftFreeTextByQuestionId[question.id] ?? ""}
+                    onChange={(event) =>
+                      setDraftFreeTextByQuestionId((current) => ({
+                        ...current,
+                        [question.id]: event.target.value,
+                      }))}
+                    placeholder="Digite uma resposta opcional"
+                  />
+                </div>
+              ) : null}
             </div>
           ))}
 

--- a/ui/src/fixtures/issueThreadInteractionFixtures.ts
+++ b/ui/src/fixtures/issueThreadInteractionFixtures.ts
@@ -148,6 +148,12 @@ function createAskUserQuestionsInteraction(
               label: "Collapse all descendants by default",
               description: "Show only root tasks until the operator expands the tree.",
             },
+            {
+              id: "other-mode",
+              label: "Outra abordagem",
+              description: "Descreva uma alternativa em texto livre.",
+              allowFreeText: true,
+            },
           ],
         },
         {
@@ -295,7 +301,8 @@ export const answeredAskUserQuestionsInteraction = createAskUserQuestionsInterac
     answers: [
       {
         questionId: "collapse-depth",
-        optionIds: ["visible-root"],
+        optionIds: ["other-mode"],
+        freeText: "Mostrar raiz + filhos diretos, com toggle manual para netos.",
       },
       {
         questionId: "post-submit-summary",

--- a/ui/src/fixtures/issueThreadInteractionFixtures.ts
+++ b/ui/src/fixtures/issueThreadInteractionFixtures.ts
@@ -148,12 +148,6 @@ function createAskUserQuestionsInteraction(
               label: "Collapse all descendants by default",
               description: "Show only root tasks until the operator expands the tree.",
             },
-            {
-              id: "other-mode",
-              label: "Outra abordagem",
-              description: "Descreva uma alternativa em texto livre.",
-              allowFreeText: true,
-            },
           ],
         },
         {
@@ -301,8 +295,7 @@ export const answeredAskUserQuestionsInteraction = createAskUserQuestionsInterac
     answers: [
       {
         questionId: "collapse-depth",
-        optionIds: ["other-mode"],
-        freeText: "Mostrar raiz + filhos diretos, com toggle manual para netos.",
+        optionIds: ["visible-root"],
       },
       {
         questionId: "post-submit-summary",
@@ -314,6 +307,66 @@ export const answeredAskUserQuestionsInteraction = createAskUserQuestionsInterac
       "- Preserve inline answer chips and resolver metadata in the answered state.",
       "- Add a short summary note so future reviewers understand the operator's intent without replaying the form.",
     ].join("\n"),
+  },
+});
+
+export const pendingAskUserQuestionsWithFreeTextInteraction = createAskUserQuestionsInteraction({
+  payload: {
+    version: 1,
+    title: "Before I wire the persistence layer, which preview behavior do you want?",
+    submitLabel: "Send answers",
+    questions: [
+      {
+        id: "collapse-depth",
+        prompt: "How aggressive should the suggested-task preview collapse descendant work?",
+        helpText:
+          "We need enough context to review the tree without making the feed feel like a project plan.",
+        selectionMode: "single",
+        required: true,
+        options: [
+          {
+            id: "visible-root",
+            label: "Only collapse hidden descendants",
+            description: "Keep top-level and visible child tasks expanded.",
+          },
+          {
+            id: "collapse-all",
+            label: "Collapse all descendants by default",
+            description: "Show only root tasks until the operator expands the tree.",
+          },
+          {
+            id: "other-mode",
+            label: "Other approach",
+            description: "Describe an alternative in free text.",
+            allowFreeText: true,
+          },
+        ],
+      },
+      {
+        id: "post-submit-summary",
+        prompt: "What should the answered-state card emphasize after submission?",
+        helpText: "Pick every summary treatment that would help future reviewers.",
+        selectionMode: "multi",
+        required: true,
+        options: [
+          {
+            id: "answers-inline",
+            label: "Inline answer pills",
+            description: "Keep the exact operator choices visible under each question.",
+          },
+          {
+            id: "summary-note",
+            label: "Short markdown summary",
+            description: "Add a compact narrative summary at the bottom of the card.",
+          },
+          {
+            id: "resolver-meta",
+            label: "Resolver metadata",
+            description: "Show who answered and when without opening the raw thread.",
+          },
+        ],
+      },
+    ],
   },
 });
 

--- a/ui/src/lib/issue-thread-interactions.test.ts
+++ b/ui/src/lib/issue-thread-interactions.test.ts
@@ -147,4 +147,26 @@ describe("issue thread interaction helpers", () => {
 
     expect(labels).toEqual(["Option 2", "Option 1"]);
   });
+
+  it("includes free-text responses in answered labels", () => {
+    const labels = getQuestionAnswerLabels({
+      question: {
+        id: "question-1",
+        prompt: "Pick options",
+        selectionMode: "single",
+        options: [
+          { id: "option-other", label: "Outra" },
+        ],
+      },
+      answers: [
+        {
+          questionId: "question-1",
+          optionIds: ["option-other"],
+          freeText: "  detalhar o caso especial  ",
+        },
+      ],
+    });
+
+    expect(labels).toEqual(["Outra", "Outra: detalhar o caso especial"]);
+  });
 });

--- a/ui/src/lib/issue-thread-interactions.test.ts
+++ b/ui/src/lib/issue-thread-interactions.test.ts
@@ -155,7 +155,7 @@ describe("issue thread interaction helpers", () => {
         prompt: "Pick options",
         selectionMode: "single",
         options: [
-          { id: "option-other", label: "Outra" },
+          { id: "option-other", label: "Other", allowFreeText: true },
         ],
       },
       answers: [
@@ -167,6 +167,6 @@ describe("issue thread interaction helpers", () => {
       ],
     });
 
-    expect(labels).toEqual(["Outra", "Outra: detalhar o caso especial"]);
+    expect(labels).toEqual(["Other", "Other: detalhar o caso especial"]);
   });
 });

--- a/ui/src/lib/issue-thread-interactions.ts
+++ b/ui/src/lib/issue-thread-interactions.ts
@@ -132,12 +132,17 @@ export function getQuestionAnswerLabels(args: {
   answers: readonly AskUserQuestionsAnswer[];
 }) {
   const { question, answers } = args;
-  const selectedIds =
-    answers.find((answer) => answer.questionId === question.id)?.optionIds ?? [];
+  const questionAnswer = answers.find((answer) => answer.questionId === question.id);
+  const selectedIds = questionAnswer?.optionIds ?? [];
   const optionLabelById = new Map(
     question.options.map((option) => [option.id, option.label] as const),
   );
-  return selectedIds
+  const labels = selectedIds
     .map((optionId) => optionLabelById.get(optionId))
     .filter((label): label is string => typeof label === "string");
+  const freeText = questionAnswer?.freeText?.trim() ?? "";
+  if (freeText.length > 0) {
+    labels.push(`Outra: ${freeText}`);
+  }
+  return labels;
 }

--- a/ui/src/lib/issue-thread-interactions.ts
+++ b/ui/src/lib/issue-thread-interactions.ts
@@ -142,7 +142,10 @@ export function getQuestionAnswerLabels(args: {
     .filter((label): label is string => typeof label === "string");
   const freeText = questionAnswer?.freeText?.trim() ?? "";
   if (freeText.length > 0) {
-    labels.push(`Outra: ${freeText}`);
+    const freeTextOptionLabel = question.options.find(
+      (option) => selectedIds.includes(option.id) && option.allowFreeText === true,
+    )?.label;
+    labels.push(`${freeTextOptionLabel ?? "Free response"}: ${freeText}`);
   }
   return labels;
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through issues, comments, and structured board interactions.
> - The issue thread interaction subsystem renders agent requests such as `ask_user_questions` and persists the user's response.
> - Today those cards only support discrete option buttons, so an "Other"/open-ended answer cannot carry the user's typed text.
> - AREA-132 approved the additive design: mark specific options as allowing free text and store one optional free-text slot per answered question.
> - This pull request implements that design across shared types/validators, server response handling, UI rendering, client helpers, fixtures, tests, and plugin docs.
> - The benefit is a backward-compatible way for agents to ask structured questions while still accepting free-form context when a specific option needs it.

## What Changed

- Added `allowFreeText?: boolean` to `AskUserQuestionsQuestionOption` shared types and validators.
- Added optional `freeText?: string | null` to `AskUserQuestionsAnswer` and response validation.
- Updated server interaction response handling to preserve free-text answers alongside selected option IDs.
- Updated the issue thread interaction card UI to render a text field for selected options that allow free text.
- Updated client helpers, fixtures, and tests for the new free-text answer shape.
- Documented the new optional fields in the plugin spec.

## Verification

- Grace/Suzy ran the targeted/full suites while addressing review and CI fixes:
  - `pnpm --filter @paperclipai/server test -- --run server/src/__tests__/issue-thread-interactions-service.test.ts`
  - `pnpm --filter @paperclipai/ui test -- --run ui/src/lib/issue-thread-interactions.test.ts ui/src/components/IssueThreadInteractionCard.test.tsx`
  - `pnpm --filter @paperclipai/ui test -- --run`
  - `pnpm --filter @paperclipai/server test -- --run server/src/__tests__/issue-thread-interactions-service.test.ts`
- Latest CI fix validates the free-text rejection path before resolving the interaction, matching the failing `verify` assertion from head `8f4dc9ce`. Latest head: `87dee7cf` (`fix(test): validate free-text rejection before resolving interaction`).
- Earlier direct Vitest execution in the adapter-owned checkout failed due workspace ownership (`EACCES` writing `vitest.config.ts.timestamp-...mjs`), so most successful verification was run by the implementation agent in its writable environment; the latest server interaction test was also run from Suzy's writable fork checkout.

## Risks

- Low migration risk: all schema/type additions are optional and absent/false preserves current behavior.
- Main behavioral risk is UI state handling around selecting/deselecting a free-text option; covered by the added component/client tests.
- Server accepts only the additive free-text field and still preserves existing option ID handling.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex GPT-5.5 via OpenClaw cloud/local agent workflow; implementation commit produced by the assigned Paperclip coding agent and PR publication completed by Suzy using authenticated GitHub access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge





