### PR TITLE
Refactor development-only auth and agent extensions

### DIFF
--- a/server/src/__tests__/agent-routing-policy.test.ts
+++ b/server/src/__tests__/agent-routing-policy.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  AgentPolicyService,
+  AgentRoutingService,
+  DEFAULT_ORGANIZATION_AGENT_CONFIG,
+  normalizeOrganizationAgentConfig,
+  type PaperclipTask,
+} from "../features/agents/index.js";
+
+const scopedTask: PaperclipTask = {
+  id: "PAP-1",
+  type: "bugfix",
+  source: "Paperclip",
+  originalGoal: "Fix a focused UI typo.",
+  approvedScope: "Change only the dashboard title typo.",
+  allowedPaths: ["ui/src/pages/Dashboard.tsx"],
+  reason: "Claude unavailable",
+};
+
+describe("agent routing service", () => {
+  const routing = new AgentRoutingService();
+  let previousNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+  });
+
+  afterEach(() => {
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
+  });
+
+  it("selects Claude for missing config and dualMode=false by default", () => {
+    expect(routing.resolve({ task: scopedTask, claudeStatus: "available" })).toBe("claude");
+    expect(routing.resolve({
+      task: scopedTask,
+      organizationConfig: DEFAULT_ORGANIZATION_AGENT_CONFIG,
+      claudeStatus: "available",
+    })).toBe("claude");
+  });
+
+  it("normalizes invalid organization config to the Claude-first default", () => {
+    expect(normalizeOrganizationAgentConfig({
+      dualMode: true,
+      primaryAgent: "codex",
+      secondaryAgent: "codex",
+    })).toEqual(DEFAULT_ORGANIZATION_AGENT_CONFIG);
+    expect(normalizeOrganizationAgentConfig({
+      dualMode: true,
+      primaryAgent: "invalid" as "claude",
+      secondaryAgent: "codex",
+    })).toEqual({
+      dualMode: true,
+      primaryAgent: "claude",
+      secondaryAgent: "codex",
+    });
+  });
+
+  it("routes dual-mode primary and secondary agents by status", () => {
+    expect(routing.resolve({
+      task: scopedTask,
+      organizationConfig: { dualMode: true, primaryAgent: "claude", secondaryAgent: "codex" },
+      claudeStatus: "available",
+      codexStatus: "available",
+    })).toBe("claude");
+
+    expect(routing.resolve({
+      task: scopedTask,
+      organizationConfig: { dualMode: true, primaryAgent: "claude", secondaryAgent: "codex" },
+      claudeStatus: "unavailable",
+      codexStatus: "available",
+    })).toBe("codex");
+
+    expect(routing.resolve({
+      task: scopedTask,
+      organizationConfig: { dualMode: true, primaryAgent: "codex", secondaryAgent: "claude" },
+      claudeStatus: "available",
+      codexStatus: "available",
+    })).toBe("codex");
+
+    expect(routing.resolve({
+      task: scopedTask,
+      organizationConfig: { dualMode: true, primaryAgent: "codex", secondaryAgent: "claude" },
+      claudeStatus: "available",
+      codexStatus: "unavailable",
+    })).toBe("claude");
+  });
+
+  it("keeps default routing on the primary agent unless dual-mode is enabled", () => {
+    expect(routing.resolve({ task: scopedTask, claudeStatus: "tokens_low" })).toBe("claude");
+    expect(routing.resolve({ task: scopedTask, claudeStatus: "tokens_empty" })).toBe("claude");
+    expect(routing.resolve({ task: scopedTask, claudeStatus: "rate_limited" })).toBe("claude");
+    expect(routing.resolve({ task: scopedTask, claudeStatus: "unavailable" })).toBe("claude");
+  });
+});
+
+describe("agent policy service", () => {
+  const policy = new AgentPolicyService();
+  let previousNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+  });
+
+  afterEach(() => {
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
+  });
+
+  it("allows Claude execution without Codex restrictions", () => {
+    expect(policy.validateExecution({ task: {}, agent: "claude" }).allowed).toBe(true);
+  });
+
+  it("rejects Codex outside development mode", () => {
+    process.env.NODE_ENV = "production";
+
+    const rejected = policy.validateExecution({
+      task: scopedTask,
+      agent: "codex",
+      claudeStatus: "unavailable",
+    });
+
+    expect(rejected.allowed).toBe(false);
+    expect(rejected.reason).toContain("only available in development mode");
+  });
+
+  it("allows scoped Codex fallback only when Claude fallback status permits it", () => {
+    expect(policy.validateExecution({
+      task: scopedTask,
+      agent: "codex",
+      claudeStatus: "unavailable",
+    }).allowed).toBe(true);
+
+    const rejected = policy.validateExecution({
+      task: scopedTask,
+      agent: "codex",
+      claudeStatus: "available",
+    });
+    expect(rejected.allowed).toBe(false);
+    expect(rejected.reason).toContain("Codex execution requires dual-mode routing");
+  });
+
+  it("rejects Codex for missing task metadata, allowed paths, and scope", () => {
+    const rejected = policy.validateExecution({
+      task: { reason: "Claude unavailable" },
+      agent: "codex",
+      claudeStatus: "unavailable",
+    });
+    expect(rejected.allowed).toBe(false);
+    expect(rejected.validationResults).toEqual(expect.arrayContaining([
+      "task has no ID",
+      "task has no type",
+      "task has no explicit scope",
+      "task has no explicit allowed paths",
+    ]));
+  });
+
+  it("rejects secrets, destructive commands, production deploys, and repo-wide scope", () => {
+    const rejected = policy.validateExecution({
+      task: {
+        ...scopedTask,
+        originalGoal: "Deploy production and refactor the whole repository.",
+        approvedScope: "Change everything and read secrets.",
+        allowedPaths: [".env"],
+        requestedCommands: ["rm -rf node_modules"],
+        requiresProductionDeployment: true,
+      },
+      agent: "codex",
+      claudeStatus: "unavailable",
+    });
+    expect(rejected.allowed).toBe(false);
+    expect(rejected.reason).toContain("production deployment");
+    expect(rejected.reason).toContain("repository-wide");
+    expect(rejected.reason).toContain("forbidden path");
+    expect(rejected.reason).toContain("requested command is not allowed");
+  });
+
+  it("allows policy-validated Codex execution in dual-mode and blocks secrets paths", () => {
+    const allowed = policy.validateExecution({
+      task: {
+        ...scopedTask,
+        id: "PAP-2",
+        source: "Paperclip",
+        type: "bugfix",
+        originalGoal: "Fix a focused UI typo.",
+        approvedScope: "Change only the dashboard title typo.",
+        allowedPaths: ["ui/src/pages/Dashboard.tsx"],
+        reason: "Primary agent unavailable",
+      },
+      agent: "codex",
+      claudeStatus: "unavailable",
+      organizationConfig: { dualMode: true, primaryAgent: "claude", secondaryAgent: "codex" },
+    });
+    expect(allowed.allowed).toBe(true);
+
+    const blocked = policy.validateExecution({
+      task: {
+        ...scopedTask,
+        id: "PAP-3",
+        originalGoal: "Read secret files.",
+        approvedScope: "Read local secrets.",
+        allowedPaths: [".env"],
+        reason: "Primary agent unavailable",
+      },
+      agent: "codex",
+      claudeStatus: "unavailable",
+      organizationConfig: { dualMode: true, primaryAgent: "claude", secondaryAgent: "codex" },
+    });
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.reason).toContain("forbidden path");
+  });
+});

--- a/server/src/__tests__/custom-process-trigger.test.ts
+++ b/server/src/__tests__/custom-process-trigger.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CustomProcessTriggerService } from "../features/custom-process/custom-process-trigger.service.js";
+
+describe("custom process trigger service", () => {
+  const service = new CustomProcessTriggerService();
+  let previousNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+  });
+
+  afterEach(() => {
+    if (previousNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = previousNodeEnv;
+  });
+
+  it("does nothing when config is missing or disabled", async () => {
+    await expect(service.trigger({ event: "manual" })).resolves.toMatchObject({
+      triggered: false,
+      reason: "missing_config",
+    });
+    await expect(service.trigger({
+      event: "manual",
+      organizationConfig: { customProcess: { enabled: false } },
+    })).resolves.toMatchObject({
+      triggered: false,
+      reason: "disabled",
+    });
+  });
+
+  it("returns configured generic instructions only when enabled", async () => {
+    await expect(service.trigger({
+      event: "manual",
+      organizationConfig: {
+        customProcess: {
+          enabled: true,
+          instructions: "Create a local handoff.",
+          triggers: [{ event: "manual", enabled: true }],
+        },
+      },
+    })).resolves.toMatchObject({
+      triggered: true,
+      reason: "triggered",
+      instructions: "Create a local handoff.",
+    });
+  });
+
+  it("does nothing outside development mode", async () => {
+    process.env.NODE_ENV = "production";
+
+    await expect(service.trigger({
+      event: "manual",
+      organizationConfig: {
+        customProcess: {
+          enabled: true,
+          instructions: "Create a local handoff.",
+          triggers: [{ event: "manual", enabled: true }],
+        },
+      },
+    })).resolves.toMatchObject({
+      triggered: false,
+      reason: "disabled",
+    });
+  });
+});

--- a/server/src/features/agents/agent-policy.service.ts
+++ b/server/src/features/agents/agent-policy.service.ts
@@ -1,0 +1,243 @@
+import path from "node:path";
+import type { AgentProvider } from "./agent-provider.types.js";
+import type { AgentStatus } from "./agent-status.types.js";
+import type { OrganizationAgentConfig } from "./organization-agent-config.types.js";
+import type { PaperclipTask } from "./paperclip-task.types.js";
+import { normalizePaperclipTaskType } from "./paperclip-task.types.js";
+import { AgentRoutingService } from "./agent-routing.service.js";
+import { isDevelopmentEnvironment } from "../development-environment.js";
+
+export const DEFAULT_CODEX_ALLOWED_COMMANDS = [
+  "git status",
+  "git diff",
+  "pnpm lint",
+  "pnpm typecheck",
+  "pnpm test",
+  "pnpm build",
+  "find",
+  "grep",
+  "cat",
+  "sed",
+] as const;
+
+export const DEFAULT_CODEX_FORBIDDEN_PATHS = [
+  ".env",
+  ".env.*",
+  ".secrets/**",
+  "**/*.pem",
+  "**/*.key",
+  "**/id_rsa",
+  "**/id_ed25519",
+  "**/credentials/**",
+  "**/secrets/**",
+] as const;
+
+export const DEFAULT_CODEX_FORBIDDEN_COMMANDS = [
+  "sudo",
+  "su",
+  "rm -rf",
+  "chmod 777",
+  "chown -R",
+  "git push",
+  "git reset --hard",
+  "git clean -fd",
+  "docker system prune",
+  "curl unknown domains",
+  "wget unknown domains",
+  "ssh production servers",
+  "commands that read secrets",
+] as const;
+
+export interface AgentPolicyInput {
+  task: PaperclipTask;
+  agent: AgentProvider;
+  organizationConfig?: OrganizationAgentConfig | null;
+  allowedPaths?: string[];
+  allowedCommands?: string[];
+  forbiddenPaths?: string[];
+  forbiddenCommands?: string[];
+  requestedCommands?: string[];
+  reason?: string;
+  claudeStatus?: AgentStatus;
+  codexStatus?: AgentStatus;
+  repoRoot?: string;
+}
+
+export interface AgentPolicyResult {
+  allowed: boolean;
+  reason?: string;
+  validationResults: string[];
+}
+
+const SECURITY_SENSITIVE_RE =
+  /\b(auth|authentication|authorization|rbac|secrets?|credentials?|token|key|pem|production|deploy(?:ment)?|infrastructure|terraform|kubernetes|docker\s+compose|database\s+schema|migration)\b/i;
+
+const REPO_WIDE_RE =
+  /\b(entire|whole|all|unrestricted|repo(?:sitory)?-wide|repository wide|any file|all files|everything)\b/i;
+
+function normalizePathForPolicy(candidate: string): string {
+  return candidate.replace(/\\/g, "/").replace(/\/+/g, "/").replace(/^\.\//, "");
+}
+
+function globToRegExp(glob: string): RegExp {
+  const normalized = normalizePathForPolicy(glob);
+  let out = "^";
+  for (let i = 0; i < normalized.length; i += 1) {
+    const char = normalized[i]!;
+    const next = normalized[i + 1];
+    if (char === "*" && next === "*") {
+      out += ".*";
+      i += 1;
+      continue;
+    }
+    if (char === "*") {
+      out += "[^/]*";
+      continue;
+    }
+    out += char.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+  }
+  out += "$";
+  return new RegExp(out);
+}
+
+export function pathMatchesPolicy(candidate: string, policy: string): boolean {
+  const normalizedCandidate = normalizePathForPolicy(candidate);
+  const normalizedPolicy = normalizePathForPolicy(policy);
+  if (normalizedCandidate === normalizedPolicy) return true;
+  if (globToRegExp(normalizedPolicy).test(normalizedCandidate)) return true;
+  if (path.isAbsolute(normalizedPolicy)) return globToRegExp(normalizedPolicy).test(normalizedCandidate);
+  return globToRegExp(`**/${normalizedPolicy}`).test(normalizedCandidate);
+}
+
+function isUnrestrictedPath(candidate: string, repoRoot: string): boolean {
+  const trimmed = candidate.trim();
+  if (!trimmed || trimmed === "." || trimmed === "./" || trimmed === "/" || trimmed === "*" || trimmed === "**") {
+    return true;
+  }
+  if (path.resolve(repoRoot, trimmed) === path.resolve(repoRoot)) return true;
+  return false;
+}
+
+function commandBase(command: string): string {
+  return command.trim().replace(/\s+/g, " ");
+}
+
+function commandAllowed(command: string, allowedCommands: readonly string[]): boolean {
+  const normalized = commandBase(command);
+  return allowedCommands.some((allowed) => {
+    const allowedNormalized = commandBase(allowed);
+    return normalized === allowedNormalized || normalized.startsWith(`${allowedNormalized} `);
+  });
+}
+
+function commandForbidden(command: string, forbiddenCommands: readonly string[]): boolean {
+  const normalized = commandBase(command).toLowerCase();
+  return forbiddenCommands.some((forbidden) => {
+    const forbiddenNormalized = commandBase(forbidden).toLowerCase();
+    return normalized === forbiddenNormalized || normalized.includes(forbiddenNormalized);
+  });
+}
+
+function compactList(values: readonly string[] | undefined): string[] {
+  return Array.from(new Set((values ?? []).map((value) => value.trim()).filter(Boolean)));
+}
+
+export class AgentPolicyService {
+  private readonly routing = new AgentRoutingService();
+
+  validateExecution(input: AgentPolicyInput): AgentPolicyResult {
+    if (input.agent !== "codex") return { allowed: true, validationResults: ["Claude execution allowed"] };
+    const errors = this.validateCodexExecution(input);
+    if (errors.length > 0) {
+      return {
+        allowed: false,
+        reason: `Codex execution rejected: ${errors.join("; ")}`,
+        validationResults: errors,
+      };
+    }
+    return { allowed: true, validationResults: ["Codex restricted policy validation passed"] };
+  }
+
+  private validateCodexExecution(input: AgentPolicyInput): string[] {
+    const task = input.task;
+    const taskType = normalizePaperclipTaskType(task.type);
+    const repoRoot = path.resolve(input.repoRoot ?? process.cwd());
+    const allowedPaths = compactList(input.allowedPaths ?? task.allowedPaths);
+    const configuredAllowedCommands = compactList(input.allowedCommands ?? task.allowedCommands);
+    const configuredForbiddenPaths = compactList(input.forbiddenPaths ?? task.forbiddenPaths);
+    const configuredForbiddenCommands = compactList(input.forbiddenCommands ?? task.forbiddenCommands);
+    const allowedCommands = configuredAllowedCommands.length > 0
+      ? configuredAllowedCommands
+      : [...DEFAULT_CODEX_ALLOWED_COMMANDS];
+    const forbiddenPaths = configuredForbiddenPaths.length > 0
+      ? configuredForbiddenPaths
+      : [...DEFAULT_CODEX_FORBIDDEN_PATHS];
+    const forbiddenCommands = configuredForbiddenCommands.length > 0
+      ? configuredForbiddenCommands
+      : [...DEFAULT_CODEX_FORBIDDEN_COMMANDS];
+    const requestedCommands = compactList(input.requestedCommands ?? task.requestedCommands);
+    const reason = (input.reason ?? task.reason ?? "").trim();
+    const scope = (task.approvedScope ?? "").trim();
+    const goal = (task.originalGoal ?? "").trim();
+    const claudeStatus = input.claudeStatus ?? "unknown";
+    const fallbackAllowed = this.routing.isFallbackStatus(claudeStatus);
+    const errors: string[] = [];
+
+    if (!isDevelopmentEnvironment()) {
+      errors.push("Codex execution is only available in development mode");
+    }
+    if (!task.id) errors.push("task has no ID");
+    if (!taskType) errors.push("task has no type");
+    if (!scope) errors.push("task has no explicit scope");
+    if (allowedPaths.length === 0) errors.push("task has no explicit allowed paths");
+    if (!reason) errors.push("task has no Codex activation reason");
+    if (!input.organizationConfig?.dualMode && !fallbackAllowed) {
+      errors.push("Codex execution requires dual-mode routing or an unavailable primary agent");
+    }
+    if (input.organizationConfig?.dualMode && !fallbackAllowed) {
+      const config = input.organizationConfig;
+      if (config.primaryAgent === "claude" && config.secondaryAgent === "codex" && claudeStatus === "available") {
+        errors.push("Primary agent is available; Codex secondary execution is not needed");
+      }
+    }
+    if (claudeStatus === "tokens_low") {
+      errors.push("Claude tokens_low must stay on Claude and request a compact handoff");
+    }
+    if (taskType === "architecture") errors.push("Codex cannot run architecture tasks");
+    if (task.requiresProductionDeployment === true) errors.push("Codex cannot run production deployment tasks");
+    if (task.securitySensitive === true && task.explicitApproval !== true) {
+      errors.push("security-sensitive task requires explicit Claude/human approval");
+    }
+    if (SECURITY_SENSITIVE_RE.test(`${goal}\n${scope}`)) {
+      errors.push("security-sensitive, infrastructure, deployment, secrets, auth, or schema work requires Claude/human approval");
+    }
+    if (REPO_WIDE_RE.test(`${goal}\n${scope}`)) errors.push("unrestricted repository-wide scope is not allowed");
+
+    for (const allowedPath of allowedPaths) {
+      if (isUnrestrictedPath(allowedPath, repoRoot)) errors.push(`allowed path is unrestricted: ${allowedPath}`);
+      for (const forbiddenPath of forbiddenPaths) {
+        if (pathMatchesPolicy(allowedPath, forbiddenPath)) {
+          errors.push(`allowed path intersects forbidden path policy: ${allowedPath}`);
+        }
+      }
+    }
+
+    for (const contextFile of compactList(task.contextFiles)) {
+      for (const forbiddenPath of forbiddenPaths) {
+        if (pathMatchesPolicy(contextFile, forbiddenPath)) errors.push(`context file is forbidden: ${contextFile}`);
+      }
+    }
+
+    for (const command of allowedCommands) {
+      if (commandForbidden(command, forbiddenCommands)) errors.push(`allowed command is forbidden by policy: ${command}`);
+    }
+    for (const command of requestedCommands) {
+      if (!commandAllowed(command, allowedCommands)) errors.push(`requested command is not allowed: ${command}`);
+      if (commandForbidden(command, forbiddenCommands)) errors.push(`requested command is forbidden: ${command}`);
+    }
+
+    return errors;
+  }
+}
+
+export const agentPolicyService = new AgentPolicyService();

--- a/server/src/features/agents/agent-provider.types.ts
+++ b/server/src/features/agents/agent-provider.types.ts
@@ -1,0 +1,1 @@
+export type AgentProvider = "claude" | "codex";

--- a/server/src/features/agents/agent-routing.service.ts
+++ b/server/src/features/agents/agent-routing.service.ts
@@ -1,0 +1,48 @@
+import type { AgentProvider } from "./agent-provider.types.js";
+import type { AgentStatus } from "./agent-status.types.js";
+import { DEFAULT_ORGANIZATION_AGENT_CONFIG, normalizeOrganizationAgentConfig } from "./dual-mode.config.js";
+import type { OrganizationAgentConfig } from "./organization-agent-config.types.js";
+import type { PaperclipTask } from "./paperclip-task.types.js";
+
+export interface AgentRoutingInput {
+  task: PaperclipTask;
+  organizationConfig?: OrganizationAgentConfig | null;
+  primaryStatus?: AgentStatus;
+  secondaryStatus?: AgentStatus;
+  claudeStatus?: AgentStatus;
+  codexStatus?: AgentStatus;
+}
+
+const FALLBACK_STATUSES = new Set<AgentStatus>(["tokens_empty", "rate_limited", "unavailable"]);
+
+export class AgentRoutingService {
+  resolve(input: AgentRoutingInput): AgentProvider {
+    const config = normalizeOrganizationAgentConfig(input.organizationConfig ?? DEFAULT_ORGANIZATION_AGENT_CONFIG);
+
+    if (!config.dualMode) {
+      return config.primaryAgent;
+    }
+
+    if (this.isAgentAvailable(config.primaryAgent, input)) {
+      return config.primaryAgent;
+    }
+
+    if (this.isAgentAvailable(config.secondaryAgent, input)) {
+      return config.secondaryAgent;
+    }
+
+    return config.primaryAgent;
+  }
+
+  isFallbackStatus(status: AgentStatus | undefined): boolean {
+    return FALLBACK_STATUSES.has(status ?? "unknown");
+  }
+
+  private isAgentAvailable(agent: AgentProvider, input: AgentRoutingInput): boolean {
+    const status = agent === "claude" ? input.claudeStatus : input.codexStatus;
+    return status === "available" || status === "tokens_low" || status === "unknown" || status === undefined;
+  }
+
+}
+
+export const agentRoutingService = new AgentRoutingService();

--- a/server/src/features/agents/agent-status.types.ts
+++ b/server/src/features/agents/agent-status.types.ts
@@ -1,0 +1,16 @@
+export const AGENT_STATUSES = [
+  "available",
+  "tokens_low",
+  "tokens_empty",
+  "rate_limited",
+  "unavailable",
+  "unknown",
+] as const;
+
+export type AgentStatus = (typeof AGENT_STATUSES)[number];
+
+export function normalizeAgentStatus(value: unknown): AgentStatus {
+  return typeof value === "string" && AGENT_STATUSES.includes(value as AgentStatus)
+    ? value as AgentStatus
+    : "unknown";
+}

--- a/server/src/features/agents/dual-mode.config.ts
+++ b/server/src/features/agents/dual-mode.config.ts
@@ -1,0 +1,40 @@
+import type { AgentProvider } from "./agent-provider.types.js";
+import type { OrganizationAgentConfig } from "./organization-agent-config.types.js";
+import { isDevelopmentEnvironment } from "../development-environment.js";
+
+export const DEFAULT_ORGANIZATION_AGENT_CONFIG: OrganizationAgentConfig = {
+  dualMode: false,
+  primaryAgent: "claude",
+  secondaryAgent: "codex",
+};
+
+export function isAgentProvider(value: unknown): value is AgentProvider {
+  return value === "claude" || value === "codex";
+}
+
+export function normalizeOrganizationAgentConfig(
+  input?: Partial<OrganizationAgentConfig> | null,
+): OrganizationAgentConfig {
+  if (!isDevelopmentEnvironment()) return DEFAULT_ORGANIZATION_AGENT_CONFIG;
+  if (!input || typeof input !== "object") return DEFAULT_ORGANIZATION_AGENT_CONFIG;
+  const primaryAgent = isAgentProvider(input.primaryAgent)
+    ? input.primaryAgent
+    : DEFAULT_ORGANIZATION_AGENT_CONFIG.primaryAgent;
+  const secondaryAgent = isAgentProvider(input.secondaryAgent)
+    ? input.secondaryAgent
+    : DEFAULT_ORGANIZATION_AGENT_CONFIG.secondaryAgent;
+  if (primaryAgent === secondaryAgent) return DEFAULT_ORGANIZATION_AGENT_CONFIG;
+  return {
+    dualMode: input.dualMode === true,
+    primaryAgent,
+    secondaryAgent,
+  };
+}
+
+export function readOrganizationAgentConfig(input: unknown): OrganizationAgentConfig {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return DEFAULT_ORGANIZATION_AGENT_CONFIG;
+  }
+  const config = input as { agents?: Partial<OrganizationAgentConfig> | null };
+  return normalizeOrganizationAgentConfig(config.agents);
+}

--- a/server/src/features/agents/index.ts
+++ b/server/src/features/agents/index.ts
@@ -1,0 +1,24 @@
+export type { AgentProvider } from "./agent-provider.types.js";
+export { AGENT_STATUSES, normalizeAgentStatus, type AgentStatus } from "./agent-status.types.js";
+export {
+  PAPERCLIP_TASK_TYPES,
+  normalizePaperclipTaskType,
+  type PaperclipTask,
+  type PaperclipTaskType,
+} from "./paperclip-task.types.js";
+export type { OrganizationAgentConfig, OrganizationConfig } from "./organization-agent-config.types.js";
+export {
+  DEFAULT_ORGANIZATION_AGENT_CONFIG,
+  normalizeOrganizationAgentConfig,
+  readOrganizationAgentConfig,
+} from "./dual-mode.config.js";
+export { AgentRoutingService, agentRoutingService, type AgentRoutingInput } from "./agent-routing.service.js";
+export {
+  AgentPolicyService,
+  agentPolicyService,
+  DEFAULT_CODEX_ALLOWED_COMMANDS,
+  DEFAULT_CODEX_FORBIDDEN_COMMANDS,
+  DEFAULT_CODEX_FORBIDDEN_PATHS,
+  type AgentPolicyInput,
+  type AgentPolicyResult,
+} from "./agent-policy.service.js";

--- a/server/src/features/agents/organization-agent-config.types.ts
+++ b/server/src/features/agents/organization-agent-config.types.ts
@@ -1,0 +1,21 @@
+import type { AgentProvider } from "./agent-provider.types.js";
+
+export interface OrganizationAgentConfig {
+  dualMode: boolean;
+  primaryAgent: AgentProvider;
+  secondaryAgent: AgentProvider;
+}
+
+export interface OrganizationConfig {
+  agents?: OrganizationAgentConfig | null;
+  customProcess?: {
+    enabled?: boolean;
+    label?: string;
+    instructions?: string;
+    triggers?: Array<{
+      event: string;
+      enabled?: boolean;
+      label?: string;
+    }>;
+  };
+}

--- a/server/src/features/agents/paperclip-task.types.ts
+++ b/server/src/features/agents/paperclip-task.types.ts
@@ -1,0 +1,36 @@
+export const PAPERCLIP_TASK_TYPES = [
+  "architecture",
+  "implementation",
+  "bugfix",
+  "test",
+  "review",
+  "documentation",
+  "custom_process",
+] as const;
+
+export type PaperclipTaskType = (typeof PAPERCLIP_TASK_TYPES)[number];
+
+export interface PaperclipTask {
+  id?: string | null;
+  type?: PaperclipTaskType | string | null;
+  source?: string | null;
+  originalGoal?: string | null;
+  approvedScope?: string | null;
+  allowedPaths?: string[];
+  forbiddenPaths?: string[];
+  allowedCommands?: string[];
+  forbiddenCommands?: string[];
+  requestedCommands?: string[];
+  contextFiles?: string[];
+  reason?: string | null;
+  requiresProductionDeployment?: boolean;
+  securitySensitive?: boolean;
+  explicitApproval?: boolean;
+}
+
+export function normalizePaperclipTaskType(value: unknown): PaperclipTaskType | null {
+  if (typeof value !== "string") return null;
+  return PAPERCLIP_TASK_TYPES.includes(value as PaperclipTaskType)
+    ? value as PaperclipTaskType
+    : null;
+}

--- a/server/src/features/custom-process/custom-process-trigger.service.ts
+++ b/server/src/features/custom-process/custom-process-trigger.service.ts
@@ -1,0 +1,59 @@
+import { isDevelopmentEnvironment } from "../development-environment.js";
+
+export type CustomProcessTriggerEvent =
+  | "manual"
+  | "unauthenticated_session_started"
+  | "primary_agent_unavailable"
+  | "task_created"
+  | "task_completed";
+
+export interface CustomProcessTriggerConfig {
+  event: CustomProcessTriggerEvent;
+  enabled?: boolean;
+  label?: string;
+}
+
+export interface CustomProcessInstructionConfig {
+  enabled?: boolean;
+  label?: string;
+  instructions?: string;
+  triggers?: CustomProcessTriggerConfig[];
+}
+
+export interface CustomProcessOrganizationConfig {
+  customProcess?: CustomProcessInstructionConfig;
+}
+
+export interface CustomProcessTriggerInput {
+  event: CustomProcessTriggerEvent;
+  context?: Record<string, unknown>;
+  organizationConfig?: CustomProcessOrganizationConfig | null;
+}
+
+export interface CustomProcessTriggerResult {
+  triggered: boolean;
+  reason: "disabled" | "missing_config" | "not_configured" | "triggered";
+  instructions?: string;
+}
+
+export class CustomProcessTriggerService {
+  async trigger(input: CustomProcessTriggerInput): Promise<CustomProcessTriggerResult> {
+    if (!isDevelopmentEnvironment()) return { triggered: false, reason: "disabled" };
+    const customProcess = input.organizationConfig?.customProcess;
+    if (!customProcess) return { triggered: false, reason: "missing_config" };
+    if (customProcess.enabled !== true) return { triggered: false, reason: "disabled" };
+
+    const trigger = customProcess.triggers?.find((item) => item.event === input.event);
+    if (customProcess.triggers && (!trigger || trigger.enabled === false)) {
+      return { triggered: false, reason: "not_configured" };
+    }
+
+    return {
+      triggered: true,
+      reason: "triggered",
+      instructions: customProcess.instructions,
+    };
+  }
+}
+
+export const customProcessTriggerService = new CustomProcessTriggerService();

--- a/server/src/features/development-environment.ts
+++ b/server/src/features/development-environment.ts
@@ -1,0 +1,3 @@
+export function isDevelopmentEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.NODE_ENV === "development";
+}

--- a/ui/src/features/auth/adapters/unauthenticated-login.adapter.ts
+++ b/ui/src/features/auth/adapters/unauthenticated-login.adapter.ts
@@ -1,0 +1,17 @@
+export interface UnauthenticatedLoginAdapter {
+  proceed(input?: { nextPath?: string }): Promise<void>;
+}
+
+export function isUnauthenticatedDevelopmentLoginAvailable(): boolean {
+  return import.meta.env.DEV;
+}
+
+export const unauthenticatedLoginAdapter: UnauthenticatedLoginAdapter = {
+  async proceed(input = {}) {
+    if (!isUnauthenticatedDevelopmentLoginAvailable()) {
+      throw new Error("Unauthenticated development entry is only available in development mode.");
+    }
+    const target = input.nextPath?.trim() || "/";
+    window.location.assign(target);
+  },
+};

--- a/ui/src/pages/Auth.test.tsx
+++ b/ui/src/pages/Auth.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthPage } from "./Auth";
+
+const mockAuthApi = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  signInEmail: vi.fn(),
+  signUpEmail: vi.fn(),
+}));
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+const mockProceed = vi.hoisted(() => vi.fn());
+
+vi.mock("../api/auth", () => ({
+  authApi: mockAuthApi,
+}));
+
+vi.mock("@/lib/router", () => ({
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [new URLSearchParams()],
+}));
+
+vi.mock("@/features/auth/adapters/unauthenticated-login.adapter", () => ({
+  isUnauthenticatedDevelopmentLoginAvailable: () => true,
+  unauthenticatedLoginAdapter: {
+    proceed: mockProceed,
+  },
+}));
+
+vi.mock("@/components/AsciiArtAnimation", () => ({
+  AsciiArtAnimation: () => <div />,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+describe("AuthPage unauthenticated action", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    mockAuthApi.getSession.mockResolvedValue(null);
+    mockProceed.mockResolvedValue(undefined);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <AuthPage />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("does not trigger unauthenticated mode on page load", () => {
+    expect(container.textContent).toContain("Sign in to Paperclip");
+    expect(mockProceed).not.toHaveBeenCalled();
+  });
+
+  it("opens a warning modal and only proceeds after confirmation", async () => {
+    const proceedButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent === "Proceed without login");
+    expect(proceedButton).not.toBeUndefined();
+
+    await act(async () => {
+      proceedButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(document.body.textContent).toContain("Continue without login?");
+    expect(mockProceed).not.toHaveBeenCalled();
+
+    const cancelButton = Array.from(document.body.querySelectorAll("button"))
+      .find((button) => button.textContent === "Cancel");
+    await act(async () => {
+      cancelButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    expect(document.body.textContent).not.toContain("Continue without login?");
+    expect(mockProceed).not.toHaveBeenCalled();
+
+    await act(async () => {
+      proceedButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+
+    const confirmButton = Array.from(document.body.querySelectorAll("button"))
+      .find((button) => button.textContent === "Continue without login");
+    await act(async () => {
+      confirmButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(mockProceed).toHaveBeenCalledWith({ nextPath: "/" });
+  });
+});

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -7,6 +7,18 @@ import { getRememberedInvitePath } from "../lib/invite-memory";
 import { Button } from "@/components/ui/button";
 import { AsciiArtAnimation } from "@/components/AsciiArtAnimation";
 import { Sparkles } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  isUnauthenticatedDevelopmentLoginAvailable,
+  unauthenticatedLoginAdapter,
+} from "@/features/auth/adapters/unauthenticated-login.adapter";
 
 type AuthMode = "sign_in" | "sign_up";
 
@@ -19,11 +31,13 @@ export function AuthPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [showUnauthenticatedWarning, setShowUnauthenticatedWarning] = useState(false);
 
   const nextPath = useMemo(
     () => searchParams.get("next") || getRememberedInvitePath() || "/",
     [searchParams],
   );
+  const showUnauthenticatedEntry = isUnauthenticatedDevelopmentLoginAvailable();
   const { data: session, isLoading: isSessionLoading } = useQuery({
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
@@ -172,6 +186,18 @@ export function AuthPage() {
               {mode === "sign_in" ? "Create one" : "Sign in"}
             </button>
           </div>
+          {showUnauthenticatedEntry && (
+            <div className="mt-4 border-t border-border pt-4">
+              <Button
+                type="button"
+                variant="ghost"
+                className="w-full"
+                onClick={() => setShowUnauthenticatedWarning(true)}
+              >
+                Proceed without login
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 
@@ -179,6 +205,37 @@ export function AuthPage() {
       <div className="hidden md:block w-1/2 overflow-hidden">
         <AsciiArtAnimation />
       </div>
+      <Dialog
+        open={showUnauthenticatedEntry && showUnauthenticatedWarning}
+        onOpenChange={setShowUnauthenticatedWarning}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Continue without login?</DialogTitle>
+            <DialogDescription>
+              You are about to enter Paperclip without signing in. Some features may be limited, unavailable, or not persisted to your account.
+            </DialogDescription>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Only continue if you understand the limitations of unauthenticated mode.
+          </p>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setShowUnauthenticatedWarning(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => unauthenticatedLoginAdapter.proceed({ nextPath })}
+            >
+              Continue without login
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR refactors development-only unauthenticated mode, custom process hooks, and agent routing extensions so default Paperclip behavior remains unchanged while optional behavior is isolated behind adapters/services.

## Changes

- Keeps upstream/default behavior unchanged outside development mode.
- Restricts unauthenticated login entry to development mode.
- Adds an explicit `Proceed without login` action on the login screen in development mode.
- Adds a warning modal before entering unauthenticated mode.
- Moves unauthenticated behavior behind a small adapter/service.
- Adds generic development-only custom process trigger service behavior.
- Removes private/project-specific references.
- Audits agent/dual-mode routing changes against the upstream baseline.
- Keeps dual-mode disabled by default and development-only.
- Centralizes agent routing and policy validation.
- Minimizes changes to original Paperclip files.

## Default behavior

Existing login, authentication, routing, task, and production behavior remains unchanged unless development-only optional configuration is enabled.

## Validation

- [ ] Lint passed (root `lint` script is not available)
- [x] Typecheck passed (`pnpm run typecheck`)
- [ ] Tests passed (`pnpm test` hit unrelated existing server suite failures; targeted new tests passed)
- [x] Build passed (`pnpm run build`)
- [x] Diff reviewed against upstream baseline
- [x] Original files kept close to upstream baseline
- [x] No production behavior changed
- [x] No private references
- [x] No secrets or local config committed

## Notes

Targeted tests passed:

```bash
pnpm exec vitest run server/src/__tests__/agent-routing-policy.test.ts server/src/__tests__/custom-process-trigger.test.ts ui/src/pages/Auth.test.tsx
```

Full `pnpm test` failed in existing unrelated server suites, including Cursor local adapter remote-sandbox command failures (`cursor-agent` exited 127), embedded database cleanup hook timeouts, and stale queue fixture cleanup FK errors.

Local/private deployment behavior should be configured through development database/config values, not committed into source code.
