### PR TITLE
Add launchd heartbeat endpoint

### DIFF
--- a/server/src/__tests__/launchd-heartbeats.test.ts
+++ b/server/src/__tests__/launchd-heartbeats.test.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { launchdHeartbeatRoutes } from "../routes/launchd-heartbeats.js";
+import { LaunchdHeartbeatAggregator } from "../services/launchd-heartbeats.js";
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    agent_id: "com.aisarva.investments-hermes",
+    use_case: "investments",
+    status: "running",
+    last_action: "scanned 24 tickers",
+    last_action_ts: "2026-05-17T08:30:00-05:00",
+    queue_depth: 3,
+    spend_today_usd: 0,
+    spend_today_calls: { cc: 142, codex: 87, gemini: 23 },
+    error_log_size_mb: 12.3,
+    ...overrides,
+  };
+}
+
+async function tempStorePath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-heartbeats-"));
+  return path.join(dir, "heartbeats.jsonl");
+}
+
+function createApp(aggregator: LaunchdHeartbeatAggregator) {
+  const app = express();
+  app.use(express.json());
+  app.use("/heartbeat", launchdHeartbeatRoutes(aggregator));
+  return app;
+}
+
+describe("launchd heartbeat routes", () => {
+  it("records heartbeats and exposes aggregated status", async () => {
+    const storePath = await tempStorePath();
+    const aggregator = new LaunchdHeartbeatAggregator({
+      storePath,
+      now: () => new Date("2026-05-17T13:30:00.000Z"),
+    });
+
+    const post = await request(createApp(aggregator)).post("/heartbeat").send(payload());
+
+    expect(post.status).toBe(202);
+    expect(post.body.last_payload.agent_id).toBe("com.aisarva.investments-hermes");
+    expect(post.body.last_payload.status).toBe("running");
+
+    const status = await request(createApp(aggregator)).get("/heartbeat/status");
+
+    expect(status.status).toBe(200);
+    expect(status.body.heartbeats["com.aisarva.investments-hermes"]).toMatchObject({
+      last_seen: "2026-05-17T13:30:00.000Z",
+      stale: false,
+      last_payload: {
+        agent_id: "com.aisarva.investments-hermes",
+        status: "running",
+      },
+    });
+
+    const persisted = await fs.readFile(storePath, "utf-8");
+    expect(persisted).toContain("com.aisarva.investments-hermes");
+  });
+
+  it("marks agents crashed when the last heartbeat is older than five minutes", async () => {
+    let now = new Date("2026-05-17T13:30:00.000Z");
+    const aggregator = new LaunchdHeartbeatAggregator({
+      storePath: await tempStorePath(),
+      now: () => now,
+    });
+    await aggregator.record(payload({ status: "running" }));
+
+    now = new Date("2026-05-17T13:35:01.000Z");
+    const status = await aggregator.status();
+
+    expect(status.heartbeats["com.aisarva.investments-hermes"]).toMatchObject({
+      stale: true,
+      last_payload: {
+        status: "crashed",
+      },
+    });
+  });
+
+  it("hydrates the latest known heartbeat from jsonl on restart", async () => {
+    const storePath = await tempStorePath();
+    const first = new LaunchdHeartbeatAggregator({
+      storePath,
+      now: () => new Date("2026-05-17T13:30:00.000Z"),
+    });
+    await first.record(payload({ queue_depth: 1 }));
+    await first.record(payload({ queue_depth: 4 }));
+
+    const reloaded = new LaunchdHeartbeatAggregator({
+      storePath,
+      now: () => new Date("2026-05-17T13:31:00.000Z"),
+    });
+
+    await expect(reloaded.status()).resolves.toMatchObject({
+      heartbeats: {
+        "com.aisarva.investments-hermes": {
+          last_payload: {
+            queue_depth: 4,
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects malformed heartbeat payloads", async () => {
+    const res = await request(
+      createApp(new LaunchdHeartbeatAggregator({ storePath: await tempStorePath() })),
+    )
+      .post("/heartbeat")
+      .send({ status: "running" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("agent_id");
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -41,6 +41,7 @@ import { accessRoutes } from "./routes/access.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
+import { launchdHeartbeatRoutes } from "./routes/launchd-heartbeats.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
@@ -160,6 +161,7 @@ export async function createApp(
       bindHost: opts.bindHost,
     }),
   );
+  app.use("/heartbeat", launchdHeartbeatRoutes());
   app.use(
     actorMiddleware(db, {
       deploymentMode: opts.deploymentMode,

--- a/server/src/routes/launchd-heartbeats.ts
+++ b/server/src/routes/launchd-heartbeats.ts
@@ -1,0 +1,35 @@
+import { Router } from "express";
+import {
+  InvalidLaunchdHeartbeatError,
+  launchdHeartbeatAggregator,
+  type LaunchdHeartbeatAggregator,
+} from "../services/launchd-heartbeats.js";
+
+export function launchdHeartbeatRoutes(
+  aggregator: LaunchdHeartbeatAggregator = launchdHeartbeatAggregator,
+) {
+  const router = Router();
+
+  router.post("/", async (req, res, next) => {
+    try {
+      const record = await aggregator.record(req.body);
+      res.status(202).json(record);
+    } catch (error) {
+      if (error instanceof InvalidLaunchdHeartbeatError) {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+      next(error);
+    }
+  });
+
+  router.get("/status", async (_req, res, next) => {
+    try {
+      res.json(await aggregator.status());
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}

--- a/server/src/services/launchd-heartbeats.ts
+++ b/server/src/services/launchd-heartbeats.ts
@@ -1,0 +1,198 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+
+export const LAUNCHD_HEARTBEAT_STALE_MS = 5 * 60 * 1000;
+
+const VALID_STATUSES = new Set(["running", "idle", "blocked", "crashed"]);
+
+export type LaunchdHeartbeatStatus = "running" | "idle" | "blocked" | "crashed";
+
+export interface LaunchdHeartbeatPayload {
+  agent_id: string;
+  use_case: string;
+  status: LaunchdHeartbeatStatus;
+  last_action: string;
+  last_action_ts: string;
+  queue_depth: number;
+  spend_today_usd: number;
+  spend_today_calls: Record<string, number>;
+  error_log_size_mb: number;
+}
+
+export interface LaunchdHeartbeatRecord {
+  last_seen: string;
+  last_payload: LaunchdHeartbeatPayload;
+  stale: boolean;
+}
+
+export interface LaunchdHeartbeatStatusResponse {
+  generated_at: string;
+  stale_after_ms: number;
+  heartbeats: Record<string, LaunchdHeartbeatRecord>;
+}
+
+export class InvalidLaunchdHeartbeatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidLaunchdHeartbeatError";
+  }
+}
+
+function defaultStorePath(): string {
+  return path.resolve(resolvePaperclipInstanceRoot(), "data", "heartbeats.jsonl");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(raw: Record<string, unknown>, key: string): string {
+  const value = raw[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new InvalidLaunchdHeartbeatError(`${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalNumber(raw: Record<string, unknown>, key: string, fallback: number): number {
+  const value = raw[key];
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new InvalidLaunchdHeartbeatError(`${key} must be a finite number`);
+  }
+  return value;
+}
+
+function optionalSpendCalls(raw: Record<string, unknown>): Record<string, number> {
+  const value = raw.spend_today_calls;
+  if (value === undefined || value === null) return {};
+  if (!isRecord(value)) {
+    throw new InvalidLaunchdHeartbeatError("spend_today_calls must be an object");
+  }
+
+  const spendCalls: Record<string, number> = {};
+  for (const [key, calls] of Object.entries(value)) {
+    if (typeof calls !== "number" || !Number.isFinite(calls)) {
+      throw new InvalidLaunchdHeartbeatError(`spend_today_calls.${key} must be a finite number`);
+    }
+    spendCalls[key] = calls;
+  }
+  return spendCalls;
+}
+
+export function normalizeLaunchdHeartbeatPayload(value: unknown): LaunchdHeartbeatPayload {
+  if (!isRecord(value)) {
+    throw new InvalidLaunchdHeartbeatError("heartbeat payload must be an object");
+  }
+
+  const status = requiredString(value, "status");
+  if (!VALID_STATUSES.has(status)) {
+    throw new InvalidLaunchdHeartbeatError("status must be running, idle, blocked, or crashed");
+  }
+
+  return {
+    agent_id: requiredString(value, "agent_id"),
+    use_case: requiredString(value, "use_case"),
+    status: status as LaunchdHeartbeatStatus,
+    last_action: requiredString(value, "last_action"),
+    last_action_ts: requiredString(value, "last_action_ts"),
+    queue_depth: optionalNumber(value, "queue_depth", 0),
+    spend_today_usd: optionalNumber(value, "spend_today_usd", 0),
+    spend_today_calls: optionalSpendCalls(value),
+    error_log_size_mb: optionalNumber(value, "error_log_size_mb", 0),
+  };
+}
+
+export class LaunchdHeartbeatAggregator {
+  private readonly storePath: string;
+  private readonly now: () => Date;
+  private readonly records = new Map<
+    string,
+    { last_seen: string; last_payload: LaunchdHeartbeatPayload }
+  >();
+  private loaded = false;
+
+  constructor(opts: { storePath?: string; now?: () => Date } = {}) {
+    this.storePath = opts.storePath ?? defaultStorePath();
+    this.now = opts.now ?? (() => new Date());
+  }
+
+  async record(value: unknown): Promise<LaunchdHeartbeatRecord> {
+    await this.load();
+    const payload = normalizeLaunchdHeartbeatPayload(value);
+    const record = {
+      last_seen: this.now().toISOString(),
+      last_payload: payload,
+    };
+    this.records.set(payload.agent_id, record);
+    await this.append(record);
+    return this.snapshotRecord(record, this.now());
+  }
+
+  async status(): Promise<LaunchdHeartbeatStatusResponse> {
+    await this.load();
+    const generatedAt = this.now();
+    const heartbeats: Record<string, LaunchdHeartbeatRecord> = {};
+    for (const [agentId, record] of this.records.entries()) {
+      heartbeats[agentId] = this.snapshotRecord(record, generatedAt);
+    }
+    return {
+      generated_at: generatedAt.toISOString(),
+      stale_after_ms: LAUNCHD_HEARTBEAT_STALE_MS,
+      heartbeats,
+    };
+  }
+
+  private async load(): Promise<void> {
+    if (this.loaded) return;
+    this.loaded = true;
+
+    let raw = "";
+    try {
+      raw = await fs.readFile(this.storePath, "utf-8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      return;
+    }
+
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      try {
+        const parsed = JSON.parse(line) as unknown;
+        if (!isRecord(parsed)) continue;
+        const payload = normalizeLaunchdHeartbeatPayload(parsed.last_payload);
+        const lastSeen =
+          typeof parsed.last_seen === "string" && parsed.last_seen.trim()
+            ? parsed.last_seen
+            : this.now().toISOString();
+        this.records.set(payload.agent_id, { last_seen: lastSeen, last_payload: payload });
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  private async append(record: {
+    last_seen: string;
+    last_payload: LaunchdHeartbeatPayload;
+  }): Promise<void> {
+    await fs.mkdir(path.dirname(this.storePath), { recursive: true });
+    await fs.appendFile(this.storePath, `${JSON.stringify(record)}\n`, "utf-8");
+  }
+
+  private snapshotRecord(
+    record: { last_seen: string; last_payload: LaunchdHeartbeatPayload },
+    now: Date,
+  ): LaunchdHeartbeatRecord {
+    const ageMs = now.getTime() - new Date(record.last_seen).getTime();
+    const stale = Number.isFinite(ageMs) && ageMs > LAUNCHD_HEARTBEAT_STALE_MS;
+    return {
+      last_seen: record.last_seen,
+      stale,
+      last_payload: stale ? { ...record.last_payload, status: "crashed" } : { ...record.last_payload },
+    };
+  }
+}
+
+export const launchdHeartbeatAggregator = new LaunchdHeartbeatAggregator();


### PR DESCRIPTION
## Summary
- add unauthenticated local `/heartbeat` POST route for launchd agent status payloads
- add `/heartbeat/status` aggregation with stale-after-5-minutes crash projection
- append heartbeat records to the default instance JSONL store for restart hydration

## Validation
- `pnpm vitest run server/src/__tests__/launchd-heartbeats.test.ts`
- `pnpm --filter @paperclipai/server typecheck`

Refs DataSarva/chakra#86
