### PR TITLE
fix(execution-workspace): clear closedAt when un-archiving workspace (POLA-5646)

### DIFF
--- a/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
+++ b/docs/guides/board-operator/execution-workspaces-and-runtime-services.md
@@ -54,6 +54,17 @@ Execution workspaces are durable until a human closes them.
 - Closing an execution workspace stops its runtime services and cleans up its workspace artifacts when allowed.
 - Shared workspaces that point at the project primary checkout are treated more conservatively during cleanup than disposable isolated workspaces.
 
+### Archived-workspace lockout (POLA-5646)
+
+**Root cause**: When an execution workspace was un-archived (status changed from `archived` or `cleanup_failed` back to `active`/`idle`), the `closedAt` timestamp was not cleared. The `isClosedIsolatedExecutionWorkspace` guard (in `packages/shared/src/execution-workspace-guards.ts`) considers a workspace closed when either the status is `archived`/`cleanup_failed` **or** `closedAt` is non-null. A reactivated workspace with a stale `closedAt` therefore remained blocked, preventing checkout for any issue linked to that workspace.
+
+**Fix**: The `PATCH /api/execution-workspaces/:id` route now clears `closedAt`, `cleanupReason`, and `cleanupEligibleAt` to `null` when the requested status transition is away from `archived`/`cleanup_failed` and the existing `closedAt` is set.
+
+**Prevention guidance**:
+- When adding new closure-related fields to execution workspaces, ensure all fields are cleared on re-activation to avoid ghost-locks.
+- The `isClosedIsolatedExecutionWorkspace` guard and the PATCH route lifecycle logic are coupled -- changes to either must be reviewed together.
+- Test re-activation paths explicitly: archive a workspace, un-archive it, and verify checkout succeeds for a linked issue.
+
 ## Resolved workspace logic during heartbeat runs
 
 Heartbeat still resolves a workspace for the run, but that is about code location and session continuity, not runtime-service control.

--- a/packages/shared/src/__tests__/execution-workspace-guards.test.ts
+++ b/packages/shared/src/__tests__/execution-workspace-guards.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { isClosedIsolatedExecutionWorkspace } from "../execution-workspace-guards.js";
+
+describe("isClosedIsolatedExecutionWorkspace", () => {
+  it("returns false for null/undefined", () => {
+    expect(isClosedIsolatedExecutionWorkspace(null)).toBe(false);
+    expect(isClosedIsolatedExecutionWorkspace(undefined)).toBe(false);
+  });
+
+  it("returns false for non-isolated workspace modes", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({
+        mode: "shared_workspace" as const,
+        status: "archived" as const,
+        closedAt: new Date(),
+        name: "test",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for archived status", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({
+        mode: "isolated_workspace" as const,
+        status: "archived" as const,
+        closedAt: null,
+        name: "test",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for cleanup_failed status", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({
+        mode: "isolated_workspace" as const,
+        status: "cleanup_failed" as const,
+        closedAt: null,
+        name: "test",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when closedAt is set even with active status", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({
+        mode: "isolated_workspace" as const,
+        status: "active" as const,
+        closedAt: new Date(),
+        name: "test",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for active status with null closedAt", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({
+        mode: "isolated_workspace" as const,
+        status: "active" as const,
+        closedAt: null,
+        name: "test",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for idle status with null closedAt", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({
+        mode: "isolated_workspace" as const,
+        status: "idle" as const,
+        closedAt: null,
+        name: "test",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/execution-workspace-guards.ts
+++ b/packages/shared/src/execution-workspace-guards.ts
@@ -5,7 +5,7 @@ type ExecutionWorkspaceGuardTarget = Pick<ExecutionWorkspace, "closedAt" | "mode
 const CLOSED_EXECUTION_WORKSPACE_STATUSES = new Set<ExecutionWorkspace["status"]>(["archived", "cleanup_failed"]);
 
 export function isClosedIsolatedExecutionWorkspace(
-  workspace: Pick<ExecutionWorkspaceGuardTarget, "closedAt" | "mode" | "status"> | null | undefined,
+  workspace: ExecutionWorkspaceGuardTarget | null | undefined,
 ): boolean {
   if (!workspace) return false;
   if (workspace.mode !== "isolated_workspace") return false;

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -592,10 +592,11 @@ export function executionWorkspaceRoutes(db: Db) {
         req.body.status !== undefined &&
         req.body.status !== "archived" &&
         req.body.status !== "cleanup_failed" &&
-        (existing.status === "archived" || existing.status === "cleanup_failed") &&
-        existing.closedAt != null
+        (existing.status === "archived" || existing.status === "cleanup_failed")
       ) {
-        patch.closedAt = null;
+        if (existing.closedAt != null) {
+          patch.closedAt = null;
+        }
         patch.cleanupReason = null;
         patch.cleanupEligibleAt = null;
       }

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -588,6 +588,17 @@ export function executionWorkspaceRoutes(db: Db) {
         return;
       }
     } else {
+      if (
+        req.body.status !== undefined &&
+        req.body.status !== "archived" &&
+        req.body.status !== "cleanup_failed" &&
+        (existing.status === "archived" || existing.status === "cleanup_failed") &&
+        existing.closedAt != null
+      ) {
+        patch.closedAt = null;
+        patch.cleanupReason = null;
+        patch.cleanupEligibleAt = null;
+      }
       const updatedWorkspace = await svc.update(id, patch);
       if (!updatedWorkspace) {
         res.status(404).json({ error: "Execution workspace not found" });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Execution workspaces provide isolated git worktrees for agent code changes
> - When a workspace is archived (closed), it sets `closedAt` timestamp and can create child workspaces that inherit the parent's execution workspace
> - An issue linked to a `closed` workspace cannot be checked out — the guard `isClosedIsolatedExecutionWorkspace` treats any non-null `closedAt` as closed
> - The bug: when an archived workspace was un-archived (status changed from `archived`/`cleanup_failed` to another status), `closedAt` was never cleared. Re-activated workspaces remained blocked.
> - This caused [POLA-3621](https://github.com/paperclipai/paperclip/issues/3621) to be locked — it inherited a closed workspace from [POLA-3450](https://github.com/paperclipai/paperclip/issues/3450) and could never be checked out.
> - This PR clears `closedAt`, `cleanupReason`, and `cleanupEligibleAt` when transitioning away from `archived`/`cleanup_failed` status.

## What Changed

- **`server/src/routes/execution-workspaces.ts`**: Clear `closedAt`, `cleanupReason`, and `cleanupEligibleAt` when transitioning status away from `archived`/`cleanup_failed`. `cleanupReason`/`cleanupEligibleAt` are cleared unconditionally (even if `closedAt` was null — edge case from partial failure paths).
- **`packages/shared/src/__tests__/execution-workspace-guards.test.ts`**: 7 unit tests for `isClosedIsolatedExecutionWorkspace` covering all closure states.
- **`docs/guides/board-operator/execution-workspaces-and-runtime-services.md`**: Operator note documenting root cause and prevention guidance for archived-workspace lockouts.

## Verification

- `npx vitest run packages/shared/src/__tests__/execution-workspace-guards.test.ts` — 7 tests pass
- `npx vitest run server/src/__tests__/execution-workspaces-routes.test.ts` — passes
- `npx vitest run server/src/__tests__/issue-closed-workspace-routes.test.ts` — 4 tests pass

## Risks

Low risk. The change only affects the un-archive path. It clears three fields (`closedAt`, `cleanupReason`, `cleanupEligibleAt`) that should have been cleared during un-archive. No behavioral change for other status transitions. The `cleanupReason`/`cleanupEligibleAt` unconditional clear is safe — these fields are only relevant for cleanup-failed/archived workspaces and should not persist after reactivation.

## Model Used

- **Provider**: DeepSeek
- **Model**: deepseek-v4-pro (via Paperclip opencode_local adapter)
- **Context**: Standard session context
- **Capabilities**: Tool use, code editing, reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge