### PR TITLE
Fix stale watchdog recovery for lost runs

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -479,7 +479,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       });
     }
 
-    return { companyId, agentId, runId, wakeupRequestId, issueId };
+    return { companyId, agentId, runId, wakeupRequestId, issueId, issuePrefix };
   }
 
   async function seedEnvironmentLeaseFixture(input: {
@@ -956,6 +956,56 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
     expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("retires stale watchdog evaluations when terminalizing a lost local process", async () => {
+    const { companyId, agentId, runId, issueId, issuePrefix } = await seedRunFixture({
+      processPid: 999_999_999,
+    });
+    const evaluationIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: evaluationIssueId,
+      companyId,
+      parentId: issueId,
+      title: "Review silent active run for CodexCoder",
+      status: "todo",
+      priority: "high",
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+      originKind: "stale_active_run_evaluation",
+      originId: runId,
+      originRunId: runId,
+      originFingerprint: `stale_active_run:${companyId}:${runId}`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: evaluationIssueId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+    await db.update(issues).set({ status: "blocked" }).where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+
+    expect(result).toMatchObject({ reaped: 1, runIds: [runId] });
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    const failedRun = runs.find((row) => row.id === runId);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_lost");
+    expect(retryRun?.status).toBe("queued");
+
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(sourceIssue?.status).toBe("in_progress");
+    expect(sourceIssue?.executionRunId).toBe(retryRun?.id ?? null);
+    await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([]);
+
+    const [evaluationIssue] = await db.select().from(issues).where(eq(issues.id, evaluationIssueId));
+    expect(evaluationIssue?.status).toBe("cancelled");
   });
 
   it("releases active environment leases when an orphaned run is reaped", async () => {
@@ -2490,6 +2540,90 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
   });
 
+  it("routes adapter quota recovery off a CEO-owned issue to an invokable engineering owner", async () => {
+    const { companyId, agentId: ceoId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "adapter_failed",
+      runError: "Codex usage limit reached. Try again later.",
+    });
+    const engineerId = randomUUID();
+
+    await db
+      .update(agents)
+      .set({
+        name: "CEO",
+        role: "ceo",
+        title: null,
+        capabilities: null,
+      })
+      .where(eq(agents.id, ceoId));
+    await db.insert(agents).values({
+      id: engineerId,
+      companyId,
+      name: "Forge",
+      role: "general",
+      title: "Engineer (BE/FE, GCP, AI)",
+      capabilities: "Owns backend/frontend runtime repair and adapter recovery.",
+      status: "idle",
+      reportsTo: ceoId,
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.assigneeAgentId).toBe(engineerId);
+
+    const recoveryAction = await waitForValue(async () =>
+      db.select().from(issueRecoveryActions).where(
+        and(
+          eq(issueRecoveryActions.companyId, companyId),
+          eq(issueRecoveryActions.sourceIssueId, issueId),
+        ),
+      ).then((rows) => rows[0] ?? null),
+    );
+    expect(recoveryAction).toMatchObject({
+      ownerType: "agent",
+      ownerAgentId: engineerId,
+      previousOwnerAgentId: ceoId,
+      returnOwnerAgentId: ceoId,
+      recoveryIssueId: null,
+    });
+    expect(recoveryAction?.evidence).toMatchObject({
+      latestRunId: runId,
+      latestRunErrorCode: "adapter_failed",
+      retryReason: "issue_continuation_needed",
+    });
+
+    const recoveryWakeup = await waitForValue(async () => {
+      const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, engineerId));
+      return wakeups.find((wakeup) => {
+        const payload = wakeup.payload as Record<string, unknown> | null;
+        return payload?.issueId === issueId &&
+          payload?.recoveryActionId === recoveryAction?.id &&
+          payload?.strandedRunId === runId;
+      }) ?? null;
+    });
+    expect(recoveryWakeup?.reason).toBe("source_scoped_recovery_action");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("Latest retry adapter failure");
+    expect(comments[0]?.body).toContain("adapter_failed");
+    expect(comments[0]?.body).toContain("Codex usage limit reached");
+    expect(comments[0]?.body).toContain("Recovery owner: [Forge]");
+    expect(comments[0]?.body).not.toContain("Recovery owner: [CEO]");
+  });
+
   it("redacts error-code-only stranded recovery failures in issue copy", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",
@@ -2518,7 +2652,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
     expect(comments).toHaveLength(1);
-    expect(comments[0]?.body).toContain("Latest retry failure details were withheld from the issue thread");
+    expect(comments[0]?.body).toContain("Latest retry adapter failure");
+    expect(comments[0]?.body).toContain("adapter_exit_code");
     expect(comments[0]?.body).not.toContain("- Failure: none recorded");
   });
 
@@ -2705,7 +2840,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
     expect(comments).toHaveLength(2);
-    expect(comments[1]?.body).toContain("Latest retry failure details were withheld from the issue thread");
+    expect(comments[1]?.body).toContain("Latest retry adapter failure");
+    expect(comments[1]?.body).toContain("adapter_failed");
+    expect(comments[1]?.body).toContain("adapter failed while retrying recovery issue");
   });
 
   it("does not escalate paused-tree recovery when the automatic continuation retry was cancelled by the hold", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2624,7 +2624,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).not.toContain("Recovery owner: [CEO]");
   });
 
-  it("redacts error-code-only stranded recovery failures in issue copy", async () => {
+  it("surfaces adapter error-code-only stranded recovery failures in issue copy", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",
       runStatus: "failed",
@@ -2655,6 +2655,38 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Latest retry adapter failure");
     expect(comments[0]?.body).toContain("adapter_exit_code");
     expect(comments[0]?.body).not.toContain("- Failure: none recorded");
+  });
+
+  it("redacts non-adapter usage-like error codes in issue copy", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "memory_usage_exceeded",
+      runError: null,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+
+    const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      retryReason: "issue_continuation_needed",
+    });
+    expect(recoveryAction.evidence).toMatchObject({
+      latestRunErrorCode: "memory_usage_exceeded",
+    });
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("Latest retry failure details were withheld");
+    expect(comments[0]?.body).not.toContain("Latest retry adapter failure");
+    expect(comments[0]?.body).not.toContain("memory_usage_exceeded");
   });
 
   it("reuses the raced stranded recovery issue when duplicate active recovery creation conflicts", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6466,7 +6466,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const reaped: string[] = [];
 
     for (const { run, adapterType, adapterConfig } of activeRuns) {
-      if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
+      const hasRunningProcessHandle = runningProcesses.has(run.id);
+      const hasActiveExecution = activeRunExecutions.has(run.id);
+      if (hasRunningProcessHandle) continue;
 
       // Apply staleness threshold to avoid false positives
       if (staleThresholdMs > 0) {
@@ -6477,6 +6479,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
+      if (hasActiveExecution) {
+        const hasTrackedProcessMetadata = tracksLocalChild && Boolean(run.processPid || run.processGroupId);
+        const trackedProcessLost = hasTrackedProcessMetadata && !processPidAlive && !processGroupAlive;
+        if (!trackedProcessLost) continue;
+      }
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
@@ -6539,6 +6546,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         status: finalizedRun.status,
         failureReason: finalizedRun.error ?? undefined,
       });
+      await recovery.retireResolvedStaleRunEvaluations({
+        companyId: finalizedRun.companyId,
+        runId: finalizedRun.id,
+        restoreSourceStatus: true,
+      });
 
       let retriedRun: typeof heartbeatRuns.$inferSelect | null = null;
       if (shouldRetry) {
@@ -6567,6 +6579,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       await finalizeAgentStatus(run.agentId, "failed");
       await startNextQueuedRunForAgent(run.agentId);
+      activeRunExecutions.delete(run.id);
       runningProcesses.delete(run.id);
       reaped.push(run.id);
     }
@@ -7756,7 +7769,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       let outcome: "succeeded" | "failed" | "cancelled" | "timed_out";
       const latestRun = await getRun(run.id);
-      if (isHeartbeatRunTerminalStatus(latestRun?.status)) {
+      const latestRunAlreadyTerminal = isHeartbeatRunTerminalStatus(latestRun?.status);
+      if (latestRunAlreadyTerminal) {
         outcome = latestRun.status;
       } else if (adapterResult.timedOut) {
         outcome = "timed_out";
@@ -7765,22 +7779,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       } else {
         outcome = "failed";
       }
+      const adapterFallbackErrorMessage =
+        adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed");
       const runErrorMessage =
         outcome === "cancelled"
           ? (latestRun?.error ?? adapterResult.errorMessage ?? "Cancelled")
           : outcome === "succeeded"
             ? null
             : redactCurrentUserText(
-                adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
+                latestRunAlreadyTerminal ? (latestRun?.error ?? adapterFallbackErrorMessage) : adapterFallbackErrorMessage,
                 currentUserRedactionOptions,
               );
+      const adapterFallbackErrorCode = outcome === "timed_out" ? "timeout" : (adapterResult.errorCode ?? "adapter_failed");
       const runErrorCode =
         outcome === "timed_out"
-          ? "timeout"
+          ? (latestRunAlreadyTerminal ? (latestRun?.errorCode ?? "timeout") : "timeout")
           : outcome === "cancelled"
             ? (latestRun?.errorCode ?? "cancelled")
             : outcome === "failed"
-              ? (adapterResult.errorCode ?? "adapter_failed")
+              ? (latestRunAlreadyTerminal ? (latestRun?.errorCode ?? adapterFallbackErrorCode) : adapterFallbackErrorCode)
               : null;
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
@@ -7845,7 +7862,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       );
 
       let persistedRun = await setRunStatus(run.id, status, {
-        finishedAt: new Date(),
+        finishedAt: latestRunAlreadyTerminal ? (latestRun?.finishedAt ?? new Date()) : new Date(),
         error: runErrorMessage,
         errorCode: runErrorCode,
         exitCode: adapterResult.exitCode,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -134,13 +134,7 @@ function compactFailureText(value: string) {
 function isAdapterTerminalFailureRun(run: LatestIssueRun) {
   if (!run) return false;
   const errorCode = readNonEmptyString(run.errorCode)?.toLowerCase() ?? null;
-  if (
-    errorCode?.startsWith("adapter_") ||
-    errorCode?.includes("usage") ||
-    errorCode?.includes("quota") ||
-    errorCode?.includes("rate_limit") ||
-    errorCode?.includes("rate-limit")
-  ) return true;
+  if (errorCode?.startsWith("adapter_")) return true;
 
   const error = readNonEmptyString(run.error)?.toLowerCase() ?? null;
   return Boolean(
@@ -1705,7 +1699,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       "",
       "## Ownership",
       "",
-      "- Selected owner: the first invokable manager/creator/executive candidate with budget available.",
+      "- Selected owner: for adapter/quota failures, the first invokable engineering candidate with budget available; otherwise the first invokable manager/creator/executive candidate.",
       "",
       "## Required Action",
       "",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -60,6 +60,7 @@ import {
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
@@ -125,8 +126,47 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+function compactFailureText(value: string) {
+  const compacted = redactSensitiveText(value).replace(/\s+/g, " ").trim();
+  return compacted.length > 500 ? `${compacted.slice(0, 497)}...` : compacted;
+}
+
+function isAdapterTerminalFailureRun(run: LatestIssueRun) {
+  if (!run) return false;
+  const errorCode = readNonEmptyString(run.errorCode)?.toLowerCase() ?? null;
+  if (
+    errorCode?.startsWith("adapter_") ||
+    errorCode?.includes("usage") ||
+    errorCode?.includes("quota") ||
+    errorCode?.includes("rate_limit") ||
+    errorCode?.includes("rate-limit")
+  ) return true;
+
+  const error = readNonEmptyString(run.error)?.toLowerCase() ?? null;
+  return Boolean(
+    error &&
+      (error.includes("usage limit") ||
+        error.includes("quota") ||
+        error.includes("rate limit") ||
+        error.includes("rate-limit")),
+  );
+}
+
 function summarizeRunFailureForIssueComment(run: LatestIssueRun) {
   if (!run) return null;
+
+  if (isAdapterTerminalFailureRun(run)) {
+    const code = readNonEmptyString(run.errorCode);
+    const message = readNonEmptyString(run.error);
+    const parts = [
+      code ? `code \`${compactFailureText(code)}\`` : null,
+      message ? `message: ${compactFailureText(message)}` : null,
+    ].filter((part): part is string => Boolean(part));
+
+    if (parts.length > 0) {
+      return ` Latest retry adapter failure: ${parts.join("; ")}.`;
+    }
+  }
 
   if (readNonEmptyString(run.error) || readNonEmptyString(run.errorCode)) {
     return " Latest retry failure details were withheld from the issue thread; inspect the linked run for evidence.";
@@ -723,6 +763,137 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function retireResolvedStaleRunEvaluations(opts?: {
+    companyId?: string;
+    runId?: string;
+    restoreSourceStatus?: boolean;
+  }) {
+    const openEvaluations = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          opts?.companyId ? eq(issues.companyId, opts.companyId) : undefined,
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          opts?.runId ? eq(issues.originId, opts.runId) : undefined,
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      );
+    const runIds = [
+      ...new Set(
+        openEvaluations
+          .map((issue) => readNonEmptyString(issue.originId))
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ];
+    if (runIds.length === 0) {
+      return {
+        retired: 0,
+        blockerRelationsRemoved: 0,
+        sourceIssuesRestored: 0,
+        retiredIssueIds: [] as string[],
+      };
+    }
+
+    const terminalRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          opts?.companyId ? eq(heartbeatRuns.companyId, opts.companyId) : undefined,
+          inArray(heartbeatRuns.id, runIds),
+          inArray(heartbeatRuns.status, [...HEARTBEAT_RUN_TERMINAL_STATUSES]),
+        ),
+      );
+    const terminalRunById = new Map(terminalRuns.map((run) => [run.id, run]));
+    const result = {
+      retired: 0,
+      blockerRelationsRemoved: 0,
+      sourceIssuesRestored: 0,
+      retiredIssueIds: [] as string[],
+    };
+
+    for (const evaluation of openEvaluations) {
+      const runId = readNonEmptyString(evaluation.originId);
+      const run = runId ? terminalRunById.get(runId) : null;
+      if (!run) continue;
+
+      const blockerRows = await db
+        .select({ sourceIssueId: issueRelations.relatedIssueId })
+        .from(issueRelations)
+        .where(
+          and(
+            eq(issueRelations.companyId, evaluation.companyId),
+            eq(issueRelations.issueId, evaluation.id),
+            eq(issueRelations.type, "blocks"),
+          ),
+        );
+      const sourceIssueIds = [
+        ...new Set(
+          [
+            evaluation.parentId,
+            ...blockerRows.map((row) => row.sourceIssueId),
+          ].filter((id): id is string => Boolean(id)),
+        ),
+      ];
+
+      for (const sourceIssueId of sourceIssueIds) {
+        const sourceIssue = await db
+          .select()
+          .from(issues)
+          .where(and(eq(issues.companyId, evaluation.companyId), eq(issues.id, sourceIssueId)))
+          .then((rows) => rows[0] ?? null);
+        if (!sourceIssue) continue;
+
+        const blockerIds = await existingBlockerIssueIds(sourceIssue.companyId, sourceIssue.id);
+        if (!blockerIds.includes(evaluation.id)) continue;
+
+        const remainingBlockerIds = blockerIds.filter((blockerId) => blockerId !== evaluation.id);
+        const shouldRestoreSource =
+          opts?.restoreSourceStatus === true &&
+          sourceIssue.status === "blocked" &&
+          remainingBlockerIds.length === 0 &&
+          sourceIssue.assigneeAgentId === run.agentId &&
+          !sourceIssue.assigneeUserId;
+        await issuesSvc.update(sourceIssue.id, {
+          blockedByIssueIds: remainingBlockerIds,
+          ...(shouldRestoreSource ? { status: "in_progress" } : {}),
+        });
+        result.blockerRelationsRemoved += 1;
+        if (shouldRestoreSource) result.sourceIssuesRestored += 1;
+      }
+
+      await issuesSvc.update(evaluation.id, { status: "cancelled" });
+      await issuesSvc.addComment(evaluation.id, [
+        "Paperclip retired this stale active-run evaluation because the source run is now terminal.",
+        "",
+        `- Source run: \`${run.id}\``,
+        `- Source run status: \`${run.status}\``,
+      ].join("\n"), { runId: run.id }, { authorType: "system" });
+      await logActivity(db, {
+        companyId: evaluation.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: run.id,
+        action: "heartbeat.output_stale_evaluation_retired",
+        entityType: "issue",
+        entityId: evaluation.id,
+        details: {
+          source: "recovery.retire_resolved_stale_run_evaluations",
+          evaluationIssueId: evaluation.id,
+          sourceRunId: run.id,
+          sourceRunStatus: run.status,
+        },
+      });
+      result.retired += 1;
+      result.retiredIssueIds.push(evaluation.id);
+    }
+
+    return result;
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -1155,6 +1326,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function scanSilentActiveRuns(opts?: { now?: Date; companyId?: string }) {
     const now = opts?.now ?? new Date();
+    const retired = await retireResolvedStaleRunEvaluations({
+      companyId: opts?.companyId,
+      restoreSourceStatus: true,
+    });
     const suspicionBefore = new Date(now.getTime() - ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS);
     const candidates = await db
       .select()
@@ -1176,6 +1351,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       escalated: 0,
       snoozed: 0,
       skipped: 0,
+      retired: retired.retired,
+      blockerRelationsRemoved: retired.blockerRelationsRemoved,
+      sourceIssuesRestored: retired.sourceIssuesRestored,
       evaluationIssueIds: [] as string[],
     };
 
@@ -1377,8 +1555,60 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     ].join("\n");
   }
 
-  async function resolveStrandedIssueRecoveryOwnerAgentId(issue: typeof issues.$inferSelect) {
+  function isEngineeringRecoveryOwnerCandidate(agent: typeof agents.$inferSelect) {
+    const haystack = [
+      agent.role,
+      agent.title,
+      agent.capabilities,
+    ].filter((value): value is string => Boolean(value)).join(" ").toLowerCase();
+
+    return /\b(cto|engineer|engineering|software|developer|dev|backend|frontend|full[- ]?stack|infrastructure|tech lead|technical)\b/.test(haystack);
+  }
+
+  async function engineeringRecoveryCandidateIds(companyId: string, excludeAgentIds: Set<string>) {
+    const rows = await db
+      .select()
+      .from(agents)
+      .where(eq(agents.companyId, companyId));
+    const reportCounts = new Map<string, number>();
+    for (const agent of rows) {
+      if (!agent.reportsTo) continue;
+      reportCounts.set(agent.reportsTo, (reportCounts.get(agent.reportsTo) ?? 0) + 1);
+    }
+
+    return rows
+      .filter((agent) =>
+        !excludeAgentIds.has(agent.id) &&
+        agent.role !== "ceo" &&
+        isEngineeringRecoveryOwnerCandidate(agent)
+      )
+      .sort((left, right) => {
+        const leftRoleRank = left.role === "cto" ? 0 : 1;
+        const rightRoleRank = right.role === "cto" ? 0 : 1;
+        if (leftRoleRank !== rightRoleRank) return leftRoleRank - rightRoleRank;
+
+        const leftManagerRank = (reportCounts.get(left.id) ?? 0) > 0 ? 0 : 1;
+        const rightManagerRank = (reportCounts.get(right.id) ?? 0) > 0 ? 0 : 1;
+        if (leftManagerRank !== rightManagerRank) return leftManagerRank - rightManagerRank;
+
+        const createdCompare = left.createdAt.getTime() - right.createdAt.getTime();
+        return createdCompare !== 0 ? createdCompare : left.id.localeCompare(right.id);
+      })
+      .map((agent) => agent.id);
+  }
+
+  async function resolveStrandedIssueRecoveryOwnerAgentId(issue: typeof issues.$inferSelect, latestRun?: LatestIssueRun) {
     const candidateIds: string[] = [];
+    const terminalAdapterFailure = isAdapterTerminalFailureRun(latestRun ?? null);
+    if (terminalAdapterFailure) {
+      candidateIds.push(
+        ...await engineeringRecoveryCandidateIds(
+          issue.companyId,
+          new Set([latestRun?.agentId, issue.assigneeAgentId].filter((id): id is string => Boolean(id))),
+        ),
+      );
+    }
+
     if (issue.assigneeAgentId) {
       const assignee = await getAgent(issue.assigneeAgentId);
       if (assignee?.reportsTo) candidateIds.push(assignee.reportsTo);
@@ -1497,7 +1727,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const existing = await findOpenStrandedIssueRecoveryIssue(input.issue.companyId, input.issue.id);
     if (existing) return existing;
 
-    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
+    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue, input.latestRun);
     if (!ownerAgentId) return null;
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
@@ -1623,7 +1853,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";
-    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
+    const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue, input.latestRun);
     const now = new Date();
     const action = await recoveryActionsSvc.upsertSourceScoped({
       companyId: input.issue.companyId,
@@ -3044,6 +3274,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     escalateStrandedRecoveryIssueInPlace,
     escalateStrandedAssignedIssue,
     recordWatchdogDecision,
+    retireResolvedStaleRunEvaluations,
     scanSilentActiveRuns,
     reconcileStrandedAssignedIssues,
     buildIssueGraphLivenessAutoRecoveryPreview,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that keeps autonomous agent work visible, owned, and recoverable.
> - Heartbeat recovery is the subsystem that prevents agent runs and their issue blockers from getting stuck without a live execution path.
> - Silent local CLI runs could remain unresolved when stale active-run bookkeeping survived after the child process was already gone.
> - Critical stale active-run watchdog issues could continue blocking the source issue even after the source run became terminal.
> - Adapter quota failures could route technical recovery back to the CEO, which left engineering recovery work in a non-actionable owner queue.
> - This pull request fixes those recovery paths for [SHT-30](/SHT/issues/SHT-30).
> - The benefit is that lost runs terminalize promptly, stale watchdog blockers retire automatically, and adapter recovery routes to an invokable engineering owner when possible.

## What Changed

- Updated orphaned-run reaping so stale `activeRunExecutions` entries no longer suppress terminalization when a tracked local child pid/pgid is gone.
- Added stale active-run evaluation retirement for terminal source runs, including blocker removal, source issue restoration when safe, cancellation of the watchdog evaluation, and activity/comment audit trail.
- Preserved terminal run error/status details when an adapter result arrives after another worker already terminalized the run.
- Routed adapter quota/failure recovery toward invokable engineering owners before falling back to existing manager/creator/executive candidates, avoiding CEO-owned technical recovery where possible.
- Added regression coverage for lost-child terminalization with stale watchdog blocker cleanup and adapter-quota recovery off a CEO-owned issue.

## Verification

- `pnpm --filter @paperclipai/server typecheck`
  - Output excerpt: `@paperclipai/server@0.3.1 typecheck ... tsc --noEmit`; command exited 0 with no TypeScript diagnostics.
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`
  - Output excerpt: `Test Files  1 passed (1)` / `Tests  46 passed (46)`.
- `pnpm exec vitest run server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`
  - Output excerpt: `Test Files  1 passed (1)` / `Tests  8 passed (8)`.
- `pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts`
  - Output excerpt: `Test Files  2 passed (2)` / `Tests  23 passed (23)`.
- `git diff --check master...HEAD`
  - Output excerpt: no output; command exited 0.

## Risks

- Low migration risk: no database schema or API contract changes.
- Recovery behavior changes can affect issue ownership and blocker cleanup, so the PR is covered by targeted lost-process, watchdog, source-scoped recovery, and issue-liveness regression tests.
- Engineering-owner detection is heuristic and may classify some technical roles broadly; existing invokable/budget checks still gate final owner selection.
- No UI changes; screenshots are not applicable.
- No user-facing command/docs contract changed; documentation updates are not applicable.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex using GPT-5 (`gpt-5`) with shell/tool execution. Context window was not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
