### PR TITLE
feat: add agent avatar support

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -145,6 +145,7 @@ Invariant: every business record belongs to exactly one company.
 - `role` text not null
 - `title` text null
 - `icon` text null
+- `avatar_asset_id` via `agent_avatars` null; user-uploaded agent avatar image asset
 - `status` enum: `active | paused | idle | running | error | pending_approval | terminated`
 - `reports_to` uuid fk `agents.id` null
 - `capabilities` text null

--- a/packages/db/src/migrations/0086_agent_avatars.sql
+++ b/packages/db/src/migrations/0086_agent_avatars.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS "agent_avatars" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"agent_id" uuid NOT NULL,
+	"company_id" uuid NOT NULL,
+	"asset_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'agent_avatars_agent_id_agents_id_fk') THEN
+		ALTER TABLE "agent_avatars" ADD CONSTRAINT "agent_avatars_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'agent_avatars_asset_id_assets_id_fk') THEN
+		ALTER TABLE "agent_avatars" ADD CONSTRAINT "agent_avatars_asset_id_assets_id_fk" FOREIGN KEY ("asset_id") REFERENCES "public"."assets"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'agent_avatars_company_id_companies_id_fk') THEN
+		ALTER TABLE "agent_avatars" ADD CONSTRAINT "agent_avatars_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_avatars_company_idx" ON "agent_avatars" USING btree ("company_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_avatars_agent_uq" ON "agent_avatars" USING btree ("agent_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_avatars_asset_uq" ON "agent_avatars" USING btree ("asset_id");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -603,6 +603,13 @@
       "when": 1778787362162,
       "tag": "0085_tranquil_the_executioner",
       "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "7",
+      "when": 1778956800000,
+      "tag": "0086_agent_avatars",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agent_avatars.ts
+++ b/packages/db/src/schema/agent_avatars.ts
@@ -1,0 +1,21 @@
+import { index, pgTable, uuid, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+import { agents } from "./agents.js";
+import { assets } from "./assets.js";
+import { companies } from "./companies.js";
+
+export const agentAvatars = pgTable(
+  "agent_avatars",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    agentId: uuid("agent_id").notNull().references(() => agents.id, { onDelete: "cascade" }),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    assetId: uuid("asset_id").notNull().references(() => assets.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyIdx: index("agent_avatars_company_idx").on(table.companyId),
+    agentUq: uniqueIndex("agent_avatars_agent_uq").on(table.agentId),
+    assetUq: uniqueIndex("agent_avatars_asset_uq").on(table.assetId),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -5,6 +5,7 @@ export { instanceSettings } from "./instance_settings.js";
 export { instanceUserRoles } from "./instance_user_roles.js";
 export { userSidebarPreferences } from "./user_sidebar_preferences.js";
 export { agents } from "./agents.js";
+export { agentAvatars } from "./agent_avatars.js";
 export { boardApiKeys } from "./board_api_keys.js";
 export { cliAuthChallenges } from "./cli_auth_challenges.js";
 export { companyMemberships } from "./company_memberships.js";

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -78,6 +78,8 @@ export interface Agent {
   role: AgentRole;
   title: string | null;
   icon: string | null;
+  avatarAssetId?: string | null;
+  avatarUrl?: string | null;
   status: AgentStatus;
   reportsTo: string | null;
   capabilities: string | null;

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -94,6 +94,7 @@ export const updateAgentSchema = createAgentSchema
   .omit({ permissions: true })
   .partial()
   .extend({
+    avatarAssetId: z.string().uuid().nullable().optional(),
     permissions: z.never().optional(),
     replaceAdapterConfig: z.boolean().optional(),
     status: z.enum(AGENT_STATUSES).optional(),

--- a/server/src/__tests__/assets.test.ts
+++ b/server/src/__tests__/assets.test.ts
@@ -431,6 +431,21 @@ describe("POST /api/companies/:companyId/agents/:agentId/avatar", () => {
     expect(createAssetMock).not.toHaveBeenCalled();
   });
 
+  it("reports the avatar size limit in megabytes", async () => {
+    const app = await createApp(createStorageService("image/png"), createDbStub());
+    createAssetMock.mockResolvedValue(createAsset());
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents/agent-1/avatar")
+        .attach("file", Buffer.alloc((5 * 1024 * 1024) + 1), { filename: "avatar.png", contentType: "image/png" }),
+    );
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe("Image exceeds 5 MB");
+    expect(createAssetMock).not.toHaveBeenCalled();
+  });
+
   it("rejects avatar uploads for agents outside the route company", async () => {
     const app = await createApp(createStorageService("image/png"), createDbStub({ id: "agent-1", companyId: "company-2" }));
     getAgentByIdMock.mockResolvedValue({

--- a/server/src/__tests__/assets.test.ts
+++ b/server/src/__tests__/assets.test.ts
@@ -4,9 +4,12 @@ import request from "supertest";
 import { MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import type { StorageService } from "../storage/types.js";
 
-const { createAssetMock, getAssetByIdMock, logActivityMock } = vi.hoisted(() => ({
+const { canUserMock, createAssetMock, getAssetByIdMock, getAgentByIdMock, hasPermissionMock, logActivityMock } = vi.hoisted(() => ({
+  canUserMock: vi.fn(),
   createAssetMock: vi.fn(),
   getAssetByIdMock: vi.fn(),
+  getAgentByIdMock: vi.fn(),
+  hasPermissionMock: vi.fn(),
   logActivityMock: vi.fn(),
 }));
 
@@ -23,6 +26,13 @@ function registerModuleMocks() {
   }));
 
   vi.doMock("../services/index.js", () => ({
+    accessService: vi.fn(() => ({
+      canUser: canUserMock,
+      hasPermission: hasPermissionMock,
+    })),
+    agentService: vi.fn(() => ({
+      getById: getAgentByIdMock,
+    })),
     assetService: vi.fn(() => ({
       create: createAssetMock,
       getById: getAssetByIdMock,
@@ -91,18 +101,39 @@ function createStorageService(contentType = "image/png"): TestStorageService {
   };
 }
 
-async function createApp(storage: ReturnType<typeof createStorageService>) {
+function createDbStub(agent: { id: string; companyId: string } | null = { id: "agent-1", companyId: "company-1" }) {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => Promise.resolve(agent ? [agent] : [])),
+      })),
+    })),
+  };
+}
+
+const ONE_PIXEL_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lNQ2NwAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+async function createApp(
+  storage: ReturnType<typeof createStorageService>,
+  db: Record<string, unknown> = {},
+  actor: Express.Request["actor"] = {
+    type: "board",
+    source: "local_implicit",
+    userId: "user-1",
+  },
+) {
   const { assetRoutes } = await vi.importActual<typeof import("../routes/assets.js")>("../routes/assets.js");
+  const { errorHandler } = await vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js");
   const app = express();
   app.use((req, _res, next) => {
-    req.actor = {
-      type: "board",
-      source: "local_implicit",
-      userId: "user-1",
-    };
+    req.actor = actor;
     next();
   });
-  app.use("/api", assetRoutes({} as any, storage));
+  app.use("/api", assetRoutes(db as any, storage));
+  app.use(errorHandler);
   return app;
 }
 
@@ -145,7 +176,10 @@ describe("POST /api/companies/:companyId/assets/images", () => {
     registerModuleMocks();
     vi.clearAllMocks();
     createAssetMock.mockReset();
+    canUserMock.mockReset();
     getAssetByIdMock.mockReset();
+    getAgentByIdMock.mockReset();
+    hasPermissionMock.mockReset();
     logActivityMock.mockReset();
   });
 
@@ -207,7 +241,10 @@ describe("POST /api/companies/:companyId/logo", () => {
     registerModuleMocks();
     vi.clearAllMocks();
     createAssetMock.mockReset();
+    canUserMock.mockReset();
     getAssetByIdMock.mockReset();
+    getAgentByIdMock.mockReset();
+    hasPermissionMock.mockReset();
     logActivityMock.mockReset();
   });
 
@@ -327,6 +364,161 @@ describe("POST /api/companies/:companyId/logo", () => {
 
     expect(res.status).toBe(422);
     expect(res.body.error).toBe("SVG could not be sanitized");
+    expect(createAssetMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/companies/:companyId/agents/:agentId/avatar", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/index.js");
+    vi.doUnmock("../routes/assets.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    createAssetMock.mockReset();
+    canUserMock.mockReset();
+    getAssetByIdMock.mockReset();
+    getAgentByIdMock.mockReset();
+    hasPermissionMock.mockReset();
+    logActivityMock.mockReset();
+    getAgentByIdMock.mockResolvedValue({
+      id: "agent-1",
+      companyId: "company-1",
+      role: "engineer",
+      permissions: { canCreateAgents: false },
+    });
+    hasPermissionMock.mockResolvedValue(false);
+    canUserMock.mockResolvedValue(false);
+  });
+
+  it("accepts decoded PNG avatar uploads for an agent in the company", async () => {
+    const png = createStorageService("image/png");
+    const app = await createApp(png, createDbStub());
+
+    createAssetMock.mockResolvedValue(createAsset());
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents/agent-1/avatar")
+        .attach("file", ONE_PIXEL_PNG, { filename: "avatar.png", contentType: "image/png" }),
+    );
+
+    expect(res.status, JSON.stringify({ body: res.body, text: res.text })).toBe(201);
+    expect(res.body.contentPath).toBe("/api/assets/asset-1/content");
+    expect(png.__calls.putFileInputs[0]).toMatchObject({
+      companyId: "company-1",
+      namespace: "assets/agents/agent-1/avatar",
+      originalFilename: "avatar.png",
+      contentType: "image/png",
+      body: expect.any(Buffer),
+    });
+  });
+
+  it("rejects spoofed avatar images that cannot be decoded", async () => {
+    const app = await createApp(createStorageService("image/png"), createDbStub());
+    createAssetMock.mockResolvedValue(createAsset());
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents/agent-1/avatar")
+        .attach("file", Buffer.from("not really png"), { filename: "avatar.png", contentType: "image/png" }),
+    );
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe("Image could not be decoded");
+    expect(createAssetMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects avatar uploads for agents outside the route company", async () => {
+    const app = await createApp(createStorageService("image/png"), createDbStub({ id: "agent-1", companyId: "company-2" }));
+    getAgentByIdMock.mockResolvedValue({
+      id: "agent-1",
+      companyId: "company-2",
+      role: "engineer",
+      permissions: { canCreateAgents: false },
+    });
+    createAssetMock.mockResolvedValue(createAsset());
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents/agent-1/avatar")
+        .attach("file", ONE_PIXEL_PNG, { filename: "avatar.png", contentType: "image/png" }),
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Agent not found");
+    expect(createAssetMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent-key uploads for another agent without creator permission", async () => {
+    const app = await createApp(
+      createStorageService("image/png"),
+      createDbStub(),
+      {
+        type: "agent",
+        source: "agent_key",
+        agentId: "agent-2",
+        companyId: "company-1",
+      },
+    );
+    getAgentByIdMock.mockImplementation(async (id: string) => {
+      if (id === "agent-1") {
+        return {
+          id: "agent-1",
+          companyId: "company-1",
+          role: "engineer",
+          permissions: { canCreateAgents: false },
+        };
+      }
+      if (id === "agent-2") {
+        return {
+          id: "agent-2",
+          companyId: "company-1",
+          role: "engineer",
+          permissions: { canCreateAgents: false },
+        };
+      }
+      return null;
+    });
+    hasPermissionMock.mockResolvedValue(false);
+    createAssetMock.mockResolvedValue(createAsset());
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents/agent-1/avatar")
+        .attach("file", ONE_PIXEL_PNG, { filename: "avatar.png", contentType: "image/png" }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Only CEO or agent creators can modify other agents");
+    expect(createAssetMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects board uploads without agent-management permission", async () => {
+    const app = await createApp(
+      createStorageService("image/png"),
+      createDbStub(),
+      {
+        type: "board",
+        source: "session",
+        userId: "user-2",
+        companyIds: ["company-1"],
+        memberships: [{ companyId: "company-1", membershipRole: "member", status: "active" }],
+      },
+    );
+    canUserMock.mockResolvedValue(false);
+    createAssetMock.mockResolvedValue(createAsset());
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .post("/api/companies/company-1/agents/agent-1/avatar")
+        .attach("file", ONE_PIXEL_PNG, { filename: "avatar.png", contentType: "image/png" }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Missing permission: agents:create");
     expect(createAssetMock).not.toHaveBeenCalled();
   });
 });

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -1,13 +1,15 @@
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
+import sharp from "sharp";
 import createDOMPurify from "dompurify";
 import { JSDOM } from "jsdom";
 import type { Db } from "@paperclipai/db";
 import { createAssetImageMetadataSchema } from "@paperclipai/shared";
 import type { StorageService } from "../storage/types.js";
-import { assetService, logActivity } from "../services/index.js";
+import { accessService, agentService, assetService, logActivity } from "../services/index.js";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
+import { forbidden } from "../errors.js";
 const SVG_CONTENT_TYPE = "image/svg+xml";
 const ALLOWED_COMPANY_LOGO_CONTENT_TYPES = new Set([
   "image/png",
@@ -17,6 +19,47 @@ const ALLOWED_COMPANY_LOGO_CONTENT_TYPES = new Set([
   "image/gif",
   SVG_CONTENT_TYPE,
 ]);
+const ALLOWED_AGENT_AVATAR_CONTENT_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/webp",
+  "image/gif",
+]);
+const AGENT_AVATAR_MAX_BYTES = 5 * 1024 * 1024;
+const AGENT_AVATAR_MAX_PIXELS = 16_000_000;
+
+async function validateRasterImageBuffer(input: {
+  body: Buffer;
+  contentType: string;
+}): Promise<string | null> {
+  if (!ALLOWED_AGENT_AVATAR_CONTENT_TYPES.has(input.contentType)) {
+    return `Unsupported image type: ${input.contentType || "unknown"}`;
+  }
+  if (input.body.length <= 0) {
+    return "Image is empty";
+  }
+
+  try {
+    const metadata = await sharp(input.body, { animated: input.contentType === "image/gif" }).metadata();
+    const expectedFormat =
+      input.contentType === "image/jpeg" || input.contentType === "image/jpg"
+        ? "jpeg"
+        : input.contentType.replace("image/", "");
+    if (metadata.format !== expectedFormat) {
+      return "File contents do not match the declared image type";
+    }
+    if (!metadata.width || !metadata.height) {
+      return "Image dimensions could not be read";
+    }
+    if (metadata.width * metadata.height > AGENT_AVATAR_MAX_PIXELS) {
+      return "Image dimensions are too large";
+    }
+  } catch {
+    return "Image could not be decoded";
+  }
+  return null;
+}
 
 function sanitizeSvgBuffer(input: Buffer): Buffer | null {
   const raw = input.toString("utf8").trim();
@@ -85,6 +128,8 @@ function sanitizeSvgBuffer(input: Buffer): Buffer | null {
 export function assetRoutes(db: Db, storage: StorageService) {
   const router = Router();
   const svc = assetService(db);
+  const agentsSvc = agentService(db);
+  const access = accessService(db);
   const assetUpload = multer({
     storage: multer.memoryStorage(),
     limits: { fileSize: MAX_ATTACHMENT_BYTES, files: 1 },
@@ -92,6 +137,10 @@ export function assetRoutes(db: Db, storage: StorageService) {
   const companyLogoUpload = multer({
     storage: multer.memoryStorage(),
     limits: { fileSize: MAX_ATTACHMENT_BYTES, files: 1 },
+  });
+  const agentAvatarUpload = multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: AGENT_AVATAR_MAX_BYTES, files: 1 },
   });
 
   async function runSingleFileUpload(
@@ -105,6 +154,38 @@ export function assetRoutes(db: Db, storage: StorageService) {
         else resolve();
       });
     });
+  }
+
+  function canCreateAgents(agent: { role: string; permissions: Record<string, unknown> | null | undefined }) {
+    if (!agent.permissions || typeof agent.permissions !== "object") return false;
+    return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
+  }
+
+  async function assertCanUploadAgentAvatar(req: Request, targetAgent: { id: string; companyId: string }) {
+    assertCompanyAccess(req, targetAgent.companyId);
+    if (req.actor.type === "board") {
+      if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return;
+      const allowed = await access.canUser(targetAgent.companyId, req.actor.userId, "agents:create");
+      if (!allowed) throw forbidden("Missing permission: agents:create");
+      return;
+    }
+    if (!req.actor.agentId) throw forbidden("Agent authentication required");
+
+    const actorAgent = await agentsSvc.getById(req.actor.agentId);
+    if (!actorAgent || actorAgent.companyId !== targetAgent.companyId) {
+      throw forbidden("Agent key cannot access another company");
+    }
+
+    if (actorAgent.id === targetAgent.id) return;
+    if (actorAgent.role === "ceo") return;
+    const allowedByGrant = await access.hasPermission(
+      targetAgent.companyId,
+      "agent",
+      actorAgent.id,
+      "agents:create",
+    );
+    if (allowedByGrant || canCreateAgents(actorAgent)) return;
+    throw forbidden("Only CEO or agent creators can modify other agents");
   }
 
   router.post("/companies/:companyId/assets/images", async (req, res) => {
@@ -289,6 +370,103 @@ export function assetRoutes(db: Db, storage: StorageService) {
         contentType: asset.contentType,
         byteSize: asset.byteSize,
         namespace: "assets/companies",
+      },
+    });
+
+    res.status(201).json({
+      assetId: asset.id,
+      companyId: asset.companyId,
+      provider: asset.provider,
+      objectKey: asset.objectKey,
+      contentType: asset.contentType,
+      byteSize: asset.byteSize,
+      sha256: asset.sha256,
+      originalFilename: asset.originalFilename,
+      createdByAgentId: asset.createdByAgentId,
+      createdByUserId: asset.createdByUserId,
+      createdAt: asset.createdAt,
+      updatedAt: asset.updatedAt,
+      contentPath: `/api/assets/${asset.id}/content`,
+    });
+  });
+
+  router.post("/companies/:companyId/agents/:agentId/avatar", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    const agentId = req.params.agentId as string;
+    assertCompanyAccess(req, companyId);
+
+    const agent = await agentsSvc.getById(agentId);
+    if (!agent || agent.companyId !== companyId) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    await assertCanUploadAgentAvatar(req, agent);
+
+    try {
+      await runSingleFileUpload(agentAvatarUpload, req, res);
+    } catch (err) {
+      if (err instanceof multer.MulterError) {
+        if (err.code === "LIMIT_FILE_SIZE") {
+          res.status(422).json({ error: `Image exceeds ${AGENT_AVATAR_MAX_BYTES} bytes` });
+          return;
+        }
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      throw err;
+    }
+
+    const file = (req as Request & { file?: { mimetype: string; buffer: Buffer; originalname: string } }).file;
+    if (!file) {
+      res.status(400).json({ error: "Missing file field 'file'" });
+      return;
+    }
+
+    const contentType = (file.mimetype || "").toLowerCase();
+    const validationError = await validateRasterImageBuffer({
+      body: file.buffer,
+      contentType,
+    });
+    if (validationError) {
+      res.status(422).json({ error: validationError });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    const stored = await storage.putFile({
+      companyId,
+      namespace: `assets/agents/${agentId}/avatar`,
+      originalFilename: file.originalname || null,
+      contentType,
+      body: file.buffer,
+    });
+
+    const asset = await svc.create(companyId, {
+      provider: stored.provider,
+      objectKey: stored.objectKey,
+      contentType: stored.contentType,
+      byteSize: stored.byteSize,
+      sha256: stored.sha256,
+      originalFilename: stored.originalFilename,
+      createdByAgentId: actor.agentId,
+      createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+    });
+
+    await logActivity(db, {
+      companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "asset.created",
+      entityType: "asset",
+      entityId: asset.id,
+      details: {
+        originalFilename: asset.originalFilename,
+        contentType: asset.contentType,
+        byteSize: asset.byteSize,
+        namespace: `assets/agents/${agentId}/avatar`,
+        avatarForAgentId: agentId,
       },
     });
 

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -27,6 +27,7 @@ const ALLOWED_AGENT_AVATAR_CONTENT_TYPES = new Set([
   "image/gif",
 ]);
 const AGENT_AVATAR_MAX_BYTES = 5 * 1024 * 1024;
+const AGENT_AVATAR_MAX_MEGABYTES = AGENT_AVATAR_MAX_BYTES / (1024 * 1024);
 const AGENT_AVATAR_MAX_PIXELS = 16_000_000;
 
 async function validateRasterImageBuffer(input: {
@@ -162,7 +163,6 @@ export function assetRoutes(db: Db, storage: StorageService) {
   }
 
   async function assertCanUploadAgentAvatar(req: Request, targetAgent: { id: string; companyId: string }) {
-    assertCompanyAccess(req, targetAgent.companyId);
     if (req.actor.type === "board") {
       if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) return;
       const allowed = await access.canUser(targetAgent.companyId, req.actor.userId, "agents:create");
@@ -407,7 +407,7 @@ export function assetRoutes(db: Db, storage: StorageService) {
     } catch (err) {
       if (err instanceof multer.MulterError) {
         if (err.code === "LIMIT_FILE_SIZE") {
-          res.status(422).json({ error: `Image exceeds ${AGENT_AVATAR_MAX_BYTES} bytes` });
+          res.status(422).json({ error: `Image exceeds ${AGENT_AVATAR_MAX_MEGABYTES} MB` });
           return;
         }
         res.status(400).json({ error: err.message });

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -2,7 +2,9 @@ import { createHash, randomBytes } from "node:crypto";
 import { and, desc, eq, gte, inArray, lt, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
+  assets,
   agents,
+  agentAvatars,
   agentConfigRevisions,
   agentApiKeys,
   agentRuntimeState,
@@ -56,6 +58,8 @@ interface RevisionMetadata {
 interface UpdateAgentOptions {
   recordRevision?: RevisionMetadata;
 }
+
+type AgentPatch = Partial<typeof agents.$inferInsert> & { avatarAssetId?: string | null };
 
 interface AgentShortnameRow {
   id: string;
@@ -221,6 +225,39 @@ export function agentService(db: Db) {
     };
   }
 
+  const agentSelection = {
+    id: agents.id,
+    companyId: agents.companyId,
+    name: agents.name,
+    role: agents.role,
+    title: agents.title,
+    icon: agents.icon,
+    status: agents.status,
+    reportsTo: agents.reportsTo,
+    capabilities: agents.capabilities,
+    adapterType: agents.adapterType,
+    adapterConfig: agents.adapterConfig,
+    runtimeConfig: agents.runtimeConfig,
+    defaultEnvironmentId: agents.defaultEnvironmentId,
+    budgetMonthlyCents: agents.budgetMonthlyCents,
+    spentMonthlyCents: agents.spentMonthlyCents,
+    pauseReason: agents.pauseReason,
+    pausedAt: agents.pausedAt,
+    permissions: agents.permissions,
+    lastHeartbeatAt: agents.lastHeartbeatAt,
+    metadata: agents.metadata,
+    avatarAssetId: agentAvatars.assetId,
+    createdAt: agents.createdAt,
+    updatedAt: agents.updatedAt,
+  };
+
+  function agentQuery(database: Pick<Db, "select">) {
+    return database
+      .select(agentSelection)
+      .from(agents)
+      .leftJoin(agentAvatars, eq(agentAvatars.agentId, agents.id));
+  }
+
   function withUrlKey<T extends { id: string; name: string }>(row: T) {
     return {
       ...row,
@@ -228,9 +265,12 @@ export function agentService(db: Db) {
     };
   }
 
-  function normalizeAgentRow(row: typeof agents.$inferSelect) {
+  function normalizeAgentRow(row: typeof agents.$inferSelect & { avatarAssetId?: string | null }) {
+    const avatarAssetId = row.avatarAssetId ?? null;
     return withUrlKey({
       ...row,
+      avatarAssetId,
+      avatarUrl: avatarAssetId ? `/api/assets/${avatarAssetId}/content` : null,
       permissions: normalizeAgentPermissions(row.permissions, row.role),
     });
   }
@@ -268,9 +308,7 @@ export function agentService(db: Db) {
   }
 
   async function getById(id: string) {
-    const row = await db
-      .select()
-      .from(agents)
+    const row = await agentQuery(db)
       .where(eq(agents.id, id))
       .then((rows) => rows[0] ?? null);
     if (!row) return null;
@@ -326,55 +364,99 @@ export function agentService(db: Db) {
 
   async function updateAgent(
     id: string,
-    data: Partial<typeof agents.$inferInsert>,
+    data: AgentPatch,
     options?: UpdateAgentOptions,
   ) {
     const existing = await getById(id);
     if (!existing) return null;
+    const { avatarAssetId, ...agentPatch } = data;
 
-    if (existing.status === "terminated" && data.status && data.status !== "terminated") {
+    if (existing.status === "terminated" && agentPatch.status && agentPatch.status !== "terminated") {
       throw conflict("Terminated agents cannot be resumed");
     }
     if (
       existing.status === "pending_approval" &&
-      data.status &&
-      data.status !== "pending_approval" &&
-      data.status !== "terminated"
+      agentPatch.status &&
+      agentPatch.status !== "pending_approval" &&
+      agentPatch.status !== "terminated"
     ) {
       throw conflict("Pending approval agents cannot be activated directly");
     }
 
-    if (data.reportsTo !== undefined) {
-      if (data.reportsTo) {
-        await ensureManager(existing.companyId, data.reportsTo);
+    if (agentPatch.reportsTo !== undefined) {
+      if (agentPatch.reportsTo) {
+        await ensureManager(existing.companyId, agentPatch.reportsTo);
       }
-      await assertNoCycle(id, data.reportsTo);
+      await assertNoCycle(id, agentPatch.reportsTo);
     }
 
-    if (data.name !== undefined) {
+    if (agentPatch.name !== undefined) {
       const previousShortname = normalizeAgentUrlKey(existing.name);
-      const nextShortname = normalizeAgentUrlKey(data.name);
+      const nextShortname = normalizeAgentUrlKey(agentPatch.name);
       if (previousShortname !== nextShortname) {
-        await assertCompanyShortnameAvailable(existing.companyId, data.name, { excludeAgentId: id });
+        await assertCompanyShortnameAvailable(existing.companyId, agentPatch.name, { excludeAgentId: id });
       }
     }
 
-    const normalizedPatch = { ...data } as Partial<typeof agents.$inferInsert>;
-    if (data.permissions !== undefined) {
-      const role = (data.role ?? existing.role) as string;
-      normalizedPatch.permissions = normalizeAgentPermissions(data.permissions, role);
+    const normalizedPatch = { ...agentPatch } as Partial<typeof agents.$inferInsert>;
+    if (agentPatch.permissions !== undefined) {
+      const role = (agentPatch.role ?? existing.role) as string;
+      normalizedPatch.permissions = normalizeAgentPermissions(agentPatch.permissions, role);
     }
 
     const shouldRecordRevision = Boolean(options?.recordRevision) && hasConfigPatchFields(normalizedPatch);
     const beforeConfig = shouldRecordRevision ? buildConfigSnapshot(existing) : null;
 
-    const updated = await db
-      .update(agents)
-      .set({ ...normalizedPatch, updatedAt: new Date() })
-      .where(eq(agents.id, id))
-      .returning()
-      .then((rows) => rows[0] ?? null);
-    const normalizedUpdated = updated ? normalizeAgentRow(updated) : null;
+    const normalizedUpdated = await db.transaction(async (tx) => {
+      if (avatarAssetId !== undefined && avatarAssetId !== null) {
+        const nextAvatarAsset = await tx
+          .select({ id: assets.id, companyId: assets.companyId })
+          .from(assets)
+          .where(eq(assets.id, avatarAssetId))
+          .then((rows) => rows[0] ?? null);
+        if (!nextAvatarAsset) throw notFound("Avatar asset not found");
+        if (nextAvatarAsset.companyId !== existing.companyId) {
+          throw unprocessable("Avatar asset must belong to the same company");
+        }
+      }
+
+      const updated = await tx
+        .update(agents)
+        .set({ ...normalizedPatch, updatedAt: new Date() })
+        .where(eq(agents.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!updated) return null;
+
+      if (avatarAssetId === null) {
+        await tx.delete(agentAvatars).where(eq(agentAvatars.agentId, id));
+      } else if (avatarAssetId !== undefined) {
+        await tx
+          .insert(agentAvatars)
+          .values({
+            agentId: id,
+            companyId: existing.companyId,
+            assetId: avatarAssetId,
+          })
+          .onConflictDoUpdate({
+            target: agentAvatars.agentId,
+            set: {
+              assetId: avatarAssetId,
+              companyId: existing.companyId,
+              updatedAt: new Date(),
+            },
+          });
+      }
+
+      if (avatarAssetId !== undefined && existing.avatarAssetId && existing.avatarAssetId !== avatarAssetId) {
+        await tx.delete(assets).where(eq(assets.id, existing.avatarAssetId));
+      }
+
+      const row = await agentQuery(tx)
+        .where(eq(agents.id, id))
+        .then((rows) => rows[0] ?? null);
+      return row ? normalizeAgentRow(row) : null;
+    });
 
     if (normalizedUpdated && shouldRecordRevision && beforeConfig) {
       const afterConfig = buildConfigSnapshot(normalizedUpdated);
@@ -403,8 +485,8 @@ export function agentService(db: Db) {
       if (!options?.includeTerminated) {
         conditions.push(ne(agents.status, "terminated"));
       }
-      const rows = await db.select().from(agents).where(and(...conditions));
-      const hydrated = await hydrateAgentSpend(rows);
+      const rowsWithAvatars = await agentQuery(db).where(and(...conditions));
+      const hydrated = await hydrateAgentSpend(rowsWithAvatars);
       return hydrated.map(normalizeAgentRow);
     },
 
@@ -451,7 +533,7 @@ export function agentService(db: Db) {
         .where(eq(agents.id, id))
         .returning()
         .then((rows) => rows[0] ?? null);
-      return updated ? normalizeAgentRow(updated) : null;
+      return updated ? getById(id) : null;
     },
 
     resume: async (id: string) => {
@@ -473,7 +555,7 @@ export function agentService(db: Db) {
         .where(eq(agents.id, id))
         .returning()
         .then((rows) => rows[0] ?? null);
-      return updated ? normalizeAgentRow(updated) : null;
+      return updated ? getById(id) : null;
     },
 
     terminate: async (id: string) => {
@@ -522,6 +604,10 @@ export function agentService(db: Db) {
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.agentId, id));
         await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.agentId, id));
+        if (existing.avatarAssetId) {
+          await tx.delete(agentAvatars).where(eq(agentAvatars.agentId, id));
+          await tx.delete(assets).where(eq(assets.id, existing.avatarAssetId));
+        }
         const deleted = await tx
           .delete(agents)
           .where(eq(agents.id, id))
@@ -540,7 +626,7 @@ export function agentService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (updated) {
-        return { agent: normalizeAgentRow(updated), activated: true };
+        return { agent: (await getById(id)) ?? normalizeAgentRow(updated), activated: true };
       }
 
       const existing = await getById(id);
@@ -561,7 +647,7 @@ export function agentService(db: Db) {
         .returning()
         .then((rows) => rows[0] ?? null);
 
-      return updated ? normalizeAgentRow(updated) : null;
+      return updated ? getById(id) : null;
     },
 
     listConfigRevisions: async (id: string) =>

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -5,6 +5,7 @@ import {
   companyLogos,
   assets,
   agents,
+  agentAvatars,
   agentApiKeys,
   agentRuntimeState,
   agentTaskSessions,
@@ -287,6 +288,7 @@ export function companyService(db: Db) {
         await tx.delete(documents).where(eq(documents.companyId, id));
         await tx.delete(issues).where(eq(issues.companyId, id));
         await tx.delete(companyLogos).where(eq(companyLogos.companyId, id));
+        await tx.delete(agentAvatars).where(eq(agentAvatars.companyId, id));
         await tx.delete(assets).where(eq(assets.companyId, id));
         await tx.delete(goals).where(eq(goals.companyId, id));
         await tx.delete(projects).where(eq(projects.companyId, id));

--- a/ui/src/api/assets.ts
+++ b/ui/src/api/assets.ts
@@ -26,4 +26,16 @@ export const assetsApi = {
     form.append("file", safeFile);
     return api.postForm<AssetImage>(`/companies/${companyId}/logo`, form);
   },
+
+  uploadAgentAvatar: async (companyId: string, agentId: string, file: File) => {
+    const buffer = await file.arrayBuffer();
+    const safeFile = new File([buffer], file.name, { type: file.type });
+
+    const form = new FormData();
+    form.append("file", safeFile);
+    return api.postForm<AssetImage>(
+      `/companies/${companyId}/agents/${agentId}/avatar`,
+      form,
+    );
+  },
 };

--- a/ui/src/components/AgentIconPicker.test.tsx
+++ b/ui/src/components/AgentIconPicker.test.tsx
@@ -1,0 +1,21 @@
+// @vitest-environment node
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AgentIcon } from "./AgentIconPicker";
+
+describe("AgentIcon", () => {
+  it("renders an uploaded avatar image before the symbolic icon fallback", () => {
+    const html = renderToStaticMarkup(
+      <AgentIcon
+        icon="code"
+        avatarUrl="/api/assets/avatar-1/content"
+        className="h-full w-full"
+      />,
+    );
+
+    expect(html).toContain('src="/api/assets/avatar-1/content"');
+    expect(html).toContain("object-cover");
+    expect(html).not.toContain("lucide-code");
+  });
+});

--- a/ui/src/components/AgentIconPicker.tsx
+++ b/ui/src/components/AgentIconPicker.tsx
@@ -1,5 +1,8 @@
-import { useState, useMemo } from "react";
+import { useId, useMemo, useRef, useState } from "react";
 import {
+  Camera,
+  LoaderCircle,
+  Trash2,
   type LucideIcon,
 } from "lucide-react";
 import { AGENT_ICON_NAMES, type AgentIconName } from "@paperclipai/shared";
@@ -16,23 +19,51 @@ const DEFAULT_ICON: AgentIconName = "bot";
 
 interface AgentIconProps {
   icon: string | null | undefined;
+  avatarUrl?: string | null;
   className?: string;
+  imageClassName?: string;
 }
 
-export function AgentIcon({ icon, className }: AgentIconProps) {
+export function AgentIcon({ icon, avatarUrl, className, imageClassName }: AgentIconProps) {
+  if (avatarUrl) {
+    return (
+      <img
+        src={avatarUrl}
+        alt=""
+        className={cn("h-full w-full object-cover", className, imageClassName)}
+        draggable={false}
+      />
+    );
+  }
   const Icon = getAgentIcon(icon);
   return <Icon className={className} />;
 }
 
 interface AgentIconPickerProps {
   value: string | null | undefined;
+  avatarUrl?: string | null;
   onChange: (icon: string) => void;
+  onAvatarUpload?: (file: File) => void;
+  onAvatarRemove?: () => void;
+  isUploadingAvatar?: boolean;
+  isRemovingAvatar?: boolean;
   children: React.ReactNode;
 }
 
-export function AgentIconPicker({ value, onChange, children }: AgentIconPickerProps) {
+export function AgentIconPicker({
+  value,
+  avatarUrl,
+  onChange,
+  onAvatarUpload,
+  onAvatarRemove,
+  isUploadingAvatar = false,
+  isRemovingAvatar = false,
+  children,
+}: AgentIconPickerProps) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const inputId = useId();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const filtered = useMemo(() => {
     const entries = AGENT_ICON_NAMES.map((name) => [name, AGENT_ICONS[name]] as const);
@@ -45,6 +76,45 @@ export function AgentIconPicker({ value, onChange, children }: AgentIconPickerPr
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
       <PopoverContent className="w-72 p-3" align="start">
+        {onAvatarUpload ? (
+          <div className="mb-3 flex items-center gap-2 border-b border-border pb-3">
+            <input
+              ref={fileInputRef}
+              id={inputId}
+              type="file"
+              accept="image/png,image/jpeg,image/webp,image/gif"
+              className="sr-only"
+              disabled={isUploadingAvatar || isRemovingAvatar}
+              onChange={(event) => {
+                const file = event.target.files?.[0];
+                event.currentTarget.value = "";
+                if (!file) return;
+                onAvatarUpload(file);
+              }}
+            />
+            <button
+              type="button"
+              className="inline-flex h-8 flex-1 items-center justify-center gap-1.5 rounded-md border border-border px-2 text-xs hover:bg-accent disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isUploadingAvatar || isRemovingAvatar}
+            >
+              {isUploadingAvatar ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" /> : <Camera className="h-3.5 w-3.5" />}
+              {avatarUrl ? "Change image" : "Upload image"}
+            </button>
+            {avatarUrl && onAvatarRemove ? (
+              <button
+                type="button"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-border text-muted-foreground hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={onAvatarRemove}
+                disabled={isUploadingAvatar || isRemovingAvatar}
+                aria-label="Remove image"
+                title="Remove image"
+              >
+                {isRemovingAvatar ? <LoaderCircle className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+              </button>
+            ) : null}
+          </div>
+        ) : null}
         <Input
           placeholder="Search icons..."
           value={search}

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -834,6 +834,44 @@ export function AgentDetail() {
     },
   });
 
+  const uploadAvatar = useMutation({
+    mutationFn: async (file: File) => {
+      if (!agent || !resolvedCompanyId) {
+        throw new Error("Select a company before uploading an agent avatar.");
+      }
+      const asset = await assetsApi.uploadAgentAvatar(resolvedCompanyId, agent.id, file);
+      return agentsApi.update(agentLookupRef, { avatarAssetId: asset.assetId }, resolvedCompanyId);
+    },
+    onSuccess: () => {
+      setActionError(null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(routeAgentRef) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentLookupRef) });
+      if (resolvedCompanyId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(resolvedCompanyId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.org(resolvedCompanyId) });
+      }
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to upload avatar");
+    },
+  });
+
+  const removeAvatar = useMutation({
+    mutationFn: () => agentsApi.update(agentLookupRef, { avatarAssetId: null }, resolvedCompanyId ?? undefined),
+    onSuccess: () => {
+      setActionError(null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(routeAgentRef) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentLookupRef) });
+      if (resolvedCompanyId) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(resolvedCompanyId) });
+        queryClient.invalidateQueries({ queryKey: queryKeys.org(resolvedCompanyId) });
+      }
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Failed to remove avatar");
+    },
+  });
+
   const resetTaskSession = useMutation({
     mutationFn: (taskKey: string | null) =>
       agentsApi.resetSession(agentLookupRef, taskKey, resolvedCompanyId ?? undefined),
@@ -921,10 +959,19 @@ export function AgentDetail() {
         <div className="flex items-center gap-3 min-w-0">
           <AgentIconPicker
             value={agent.icon}
+            avatarUrl={agent.avatarUrl}
             onChange={(icon) => updateIcon.mutate(icon)}
+            onAvatarUpload={(file) => uploadAvatar.mutate(file)}
+            onAvatarRemove={agent.avatarUrl ? () => removeAvatar.mutate() : undefined}
+            isUploadingAvatar={uploadAvatar.isPending}
+            isRemovingAvatar={removeAvatar.isPending}
           >
-            <button className="shrink-0 flex items-center justify-center h-12 w-12 rounded-lg bg-accent hover:bg-accent/80 transition-colors">
-              <AgentIcon icon={agent.icon} className="h-6 w-6" />
+            <button
+              type="button"
+              aria-label="Edit agent avatar or icon"
+              className="shrink-0 flex h-12 w-12 items-center justify-center overflow-hidden rounded-lg bg-accent transition-colors hover:bg-accent/80"
+            >
+              <AgentIcon icon={agent.icon} avatarUrl={agent.avatarUrl} className={agent.avatarUrl ? "h-full w-full" : "h-6 w-6"} />
             </button>
           </AgentIconPicker>
           <div className="min-w-0">

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -9,6 +9,7 @@ import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useSidebar } from "../context/SidebarContext";
 import { queryKeys } from "../lib/queryKeys";
 import { StatusBadge } from "../components/StatusBadge";
+import { AgentIcon } from "../components/AgentIconPicker";
 import { agentStatusDot, agentStatusDotDefault } from "../lib/status-colors";
 import { EntityRow } from "../components/EntityRow";
 import { EmptyState } from "../components/EmptyState";
@@ -233,9 +234,14 @@ export function Agents() {
                 to={agentUrl(agent)}
                 className={agent.pausedAt && tab !== "paused" ? "opacity-50" : ""}
                 leading={
-                  <span className="relative flex h-2.5 w-2.5">
+                  <span className="relative flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted">
+                    <AgentIcon
+                      icon={agent.icon}
+                      avatarUrl={agent.avatarUrl}
+                      className={agent.avatarUrl ? "h-full w-full" : "h-3.5 w-3.5 text-muted-foreground"}
+                    />
                     <span
-                      className={`absolute inline-flex h-full w-full rounded-full ${agentStatusDot[agent.status] ?? agentStatusDotDefault}`}
+                      className={`absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-background ${agentStatusDot[agent.status] ?? agentStatusDotDefault}`}
                     />
                   </span>
                 }
@@ -337,8 +343,13 @@ function OrgTreeNode({
         to={agent ? agentUrl(agent) : `/agents/${node.id}`}
         className={cn("flex items-center gap-3 px-3 py-2 hover:bg-accent/30 transition-colors w-full text-left no-underline text-inherit", agent?.pausedAt && tab !== "paused" && "opacity-50")}
       >
-        <span className="relative flex h-2.5 w-2.5 shrink-0">
-          <span className={`absolute inline-flex h-full w-full rounded-full ${statusColor}`} />
+        <span className="relative flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted">
+          <AgentIcon
+            icon={agent?.icon}
+            avatarUrl={agent?.avatarUrl}
+            className={agent?.avatarUrl ? "h-full w-full" : "h-3.5 w-3.5 text-muted-foreground"}
+          />
+          <span className={`absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-background ${statusColor}`} />
         </span>
         <div className="flex-1 min-w-0">
           <span className="text-sm font-medium">{node.name}</span>

--- a/ui/src/pages/OrgChart.tsx
+++ b/ui/src/pages/OrgChart.tsx
@@ -583,8 +583,12 @@ export function OrgChart() {
                 <div className="flex items-center px-4 py-3 gap-3">
                   {/* Agent icon + status dot */}
                   <div className="relative shrink-0">
-                    <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center">
-                      <AgentIcon icon={agent?.icon} className="h-4.5 w-4.5 text-foreground/70" />
+                    <div className="w-9 h-9 rounded-full bg-muted flex items-center justify-center overflow-hidden">
+                      <AgentIcon
+                        icon={agent?.icon}
+                        avatarUrl={agent?.avatarUrl}
+                        className={agent?.avatarUrl ? "h-full w-full" : "h-4.5 w-4.5 text-foreground/70"}
+                      />
                     </div>
                     <span
                       className="absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-card"


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies by giving operators a control plane for defining agents, supervising work, and keeping company state visible.
> - Agent identity is part of that control-plane surface: agents already have names, roles, icons, hierarchy, permissions, and organization-chart placement.
> - Organization-level avatar/logo upload already existed, but individual agents were limited to symbolic icons.
> - That made agent identity less clear in lists, detail headers, and org-chart views, especially for companies that want richer visual differentiation between agents.
> - Agent avatars need to be handled like real user-uploaded media, with company scoping, permission checks, image validation, size limits, and asset-backed storage.
> - This pull request adds uploaded image avatars for individual agents while reusing the existing asset/upload and icon-picker patterns where possible.
> - The benefit is a more expressive agent identity model without weakening Paperclip’s company-scoped access and upload safety expectations.

## What Changed

- Added `agent_avatars` database schema and migration to associate one uploaded asset with one agent.
- Extended shared agent types and update validation with `avatarAssetId` and `avatarUrl`.
- Added a company-scoped agent avatar upload endpoint with file-size limits, MIME/type checks, raster image decoding through `sharp`, dimension limits, activity logging, and agent-management authorization.
- Updated agent services to hydrate avatar URLs, attach/remove avatar assets, clean up avatar records on replacement/removal, and preserve avatar fields across agent mutations.
- Reused the existing `AgentIconPicker` flow to support upload, change, remove, and image rendering.
- Displayed uploaded avatars in the agent detail header, agent list, and org chart.
- Updated implementation docs to include agent avatar asset support.
- Added tests for avatar image validation, company scoping, authorization, and UI avatar rendering.

## Verification

- `git diff --check`
- `pnpm exec vitest run src/__tests__/assets.test.ts` from `server/`
- `pnpm exec vitest run src/components/AgentIconPicker.test.tsx` from `ui/`
- `pnpm --filter @paperclipai/db typecheck`
- `pnpm --filter @paperclipai/shared typecheck`

Known unrelated local blockers:

- `pnpm --filter @paperclipai/server typecheck` currently fails on existing cursor-cloud/plugin-sdk/environment-runtime type issues.
- `pnpm --filter @paperclipai/ui typecheck` currently fails on existing missing `@paperclipai/adapter-cursor-cloud/ui`, `i18next`, and `react-i18next` types.

Manual UI check recommended:

- Open an agent detail page.
- Click the agent icon/avatar control.
- Upload a PNG/JPEG/WEBP/GIF avatar.
- Confirm the avatar appears in the detail header, agent list, and org chart.
- Remove the avatar and confirm the symbolic icon fallback returns.

## Risks

- Low-to-moderate migration risk: this adds a new `agent_avatars` table and indexes but does not alter existing agent rows.
- Upload/attach remains a two-step flow, matching the existing organization logo pattern. If upload succeeds and the later agent update fails, an unattached asset can remain.
- Image handling is intentionally stricter than general asset uploads; unsupported or malformed images will be rejected.
- Permission behavior now treats avatar upload as agent mutation, so users without agent-management access cannot upload avatars for other agents.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent, with tool use for local repository inspection, file editing, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [X] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [X] I will address all Greptile and reviewer comments before requesting merge