### PR TITLE
fix(heartbeat): pre-enqueue terminal-issue skip + bulk stale queued-run cancel API

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   agents,
@@ -825,5 +825,92 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(wakeup?.status).toBe("skipped");
     expect(wakeup?.error).toContain("continuation summary says the executor should wait");
     expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
+  it("skips non-interaction wakeups for done issues before enqueuing a queued run", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Already done",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const result = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_children_completed",
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_children_completed",
+      },
+    });
+
+    expect(result).toBeNull();
+
+    const skippedWakeups = await db
+      .select({ reason: agentWakeupRequests.reason, status: agentWakeupRequests.status })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(skippedWakeups.length).toBe(1);
+    expect(skippedWakeups[0]?.status).toBe("skipped");
+    expect(skippedWakeups[0]?.reason).toBe("issue_terminal_status");
+
+    const queuedRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(queuedRuns.length).toBe(0);
+  });
+
+  it("allows comment-driven interaction wakeups for done issues", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    const commentId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Done but commented",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const result = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      contextSnapshot: {
+        issueId,
+        commentId,
+        wakeCommentId: commentId,
+        wakeReason: "issue_commented",
+      },
+    });
+
+    expect(result).not.toBeNull();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const skippedWakeups = await db
+      .select({ reason: agentWakeupRequests.reason, status: agentWakeupRequests.status })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.status, "skipped"),
+        ),
+      );
+    expect(skippedWakeups.length).toBe(0);
   });
 });

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -827,5 +827,92 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     expect(wakeup?.status).toBe("skipped");
     expect(wakeup?.error).toContain("continuation summary says the executor should wait");
     expect(countExecuteCallsForRun(runId)).toBe(0);
+  });
+
+  it("skips non-interaction wakeups for done issues before enqueuing a queued run", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Already done",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const result = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_children_completed",
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_children_completed",
+      },
+    });
+
+    expect(result).toBeNull();
+
+    const skippedWakeups = await db
+      .select({ reason: agentWakeupRequests.reason, status: agentWakeupRequests.status })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(skippedWakeups.length).toBe(1);
+    expect(skippedWakeups[0]?.status).toBe("skipped");
+    expect(skippedWakeups[0]?.reason).toBe("issue_terminal_status");
+
+    const queuedRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(queuedRuns.length).toBe(0);
+  });
+
+  it("allows comment-driven interaction wakeups for done issues", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    const commentId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Done but commented",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const result = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      contextSnapshot: {
+        issueId,
+        commentId,
+        wakeCommentId: commentId,
+        wakeReason: "issue_commented",
+      },
+    });
+
+    expect(result).not.toBeNull();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const skippedWakeups = await db
+      .select({ reason: agentWakeupRequests.reason, status: agentWakeupRequests.status })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.status, "skipped"),
+        ),
+      );
+    expect(skippedWakeups.length).toBe(0);
   });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3493,6 +3493,34 @@ export function agentRoutes(
     res.json(run);
   });
 
+  router.post("/heartbeat-runs/stale/cancel", async (req, res) => {
+    assertBoard(req);
+    const companyId = typeof req.body?.companyId === "string" ? req.body.companyId : null;
+    if (!companyId) {
+      res.status(400).json({ error: "companyId is required" });
+      return;
+    }
+    assertCompanyAccess(req, companyId);
+    const result = await heartbeat.cancelStaleQueuedRuns(companyId);
+
+    if (result.cancelled.length > 0) {
+      await logActivity(db, {
+        companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "heartbeat.stale_queued_cancelled",
+        entityType: "company",
+        entityId: companyId,
+        details: {
+          cancelledCount: result.cancelledCount,
+          cancelledRunIds: result.cancelled.map((entry) => entry.runId),
+        },
+      });
+    }
+
+    res.json(result);
+  });
+
   router.post("/heartbeat-runs/:runId/watchdog-decisions", async (req, res) => {
     const runId = req.params.runId as string;
     const existing = await heartbeat.getRun(runId);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3469,30 +3469,6 @@ export function agentRoutes(
     );
   });
 
-  router.post("/heartbeat-runs/:runId/cancel", async (req, res) => {
-    assertBoard(req);
-    const runId = req.params.runId as string;
-    const existing = await heartbeat.getRun(runId);
-    if (existing) {
-      assertCompanyAccess(req, existing.companyId);
-    }
-    const run = await heartbeat.cancelRun(runId);
-
-    if (run) {
-      await logActivity(db, {
-        companyId: run.companyId,
-        actorType: "user",
-        actorId: req.actor.userId ?? "board",
-        action: "heartbeat.cancelled",
-        entityType: "heartbeat_run",
-        entityId: run.id,
-        details: { agentId: run.agentId },
-      });
-    }
-
-    res.json(run);
-  });
-
   router.post("/heartbeat-runs/stale/cancel", async (req, res) => {
     assertBoard(req);
     const companyId = typeof req.body?.companyId === "string" ? req.body.companyId : null;
@@ -3519,6 +3495,30 @@ export function agentRoutes(
     }
 
     res.json(result);
+  });
+
+  router.post("/heartbeat-runs/:runId/cancel", async (req, res) => {
+    assertBoard(req);
+    const runId = req.params.runId as string;
+    const existing = await heartbeat.getRun(runId);
+    if (existing) {
+      assertCompanyAccess(req, existing.companyId);
+    }
+    const run = await heartbeat.cancelRun(runId);
+
+    if (run) {
+      await logActivity(db, {
+        companyId: run.companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "heartbeat.cancelled",
+        entityType: "heartbeat_run",
+        entityId: run.id,
+        details: { agentId: run.agentId },
+      });
+    }
+
+    res.json(run);
   });
 
   router.post("/heartbeat-runs/:runId/watchdog-decisions", async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3228,6 +3228,34 @@ export function agentRoutes(
     res.json(run);
   });
 
+  router.post("/heartbeat-runs/stale/cancel", async (req, res) => {
+    assertBoard(req);
+    const companyId = typeof req.body?.companyId === "string" ? req.body.companyId : null;
+    if (!companyId) {
+      res.status(400).json({ error: "companyId is required" });
+      return;
+    }
+    assertCompanyAccess(req, companyId);
+    const result = await heartbeat.cancelStaleQueuedRuns(companyId);
+
+    if (result.cancelled.length > 0) {
+      await logActivity(db, {
+        companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "heartbeat.stale_queued_cancelled",
+        entityType: "company",
+        entityId: companyId,
+        details: {
+          cancelledCount: result.cancelledCount,
+          cancelledRunIds: result.cancelled.map((entry) => entry.runId),
+        },
+      });
+    }
+
+    res.json(result);
+  });
+
   router.post("/heartbeat-runs/:runId/watchdog-decisions", async (req, res) => {
     const runId = req.params.runId as string;
     const existing = await heartbeat.getRun(runId);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3204,30 +3204,6 @@ export function agentRoutes(
     );
   });
 
-  router.post("/heartbeat-runs/:runId/cancel", async (req, res) => {
-    assertBoard(req);
-    const runId = req.params.runId as string;
-    const existing = await heartbeat.getRun(runId);
-    if (existing) {
-      assertCompanyAccess(req, existing.companyId);
-    }
-    const run = await heartbeat.cancelRun(runId);
-
-    if (run) {
-      await logActivity(db, {
-        companyId: run.companyId,
-        actorType: "user",
-        actorId: req.actor.userId ?? "board",
-        action: "heartbeat.cancelled",
-        entityType: "heartbeat_run",
-        entityId: run.id,
-        details: { agentId: run.agentId },
-      });
-    }
-
-    res.json(run);
-  });
-
   router.post("/heartbeat-runs/stale/cancel", async (req, res) => {
     assertBoard(req);
     const companyId = typeof req.body?.companyId === "string" ? req.body.companyId : null;
@@ -3254,6 +3230,30 @@ export function agentRoutes(
     }
 
     res.json(result);
+  });
+
+  router.post("/heartbeat-runs/:runId/cancel", async (req, res) => {
+    assertBoard(req);
+    const runId = req.params.runId as string;
+    const existing = await heartbeat.getRun(runId);
+    if (existing) {
+      assertCompanyAccess(req, existing.companyId);
+    }
+    const run = await heartbeat.cancelRun(runId);
+
+    if (run) {
+      await logActivity(db, {
+        companyId: run.companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "heartbeat.cancelled",
+        entityType: "heartbeat_run",
+        entityId: run.id,
+        details: { agentId: run.agentId },
+      });
+    }
+
+    res.json(run);
   });
 
   router.post("/heartbeat-runs/:runId/watchdog-decisions", async (req, res) => {

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -2826,6 +2826,17 @@ registry.registerPath({
 
 registry.registerPath({
   method: "post",
+  path: "/api/heartbeat-runs/stale/cancel",
+  tags: ["runs"],
+  summary: "Cancel stale queued runs for a company",
+  request: {
+    body: jsonBody(z.object({ companyId: z.string() })),
+  },
+  responses: { 200: r.ok(), 400: r.badRequest, 401: r.unauthorized },
+});
+
+registry.registerPath({
+  method: "post",
   path: "/api/heartbeat-runs/{runId}/watchdog-decisions",
   tags: ["runs"],
   summary: "Submit watchdog decisions for a run",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -10339,6 +10339,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           return { kind: "skipped" as const };
         }
 
+        const isTerminalIssue = issue.status === "done" || issue.status === "cancelled";
+        const isInteractionWake = allowsIssueInteractionWake(enrichedContextSnapshot);
+        if (isTerminalIssue && !isInteractionWake) {
+          await tx.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason: "issue_terminal_status",
+            payload,
+            status: "skipped",
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            finishedAt: new Date(),
+          });
+          return { kind: "skipped" as const };
+        }
+
         const cancelStaleScheduledRetry = async (scheduledRun: typeof heartbeatRuns.$inferSelect) => {
           const issueCancelled = issue.status === "cancelled";
           if (
@@ -11206,6 +11225,38 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     await cancelPendingWakeupsForBudgetScope(scope);
   }
 
+  async function cancelStaleQueuedRuns(companyId: string) {
+    const queuedRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.status, "queued"),
+        ),
+      );
+
+    const cancelled: Array<{ runId: string; reason: string; issueId: string | null }> = [];
+
+    for (const run of queuedRuns) {
+      const context = parseObject(run.contextSnapshot);
+      const issueId = readNonEmptyString(context.issueId);
+      if (!issueId) continue;
+
+      const staleness = await evaluateQueuedRunStaleness(run, issueId, context);
+      if (staleness.stale) {
+        await cancelQueuedRunForStaleIssue(run, issueId, staleness);
+        cancelled.push({ runId: run.id, reason: staleness.reason, issueId });
+        logger.info(
+          { runId: run.id, issueId, errorCode: staleness.errorCode },
+          "cancelStaleQueuedRuns: cancelled stale queued run",
+        );
+      }
+    }
+
+    return { cancelledCount: cancelled.length, cancelled };
+  }
+
   return {
     list: async (companyId: string, agentId?: string, limit?: number) => {
       const safeForLegacyEncoding = await hasUnsafeTextProjectionDatabase();
@@ -11523,6 +11574,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     cancelRun: (runId: string, reason?: string, options?: CancelRunOptions) => cancelRunInternal(runId, reason, options),
+
+   cancelStaleQueuedRuns,
 
     cancelActiveForAgent: (agentId: string, reason?: string) => cancelActiveForAgentInternal(agentId, reason),
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8758,6 +8758,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           return { kind: "skipped" as const };
         }
 
+        const isTerminalIssue = issue.status === "done" || issue.status === "cancelled";
+        const isInteractionWake = allowsIssueInteractionWake(enrichedContextSnapshot);
+        if (isTerminalIssue && !isInteractionWake) {
+          await tx.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason: "issue_terminal_status",
+            payload,
+            status: "skipped",
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            finishedAt: new Date(),
+          });
+          return { kind: "skipped" as const };
+        }
+
         const cancelStaleScheduledRetry = async (scheduledRun: typeof heartbeatRuns.$inferSelect) => {
           const issueCancelled = issue.status === "cancelled";
           if (
@@ -9488,6 +9507,38 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     await cancelPendingWakeupsForBudgetScope(scope);
   }
 
+  async function cancelStaleQueuedRuns(companyId: string) {
+    const queuedRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.status, "queued"),
+        ),
+      );
+
+    const cancelled: Array<{ runId: string; reason: string; issueId: string | null }> = [];
+
+    for (const run of queuedRuns) {
+      const context = parseObject(run.contextSnapshot);
+      const issueId = readNonEmptyString(context.issueId);
+      if (!issueId) continue;
+
+      const staleness = await evaluateQueuedRunStaleness(run, issueId, context);
+      if (staleness.stale) {
+        await cancelQueuedRunForStaleIssue(run, issueId, staleness);
+        cancelled.push({ runId: run.id, reason: staleness.reason, issueId });
+        logger.info(
+          { runId: run.id, issueId, errorCode: staleness.errorCode },
+          "cancelStaleQueuedRuns: cancelled stale queued run",
+        );
+      }
+    }
+
+    return { cancelledCount: cancelled.length, cancelled };
+  }
+
   return {
     list: async (companyId: string, agentId?: string, limit?: number) => {
       const safeForLegacyEncoding = await hasUnsafeTextProjectionDatabase();
@@ -9797,6 +9848,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     cancelRun: (runId: string) => cancelRunInternal(runId),
+
+    cancelStaleQueuedRuns,
 
     cancelActiveForAgent: (agentId: string) => cancelActiveForAgentInternal(agentId),
 


### PR DESCRIPTION
## Summary

- **Pre-enqueue terminal-issue skip**: Non-interaction wakes for `done`/`cancelled` issues are skipped before consuming a queue slot in `enqueueWakeup()`
- **Bulk stale queued-run cancel API**: `POST /heartbeat-runs/stale/cancel` (board-only) iterates all `queued` runs and cancels stale ones via existing `evaluateQueuedRunStaleness()` with audit trail
- **Regression tests**: 2 new tests covering pre-enqueue done-issue skip and comment-interaction exception

## Changes (3 files, +169 lines)

| File | Change |
|------|--------|
| `server/src/services/heartbeat.ts` | Pre-enqueue skip + `cancelStaleQueuedRuns()` bulk cancel function |
| `server/src/routes/agents.ts` | `POST /heartbeat-runs/stale/cancel` (board-only) |
| `server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts` | 2 regression tests |

## Acceptance Criteria (POLA-2933)

1. ✅ Queued heartbeat runs are skipped/cancelled before adapter invocation when their scoped issue is terminal, no longer assigned to that agent, or blocked without new actionable context
2. ✅ Comment/children-completed wakeups on blocked or done issues coalesce or no-op instead of adding duplicate queued runs
3. ✅ Operators have an audited API or maintenance command to cancel stale queued runs without direct database edits
4. ✅ Focused regression around issue-state changes after wake enqueue but before run start

## Test Results

All 10 tests pass (8 existing + 2 new):

```
✓ cancels queued runs when the issue assignee changes before the run starts
✓ cancels queued runs when the issue reaches a terminal status before the run starts
✓ cancels queued max-turn continuations when the issue is no longer in_progress
✓ cancels queued max-turn continuations when another continuation owns the issue lock
✓ cancels queued in_review runs when the current participant changes
✓ still runs comment-driven wakes on in_review issues
✓ baseline: runs queued runs when the issue is in_progress with the same assignee
✓ cancels queued continuation recovery when the continuation summary parks executor work for review
✓ skips non-interaction wakeups for done issues before enqueuing a queued run  ← NEW
✓ allows comment-driven interaction wakeups for done issues  ← NEW
```

Closes POLA-2933.