### PR TITLE
feat(monitor): billing/quota cascade guard in productivity-review evaluator

### DIFF
--- a/doc/productivity-monitor.md
+++ b/doc/productivity-monitor.md
@@ -1,0 +1,97 @@
+# Productivity Monitor
+
+Paperclip's productivity monitor watches active agent issues and spawns a review issue when an agent shows signs of stalling, looping, or excessive churn. This document describes how the evaluator works, its triggers, its guard rails, and the metrics it emits.
+
+## When Reconciliation Runs
+
+`reconcileProductivityReviews()` is called on a cron schedule. It scans all `todo`/`in_progress` agent-assigned issues and evaluates each against the configured thresholds.
+
+## Triggers
+
+Each candidate issue is evaluated for three independent triggers. The first matching trigger wins:
+
+| Trigger | Default | Description |
+|---|---|---|
+| `no_comment_streak` | 10 consecutive terminal runs | The last N completed runs for this issue produced no agent-authored comment. |
+| `high_churn` | 10 runs/1h or 30 runs/6h | The agent is cycling through runs too fast relative to comment output. |
+| `long_active_duration` | 6 hours | The issue has been in `in_progress` continuously for too long. |
+
+## Review Issue Lifecycle
+
+When a trigger fires, a child review issue is created under the source issue and assigned to the agent's manager (CTO/CEO fallback). The review issue uses `originKind: issue_productivity_review` and an `originFingerprint` keyed to the source issue.
+
+Subsequent reconciliation passes refresh the open review with updated evidence up to `maxRefreshComments` times (default 3) at no more than one refresh per `refreshIntervalMs` (default 1 hour).
+
+If a review is resolved (`done`) within the snooze window (default 6 hours), re-evaluation is suppressed for that window.
+
+A creation cap prevents more than `maxCreationsPerWindow` (default 3) non-cancelled reviews per source issue within `creationWindowMs` (default 24 hours).
+
+## Billing Cascade Guard
+
+### Problem
+
+A shared-account plan-cap exhaustion (e.g., Anthropic `out of extra usage · resets <time>`) causes all agent runs to fail immediately with zero useful output. The no-comment streak and high-churn detectors cannot distinguish this from genuinely unproductive behavior, leading to cascading productivity-review issues.
+
+### Guard Behavior
+
+Before computing streaks, `collectEvidence()` inspects the terminal runs in the sampled window. If the fraction of runs classified as billing/quota errors meets or exceeds `billingCascadeThreshold` (default **0.5**, i.e. 50%), the review is suppressed entirely and no review issue is created.
+
+A run is classified as a billing/quota error if any of the following match:
+
+- `errorCode === "claude_plan_cap_exhausted"` (set by the adapter-side classifier per TAP-979)
+- `error`, `stderrExcerpt`, or `stdoutExcerpt` matches one of these patterns:
+  - `out of extra usage`
+  - `resets <digits>` (e.g., "resets 11am ET")
+  - `try again at `
+  - `upgrade to pro`
+  - `usage limit`
+  - `plan…cap` (within 20 chars)
+  - `claude_plan_cap_exhausted`
+
+### Suppression Metric
+
+When the guard fires, a structured log entry is emitted at `INFO` level:
+
+```json
+{
+  "metric": "productivity_review.suppressed_billing_cascade",
+  "companyId": "...",
+  "issueId": "...",
+  "agentId": "...",
+  "billingCascadeRatio": 1.0,
+  "billingCascadeCount": 10,
+  "totalTerminalRuns": 10,
+  "billingCascadeThreshold": 0.5
+}
+```
+
+Search logs for `productivity_review.suppressed_billing_cascade` to audit how often the guard fires.
+
+### Tuning
+
+The threshold is configurable via `thresholds.billingCascadeThreshold` passed to `reconcileProductivityReviews()` or `collectEvidence()`. Valid range is `[0, 1]`; values outside that range fall back to the default.
+
+- Set to `0` to disable suppression (every window triggers a review regardless of billing errors).
+- Set to `1` to suppress only when **all** terminal runs are billing errors.
+- Default `0.5` means a majority (≥50%) of billing errors suppresses the review.
+
+## Configuration Reference
+
+All thresholds can be overridden per reconciliation call via the `thresholds` parameter:
+
+| Key | Default | Description |
+|---|---|---|
+| `noCommentStreakRuns` | 10 | Consecutive terminal runs with no comment to trigger. |
+| `longActiveMs` | 21600000 (6h) | Active duration in ms to trigger `long_active_duration`. |
+| `highChurnHourly` | 10 | Runs or assignee-run comments per 1-hour window. |
+| `highChurnSixHours` | 30 | Runs or assignee-run comments per 6-hour window. |
+| `resolvedSnoozeMs` | 21600000 (6h) | Snooze window after a review is resolved. |
+| `refreshIntervalMs` | 3600000 (1h) | Minimum interval between refresh comments on an open review. |
+| `maxRefreshComments` | 3 | Maximum refresh comments before the review stops updating. |
+| `creationWindowMs` | 86400000 (24h) | Rolling window for the creation cap. |
+| `maxCreationsPerWindow` | 3 | Max non-cancelled reviews per source issue per window. |
+| `billingCascadeThreshold` | 0.5 | Billing-error fraction needed to suppress the review. |
+
+## Soft-Stop Holds
+
+For `no_comment_streak` and `high_churn` triggers, the runtime can hold a new heartbeat from starting if an open review exists for the same issue. Long-active reviews do **not** hold continuations. Check `isProductivityReviewContinuationHoldActive()` before queuing a retry.

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { MAX_ISSUE_REQUEST_DEPTH } from "@paperclipai/shared";
 import {
+  DEFAULT_PRODUCTIVITY_REVIEW_BILLING_CASCADE_THRESHOLD,
   DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS,
   DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
   DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
@@ -120,6 +121,8 @@ describeEmbeddedPostgres("productivity review service", () => {
     count: number;
     now: Date;
     withRunComments?: boolean;
+    error?: string;
+    errorCode?: string;
   }) {
     const runs: Array<typeof heartbeatRuns.$inferInsert> = [];
     for (let index = 0; index < input.count; index += 1) {
@@ -129,14 +132,16 @@ describeEmbeddedPostgres("productivity review service", () => {
         id: runId,
         companyId: input.companyId,
         agentId: input.agentId,
-        status: "succeeded",
+        status: input.error ? "failed" : "succeeded",
         invocationSource: "assignment",
         triggerDetail: "system",
         startedAt: createdAt,
         finishedAt: new Date(createdAt.getTime() + 30_000),
         contextSnapshot: { issueId: input.issueId, taskId: input.issueId },
-        livenessState: "advanced",
+        livenessState: input.error ? "failed" : "advanced",
         nextAction: "Continue processing the next batch.",
+        error: input.error ?? null,
+        errorCode: input.errorCode ?? null,
         createdAt,
         updatedAt: createdAt,
       });
@@ -562,5 +567,91 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(result.failed).toBe(0);
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.requestDepth).toBe(MAX_ISSUE_REQUEST_DEPTH);
+  });
+
+  it("suppresses productivity review when >=50% of terminal runs are billing/quota errors (positive guard)", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+
+    // Insert runs that simulate a billing cascade: all terminal runs have plan-cap error text.
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+      error: "You've hit your usage limit. out of extra usage · resets 11am ET",
+      errorCode: "adapter_failed",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("still creates review for genuine unproductive runs that have no billing errors (negative guard)", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+
+    // Insert runs with no billing error — genuine inactivity (no comments, real tool failures).
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `no_comment_streak`");
+  });
+
+  it("suppresses review when billing errors meet the threshold but does not suppress below it", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+
+    // 5 billing error runs + 5 normal no-comment runs = 50% billing → suppressed at default threshold.
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 5,
+      now,
+      error: "out of extra usage · resets 11am ET",
+      errorCode: "adapter_failed",
+    });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 5,
+      now: new Date(now.getTime() + 5 * 60_000),
+    });
+
+    const suppressedResult = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+      thresholds: { billingCascadeThreshold: DEFAULT_PRODUCTIVITY_REVIEW_BILLING_CASCADE_THRESHOLD },
+    });
+    expect(suppressedResult.created).toBe(0);
+
+    // With threshold=0.6, the 50% billing ratio is below the threshold → review IS created.
+    const unsuppressedResult = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+      thresholds: { billingCascadeThreshold: 0.6 },
+    });
+    expect(unsuppressedResult.created).toBe(1);
   });
 });

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -30,6 +30,8 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS = 3;
 export const DEFAULT_PRODUCTIVITY_REVIEW_CREATION_WINDOW_MS = 24 * 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 3;
+// Billing cascade guard: suppress reviews when this fraction of terminal runs are billing/quota errors.
+export const DEFAULT_PRODUCTIVITY_REVIEW_BILLING_CASCADE_THRESHOLD = 0.5;
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
@@ -53,6 +55,8 @@ type ProductivityReviewThresholds = {
   maxRefreshComments: number;
   creationWindowMs: number;
   maxCreationsPerWindow: number;
+  // Fraction [0,1] of terminal runs that must match a billing/quota error to suppress the review.
+  billingCascadeThreshold: number;
 };
 
 type ProductivityReviewEvidence = {
@@ -91,6 +95,23 @@ type EnqueueWakeup = (
     contextSnapshot?: Record<string, unknown>;
   },
 ) => Promise<unknown | null>;
+
+// Error text patterns that indicate a billing or quota exhaustion run rather than unproductive work.
+const BILLING_CASCADE_PATTERNS = [
+  /out of extra usage/i,
+  /resets \d/i,
+  /try again at /i,
+  /upgrade to pro/i,
+  /usage limit/i,
+  /plan.{0,20}cap/i,
+  /claude_plan_cap_exhausted/i,
+];
+
+function isBillingCascadeRun(run: HeartbeatRunRow): boolean {
+  if (run.errorCode === "claude_plan_cap_exhausted") return true;
+  const errorText = [run.error, run.stderrExcerpt, run.stdoutExcerpt].filter(Boolean).join(" ");
+  return errorText.length > 0 && BILLING_CASCADE_PATTERNS.some((p) => p.test(errorText));
+}
 
 function productivityReviewFingerprint(sourceIssueId: string) {
   return `productivity-review:${sourceIssueId}`;
@@ -176,6 +197,10 @@ function buildThresholds(overrides?: Partial<ProductivityReviewThresholds>): Pro
       overrides?.maxCreationsPerWindow ?? DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW,
       DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW,
     ),
+    billingCascadeThreshold: (() => {
+      const v = overrides?.billingCascadeThreshold ?? DEFAULT_PRODUCTIVITY_REVIEW_BILLING_CASCADE_THRESHOLD;
+      return Number.isFinite(v) && v >= 0 && v <= 1 ? v : DEFAULT_PRODUCTIVITY_REVIEW_BILLING_CASCADE_THRESHOLD;
+    })(),
   };
 }
 
@@ -423,6 +448,29 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     const terminalRuns = latestRuns.filter((run) =>
       TERMINAL_RUN_STATUSES.includes(run.status as (typeof TERMINAL_RUN_STATUSES)[number]),
     );
+
+    // Billing cascade guard: if enough terminal runs are billing/quota errors, suppress the review.
+    if (terminalRuns.length > 0) {
+      const billingCount = terminalRuns.filter(isBillingCascadeRun).length;
+      const billingRatio = billingCount / terminalRuns.length;
+      if (billingRatio >= thresholds.billingCascadeThreshold) {
+        logger.info(
+          {
+            metric: "productivity_review.suppressed_billing_cascade",
+            companyId: sourceIssue.companyId,
+            issueId: sourceIssue.id,
+            agentId: sourceAgent.id,
+            billingCascadeRatio: billingRatio,
+            billingCascadeCount: billingCount,
+            totalTerminalRuns: terminalRuns.length,
+            billingCascadeThreshold: thresholds.billingCascadeThreshold,
+          },
+          "productivity_review.suppressed_billing_cascade",
+        );
+        return null;
+      }
+    }
+
     let noCommentStreak = 0;
     for (const run of terminalRuns) {
       if (commentRunIds.has(run.id)) break;


### PR DESCRIPTION
## Summary

Add a billing/quota cascade guard to the productivity-review evaluator so a single shared-account plan-cap exhaustion does not cascade into a flood of productivity-review issues.

### Problem

When a shared API account (e.g., Anthropic `out of extra usage · resets <time>`) hits its plan cap, every agent run terminates immediately with no useful output. The existing `no_comment_streak` and `high_churn` detectors cannot distinguish this from genuinely unproductive behavior, so they spawn a productivity-review issue per affected agent issue — turning one infra event into a wave of paging.

### Guard Behavior

`collectEvidence()` now inspects the terminal runs in the sampled window before computing streaks. If the fraction of runs classified as billing/quota errors meets or exceeds `billingCascadeThreshold` (default **0.5**), the review is suppressed and no review issue is created.

A run is classified as a billing/quota error when:
- `errorCode === 'claude_plan_cap_exhausted'`, or
- error text matches known plan-cap / quota patterns (`out of extra usage`, `try again at <reset>`, etc.).

When suppression fires, the evaluator emits a structured `productivity_review.suppressed_billing_cascade` log entry with the company/issue/agent IDs, the cascade ratio, the run count, and the threshold — so the suppression itself is observable.

### Changes

- `server/src/services/productivity-review.ts`
  - Add `DEFAULT_PRODUCTIVITY_REVIEW_BILLING_CASCADE_THRESHOLD = 0.5`.
  - Add `billingCascadeThreshold` to `ProductivityReviewThresholds` (tunable).
  - Add `isBillingCascadeRun()` pattern matcher (errorCode + text patterns).
  - Short-circuit `collectEvidence()` when the cascade ratio meets the threshold.
  - Emit `productivity_review.suppressed_billing_cascade` structured log.
- `server/src/__tests__/productivity-review-service.test.ts`
  - Three new integration tests: positive suppression, negative pass-through, and threshold boundary.
- `doc/productivity-monitor.md`
  - New reference doc covering the evaluator's triggers, lifecycle, and the new billing cascade guard.

### Test plan

- [x] `npx vitest run server/src/__tests__/productivity-review-service.test.ts` — **14/14 pass** (post-rebase against current `master`)
- [x] Rebased cleanly onto current `master`; no conflicts on the touched files since merge base.

### Notes

- Threshold is configurable via `ProductivityReviewThresholds.billingCascadeThreshold`.
- The guard is defense-in-depth — operators may also block source issues at the cap site — but it prevents the noise from reaching the manager review queue without operator intervention.
- See `doc/productivity-monitor.md` ("Billing Cascade Guard") for the full spec.
