### PR TITLE
docs(skills): default non-universal skill bundles to required: false

### DIFF
--- a/skills/paperclip-converting-plans-to-tasks/SKILL.md
+++ b/skills/paperclip-converting-plans-to-tasks/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: paperclip-converting-plans-to-tasks
+required: false
 description: >
   The Paperclip way of converting a plan into executable tasks. Use whenever
   you are asked to plan, scope, or break down work inside a Paperclip company.

--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: paperclip-create-agent
+required: false
 description: >
   Create new agents in Paperclip with governance-aware hiring. Use when you need
   to inspect adapter configuration options, compare existing agent configs,

--- a/skills/paperclip-create-plugin/SKILL.md
+++ b/skills/paperclip-create-plugin/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: paperclip-create-plugin
+required: false
 description: >
   Create and develop external Paperclip plugins with the CLI-first workflow.
   Use when scaffolding a new plugin, working on a local plugin against a running


### PR DESCRIPTION
## Summary

Adds `required: false` to the frontmatter of three skill bundles in `skills/`:

- `paperclip-converting-plans-to-tasks/SKILL.md`
- `paperclip-create-agent/SKILL.md`
- `paperclip-create-plugin/SKILL.md`

`paperclip-dev` already ships with `required: false` (unchanged). `paperclip` and `para-memory-files` remain required (universal — every agent needs them on every heartbeat).

## Why

`listPaperclipSkillEntries` in `packages/adapter-utils/src/server-utils.ts` defaults each skill directory to `required: true` when no explicit frontmatter says otherwise. For adapters like `claude_local` that materialise the skill bundle into every prompt, the three skills above add ~96 KB to **every** heartbeat across a 30+ agent company — only a handful of agents actually need them, and the skill autoloading system already pulls them in on demand when the task matches the skill's `description`.

In our deployment this pushed claude_local agents over upstream Anthropic rate limits and produced the endless-run/budget-burn pattern tracked downstream as COO-1560 / COO-1712. We've been carrying the same change as a manual edit to the installed npm cache, but it gets clobbered every time we run `npx paperclipai@<version>` against a new cache directory — the only durable fix is upstream.

## What changes for users

- Agents that already used these skills will still get them — skill autoloading reads `description` and pulls the skill in when the task matches.
- Agents that don't need them no longer pay the prompt-bundle cost on every heartbeat.
- No behavior change for `paperclip-dev` (already had `required: false`), `paperclip`, or `para-memory-files`.

## Test plan

- [x] `head -10` of each touched file shows `required: false` on line 3
- [x] No other files changed; diff is +3 / -0
- [ ] After this lands in a tagged release, downstream operator confirms `head -10` of each `SKILL.md` in the freshly-installed `@paperclipai/server/skills/` cache shows `required: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)