### PR TITLE
Gate development extensions behind experimental flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ tmp/
 feedback-export-*
 diagnostics/
 
+# Local custom Docker/config overrides
+docker/custom-configs/
+
 # Editor / tool temp files
 *.tmp
 .vscode/

--- a/packages/shared/src/experimental-features.ts
+++ b/packages/shared/src/experimental-features.ts
@@ -1,0 +1,78 @@
+export const EXPERIMENTAL_FEATURE_KEYS = [
+  "unauthenticated_login",
+  "agent_dual_mode",
+  "custom_process_triggers",
+] as const;
+
+export type ExperimentalFeatureKey = (typeof EXPERIMENTAL_FEATURE_KEYS)[number];
+
+export interface ExperimentalFeatureDefinition {
+  key: ExperimentalFeatureKey;
+  title: string;
+  description: string;
+  warning?: string;
+  defaultEnabled: false;
+  requiresDevelopmentEnvironment?: boolean;
+}
+
+export interface CompanyExperimentalFeaturesConfig {
+  enabledFeatures?: Partial<Record<ExperimentalFeatureKey, boolean>>;
+}
+
+export interface CompanyConfig {
+  experimentalFeatures?: CompanyExperimentalFeaturesConfig;
+}
+
+export type CompanyExperimentalFeaturesByCompanyId = Record<string, CompanyExperimentalFeaturesConfig>;
+
+export interface ExperimentalFeatureResolverInput {
+  feature: ExperimentalFeatureKey;
+  environmentExperimentalModeEnabled: boolean;
+  isDevelopmentEnvironment: boolean;
+  companyEnabledFeatures?: Partial<Record<ExperimentalFeatureKey, boolean>>;
+}
+
+export const PAPERCLIP_EXPERIMENTAL_MODE_ENV = "PAPERCLIP_EXPERIMENTAL_MODE";
+
+export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDefinition[] = [
+  {
+    key: "unauthenticated_login",
+    title: "Unauthenticated login",
+    description: "Allows entering the app without signing in for local development and testing.",
+    warning: "Only intended for local development. Do not enable in production.",
+    defaultEnabled: false,
+    requiresDevelopmentEnvironment: true,
+  },
+  {
+    key: "agent_dual_mode",
+    title: "Agent dual mode",
+    description: "Enables experimental primary/secondary agent routing for development workflows.",
+    warning: "Experimental agent routing must remain policy validated.",
+    defaultEnabled: false,
+    requiresDevelopmentEnvironment: true,
+  },
+  {
+    key: "custom_process_triggers",
+    title: "Custom process triggers",
+    description: "Enables configurable local process triggers for development integrations.",
+    warning: "Do not store secrets or private URLs in process instructions.",
+    defaultEnabled: false,
+    requiresDevelopmentEnvironment: true,
+  },
+];
+
+export function isPaperclipExperimentalModeEnabled(
+  env: Record<string, string | undefined>,
+): boolean {
+  return env[PAPERCLIP_EXPERIMENTAL_MODE_ENV] === "true";
+}
+
+export function isExperimentalFeatureEnabled(input: ExperimentalFeatureResolverInput): boolean {
+  const definition = EXPERIMENTAL_FEATURES.find((feature) => feature.key === input.feature);
+
+  if (!definition) return false;
+  if (!input.environmentExperimentalModeEnabled) return false;
+  if (definition.requiresDevelopmentEnvironment && !input.isDevelopmentEnvironment) return false;
+
+  return input.companyEnabledFeatures?.[input.feature] === true;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -303,6 +303,12 @@ export type {
   AgentSkillEntry,
   AgentSkillSnapshot,
   AgentSkillSyncRequest,
+  CompanyExperimentalFeaturesByCompanyId,
+  CompanyExperimentalFeaturesConfig,
+  CompanyConfig,
+  ExperimentalFeatureDefinition,
+  ExperimentalFeatureKey,
+  ExperimentalFeatureResolverInput,
   InstanceExperimentalSettings,
   InstanceGeneralSettings,
   InstanceSettings,
@@ -680,6 +686,14 @@ export {
 } from "./types/instance.js";
 
 export {
+  EXPERIMENTAL_FEATURES,
+  EXPERIMENTAL_FEATURE_KEYS,
+  PAPERCLIP_EXPERIMENTAL_MODE_ENV,
+  isExperimentalFeatureEnabled,
+  isPaperclipExperimentalModeEnabled,
+} from "./experimental-features.js";
+
+export {
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
 } from "./execution-workspace-guards.js";
@@ -691,6 +705,8 @@ export {
   instanceExperimentalSettingsSchema,
   patchInstanceExperimentalSettingsSchema,
   issueGraphLivenessAutoRecoveryRequestSchema,
+  companyExperimentalFeaturesConfigSchema,
+  experimentalFeatureKeySchema,
   type PatchInstanceExperimentalSettings,
   type IssueGraphLivenessAutoRecoveryRequest,
 } from "./validators/index.js";

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -41,6 +41,14 @@ export {
   MAX_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
 } from "./instance.js";
 export type {
+  CompanyExperimentalFeaturesByCompanyId,
+  CompanyExperimentalFeaturesConfig,
+  CompanyConfig,
+  ExperimentalFeatureDefinition,
+  ExperimentalFeatureKey,
+  ExperimentalFeatureResolverInput,
+} from "../experimental-features.js";
+export type {
   CompanySkillSourceType,
   CompanySkillTrustLevel,
   CompanySkillCompatibility,

--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -1,4 +1,5 @@
 import type { FeedbackDataSharingPreference } from "./feedback.js";
+import type { CompanyExperimentalFeaturesByCompanyId } from "../experimental-features.js";
 
 export const DAILY_RETENTION_PRESETS = [3, 7, 14] as const;
 export const WEEKLY_RETENTION_PRESETS = [1, 2, 4] as const;
@@ -32,6 +33,7 @@ export interface InstanceExperimentalSettings {
   autoRestartDevServerWhenIdle: boolean;
   enableIssueGraphLivenessAutoRecovery: boolean;
   issueGraphLivenessAutoRecoveryLookbackHours: number;
+  companyExperimentalFeatures: CompanyExperimentalFeaturesByCompanyId;
 }
 
 export interface InstanceSettings {

--- a/packages/shared/src/validators/experimental-features.ts
+++ b/packages/shared/src/validators/experimental-features.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+import { EXPERIMENTAL_FEATURE_KEYS } from "../experimental-features.js";
+
+export const experimentalFeatureKeySchema = z.enum(EXPERIMENTAL_FEATURE_KEYS);
+
+export const companyExperimentalFeaturesConfigSchema = z
+  .object({
+    enabledFeatures: z.record(experimentalFeatureKeySchema, z.boolean()).optional(),
+  })
+  .strict();

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -12,6 +12,11 @@ export {
 } from "./instance.js";
 
 export {
+  companyExperimentalFeaturesConfigSchema,
+  experimentalFeatureKeySchema,
+} from "./experimental-features.js";
+
+export {
   upsertBudgetPolicySchema,
   resolveBudgetIncidentSchema,
   type UpsertBudgetPolicy,

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -10,6 +10,7 @@ import {
   MIN_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
 } from "../types/instance.js";
 import { feedbackDataSharingPreferenceSchema } from "./feedback.js";
+import { companyExperimentalFeaturesConfigSchema } from "./experimental-features.js";
 
 function presetSchema<T extends readonly number[]>(presets: T, label: string) {
   return z.number().refine(
@@ -46,6 +47,7 @@ export const instanceExperimentalSettingsSchema = z.object({
     .min(MIN_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS)
     .max(MAX_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS)
     .default(DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS),
+  companyExperimentalFeatures: z.record(z.string(), companyExperimentalFeaturesConfigSchema).default({}),
 }).strict();
 
 export const patchInstanceExperimentalSettingsSchema = instanceExperimentalSettingsSchema.partial();

--- a/server/src/__tests__/auth-routes.test.ts
+++ b/server/src/__tests__/auth-routes.test.ts
@@ -161,4 +161,52 @@ describe.sequential("auth routes", () => {
 
     expect(res.status).toBe(400);
   });
+
+  it("returns unavailable for unauthenticated login when no company is selected", async () => {
+    const app = await createApp({ type: "none", source: "none" }, { id: "settings-1", experimental: {} });
+
+    const res = await request(app).get("/api/auth/unauthenticated-login/availability");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ available: false });
+  });
+
+  it("resolves unauthenticated login availability without requiring a board session", async () => {
+    const previousExperimentalMode = process.env.PAPERCLIP_EXPERIMENTAL_MODE;
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.PAPERCLIP_EXPERIMENTAL_MODE = "true";
+    process.env.NODE_ENV = "development";
+
+    try {
+      const app = await createApp(
+        { type: "none", source: "none" },
+        {
+          id: "settings-1",
+          experimental: {
+            companyExperimentalFeatures: {
+              "company-1": {
+                enabledFeatures: { unauthenticated_login: true },
+              },
+            },
+          },
+        },
+      );
+
+      const res = await request(app).get("/api/auth/unauthenticated-login/availability?companyId=company-1");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ available: true });
+    } finally {
+      if (previousExperimentalMode === undefined) {
+        delete process.env.PAPERCLIP_EXPERIMENTAL_MODE;
+      } else {
+        process.env.PAPERCLIP_EXPERIMENTAL_MODE = previousExperimentalMode;
+      }
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
 });

--- a/server/src/__tests__/experimental-features.test.ts
+++ b/server/src/__tests__/experimental-features.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { isExperimentalFeatureEnabled } from "@paperclipai/shared";
+import { AgentRoutingService } from "../services/experimental-agent-routing.js";
+import { CustomProcessTriggerService } from "../services/custom-process-trigger.js";
+
+const enabledCompanyFeatures = {
+  enabledFeatures: {
+    agent_dual_mode: true,
+    custom_process_triggers: true,
+  },
+};
+
+describe("experimental feature resolver", () => {
+  it("requires environment mode, development mode, and company flag", () => {
+    expect(isExperimentalFeatureEnabled({
+      feature: "unauthenticated_login",
+      environmentExperimentalModeEnabled: false,
+      isDevelopmentEnvironment: true,
+      companyEnabledFeatures: { unauthenticated_login: true },
+    })).toBe(false);
+    expect(isExperimentalFeatureEnabled({
+      feature: "unauthenticated_login",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: false,
+      companyEnabledFeatures: { unauthenticated_login: true },
+    })).toBe(false);
+    expect(isExperimentalFeatureEnabled({
+      feature: "unauthenticated_login",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: true,
+      companyEnabledFeatures: {},
+    })).toBe(false);
+    expect(isExperimentalFeatureEnabled({
+      feature: "unauthenticated_login",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: true,
+      companyEnabledFeatures: { unauthenticated_login: true },
+    })).toBe(true);
+  });
+});
+
+describe("experimental agent routing", () => {
+  const routing = new AgentRoutingService();
+
+  it("keeps default routing unless the agent dual mode flag resolves enabled", () => {
+    expect(routing.resolve({
+      organizationConfig: { dualMode: true, primaryAgent: "claude", secondaryAgent: "codex" },
+      claudeStatus: "unavailable",
+      codexStatus: "available",
+      environmentExperimentalModeEnabled: false,
+      isDevelopmentEnvironment: true,
+      companyExperimentalFeatures: enabledCompanyFeatures,
+    })).toBe("claude");
+
+    expect(routing.resolve({
+      organizationConfig: { dualMode: true, primaryAgent: "claude", secondaryAgent: "codex" },
+      claudeStatus: "unavailable",
+      codexStatus: "available",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: true,
+      companyExperimentalFeatures: enabledCompanyFeatures,
+    })).toBe("codex");
+  });
+});
+
+describe("experimental custom process triggers", () => {
+  const service = new CustomProcessTriggerService();
+
+  it("is a no-op unless the custom process trigger flag resolves enabled", async () => {
+    await expect(service.trigger({
+      event: "manual",
+      environmentExperimentalModeEnabled: false,
+      isDevelopmentEnvironment: true,
+      companyExperimentalFeatures: enabledCompanyFeatures,
+      customProcess: {
+        enabled: true,
+        instructions: "Create a local handoff.",
+      },
+    })).resolves.toMatchObject({ triggered: false, reason: "disabled" });
+
+    await expect(service.trigger({
+      event: "manual",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: true,
+      companyExperimentalFeatures: enabledCompanyFeatures,
+      customProcess: {
+        enabled: true,
+        instructions: "Create a local handoff.",
+      },
+    })).resolves.toMatchObject({
+      triggered: true,
+      reason: "triggered",
+      instructions: "Create a local handoff.",
+    });
+  });
+});

--- a/server/src/development-environment.ts
+++ b/server/src/development-environment.ts
@@ -1,0 +1,3 @@
+export function isDevelopmentEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.NODE_ENV === "development";
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -5,10 +5,14 @@ import { authUsers } from "@paperclipai/db";
 import {
   authSessionSchema,
   currentUserProfileSchema,
+  isExperimentalFeatureEnabled,
+  isPaperclipExperimentalModeEnabled,
   updateCurrentUserProfileSchema,
 } from "@paperclipai/shared";
 import { unauthorized } from "../errors.js";
 import { validate } from "../middleware/validate.js";
+import { isDevelopmentEnvironment } from "../development-environment.js";
+import { instanceSettingsService } from "../services/instance-settings.js";
 
 async function loadCurrentUserProfile(db: Db, userId: string) {
   const user = await db
@@ -36,6 +40,25 @@ async function loadCurrentUserProfile(db: Db, userId: string) {
 
 export function authRoutes(db: Db) {
   const router = Router();
+
+  router.get("/unauthenticated-login/availability", async (req, res) => {
+    const companyId = typeof req.query.companyId === "string" ? req.query.companyId.trim() : "";
+    if (!companyId) {
+      res.json({ available: false });
+      return;
+    }
+
+    const experimental = await instanceSettingsService(db).getExperimental();
+    const companyExperimentalFeatures = experimental.companyExperimentalFeatures[companyId];
+    const available = isExperimentalFeatureEnabled({
+      feature: "unauthenticated_login",
+      environmentExperimentalModeEnabled: isPaperclipExperimentalModeEnabled(process.env),
+      isDevelopmentEnvironment: isDevelopmentEnvironment(),
+      companyEnabledFeatures: companyExperimentalFeatures?.enabledFeatures,
+    });
+
+    res.json({ available });
+  });
 
   router.get("/get-session", async (req, res) => {
     if (req.actor.type !== "board" || !req.actor.userId) {

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -6,6 +6,7 @@ import {
   companyPortabilityImportSchema,
   companyPortabilityPreviewSchema,
   createCompanySchema,
+  companyExperimentalFeaturesConfigSchema,
   feedbackTargetTypeSchema,
   feedbackTraceStatusSchema,
   feedbackVoteValueSchema,
@@ -21,6 +22,7 @@ import {
   companyPortabilityService,
   companyService,
   feedbackService,
+  instanceSettingsService,
   logActivity,
 } from "../services/index.js";
 import type { StorageService } from "../storage/types.js";
@@ -34,6 +36,7 @@ export function companyRoutes(db: Db, storage?: StorageService) {
   const access = accessService(db);
   const budgets = budgetService(db);
   const feedback = feedbackService(db);
+  const instanceSettings = instanceSettingsService(db);
 
   function parseBooleanQuery(value: unknown) {
     return value === true || value === "true" || value === "1";
@@ -353,6 +356,35 @@ export function companyRoutes(db: Db, storage?: StorageService) {
     });
     res.json(company);
   });
+
+  router.patch(
+    "/:companyId/experimental-features",
+    validate(companyExperimentalFeaturesConfigSchema),
+    async (req, res) => {
+      assertBoard(req);
+      const companyId = req.params.companyId as string;
+      assertCompanyAccess(req, companyId);
+      const company = await svc.getById(companyId);
+      if (!company) {
+        res.status(404).json({ error: "Company not found" });
+        return;
+      }
+      const updated = await instanceSettings.updateCompanyExperimentalFeatures(companyId, req.body);
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "company.experimental_features_updated",
+        entityType: "company",
+        entityId: companyId,
+        details: req.body,
+      });
+      res.json(updated.experimental.companyExperimentalFeatures[companyId] ?? {});
+    },
+  );
 
   router.patch("/:companyId/branding", validate(updateCompanyBrandingSchema), async (req, res) => {
     const companyId = req.params.companyId as string;

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -36,7 +36,6 @@ export function companyRoutes(db: Db, storage?: StorageService) {
   const access = accessService(db);
   const budgets = budgetService(db);
   const feedback = feedbackService(db);
-  const instanceSettings = instanceSettingsService(db);
 
   function parseBooleanQuery(value: unknown) {
     return value === true || value === "true" || value === "1";
@@ -369,6 +368,7 @@ export function companyRoutes(db: Db, storage?: StorageService) {
         res.status(404).json({ error: "Company not found" });
         return;
       }
+      const instanceSettings = instanceSettingsService(db);
       const updated = await instanceSettings.updateCompanyExperimentalFeatures(companyId, req.body);
       const actor = getActorInfo(req);
       await logActivity(db, {

--- a/server/src/services/custom-process-trigger.ts
+++ b/server/src/services/custom-process-trigger.ts
@@ -1,0 +1,66 @@
+import {
+  isExperimentalFeatureEnabled,
+  isPaperclipExperimentalModeEnabled,
+  type CompanyExperimentalFeaturesConfig,
+} from "@paperclipai/shared";
+import { isDevelopmentEnvironment } from "../development-environment.js";
+
+export type CustomProcessTriggerEvent =
+  | "manual"
+  | "unauthenticated_session_started"
+  | "primary_agent_unavailable"
+  | "task_created"
+  | "task_completed";
+
+export interface CustomProcessInstructionConfig {
+  enabled?: boolean;
+  instructions?: string;
+  triggers?: Array<{
+    event: CustomProcessTriggerEvent;
+    enabled?: boolean;
+  }>;
+}
+
+export interface CustomProcessTriggerInput {
+  event: CustomProcessTriggerEvent;
+  companyExperimentalFeatures?: CompanyExperimentalFeaturesConfig | null;
+  customProcess?: CustomProcessInstructionConfig | null;
+  environmentExperimentalModeEnabled?: boolean;
+  isDevelopmentEnvironment?: boolean;
+}
+
+export interface CustomProcessTriggerResult {
+  triggered: boolean;
+  reason: "disabled" | "missing_config" | "not_configured" | "triggered";
+  instructions?: string;
+}
+
+function isCustomProcessTriggersEnabled(input: CustomProcessTriggerInput): boolean {
+  return isExperimentalFeatureEnabled({
+    feature: "custom_process_triggers",
+    environmentExperimentalModeEnabled:
+      input.environmentExperimentalModeEnabled ?? isPaperclipExperimentalModeEnabled(process.env),
+    isDevelopmentEnvironment: input.isDevelopmentEnvironment ?? isDevelopmentEnvironment(),
+    companyEnabledFeatures: input.companyExperimentalFeatures?.enabledFeatures,
+  });
+}
+
+export class CustomProcessTriggerService {
+  async trigger(input: CustomProcessTriggerInput): Promise<CustomProcessTriggerResult> {
+    if (!isCustomProcessTriggersEnabled(input)) return { triggered: false, reason: "disabled" };
+    const customProcess = input.customProcess;
+    if (!customProcess) return { triggered: false, reason: "missing_config" };
+    if (customProcess.enabled !== true) return { triggered: false, reason: "disabled" };
+
+    const trigger = customProcess.triggers?.find((item) => item.event === input.event);
+    if (customProcess.triggers && (!trigger || trigger.enabled === false)) {
+      return { triggered: false, reason: "not_configured" };
+    }
+
+    return {
+      triggered: true,
+      reason: "triggered",
+      instructions: customProcess.instructions,
+    };
+  }
+}

--- a/server/src/services/experimental-agent-routing.ts
+++ b/server/src/services/experimental-agent-routing.ts
@@ -1,0 +1,75 @@
+import {
+  isExperimentalFeatureEnabled,
+  isPaperclipExperimentalModeEnabled,
+  type CompanyExperimentalFeaturesConfig,
+} from "@paperclipai/shared";
+import { isDevelopmentEnvironment } from "../development-environment.js";
+
+export type AgentProvider = "claude" | "codex";
+export type AgentStatus = "available" | "tokens_low" | "tokens_empty" | "rate_limited" | "unavailable" | "unknown";
+
+export interface OrganizationAgentConfig {
+  dualMode?: boolean;
+  primaryAgent?: AgentProvider;
+  secondaryAgent?: AgentProvider;
+}
+
+export interface AgentRoutingInput {
+  organizationConfig?: OrganizationAgentConfig | null;
+  claudeStatus?: AgentStatus;
+  codexStatus?: AgentStatus;
+  companyExperimentalFeatures?: CompanyExperimentalFeaturesConfig | null;
+  environmentExperimentalModeEnabled?: boolean;
+  isDevelopmentEnvironment?: boolean;
+}
+
+export const DEFAULT_ORGANIZATION_AGENT_CONFIG = {
+  dualMode: false,
+  primaryAgent: "claude",
+  secondaryAgent: "codex",
+} satisfies Required<OrganizationAgentConfig>;
+
+function isAgentProvider(value: unknown): value is AgentProvider {
+  return value === "claude" || value === "codex";
+}
+
+function normalizeOrganizationAgentConfig(input?: OrganizationAgentConfig | null) {
+  if (!input || typeof input !== "object") return DEFAULT_ORGANIZATION_AGENT_CONFIG;
+  const primaryAgent = isAgentProvider(input.primaryAgent)
+    ? input.primaryAgent
+    : DEFAULT_ORGANIZATION_AGENT_CONFIG.primaryAgent;
+  const secondaryAgent = isAgentProvider(input.secondaryAgent)
+    ? input.secondaryAgent
+    : DEFAULT_ORGANIZATION_AGENT_CONFIG.secondaryAgent;
+  if (primaryAgent === secondaryAgent) return DEFAULT_ORGANIZATION_AGENT_CONFIG;
+  return {
+    dualMode: input.dualMode === true,
+    primaryAgent,
+    secondaryAgent,
+  };
+}
+
+function isAgentDualModeEnabled(input: AgentRoutingInput): boolean {
+  return isExperimentalFeatureEnabled({
+    feature: "agent_dual_mode",
+    environmentExperimentalModeEnabled:
+      input.environmentExperimentalModeEnabled ?? isPaperclipExperimentalModeEnabled(process.env),
+    isDevelopmentEnvironment: input.isDevelopmentEnvironment ?? isDevelopmentEnvironment(),
+    companyEnabledFeatures: input.companyExperimentalFeatures?.enabledFeatures,
+  });
+}
+
+export class AgentRoutingService {
+  resolve(input: AgentRoutingInput): AgentProvider {
+    const config = normalizeOrganizationAgentConfig(input.organizationConfig);
+    if (!isAgentDualModeEnabled(input) || !config.dualMode) return config.primaryAgent;
+    if (this.isAgentAvailable(config.primaryAgent, input)) return config.primaryAgent;
+    if (this.isAgentAvailable(config.secondaryAgent, input)) return config.secondaryAgent;
+    return config.primaryAgent;
+  }
+
+  private isAgentAvailable(agent: AgentProvider, input: AgentRoutingInput): boolean {
+    const status = agent === "claude" ? input.claudeStatus : input.codexStatus;
+    return status === "available" || status === "tokens_low" || status === "unknown" || status === undefined;
+  }
+}

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -11,6 +11,7 @@ import {
   type PatchInstanceGeneralSettings,
   type InstanceSettings,
   type PatchInstanceExperimentalSettings,
+  type CompanyExperimentalFeaturesConfig,
 } from "@paperclipai/shared";
 import { eq } from "drizzle-orm";
 
@@ -46,6 +47,7 @@ function normalizeExperimentalSettings(raw: unknown): InstanceExperimentalSettin
       issueGraphLivenessAutoRecoveryLookbackHours:
         parsed.data.issueGraphLivenessAutoRecoveryLookbackHours ??
         DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
+      companyExperimentalFeatures: parsed.data.companyExperimentalFeatures ?? {},
     };
   }
   return {
@@ -55,6 +57,7 @@ function normalizeExperimentalSettings(raw: unknown): InstanceExperimentalSettin
     enableIssueGraphLivenessAutoRecovery: false,
     issueGraphLivenessAutoRecoveryLookbackHours:
       DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
+    companyExperimentalFeatures: {},
   };
 }
 
@@ -143,6 +146,36 @@ export function instanceSettingsService(db: Db) {
       const nextExperimental = normalizeExperimentalSettings({
         ...normalizeExperimentalSettings(current.experimental),
         ...patch,
+      });
+      const now = new Date();
+      const [updated] = await db
+        .update(instanceSettings)
+        .set({
+          experimental: { ...nextExperimental },
+          updatedAt: now,
+        })
+        .where(eq(instanceSettings.id, current.id))
+        .returning();
+      return toInstanceSettings(updated ?? current);
+    },
+
+    updateCompanyExperimentalFeatures: async (
+      companyId: string,
+      config: CompanyExperimentalFeaturesConfig,
+    ): Promise<InstanceSettings> => {
+      const current = await getOrCreateRow();
+      const currentExperimental = normalizeExperimentalSettings(current.experimental);
+      const nextExperimental = normalizeExperimentalSettings({
+        ...currentExperimental,
+        companyExperimentalFeatures: {
+          ...currentExperimental.companyExperimentalFeatures,
+          [companyId]: {
+            enabledFeatures: {
+              ...(currentExperimental.companyExperimentalFeatures[companyId]?.enabledFeatures ?? {}),
+              ...(config.enabledFeatures ?? {}),
+            },
+          },
+        },
       });
       const now = new Date();
       const [updated] = await db

--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -14,6 +14,10 @@ type AuthErrorBody =
   }
   | null;
 
+type UnauthenticatedLoginAvailability = {
+  available: boolean;
+};
+
 export class AuthApiError extends Error {
   status: number;
   code: string | null;
@@ -89,6 +93,21 @@ async function authPatch<T>(path: string, body: Record<string, unknown>, parse: 
 }
 
 export const authApi = {
+  getUnauthenticatedLoginAvailability: async (companyId: string): Promise<UnauthenticatedLoginAvailability> => {
+    const params = new URLSearchParams({ companyId });
+    const res = await fetch(`/api/auth/unauthenticated-login/availability?${params.toString()}`, {
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+    const payload = await res.json().catch(() => null);
+    if (!res.ok) {
+      throw new Error((payload as { error?: string } | null)?.error ?? `Failed to load availability (${res.status})`);
+    }
+    return {
+      available: payload && typeof payload === "object" && (payload as Record<string, unknown>).available === true,
+    };
+  },
+
   getSession: async (): Promise<AuthSession | null> => {
     const res = await fetch("/api/auth/get-session", {
       credentials: "include",

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -1,5 +1,6 @@
 import type {
   Company,
+  CompanyExperimentalFeaturesConfig,
   CompanyPortabilityExportRequest,
   CompanyPortabilityExportPreviewResult,
   CompanyPortabilityExportResult,
@@ -42,6 +43,14 @@ export const companiesApi = {
   ) => api.patch<Company>(`/companies/${companyId}`, data),
   updateBranding: (companyId: string, data: UpdateCompanyBranding) =>
     api.patch<Company>(`/companies/${companyId}/branding`, data),
+  updateExperimentalFeatures: (
+    companyId: string,
+    data: CompanyExperimentalFeaturesConfig,
+  ) =>
+    api.patch<CompanyExperimentalFeaturesConfig>(
+      `/companies/${companyId}/experimental-features`,
+      data,
+    ),
   archive: (companyId: string) => api.post<Company>(`/companies/${companyId}/archive`, {}),
   remove: (companyId: string) => api.delete<{ ok: true }>(`/companies/${companyId}`),
   exportBundle: (

--- a/ui/src/components/ExperimentalFeaturesSettings.tsx
+++ b/ui/src/components/ExperimentalFeaturesSettings.tsx
@@ -1,0 +1,126 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  EXPERIMENTAL_FEATURES,
+  type ExperimentalFeatureDefinition,
+  type ExperimentalFeatureKey,
+} from "@paperclipai/shared";
+import { companiesApi } from "@/api/companies";
+import { instanceSettingsApi } from "@/api/instanceSettings";
+import { queryKeys } from "@/lib/queryKeys";
+import {
+  isUiExperimentalFeatureEnabled,
+  isUiExperimentalModeEnabled,
+  UI_EXPERIMENTAL_MODE_ENV,
+} from "@/lib/experimental-features";
+import { ToggleSwitch } from "@/components/ui/toggle-switch";
+
+function statusForFeature(input: {
+  feature: ExperimentalFeatureDefinition;
+  checked: boolean;
+  enabled: boolean;
+}) {
+  if (input.enabled) return "Enabled";
+  if (input.checked) return "Configured, inactive";
+  if (input.feature.requiresDevelopmentEnvironment && !import.meta.env.DEV) {
+    return "Development only";
+  }
+  return "Off";
+}
+
+export function ExperimentalFeaturesSettings({ companyId }: { companyId: string }) {
+  const queryClient = useQueryClient();
+  const experimentalModeEnabled = isUiExperimentalModeEnabled();
+  const experimentalQuery = useQuery({
+    queryKey: queryKeys.instance.experimentalSettings,
+    queryFn: () => instanceSettingsApi.getExperimental(),
+    retry: false,
+  });
+  const currentConfig = experimentalQuery.data?.companyExperimentalFeatures[companyId] ?? {};
+  const enabledFeatures = currentConfig.enabledFeatures ?? {};
+
+  const mutation = useMutation({
+    mutationFn: (nextEnabledFeatures: Partial<Record<ExperimentalFeatureKey, boolean>>) =>
+      companiesApi.updateExperimentalFeatures(companyId, {
+        enabledFeatures: nextEnabledFeatures,
+      }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.instance.experimentalSettings,
+      });
+    },
+  });
+
+  return (
+    <div className="space-y-4" data-testid="company-settings-experimental-features-section">
+      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        Experimental features
+      </div>
+      <div className="space-y-4 rounded-md border border-border px-4 py-4">
+        <p className="text-sm text-muted-foreground">
+          Enable experimental features for this company. These features may be unstable and are intended for development
+          or local testing.
+        </p>
+
+        {!experimentalModeEnabled && (
+          <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+            Experimental mode is disabled by environment configuration. Enable {UI_EXPERIMENTAL_MODE_ENV} to use these
+            flags.
+          </div>
+        )}
+
+        {experimentalQuery.error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+            {experimentalQuery.error instanceof Error
+              ? experimentalQuery.error.message
+              : "Failed to load experimental features."}
+          </div>
+        )}
+
+        <div className="divide-y divide-border">
+          {EXPERIMENTAL_FEATURES.map((feature) => {
+            const checked = enabledFeatures[feature.key] === true;
+            const enabled = isUiExperimentalFeatureEnabled(feature.key, currentConfig);
+            const disabled =
+              mutation.isPending ||
+              experimentalQuery.isLoading ||
+              !experimentalModeEnabled ||
+              (feature.requiresDevelopmentEnvironment === true && !import.meta.env.DEV);
+            return (
+              <div key={feature.key} className="flex items-start justify-between gap-4 py-4 first:pt-0 last:pb-0">
+                <div className="min-w-0 space-y-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-sm font-medium">{feature.title}</h3>
+                    <span className="rounded-sm bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                      {statusForFeature({ feature, checked, enabled })}
+                    </span>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{feature.description}</p>
+                  {feature.warning && (
+                    <p className="text-xs text-amber-700 dark:text-amber-300">{feature.warning}</p>
+                  )}
+                </div>
+                <ToggleSwitch
+                  checked={checked}
+                  disabled={disabled}
+                  onCheckedChange={(nextChecked) =>
+                    mutation.mutate({
+                      ...enabledFeatures,
+                      [feature.key]: nextChecked,
+                    })
+                  }
+                  aria-label={`Toggle ${feature.title}`}
+                />
+              </div>
+            );
+          })}
+        </div>
+
+        {mutation.error && (
+          <div className="text-sm text-destructive">
+            {mutation.error instanceof Error ? mutation.error.message : "Failed to update experimental features."}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/lib/experimental-features.ts
+++ b/ui/src/lib/experimental-features.ts
@@ -1,0 +1,23 @@
+import {
+  isExperimentalFeatureEnabled,
+  type CompanyExperimentalFeaturesConfig,
+  type ExperimentalFeatureKey,
+} from "@paperclipai/shared";
+
+export const UI_EXPERIMENTAL_MODE_ENV = "VITE_PAPERCLIP_EXPERIMENTAL_MODE";
+
+export function isUiExperimentalModeEnabled(): boolean {
+  return import.meta.env.VITE_PAPERCLIP_EXPERIMENTAL_MODE === "true";
+}
+
+export function isUiExperimentalFeatureEnabled(
+  feature: ExperimentalFeatureKey,
+  companyExperimentalFeatures?: CompanyExperimentalFeaturesConfig,
+): boolean {
+  return isExperimentalFeatureEnabled({
+    feature,
+    environmentExperimentalModeEnabled: isUiExperimentalModeEnabled(),
+    isDevelopmentEnvironment: import.meta.env.DEV,
+    companyEnabledFeatures: companyExperimentalFeatures?.enabledFeatures,
+  });
+}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -122,6 +122,8 @@ export const queryKeys = {
   },
   auth: {
     session: ["auth", "session"] as const,
+    unauthenticatedLoginAvailability: (companyId: string) =>
+      ["auth", "unauthenticated-login-availability", companyId] as const,
   },
   sidebarPreferences: {
     companyOrder: (userId: string) => ["sidebar-preferences", "company-order", userId] as const,

--- a/ui/src/lib/unauthenticated-login.adapter.ts
+++ b/ui/src/lib/unauthenticated-login.adapter.ts
@@ -1,20 +1,18 @@
-import type { CompanyExperimentalFeaturesConfig } from "@paperclipai/shared";
-import { isUiExperimentalFeatureEnabled } from "@/lib/experimental-features";
+import { authApi } from "@/api/auth";
 
 export interface UnauthenticatedLoginAdapterInput {
   nextPath?: string;
-  companyExperimentalFeatures?: CompanyExperimentalFeaturesConfig;
-}
-
-export function isUnauthenticatedDevelopmentLoginAvailable(
-  companyExperimentalFeatures?: CompanyExperimentalFeaturesConfig,
-): boolean {
-  return isUiExperimentalFeatureEnabled("unauthenticated_login", companyExperimentalFeatures);
+  companyId?: string | null;
 }
 
 export const unauthenticatedLoginAdapter = {
   async proceed(input: UnauthenticatedLoginAdapterInput = {}) {
-    if (!isUnauthenticatedDevelopmentLoginAvailable(input.companyExperimentalFeatures)) {
+    if (!input.companyId) {
+      throw new Error("Unauthenticated development entry is disabled.");
+    }
+
+    const availability = await authApi.getUnauthenticatedLoginAvailability(input.companyId);
+    if (!availability.available) {
       throw new Error("Unauthenticated development entry is disabled.");
     }
     const target = input.nextPath?.trim() || "/";

--- a/ui/src/lib/unauthenticated-login.adapter.ts
+++ b/ui/src/lib/unauthenticated-login.adapter.ts
@@ -1,0 +1,23 @@
+import type { CompanyExperimentalFeaturesConfig } from "@paperclipai/shared";
+import { isUiExperimentalFeatureEnabled } from "@/lib/experimental-features";
+
+export interface UnauthenticatedLoginAdapterInput {
+  nextPath?: string;
+  companyExperimentalFeatures?: CompanyExperimentalFeaturesConfig;
+}
+
+export function isUnauthenticatedDevelopmentLoginAvailable(
+  companyExperimentalFeatures?: CompanyExperimentalFeaturesConfig,
+): boolean {
+  return isUiExperimentalFeatureEnabled("unauthenticated_login", companyExperimentalFeatures);
+}
+
+export const unauthenticatedLoginAdapter = {
+  async proceed(input: UnauthenticatedLoginAdapterInput = {}) {
+    if (!isUnauthenticatedDevelopmentLoginAvailable(input.companyExperimentalFeatures)) {
+      throw new Error("Unauthenticated development entry is disabled.");
+    }
+    const target = input.nextPath?.trim() || "/";
+    window.location.assign(target);
+  },
+};

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -8,7 +8,6 @@ import { Button } from "@/components/ui/button";
 import { AsciiArtAnimation } from "@/components/AsciiArtAnimation";
 import { Sparkles } from "lucide-react";
 import { useCompany } from "@/context/CompanyContext";
-import { instanceSettingsApi } from "@/api/instanceSettings";
 import {
   Dialog,
   DialogContent,
@@ -17,10 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  isUnauthenticatedDevelopmentLoginAvailable,
-  unauthenticatedLoginAdapter,
-} from "@/lib/unauthenticated-login.adapter";
+import { unauthenticatedLoginAdapter } from "@/lib/unauthenticated-login.adapter";
 
 type AuthMode = "sign_in" | "sign_up";
 
@@ -40,17 +36,13 @@ export function AuthPage() {
     () => searchParams.get("next") || getRememberedInvitePath() || "/",
     [searchParams],
   );
-  const experimentalQuery = useQuery({
-    queryKey: queryKeys.instance.experimentalSettings,
-    queryFn: () => instanceSettingsApi.getExperimental(),
+  const unauthenticatedAvailabilityQuery = useQuery({
+    queryKey: queryKeys.auth.unauthenticatedLoginAvailability(selectedCompanyId ?? ""),
+    queryFn: () => authApi.getUnauthenticatedLoginAvailability(selectedCompanyId ?? ""),
     retry: false,
     enabled: Boolean(selectedCompanyId),
   });
-  const companyExperimentalFeatures = selectedCompanyId
-    ? experimentalQuery.data?.companyExperimentalFeatures[selectedCompanyId]
-    : undefined;
-  const showUnauthenticatedEntry =
-    isUnauthenticatedDevelopmentLoginAvailable(companyExperimentalFeatures);
+  const showUnauthenticatedEntry = unauthenticatedAvailabilityQuery.data?.available === true;
   const { data: session, isLoading: isSessionLoading } = useQuery({
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
@@ -246,7 +238,7 @@ export function AuthPage() {
               onClick={() =>
                 unauthenticatedLoginAdapter.proceed({
                   nextPath,
-                  companyExperimentalFeatures,
+                  companyId: selectedCompanyId,
                 })
               }
             >

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -7,6 +7,20 @@ import { getRememberedInvitePath } from "../lib/invite-memory";
 import { Button } from "@/components/ui/button";
 import { AsciiArtAnimation } from "@/components/AsciiArtAnimation";
 import { Sparkles } from "lucide-react";
+import { useCompany } from "@/context/CompanyContext";
+import { instanceSettingsApi } from "@/api/instanceSettings";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  isUnauthenticatedDevelopmentLoginAvailable,
+  unauthenticatedLoginAdapter,
+} from "@/lib/unauthenticated-login.adapter";
 
 type AuthMode = "sign_in" | "sign_up";
 
@@ -19,11 +33,24 @@ export function AuthPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [showUnauthenticatedWarning, setShowUnauthenticatedWarning] = useState(false);
+  const { selectedCompanyId } = useCompany();
 
   const nextPath = useMemo(
     () => searchParams.get("next") || getRememberedInvitePath() || "/",
     [searchParams],
   );
+  const experimentalQuery = useQuery({
+    queryKey: queryKeys.instance.experimentalSettings,
+    queryFn: () => instanceSettingsApi.getExperimental(),
+    retry: false,
+    enabled: Boolean(selectedCompanyId),
+  });
+  const companyExperimentalFeatures = selectedCompanyId
+    ? experimentalQuery.data?.companyExperimentalFeatures[selectedCompanyId]
+    : undefined;
+  const showUnauthenticatedEntry =
+    isUnauthenticatedDevelopmentLoginAvailable(companyExperimentalFeatures);
   const { data: session, isLoading: isSessionLoading } = useQuery({
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
@@ -172,6 +199,18 @@ export function AuthPage() {
               {mode === "sign_in" ? "Create one" : "Sign in"}
             </button>
           </div>
+          {showUnauthenticatedEntry && (
+            <div className="mt-4 border-t border-border pt-4">
+              <Button
+                type="button"
+                variant="ghost"
+                className="w-full"
+                onClick={() => setShowUnauthenticatedWarning(true)}
+              >
+                Proceed without login
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 
@@ -179,6 +218,43 @@ export function AuthPage() {
       <div className="hidden md:block w-1/2 overflow-hidden">
         <AsciiArtAnimation />
       </div>
+      <Dialog
+        open={showUnauthenticatedEntry && showUnauthenticatedWarning}
+        onOpenChange={setShowUnauthenticatedWarning}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Continue without login?</DialogTitle>
+            <DialogDescription>
+              You are about to enter Paperclip without signing in. Some features may be limited, unavailable, or not
+              persisted to your account.
+            </DialogDescription>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Only continue if you understand the limitations of unauthenticated mode.
+          </p>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setShowUnauthenticatedWarning(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() =>
+                unauthenticatedLoginAdapter.proceed({
+                  nextPath,
+                  companyExperimentalFeatures,
+                })
+              }
+            >
+              Continue without login
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -228,6 +228,14 @@ export function CompanySettings() {
     );
   }
 
+  if (!selectedCompanyId) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        No company selected. Select a company from the switcher above.
+      </div>
+    );
+  }
+
   function handleSaveGeneral() {
     generalMutation.mutate({
       name: companyName.trim(),
@@ -433,7 +441,7 @@ export function CompanySettings() {
         </div>
       </div>
 
-      <ExperimentalFeaturesSettings companyId={selectedCompanyId!} />
+      <ExperimentalFeaturesSettings companyId={selectedCompanyId} />
 
       {/* Invites */}
       <div className="space-y-4" data-testid="company-settings-invites-section">

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -13,6 +13,7 @@ import { queryKeys } from "../lib/queryKeys";
 import { Button } from "@/components/ui/button";
 import { Settings, Check, Download, Upload } from "lucide-react";
 import { CompanyPatternIcon } from "../components/CompanyPatternIcon";
+import { ExperimentalFeaturesSettings } from "@/components/ExperimentalFeaturesSettings";
 import {
   Field,
   ToggleField,
@@ -431,6 +432,8 @@ export function CompanySettings() {
           />
         </div>
       </div>
+
+      <ExperimentalFeaturesSettings companyId={selectedCompanyId!} />
 
       {/* Invites */}
       <div className="space-y-4" data-testid="company-settings-invites-section">


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Experimental or local-only development behavior must stay outside the default production path.
> - The fork had development extensions that needed a generic upstream-friendly control surface instead of direct custom behavior.
> - A centralized resolver keeps feature availability predictable across server and UI code.
> - Per-company settings let operators opt into individual experiments without enabling them globally by accident.
> - This pull request gates development extensions behind an environment master switch, per-company flags, and development-environment checks.
> - The benefit is a minimal default-off path that preserves production behavior while keeping local experiments reviewable.

## What Changed

- Added shared experimental feature definitions, key types, metadata, validators, and a resolver.
- Added `PAPERCLIP_EXPERIMENTAL_MODE` as the server-side master switch and a Vite UI bridge for the settings page.
- Stored per-company experimental flags in existing instance experimental settings JSON, avoiding a database migration.
- Added a compact company settings section that lists experimental flags from the shared definitions.
- Added a public `/api/auth/unauthenticated-login/availability` endpoint that returns only the resolved unauthenticated-login availability boolean.
- Gated unauthenticated login UI/adapter, agent dual-mode routing helper, and custom process trigger helper behind the shared resolver.
- Kept risky flags development-only and disabled by default.
- Added `docker/custom-configs/` to `.gitignore` for local-only Docker/config overrides.
- Fixed PR review/CI follow-ups by removing the login page dependency on protected instance settings, guarding `selectedCompanyId`, and lazy-loading the company settings service inside the new handler.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/companies-route-path-guard.test.ts src/__tests__/company-branding-route.test.ts src/__tests__/company-portability-routes.test.ts src/__tests__/auth-routes.test.ts src/__tests__/experimental-features.test.ts`: passed.
- `pnpm typecheck`: passed.
- `pnpm build`: passed.
- `git diff --check`: passed.
- Earlier broader `pnpm test` was run and hit existing environment-sensitive failures unrelated to this PR: local Cursor command expectations, embedded Postgres hook timeouts, and a heartbeat stale-queue cleanup FK failure.
- UI screenshot note: this environment did not have a browser-authenticated app session suitable for before/after screenshots. Manual verification path: Company Settings → Experimental features; login page shows `Proceed without login` only when the env master switch, development mode, and company flag are all enabled.

## Risks

- Low production risk: all new experimental flags default to disabled and require both environment and company opt-in.
- The unauthenticated-login availability endpoint is intentionally unauthenticated, but it returns only a boolean and still requires the master env switch, development environment, and company flag.
- Settings persistence uses existing instance settings JSON; concurrent updates are low-risk for this experimental admin surface but still use normal read-modify-write behavior.
- No database migration is included.

## Model Used

- OpenAI Codex, GPT-5 coding agent, with repository tool use and local command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass for the changed/failing areas
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
