### PR TITLE
fix(server): evict queued runs past 10-min grace window

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -132,6 +132,7 @@ function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
 }
 
 const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed_out"]);
+const QUEUED_STALE_MS = 10 * 60 * 1000; // 10 min = 2× default heartbeatSchedulerIntervalMs
 const ISSUE_LIST_DESCRIPTION_MAX_CHARS = 1200;
 
 function escapeLikePattern(value: string): string {
@@ -910,12 +911,20 @@ export function issueService(db: Db) {
 
   async function isTerminalOrMissingHeartbeatRun(runId: string) {
     const run = await db
-      .select({ status: heartbeatRuns.status })
+      .select({ status: heartbeatRuns.status, createdAt: heartbeatRuns.createdAt })
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId))
       .then((rows) => rows[0] ?? null);
     if (!run) return true;
-    return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
+    if (TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return true;
+    // A run stuck in `queued` past the grace window never successfully
+    // transitioned to `running` — treat it as abandoned so the lock can be
+    // adopted/evicted (paperclipai/paperclip#PRI-349).
+    if (run.status === "queued" && run.createdAt) {
+      const age = Date.now() - new Date(run.createdAt).getTime();
+      if (age > QUEUED_STALE_MS) return true;
+    }
+    return false;
   }
 
   async function adoptStaleCheckoutRun(input: {


### PR DESCRIPTION
## Problem

`isTerminalOrMissingHeartbeatRun` only recognises `succeeded`, `failed`, `cancelled`, and `timed_out` as terminal. A run stuck in `queued` — one that was dispatched but never transitioned to `running` — is not evictable, so `adoptStaleCheckoutRun` returns null, `assertCheckoutOwner` throws 409, and the issue stays wedged indefinitely until the queued run eventually self-resolves.

This affects all three call sites: `adoptStaleCheckoutRun`, the Fix-C pre-check on `checkout`, and `assertCheckoutOwner`.

## Fix

Add a `QUEUED_STALE_MS` constant (10 min = 2× default `heartbeatSchedulerIntervalMs`) and treat `queued` runs older than that as abandoned/evictable.

```ts
const QUEUED_STALE_MS = 10 * 60 * 1000;

// inside isTerminalOrMissingHeartbeatRun — also select createdAt:
if (run.status === "queued" && run.createdAt) {
  const age = Date.now() - new Date(run.createdAt).getTime();
  if (age > QUEUED_STALE_MS) return true;
}
```

All three call sites pick this up for free since they all go through `isTerminalOrMissingHeartbeatRun`.

## Properties

- **No schema change** — `heartbeatRuns.createdAt` already exists and is selected elsewhere.
- **No behavioral change for healthy runs** — only runs that never transition `queued → running` past the grace window are affected.
- **Grace window is tunable** via the constant if 10 min proves too aggressive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)