### PR TITLE
fix: validate x-paperclip-run-id as UUID

### DIFF
--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -33,7 +33,8 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
           }
         : { type: "none", source: "none" };
 
-    const runIdHeader = req.header("x-paperclip-run-id");
+    const rawRunId = req.header("x-paperclip-run-id");
+    const runIdHeader = rawRunId && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(rawRunId) ? rawRunId : undefined;
 
     const authHeader = req.header("authorization");
     if (!authHeader?.toLowerCase().startsWith("bearer ")) {


### PR DESCRIPTION
## Summary
- Validates the `x-paperclip-run-id` header value as a UUID before propagating it to `req.actor.runId`
- Non-UUID values (e.g., `codex-manual-2026-05-02-mejer-gca`) are silently dropped rather than passed to the database layer where they cause `PostgresError: invalid input syntax for type uuid`

## Problem
Callers sending human-readable slugs in the `x-paperclip-run-id` header cause 500 errors when the value reaches a PostgreSQL UUID column. The header value flows through the auth middleware into `originRunId` on issue creation/update without any format validation.

## Fix
One-line UUID regex check at the point of ingestion in `server/src/middleware/auth.ts`. Invalid values become `undefined` — same as if the header were absent.

## Test plan
- [ ] Existing tests pass (no behavior change for valid UUIDs or absent header)
- [ ] Send `x-paperclip-run-id: not-a-uuid` → header ignored, request succeeds
- [ ] Send `x-paperclip-run-id: 550e8400-e29b-41d4-a716-446655440000` → header propagated normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)