### PR TITLE
Fix invalid bearer auth fallback on issue updates

### DIFF
--- a/server/src/__tests__/auth-session-route.test.ts
+++ b/server/src/__tests__/auth-session-route.test.ts
@@ -66,6 +66,57 @@ describe("actorMiddleware authenticated session profile", () => {
     });
   });
 
+  it("rejects invalid bearer tokens instead of falling back to local trusted board access", async () => {
+    const app = express();
+    app.use(
+      actorMiddleware(createDb(), {
+        deploymentMode: "local_trusted",
+      }),
+    );
+    app.patch("/api/issues/:id", (req, res) => {
+      res.json(req.actor);
+    });
+    app.use(
+      (
+        err: { status?: number; message?: string },
+        _req: express.Request,
+        res: express.Response,
+        _next: express.NextFunction,
+      ) => {
+        res.status(err.status ?? 500).json({ error: err.message ?? "Internal server error" });
+      },
+    );
+
+    const res = await request(app)
+      .patch("/api/issues/issue-1")
+      .set("Authorization", "Bearer definitely-not-valid")
+      .send({ status: "done" });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Invalid bearer token" });
+  });
+
+  it("keeps local trusted implicit board access when no bearer token is sent", async () => {
+    const app = express();
+    app.use(
+      actorMiddleware(createDb(), {
+        deploymentMode: "local_trusted",
+      }),
+    );
+    app.patch("/api/issues/:id", (req, res) => {
+      res.json(req.actor);
+    });
+
+    const res = await request(app).patch("/api/issues/issue-1").send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      type: "board",
+      userId: "local-board",
+      source: "local_implicit",
+    });
+  });
+
   it("trusts Cloud tenant identity headers and seeds board access", async () => {
     process.env.PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN = "tenant-token";
     const inserts: Array<{ values: Record<string, unknown> }> = [];

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -8,6 +8,7 @@ import type { DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "./logger.js";
 import { boardAuthService } from "../services/board-auth.js";
+import { unauthorized } from "../errors.js";
 
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
@@ -102,7 +103,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
 
     const token = authHeader.slice("bearer ".length).trim();
     if (!token) {
-      next();
+      next(unauthorized("Invalid bearer token"));
       return;
     }
 
@@ -138,7 +139,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
     if (!key) {
       const claims = verifyLocalAgentJwt(token);
       if (!claims) {
-        next();
+        next(unauthorized("Invalid bearer token"));
         return;
       }
 
@@ -149,12 +150,12 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
         .then((rows) => rows[0] ?? null);
 
       if (!agentRecord || agentRecord.companyId !== claims.company_id) {
-        next();
+        next(unauthorized("Invalid bearer token"));
         return;
       }
 
       if (agentRecord.status === "terminated" || agentRecord.status === "pending_approval") {
-        next();
+        next(unauthorized("Invalid bearer token"));
         return;
       }
 
@@ -182,7 +183,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
       .then((rows) => rows[0] ?? null);
 
     if (!agentRecord || agentRecord.status === "terminated" || agentRecord.status === "pending_approval") {
-      next();
+      next(unauthorized("Invalid bearer token"));
       return;
     }
 


### PR DESCRIPTION
## Summary
- Reject present-but-invalid bearer tokens in actor middleware with 401 instead of falling through to local trusted board access.
- Add regression coverage for a PATCH-style issue update path with a bad bearer token and the no-token local trusted baseline.

## Evidence
- `pnpm vitest run server/src/__tests__/auth-session-route.test.ts` - 4 tests passed
- `pnpm --filter @paperclipai/server typecheck` - passed

## Diff stat
```text
 server/src/__tests__/auth-session-route.test.ts | 51 +++++++++++++++++++++++++
 server/src/middleware/auth.ts                   | 11 +++---
 2 files changed, 57 insertions(+), 5 deletions(-)
```

## Relevant diff excerpt
```diff
diff --git a/server/src/middleware/auth.ts b/server/src/middleware/auth.ts
@@
 import { boardAuthService } from "../services/board-auth.js";
+import { unauthorized } from "../errors.js";
@@
     const token = authHeader.slice("bearer ".length).trim();
     if (!token) {
-      next();
+      next(unauthorized("Invalid bearer token"));
       return;
     }
@@
       const claims = verifyLocalAgentJwt(token);
       if (!claims) {
-        next();
+        next(unauthorized("Invalid bearer token"));
         return;
       }
@@
       if (!agentRecord || agentRecord.companyId !== claims.company_id) {
-        next();
+        next(unauthorized("Invalid bearer token"));
         return;
       }
```

Linked ITO ticket: ITO-594