### PR TITLE
docs: add v2026.517.0 release changelog

### DIFF
--- a/releases/v2026.517.0.md
+++ b/releases/v2026.517.0.md
@@ -1,0 +1,30 @@
+# v2026.517.0
+
+> Released: 2026-05-17
+
+## Highlights
+
+- **Grok Build is now a first-class local runtime** - Paperclip can configure and run `grok_local` through the built-in adapter registry, with server, UI, CLI, transcript parsing, session handling, diagnostics, and focused adapter coverage. ([#6087](https://github.com/paperclipai/paperclip/pull/6087), @devinfoley)
+- **Issue documents can be locked for safer handoffs** - Board-managed document locks preserve approved snapshots, route agent writes to derived documents, expose lock state in the UI and API, and record lock activity. ([#6009](https://github.com/paperclipai/paperclip/pull/6009), @cryppadotta)
+- **The Issues board scales better with large columns** - High-volume Kanban columns now support compact cards, collapsed cold lanes, per-column reveal limits, persisted density controls, and matching UI coverage. ([#5309](https://github.com/paperclipai/paperclip/pull/5309), @eibrahim)
+- **Internationalization groundwork is in place** - The board UI now has an i18next foundation, locale validation, runtime package declarations, and a validated catalog of supported locale resources for future translated surfaces. ([#6058](https://github.com/paperclipai/paperclip/pull/6058), [#5943](https://github.com/paperclipai/paperclip/pull/5943), [#6070](https://github.com/paperclipai/paperclip/pull/6070), @cryppadotta)
+
+## Improvements
+
+- **Live issue document updates refresh open boards** - Document create, update, restore, and delete activity now invalidates the relevant list, active-document, and revision caches without forcing operators to reload the issue page. ([#6005](https://github.com/paperclipai/paperclip/pull/6005), @cryppadotta)
+- **Cloudflare sandbox execution is more reliable** - The Cloudflare bridge now has larger execution capacity, SSE keepalives, safer stdout handling, sandbox-aware probe budgets, and a corrected Pi sandbox install path. ([#5967](https://github.com/paperclipai/paperclip/pull/5967), @devinfoley)
+- **LLM Wiki packaging and plugin migrations are safer** - The packaged plugin now includes required assets, uses a visible bootstrap template, and validates and applies spaces migrations through explicit namespace-safe SQL. ([#6010](https://github.com/paperclipai/paperclip/pull/6010), @cryppadotta)
+- **PR verification runs faster** - The GitHub PR workflow now fans out typecheck, release-registry checks, grouped general tests, and build work instead of serializing them behind one monolithic verify job. ([#6137](https://github.com/paperclipai/paperclip/pull/6137), @devinfoley)
+- **Multilingual issue flows have regression coverage** - Board issue creation, server issue/comment/document round trips, and scoped wake payload rendering now cover Chinese, Japanese, and Hindi text preservation. ([#6069](https://github.com/paperclipai/paperclip/pull/6069), @cryppadotta)
+
+## Fixes
+
+- **Grok reasoning streams regain readable turn boundaries** - Paperclip now restores missing line breaks between streamed Grok reasoning chunks so the live Working panel no longer merges separate thoughts into run-on text. ([#6142](https://github.com/paperclipai/paperclip/pull/6142), @devinfoley)
+- **Identifier-based wakeups bind to the right project workspace** - Heartbeat wakeup context now carries the resolved `projectId` and canonicalizes identifier-style issue references before workspace resolution. ([#6026](https://github.com/paperclipai/paperclip/pull/6026), @devinfoley)
+- **Company export tolerates missing local run logs** - Optional comment attribution metadata now degrades gracefully when historical heartbeat run log files are missing, preserving exportable issue comments. ([#5960](https://github.com/paperclipai/paperclip/pull/5960), @cryppadotta)
+
+## Contributors
+
+Thank you to everyone who contributed to this release!
+
+@eibrahim


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for autonomous AI companies.
> - Stable releases need a reviewer-readable changelog artifact that summarizes what changed for operators and contributors.
> - The last stable release tag is `v2026.513.0`, and the requested release date is 2026-05-17.
> - The release changelog skill maps that date to stable version `2026.517.0` and requires the range `v2026.513.0..origin/master`.
> - I reviewed the commits, PR metadata, migration/API surfaces, and contributor attribution in that range.
> - This pull request adds the `releases/v2026.517.0.md` changelog for human release sign-off.
> - The benefit is a stable release note artifact that is ready to review before publishing the release.

## What Changed

- Added `releases/v2026.517.0.md` for the 2026-05-17 stable release.
- Summarized user-facing highlights, improvements, fixes, and contributor attribution from `v2026.513.0..origin/master`.
- Omitted Breaking Changes and Upgrade Guide sections after checking for destructive migrations, removed API surfaces, and breaking-change commit signals.

## Verification

- `./scripts/release.sh stable --date 2026-05-17 --print-version` -> `2026.517.0`.
- `git tag --list 'v*' --sort=-version:refname | head -10` confirmed `v2026.513.0` is the latest stable tag.
- `git log v2026.513.0..origin/master --oneline --no-merges` reviewed the 16 release-range commits.
- `git diff --name-only v2026.513.0..origin/master -- .changeset` returned no changeset files.
- `git log v2026.513.0..origin/master --format='%s' | rg -n 'BREAKING CHANGE|BREAKING:|^[a-z]+!:' || true` returned no breaking-change signals.
- `git diff --name-only v2026.513.0..origin/master -- packages/db/src/migrations packages/db/src/schema server/src/routes server/src/api server/src` reviewed the DB/API/server touchpoints; only an additive document-lock migration appeared in the DB schema/migration path.
- `test -f releases/v2026.517.0.md` passed.
- `rg -n -- '-canary|canary/' releases/v2026.517.0.md || true` returned no canary filename/title language.
- `git diff --cached --check` passed before commit.

## Risks

- Low risk: docs-only release changelog addition.
- Changelog grouping is editorial; reviewers may want wording or prioritization changes before release publication.
- Contributor attribution intentionally excludes bot accounts and Paperclip founders from the Contributors section per the release changelog skill.

> Checked [`ROADMAP.md`](ROADMAP.md); this is release documentation, not new roadmap-level core feature work.

## Model Used

- OpenAI Codex, GPT-5 coding agent via Paperclip `codex_local`, with shell, git, GitHub CLI, and repository file editing enabled. Exact backend sub-version and context window were not surfaced by the Paperclip runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
