### PR TITLE
fix(cli): prevent auth login crash when xdg-open is missing

### DIFF
--- a/cli/src/client/board-auth.ts
+++ b/cli/src/client/board-auth.ts
@@ -171,23 +171,23 @@ async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
 
 export function openUrl(url: string): boolean {
   const platform = process.platform;
-  try {
-    if (platform === "darwin") {
-      const child = spawn("open", [url], { detached: true, stdio: "ignore" });
+  const launch = (cmd: string, args: string[]): boolean => {
+    try {
+      const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
+      // Absorb async spawn errors (e.g. ENOENT when xdg-open is missing on
+      // headless hosts). Without this listener, Node emits 'error' as an
+      // unhandled event and crashes the CLI before the approval poll loop
+      // can run, even though the printed URL is still valid.
+      child.on("error", () => {});
       child.unref();
       return true;
+    } catch {
+      return false;
     }
-    if (platform === "win32") {
-      const child = spawn("cmd", ["/c", "start", "", url], { detached: true, stdio: "ignore" });
-      child.unref();
-      return true;
-    }
-    const child = spawn("xdg-open", [url], { detached: true, stdio: "ignore" });
-    child.unref();
-    return true;
-  } catch {
-    return false;
-  }
+  };
+  if (platform === "darwin") return launch("open", [url]);
+  if (platform === "win32") return launch("cmd", ["/c", "start", "", url]);
+  return launch("xdg-open", [url]);
 }
 
 export async function loginBoardCli(params: {


### PR DESCRIPTION
## Thinking Path
> - Paperclip orchestrates AI agents, and its CLI is part of the operator control surface for managing board-level access.
> - The affected subsystem is CLI board authentication, specifically the browser-open convenience path used during `paperclipai auth login`.
> - On headless Linux hosts, `xdg-open` is often missing because there is no desktop environment installed.
> - In that situation, `spawn()` emits an asynchronous `error` event (`ENOENT`) that escapes the current synchronous `try/catch` in `openUrl()`.
> - That unhandled child-process error can terminate the CLI before the auth approval polling loop completes, even though the printed approval URL is still valid.
> - This pull request makes browser launch failure explicitly non-fatal by absorbing async spawn errors while preserving the existing best-effort open behavior.
> - The benefit is reliable CLI auth on headless hosts without changing the auth challenge or polling model.

## What Changed
- Refactored `openUrl()` to route platform launch logic through a small `launch()` helper.
- Added a noop `child.on("error", () => {})` listener so asynchronous spawn failures do not crash the CLI.
- Preserved the existing launch commands for macOS (`open`), Windows (`cmd /c start`), and Linux (`xdg-open`).

## Verification
- Reproduced on a headless Linux host without `xdg-open` installed.
- Ran: `paperclipai auth login --api-base http://<host>:3100`
- Before fix: CLI printed the approval URL, then crashed with `spawn xdg-open ENOENT`; browser approval could still succeed, but the CLI did not persist the auth store.
- After fix: CLI continued polling after printing the URL, approval succeeded, and the auth store was written normally.
- Change is narrowly scoped to URL-launch convenience code and does not modify the challenge creation or approval polling flow.

## Risks
- Low risk.
- The only behavior change is that URL-launch failures are now explicitly non-fatal.
- If browser launch fails for any other reason, the CLI still prints the approval URL, which remains the source of truth for the user.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used
- Anthropic Claude Opus 4.7 via Hermes
- Tool-assisted reproduction against a live Paperclip deployment on a headless Linux host
- No code generation beyond the narrowly scoped patch and PR drafting flow

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
