### PR TITLE
[codex] Enable Grok adapter canary publishing

### DIFF
--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -37,7 +37,7 @@
   {
     "dir": "packages/adapters/grok-local",
     "name": "@paperclipai/adapter-grok-local",
-    "publishFromCi": false
+    "publishFromCi": true
   },
   {
     "dir": "packages/adapters/opencode-local",


### PR DESCRIPTION
## Thinking Path

> - Paperclip publishes its CLI, server, UI, and adapter packages through the shared release workflow.
> - Canary releases are driven by the GitHub release workflow on pushes to `master`.
> - The release workflow does not publish every public package automatically; it uses `scripts/release-package-manifest.json` as the CI enrollment source of truth.
> - The Grok adapter is public and already present in the manifest, but its `publishFromCi` flag was still disabled.
> - Because of that flag, normal canary publishes skipped `@paperclipai/adapter-grok-local` even when the main package received a canary.
> - This pull request enables Grok in the release manifest so future canary runs include it.
> - The benefit is that Grok adapter canaries stay aligned with the rest of the package release set.

## What Changed

- Set `packages/adapters/grok-local` / `@paperclipai/adapter-grok-local` to `publishFromCi: true` in `scripts/release-package-manifest.json`.

## Verification

- `node ./scripts/release-package-map.mjs check`
- `node ./scripts/release-package-map.mjs list | grep '@paperclipai/adapter-grok-local'`
- `pnpm test:release-registry`

## Risks

- Low risk: this is a release manifest-only change.
- Future canary releases will attempt to publish `@paperclipai/adapter-grok-local`; this assumes the package remains publishable and trusted publishing/package access are correctly configured for the existing npm package.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-based coding agent with shell, git, and GitHub tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
