### PR TITLE
fix(release): allow tasks:assign agents to force-release stale checkout runs

### DIFF
--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -12,6 +12,7 @@ import {
   issueComments,
   issueRelations,
   issues,
+  principalPermissionGrants,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -46,6 +47,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     await db.delete(activityLog);
     await db.delete(issues);
     await db.delete(heartbeatRuns);
+    await db.delete(principalPermissionGrants);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -280,6 +282,107 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
         prevCheckoutRunId: currentRunId,
         prevExecutionRunId: failedRunId,
         clearAssignee: true,
+      },
+    });
+  });
+
+  it("allows an agent with tasks:assign to force-release a stale run via ?force=true", async () => {
+    const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    // Daemon agent (not the assignee) with tasks:assign permission
+    const daemonAgentId = randomUUID();
+    const daemonRunId = randomUUID();
+    await db.insert(agents).values({
+      id: daemonAgentId,
+      companyId,
+      name: "ExpireDaemon",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: daemonRunId,
+      companyId,
+      agentId: daemonAgentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+    });
+    await db.insert(principalPermissionGrants).values({
+      companyId,
+      principalType: "agent",
+      principalId: daemonAgentId,
+      permissionKey: "tasks:assign",
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale force release",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: currentRunId,
+      executionRunId: failedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    // Non-assignee agent without tasks:assign is rejected
+    const otherAgentId = randomUUID();
+    const otherRunId = randomUUID();
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: otherRunId,
+      companyId,
+      agentId: otherAgentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+    });
+    await request(createApp(agentActor(companyId, otherAgentId, otherRunId)))
+      .post(`/api/issues/${issueId}/release?force=true`)
+      .expect(403);
+
+    // Daemon agent with tasks:assign succeeds and does a full release
+    const res = await request(createApp(agentActor(companyId, daemonAgentId, daemonRunId)))
+      .post(`/api/issues/${issueId}/release?force=true`)
+      .send();
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: issueId,
+      status: "todo",
+      assigneeAgentId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionLockedAt: null,
+    });
+
+    const audit = await db
+      .select({ action: activityLog.action, details: activityLog.details })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.force_released"))
+      .then((rows) => rows[0]);
+    expect(audit).toMatchObject({
+      action: "issue.force_released",
+      details: {
+        issueId,
+        prevCheckoutRunId: currentRunId,
+        prevExecutionRunId: failedRunId,
       },
     });
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3874,6 +3874,38 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, existing.companyId);
+
+    // Force-release: agents/users with tasks:assign permission can release any stale run,
+    // bypassing the assignee-only check. Used by the expire-stale-runs daemon and CTO agent.
+    // Passes undefined actorAgentId to svc.release so both assignee guards are skipped,
+    // giving identical release semantics (status->todo, assignee cleared).
+    if (req.query.force === "true") {
+      await assertCanAssignTasks(req, existing.companyId);
+      const released = await svc.release(id, undefined, null);
+      if (!released) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: released.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "issue.force_released",
+        entityType: "issue",
+        entityId: released.id,
+        details: {
+          issueId: released.id,
+          prevCheckoutRunId: existing.checkoutRunId,
+          prevExecutionRunId: existing.executionRunId,
+        },
+      });
+      res.json(released);
+      return;
+    }
+
     if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
     const actorRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !actorRunId) return;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents; issues have checkout runs that agents hold during heartbeats.
> - When a heartbeat exits without releasing its checkout, the issue stays locked indefinitely.
> - The `expire-stale-runs.py` daemon detects these stale locks and calls `POST /api/issues/:id/release`.
> - The release endpoint enforces assignee-only access — it throws `409: Only assignee can release issue` when a non-assignee (like the daemon) calls it.
> - The daemon already runs with a service API key (CTO agent) that has `tasks:assign` permission, which is the right authority gate for this operation.
> - This PR adds `?force=true` to the release endpoint: callers with `tasks:assign` bypass the assignee guard, get identical full-release semantics (status→todo, assignee cleared), and leave a distinct audit event.
> - The benefit is that stale checkout locks are now automatically cleared without human DB intervention.

## What Changed

- **`server/src/routes/issues.ts`**: `POST /issues/:id/release` now accepts `?force=true`. When present, it gates on `assertCanAssignTasks` (same guard used for routine management and issue assignment), calls `svc.release(id, undefined, null)` to skip both assignee checks, and logs an `issue.force_released` audit event with previous run IDs.
- **`server/src/__tests__/issue-stale-execution-lock-routes.test.ts`**: New test covering: (a) agent without `tasks:assign` gets 403, (b) daemon agent with `tasks:assign` force-releases successfully and produces correct audit log. Also adds `principalPermissionGrants` to `afterEach` cleanup.

## Verification

- Run `pnpm test server/src/__tests__/issue-stale-execution-lock-routes.test.ts`
- End-to-end: run `expire-stale-runs.py` against an instance with a stale checkout — confirm it no longer gets `409` and the issue transitions to `todo`.

## Risks

- **Privilege escalation**: only agents/users with `tasks:assign` can use `?force=true`; regular agents cannot. The same permission already gates routine creation and issue assignment.
- **Behavior difference vs. `adminForceRelease`**: force-release via this path fully resets the issue (status→todo, assignee cleared), matching normal release semantics. `adminForceRelease` only clears run IDs. This is intentional — the daemon wants the issue back in the todo queue.
- Low risk overall; no schema changes, no new permission type.

## Model Used

- Provider: Anthropic  
- Model ID: claude-sonnet-4-6  
- Context: 200k token context window  
- Capabilities: tool use, code editing, multi-file reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge