### PR TITLE
Add experimental flags for local auth and agent routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ tmp/
 feedback-export-*
 diagnostics/
 
+# Local custom Docker/config overrides
+docker/custom-configs/
+
 # Editor / tool temp files
 *.tmp
 .vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN pnpm install --frozen-lockfile
 
 FROM base AS build
 WORKDIR /app
+ARG VITE_PAPERCLIP_EXPERIMENTAL_MODE=false
+ENV VITE_PAPERCLIP_EXPERIMENTAL_MODE=${VITE_PAPERCLIP_EXPERIMENTAL_MODE}
 COPY --from=deps /app /app
 COPY . .
 RUN pnpm --filter @paperclipai/ui build

--- a/packages/shared/src/experimental-features.ts
+++ b/packages/shared/src/experimental-features.ts
@@ -1,0 +1,85 @@
+import type { HumanCompanyMembershipRole } from "./constants.js";
+
+export const EXPERIMENTAL_FEATURE_KEYS = [
+  "unauthenticated_login",
+  "agent_dual_mode",
+] as const;
+
+export type ExperimentalFeatureKey = (typeof EXPERIMENTAL_FEATURE_KEYS)[number];
+
+export interface ExperimentalFeatureDefinition {
+  key: ExperimentalFeatureKey;
+  title: string;
+  description: string;
+  warning?: string;
+  defaultEnabled: false;
+  requiresDevelopmentEnvironment?: boolean;
+}
+
+export type ExperimentalAgentProvider = "claude" | "codex";
+
+export interface ExperimentalAgentDualModeConfig {
+  primaryAgent?: ExperimentalAgentProvider;
+  primaryModel?: string | null;
+  secondaryAgent?: ExperimentalAgentProvider;
+  secondaryModel?: string | null;
+}
+
+export interface ExperimentalUnauthenticatedLoginConfig {
+  accessLevel?: HumanCompanyMembershipRole;
+}
+
+export interface CompanyExperimentalFeaturesConfig {
+  enabledFeatures?: Partial<Record<ExperimentalFeatureKey, boolean>>;
+  unauthenticatedLogin?: ExperimentalUnauthenticatedLoginConfig;
+  agentDualMode?: ExperimentalAgentDualModeConfig;
+}
+
+export interface CompanyConfig {
+  experimentalFeatures?: CompanyExperimentalFeaturesConfig;
+}
+
+export type CompanyExperimentalFeaturesByCompanyId = Record<string, CompanyExperimentalFeaturesConfig>;
+
+export interface ExperimentalFeatureResolverInput {
+  feature: ExperimentalFeatureKey;
+  environmentExperimentalModeEnabled: boolean;
+  isDevelopmentEnvironment: boolean;
+  companyEnabledFeatures?: Partial<Record<ExperimentalFeatureKey, boolean>>;
+}
+
+export const PAPERCLIP_EXPERIMENTAL_MODE_ENV = "PAPERCLIP_EXPERIMENTAL_MODE";
+
+export const EXPERIMENTAL_FEATURES: ExperimentalFeatureDefinition[] = [
+  {
+    key: "unauthenticated_login",
+    title: "Join without login",
+    description: "Allows entering the app without signing in when explicitly enabled for this company.",
+    warning: "Only available when PAPERCLIP_EXPERIMENTAL_MODE is enabled for this environment.",
+    defaultEnabled: false,
+    requiresDevelopmentEnvironment: true,
+  },
+  {
+    key: "agent_dual_mode",
+    title: "Dual-mode agent routing",
+    description: "Enables experimental primary/secondary agent routing when explicitly enabled for this company.",
+    warning: "Experimental agent routing must remain policy validated.",
+    defaultEnabled: false,
+    requiresDevelopmentEnvironment: true,
+  },
+];
+
+export function isPaperclipExperimentalModeEnabled(
+  env: Record<string, string | undefined>,
+): boolean {
+  return env[PAPERCLIP_EXPERIMENTAL_MODE_ENV] === "true";
+}
+
+export function isExperimentalFeatureEnabled(input: ExperimentalFeatureResolverInput): boolean {
+  const definition = EXPERIMENTAL_FEATURES.find((feature) => feature.key === input.feature);
+
+  if (!definition) return false;
+  if (!input.environmentExperimentalModeEnabled) return false;
+
+  return input.companyEnabledFeatures?.[input.feature] === true;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -303,6 +303,14 @@ export type {
   AgentSkillEntry,
   AgentSkillSnapshot,
   AgentSkillSyncRequest,
+  CompanyExperimentalFeaturesByCompanyId,
+  CompanyExperimentalFeaturesConfig,
+  CompanyConfig,
+  ExperimentalAgentDualModeConfig,
+  ExperimentalAgentProvider,
+  ExperimentalFeatureDefinition,
+  ExperimentalFeatureKey,
+  ExperimentalFeatureResolverInput,
   InstanceExperimentalSettings,
   InstanceGeneralSettings,
   InstanceSettings,
@@ -680,6 +688,14 @@ export {
 } from "./types/instance.js";
 
 export {
+  EXPERIMENTAL_FEATURES,
+  EXPERIMENTAL_FEATURE_KEYS,
+  PAPERCLIP_EXPERIMENTAL_MODE_ENV,
+  isExperimentalFeatureEnabled,
+  isPaperclipExperimentalModeEnabled,
+} from "./experimental-features.js";
+
+export {
   getClosedIsolatedExecutionWorkspaceMessage,
   isClosedIsolatedExecutionWorkspace,
 } from "./execution-workspace-guards.js";
@@ -691,6 +707,10 @@ export {
   instanceExperimentalSettingsSchema,
   patchInstanceExperimentalSettingsSchema,
   issueGraphLivenessAutoRecoveryRequestSchema,
+  companyExperimentalFeaturesConfigSchema,
+  experimentalAgentDualModeConfigSchema,
+  experimentalAgentProviderSchema,
+  experimentalFeatureKeySchema,
   type PatchInstanceExperimentalSettings,
   type IssueGraphLivenessAutoRecoveryRequest,
 } from "./validators/index.js";

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -41,6 +41,16 @@ export {
   MAX_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
 } from "./instance.js";
 export type {
+  CompanyExperimentalFeaturesByCompanyId,
+  CompanyExperimentalFeaturesConfig,
+  CompanyConfig,
+  ExperimentalAgentDualModeConfig,
+  ExperimentalAgentProvider,
+  ExperimentalFeatureDefinition,
+  ExperimentalFeatureKey,
+  ExperimentalFeatureResolverInput,
+} from "../experimental-features.js";
+export type {
   CompanySkillSourceType,
   CompanySkillTrustLevel,
   CompanySkillCompatibility,

--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -1,4 +1,5 @@
 import type { FeedbackDataSharingPreference } from "./feedback.js";
+import type { CompanyExperimentalFeaturesByCompanyId } from "../experimental-features.js";
 
 export const DAILY_RETENTION_PRESETS = [3, 7, 14] as const;
 export const WEEKLY_RETENTION_PRESETS = [1, 2, 4] as const;
@@ -32,6 +33,7 @@ export interface InstanceExperimentalSettings {
   autoRestartDevServerWhenIdle: boolean;
   enableIssueGraphLivenessAutoRecovery: boolean;
   issueGraphLivenessAutoRecoveryLookbackHours: number;
+  companyExperimentalFeatures: CompanyExperimentalFeaturesByCompanyId;
 }
 
 export interface InstanceSettings {

--- a/packages/shared/src/validators/experimental-features.ts
+++ b/packages/shared/src/validators/experimental-features.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { HUMAN_COMPANY_MEMBERSHIP_ROLES } from "../constants.js";
+import { EXPERIMENTAL_FEATURE_KEYS } from "../experimental-features.js";
+
+export const experimentalFeatureKeySchema = z.enum(EXPERIMENTAL_FEATURE_KEYS);
+export const experimentalAgentProviderSchema = z.enum(["claude", "codex"]);
+
+export const experimentalAgentDualModeConfigSchema = z
+  .object({
+    primaryAgent: experimentalAgentProviderSchema.optional(),
+    primaryModel: z.string().trim().min(1).nullable().optional(),
+    secondaryAgent: experimentalAgentProviderSchema.optional(),
+    secondaryModel: z.string().trim().min(1).nullable().optional(),
+  })
+  .strict();
+
+export const experimentalUnauthenticatedLoginConfigSchema = z
+  .object({
+    accessLevel: z.enum(HUMAN_COMPANY_MEMBERSHIP_ROLES).optional(),
+  })
+  .strict();
+
+export const companyExperimentalFeaturesConfigSchema = z
+  .object({
+    enabledFeatures: z.record(experimentalFeatureKeySchema, z.boolean()).optional(),
+    unauthenticatedLogin: experimentalUnauthenticatedLoginConfigSchema.optional(),
+    agentDualMode: experimentalAgentDualModeConfigSchema.optional(),
+  })
+  .strict();

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -12,6 +12,13 @@ export {
 } from "./instance.js";
 
 export {
+  companyExperimentalFeaturesConfigSchema,
+  experimentalAgentDualModeConfigSchema,
+  experimentalAgentProviderSchema,
+  experimentalFeatureKeySchema,
+} from "./experimental-features.js";
+
+export {
   upsertBudgetPolicySchema,
   resolveBudgetIncidentSchema,
   type UpsertBudgetPolicy,

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -10,6 +10,7 @@ import {
   MIN_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
 } from "../types/instance.js";
 import { feedbackDataSharingPreferenceSchema } from "./feedback.js";
+import { companyExperimentalFeaturesConfigSchema } from "./experimental-features.js";
 
 function presetSchema<T extends readonly number[]>(presets: T, label: string) {
   return z.number().refine(
@@ -46,6 +47,7 @@ export const instanceExperimentalSettingsSchema = z.object({
     .min(MIN_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS)
     .max(MAX_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS)
     .default(DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS),
+  companyExperimentalFeatures: z.record(z.string(), companyExperimentalFeaturesConfigSchema).default({}),
 }).strict();
 
 export const patchInstanceExperimentalSettingsSchema = instanceExperimentalSettingsSchema.partial();

--- a/server/src/__tests__/auth-routes.test.ts
+++ b/server/src/__tests__/auth-routes.test.ts
@@ -161,4 +161,91 @@ describe.sequential("auth routes", () => {
 
     expect(res.status).toBe(400);
   });
+
+  it("returns unavailable for unauthenticated login when no company is selected", async () => {
+    const app = await createApp({ type: "none", source: "none" }, { id: "settings-1", experimental: {} });
+
+    const res = await request(app).get("/api/auth/unauthenticated-login/availability");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ available: false, companyId: null });
+  });
+
+  it("resolves unauthenticated login availability without requiring a board session", async () => {
+    const previousExperimentalMode = process.env.PAPERCLIP_EXPERIMENTAL_MODE;
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.PAPERCLIP_EXPERIMENTAL_MODE = "true";
+    process.env.NODE_ENV = "development";
+
+    try {
+      const app = await createApp(
+        { type: "none", source: "none" },
+        {
+          id: "settings-1",
+          experimental: {
+            companyExperimentalFeatures: {
+              "company-1": {
+                enabledFeatures: { unauthenticated_login: true },
+              },
+            },
+          },
+        },
+      );
+
+      const res = await request(app).get("/api/auth/unauthenticated-login/availability?companyId=company-1");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ available: true, companyId: "company-1" });
+    } finally {
+      if (previousExperimentalMode === undefined) {
+        delete process.env.PAPERCLIP_EXPERIMENTAL_MODE;
+      } else {
+        process.env.PAPERCLIP_EXPERIMENTAL_MODE = previousExperimentalMode;
+      }
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
+
+  it("resolves unauthenticated login availability from enabled company config", async () => {
+    const previousExperimentalMode = process.env.PAPERCLIP_EXPERIMENTAL_MODE;
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.PAPERCLIP_EXPERIMENTAL_MODE = "true";
+    process.env.NODE_ENV = "development";
+
+    try {
+      const app = await createApp(
+        { type: "none", source: "none" },
+        {
+          id: "settings-1",
+          experimental: {
+            companyExperimentalFeatures: {
+              "company-1": {
+                enabledFeatures: { unauthenticated_login: true },
+              },
+            },
+          },
+        },
+      );
+
+      const res = await request(app).get("/api/auth/unauthenticated-login/availability");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ available: true, companyId: "company-1" });
+    } finally {
+      if (previousExperimentalMode === undefined) {
+        delete process.env.PAPERCLIP_EXPERIMENTAL_MODE;
+      } else {
+        process.env.PAPERCLIP_EXPERIMENTAL_MODE = previousExperimentalMode;
+      }
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
+    }
+  });
 });

--- a/server/src/__tests__/experimental-features.test.ts
+++ b/server/src/__tests__/experimental-features.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { isExperimentalFeatureEnabled } from "@paperclipai/shared";
+import { AgentRoutingService } from "../services/experimental-agent-routing.js";
+
+const enabledCompanyFeatures = {
+  enabledFeatures: {
+    agent_dual_mode: true,
+  },
+};
+
+describe("experimental feature resolver", () => {
+  it("requires environment mode and company flag", () => {
+    expect(isExperimentalFeatureEnabled({
+      feature: "unauthenticated_login",
+      environmentExperimentalModeEnabled: false,
+      isDevelopmentEnvironment: true,
+      companyEnabledFeatures: { unauthenticated_login: true },
+    })).toBe(false);
+    expect(isExperimentalFeatureEnabled({
+      feature: "unauthenticated_login",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: false,
+      companyEnabledFeatures: { unauthenticated_login: true },
+    })).toBe(true);
+    expect(isExperimentalFeatureEnabled({
+      feature: "unauthenticated_login",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: true,
+      companyEnabledFeatures: {},
+    })).toBe(false);
+    expect(isExperimentalFeatureEnabled({
+      feature: "unauthenticated_login",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: true,
+      companyEnabledFeatures: { unauthenticated_login: true },
+    })).toBe(true);
+  });
+});
+
+describe("experimental agent routing", () => {
+  const routing = new AgentRoutingService();
+
+  it("keeps default routing unless the agent dual mode flag resolves enabled", () => {
+    expect(routing.resolve({
+      organizationConfig: { dualMode: true, primaryAgent: "claude", secondaryAgent: "codex" },
+      claudeStatus: "unavailable",
+      codexStatus: "available",
+      environmentExperimentalModeEnabled: false,
+      isDevelopmentEnvironment: true,
+      companyExperimentalFeatures: enabledCompanyFeatures,
+    })).toBe("claude");
+
+    expect(routing.resolve({
+      organizationConfig: { dualMode: true, primaryAgent: "claude", secondaryAgent: "codex" },
+      claudeStatus: "unavailable",
+      codexStatus: "available",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: true,
+      companyExperimentalFeatures: enabledCompanyFeatures,
+    })).toBe("codex");
+  });
+
+  it("can resolve routing from company experimental dual-mode config", () => {
+    expect(routing.resolve({
+      claudeStatus: "unavailable",
+      codexStatus: "available",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: true,
+      companyExperimentalFeatures: {
+        enabledFeatures: { agent_dual_mode: true },
+        agentDualMode: {
+          primaryAgent: "claude",
+          primaryModel: "claude-sonnet-4-5",
+          secondaryAgent: "codex",
+          secondaryModel: "gpt-5.4-codex",
+        },
+      },
+    })).toBe("codex");
+  });
+
+  it("resolves an execution adapter without rewriting non-primary adapters", () => {
+    expect(routing.resolveExecution({
+      currentAdapterType: "claude_local",
+      claudeStatus: "tokens_empty",
+      codexStatus: "available",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: true,
+      companyExperimentalFeatures: {
+        enabledFeatures: { agent_dual_mode: true },
+        agentDualMode: {
+          primaryAgent: "claude",
+          primaryModel: "claude-sonnet-4-5",
+          secondaryAgent: "codex",
+          secondaryModel: "gpt-5.3-codex",
+        },
+      },
+    })).toEqual({
+      provider: "codex",
+      adapterType: "codex_local",
+      model: "gpt-5.3-codex",
+      routed: true,
+    });
+
+    expect(routing.resolveExecution({
+      currentAdapterType: "codex_local",
+      claudeStatus: "tokens_empty",
+      codexStatus: "available",
+      environmentExperimentalModeEnabled: true,
+      isDevelopmentEnvironment: true,
+      companyExperimentalFeatures: {
+        enabledFeatures: { agent_dual_mode: true },
+        agentDualMode: {
+          primaryAgent: "claude",
+          secondaryAgent: "codex",
+        },
+      },
+    })).toMatchObject({
+      provider: "codex",
+      adapterType: "codex_local",
+      routed: false,
+    });
+  });
+});

--- a/server/src/development-environment.ts
+++ b/server/src/development-environment.ts
@@ -1,0 +1,3 @@
+export function isDevelopmentEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.NODE_ENV === "development";
+}

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -8,6 +8,7 @@ import type { DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
+import { resolveUnauthenticatedLoginSession } from "../services/unauthenticated-login-session.js";
 
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
@@ -90,6 +91,17 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
             isInstanceAdmin: Boolean(roleRow),
             runId: runIdHeader ?? undefined,
             source: "session",
+          };
+          next();
+          return;
+        }
+      }
+      if (opts.deploymentMode === "authenticated") {
+        const unauthenticatedLoginActor = await resolveUnauthenticatedLoginSession(db, req.header("cookie"));
+        if (unauthenticatedLoginActor) {
+          req.actor = {
+            ...unauthenticatedLoginActor,
+            runId: runIdHeader ?? undefined,
           };
           next();
           return;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -9,6 +9,12 @@ import {
 } from "@paperclipai/shared";
 import { unauthorized } from "../errors.js";
 import { validate } from "../middleware/validate.js";
+import {
+  createUnauthenticatedLoginSession,
+  isUnauthenticatedLoginAvailable,
+  resolveUnauthenticatedLoginCompanyId,
+  serializeUnauthenticatedLoginCookie,
+} from "../services/unauthenticated-login-session.js";
 
 async function loadCurrentUserProfile(db: Db, userId: string) {
   const user = await db
@@ -36,6 +42,26 @@ async function loadCurrentUserProfile(db: Db, userId: string) {
 
 export function authRoutes(db: Db) {
   const router = Router();
+
+  router.get("/unauthenticated-login/availability", async (req, res) => {
+    const companyId = typeof req.query.companyId === "string" ? req.query.companyId.trim() : "";
+    const resolvedCompanyId = companyId || await resolveUnauthenticatedLoginCompanyId(db);
+    const available = resolvedCompanyId ? await isUnauthenticatedLoginAvailable(db, resolvedCompanyId) : false;
+
+    res.json({ available, companyId: available ? resolvedCompanyId : null });
+  });
+
+  router.post("/unauthenticated-login/session", async (req, res) => {
+    const companyId = typeof req.body?.companyId === "string" ? req.body.companyId.trim() : "";
+    const token = await createUnauthenticatedLoginSession(db, companyId);
+    if (!token) {
+      res.status(403).json({ error: "Unauthenticated development entry is disabled." });
+      return;
+    }
+
+    res.setHeader("Set-Cookie", serializeUnauthenticatedLoginCookie(token));
+    res.json({ ok: true });
+  });
 
   router.get("/get-session", async (req, res) => {
     if (req.actor.type !== "board" || !req.actor.userId) {

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -6,6 +6,7 @@ import {
   companyPortabilityImportSchema,
   companyPortabilityPreviewSchema,
   createCompanySchema,
+  companyExperimentalFeaturesConfigSchema,
   feedbackTargetTypeSchema,
   feedbackTraceStatusSchema,
   feedbackVoteValueSchema,
@@ -21,6 +22,7 @@ import {
   companyPortabilityService,
   companyService,
   feedbackService,
+  instanceSettingsService,
   logActivity,
 } from "../services/index.js";
 import type { StorageService } from "../storage/types.js";
@@ -353,6 +355,36 @@ export function companyRoutes(db: Db, storage?: StorageService) {
     });
     res.json(company);
   });
+
+  router.patch(
+    "/:companyId/experimental-features",
+    validate(companyExperimentalFeaturesConfigSchema),
+    async (req, res) => {
+      assertBoard(req);
+      const companyId = req.params.companyId as string;
+      assertInstanceAdmin(req);
+      const company = await svc.getById(companyId);
+      if (!company) {
+        res.status(404).json({ error: "Company not found" });
+        return;
+      }
+      const instanceSettings = instanceSettingsService(db);
+      const updated = await instanceSettings.updateCompanyExperimentalFeatures(companyId, req.body);
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "company.experimental_features_updated",
+        entityType: "company",
+        entityId: companyId,
+        details: req.body,
+      });
+      res.json(updated.experimental.companyExperimentalFeatures[companyId] ?? {});
+    },
+  );
 
   router.patch("/:companyId/branding", validate(updateCompanyBrandingSchema), async (req, res) => {
     const companyId = req.params.companyId as string;

--- a/server/src/services/experimental-agent-routing.ts
+++ b/server/src/services/experimental-agent-routing.ts
@@ -1,0 +1,141 @@
+import {
+  isExperimentalFeatureEnabled,
+  isPaperclipExperimentalModeEnabled,
+  type CompanyExperimentalFeaturesConfig,
+} from "@paperclipai/shared";
+import { isDevelopmentEnvironment } from "../development-environment.js";
+
+export type AgentProvider = "claude" | "codex";
+export type AgentStatus = "available" | "tokens_low" | "tokens_empty" | "rate_limited" | "unavailable" | "unknown";
+
+export interface OrganizationAgentConfig {
+  dualMode?: boolean;
+  primaryAgent?: AgentProvider;
+  primaryModel?: string | null;
+  secondaryAgent?: AgentProvider;
+  secondaryModel?: string | null;
+}
+
+export interface AgentRoutingInput {
+  organizationConfig?: OrganizationAgentConfig | null;
+  claudeStatus?: AgentStatus;
+  codexStatus?: AgentStatus;
+  companyExperimentalFeatures?: CompanyExperimentalFeaturesConfig | null;
+  environmentExperimentalModeEnabled?: boolean;
+  isDevelopmentEnvironment?: boolean;
+}
+
+export const DEFAULT_ORGANIZATION_AGENT_CONFIG = {
+  dualMode: false,
+  primaryAgent: "claude",
+  primaryModel: null,
+  secondaryAgent: "codex",
+  secondaryModel: null,
+} satisfies Required<OrganizationAgentConfig>;
+
+export function adapterTypeForAgentProvider(provider: AgentProvider): "claude_local" | "codex_local" {
+  return provider === "claude" ? "claude_local" : "codex_local";
+}
+
+export function agentProviderForAdapterType(adapterType: string | null | undefined): AgentProvider | null {
+  if (adapterType === "claude_local") return "claude";
+  if (adapterType === "codex_local") return "codex";
+  return null;
+}
+
+function isAgentProvider(value: unknown): value is AgentProvider {
+  return value === "claude" || value === "codex";
+}
+
+function normalizeOrganizationAgentConfig(input?: OrganizationAgentConfig | null) {
+  if (!input || typeof input !== "object") return DEFAULT_ORGANIZATION_AGENT_CONFIG;
+  const primaryAgent = isAgentProvider(input.primaryAgent)
+    ? input.primaryAgent
+    : DEFAULT_ORGANIZATION_AGENT_CONFIG.primaryAgent;
+  const secondaryAgent = isAgentProvider(input.secondaryAgent)
+    ? input.secondaryAgent
+    : DEFAULT_ORGANIZATION_AGENT_CONFIG.secondaryAgent;
+  if (primaryAgent === secondaryAgent) return DEFAULT_ORGANIZATION_AGENT_CONFIG;
+  return {
+    dualMode: input.dualMode === true,
+    primaryAgent,
+    primaryModel: typeof input.primaryModel === "string" ? input.primaryModel : null,
+    secondaryAgent,
+    secondaryModel: typeof input.secondaryModel === "string" ? input.secondaryModel : null,
+  };
+}
+
+function resolveOrganizationAgentConfig(input: AgentRoutingInput): OrganizationAgentConfig | null | undefined {
+  if (input.organizationConfig) return input.organizationConfig;
+  if (!input.companyExperimentalFeatures?.agentDualMode) return input.organizationConfig;
+  return {
+    dualMode: input.companyExperimentalFeatures.enabledFeatures?.agent_dual_mode === true,
+    ...input.companyExperimentalFeatures.agentDualMode,
+  };
+}
+
+function isAgentDualModeEnabled(input: AgentRoutingInput): boolean {
+  return isExperimentalFeatureEnabled({
+    feature: "agent_dual_mode",
+    environmentExperimentalModeEnabled:
+      input.environmentExperimentalModeEnabled ?? isPaperclipExperimentalModeEnabled(process.env),
+    isDevelopmentEnvironment: input.isDevelopmentEnvironment ?? isDevelopmentEnvironment(),
+    companyEnabledFeatures: input.companyExperimentalFeatures?.enabledFeatures,
+  });
+}
+
+function validateAgentRoutingPolicy(input: AgentRoutingInput, config: Required<OrganizationAgentConfig>): boolean {
+  if (!isAgentDualModeEnabled(input)) return false;
+  if (!config.dualMode) return false;
+  return config.primaryAgent !== config.secondaryAgent;
+}
+
+export class AgentRoutingService {
+  resolve(input: AgentRoutingInput): AgentProvider {
+    const config = normalizeOrganizationAgentConfig(resolveOrganizationAgentConfig(input));
+    if (!validateAgentRoutingPolicy(input, config)) return config.primaryAgent;
+    if (this.isAgentAvailable(config.primaryAgent, input)) return config.primaryAgent;
+    if (this.isAgentAvailable(config.secondaryAgent, input)) return config.secondaryAgent;
+    return config.primaryAgent;
+  }
+
+  resolveExecution(input: AgentRoutingInput & { currentAdapterType: string }): {
+    provider: AgentProvider | null;
+    adapterType: string;
+    model: string | null;
+    routed: boolean;
+  } {
+    const currentProvider = agentProviderForAdapterType(input.currentAdapterType);
+    if (!currentProvider) {
+      return {
+        provider: null,
+        adapterType: input.currentAdapterType,
+        model: null,
+        routed: false,
+      };
+    }
+
+    const config = normalizeOrganizationAgentConfig(resolveOrganizationAgentConfig(input));
+    if (!validateAgentRoutingPolicy(input, config) || currentProvider !== config.primaryAgent) {
+      return {
+        provider: currentProvider,
+        adapterType: input.currentAdapterType,
+        model: currentProvider === config.primaryAgent ? config.primaryModel : config.secondaryModel,
+        routed: false,
+      };
+    }
+
+    const provider = this.resolve(input);
+    return {
+      provider,
+      adapterType: adapterTypeForAgentProvider(provider),
+      model: provider === config.primaryAgent ? config.primaryModel : config.secondaryModel,
+      routed: provider !== currentProvider,
+    };
+  }
+
+  private isAgentAvailable(agent: AgentProvider, input: AgentRoutingInput): boolean {
+    const status = agent === "claude" ? input.claudeStatus : input.codexStatus;
+    return status === "available" || status === "tokens_low" || status === "unknown" || status === undefined;
+  }
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -20,6 +20,7 @@ import {
   type ModelProfileKey,
   type RunLivenessState,
 } from "@paperclipai/shared";
+import { DEFAULT_CODEX_LOCAL_MODEL } from "@paperclipai/adapter-codex-local";
 import {
   agents,
   agentRuntimeState,
@@ -165,11 +166,18 @@ import { environmentRuntimeService } from "./environment-runtime.js";
 import { environmentRunOrchestrator } from "./environment-run-orchestrator.js";
 import { isUnsafeSessionWorkspaceCwd } from "./session-workspace-cwd.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
+import {
+  AgentRoutingService,
+  adapterTypeForAgentProvider,
+  type AgentProvider,
+  type AgentStatus,
+} from "./experimental-agent-routing.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const MAX_PERSISTED_LOG_CHUNK_CHARS = 64 * 1024;
 const MAX_RUN_EVENT_PAYLOAD_STRING_CHARS = 16 * 1024;
 const MAX_RUN_EVENT_PAYLOAD_ARRAY_ITEMS = 50;
+const EXPERIMENTAL_AGENT_ROUTING_STATUS_LOOKBACK_MS = 2 * 60 * 60 * 1000;
 
 export function redactDetectedSuccessfulRunProgressSummaryForBoard(
   summary: string,
@@ -2333,6 +2341,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   });
   const workspaceOperationsSvc = workspaceOperationService(db);
   const activeRunExecutions = new Set<string>();
+  const agentRouting = new AgentRoutingService();
   const budgetHooks = {
     cancelWorkForScope: cancelBudgetScopeWork,
   };
@@ -6764,6 +6773,102 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     });
   }
 
+  function isExperimentalProviderQuotaBlocked(error: string | null | undefined): boolean {
+    const normalized = (error ?? "").toLowerCase();
+    return (
+      normalized.includes("hit your limit") ||
+      normalized.includes("usage limit") ||
+      normalized.includes("rate limit") ||
+      normalized.includes("rate_limited") ||
+      normalized.includes("quota")
+    );
+  }
+
+  async function resolveExperimentalProviderStatus(
+    companyId: string,
+    provider: AgentProvider,
+    currentRunId: string,
+  ): Promise<AgentStatus> {
+    const adapterType = adapterTypeForAgentProvider(provider);
+    const cutoff = new Date(Date.now() - EXPERIMENTAL_AGENT_ROUTING_STATUS_LOOKBACK_MS);
+    const recentRuns = await db
+      .select({
+        id: heartbeatRuns.id,
+        status: heartbeatRuns.status,
+        error: heartbeatRuns.error,
+      })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+      .where(and(
+        eq(heartbeatRuns.companyId, companyId),
+        eq(agents.adapterType, adapterType),
+        eq(heartbeatRuns.status, "failed"),
+        gt(heartbeatRuns.createdAt, cutoff),
+      ))
+      .orderBy(desc(heartbeatRuns.createdAt))
+      .limit(50);
+
+    if (recentRuns.some((row) => row.id !== currentRunId && isExperimentalProviderQuotaBlocked(row.error))) {
+      return provider === "claude" ? "tokens_empty" : "rate_limited";
+    }
+
+    return "available";
+  }
+
+  async function resolveExperimentalRoutedAgent(
+    agent: typeof agents.$inferSelect,
+    run: typeof heartbeatRuns.$inferSelect,
+  ): Promise<typeof agents.$inferSelect> {
+    const experimentalSettings = await instanceSettings.getExperimental();
+    const companyExperimentalFeatures = experimentalSettings.companyExperimentalFeatures[agent.companyId];
+    const routing = agentRouting.resolveExecution({
+      currentAdapterType: agent.adapterType,
+      companyExperimentalFeatures,
+      claudeStatus: await resolveExperimentalProviderStatus(agent.companyId, "claude", run.id),
+      codexStatus: await resolveExperimentalProviderStatus(agent.companyId, "codex", run.id),
+    });
+
+    if (!routing.routed || !routing.provider) return agent;
+
+    const nextConfig = {
+      ...parseObject(agent.adapterConfig),
+    };
+    if (routing.model) {
+      nextConfig.model = routing.model;
+    } else if (routing.provider === "codex") {
+      nextConfig.model = DEFAULT_CODEX_LOCAL_MODEL;
+    } else {
+      delete nextConfig.model;
+    }
+    if (routing.provider === "codex") {
+      nextConfig.command = typeof nextConfig.command === "string" && nextConfig.command.trim()
+        ? nextConfig.command
+        : "codex";
+      nextConfig.dangerouslyBypassApprovalsAndSandbox = asBoolean(
+        nextConfig.dangerouslyBypassApprovalsAndSandbox,
+        asBoolean(nextConfig.dangerouslySkipPermissions, true),
+      );
+    }
+
+    logger.info(
+      {
+        companyId: agent.companyId,
+        agentId: agent.id,
+        runId: run.id,
+        fromAdapterType: agent.adapterType,
+        toAdapterType: routing.adapterType,
+        provider: routing.provider,
+      },
+      "experimental dual-mode agent routing selected alternate adapter",
+    );
+
+    return {
+      ...agent,
+      adapterType: routing.adapterType,
+      adapterConfig: nextConfig,
+    };
+  }
+
   async function executeRun(runId: string) {
     let run = await getRun(runId);
     if (!run) return;
@@ -6781,7 +6886,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     activeRunExecutions.add(run.id);
 
     try {
-    const agent = await getAgent(run.agentId);
+    let agent = await getAgent(run.agentId);
     if (!agent) {
       await setRunStatus(runId, "failed", {
         error: "Agent not found",
@@ -6796,6 +6901,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (failedRun) await releaseIssueExecutionAndPromote(failedRun);
       return;
     }
+    agent = await resolveExperimentalRoutedAgent(agent, run);
 
     const runtime = await ensureRuntimeState(agent);
     const context = parseObject(run.contextSnapshot);

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -11,8 +11,9 @@ import {
   type PatchInstanceGeneralSettings,
   type InstanceSettings,
   type PatchInstanceExperimentalSettings,
+  type CompanyExperimentalFeaturesConfig,
 } from "@paperclipai/shared";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 const DEFAULT_SINGLETON_KEY = "default";
 
@@ -46,6 +47,7 @@ function normalizeExperimentalSettings(raw: unknown): InstanceExperimentalSettin
       issueGraphLivenessAutoRecoveryLookbackHours:
         parsed.data.issueGraphLivenessAutoRecoveryLookbackHours ??
         DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
+      companyExperimentalFeatures: parsed.data.companyExperimentalFeatures ?? {},
     };
   }
   return {
@@ -55,6 +57,7 @@ function normalizeExperimentalSettings(raw: unknown): InstanceExperimentalSettin
     enableIssueGraphLivenessAutoRecovery: false,
     issueGraphLivenessAutoRecoveryLookbackHours:
       DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
+    companyExperimentalFeatures: {},
   };
 }
 
@@ -154,6 +157,95 @@ export function instanceSettingsService(db: Db) {
         .where(eq(instanceSettings.id, current.id))
         .returning();
       return toInstanceSettings(updated ?? current);
+    },
+
+    updateCompanyExperimentalFeatures: async (
+      companyId: string,
+      config: CompanyExperimentalFeaturesConfig,
+    ): Promise<InstanceSettings> => {
+      return db.transaction(async (tx) => {
+        let current = await tx
+          .select()
+          .from(instanceSettings)
+          .where(eq(instanceSettings.singletonKey, DEFAULT_SINGLETON_KEY))
+          .then((rows) => rows[0] ?? null);
+
+        if (!current) {
+          const now = new Date();
+          const [created] = await tx
+            .insert(instanceSettings)
+            .values({
+              singletonKey: DEFAULT_SINGLETON_KEY,
+              general: {},
+              experimental: {},
+              createdAt: now,
+              updatedAt: now,
+            })
+            .onConflictDoUpdate({
+              target: [instanceSettings.singletonKey],
+              set: {
+                updatedAt: now,
+              },
+            })
+            .returning();
+          current = created ?? null;
+        }
+
+        if (!current) throw new Error("Failed to initialize instance settings row");
+
+        await tx.execute(sql`
+          select id
+          from ${instanceSettings}
+          where ${instanceSettings.id} = ${current.id}
+          for update
+        `);
+
+        current = await tx
+          .select()
+          .from(instanceSettings)
+          .where(eq(instanceSettings.id, current.id))
+          .then((rows) => rows[0] ?? current);
+
+        const currentExperimental = normalizeExperimentalSettings(current.experimental);
+        const currentCompanyConfig = currentExperimental.companyExperimentalFeatures[companyId] ?? {};
+        const nextExperimental = normalizeExperimentalSettings({
+          ...currentExperimental,
+          companyExperimentalFeatures: {
+            ...currentExperimental.companyExperimentalFeatures,
+            [companyId]: {
+              ...currentCompanyConfig,
+              enabledFeatures: {
+                ...(currentCompanyConfig.enabledFeatures ?? {}),
+                ...(config.enabledFeatures ?? {}),
+              },
+              unauthenticatedLogin:
+                config.unauthenticatedLogin === undefined
+                  ? currentCompanyConfig.unauthenticatedLogin
+                  : {
+                      ...(currentCompanyConfig.unauthenticatedLogin ?? {}),
+                      ...config.unauthenticatedLogin,
+                    },
+              agentDualMode:
+                config.agentDualMode === undefined
+                  ? currentCompanyConfig.agentDualMode
+                  : {
+                      ...(currentCompanyConfig.agentDualMode ?? {}),
+                      ...config.agentDualMode,
+                    },
+            },
+          },
+        });
+        const now = new Date();
+        const [updated] = await tx
+          .update(instanceSettings)
+          .set({
+            experimental: { ...nextExperimental },
+            updatedAt: now,
+          })
+          .where(eq(instanceSettings.id, current.id))
+          .returning();
+        return toInstanceSettings(updated ?? current);
+      });
     },
 
     listCompanyIds: async (): Promise<string[]> =>

--- a/server/src/services/unauthenticated-login-session.ts
+++ b/server/src/services/unauthenticated-login-session.ts
@@ -1,0 +1,191 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { authUsers, companies, companyMemberships, instanceUserRoles } from "@paperclipai/db";
+import {
+  HUMAN_COMPANY_MEMBERSHIP_ROLES,
+  type HumanCompanyMembershipRole,
+  isExperimentalFeatureEnabled,
+  isPaperclipExperimentalModeEnabled,
+} from "@paperclipai/shared";
+import { isDevelopmentEnvironment } from "../development-environment.js";
+import { instanceSettingsService } from "./instance-settings.js";
+
+export const UNAUTHENTICATED_LOGIN_SESSION_COOKIE = "paperclip_unauthenticated_login";
+
+const LOCAL_BOARD_USER_ID = "local-board";
+const LOCAL_BOARD_USER_EMAIL = "local@paperclip.local";
+const LOCAL_BOARD_USER_NAME = "Board";
+const DEFAULT_UNAUTHENTICATED_LOGIN_ACCESS_LEVEL: HumanCompanyMembershipRole = "viewer";
+const SESSION_TTL_MS = 8 * 60 * 60 * 1000;
+
+type SessionRecord = {
+  companyId: string;
+  expiresAt: number;
+};
+
+const sessions = new Map<string, SessionRecord>();
+
+function cleanupExpiredSessions(now = Date.now()) {
+  for (const [token, session] of sessions.entries()) {
+    if (session.expiresAt <= now) sessions.delete(token);
+  }
+}
+
+export function parseCookieHeader(header: string | undefined, name: string): string | null {
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const [rawKey, ...rawValue] = part.trim().split("=");
+    if (rawKey !== name) continue;
+    return decodeURIComponent(rawValue.join("="));
+  }
+  return null;
+}
+
+export function serializeUnauthenticatedLoginCookie(token: string): string {
+  return [
+    `${UNAUTHENTICATED_LOGIN_SESSION_COOKIE}=${encodeURIComponent(token)}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    `Max-Age=${Math.floor(SESSION_TTL_MS / 1000)}`,
+  ].join("; ");
+}
+
+export async function isUnauthenticatedLoginAvailable(db: Db, companyId: string): Promise<boolean> {
+  if (!companyId) return false;
+
+  const company = await db
+    .select({ id: companies.id })
+    .from(companies)
+    .where(eq(companies.id, companyId))
+    .then((rows) => rows[0] ?? null);
+  if (!company) return false;
+
+  const experimental = await instanceSettingsService(db).getExperimental();
+  const companyExperimentalFeatures = experimental.companyExperimentalFeatures[companyId];
+  return isExperimentalFeatureEnabled({
+    feature: "unauthenticated_login",
+    environmentExperimentalModeEnabled: isPaperclipExperimentalModeEnabled(process.env),
+    isDevelopmentEnvironment: isDevelopmentEnvironment(),
+    companyEnabledFeatures: companyExperimentalFeatures?.enabledFeatures,
+  });
+}
+
+export async function resolveUnauthenticatedLoginCompanyId(db: Db): Promise<string | null> {
+  const experimental = await instanceSettingsService(db).getExperimental();
+  for (const companyId of Object.keys(experimental.companyExperimentalFeatures)) {
+    if (await isUnauthenticatedLoginAvailable(db, companyId)) return companyId;
+  }
+  return null;
+}
+
+async function ensureLocalBoardUser(db: Db) {
+  const now = new Date();
+  await db
+    .insert(authUsers)
+    .values({
+      id: LOCAL_BOARD_USER_ID,
+      name: LOCAL_BOARD_USER_NAME,
+      email: LOCAL_BOARD_USER_EMAIL,
+      emailVerified: true,
+      image: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing({
+      target: authUsers.id,
+    });
+}
+
+async function ensureLocalBoardMembership(db: Db, companyId: string) {
+  const accessLevel = await resolveUnauthenticatedLoginAccessLevel(db, companyId);
+  await db
+    .insert(companyMemberships)
+    .values({
+      companyId,
+      principalType: "user",
+      principalId: LOCAL_BOARD_USER_ID,
+      status: "active",
+      membershipRole: accessLevel,
+    })
+    .onConflictDoUpdate({
+      target: [
+        companyMemberships.companyId,
+        companyMemberships.principalType,
+        companyMemberships.principalId,
+      ],
+      set: {
+        status: "active",
+        membershipRole: accessLevel,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+async function resolveUnauthenticatedLoginAccessLevel(
+  db: Db,
+  companyId: string,
+): Promise<HumanCompanyMembershipRole> {
+  const experimental = await instanceSettingsService(db).getExperimental();
+  const configuredAccessLevel =
+    experimental.companyExperimentalFeatures[companyId]?.unauthenticatedLogin?.accessLevel;
+  return configuredAccessLevel && HUMAN_COMPANY_MEMBERSHIP_ROLES.includes(configuredAccessLevel)
+    ? configuredAccessLevel
+    : DEFAULT_UNAUTHENTICATED_LOGIN_ACCESS_LEVEL;
+}
+
+async function isLocalBoardInstanceAdmin(db: Db): Promise<boolean> {
+  const role = await db
+    .select({ id: instanceUserRoles.id })
+    .from(instanceUserRoles)
+    .where(and(eq(instanceUserRoles.userId, LOCAL_BOARD_USER_ID), eq(instanceUserRoles.role, "instance_admin")))
+    .then((rows) => rows[0] ?? null);
+  return Boolean(role);
+}
+
+export async function createUnauthenticatedLoginSession(db: Db, companyId: string): Promise<string | null> {
+  if (!(await isUnauthenticatedLoginAvailable(db, companyId))) return null;
+
+  await ensureLocalBoardUser(db);
+  await ensureLocalBoardMembership(db, companyId);
+
+  cleanupExpiredSessions();
+  const token = randomUUID();
+  sessions.set(token, {
+    companyId,
+    expiresAt: Date.now() + SESSION_TTL_MS,
+  });
+  return token;
+}
+
+export async function resolveUnauthenticatedLoginSession(
+  db: Db,
+  cookieHeader: string | undefined,
+): Promise<Express.Request["actor"] | null> {
+  const token = parseCookieHeader(cookieHeader, UNAUTHENTICATED_LOGIN_SESSION_COOKIE);
+  if (!token) return null;
+
+  cleanupExpiredSessions();
+  const session = sessions.get(token);
+  if (!session) return null;
+  if (!(await isUnauthenticatedLoginAvailable(db, session.companyId))) {
+    sessions.delete(token);
+    return null;
+  }
+
+  return {
+    type: "board",
+    userId: LOCAL_BOARD_USER_ID,
+    userName: LOCAL_BOARD_USER_NAME,
+    userEmail: LOCAL_BOARD_USER_EMAIL,
+    companyIds: [session.companyId],
+    memberships: [{
+      companyId: session.companyId,
+      membershipRole: await resolveUnauthenticatedLoginAccessLevel(db, session.companyId),
+      status: "active",
+    }],
+    isInstanceAdmin: await isLocalBoardInstanceAdmin(db),
+    source: "session",
+  };
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -29,6 +29,7 @@ import { Costs } from "./pages/Costs";
 import { Activity } from "./pages/Activity";
 import { Inbox } from "./pages/Inbox";
 import { CompanySettings } from "./pages/CompanySettings";
+import { CompanyExperimentalFeatures } from "./pages/CompanyExperimentalFeatures";
 import { CompanyEnvironments } from "./pages/CompanyEnvironments";
 import { CompanyAccess } from "./pages/CompanyAccess";
 import { CompanyInvites } from "./pages/CompanyInvites";
@@ -68,6 +69,7 @@ function boardRoutes() {
       <Route path="onboarding" element={<OnboardingRoutePage />} />
       <Route path="companies" element={<Companies />} />
       <Route path="company/settings" element={<CompanySettings />} />
+      <Route path="company/settings/experimental-features" element={<CompanyExperimentalFeatures />} />
       <Route path="company/settings/environments" element={<CompanyEnvironments />} />
       <Route path="company/settings/access" element={<CompanyAccess />} />
       <Route path="company/settings/invites" element={<CompanyInvites />} />

--- a/ui/src/api/auth.ts
+++ b/ui/src/api/auth.ts
@@ -14,6 +14,11 @@ type AuthErrorBody =
   }
   | null;
 
+type UnauthenticatedLoginAvailability = {
+  available: boolean;
+  companyId?: string | null;
+};
+
 export class AuthApiError extends Error {
   status: number;
   code: string | null;
@@ -89,6 +94,31 @@ async function authPatch<T>(path: string, body: Record<string, unknown>, parse: 
 }
 
 export const authApi = {
+  getUnauthenticatedLoginAvailability: async (companyId?: string | null): Promise<UnauthenticatedLoginAvailability> => {
+    const params = new URLSearchParams();
+    if (companyId) params.set("companyId", companyId);
+    const query = params.toString();
+    const res = await fetch(`/api/auth/unauthenticated-login/availability${query ? `?${query}` : ""}`, {
+      credentials: "include",
+      headers: { Accept: "application/json" },
+    });
+    const payload = await res.json().catch(() => null);
+    if (!res.ok) {
+      throw new Error((payload as { error?: string } | null)?.error ?? `Failed to load availability (${res.status})`);
+    }
+    return {
+      available: payload && typeof payload === "object" && (payload as Record<string, unknown>).available === true,
+      companyId:
+        payload && typeof payload === "object" && typeof (payload as Record<string, unknown>).companyId === "string"
+          ? ((payload as Record<string, unknown>).companyId as string)
+          : null,
+    };
+  },
+
+  startUnauthenticatedLoginSession: async (companyId: string): Promise<void> => {
+    await authPost("/unauthenticated-login/session", { companyId });
+  },
+
   getSession: async (): Promise<AuthSession | null> => {
     const res = await fetch("/api/auth/get-session", {
       credentials: "include",

--- a/ui/src/api/companies.ts
+++ b/ui/src/api/companies.ts
@@ -1,5 +1,6 @@
 import type {
   Company,
+  CompanyExperimentalFeaturesConfig,
   CompanyPortabilityExportRequest,
   CompanyPortabilityExportPreviewResult,
   CompanyPortabilityExportResult,
@@ -42,6 +43,14 @@ export const companiesApi = {
   ) => api.patch<Company>(`/companies/${companyId}`, data),
   updateBranding: (companyId: string, data: UpdateCompanyBranding) =>
     api.patch<Company>(`/companies/${companyId}/branding`, data),
+  updateExperimentalFeatures: (
+    companyId: string,
+    data: CompanyExperimentalFeaturesConfig,
+  ) =>
+    api.patch<CompanyExperimentalFeaturesConfig>(
+      `/companies/${companyId}/experimental-features`,
+      data,
+    ),
   archive: (companyId: string) => api.post<Company>(`/companies/${companyId}/archive`, {}),
   remove: (companyId: string) => api.delete<{ ok: true }>(`/companies/${companyId}`),
   exportBundle: (

--- a/ui/src/components/CompanySettingsSidebar.test.tsx
+++ b/ui/src/components/CompanySettingsSidebar.test.tsx
@@ -10,6 +10,9 @@ const sidebarNavItemMock = vi.hoisted(() => vi.fn());
 const mockSidebarBadgesApi = vi.hoisted(() => ({
   get: vi.fn(),
 }));
+const mockAccessApi = vi.hoisted(() => ({
+  getCurrentBoardAccess: vi.fn(),
+}));
 
 vi.mock("@/lib/router", () => ({
   Link: ({
@@ -61,6 +64,10 @@ vi.mock("@/api/sidebarBadges", () => ({
   sidebarBadgesApi: mockSidebarBadgesApi,
 }));
 
+vi.mock("@/api/access", () => ({
+  accessApi: mockAccessApi,
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -75,6 +82,7 @@ describe("CompanySettingsSidebar", () => {
   let container: HTMLDivElement;
 
   beforeEach(() => {
+    vi.stubEnv("VITE_PAPERCLIP_EXPERIMENTAL_MODE", "true");
     container = document.createElement("div");
     document.body.appendChild(container);
     mockSidebarBadgesApi.get.mockResolvedValue({
@@ -83,11 +91,21 @@ describe("CompanySettingsSidebar", () => {
       failedRuns: 0,
       joinRequests: 2,
     });
+    mockAccessApi.getCurrentBoardAccess.mockResolvedValue({
+      user: { id: "user-1", email: "admin@paperclip.local", name: "Admin", image: null },
+      userId: "user-1",
+      isInstanceAdmin: true,
+      companyIds: ["company-1"],
+      memberships: [],
+      source: "session",
+      keyId: null,
+    });
   });
 
   afterEach(() => {
     container.remove();
     document.body.innerHTML = "";
+    vi.unstubAllEnvs();
     vi.clearAllMocks();
   });
 
@@ -109,6 +127,7 @@ describe("CompanySettingsSidebar", () => {
     expect(container.textContent).toContain("Paperclip");
     expect(container.textContent).toContain("Company Settings");
     expect(container.textContent).toContain("General");
+    expect(container.textContent).toContain("Experimental");
     expect(container.textContent).toContain("Environments");
     expect(container.textContent).toContain("Access");
     expect(container.textContent).toContain("Invites");
@@ -117,6 +136,13 @@ describe("CompanySettingsSidebar", () => {
       expect.objectContaining({
         to: "/company/settings",
         label: "General",
+        end: true,
+      }),
+    );
+    expect(sidebarNavItemMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/company/settings/experimental-features",
+        label: "Experimental",
         end: true,
       }),
     );
@@ -147,6 +173,70 @@ describe("CompanySettingsSidebar", () => {
         to: "/company/settings/secrets",
         label: "Secrets",
         end: true,
+      }),
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("hides the experimental section when experimental mode is disabled", async () => {
+    vi.stubEnv("VITE_PAPERCLIP_EXPERIMENTAL_MODE", "false");
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CompanySettingsSidebar />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(container.textContent).not.toContain("Experimental");
+    expect(sidebarNavItemMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/company/settings/experimental-features",
+      }),
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("hides the experimental section for non-admin users", async () => {
+    mockAccessApi.getCurrentBoardAccess.mockResolvedValue({
+      user: { id: "user-1", email: "member@paperclip.local", name: "Member", image: null },
+      userId: "user-1",
+      isInstanceAdmin: false,
+      companyIds: ["company-1"],
+      memberships: [{ companyId: "company-1", membershipRole: "admin", status: "active" }],
+      source: "session",
+      keyId: null,
+    });
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <CompanySettingsSidebar />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(container.textContent).not.toContain("Experimental");
+    expect(sidebarNavItemMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/company/settings/experimental-features",
       }),
     );
 

--- a/ui/src/components/CompanySettingsSidebar.tsx
+++ b/ui/src/components/CompanySettingsSidebar.tsx
@@ -1,7 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, KeyRound, MailPlus, MonitorCog, Settings, Shield, SlidersHorizontal } from "lucide-react";
+import {
+  ChevronLeft,
+  FlaskConical,
+  KeyRound,
+  MailPlus,
+  MonitorCog,
+  Settings,
+  Shield,
+  SlidersHorizontal,
+} from "lucide-react";
 import { sidebarBadgesApi } from "@/api/sidebarBadges";
 import { ApiError } from "@/api/client";
+import { useExperimentalFeaturesAccess } from "@/hooks/useExperimentalFeaturesAccess";
 import { Link } from "@/lib/router";
 import { queryKeys } from "@/lib/queryKeys";
 import { useCompany } from "@/context/CompanyContext";
@@ -11,6 +21,7 @@ import { SidebarNavItem } from "./SidebarNavItem";
 export function CompanySettingsSidebar() {
   const { selectedCompany, selectedCompanyId } = useCompany();
   const { isMobile, setSidebarOpen } = useSidebar();
+  const { canViewExperimentalFeatures } = useExperimentalFeaturesAccess();
   const { data: badges } = useQuery({
     queryKey: selectedCompanyId
       ? queryKeys.sidebarBadges(selectedCompanyId)
@@ -54,6 +65,14 @@ export function CompanySettingsSidebar() {
       <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide px-3 py-2">
         <div className="flex flex-col gap-0.5">
           <SidebarNavItem to="/company/settings" label="General" icon={SlidersHorizontal} end />
+          {canViewExperimentalFeatures && (
+            <SidebarNavItem
+              to="/company/settings/experimental-features"
+              label="Experimental"
+              icon={FlaskConical}
+              end
+            />
+          )}
           <SidebarNavItem
             to="/company/settings/environments"
             label="Environments"

--- a/ui/src/components/ExperimentalFeaturesSettings.tsx
+++ b/ui/src/components/ExperimentalFeaturesSettings.tsx
@@ -1,0 +1,411 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  EXPERIMENTAL_FEATURES,
+  HUMAN_COMPANY_MEMBERSHIP_ROLE_LABELS,
+  HUMAN_COMPANY_MEMBERSHIP_ROLES,
+  type CompanyExperimentalFeaturesConfig,
+  type ExperimentalAgentProvider,
+  type ExperimentalFeatureDefinition,
+  type HumanCompanyMembershipRole,
+} from "@paperclipai/shared";
+import { agentsApi, type AdapterModel } from "@/api/agents";
+import { companiesApi } from "@/api/companies";
+import { instanceSettingsApi } from "@/api/instanceSettings";
+import { queryKeys } from "@/lib/queryKeys";
+import {
+  isUiExperimentalFeatureEnabled,
+  isUiExperimentalModeEnabled,
+  UI_EXPERIMENTAL_MODE_ENV,
+} from "@/lib/experimental-features";
+import { ToggleSwitch } from "@/components/ui/toggle-switch";
+import { Field } from "@/components/agent-config-primitives";
+
+const agentProviderOptions: Array<{
+  value: ExperimentalAgentProvider;
+  label: string;
+  adapterType: string;
+}> = [
+  { value: "claude", label: "Claude", adapterType: "claude_local" },
+  { value: "codex", label: "Codex", adapterType: "codex_local" },
+];
+
+const selectClassName = "w-full rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none";
+const compactSelectClassName = "min-w-32 rounded-md border border-border bg-transparent px-2.5 py-1.5 text-sm outline-none";
+
+const unauthenticatedAccessLevelOptions = HUMAN_COMPANY_MEMBERSHIP_ROLES.map((value) => ({
+  value,
+  label: HUMAN_COMPANY_MEMBERSHIP_ROLE_LABELS[value],
+}));
+
+function adapterTypeForProvider(provider: ExperimentalAgentProvider) {
+  return agentProviderOptions.find((option) => option.value === provider)?.adapterType ?? "claude_local";
+}
+
+function fallbackProvider(provider: ExperimentalAgentProvider): ExperimentalAgentProvider {
+  return provider === "claude" ? "codex" : "claude";
+}
+
+function modelOptions(models: AdapterModel[] | undefined, selectedModel?: string | null) {
+  const byId = new Map<string, AdapterModel>();
+  for (const model of models ?? []) {
+    byId.set(model.id, model);
+  }
+  if (selectedModel && !byId.has(selectedModel)) {
+    byId.set(selectedModel, { id: selectedModel, label: selectedModel });
+  }
+  return Array.from(byId.values());
+}
+
+function statusForFeature(input: {
+  feature: ExperimentalFeatureDefinition;
+  checked: boolean;
+  enabled: boolean;
+}) {
+  if (input.enabled) return "Enabled";
+  if (input.checked) return "Configured, inactive";
+  return "Off";
+}
+
+export function ExperimentalFeaturesSettings({ companyId }: { companyId: string }) {
+  const queryClient = useQueryClient();
+  const experimentalModeEnabled = isUiExperimentalModeEnabled();
+  const experimentalQuery = useQuery({
+    queryKey: queryKeys.instance.experimentalSettings,
+    queryFn: () => instanceSettingsApi.getExperimental(),
+    retry: false,
+  });
+  const currentConfig = experimentalQuery.data?.companyExperimentalFeatures?.[companyId] ?? {};
+  const enabledFeatures = currentConfig.enabledFeatures ?? {};
+
+  const mutation = useMutation({
+    mutationFn: (nextConfig: CompanyExperimentalFeaturesConfig) =>
+      companiesApi.updateExperimentalFeatures(companyId, nextConfig),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.instance.experimentalSettings,
+      });
+    },
+  });
+
+  return (
+    <div className="space-y-4" data-testid="company-settings-experimental-features-section">
+      <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+        Experimental features
+      </div>
+      <div className="space-y-4 rounded-md border border-border px-4 py-4">
+        <p className="text-sm text-muted-foreground">
+          Enable experimental features for this company. These features may be unstable and are intended for development
+          or local testing.
+        </p>
+
+        {!experimentalModeEnabled && (
+          <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+            Experimental mode is disabled by environment configuration. Enable {UI_EXPERIMENTAL_MODE_ENV} to use these
+            flags.
+          </div>
+        )}
+
+        {experimentalQuery.error && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+            {experimentalQuery.error instanceof Error
+              ? experimentalQuery.error.message
+              : "Failed to load experimental features."}
+          </div>
+        )}
+
+        <div className="divide-y divide-border">
+          {EXPERIMENTAL_FEATURES.map((feature) => {
+            const checked = enabledFeatures[feature.key] === true;
+            const enabled = isUiExperimentalFeatureEnabled(feature.key, currentConfig);
+            const disabled =
+              mutation.isPending ||
+              experimentalQuery.isLoading ||
+              !experimentalModeEnabled;
+            return (
+              <div key={feature.key} className="flex items-start justify-between gap-4 py-4 first:pt-0 last:pb-0">
+                <div className="min-w-0 space-y-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-sm font-medium">{feature.title}</h3>
+                    <span className="rounded-sm bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+                      {statusForFeature({ feature, checked, enabled })}
+                    </span>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{feature.description}</p>
+                  {feature.warning && (
+                    <p className="text-xs text-amber-700 dark:text-amber-300">{feature.warning}</p>
+                  )}
+                </div>
+                <div className="flex shrink-0 items-start gap-3">
+                  <ToggleSwitch
+                    checked={checked}
+                    disabled={disabled}
+                    onCheckedChange={(nextChecked) =>
+                      mutation.mutate({
+                        ...currentConfig,
+                        enabledFeatures: {
+                          ...enabledFeatures,
+                          [feature.key]: nextChecked,
+                        },
+                      })
+                    }
+                    aria-label={`Toggle ${feature.title}`}
+                  />
+                  {feature.key === "unauthenticated_login" && (
+                    <label className="space-y-1 text-xs text-muted-foreground">
+                      <span>Access level</span>
+                      <select
+                        className={compactSelectClassName}
+                        value={currentConfig.unauthenticatedLogin?.accessLevel ?? "viewer"}
+                        disabled={disabled}
+                        onChange={(event) =>
+                          mutation.mutate({
+                            ...currentConfig,
+                            enabledFeatures,
+                            unauthenticatedLogin: {
+                              ...(currentConfig.unauthenticatedLogin ?? {}),
+                              accessLevel: event.target.value as HumanCompanyMembershipRole,
+                            },
+                          })
+                        }
+                        aria-label="Join without login access level"
+                      >
+                        {unauthenticatedAccessLevelOptions.map((option) => (
+                          <option key={option.value} value={option.value}>{option.label}</option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <DualModeAgentRoutingConfig
+          companyId={companyId}
+          currentConfig={currentConfig}
+          experimentalModeEnabled={experimentalModeEnabled}
+          loading={experimentalQuery.isLoading}
+          saving={mutation.isPending}
+          onChange={(agentDualMode) =>
+            mutation.mutate({
+              ...currentConfig,
+              enabledFeatures,
+              agentDualMode,
+            })
+          }
+        />
+
+        {mutation.error && (
+          <div className="text-sm text-destructive">
+            {mutation.error instanceof Error ? mutation.error.message : "Failed to update experimental features."}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DualModeAgentRoutingConfig({
+  companyId,
+  currentConfig,
+  experimentalModeEnabled,
+  loading,
+  saving,
+  onChange,
+}: {
+  companyId: string;
+  currentConfig: CompanyExperimentalFeaturesConfig;
+  experimentalModeEnabled: boolean;
+  loading: boolean;
+  saving: boolean;
+  onChange: (agentDualMode: NonNullable<CompanyExperimentalFeaturesConfig["agentDualMode"]>) => void;
+}) {
+  const config = currentConfig.agentDualMode ?? {};
+  const primaryAgent = config.primaryAgent ?? "claude";
+  const secondaryAgent =
+    config.secondaryAgent && config.secondaryAgent !== primaryAgent
+      ? config.secondaryAgent
+      : fallbackProvider(primaryAgent);
+  const dualModeConfigured = currentConfig.enabledFeatures?.agent_dual_mode === true;
+  const dualModeActive = isUiExperimentalFeatureEnabled("agent_dual_mode", currentConfig);
+  const controlsDisabled =
+    saving ||
+    loading ||
+    !experimentalModeEnabled ||
+    !dualModeConfigured;
+
+  const claudeModelsQuery = useQuery({
+    queryKey: queryKeys.agents.adapterModels(companyId, "claude_local"),
+    queryFn: () => agentsApi.adapterModels(companyId, "claude_local"),
+    enabled: !!companyId,
+    retry: false,
+  });
+  const codexModelsQuery = useQuery({
+    queryKey: queryKeys.agents.adapterModels(companyId, "codex_local"),
+    queryFn: () => agentsApi.adapterModels(companyId, "codex_local"),
+    enabled: !!companyId,
+    retry: false,
+  });
+
+  const selectedClaudeModel =
+    primaryAgent === "claude"
+      ? config.primaryModel
+      : secondaryAgent === "claude"
+        ? config.secondaryModel
+        : null;
+  const selectedCodexModel =
+    primaryAgent === "codex"
+      ? config.primaryModel
+      : secondaryAgent === "codex"
+        ? config.secondaryModel
+        : null;
+
+  const modelsByProvider = useMemo(
+    () => ({
+      claude: modelOptions(claudeModelsQuery.data, selectedClaudeModel),
+      codex: modelOptions(codexModelsQuery.data, selectedCodexModel),
+    }),
+    [
+      claudeModelsQuery.data,
+      codexModelsQuery.data,
+      selectedClaudeModel,
+      selectedCodexModel,
+    ],
+  );
+
+  function updateConfig(nextConfig: NonNullable<CompanyExperimentalFeaturesConfig["agentDualMode"]>) {
+    onChange({
+      primaryAgent,
+      primaryModel: config.primaryModel ?? null,
+      secondaryAgent,
+      secondaryModel: config.secondaryModel ?? null,
+      ...nextConfig,
+    });
+  }
+
+  const modelLoadFailed = claudeModelsQuery.isError || codexModelsQuery.isError;
+
+  return (
+    <div className="border-t border-border pt-4">
+      <div className="mb-3 space-y-1">
+        <h3 className="text-sm font-medium">Dual-mode routing config</h3>
+        <p className="text-sm text-muted-foreground">
+          Choose the primary and secondary local agent providers and model overrides used when the dual-mode flag is
+          active.
+        </p>
+      </div>
+
+      {!dualModeConfigured && (
+        <div className="mb-3 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+          Enable Dual-mode agent routing above to edit routing configuration.
+        </div>
+      )}
+      {dualModeConfigured && !dualModeActive && (
+        <div className="mb-3 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+          Dual-mode routing is configured but inactive until the environment master flag and company flag both pass.
+        </div>
+      )}
+      {modelLoadFailed && (
+        <div className="mb-3 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+          Some adapter models could not be loaded. Existing saved model values are still shown.
+        </div>
+      )}
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <Field label="Primary agent" hint="The provider used first when dual-mode routing is active.">
+          <select
+            className={selectClassName}
+            value={primaryAgent}
+            disabled={controlsDisabled}
+            onChange={(event) => {
+              const nextPrimaryAgent = event.target.value as ExperimentalAgentProvider;
+              updateConfig({
+                primaryAgent: nextPrimaryAgent,
+                primaryModel: null,
+                secondaryAgent:
+                  nextPrimaryAgent === secondaryAgent ? fallbackProvider(nextPrimaryAgent) : secondaryAgent,
+              });
+            }}
+          >
+            {agentProviderOptions.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="Primary model" hint="Optional model override for the primary provider.">
+          <ModelSelect
+            disabled={controlsDisabled}
+            models={modelsByProvider[primaryAgent]}
+            value={config.primaryModel ?? ""}
+            adapterType={adapterTypeForProvider(primaryAgent)}
+            onChange={(primaryModel) => updateConfig({ primaryModel })}
+          />
+        </Field>
+
+        <Field label="Secondary agent" hint="The provider used when policy allows fallback from the primary provider.">
+          <select
+            className={selectClassName}
+            value={secondaryAgent}
+            disabled={controlsDisabled}
+            onChange={(event) => {
+              const nextSecondaryAgent = event.target.value as ExperimentalAgentProvider;
+              updateConfig({
+                secondaryAgent: nextSecondaryAgent,
+                secondaryModel: null,
+                primaryAgent:
+                  nextSecondaryAgent === primaryAgent ? fallbackProvider(nextSecondaryAgent) : primaryAgent,
+              });
+            }}
+          >
+            {agentProviderOptions.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="Secondary model" hint="Optional model override for the secondary provider.">
+          <ModelSelect
+            disabled={controlsDisabled}
+            models={modelsByProvider[secondaryAgent]}
+            value={config.secondaryModel ?? ""}
+            adapterType={adapterTypeForProvider(secondaryAgent)}
+            onChange={(secondaryModel) => updateConfig({ secondaryModel })}
+          />
+        </Field>
+      </div>
+    </div>
+  );
+}
+
+function ModelSelect({
+  disabled,
+  models,
+  value,
+  adapterType,
+  onChange,
+}: {
+  disabled: boolean;
+  models: AdapterModel[];
+  value: string;
+  adapterType: string;
+  onChange: (value: string | null) => void;
+}) {
+  return (
+    <select
+      className={selectClassName}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value || null)}
+    >
+      <option value="">Adapter default</option>
+      {models.map((model) => (
+        <option key={`${adapterType}:${model.id}`} value={model.id}>
+          {model.label || model.id}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/ui/src/components/access/CompanySettingsNav.test.tsx
+++ b/ui/src/components/access/CompanySettingsNav.test.tsx
@@ -2,12 +2,16 @@
 
 import { act } from "react";
 import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CompanySettingsNav, getCompanySettingsTab } from "./CompanySettingsNav";
 
 let currentPathname = "/company/settings";
 const navigateMock = vi.hoisted(() => vi.fn());
 const pageTabBarMock = vi.hoisted(() => vi.fn());
+const mockAccessApi = vi.hoisted(() => ({
+  getCurrentBoardAccess: vi.fn(),
+}));
 
 vi.mock("@/lib/router", () => ({
   useLocation: () => ({ pathname: currentPathname, search: "", hash: "" }),
@@ -37,27 +41,64 @@ vi.mock("@/components/PageTabBar", () => ({
   },
 }));
 
+vi.mock("@/api/access", () => ({
+  accessApi: mockAccessApi,
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+function renderWithQueryClient(container: HTMLDivElement) {
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  root.render(
+    <QueryClientProvider client={queryClient}>
+      <CompanySettingsNav />
+    </QueryClientProvider>,
+  );
+  return root;
+}
 
 describe("CompanySettingsNav", () => {
   let container: HTMLDivElement;
 
   beforeEach(() => {
+    vi.stubEnv("VITE_PAPERCLIP_EXPERIMENTAL_MODE", "true");
     container = document.createElement("div");
     document.body.appendChild(container);
     currentPathname = "/company/settings";
+    mockAccessApi.getCurrentBoardAccess.mockResolvedValue({
+      user: { id: "user-1", email: "admin@paperclip.local", name: "Admin", image: null },
+      userId: "user-1",
+      isInstanceAdmin: true,
+      companyIds: ["company-1"],
+      memberships: [],
+      source: "session",
+      keyId: null,
+    });
   });
 
   afterEach(() => {
     container.remove();
     document.body.innerHTML = "";
+    vi.unstubAllEnvs();
     vi.clearAllMocks();
   });
 
   it("maps company settings routes to the expected shared tab value", () => {
     expect(getCompanySettingsTab("/company/settings")).toBe("general");
     expect(getCompanySettingsTab("/PAP/company/settings")).toBe("general");
+    expect(getCompanySettingsTab("/company/settings/experimental-features")).toBe("experimental-features");
+    expect(getCompanySettingsTab("/PAP/company/settings/experimental-features")).toBe("experimental-features");
     expect(getCompanySettingsTab("/company/settings/environments")).toBe("environments");
     expect(getCompanySettingsTab("/PAP/company/settings/environments")).toBe("environments");
     expect(getCompanySettingsTab("/company/settings/access")).toBe("access");
@@ -67,11 +108,12 @@ describe("CompanySettingsNav", () => {
 
   it("renders the active tab and navigates when a different tab is selected", async () => {
     currentPathname = "/PAP/company/settings/access";
-    const root = createRoot(container);
+    let root: ReturnType<typeof createRoot>;
 
     await act(async () => {
-      root.render(<CompanySettingsNav />);
+      root = renderWithQueryClient(container);
     });
+    await flushReact();
 
     expect(container.textContent).toContain("access");
     expect(pageTabBarMock).toHaveBeenCalledWith(
@@ -79,6 +121,7 @@ describe("CompanySettingsNav", () => {
         value: "access",
         items: [
           { value: "general", label: "General" },
+          { value: "experimental-features", label: "Experimental" },
           { value: "environments", label: "Environments" },
           { value: "access", label: "Access" },
           { value: "invites", label: "Invites" },
@@ -94,6 +137,64 @@ describe("CompanySettingsNav", () => {
     });
 
     expect(navigateMock).toHaveBeenCalledWith("/company/settings/invites");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("hides the experimental tab when experimental mode is disabled", async () => {
+    vi.stubEnv("VITE_PAPERCLIP_EXPERIMENTAL_MODE", "false");
+    let root: ReturnType<typeof createRoot>;
+
+    await act(async () => {
+      root = renderWithQueryClient(container);
+    });
+    await flushReact();
+
+    expect(pageTabBarMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          { value: "general", label: "General" },
+          { value: "environments", label: "Environments" },
+          { value: "access", label: "Access" },
+          { value: "invites", label: "Invites" },
+        ],
+      }),
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("hides the experimental tab for non-admin users", async () => {
+    mockAccessApi.getCurrentBoardAccess.mockResolvedValue({
+      user: { id: "user-1", email: "member@paperclip.local", name: "Member", image: null },
+      userId: "user-1",
+      isInstanceAdmin: false,
+      companyIds: ["company-1"],
+      memberships: [{ companyId: "company-1", membershipRole: "admin", status: "active" }],
+      source: "session",
+      keyId: null,
+    });
+    let root: ReturnType<typeof createRoot>;
+
+    await act(async () => {
+      root = renderWithQueryClient(container);
+    });
+    await flushReact();
+
+    expect(pageTabBarMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [
+          { value: "general", label: "General" },
+          { value: "environments", label: "Environments" },
+          { value: "access", label: "Access" },
+          { value: "invites", label: "Invites" },
+        ],
+      }),
+    );
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/access/CompanySettingsNav.tsx
+++ b/ui/src/components/access/CompanySettingsNav.tsx
@@ -1,9 +1,11 @@
 import { PageTabBar } from "@/components/PageTabBar";
 import { Tabs } from "@/components/ui/tabs";
+import { useExperimentalFeaturesAccess } from "@/hooks/useExperimentalFeaturesAccess";
 import { useLocation, useNavigate } from "@/lib/router";
 
 const items = [
   { value: "general", label: "General", href: "/company/settings" },
+  { value: "experimental-features", label: "Experimental", href: "/company/settings/experimental-features" },
   { value: "environments", label: "Environments", href: "/company/settings/environments" },
   { value: "access", label: "Access", href: "/company/settings/access" },
   { value: "invites", label: "Invites", href: "/company/settings/invites" },
@@ -12,6 +14,10 @@ const items = [
 type CompanySettingsTab = (typeof items)[number]["value"];
 
 export function getCompanySettingsTab(pathname: string): CompanySettingsTab {
+  if (pathname.includes("/company/settings/experimental-features")) {
+    return "experimental-features";
+  }
+
   if (pathname.includes("/company/settings/environments")) {
     return "environments";
   }
@@ -30,10 +36,14 @@ export function getCompanySettingsTab(pathname: string): CompanySettingsTab {
 export function CompanySettingsNav() {
   const location = useLocation();
   const navigate = useNavigate();
+  const { canViewExperimentalFeatures } = useExperimentalFeaturesAccess();
+  const visibleItems = canViewExperimentalFeatures
+    ? items
+    : items.filter((item) => item.value !== "experimental-features");
   const activeTab = getCompanySettingsTab(location.pathname);
 
   function handleTabChange(value: string) {
-    const nextTab = items.find((item) => item.value === value);
+    const nextTab = visibleItems.find((item) => item.value === value);
     if (!nextTab || nextTab.value === activeTab) return;
     navigate(nextTab.href);
   }
@@ -41,7 +51,7 @@ export function CompanySettingsNav() {
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange}>
       <PageTabBar
-        items={items.map(({ value, label }) => ({ value, label }))}
+        items={visibleItems.map(({ value, label }) => ({ value, label }))}
         value={activeTab}
         onValueChange={handleTabChange}
         align="start"

--- a/ui/src/hooks/useExperimentalFeaturesAccess.ts
+++ b/ui/src/hooks/useExperimentalFeaturesAccess.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import { accessApi } from "@/api/access";
+import { isUiExperimentalModeEnabled } from "@/lib/experimental-features";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function useExperimentalFeaturesAccess() {
+  const experimentalModeEnabled = isUiExperimentalModeEnabled();
+  const boardAccessQuery = useQuery({
+    queryKey: queryKeys.access.currentBoardAccess,
+    queryFn: () => accessApi.getCurrentBoardAccess(),
+    enabled: experimentalModeEnabled,
+    retry: false,
+  });
+
+  const canViewExperimentalFeatures = Boolean(
+    experimentalModeEnabled &&
+      (boardAccessQuery.data?.isInstanceAdmin || boardAccessQuery.data?.source === "local_implicit"),
+  );
+
+  return {
+    canViewExperimentalFeatures,
+    experimentalModeEnabled,
+    isLoading: experimentalModeEnabled && boardAccessQuery.isLoading,
+  };
+}

--- a/ui/src/lib/experimental-features.ts
+++ b/ui/src/lib/experimental-features.ts
@@ -1,0 +1,23 @@
+import {
+  isExperimentalFeatureEnabled,
+  type CompanyExperimentalFeaturesConfig,
+  type ExperimentalFeatureKey,
+} from "@paperclipai/shared";
+
+export const UI_EXPERIMENTAL_MODE_ENV = "VITE_PAPERCLIP_EXPERIMENTAL_MODE";
+
+export function isUiExperimentalModeEnabled(): boolean {
+  return import.meta.env.VITE_PAPERCLIP_EXPERIMENTAL_MODE === "true";
+}
+
+export function isUiExperimentalFeatureEnabled(
+  feature: ExperimentalFeatureKey,
+  companyExperimentalFeatures?: CompanyExperimentalFeaturesConfig,
+): boolean {
+  return isExperimentalFeatureEnabled({
+    feature,
+    environmentExperimentalModeEnabled: isUiExperimentalModeEnabled(),
+    isDevelopmentEnvironment: import.meta.env.DEV,
+    companyEnabledFeatures: companyExperimentalFeatures?.enabledFeatures,
+  });
+}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -122,6 +122,8 @@ export const queryKeys = {
   },
   auth: {
     session: ["auth", "session"] as const,
+    unauthenticatedLoginAvailability: (companyId: string) =>
+      ["auth", "unauthenticated-login-availability", companyId] as const,
   },
   sidebarPreferences: {
     companyOrder: (userId: string) => ["sidebar-preferences", "company-order", userId] as const,

--- a/ui/src/lib/unauthenticated-login.adapter.ts
+++ b/ui/src/lib/unauthenticated-login.adapter.ts
@@ -1,0 +1,22 @@
+import { authApi } from "@/api/auth";
+
+export interface UnauthenticatedLoginAdapterInput {
+  nextPath?: string;
+  companyId?: string | null;
+}
+
+export const unauthenticatedLoginAdapter = {
+  async proceed(input: UnauthenticatedLoginAdapterInput = {}) {
+    if (!input.companyId) {
+      throw new Error("Unauthenticated development entry is disabled.");
+    }
+
+    const availability = await authApi.getUnauthenticatedLoginAvailability(input.companyId);
+    if (!availability.available) {
+      throw new Error("Unauthenticated development entry is disabled.");
+    }
+    await authApi.startUnauthenticatedLoginSession(input.companyId);
+    const target = input.nextPath?.trim() || "/";
+    window.location.assign(target);
+  },
+};

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -289,6 +289,32 @@ function runMetrics(run: HeartbeatRun) {
   };
 }
 
+function providerForAdapterType(adapterType: string | null) {
+  if (adapterType === "codex_local") return "codex";
+  if (adapterType === "claude_local") return "claude";
+  return null;
+}
+
+function modelFromCommandArgs(commandArgs: unknown) {
+  if (!Array.isArray(commandArgs)) return null;
+  const args = commandArgs.filter((value): value is string => typeof value === "string");
+  const modelIndex = args.findIndex((value) => value === "--model" || value === "-m");
+  if (modelIndex < 0) return null;
+  return asNonEmptyString(args[modelIndex + 1]);
+}
+
+function readRunInvocationMeta(events: HeartbeatRunEvent[] | undefined) {
+  const event = events?.find((entry) => entry.eventType === "adapter.invoke");
+  const payload = asRecord(event?.payload);
+  const adapterType = asNonEmptyString(payload?.adapterType);
+  const provider = asNonEmptyString(payload?.provider) ?? providerForAdapterType(adapterType);
+  const model =
+    asNonEmptyString(payload?.model) ??
+    asNonEmptyString(asRecord(payload?.modelProfile)?.model) ??
+    modelFromCommandArgs(payload?.commandArgs);
+  return { adapterType, provider, model };
+}
+
 type RunLogChunk = { ts: string; stream: "stdout" | "stderr" | "system"; chunk: string };
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -3174,6 +3200,14 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
   const sessionId = run.sessionIdAfter || run.sessionIdBefore;
   const hasNonZeroExit = run.exitCode !== null && run.exitCode !== 0;
   const retryState = describeRunRetryState(run);
+  const { data: summaryEvents } = useQuery({
+    queryKey: ["run-summary-events", run.id],
+    queryFn: () => heartbeatsApi.events(run.id, 0, 25),
+    refetchInterval: isRunning ? 2000 : false,
+  });
+  const invocationMeta = useMemo(() => readRunInvocationMeta(summaryEvents), [summaryEvents]);
+  const effectiveAdapterType = invocationMeta.adapterType ?? adapterType;
+  const routedAdapter = Boolean(invocationMeta.adapterType && invocationMeta.adapterType !== adapterType);
 
   return (
     <div className="space-y-4 min-w-0">
@@ -3223,14 +3257,19 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
             {/* Adapter type · provider · model */}
             {(() => {
               const displayProvider = metrics.provider
+                ?? invocationMeta.provider
                 ?? asNonEmptyString(adapterConfig?.provider);
               const displayModel = metrics.model
+                ?? invocationMeta.model
                 ?? asNonEmptyString(adapterConfig?.model);
-              if (!adapterType && !displayProvider && !displayModel) return null;
+              if (!effectiveAdapterType && !displayProvider && !displayModel) return null;
               return (
                 <div className="text-[11px] text-muted-foreground font-mono flex items-center gap-1.5 flex-wrap">
-                  {adapterType && (
-                    <span className="bg-muted rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide">{adapterType.replace(/_/g, " ")}</span>
+                  {effectiveAdapterType && (
+                    <span className="bg-muted rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide">{effectiveAdapterType.replace(/_/g, " ")}</span>
+                  )}
+                  {routedAdapter && (
+                    <span className="text-[10px] text-muted-foreground">routed from {adapterType.replace(/_/g, " ")}</span>
                   )}
                   {displayProvider && displayModel && (
                     <span>{displayProvider}/{displayModel}</span>
@@ -3275,7 +3314,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                 {run.errorCode && <span className="text-muted-foreground ml-1">({run.errorCode})</span>}
               </div>
             )}
-            {run.errorCode === "claude_auth_required" && adapterType === "claude_local" && (
+            {run.errorCode === "claude_auth_required" && effectiveAdapterType === "claude_local" && (
               <div className="space-y-2">
                 <Button
                   variant="outline"
@@ -3475,7 +3514,7 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
       )}
 
       {/* Log viewer */}
-      <LogViewer run={run} adapterType={adapterType} />
+      <LogViewer run={run} adapterType={effectiveAdapterType} />
       <ScrollToBottom />
     </div>
   );

--- a/ui/src/pages/Auth.tsx
+++ b/ui/src/pages/Auth.tsx
@@ -7,6 +7,16 @@ import { getRememberedInvitePath } from "../lib/invite-memory";
 import { Button } from "@/components/ui/button";
 import { AsciiArtAnimation } from "@/components/AsciiArtAnimation";
 import { Sparkles } from "lucide-react";
+import { useCompany } from "@/context/CompanyContext";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { unauthenticatedLoginAdapter } from "@/lib/unauthenticated-login.adapter";
 
 type AuthMode = "sign_in" | "sign_up";
 
@@ -19,11 +29,21 @@ export function AuthPage() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [showUnauthenticatedWarning, setShowUnauthenticatedWarning] = useState(false);
+  const { selectedCompanyId } = useCompany();
 
   const nextPath = useMemo(
     () => searchParams.get("next") || getRememberedInvitePath() || "/",
     [searchParams],
   );
+  const requestedExperimentalCompanyId = searchParams.get("companyId")?.trim() || selectedCompanyId;
+  const unauthenticatedAvailabilityQuery = useQuery({
+    queryKey: queryKeys.auth.unauthenticatedLoginAvailability(requestedExperimentalCompanyId ?? "__auto__"),
+    queryFn: () => authApi.getUnauthenticatedLoginAvailability(requestedExperimentalCompanyId),
+    retry: false,
+  });
+  const showUnauthenticatedEntry = unauthenticatedAvailabilityQuery.data?.available === true;
+  const experimentalCompanyId = requestedExperimentalCompanyId ?? unauthenticatedAvailabilityQuery.data?.companyId ?? null;
   const { data: session, isLoading: isSessionLoading } = useQuery({
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
@@ -172,6 +192,18 @@ export function AuthPage() {
               {mode === "sign_in" ? "Create one" : "Sign in"}
             </button>
           </div>
+          {showUnauthenticatedEntry && (
+            <div className="mt-4 border-t border-border pt-4">
+              <Button
+                type="button"
+                variant="ghost"
+                className="w-full"
+                onClick={() => setShowUnauthenticatedWarning(true)}
+              >
+                Proceed without login
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 
@@ -179,6 +211,49 @@ export function AuthPage() {
       <div className="hidden md:block w-1/2 overflow-hidden">
         <AsciiArtAnimation />
       </div>
+      <Dialog
+        open={showUnauthenticatedEntry && showUnauthenticatedWarning}
+        onOpenChange={setShowUnauthenticatedWarning}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Continue without login?</DialogTitle>
+            <DialogDescription>
+              You are about to enter Paperclip without signing in. Some features may be limited, unavailable, or not
+              persisted to your account.
+            </DialogDescription>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Only continue if you understand the limitations of unauthenticated mode.
+          </p>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setShowUnauthenticatedWarning(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={async () => {
+                try {
+                  setError(null);
+                  await unauthenticatedLoginAdapter.proceed({
+                    nextPath,
+                    companyId: experimentalCompanyId,
+                  });
+                } catch (err) {
+                  setError(err instanceof Error ? err.message : "Unauthenticated development entry is disabled.");
+                  setShowUnauthenticatedWarning(false);
+                }
+              }}
+            >
+              Continue without login
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/ui/src/pages/CompanyExperimentalFeatures.tsx
+++ b/ui/src/pages/CompanyExperimentalFeatures.tsx
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import { FlaskConical } from "lucide-react";
+import { ExperimentalFeaturesSettings } from "@/components/ExperimentalFeaturesSettings";
+import { useBreadcrumbs } from "@/context/BreadcrumbContext";
+import { useCompany } from "@/context/CompanyContext";
+import { useExperimentalFeaturesAccess } from "@/hooks/useExperimentalFeaturesAccess";
+import { Navigate } from "@/lib/router";
+
+export function CompanyExperimentalFeatures() {
+  const { selectedCompany, selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const { canViewExperimentalFeatures, isLoading } = useExperimentalFeaturesAccess();
+
+  useEffect(() => {
+    setBreadcrumbs([
+      { label: selectedCompany?.name ?? "Company", href: "/dashboard" },
+      { label: "Settings", href: "/company/settings" },
+      { label: "Experimental features" },
+    ]);
+  }, [selectedCompany?.name, setBreadcrumbs]);
+
+  if (isLoading) {
+    return <div className="text-sm text-muted-foreground">Loading...</div>;
+  }
+
+  if (!canViewExperimentalFeatures) {
+    return <Navigate to="/company/settings" replace />;
+  }
+
+  if (!selectedCompanyId) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        No company selected. Select a company from the switcher above.
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl space-y-6">
+      <div className="flex items-center gap-2">
+        <FlaskConical className="h-5 w-5 text-muted-foreground" />
+        <h1 className="text-lg font-semibold">Experimental Features</h1>
+      </div>
+
+      <ExperimentalFeaturesSettings companyId={selectedCompanyId} />
+    </div>
+  );
+}

--- a/ui/src/pages/CompanySettings.tsx
+++ b/ui/src/pages/CompanySettings.tsx
@@ -227,6 +227,14 @@ export function CompanySettings() {
     );
   }
 
+  if (!selectedCompanyId) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        No company selected. Select a company from the switcher above.
+      </div>
+    );
+  }
+
   function handleSaveGeneral() {
     generalMutation.mutate({
       name: companyName.trim(),


### PR DESCRIPTION
## Summary

This PR adds a centralized experimental flags system and uses it to gate two opt-in capabilities:

- Join without login/auth
- Dual-mode agent routing

The goal is to support local, development, test, and explicitly configured experimental deployments without changing Paperclip's default behavior.

## Experimental flags model

The implementation follows a simplified `chrome://flags` style model:

- feature keys are defined centrally
- each feature has a title, description, optional warning, and disabled default
- the environment master switch must be enabled
- the company-level flag must be enabled
- instance-admin access is required to view/change company experimental flags
- missing config means disabled
- unknown flags resolve to disabled

Environment master switch:

`PAPERCLIP_EXPERIMENTAL_MODE=true`

Frontend build switch:

`VITE_PAPERCLIP_EXPERIMENTAL_MODE=true`

When the frontend experimental mode switch is not enabled, `/company/settings/experimental-features` is hidden from company settings navigation.

## Experimental features added

### Join without login/auth

Feature key:

`unauthenticated_login`

When enabled for a company:

1. The login page shows `Proceed without login`.
2. Clicking it opens an explicit warning modal.
3. `Cancel` closes the modal and does nothing.
4. `Continue without login` calls the no-auth adapter/service.
5. The server creates a short-lived unauthenticated development session only after rechecking the feature resolver.

This avoids hidden route-guard bypasses and avoids automatic login-page bypasses. The flow is visible, user-triggered, reversible, and disabled by default.

The company setting also includes an `Access level` selector for the unauthenticated session. Only instance admins can change this setting.

### Dual-mode agent routing

Feature key:

`agent_dual_mode`

When enabled for a company, the settings page exposes primary/secondary provider and model selectors. The routing policy remains centralized in the experimental agent routing service.

Default behavior is unchanged when disabled. When enabled, heartbeat execution resolves the effective adapter through the routing service before invoking the adapter. If the primary provider is quota/rate limited, the resolver can route to the secondary provider. The run detail UI now reads the `adapter.invoke` event so the card reflects the effective runtime adapter/model, for example `codex_local` routed from a configured `claude_local` agent.

## Safety and defaults

- Experimental flags are disabled by default.
- Environment master switch is required.
- Company-level flag is required.
- Instance-admin access is required to view and mutate experimental feature settings.
- Production/default behavior remains unchanged when flags are disabled.
- Existing login/auth/task behavior remains unchanged by default.
- No private/local project behavior is hardcoded.
- Local custom Docker/config overrides remain ignored via `docker/custom-configs/`.

## Upstream-friendly diff strategy

The implementation keeps optional behavior isolated in new shared definitions, adapters, services, hooks, and settings components. Existing upstream files are limited to connection points such as route registration, settings navigation, auth fallback wiring, and heartbeat adapter resolution.

No private `features/` architecture folder is introduced.

## Validation

- [x] `git diff --check`
- [x] Private-reference grep across `packages`, `server`, and `ui`
- [x] `pnpm --filter @paperclipai/ui typecheck`
- [x] `pnpm --filter @paperclipai/server typecheck`
- [x] `pnpm --filter @paperclipai/server test -- experimental-features.test.ts`
- [x] Runtime check: referenced backend-dev run invoked `codex_local` with `gpt-5.4` and succeeded
- [x] Runtime check: active retries route through `codex_local` after Claude quota failures

## Reviewer notes

Please focus review on:

1. Whether the resolver and settings shape are generic enough for future flags.
2. Whether default behavior remains unchanged when flags are disabled.
3. Whether Join without login/auth is explicit and constrained enough for experimental use.
4. Whether Dual-mode routing remains centralized and policy validated.
5. Whether existing production files are limited to minimal connection changes.
