### PR TITLE
fix: update TypeScript version and enhance ANTHROPIC_API_KEY validati…

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@playwright/test": "^1.58.2",
     "cross-env": "^10.1.0",
     "esbuild": "^0.27.3",
-    "typescript": "^5.7.3",
+    "typescript": "^5.9.3",
     "vitest": "^3.0.5"
   },
   "engines": {

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -367,13 +367,13 @@ export async function testEnvironment(
               "Unset ANTHROPIC_API_KEY from your shell environment to avoid this fallback on future probes.",
           });
         } else {
-          // Fallback also failed — report the original failure (prefer specific JSON error)
+          // Fallback also failed — report the retry failure (prefer specific JSON error)
           addProbeCheck(
-            initial.parsed,
-            initial.detail,
-            loginMeta,
-            initial.probeResult,
-            initial.parsedStream,
+            retry.parsed,
+            retry.detail,
+            retryLoginMeta,
+            retry.probeResult,
+            retry.parsedStream,
           );
         }
       } else {

--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -20,7 +20,7 @@ import {
   resolveAdapterExecutionTargetCwd,
 } from "@paperclipai/adapter-utils/execution-target";
 import path from "node:path";
-import { detectClaudeLoginRequired, parseClaudeStreamJson } from "./parse.js";
+import { describeClaudeFailure, detectClaudeLoginRequired, parseClaudeStreamJson } from "./parse.js";
 import { isBedrockModelId } from "./models.js";
 import { buildClaudeProbePermissionArgs } from "./permissions.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
@@ -105,6 +105,12 @@ export async function testEnvironment(
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
   }
+
+  // Detect if config explicitly mentions ANTHROPIC_API_KEY (even with non-string
+  // value like { type: "plain", value: "" } from the "Unset" UI action). When
+  // the config explicitly overrides it, the host env should not be considered.
+  const configExplicitlyHasAnthropicApiKey = "ANTHROPIC_API_KEY" in envConfig;
+
   const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
   const installCheck = await maybeRunSandboxInstallCommand({
     runId,
@@ -145,7 +151,12 @@ export async function testEnvironment(
     (considerHostEnv && isNonEmpty(process.env.ANTHROPIC_BEDROCK_BASE_URL));
 
   const configApiKey = env.ANTHROPIC_API_KEY;
-  const hostApiKey = considerHostEnv ? process.env.ANTHROPIC_API_KEY : undefined;
+  // When config explicitly has ANTHROPIC_API_KEY (even as an override with empty
+  // value), it takes precedence over the host env.
+  const hostApiKey =
+    considerHostEnv && !configExplicitlyHasAnthropicApiKey
+      ? process.env.ANTHROPIC_API_KEY
+      : undefined;
   if (hasBedrock) {
     const source =
       env.CLAUDE_CODE_USE_BEDROCK === "1" ||
@@ -176,6 +187,14 @@ export async function testEnvironment(
       level: "info",
       message: "ANTHROPIC_API_KEY is not set; subscription-based auth can be used if Claude is logged in.",
     });
+  }
+
+  // Build the env actually passed to the probe process. Since runChildProcess
+  // merges with process.env, explicitly set ANTHROPIC_API_KEY to empty string
+  // when the config overrides it, so the host env value doesn't leak through.
+  const probeEnv: Record<string, string> = { ...env };
+  if (configExplicitlyHasAnthropicApiKey && !isNonEmpty(configApiKey)) {
+    probeEnv.ANTHROPIC_API_KEY = "";
   }
 
   const canRunProbe =
@@ -212,71 +231,159 @@ export async function testEnvironment(
       if (maxTurns > 0) args.push("--max-turns", String(maxTurns));
       if (extraArgs.length > 0) args.push(...extraArgs);
 
-      const probe = await runAdapterExecutionTargetProcess(
-        runId,
-        target,
-        command,
-        args,
-        {
-          cwd,
-          env,
-          timeoutSec: 45,
-          graceSec: 5,
-          stdin: "Respond with hello.",
-          onLog: async () => {},
-        },
-      );
+      async function runSingleProbe(
+        probeRunEnv: Record<string, string>,
+      ): Promise<{
+        probeResult: Awaited<ReturnType<typeof runAdapterExecutionTargetProcess>>;
+        parsedStream: ReturnType<typeof parseClaudeStreamJson>;
+        parsed: Record<string, unknown> | null;
+        detail: string | null;
+      }> {
+        const probeResult = await runAdapterExecutionTargetProcess(
+          runId,
+          target,
+          command,
+          args,
+          {
+            cwd,
+            env: probeRunEnv,
+            timeoutSec: 45,
+            graceSec: 5,
+            stdin: "Respond with hello.",
+            onLog: async () => {},
+          },
+        );
 
-      const parsedStream = parseClaudeStreamJson(probe.stdout);
-      const parsed = parsedStream.resultJson;
-      const loginMeta = detectClaudeLoginRequired({
-        parsed,
-        stdout: probe.stdout,
-        stderr: probe.stderr,
-      });
-      const detail = summarizeProbeDetail(probe.stdout, probe.stderr);
+        const parsedStream = parseClaudeStreamJson(probeResult.stdout);
+        const parsed = parsedStream.resultJson;
+        const detail = summarizeProbeDetail(probeResult.stdout, probeResult.stderr);
+        return { probeResult, parsedStream, parsed, detail };
+      }
 
-      if (probe.timedOut) {
-        checks.push({
-          code: "claude_hello_probe_timed_out",
-          level: "warn",
-          message: "Claude hello probe timed out.",
-          hint: "Retry the probe. If this persists, verify Claude can run `Respond with hello` from this directory manually.",
-        });
-      } else if (loginMeta.requiresLogin) {
-        checks.push({
-          code: "claude_hello_probe_auth_required",
-          level: "warn",
-          message: "Claude CLI is installed, but login is required.",
-          ...(detail ? { detail } : {}),
-          hint: loginMeta.loginUrl
-            ? `Run \`claude login\` and complete sign-in at ${loginMeta.loginUrl}, then retry.`
-            : "Run `claude login` in this environment, then retry the probe.",
-        });
-      } else if ((probe.exitCode ?? 1) === 0) {
-        const summary = parsedStream.summary.trim();
-        const hasHello = /\bhello\b/i.test(summary);
-        checks.push({
-          code: hasHello ? "claude_hello_probe_passed" : "claude_hello_probe_unexpected_output",
-          level: hasHello ? "info" : "warn",
-          message: hasHello
-            ? "Claude hello probe succeeded."
-            : "Claude probe ran but did not return `hello` as expected.",
-          ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
-          ...(hasHello
-            ? {}
-            : {
+      function addProbeCheck(
+        parsed: Record<string, unknown> | null,
+        detail: string | null,
+        loginMeta: ReturnType<typeof detectClaudeLoginRequired>,
+        probeResult: Awaited<ReturnType<typeof runAdapterExecutionTargetProcess>>,
+        parsedStream: ReturnType<typeof parseClaudeStreamJson>,
+      ) {
+        if (probeResult.timedOut) {
+          checks.push({
+            code: "claude_hello_probe_timed_out",
+            level: "warn",
+            message: "Claude hello probe timed out.",
+            hint: "Retry the probe. If this persists, verify Claude can run `Respond with hello` from this directory manually.",
+          });
+          return;
+        }
+
+        if (loginMeta.requiresLogin) {
+          checks.push({
+            code: "claude_hello_probe_auth_required",
+            level: "warn",
+            message: "Claude CLI is installed, but login is required.",
+            ...(detail ? { detail } : {}),
+            hint: loginMeta.loginUrl
+              ? `Run \`claude login\` and complete sign-in at ${loginMeta.loginUrl}, then retry.`
+              : "Run `claude login` in this environment, then retry the probe.",
+          });
+          return;
+        }
+
+        if ((probeResult.exitCode ?? 1) === 0) {
+          const summary = parsedStream.summary.trim();
+          const hasHello = /\bhello\b/i.test(summary);
+          checks.push({
+            code: hasHello ? "claude_hello_probe_passed" : "claude_hello_probe_unexpected_output",
+            level: hasHello ? "info" : "warn",
+            message: hasHello
+              ? "Claude hello probe succeeded."
+              : "Claude probe ran but did not return `hello` as expected.",
+            ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+            ...(hasHello
+              ? {}
+              : {
                 hint: "Try the probe manually (`claude --print - --output-format stream-json --verbose`) and prompt `Respond with hello`.",
               }),
-        });
-      } else {
+          });
+          return;
+        }
+
+        // Probe failed — try to surface a specific error from the structured
+        // JSON output before falling back to the generic stderr line.
+        const failureMessage = parsed
+          ? describeClaudeFailure(parsed)
+          : null;
         checks.push({
           code: "claude_hello_probe_failed",
           level: "error",
           message: "Claude hello probe failed.",
-          ...(detail ? { detail } : {}),
+          ...(failureMessage || detail ? { detail: failureMessage ?? detail } : {}),
           hint: "Run `claude --print - --output-format stream-json --verbose` manually in this directory and prompt `Respond with hello` to debug.",
         });
+      }
+
+      const initial = await runSingleProbe(probeEnv);
+      const loginMeta = detectClaudeLoginRequired({
+        parsed: initial.parsed,
+        stdout: initial.probeResult.stdout,
+        stderr: initial.probeResult.stderr,
+      });
+
+      // Problem 1: automatic API-key → subscription fallback.
+      // When the probe failed AND ANTHROPIC_API_KEY came from the host env
+      // (not from the adapter config), retry without it. If the fallback
+      // probe succeeds using subscription auth, report the probe as a
+      // warning-level pass instead of an error-level failure.
+      const apiKeyCameFromHost =
+        isNonEmpty(hostApiKey) &&
+        !isNonEmpty(configApiKey) &&
+        !configExplicitlyHasAnthropicApiKey;
+      const shouldRetryWithoutApiKey =
+        apiKeyCameFromHost &&
+        !initial.probeResult.timedOut &&
+        !loginMeta.requiresLogin &&
+        (initial.probeResult.exitCode ?? 1) !== 0;
+
+      if (shouldRetryWithoutApiKey) {
+        const retryEnv = { ...probeEnv, ANTHROPIC_API_KEY: "" };
+        const retry = await runSingleProbe(retryEnv);
+        const retryLoginMeta = detectClaudeLoginRequired({
+          parsed: retry.parsed,
+          stdout: retry.probeResult.stdout,
+          stderr: retry.probeResult.stderr,
+        });
+
+        if ((retry.probeResult.exitCode ?? 1) === 0 && /\bhello\b/i.test(retry.parsedStream.summary.trim())) {
+          // Fallback succeeded — report a warning-level pass
+          checks.push({
+            code: "claude_hello_probe_passed_fallback",
+            level: "warn",
+            message:
+              "Claude hello probe succeeded via subscription fallback after host ANTHROPIC_API_KEY failed.",
+            detail:
+              "The ANTHROPIC_API_KEY from the host environment had insufficient credits or permissions. Paperclip retried with subscription-based auth, which succeeded.",
+            hint:
+              "Unset ANTHROPIC_API_KEY from your shell environment to avoid this fallback on future probes.",
+          });
+        } else {
+          // Fallback also failed — report the original failure (prefer specific JSON error)
+          addProbeCheck(
+            initial.parsed,
+            initial.detail,
+            loginMeta,
+            initial.probeResult,
+            initial.parsedStream,
+          );
+        }
+      } else {
+        addProbeCheck(
+          initial.parsed,
+          initial.detail,
+          loginMeta,
+          initial.probeResult,
+          initial.parsedStream,
+        );
       }
     }
   }

--- a/packages/adapters/claude-local/src/testEnvironment.ts
+++ b/packages/adapters/claude-local/src/testEnvironment.ts
@@ -1,0 +1,380 @@
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  asBoolean,
+  asNumber,
+  asStringArray,
+  parseObject,
+  ensurePathInEnv,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetDirectory,
+  maybeRunSandboxInstallCommand,
+  runAdapterExecutionTargetProcess,
+  describeAdapterExecutionTarget,
+  resolveAdapterExecutionTargetCwd,
+} from "@paperclipai/adapter-utils/execution-target";
+import path from "node:path";
+import { describeClaudeFailure, detectClaudeLoginRequired, parseClaudeStreamJson } from "./parse.js";
+import { isBedrockModelId } from "./models.js";
+import { buildClaudeProbePermissionArgs } from "./permissions.js";
+import { SANDBOX_INSTALL_COMMAND } from "../index.js";
+
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+function isNonEmpty(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function firstNonEmptyLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? ""
+  );
+}
+
+function commandLooksLike(command: string, expected: string): boolean {
+  const base = path.basename(command).toLowerCase();
+  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
+}
+
+function summarizeProbeDetail(stdout: string, stderr: string): string | null {
+  const raw = firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  if (!raw) return null;
+  const clean = raw.replace(/\s+/g, " ").trim();
+  const max = 240;
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "claude");
+  const target = ctx.executionTarget ?? null;
+  const targetIsRemote = target?.kind === "remote";
+  const targetIsSandbox = target?.kind === "remote" && target.transport === "sandbox";
+  const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
+  const targetLabel = targetIsRemote
+    ? ctx.environmentName ?? describeAdapterExecutionTarget(target)
+    : null;
+  const runId = `claude-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  if (targetLabel) {
+    checks.push({
+      code: "claude_environment_target",
+      level: "info",
+      message: `Probing inside environment: ${targetLabel}`,
+    });
+  }
+
+  try {
+    await ensureAdapterExecutionTargetDirectory(runId, target, cwd, {
+      cwd,
+      env: {},
+      createIfMissing: true,
+    });
+    checks.push({
+      code: "claude_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "claude_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+
+  const configExplicitlyHasAnthropicApiKey = "ANTHROPIC_API_KEY" in envConfig;
+
+  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const installCheck = await maybeRunSandboxInstallCommand({
+    runId,
+    target,
+    adapterKey: "claude",
+    installCommand: SANDBOX_INSTALL_COMMAND,
+    detectCommand: command,
+    env,
+  });
+  if (installCheck) checks.push(installCheck);
+  try {
+    await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
+    checks.push({
+      code: "claude_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "claude_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+    });
+  }
+
+  const considerHostEnv = !targetIsRemote;
+  const hasBedrock =
+    env.CLAUDE_CODE_USE_BEDROCK === "1" ||
+    env.CLAUDE_CODE_USE_BEDROCK === "true" ||
+    (considerHostEnv && process.env.CLAUDE_CODE_USE_BEDROCK === "1") ||
+    (considerHostEnv && process.env.CLAUDE_CODE_USE_BEDROCK === "true") ||
+    isNonEmpty(env.ANTHROPIC_BEDROCK_BASE_URL) ||
+    (considerHostEnv && isNonEmpty(process.env.ANTHROPIC_BEDROCK_BASE_URL));
+
+  const configApiKey = env.ANTHROPIC_API_KEY;
+  const hostApiKey =
+    considerHostEnv && !configExplicitlyHasAnthropicApiKey
+      ? process.env.ANTHROPIC_API_KEY
+      : undefined;
+  if (hasBedrock) {
+    const source =
+      env.CLAUDE_CODE_USE_BEDROCK === "1" ||
+      env.CLAUDE_CODE_USE_BEDROCK === "true" ||
+      isNonEmpty(env.ANTHROPIC_BEDROCK_BASE_URL)
+        ? "adapter config env"
+        : "server environment";
+    checks.push({
+      code: "claude_bedrock_auth",
+      level: "info",
+      message: "AWS Bedrock auth detected. Claude will use Bedrock for inference.",
+      detail: `Detected in ${source}.`,
+      hint: "Ensure AWS credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or AWS_PROFILE) and AWS_REGION are configured.",
+    });
+  } else if (isNonEmpty(configApiKey) || isNonEmpty(hostApiKey)) {
+    const source = isNonEmpty(configApiKey) ? "adapter config env" : "server environment";
+    checks.push({
+      code: "claude_anthropic_api_key_overrides_subscription",
+      level: "warn",
+      message:
+        "ANTHROPIC_API_KEY is set. Claude will use API-key auth instead of subscription credentials.",
+      detail: `Detected in ${source}.`,
+      hint: "Unset ANTHROPIC_API_KEY if you want subscription-based Claude login behavior.",
+    });
+  } else if (!targetIsRemote) {
+    checks.push({
+      code: "claude_subscription_mode_possible",
+      level: "info",
+      message: "ANTHROPIC_API_KEY is not set; subscription-based auth can be used if Claude is logged in.",
+    });
+  }
+
+  const probeEnv: Record<string, string> = { ...env };
+  if (configExplicitlyHasAnthropicApiKey && !isNonEmpty(configApiKey)) {
+    probeEnv.ANTHROPIC_API_KEY = "";
+  }
+
+  const canRunProbe =
+    checks.every((check) => check.code !== "claude_cwd_invalid" && check.code !== "claude_command_unresolvable");
+  if (canRunProbe) {
+    if (!commandLooksLike(command, "claude")) {
+      checks.push({
+        code: "claude_hello_probe_skipped_custom_command",
+        level: "info",
+        message: "Skipped hello probe because command is not `claude`.",
+        detail: command,
+        hint: "Use the `claude` CLI command to run the automatic login and installation probe.",
+      });
+    } else {
+      const model = asString(config.model, "").trim();
+      const effort = asString(config.effort, "").trim();
+      const chrome = asBoolean(config.chrome, false);
+      const maxTurns = asNumber(config.maxTurnsPerRun, 0);
+      const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+      const extraArgs = (() => {
+        const fromExtraArgs = asStringArray(config.extraArgs);
+        if (fromExtraArgs.length > 0) return fromExtraArgs;
+        return asStringArray(config.args);
+      })();
+
+      const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
+      args.push(...buildClaudeProbePermissionArgs({ dangerouslySkipPermissions, targetIsSandbox }));
+      if (chrome) args.push("--chrome");
+      if (model && (!hasBedrock || isBedrockModelId(model))) {
+        args.push("--model", model);
+      }
+      if (effort) args.push("--effort", effort);
+      if (maxTurns > 0) args.push("--max-turns", String(maxTurns));
+      if (extraArgs.length > 0) args.push(...extraArgs);
+
+      const helloProbeTimeoutSec = Math.max(
+        1,
+        asNumber(config.helloProbeTimeoutSec, targetIsSandbox ? 90 : 45),
+      );
+
+      async function runSingleProbe(
+        probeRunEnv: Record<string, string>,
+      ): Promise<{
+        probeResult: Awaited<ReturnType<typeof runAdapterExecutionTargetProcess>>;
+        parsedStream: ReturnType<typeof parseClaudeStreamJson>;
+        parsed: Record<string, unknown> | null;
+        detail: string | null;
+      }> {
+        const probeResult = await runAdapterExecutionTargetProcess(
+          runId,
+          target,
+          command,
+          args,
+          {
+            cwd,
+            env: probeRunEnv,
+            timeoutSec: helloProbeTimeoutSec,
+            graceSec: 5,
+            stdin: "Respond with hello.",
+            onLog: async () => {},
+          },
+        );
+
+        const parsedStream = parseClaudeStreamJson(probeResult.stdout);
+        const parsed = parsedStream.resultJson;
+        const detail = summarizeProbeDetail(probeResult.stdout, probeResult.stderr);
+        return { probeResult, parsedStream, parsed, detail };
+      }
+
+      function addProbeCheck(
+        parsed: Record<string, unknown> | null,
+        detail: string | null,
+        loginMeta: ReturnType<typeof detectClaudeLoginRequired>,
+        probeResult: Awaited<ReturnType<typeof runAdapterExecutionTargetProcess>>,
+        parsedStream: ReturnType<typeof parseClaudeStreamJson>,
+      ) {
+        if (probeResult.timedOut) {
+          checks.push({
+            code: "claude_hello_probe_timed_out",
+            level: "warn",
+            message: "Claude hello probe timed out.",
+            hint: "Retry the probe. If this persists, verify Claude can run `Respond with hello` from this directory manually.",
+          });
+          return;
+        }
+
+        if (loginMeta.requiresLogin) {
+          checks.push({
+            code: "claude_hello_probe_auth_required",
+            level: "warn",
+            message: "Claude CLI is installed, but login is required.",
+            ...(detail ? { detail } : {}),
+            hint: loginMeta.loginUrl
+              ? `Run \`claude login\` and complete sign-in at ${loginMeta.loginUrl}, then retry.`
+              : "Run `claude login` in this environment, then retry the probe.",
+          });
+          return;
+        }
+
+        if ((probeResult.exitCode ?? 1) === 0) {
+          const summary = parsedStream.summary.trim();
+          const hasHello = /\bhello\b/i.test(summary);
+          checks.push({
+            code: hasHello ? "claude_hello_probe_passed" : "claude_hello_probe_unexpected_output",
+            level: hasHello ? "info" : "warn",
+            message: hasHello
+              ? "Claude hello probe succeeded."
+              : "Claude probe ran but did not return `hello` as expected.",
+            ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
+            ...(hasHello
+              ? {}
+              : {
+                hint: "Try the probe manually (`claude --print - --output-format stream-json --verbose`) and prompt `Respond with hello`.",
+              }),
+          });
+          return;
+        }
+
+        const failureMessage = parsed
+          ? describeClaudeFailure(parsed)
+          : null;
+        checks.push({
+          code: "claude_hello_probe_failed",
+          level: "error",
+          message: "Claude hello probe failed.",
+          ...(failureMessage || detail ? { detail: failureMessage ?? detail } : {}),
+          hint: "Run `claude --print - --output-format stream-json --verbose` manually in this directory and prompt `Respond with hello` to debug.",
+        });
+      }
+
+      const initial = await runSingleProbe(probeEnv);
+      const loginMeta = detectClaudeLoginRequired({
+        parsed: initial.parsed,
+        stdout: initial.probeResult.stdout,
+        stderr: initial.probeResult.stderr,
+      });
+
+      const apiKeyCameFromHost =
+        isNonEmpty(hostApiKey) &&
+        !isNonEmpty(configApiKey) &&
+        !configExplicitlyHasAnthropicApiKey;
+      const shouldRetryWithoutApiKey =
+        apiKeyCameFromHost &&
+        !initial.probeResult.timedOut &&
+        !loginMeta.requiresLogin &&
+        (initial.probeResult.exitCode ?? 1) !== 0;
+
+      if (shouldRetryWithoutApiKey) {
+        const retryEnv = { ...probeEnv, ANTHROPIC_API_KEY: "" };
+        const retry = await runSingleProbe(retryEnv);
+        const retryLoginMeta = detectClaudeLoginRequired({
+          parsed: retry.parsed,
+          stdout: retry.probeResult.stdout,
+          stderr: retry.probeResult.stderr,
+        });
+
+        if ((retry.probeResult.exitCode ?? 1) === 0 && /\bhello\b/i.test(retry.parsedStream.summary.trim())) {
+          checks.push({
+            code: "claude_hello_probe_passed_fallback",
+            level: "warn",
+            message:
+              "Claude hello probe succeeded via subscription fallback after host ANTHROPIC_API_KEY failed.",
+            detail:
+              "The ANTHROPIC_API_KEY from the host environment had insufficient credits or permissions. Paperclip retried with subscription-based auth, which succeeded.",
+            hint:
+              "Unset ANTHROPIC_API_KEY from your shell environment to avoid this fallback on future probes.",
+          });
+        } else {
+          addProbeCheck(
+            initial.parsed,
+            initial.detail,
+            loginMeta,
+            initial.probeResult,
+            initial.parsedStream,
+          );
+        }
+      } else {
+        addProbeCheck(
+          initial.parsed,
+          initial.detail,
+          loginMeta,
+          initial.probeResult,
+          initial.parsedStream,
+        );
+      }
+    }
+  }
+
+  return {
+    adapterType: ctx.adapterType,
+    status: summarizeStatus(checks),
+    checks,
+    testedAt: new Date().toISOString(),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         specifier: ^0.27.3
         version: 0.27.3
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^3.0.5
@@ -10929,14 +10929,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
-
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -14555,7 +14547,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4

--- a/server/src/__tests__/claude-local-adapter-environment.test.ts
+++ b/server/src/__tests__/claude-local-adapter-environment.test.ts
@@ -80,6 +80,37 @@ describe("claude_local environment diagnostics", () => {
     expect(result.checks.some((check) => check.level === "error")).toBe(false);
   });
 
+  it("does not warn about host ANTHROPIC_API_KEY when config explicitly overrides it (even with non-string value)", async () => {
+    delete process.env.CLAUDE_CODE_USE_BEDROCK;
+    delete process.env.ANTHROPIC_BEDROCK_BASE_URL;
+    process.env.ANTHROPIC_API_KEY = "sk-test-host";
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "claude_local",
+      config: {
+        command: process.execPath,
+        cwd: process.cwd(),
+        env: {
+          ANTHROPIC_API_KEY: { type: "plain", value: "" },
+        },
+      },
+    });
+
+    expect(
+      result.checks.some(
+        (check) =>
+          check.code === "claude_anthropic_api_key_overrides_subscription",
+      ),
+    ).toBe(false);
+    expect(
+      result.checks.some(
+        (check) => check.code === "claude_subscription_mode_possible",
+      ),
+    ).toBe(true);
+    expect(result.checks.some((check) => check.level === "error")).toBe(false);
+  });
+
   it("returns bedrock auth info when CLAUDE_CODE_USE_BEDROCK is set in host environment", async () => {
     delete process.env.ANTHROPIC_API_KEY;
     process.env.CLAUDE_CODE_USE_BEDROCK = "1";


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The Claude Local adapter is responsible for executing Claude CLI commands and validating environment configuration
> - A bug existed where explicitly unsetting `ANTHROPIC_API_KEY` in adapter config (e.g., `{ type: "plain", value: "" }`) would still inherit the host environment's API key through process.env merging, causing incorrect probe failures
> - Additionally, when a host-provided API key failed (e.g., insufficient credits), users received a generic error instead of actionable guidance about subscription-based auth fallback
> - This pull request fixes the environment isolation bug, adds automatic subscription-auth fallback with proper diagnostics, and upgrades TypeScript to 5.9.3
> - The benefit is more reliable environment probing, clearer error messages, and better onboarding for users with subscription-based Claude auth

## What Changed

- **Environment isolation fix**: Added `configExplicitlyHasAnthropicApiKey` detection to prevent host `ANTHROPIC_API_KEY` leakage when config explicitly overrides it (even with non-string values like `{ type: "plain", value: "" }`)
- **Subscription-auth fallback**: Extracted probe execution into `runSingleProbe` helper and added automatic retry without API key when host-provided key fails; successful fallback reports as warn-level pass instead of error
- **Better error diagnostics**: Added `describeClaudeFailure` helper to surface structured Claude error messages (e.g., "Insufficient credits", "Invalid API key") instead of raw stderr
- **Fixed retry error reporting**: Changed fallback failure path to report retry probe results instead of initial probe results, ensuring subscription-login failures show actionable `claude_hello_probe_auth_required` warnings
- **TypeScript upgrade**: Bumped dev dependency from ^5.7.3 to ^5.9.3 with lock file updates
- **Regression test**: Added test verifying that `{ type: "plain", value: "" }` in config suppresses host API key inheritance and warnings

## Verification

- Run the new regression test: `pnpm test server/src/tests/claude-local-adapter-environment.test.ts`
- Manual verification: Set `ANTHROPIC_API_KEY` in host env, configure adapter with `{ type: "plain", value: "" }`, and confirm probe does not inherit the host key
- Manual verification: Set invalid `ANTHROPIC_API_KEY` in host env, run probe, and confirm fallback to subscription auth succeeds with appropriate warning message
- Manual verification: Set invalid `ANTHROPIC_API_KEY` and ensure subscription-login requirement surfaces as `claude_hello_probe_auth_required` warning instead of generic error

## Risks

- **Low risk**: The environment isolation fix is defensive and only affects cases where config explicitly overrides env vars
- **Low risk**: The subscription-auth fallback is opt-in (only triggers when host API key fails) and reports at warn level, so existing error behavior is preserved for non-fallback cases
- **Low risk**: TypeScript 5.9.3 is a minor version upgrade with backward-compatible changes

## Model Used

- Provider: Claude (Anthropic)
- Model: claude-sonnet-4-20250514
- Context window: 200K tokens
- Reasoning mode: Standard
- Capabilities: Tool use, code execution, file editing

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge