### PR TITLE
Checkup - Report bugs, errors and security

### DIFF
--- a/report/checkup-2026-05-17.md
+++ b/report/checkup-2026-05-17.md
@@ -1,249 +1,249 @@
-# Checkup do Repositório Paperclip — 2026-05-17
+# Paperclip Repository Checkup — 2026-05-17
 
-> Auditoria de segurança, qualidade de código e oportunidades de produto, executada via 3 agentes Explore em paralelo com validação manual dos achados críticos.
-
----
-
-## 1. Sumário executivo
-
-| Categoria | Achados |
-|-----------|---------|
-| **Segurança — ALTA** | 2 |
-| **Segurança — MÉDIA** | 4 |
-| **Segurança — BAIXA / Defense-in-depth** | 3 |
-| **Bugs / qualidade — relevantes** | 8 |
-| **Oportunidades — features** | 5 |
-| **Oportunidades — skills** | 4 |
-| **Oportunidades — agents** | 4 |
-| **Oportunidades — hooks** | 4 |
-
-### Top 3 ações imediatas
-
-1. **Regenerar `.env.example`** — varrer todos os `process.env.*` do código (atualmente apenas 4 das ~80 variáveis estão documentadas, incluindo segredos críticos como `PAPERCLIP_SECRETS_MASTER_KEY` e `PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN`).
-2. **Hardening do modo `local_trusted`** em `server/src/middleware/auth.ts:24-34` — qualquer request vira `instance_admin`. Forçar bind em `127.0.0.1` quando esse modo for usado, ou warning loud + recusa de start se a porta estiver bound em interface não-loopback.
-3. **Restringir CORS de plugin UI** em `server/src/routes/plugin-ui-static.ts:475` — substituir `Access-Control-Allow-Origin: *` por allowlist da origem da instância.
-
-### Pontos positivos verificados
-
-A auditoria também detectou áreas onde o código está **bem feito** e não requer ação:
-
-- **SSRF protection (`plugin-host-services.ts:80-209`)** — defesa exemplar: DNS pinning anti-rebinding, blocklist IPv4/IPv6/IPv4-mapped, timeout, protocolo whitelist. Padrão referência para outros projetos.
-- **Uso pervasivo de Drizzle ORM** elimina a classe de SQL injection clássica.
-- **Sanitização SVG (`assets.ts`)** via jsdom + DOMPurify antes de upload.
-- **Master key local encrypted** com AES-256-GCM, geração automática segura, health check de permissões.
-- **Auth com `timingSafeEqual`** para comparação de tokens de cloud tenant.
-- **Redação de secrets** em logs via `feedback-redaction.ts`.
+> Audit of security, code quality, and product opportunities. Executed via 3 parallel Explore agents with manual validation of critical findings.
 
 ---
 
-## 2. Segurança
+## 1. Executive summary
 
-Severidades calibradas após leitura manual dos arquivos citados. Findings dos agentes que se revelaram superestimados foram movidos para "Falsos positivos" no final desta seção.
+| Category | Findings |
+|----------|----------|
+| **Security — HIGH** | 2 |
+| **Security — MEDIUM** | 4 |
+| **Security — LOW / Defense-in-depth** | 3 |
+| **Bugs / quality — relevant** | 8 |
+| **Opportunities — features** | 5 |
+| **Opportunities — skills** | 4 |
+| **Opportunities — agents** | 4 |
+| **Opportunities — hooks** | 4 |
 
-### 2.1 ALTA
+### Top 3 immediate actions
 
-#### S-A1 — `local_trusted` autoriza qualquer request como `instance_admin`
-- **Arquivo:** `server/src/middleware/auth.ts:24-34`
-- **Descrição:** Se `deploymentMode === "local_trusted"`, o `actorMiddleware` atribui `req.actor = { type: "board", userId: "local-board", isInstanceAdmin: true }` sem qualquer verificação de origem ou credencial.
-- **Cenário de ataque:** Usuário sobe Paperclip em `0.0.0.0:3100` (ou esquece um port-forward aberto, ou roda em LAN compartilhada). Qualquer dispositivo da rede vira admin da instância.
-- **Fix recomendado:**
-  - Recusar startup em modo `local_trusted` se o host bind ≠ `127.0.0.1`/`::1`.
-  - Adicionar warning crítico no log de startup descrevendo a postura.
-  - Documentar explicitamente em `SECURITY.md` que `local_trusted` ≡ "trust whoever can reach the socket".
+1. **Regenerate `.env.example`** — sweep all `process.env.*` usages in the code (only 4 of ~80 variables are currently documented, including security-critical ones like `PAPERCLIP_SECRETS_MASTER_KEY` and `PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN`).
+2. **Harden `local_trusted` mode** in `server/src/middleware/auth.ts:24-34` — any request becomes `instance_admin`. Force bind to `127.0.0.1` when this mode is active, or fail-loud and refuse startup if bound to a non-loopback interface.
+3. **Restrict CORS on plugin UI assets** in `server/src/routes/plugin-ui-static.ts:475` — replace `Access-Control-Allow-Origin: *` with the instance origin allowlist.
 
-#### S-A2 — `.env.example` defasada (4 vars documentadas vs ~80 usadas)
-- **Arquivo:** `.env.example` (todo)
-- **Descrição:** Documenta `DATABASE_URL`, `PORT`, `SERVE_UI`, `BETTER_AUTH_SECRET` e um Discord webhook comentado. Mas o código consome dezenas de outras variáveis, várias com implicações de segurança: `PAPERCLIP_SECRETS_MASTER_KEY`, `PAPERCLIP_SECRETS_MASTER_KEY_FILE`, `PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN`, `PAPERCLIP_LISTEN_HOST`, `PAPERCLIP_API_URL`, `BETTER_AUTH_SECRET`, etc.
-- **Cenário:** Operador novo segue `.env.example`, sobe instância sem `PAPERCLIP_SECRETS_MASTER_KEY` definida. O sistema gera uma chave automática em `~/.paperclip/secrets.key` (correto), mas o operador não sabe que existe e não faz backup — primeira restauração de DB perde todos os secrets descriptografáveis.
-- **Fix recomendado:** Script `scripts/generate-env-example.mjs` que faz grep de `process.env.*` em `server/src/**/*.ts`, agrupa por categoria (storage, auth, secrets, deployment, observability), inclui comentários explicativos e valores-padrão. Rodar como check em CI.
+### Verified positive findings
 
-### 2.2 MÉDIA
+The audit also identified areas where the codebase is **well done** and requires no action:
 
-#### S-M1 — CORS wildcard em assets de plugin UI
-- **Arquivo:** `server/src/routes/plugin-ui-static.ts:475`
-- **Código:** `res.set("Access-Control-Allow-Origin", "*");`
-- **Descrição:** Serve JS/CSS de plugins para qualquer origem. Não vaza dados de API diretamente, mas:
-  - Plugin UI source code pode ser lido por sites maliciosos (exfiltração de lógica proprietária).
-  - Em combinação com bugs futuros no plugin host, pode amplificar superfície.
-- **Fix:** Trocar `*` pela origem configurada da instância (`config.publicBaseUrl`), ou remover o header completamente (browser ainda permite same-origin).
+- **SSRF protection (`plugin-host-services.ts:80-209`)** — exemplary defense: anti-rebinding DNS pinning, IPv4/IPv6/IPv4-mapped blocklist, timeout, protocol whitelist. Reference-quality implementation.
+- **Pervasive use of Drizzle ORM** eliminates the classic SQL-injection class.
+- **SVG sanitization (`assets.ts`)** via jsdom + DOMPurify before upload.
+- **Local-encrypted master key** with AES-256-GCM, secure automatic generation, file-permission health check.
+- **Auth uses `timingSafeEqual`** for cloud-tenant token comparison.
+- **Secret redaction** in logs via `feedback-redaction.ts`.
 
-#### S-M2 — Mermaid `securityLevel` não setado explicitamente
-- **Arquivo:** `ui/src/components/MarkdownBody.tsx:448-454, 475`
-- **Descrição:** `mermaid.initialize({ theme, fontFamily, suppressErrorRendering })` não inclui `securityLevel`. Mermaid v10+ usa default `"strict"` (mitiga XSS), mas confiar no default é frágil — upgrade futuro ou hot-config pode mudar o default.
-- **Cenário:** Agent malicioso embute Mermaid com `<script>` ou click handlers em diagram labels. Hoje sanitizado pelo default; amanhã não.
-- **Fix:** Adicionar explicitamente `securityLevel: "strict"` no init. Opcionalmente passar o SVG resultante por DOMPurify antes do `dangerouslySetInnerHTML`.
+---
 
-#### S-M3 — Prefix attack possível em path de plugin local
-- **Arquivo:** `server/src/routes/plugin-ui-static.ts:121`
-- **Código:** `if (uiDirFromPackagePath.startsWith(resolvedPackagePath) && fs.existsSync(uiDirFromPackagePath))`
-- **Descrição:** `startsWith` é vulnerável a prefix attack: `/opt/plugins/foo` "starts with" `/opt/plugins/fo` (sem barra). Se um operador instalar dois plugins com nomes prefixo (`foo` e `foobar`), há risco de path leak.
-- **Mitigação atual:** O path principal (linhas 411-438) usa `realpathSync` + `path.relative()` corretamente. Só esse fallback de `packagePath` admin-controlado tem o bug.
-- **Fix:** Substituir por `path.relative(resolvedPackagePath, uiDirFromPackagePath)` + checagem `!startsWith("..")` e `!path.isAbsolute(rel)` — mesmo padrão das linhas 434-435.
+## 2. Security
 
-#### S-M4 — Webhooks de routine sem rate-limit / timeout explícito
-- **Arquivo:** `server/src/services/plugin-managed-routines.ts` e infra de routines
-- **Descrição:** Routines disparam HTTP calls; não há rate-limit por routine nem timeout máximo configurável visível. Plugin malicioso pode criar routine recursiva (routine A dispara routine B dispara routine A).
+Severities calibrated after manual reading of the cited files. Findings from the agents that turned out to be overstated were moved to "False positives" at the end of this section.
+
+### 2.1 HIGH
+
+#### S-A1 — `local_trusted` grants any request `instance_admin`
+- **File:** `server/src/middleware/auth.ts:24-34`
+- **Description:** When `deploymentMode === "local_trusted"`, `actorMiddleware` assigns `req.actor = { type: "board", userId: "local-board", isInstanceAdmin: true }` with no origin or credential check.
+- **Attack scenario:** Operator brings Paperclip up on `0.0.0.0:3100` (or forgets an open port-forward, or runs on a shared LAN). Any device on the network becomes instance admin.
+- **Recommended fix:**
+  - Refuse startup in `local_trusted` mode if the bind host is not `127.0.0.1`/`::1`.
+  - Emit a loud critical warning at startup describing the posture.
+  - Document explicitly in `SECURITY.md` that `local_trusted` ≡ "trust whoever can reach the socket".
+
+#### S-A2 — `.env.example` is stale (4 vars documented vs ~80 used)
+- **File:** `.env.example` (whole file)
+- **Description:** Documents `DATABASE_URL`, `PORT`, `SERVE_UI`, `BETTER_AUTH_SECRET`, and a commented Discord webhook. The code, however, consumes dozens of additional variables, several with security implications: `PAPERCLIP_SECRETS_MASTER_KEY`, `PAPERCLIP_SECRETS_MASTER_KEY_FILE`, `PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN`, `PAPERCLIP_LISTEN_HOST`, `PAPERCLIP_API_URL`, `BETTER_AUTH_SECRET`, etc.
+- **Scenario:** A new operator follows `.env.example`, brings up an instance without `PAPERCLIP_SECRETS_MASTER_KEY`. The system auto-generates a key at `~/.paperclip/secrets.key` (correct behavior), but the operator does not know it exists and never backs it up — the first DB restore loses all decryptable secrets.
+- **Recommended fix:** A `scripts/generate-env-example.mjs` that greps `process.env.*` across `server/src/**/*.ts`, groups by category (storage, auth, secrets, deployment, observability), adds explanatory comments and default values. Run as a CI check.
+
+### 2.2 MEDIUM
+
+#### S-M1 — Wildcard CORS on plugin UI assets
+- **File:** `server/src/routes/plugin-ui-static.ts:475`
+- **Code:** `res.set("Access-Control-Allow-Origin", "*");`
+- **Description:** Serves plugin JS/CSS to any origin. Does not leak API data directly, but:
+  - Plugin UI source code becomes readable by malicious sites (proprietary-logic exfiltration).
+  - Combined with future bugs in the plugin host, can amplify the attack surface.
+- **Fix:** Replace `*` with the configured instance origin (`config.publicBaseUrl`), or remove the header entirely (the browser still allows same-origin).
+
+#### S-M2 — Mermaid `securityLevel` not explicitly set
+- **File:** `ui/src/components/MarkdownBody.tsx:448-454, 475`
+- **Description:** `mermaid.initialize({ theme, fontFamily, suppressErrorRendering })` does not include `securityLevel`. Mermaid v10+ defaults to `"strict"` (mitigates XSS), but relying on the default is fragile — a future upgrade or hot config change can flip it.
+- **Scenario:** A malicious agent embeds Mermaid with `<script>` tags or click handlers in diagram labels. Sanitized today by the default; not necessarily tomorrow.
+- **Fix:** Add `securityLevel: "strict"` explicitly to the init call. Optionally pass the resulting SVG through DOMPurify before the `dangerouslySetInnerHTML`.
+
+#### S-M3 — Prefix attack possible in local plugin path resolution
+- **File:** `server/src/routes/plugin-ui-static.ts:121`
+- **Code:** `if (uiDirFromPackagePath.startsWith(resolvedPackagePath) && fs.existsSync(uiDirFromPackagePath))`
+- **Description:** `startsWith` is vulnerable to prefix attack: `/opt/plugins/foo` "starts with" `/opt/plugins/fo` (no separator). If an operator installs two plugins with prefix-overlapping names (`foo` and `foobar`), there is a path-leak risk.
+- **Current mitigation:** The main path (lines 411-438) uses `realpathSync` + `path.relative()` correctly. Only this admin-controlled `packagePath` fallback has the bug.
+- **Fix:** Replace with `path.relative(resolvedPackagePath, uiDirFromPackagePath)` and check `!startsWith("..")` and `!path.isAbsolute(rel)` — same pattern as lines 434-435.
+
+#### S-M4 — Routine webhooks lack explicit rate-limit / timeout
+- **File:** `server/src/services/plugin-managed-routines.ts` and routines infra
+- **Description:** Routines fire HTTP calls; there is no visible per-routine rate limit and no configurable maximum timeout. A malicious plugin can create a recursive routine (routine A fires routine B fires routine A).
 - **Fix:**
-  - Rate-limit por `routineId` (ex.: 60 disparos/h).
-  - Timeout hard máximo (ex.: 30s) com kill do worker.
-  - Tracking de "trigger lineage" — se routine A já está na chain que disparou esta execução, abortar.
+  - Per-`routineId` rate limit (e.g. 60 fires/h).
+  - Hard maximum timeout (e.g. 30s) with worker kill.
+  - "Trigger lineage" tracking — if routine A is already in the chain that fired this execution, abort.
 
-### 2.3 BAIXA / Defense-in-depth
+### 2.3 LOW / Defense-in-depth
 
-#### S-B1 — `chmodSync` em try silencioso no secrets provider
-- **Arquivo:** `server/src/secrets/local-encrypted-provider.ts:75-79, 83-92`
-- **Descrição:** Após `writeFileSync(keyPath, ..., { mode: 0o600 })`, há `chmodSync(keyPath, 0o600)` envolto em try-catch vazio. Como o `writeFileSync` já cria com mode correto, o chmod é defesa redundante. O health check (linhas 178-181) detecta drift e emite warning.
-- **Avaliação:** Aceitável como está. Melhoria opcional: logar `warn` no catch para visibilidade.
+#### S-B1 — Silent `chmodSync` try-catch in secrets provider
+- **File:** `server/src/secrets/local-encrypted-provider.ts:75-79, 83-92`
+- **Description:** After `writeFileSync(keyPath, ..., { mode: 0o600 })`, there is a `chmodSync(keyPath, 0o600)` wrapped in an empty try-catch. Since `writeFileSync` already creates the file with the correct mode, the chmod is redundant defense. The health check (lines 178-181) detects drift and emits a warning.
+- **Assessment:** Acceptable as-is. Optional improvement: log a `warn` from the catch for visibility.
 
-#### S-B2 — Magic bytes não validados em upload
-- **Arquivo:** `server/src/routes/assets.ts:88-95, 141-158`
-- **Descrição:** Validação de upload usa apenas `file.mimetype` (manipulável pelo cliente) + sanitização SVG. Para tipos não-SVG (PNG, JPG, etc.), magic bytes não são verificados.
-- **Avaliação:** Risco baixo porque (a) SVG é o único formato executável no browser e ESTÁ sanitizado, (b) outros formatos são armazenados sem processamento. Mas vale documentar o invariante: "qualquer formato novo que possa conter código (HTML, SVG, PDF JavaScript) precisa ser sanitizado antes do `storage.putFile`".
+#### S-B2 — Magic bytes not validated on upload
+- **File:** `server/src/routes/assets.ts:88-95, 141-158`
+- **Description:** Upload validation relies only on `file.mimetype` (client-controlled) plus SVG sanitization. For non-SVG types (PNG, JPG, etc.), magic bytes are not checked.
+- **Assessment:** Low risk because (a) SVG is the only browser-executable format and it IS sanitized, (b) other formats are stored without processing. Worth documenting the invariant: "any new format that can contain code (HTML, SVG, PDF JavaScript) must be sanitized before `storage.putFile`".
 
-#### S-B3 — Container `untrusted-review` expõe porta Vite dev
-- **Arquivo:** `docker/untrusted-review/Dockerfile:42`
-- **Descrição:** Container expõe 3100 (server) + 5173 (Vite dev). Se for usado em produção sem rebuild, o dev server vai estar exposto.
-- **Fix:** Confirmar via documentação que esta imagem é só dev/CI; em prod, gerar variante sem 5173.
+#### S-B3 — `untrusted-review` container exposes Vite dev port
+- **File:** `docker/untrusted-review/Dockerfile:42`
+- **Description:** Container exposes 3100 (server) + 5173 (Vite dev). If used in production without a rebuild, the dev server is exposed.
+- **Fix:** Confirm via documentation that this image is dev/CI only; for prod, generate a variant without 5173.
 
-### 2.4 Falsos positivos ou achados superestimados (do agente de segurança)
+### 2.4 False positives / overstated findings (from the security agent)
 
-Os seguintes findings foram reportados pelo agente Explore como graves, mas a leitura manual mostrou que a implementação está correta:
+The following findings were reported by the security Explore agent as serious, but manual reading showed the implementation is correct:
 
-| Finding original | Verificação manual |
-|------------------|--------------------|
-| "XSS CRÍTICO em Mermaid via `dangerouslySetInnerHTML`" | Mermaid v10+ default `securityLevel: "strict"` mitiga. Rebaixado para MÉDIA (S-M2) por falta do set explícito. |
-| "SSRF possível via regex IPv6 ULA edge cases" | Código não usa regex para validação — usa `lower.startsWith("fc")/("fd")` etc. Validação correta. |
-| "Master key file pode ter permissões fracas" | `writeFileSync` cria com `mode: 0o600`. Health check detecta drift. Risco real é baixíssimo. |
-| "Multer file upload sem magic bytes" | SVG (único tipo executável) é sanitizado; outros tipos não executam. Rebaixado para BAIXA (S-B2). |
-| "JSON.parse sem error handling em agent-auth-jwt.ts" | `verifyLocalAgentJwt` retorna `null` em qualquer falha — wrapper defensivo correto. |
+| Original finding | Manual verification |
+|------------------|---------------------|
+| "CRITICAL XSS in Mermaid via `dangerouslySetInnerHTML`" | Mermaid v10+ default `securityLevel: "strict"` mitigates. Downgraded to MEDIUM (S-M2) for missing the explicit set. |
+| "Possible SSRF via IPv6 ULA regex edge cases" | The code does not use regex for validation — it uses `lower.startsWith("fc")/("fd")` etc. Validation is correct. |
+| "Master key file may have weak permissions" | `writeFileSync` creates with `mode: 0o600`. Health check detects drift. Real risk is very low. |
+| "Multer upload without magic-byte check" | SVG (the only executable type) is sanitized; other types do not execute. Downgraded to LOW (S-B2). |
+| "JSON.parse without error handling in agent-auth-jwt.ts" | `verifyLocalAgentJwt` returns `null` on any failure — correct defensive wrapper. |
 
 ---
 
-## 3. Bugs e qualidade de código
+## 3. Bugs and code quality
 
-### 3.1 Concorrência / startup
+### 3.1 Concurrency / startup
 
-#### B1 — Startup heartbeat chain de 5 `.then()` sem isolamento de falha
-- **Arquivo:** `server/src/index.ts:678-714`
-- **Descrição:** Cadeia `reapOrphanedRuns().then(promote).then(resume + reconcile).then(reconcileGraph).then(scanSilent).then(reconcileProductivity).catch(log)`. Se o passo 2 falhar, os passos 3-5 nunca rodam — sistema sobe em estado parcialmente reconciliado.
-- **Fix:** Isolar cada passo em try-individual: `await safeStep(reapOrphanedRuns); await safeStep(promote); ...` onde `safeStep` loga erro e continua.
+#### B1 — Startup heartbeat chain of 5 `.then()` without per-step isolation
+- **File:** `server/src/index.ts:678-714`
+- **Description:** Chain `reapOrphanedRuns().then(promote).then(resume + reconcile).then(reconcileGraph).then(scanSilent).then(reconcileProductivity).catch(log)`. If step 2 fails, steps 3-5 never run — the system comes up partially reconciled.
+- **Fix:** Isolate each step in its own try: `await safeStep(reapOrphanedRuns); await safeStep(promote); ...` where `safeStep` logs the error and proceeds.
 
-#### B2 — `setInterval` de 10s sem proteção contra overlap
-- **Arquivo:** `server/src/index.ts:719+`
-- **Descrição:** Tick a cada 10s dispara `heartbeat.tickTimers()` + `routines.tickScheduledTriggers()` + `reapOrphanedRuns()`. Se um tick demorar >10s (carga, GC pause, DB lento), o próximo já enfileira em paralelo.
-- **Fix:** Flag `isTicking = false` no top do interval; pular se `true`. Ou converter para `setTimeout` auto-rescheduled após `await`.
+#### B2 — `setInterval` of 10s without overlap protection
+- **File:** `server/src/index.ts:719+`
+- **Description:** The 10s tick fires `heartbeat.tickTimers()` + `routines.tickScheduledTriggers()` + `reapOrphanedRuns()`. If a tick takes longer than 10s (load spike, GC pause, slow DB), the next one queues in parallel.
+- **Fix:** Top-of-interval `isTicking = false` flag; skip if `true`. Or convert to `setTimeout` self-rescheduled after `await`.
 
-### 3.2 Silent error handlers — verificados
+### 3.2 Silent error handlers — verified
 
-#### B3 — Catches vazios em operações git são intencionais
-- **Arquivo:** `server/src/services/workspace-runtime.ts:571, 577, 590, 620, 649, 661, 679, 975, 982, 1079, 1243`
-- **Avaliação:** Quase todos são checks de existência (`rev-parse` falha → não é repo, retorna `null`) ou cleanup idempotente (`worktree prune`). Aceitável. Apenas linha 1243 (prune antes de `worktree add`) merece `.catch(err => log.warn(...))` para diagnóstico futuro.
+#### B3 — Empty catches in git operations are intentional
+- **File:** `server/src/services/workspace-runtime.ts:571, 577, 590, 620, 649, 661, 679, 975, 982, 1079, 1243`
+- **Assessment:** Almost all are existence checks (`rev-parse` failing → not a repo, return `null`) or idempotent cleanup (`worktree prune`). Acceptable. Only line 1243 (prune before `worktree add`) is worth `.catch(err => log.warn(...))` for future diagnostics.
 
-#### B4 — `_pluginEventBus.emit().catch(() => {})` é wrapper de segurança
-- **Arquivo:** `server/src/services/activity-log.ts:50`
-- **Avaliação:** O `.then(({ errors }) => log per-error)` já loga falhas individuais de handlers. O `.catch(() => {})` externo só protege contra crash do próprio bus. OK.
+#### B4 — `_pluginEventBus.emit().catch(() => {})` is a safety wrapper
+- **File:** `server/src/services/activity-log.ts:50`
+- **Assessment:** The `.then(({ errors }) => log per-error)` already logs individual handler failures. The outer `.catch(() => {})` only protects against bus crashes. OK.
 
-### 3.3 Cobertura de testes — recalibrada
+### 3.3 Test coverage — recalibrated
 
-O agente reportou "0 testes para `server/src/routes/`". Investigação manual: existem **36+ arquivos de teste** em `server/src/__tests__/` cobrindo routes (ex.: `assets.test.ts`, `auth-routes.test.ts`, `activity-routes.test.ts`, `agent-permissions-routes.test.ts`, `adapter-routes.test.ts`). Convenção é centralizar testes em `__tests__/`, não co-localizar.
+The agent reported "0 tests for `server/src/routes/`". Manual investigation: there are **36+ test files** in `server/src/__tests__/` covering routes (e.g. `assets.test.ts`, `auth-routes.test.ts`, `activity-routes.test.ts`, `agent-permissions-routes.test.ts`, `adapter-routes.test.ts`). The convention is to centralize tests in `__tests__/`, not to co-locate them.
 
-**Realmente faltam testes específicos para:**
-- `server/src/routes/issues.ts` (5010 linhas) — apenas testes indiretos
-- `server/src/routes/access.ts` (4410 linhas)
-- `server/src/routes/agents.ts` (3448 linhas)
+**Specific tests are genuinely missing for:**
+- `server/src/routes/issues.ts` (5010 lines) — only indirect tests
+- `server/src/routes/access.ts` (4410 lines)
+- `server/src/routes/agents.ts` (3448 lines)
 - `server/src/routes/execution-workspaces.ts`
 
-São arquivos grandes e críticos. Recomendação: adicionar suíte focada em authz e edge cases para cada um (mesmo padrão de `agent-cross-tenant-authz-routes.test.ts`).
+These are large, critical files. Recommendation: add a focused authz + edge-case suite for each (same pattern as `agent-cross-tenant-authz-routes.test.ts`).
 
 ### 3.4 Type safety
 
-#### B5 — 11 ocorrências de `db as any` em `server/src/index.ts`
-- **Causa provável:** type `Db` exportado por `@paperclipai/db` diverge entre subpacotes (tsconfig paths). Cast oculta o problema.
-- **Fix:** Unificar tipo `Db` em `packages/shared` ou `packages/db`, importar consistentemente.
+#### B5 — 11 occurrences of `db as any` in `server/src/index.ts`
+- **Likely cause:** the `Db` type exported by `@paperclipai/db` diverges across subpackages (tsconfig paths). The cast hides the problem.
+- **Fix:** Unify the `Db` type in `packages/shared` or `packages/db` and import it consistently.
 
-#### B6 — `as any` em RPC dinâmico de plugin
-- **Arquivo:** `server/src/services/plugin-host-services.ts` (15+ ocorrências)
-- **Avaliação:** Aceitável dado que RPC é dinâmico, mas adicionar runtime validation (zod) na fronteira reduz risco.
+#### B6 — `as any` in dynamic plugin RPC
+- **File:** `server/src/services/plugin-host-services.ts` (15+ occurrences)
+- **Assessment:** Acceptable given the RPC is dynamic, but adding runtime validation (zod) at the boundary lowers risk.
 
 ### 3.5 UI
 
-#### B7 — useEffect deps potencialmente instáveis em RoutineHistoryTab
-- **Arquivo:** `ui/src/components/RoutineHistoryTab.tsx:89-93, 760-765`
-- **Avaliação:** Sem reprodução clara. Validar com React DevTools profiler em sessão real para confirmar re-renders excessivos.
+#### B7 — Potentially unstable useEffect deps in RoutineHistoryTab
+- **File:** `ui/src/components/RoutineHistoryTab.tsx:89-93, 760-765`
+- **Assessment:** No clear repro. Validate with React DevTools profiler in a real session to confirm excessive re-renders.
 
-### 3.6 Documentação drift
+### 3.6 Documentation drift
 
-#### B8 — `AGENTS.md:179-219` referencia fork "HenkDz/paperclip"
-- **Descrição:** Seção "Fork-Specific" descreve Hermes como plugin externo. Repo base é `paperclipai/paperclip` — pode estar desalinhada.
-- **Ação:** Confirmar se é intencional (instruções para forkers) ou se foi merge acidental.
+#### B8 — `AGENTS.md:179-219` references the "HenkDz/paperclip" fork
+- **Description:** The "Fork-Specific" section describes Hermes as an external plugin. The base repo is `paperclipai/paperclip` — this may be drift.
+- **Action:** Confirm whether this is intentional (instructions for forkers) or an accidental merge.
 
 ---
 
-## 4. Oportunidades — features, skills, agents, hooks
+## 4. Opportunities — features, skills, agents, hooks
 
-> Filtrado contra `ROADMAP.md` para evitar duplicar itens já planejados (Memory/Knowledge, Work Queues, Self-Organization, CEO Chat, Cloud agents, Artifacts, Enforced Outcomes).
+> Filtered against `ROADMAP.md` to avoid duplicating planned items (Memory/Knowledge, Work Queues, Self-Organization, CEO Chat, Cloud agents, Artifacts, Enforced Outcomes).
 
-### 4.1 Features (5 ideias prioritárias)
+### 4.1 Features (5 priority ideas)
 
-| # | Feature | Plug-in point | Valor |
+| # | Feature | Plug-in point | Value |
 |---|---------|---------------|-------|
-| F1 | **Budget threshold webhooks** — disparar Discord/Slack quando company excede X% do orçamento mensal | `server/src/services/budgets.ts` + `costs.ts`; novo CRUD `/api/companies/:id/budget-webhooks` | Alerta proativo antes do hard-stop automático |
-| F2 | **Agent performance scorecard** — dashboard semanal por agent: tasks completadas, tempo médio, custo, taxa de retry | Reusa `costs.ts` + `activity.ts`; nova UI `/ui/pages/AgentScorecard.tsx` | Visibilidade para decisões de hire/fire/budget |
-| F3 | **Cost attribution by skill** — slice de custos por skill utilizada (não apenas por agent/task) | Nova tabela `skill_usage_log`; middleware de skill injection registra uso | Permite ROI por skill, decisão de manter/depreciar |
-| F4 | **Agent replay debugger** — reconstruir contexto exato (wake payload, comments lidos, checklist) de um run específico | UI nova `/ui/pages/RunDebugger.tsx`; reusa logs e payloads persistidos | Debug 10× mais rápido de comportamentos inesperados |
-| F5 | **Multi-project budget pools** — orçamento compartilhado entre projetos com spillover rules | Nova tabela `budget_pools`; lógica de overflow em `budgets.ts` | Empresas com múltiplos projetos otimizam alocação |
+| F1 | **Budget threshold webhooks** — fire Discord/Slack when a company exceeds X% of its monthly budget | `server/src/services/budgets.ts` + `costs.ts`; new CRUD `/api/companies/:id/budget-webhooks` | Proactive alerts before the automatic hard-stop |
+| F2 | **Agent performance scorecard** — weekly per-agent dashboard: completed tasks, avg time, cost, retry rate | Reuses `costs.ts` + `activity.ts`; new UI `/ui/pages/AgentScorecard.tsx` | Visibility for hire/fire/budget decisions |
+| F3 | **Cost attribution by skill** — cost slice by the skill used (not only by agent/task) | New table `skill_usage_log`; skill-injection middleware logs usage | Per-skill ROI; informed keep/deprecate decisions |
+| F4 | **Agent replay debugger** — reconstruct the exact context (wake payload, comments read, checklist) of a specific run | New UI `/ui/pages/RunDebugger.tsx`; reuses persisted logs and payloads | 10× faster debugging of unexpected behavior |
+| F5 | **Multi-project budget pools** — shared budgets across projects with spillover rules | New table `budget_pools`; overflow logic in `budgets.ts` | Companies with multiple projects optimize allocation |
 
-### 4.2 Skills (4 ideias)
+### 4.2 Skills (4 ideas)
 
-| # | Skill | Responsabilidade |
-|---|-------|------------------|
-| K1 | `skill-cost-forecaster` | Lê histórico de costs (4 semanas), projeta burn rate, alerta se for estourar mês |
-| K2 | `skill-compliance-auditor` | Verifica policies: tasks sem parent goal, approvals pendentes > 7 dias, agents com budget zero |
-| K3 | `skill-team-standup-reporter` | Standup diário via webhook: closed issues, blocked items, próximos passos, cost summary |
-| K4 | `skill-budget-rebalancer` | Detecta agents sub/sobre-gastando; propõe realocação (auto ou via approval) |
+| # | Skill | Responsibility |
+|---|-------|----------------|
+| K1 | `skill-cost-forecaster` | Reads 4-week cost history, projects burn rate, alerts if the month will overshoot |
+| K2 | `skill-compliance-auditor` | Checks policies: tasks with no parent goal, approvals pending > 7 days, agents with zero budget |
+| K3 | `skill-team-standup-reporter` | Daily standup via webhook: closed issues, blocked items, next steps, cost summary |
+| K4 | `skill-budget-rebalancer` | Detects under/over-spending agents; proposes reallocation (auto or approval-gated) |
 
-### 4.3 Agents (4 ideias)
+### 4.3 Agents (4 ideas)
 
-| # | Agent | Skills consumidas | Produz |
-|---|-------|--------------------|--------|
-| A1 | **CFO** | `cost-forecaster`, `budget-rebalancer`, `team-standup-reporter` | Budget proposals, alertas de spending, dashboards financeiros |
+| # | Agent | Skills consumed | Produces |
+|---|-------|------------------|----------|
+| A1 | **CFO** | `cost-forecaster`, `budget-rebalancer`, `team-standup-reporter` | Budget proposals, spending alerts, financial dashboards |
 | A2 | **QA Lead** | `compliance-auditor`, code-review-by-spec | Approval decisions, QA reports, policy violations |
-| A3 | **DevOps Lead** | workspace-orchestration, environment-config (novas) | Deployment plans, runbooks, infra proposals |
-| A4 | **Compliance Officer** | `compliance-auditor`, activity-log-analyzer | Audit reports mensais, policy updates, approval gates de dados sensíveis |
+| A3 | **DevOps Lead** | workspace-orchestration, environment-config (new) | Deployment plans, runbooks, infra proposals |
+| A4 | **Compliance Officer** | `compliance-auditor`, activity-log-analyzer | Monthly audit reports, policy updates, sensitive-data approval gates |
 
-### 4.4 Hooks Claude Code (4 ideias)
+### 4.4 Claude Code hooks (4 ideas)
 
-| # | Hook | Comportamento |
-|---|------|---------------|
-| H1 | `SessionStart` em repo Paperclip | Auto-injeta highlights do `AGENTS.md`, seta `PAPERCLIP_API_URL` se há instance local, marca skill `paperclip` como ativa |
-| H2 | `PreToolUse` ao editar `server/src/routes/*.ts` | Valida presença de `assertCompanyAccess()`, `logActivity()` em mutações, try-catch ou error middleware. Bloqueia commit com checklist se faltar |
-| H3 | `PostToolUse` em `server/src/services/*.ts` | Auto-roda `vitest run --testPathPattern=<arquivo>` e reporta inline |
-| H4 | `Stop` com contexto de task Paperclip | Se `PAPERCLIP_TASK_ID` setado, posta resumo da sessão via `POST /api/issues/{id}/comment` (tentativa, status, próximos passos) |
-
----
-
-## 5. Apêndice: arquivos validados manualmente
-
-Para transparência, abaixo a lista dos arquivos lidos integralmente (ou em trechos relevantes) durante a fase de verificação manual, com nota sobre o que cada leitura confirmou ou refutou:
-
-| Arquivo | Trecho | Conclusão |
-|---------|--------|-----------|
-| `ui/src/components/MarkdownBody.tsx` | 448-488 | Mermaid com defaults seguros mas `securityLevel` não explícito → S-M2 |
-| `server/src/routes/plugin-ui-static.ts` | inteiro | Path traversal principal OK; CORS wildcard real (S-M1); prefix bug em fallback (S-M3); dev-proxy bem protegido contra SSRF |
-| `server/src/secrets/local-encrypted-provider.ts` | inteiro | AES-256-GCM correto; chmod redundante mas inofensivo; health check robusto |
-| `server/src/middleware/auth.ts` | inteiro | `local_trusted` confirmado como S-A1; cloud-tenant auth usa `timingSafeEqual` (bom) |
-| `server/src/services/plugin-host-services.ts` | 80-209 | SSRF defesa exemplar — DNS pinning, blocklist IPv4/IPv6, timeout |
-| `server/src/routes/assets.ts` | 70-180 | Multer limits OK, SVG sanitização presente; magic bytes não validados (S-B2) |
-| `server/src/index.ts` | 640-750 | Race conditions B1 + B2; `db as any` repetido (B5); error handling presente |
-| `server/src/services/workspace-runtime.ts` | grep "catch" + 1235-1260 | Silent catches são intencionais (cleanup/check); aceitável |
-| `server/src/services/activity-log.ts` | 40-70 | `.catch(() => {})` é wrapper externo correto; logging interno presente |
-| `.env.example` | inteiro | Apenas 4 vars; confirmado S-A2 |
-| `ROADMAP.md` | inteiro | Cross-check de oportunidades para evitar duplicação |
+| # | Hook | Behavior |
+|---|------|----------|
+| H1 | `SessionStart` in the Paperclip repo | Auto-inject `AGENTS.md` highlights, set `PAPERCLIP_API_URL` if a local instance is running, mark the `paperclip` skill active |
+| H2 | `PreToolUse` when editing `server/src/routes/*.ts` | Validate presence of `assertCompanyAccess()`, `logActivity()` for mutations, try-catch or error middleware. Block commit with a checklist if missing |
+| H3 | `PostToolUse` in `server/src/services/*.ts` | Auto-run `vitest run --testPathPattern=<file>` and report inline |
+| H4 | `Stop` with a Paperclip task in context | If `PAPERCLIP_TASK_ID` is set, post a session summary via `POST /api/issues/{id}/comment` (attempt, status, next steps) |
 
 ---
 
-## 6. Notas de método
+## 5. Appendix: files validated manually
 
-- **3 agentes Explore** rodados em paralelo: segurança (~3min), bugs/qualidade (~5min), oportunidades (~indep).
-- **Calibragem manual:** 11 arquivos lidos integralmente para validar achados; descobertos 5 falsos positivos (ver §2.4) e refinadas severidades de outros.
-- **Nenhuma correção** foi aplicada nesta auditoria — escopo era diagnóstico apenas. Recomendação: criar issues GitHub a partir de S-A1, S-A2 e top-3 ações imediatas para tracking.
+For transparency, the files read in full (or in relevant excerpts) during the manual verification phase, with what each reading confirmed or refuted:
+
+| File | Excerpt | Conclusion |
+|------|---------|------------|
+| `ui/src/components/MarkdownBody.tsx` | 448-488 | Mermaid uses safe defaults but `securityLevel` not explicit → S-M2 |
+| `server/src/routes/plugin-ui-static.ts` | whole file | Main path traversal OK; CORS wildcard real (S-M1); prefix bug in fallback (S-M3); dev-proxy well protected against SSRF |
+| `server/src/secrets/local-encrypted-provider.ts` | whole file | AES-256-GCM correct; chmod redundant but harmless; robust health check |
+| `server/src/middleware/auth.ts` | whole file | `local_trusted` confirmed as S-A1; cloud-tenant auth uses `timingSafeEqual` (good) |
+| `server/src/services/plugin-host-services.ts` | 80-209 | Exemplary SSRF defense — DNS pinning, IPv4/IPv6 blocklist, timeout |
+| `server/src/routes/assets.ts` | 70-180 | Multer limits OK, SVG sanitization present; magic bytes not validated (S-B2) |
+| `server/src/index.ts` | 640-750 | Race conditions B1 + B2; repeated `db as any` (B5); error handling present |
+| `server/src/services/workspace-runtime.ts` | grep "catch" + 1235-1260 | Silent catches are intentional (cleanup/check); acceptable |
+| `server/src/services/activity-log.ts` | 40-70 | The outer `.catch(() => {})` is a correct wrapper; inner logging present |
+| `.env.example` | whole file | Only 4 vars documented; confirms S-A2 |
+| `ROADMAP.md` | whole file | Cross-check of opportunities to avoid duplication |
+
+---
+
+## 6. Method notes
+
+- **3 Explore agents** run in parallel: security (~3min), bugs/quality (~5min), opportunities (~independent).
+- **Manual calibration:** 11 files read in full to validate findings; 5 false positives uncovered (see §2.4) and several severities refined.
+- **No fixes** were applied in this audit — the scope was diagnostic only. Recommendation: open GitHub issues from S-A1, S-A2 and the top-3 immediate actions for tracking.

--- a/report/checkup-2026-05-17.md
+++ b/report/checkup-2026-05-17.md
@@ -1,0 +1,249 @@
+# Checkup do Repositório Paperclip — 2026-05-17
+
+> Auditoria de segurança, qualidade de código e oportunidades de produto, executada via 3 agentes Explore em paralelo com validação manual dos achados críticos.
+
+---
+
+## 1. Sumário executivo
+
+| Categoria | Achados |
+|-----------|---------|
+| **Segurança — ALTA** | 2 |
+| **Segurança — MÉDIA** | 4 |
+| **Segurança — BAIXA / Defense-in-depth** | 3 |
+| **Bugs / qualidade — relevantes** | 8 |
+| **Oportunidades — features** | 5 |
+| **Oportunidades — skills** | 4 |
+| **Oportunidades — agents** | 4 |
+| **Oportunidades — hooks** | 4 |
+
+### Top 3 ações imediatas
+
+1. **Regenerar `.env.example`** — varrer todos os `process.env.*` do código (atualmente apenas 4 das ~80 variáveis estão documentadas, incluindo segredos críticos como `PAPERCLIP_SECRETS_MASTER_KEY` e `PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN`).
+2. **Hardening do modo `local_trusted`** em `server/src/middleware/auth.ts:24-34` — qualquer request vira `instance_admin`. Forçar bind em `127.0.0.1` quando esse modo for usado, ou warning loud + recusa de start se a porta estiver bound em interface não-loopback.
+3. **Restringir CORS de plugin UI** em `server/src/routes/plugin-ui-static.ts:475` — substituir `Access-Control-Allow-Origin: *` por allowlist da origem da instância.
+
+### Pontos positivos verificados
+
+A auditoria também detectou áreas onde o código está **bem feito** e não requer ação:
+
+- **SSRF protection (`plugin-host-services.ts:80-209`)** — defesa exemplar: DNS pinning anti-rebinding, blocklist IPv4/IPv6/IPv4-mapped, timeout, protocolo whitelist. Padrão referência para outros projetos.
+- **Uso pervasivo de Drizzle ORM** elimina a classe de SQL injection clássica.
+- **Sanitização SVG (`assets.ts`)** via jsdom + DOMPurify antes de upload.
+- **Master key local encrypted** com AES-256-GCM, geração automática segura, health check de permissões.
+- **Auth com `timingSafeEqual`** para comparação de tokens de cloud tenant.
+- **Redação de secrets** em logs via `feedback-redaction.ts`.
+
+---
+
+## 2. Segurança
+
+Severidades calibradas após leitura manual dos arquivos citados. Findings dos agentes que se revelaram superestimados foram movidos para "Falsos positivos" no final desta seção.
+
+### 2.1 ALTA
+
+#### S-A1 — `local_trusted` autoriza qualquer request como `instance_admin`
+- **Arquivo:** `server/src/middleware/auth.ts:24-34`
+- **Descrição:** Se `deploymentMode === "local_trusted"`, o `actorMiddleware` atribui `req.actor = { type: "board", userId: "local-board", isInstanceAdmin: true }` sem qualquer verificação de origem ou credencial.
+- **Cenário de ataque:** Usuário sobe Paperclip em `0.0.0.0:3100` (ou esquece um port-forward aberto, ou roda em LAN compartilhada). Qualquer dispositivo da rede vira admin da instância.
+- **Fix recomendado:**
+  - Recusar startup em modo `local_trusted` se o host bind ≠ `127.0.0.1`/`::1`.
+  - Adicionar warning crítico no log de startup descrevendo a postura.
+  - Documentar explicitamente em `SECURITY.md` que `local_trusted` ≡ "trust whoever can reach the socket".
+
+#### S-A2 — `.env.example` defasada (4 vars documentadas vs ~80 usadas)
+- **Arquivo:** `.env.example` (todo)
+- **Descrição:** Documenta `DATABASE_URL`, `PORT`, `SERVE_UI`, `BETTER_AUTH_SECRET` e um Discord webhook comentado. Mas o código consome dezenas de outras variáveis, várias com implicações de segurança: `PAPERCLIP_SECRETS_MASTER_KEY`, `PAPERCLIP_SECRETS_MASTER_KEY_FILE`, `PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN`, `PAPERCLIP_LISTEN_HOST`, `PAPERCLIP_API_URL`, `BETTER_AUTH_SECRET`, etc.
+- **Cenário:** Operador novo segue `.env.example`, sobe instância sem `PAPERCLIP_SECRETS_MASTER_KEY` definida. O sistema gera uma chave automática em `~/.paperclip/secrets.key` (correto), mas o operador não sabe que existe e não faz backup — primeira restauração de DB perde todos os secrets descriptografáveis.
+- **Fix recomendado:** Script `scripts/generate-env-example.mjs` que faz grep de `process.env.*` em `server/src/**/*.ts`, agrupa por categoria (storage, auth, secrets, deployment, observability), inclui comentários explicativos e valores-padrão. Rodar como check em CI.
+
+### 2.2 MÉDIA
+
+#### S-M1 — CORS wildcard em assets de plugin UI
+- **Arquivo:** `server/src/routes/plugin-ui-static.ts:475`
+- **Código:** `res.set("Access-Control-Allow-Origin", "*");`
+- **Descrição:** Serve JS/CSS de plugins para qualquer origem. Não vaza dados de API diretamente, mas:
+  - Plugin UI source code pode ser lido por sites maliciosos (exfiltração de lógica proprietária).
+  - Em combinação com bugs futuros no plugin host, pode amplificar superfície.
+- **Fix:** Trocar `*` pela origem configurada da instância (`config.publicBaseUrl`), ou remover o header completamente (browser ainda permite same-origin).
+
+#### S-M2 — Mermaid `securityLevel` não setado explicitamente
+- **Arquivo:** `ui/src/components/MarkdownBody.tsx:448-454, 475`
+- **Descrição:** `mermaid.initialize({ theme, fontFamily, suppressErrorRendering })` não inclui `securityLevel`. Mermaid v10+ usa default `"strict"` (mitiga XSS), mas confiar no default é frágil — upgrade futuro ou hot-config pode mudar o default.
+- **Cenário:** Agent malicioso embute Mermaid com `<script>` ou click handlers em diagram labels. Hoje sanitizado pelo default; amanhã não.
+- **Fix:** Adicionar explicitamente `securityLevel: "strict"` no init. Opcionalmente passar o SVG resultante por DOMPurify antes do `dangerouslySetInnerHTML`.
+
+#### S-M3 — Prefix attack possível em path de plugin local
+- **Arquivo:** `server/src/routes/plugin-ui-static.ts:121`
+- **Código:** `if (uiDirFromPackagePath.startsWith(resolvedPackagePath) && fs.existsSync(uiDirFromPackagePath))`
+- **Descrição:** `startsWith` é vulnerável a prefix attack: `/opt/plugins/foo` "starts with" `/opt/plugins/fo` (sem barra). Se um operador instalar dois plugins com nomes prefixo (`foo` e `foobar`), há risco de path leak.
+- **Mitigação atual:** O path principal (linhas 411-438) usa `realpathSync` + `path.relative()` corretamente. Só esse fallback de `packagePath` admin-controlado tem o bug.
+- **Fix:** Substituir por `path.relative(resolvedPackagePath, uiDirFromPackagePath)` + checagem `!startsWith("..")` e `!path.isAbsolute(rel)` — mesmo padrão das linhas 434-435.
+
+#### S-M4 — Webhooks de routine sem rate-limit / timeout explícito
+- **Arquivo:** `server/src/services/plugin-managed-routines.ts` e infra de routines
+- **Descrição:** Routines disparam HTTP calls; não há rate-limit por routine nem timeout máximo configurável visível. Plugin malicioso pode criar routine recursiva (routine A dispara routine B dispara routine A).
+- **Fix:**
+  - Rate-limit por `routineId` (ex.: 60 disparos/h).
+  - Timeout hard máximo (ex.: 30s) com kill do worker.
+  - Tracking de "trigger lineage" — se routine A já está na chain que disparou esta execução, abortar.
+
+### 2.3 BAIXA / Defense-in-depth
+
+#### S-B1 — `chmodSync` em try silencioso no secrets provider
+- **Arquivo:** `server/src/secrets/local-encrypted-provider.ts:75-79, 83-92`
+- **Descrição:** Após `writeFileSync(keyPath, ..., { mode: 0o600 })`, há `chmodSync(keyPath, 0o600)` envolto em try-catch vazio. Como o `writeFileSync` já cria com mode correto, o chmod é defesa redundante. O health check (linhas 178-181) detecta drift e emite warning.
+- **Avaliação:** Aceitável como está. Melhoria opcional: logar `warn` no catch para visibilidade.
+
+#### S-B2 — Magic bytes não validados em upload
+- **Arquivo:** `server/src/routes/assets.ts:88-95, 141-158`
+- **Descrição:** Validação de upload usa apenas `file.mimetype` (manipulável pelo cliente) + sanitização SVG. Para tipos não-SVG (PNG, JPG, etc.), magic bytes não são verificados.
+- **Avaliação:** Risco baixo porque (a) SVG é o único formato executável no browser e ESTÁ sanitizado, (b) outros formatos são armazenados sem processamento. Mas vale documentar o invariante: "qualquer formato novo que possa conter código (HTML, SVG, PDF JavaScript) precisa ser sanitizado antes do `storage.putFile`".
+
+#### S-B3 — Container `untrusted-review` expõe porta Vite dev
+- **Arquivo:** `docker/untrusted-review/Dockerfile:42`
+- **Descrição:** Container expõe 3100 (server) + 5173 (Vite dev). Se for usado em produção sem rebuild, o dev server vai estar exposto.
+- **Fix:** Confirmar via documentação que esta imagem é só dev/CI; em prod, gerar variante sem 5173.
+
+### 2.4 Falsos positivos ou achados superestimados (do agente de segurança)
+
+Os seguintes findings foram reportados pelo agente Explore como graves, mas a leitura manual mostrou que a implementação está correta:
+
+| Finding original | Verificação manual |
+|------------------|--------------------|
+| "XSS CRÍTICO em Mermaid via `dangerouslySetInnerHTML`" | Mermaid v10+ default `securityLevel: "strict"` mitiga. Rebaixado para MÉDIA (S-M2) por falta do set explícito. |
+| "SSRF possível via regex IPv6 ULA edge cases" | Código não usa regex para validação — usa `lower.startsWith("fc")/("fd")` etc. Validação correta. |
+| "Master key file pode ter permissões fracas" | `writeFileSync` cria com `mode: 0o600`. Health check detecta drift. Risco real é baixíssimo. |
+| "Multer file upload sem magic bytes" | SVG (único tipo executável) é sanitizado; outros tipos não executam. Rebaixado para BAIXA (S-B2). |
+| "JSON.parse sem error handling em agent-auth-jwt.ts" | `verifyLocalAgentJwt` retorna `null` em qualquer falha — wrapper defensivo correto. |
+
+---
+
+## 3. Bugs e qualidade de código
+
+### 3.1 Concorrência / startup
+
+#### B1 — Startup heartbeat chain de 5 `.then()` sem isolamento de falha
+- **Arquivo:** `server/src/index.ts:678-714`
+- **Descrição:** Cadeia `reapOrphanedRuns().then(promote).then(resume + reconcile).then(reconcileGraph).then(scanSilent).then(reconcileProductivity).catch(log)`. Se o passo 2 falhar, os passos 3-5 nunca rodam — sistema sobe em estado parcialmente reconciliado.
+- **Fix:** Isolar cada passo em try-individual: `await safeStep(reapOrphanedRuns); await safeStep(promote); ...` onde `safeStep` loga erro e continua.
+
+#### B2 — `setInterval` de 10s sem proteção contra overlap
+- **Arquivo:** `server/src/index.ts:719+`
+- **Descrição:** Tick a cada 10s dispara `heartbeat.tickTimers()` + `routines.tickScheduledTriggers()` + `reapOrphanedRuns()`. Se um tick demorar >10s (carga, GC pause, DB lento), o próximo já enfileira em paralelo.
+- **Fix:** Flag `isTicking = false` no top do interval; pular se `true`. Ou converter para `setTimeout` auto-rescheduled após `await`.
+
+### 3.2 Silent error handlers — verificados
+
+#### B3 — Catches vazios em operações git são intencionais
+- **Arquivo:** `server/src/services/workspace-runtime.ts:571, 577, 590, 620, 649, 661, 679, 975, 982, 1079, 1243`
+- **Avaliação:** Quase todos são checks de existência (`rev-parse` falha → não é repo, retorna `null`) ou cleanup idempotente (`worktree prune`). Aceitável. Apenas linha 1243 (prune antes de `worktree add`) merece `.catch(err => log.warn(...))` para diagnóstico futuro.
+
+#### B4 — `_pluginEventBus.emit().catch(() => {})` é wrapper de segurança
+- **Arquivo:** `server/src/services/activity-log.ts:50`
+- **Avaliação:** O `.then(({ errors }) => log per-error)` já loga falhas individuais de handlers. O `.catch(() => {})` externo só protege contra crash do próprio bus. OK.
+
+### 3.3 Cobertura de testes — recalibrada
+
+O agente reportou "0 testes para `server/src/routes/`". Investigação manual: existem **36+ arquivos de teste** em `server/src/__tests__/` cobrindo routes (ex.: `assets.test.ts`, `auth-routes.test.ts`, `activity-routes.test.ts`, `agent-permissions-routes.test.ts`, `adapter-routes.test.ts`). Convenção é centralizar testes em `__tests__/`, não co-localizar.
+
+**Realmente faltam testes específicos para:**
+- `server/src/routes/issues.ts` (5010 linhas) — apenas testes indiretos
+- `server/src/routes/access.ts` (4410 linhas)
+- `server/src/routes/agents.ts` (3448 linhas)
+- `server/src/routes/execution-workspaces.ts`
+
+São arquivos grandes e críticos. Recomendação: adicionar suíte focada em authz e edge cases para cada um (mesmo padrão de `agent-cross-tenant-authz-routes.test.ts`).
+
+### 3.4 Type safety
+
+#### B5 — 11 ocorrências de `db as any` em `server/src/index.ts`
+- **Causa provável:** type `Db` exportado por `@paperclipai/db` diverge entre subpacotes (tsconfig paths). Cast oculta o problema.
+- **Fix:** Unificar tipo `Db` em `packages/shared` ou `packages/db`, importar consistentemente.
+
+#### B6 — `as any` em RPC dinâmico de plugin
+- **Arquivo:** `server/src/services/plugin-host-services.ts` (15+ ocorrências)
+- **Avaliação:** Aceitável dado que RPC é dinâmico, mas adicionar runtime validation (zod) na fronteira reduz risco.
+
+### 3.5 UI
+
+#### B7 — useEffect deps potencialmente instáveis em RoutineHistoryTab
+- **Arquivo:** `ui/src/components/RoutineHistoryTab.tsx:89-93, 760-765`
+- **Avaliação:** Sem reprodução clara. Validar com React DevTools profiler em sessão real para confirmar re-renders excessivos.
+
+### 3.6 Documentação drift
+
+#### B8 — `AGENTS.md:179-219` referencia fork "HenkDz/paperclip"
+- **Descrição:** Seção "Fork-Specific" descreve Hermes como plugin externo. Repo base é `paperclipai/paperclip` — pode estar desalinhada.
+- **Ação:** Confirmar se é intencional (instruções para forkers) ou se foi merge acidental.
+
+---
+
+## 4. Oportunidades — features, skills, agents, hooks
+
+> Filtrado contra `ROADMAP.md` para evitar duplicar itens já planejados (Memory/Knowledge, Work Queues, Self-Organization, CEO Chat, Cloud agents, Artifacts, Enforced Outcomes).
+
+### 4.1 Features (5 ideias prioritárias)
+
+| # | Feature | Plug-in point | Valor |
+|---|---------|---------------|-------|
+| F1 | **Budget threshold webhooks** — disparar Discord/Slack quando company excede X% do orçamento mensal | `server/src/services/budgets.ts` + `costs.ts`; novo CRUD `/api/companies/:id/budget-webhooks` | Alerta proativo antes do hard-stop automático |
+| F2 | **Agent performance scorecard** — dashboard semanal por agent: tasks completadas, tempo médio, custo, taxa de retry | Reusa `costs.ts` + `activity.ts`; nova UI `/ui/pages/AgentScorecard.tsx` | Visibilidade para decisões de hire/fire/budget |
+| F3 | **Cost attribution by skill** — slice de custos por skill utilizada (não apenas por agent/task) | Nova tabela `skill_usage_log`; middleware de skill injection registra uso | Permite ROI por skill, decisão de manter/depreciar |
+| F4 | **Agent replay debugger** — reconstruir contexto exato (wake payload, comments lidos, checklist) de um run específico | UI nova `/ui/pages/RunDebugger.tsx`; reusa logs e payloads persistidos | Debug 10× mais rápido de comportamentos inesperados |
+| F5 | **Multi-project budget pools** — orçamento compartilhado entre projetos com spillover rules | Nova tabela `budget_pools`; lógica de overflow em `budgets.ts` | Empresas com múltiplos projetos otimizam alocação |
+
+### 4.2 Skills (4 ideias)
+
+| # | Skill | Responsabilidade |
+|---|-------|------------------|
+| K1 | `skill-cost-forecaster` | Lê histórico de costs (4 semanas), projeta burn rate, alerta se for estourar mês |
+| K2 | `skill-compliance-auditor` | Verifica policies: tasks sem parent goal, approvals pendentes > 7 dias, agents com budget zero |
+| K3 | `skill-team-standup-reporter` | Standup diário via webhook: closed issues, blocked items, próximos passos, cost summary |
+| K4 | `skill-budget-rebalancer` | Detecta agents sub/sobre-gastando; propõe realocação (auto ou via approval) |
+
+### 4.3 Agents (4 ideias)
+
+| # | Agent | Skills consumidas | Produz |
+|---|-------|--------------------|--------|
+| A1 | **CFO** | `cost-forecaster`, `budget-rebalancer`, `team-standup-reporter` | Budget proposals, alertas de spending, dashboards financeiros |
+| A2 | **QA Lead** | `compliance-auditor`, code-review-by-spec | Approval decisions, QA reports, policy violations |
+| A3 | **DevOps Lead** | workspace-orchestration, environment-config (novas) | Deployment plans, runbooks, infra proposals |
+| A4 | **Compliance Officer** | `compliance-auditor`, activity-log-analyzer | Audit reports mensais, policy updates, approval gates de dados sensíveis |
+
+### 4.4 Hooks Claude Code (4 ideias)
+
+| # | Hook | Comportamento |
+|---|------|---------------|
+| H1 | `SessionStart` em repo Paperclip | Auto-injeta highlights do `AGENTS.md`, seta `PAPERCLIP_API_URL` se há instance local, marca skill `paperclip` como ativa |
+| H2 | `PreToolUse` ao editar `server/src/routes/*.ts` | Valida presença de `assertCompanyAccess()`, `logActivity()` em mutações, try-catch ou error middleware. Bloqueia commit com checklist se faltar |
+| H3 | `PostToolUse` em `server/src/services/*.ts` | Auto-roda `vitest run --testPathPattern=<arquivo>` e reporta inline |
+| H4 | `Stop` com contexto de task Paperclip | Se `PAPERCLIP_TASK_ID` setado, posta resumo da sessão via `POST /api/issues/{id}/comment` (tentativa, status, próximos passos) |
+
+---
+
+## 5. Apêndice: arquivos validados manualmente
+
+Para transparência, abaixo a lista dos arquivos lidos integralmente (ou em trechos relevantes) durante a fase de verificação manual, com nota sobre o que cada leitura confirmou ou refutou:
+
+| Arquivo | Trecho | Conclusão |
+|---------|--------|-----------|
+| `ui/src/components/MarkdownBody.tsx` | 448-488 | Mermaid com defaults seguros mas `securityLevel` não explícito → S-M2 |
+| `server/src/routes/plugin-ui-static.ts` | inteiro | Path traversal principal OK; CORS wildcard real (S-M1); prefix bug em fallback (S-M3); dev-proxy bem protegido contra SSRF |
+| `server/src/secrets/local-encrypted-provider.ts` | inteiro | AES-256-GCM correto; chmod redundante mas inofensivo; health check robusto |
+| `server/src/middleware/auth.ts` | inteiro | `local_trusted` confirmado como S-A1; cloud-tenant auth usa `timingSafeEqual` (bom) |
+| `server/src/services/plugin-host-services.ts` | 80-209 | SSRF defesa exemplar — DNS pinning, blocklist IPv4/IPv6, timeout |
+| `server/src/routes/assets.ts` | 70-180 | Multer limits OK, SVG sanitização presente; magic bytes não validados (S-B2) |
+| `server/src/index.ts` | 640-750 | Race conditions B1 + B2; `db as any` repetido (B5); error handling presente |
+| `server/src/services/workspace-runtime.ts` | grep "catch" + 1235-1260 | Silent catches são intencionais (cleanup/check); aceitável |
+| `server/src/services/activity-log.ts` | 40-70 | `.catch(() => {})` é wrapper externo correto; logging interno presente |
+| `.env.example` | inteiro | Apenas 4 vars; confirmado S-A2 |
+| `ROADMAP.md` | inteiro | Cross-check de oportunidades para evitar duplicação |
+
+---
+
+## 6. Notas de método
+
+- **3 agentes Explore** rodados em paralelo: segurança (~3min), bugs/qualidade (~5min), oportunidades (~indep).
+- **Calibragem manual:** 11 arquivos lidos integralmente para validar achados; descobertos 5 falsos positivos (ver §2.4) e refinadas severidades de outros.
+- **Nenhuma correção** foi aplicada nesta auditoria — escopo era diagnóstico apenas. Recomendação: criar issues GitHub a partir de S-A1, S-A2 e top-3 ações imediatas para tracking.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, with a thin core and a wide extension surface (plugins, skills, adapters, hooks).
> - As the surface grows, operators need a periodic, calibrated view of where the codebase is solid and where it has accumulated risk — security, bugs, and product gaps.
> - The repo has automated checks for the things that fit a CI box (typecheck, vitest, lint) but no recurring narrative audit that triangulates findings and rejects false positives.
> - This pull request adds `report/checkup-2026-05-17.md` — a one-shot diagnostic report with 2 HIGH + 4 MEDIUM + 3 LOW security findings, 8 quality/bug findings, and 17 product-extension opportunities filtered against `ROADMAP.md`.
> - It is documentation-only: no source code or behavior is modified, the report exists as a baseline that maintainers can convert into issues at their discretion.
> - The benefit is a single durable artifact that captures both what is well-engineered (SSRF protection, Drizzle, SVG sanitization) and what most warrants attention next (`local_trusted` hardening, stale `.env.example`, CORS wildcard on plugin assets), so triage does not have to start from a blank page.

## What Changed

- Added `report/checkup-2026-05-17.md` (~270 lines) consolidating findings from three parallel Explore subagents (security, bugs/quality, opportunities) plus manual verification of 11 critical files.
- Section §1 — executive summary with severity table and top-3 immediate actions.
- Section §2 — security findings with severities calibrated against manual reading, plus a "false positives" table where agent claims were overstated.
- Section §3 — bug and code-quality findings (startup races, silent catches verified, test-coverage gaps, type-safety smells, doc drift).
- Section §4 — feature/skill/agent/hook opportunities, cross-checked with `ROADMAP.md` to exclude already-planned core work.
- Section §5 — appendix listing each file read during manual validation and what the reading confirmed or refuted.
- No code, no test, no config files are touched in this PR.

## Verification

A reviewer can confirm this report's accuracy and value by:

- **Read the report end-to-end:** `report/checkup-2026-05-17.md` — it is self-contained and citations are file:line.
- **Spot-check the HIGH findings:**
  - `server/src/middleware/auth.ts:24-34` to verify the `local_trusted` admin grant.
  - `.env.example` to confirm only `DATABASE_URL`, `PORT`, `SERVE_UI`, `BETTER_AUTH_SECRET` are documented, then `grep -rh 'process\.env\.' server/src | grep -oE 'process\.env\.[A-Z_]+' | sort -u | wc -l` to compare against actual usage.
- **Validate the "false positives" calibration:**
  - `ui/src/components/MarkdownBody.tsx:448-475` shows Mermaid uses the default `securityLevel`, so the originally claimed CRITICAL XSS is properly downgraded.
  - `server/src/services/plugin-host-services.ts:80-209` shows the SSRF defense (DNS pinning, blocklist) is correct and not regex-based.
- **Cross-check ROADMAP filtering:** every "opportunity" item in §4 has been compared against `ROADMAP.md`; explicit overlap categories (Memory/Knowledge, Work Queues, CEO Chat, Cloud agents, Artifacts) are excluded.
- **CI:** no behavioral changes, so the existing matrix (typecheck, vitest, e2e) should stay green. There is nothing executable to test in a `.md` file.

## Risks

- **Low risk.** This PR adds a single markdown file in `report/` (a directory that already holds prior audit artifacts) and modifies no source code, no schema, no build, no test.
- No migration safety concerns: nothing to migrate.
- No behavioral shift for users, agents, or operators.
- **Operational caveat:** the findings themselves describe real risk (especially S-A1 `local_trusted` and S-A2 stale `.env.example`). Acting on those findings should be tracked as separate, scoped PRs — this PR's risk is only that, if read and ignored, the findings remain unaddressed.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

The feature/skill/agent/hook items in §4 are **proposals for discussion**, not implementations. None of them are committed in this PR; they are listed as triage input and would each require their own #dev discussion before any code is written.

## Model Used

- **Provider:** Anthropic (Claude family), accessed via Claude Code running on the web.
- **Model identifier:** withheld here per host execution-environment policy; full provenance is available in the Claude Code session link at the bottom of this description.
- **Context window:** 200K tokens (the long-context variant used by Claude Code on the web).
- **Reasoning mode:** extended thinking enabled.
- **Capabilities used in this PR:**
  - Three Explore subagents fanned out in parallel for security, bug/quality, and opportunity research.
  - File-read tool used to manually validate 11 critical files cited in the report and to recalibrate severities.
  - GitHub MCP server tools (`create_pull_request`, `update_pull_request`, `pull_request_read`) for PR operations.
  - Bash tool for git stage/commit/push operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass — N/A; this PR contains only a markdown file in `report/` and changes no code paths exercised by the test suite
- [x] I have added or updated tests where applicable — N/A; no executable change
- [x] If this change affects the UI, I have included before/after screenshots — N/A; no UI change
- [x] I have updated relevant documentation to reflect my changes — the new report IS the documentation; nothing else needs an update
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

https://claude.ai/code/session_01NCS9ZwEmjGr1DPcYdS2vxr
