### PR TITLE
feat(claude-local): add plugin cache MCP manifest validation gate (PRO-4472)

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -55,6 +55,7 @@ import {
   isClaudeUnknownSessionError,
 } from "./parse.js";
 import { prepareClaudeConfigSeed } from "./claude-config.js";
+import { validatePluginCacheManifests } from "./plugin-cache-validation.js";
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
@@ -647,6 +648,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     taskContextChars: taskContextNote.length,
     heartbeatPromptChars: renderedPrompt.length,
   };
+
+  const pluginManifestResults = await validatePluginCacheManifests(process.env);
+  for (const result of pluginManifestResults) {
+    if (!result.valid) {
+      const keys = result.foundKeys && result.foundKeys.length > 0
+        ? ` (found top-level keys: ${result.foundKeys.join(", ")})`
+        : "";
+      await onLog(
+        "stderr",
+        `[paperclip] Warning: plugin cache manifest "${result.filePath}" is missing the required "mcpServers" top-level key${keys}. This manifest will be skipped by Claude and may cause missing MCP tools. Fix or remove the file to clear this warning.\n`,
+      );
+    }
+  }
 
   const buildClaudeArgs = (
     resumeSessionId: string | null,

--- a/packages/adapters/claude-local/src/server/plugin-cache-validation.test.ts
+++ b/packages/adapters/claude-local/src/server/plugin-cache-validation.test.ts
@@ -1,0 +1,115 @@
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { validatePluginCacheManifests } from "./plugin-cache-validation.js";
+
+describe("validatePluginCacheManifests", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  async function makeCache(root: string): Promise<string> {
+    const cacheDir = path.join(root, "plugins", "cache");
+    await fs.mkdir(cacheDir, { recursive: true });
+    return cacheDir;
+  }
+
+  function makeEnv(claudeConfigDir: string): NodeJS.ProcessEnv {
+    return { CLAUDE_CONFIG_DIR: claudeConfigDir };
+  }
+
+  async function writeManifest(
+    cacheDir: string,
+    marketplace: string,
+    plugin: string,
+    version: string,
+    content: object,
+  ): Promise<string> {
+    const dir = path.join(cacheDir, marketplace, plugin, version);
+    await fs.mkdir(dir, { recursive: true });
+    const filePath = path.join(dir, ".mcp.json");
+    await fs.writeFile(filePath, JSON.stringify(content), "utf-8");
+    return filePath;
+  }
+
+  it("returns empty array when cache directory does not exist", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pcv-test-"));
+    cleanupDirs.push(root);
+    // no plugins/cache directory
+    const results = await validatePluginCacheManifests(makeEnv(root));
+    expect(results).toEqual([]);
+  });
+
+  it("returns valid result for a well-formed manifest", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pcv-test-"));
+    cleanupDirs.push(root);
+    const cacheDir = await makeCache(root);
+    const filePath = await writeManifest(cacheDir, "official", "playwright", "abc123", {
+      mcpServers: { playwright: { command: "npx", args: ["@playwright/mcp@latest"] } },
+    });
+
+    const results = await validatePluginCacheManifests(makeEnv(root));
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ filePath, valid: true });
+  });
+
+  it("flags a manifest with wrong top-level key instead of mcpServers", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pcv-test-"));
+    cleanupDirs.push(root);
+    const cacheDir = await makeCache(root);
+    // malformed: uses "playwright" as top-level key (the real fleet-crash shape)
+    const filePath = await writeManifest(cacheDir, "official", "playwright", "unknown", {
+      playwright: { command: "npx", args: ["@playwright/mcp@latest"] },
+    });
+
+    const results = await validatePluginCacheManifests(makeEnv(root));
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ filePath, valid: false, foundKeys: ["playwright"] });
+  });
+
+  it("flags a manifest that is not valid JSON", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pcv-test-"));
+    cleanupDirs.push(root);
+    const cacheDir = await makeCache(root);
+    const dir = path.join(cacheDir, "official", "broken", "v1");
+    await fs.mkdir(dir, { recursive: true });
+    const filePath = path.join(dir, ".mcp.json");
+    await fs.writeFile(filePath, "not-json{{", "utf-8");
+
+    const results = await validatePluginCacheManifests(makeEnv(root));
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ filePath, valid: false });
+  });
+
+  it("validates multiple manifests independently", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pcv-test-"));
+    cleanupDirs.push(root);
+    const cacheDir = await makeCache(root);
+
+    const good = await writeManifest(cacheDir, "official", "playwright", "abc123", {
+      mcpServers: { playwright: { command: "npx", args: [] } },
+    });
+    const bad = await writeManifest(cacheDir, "official", "playwright", "unknown", {
+      playwright: { command: "npx", args: [] },
+    });
+    const alsoGood = await writeManifest(cacheDir, "official", "github", "def456", {
+      mcpServers: { github: { command: "npx", args: [] } },
+    });
+
+    const results = await validatePluginCacheManifests(makeEnv(root));
+    expect(results).toHaveLength(3);
+
+    const byPath = Object.fromEntries(results.map((r) => [r.filePath, r]));
+    expect(byPath[good].valid).toBe(true);
+    expect(byPath[alsoGood].valid).toBe(true);
+    expect(byPath[bad].valid).toBe(false);
+    expect(byPath[bad].foundKeys).toEqual(["playwright"]);
+  });
+});

--- a/packages/adapters/claude-local/src/server/plugin-cache-validation.ts
+++ b/packages/adapters/claude-local/src/server/plugin-cache-validation.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveSharedClaudeConfigDir } from "./claude-config.js";
+
+export interface PluginManifestResult {
+  filePath: string;
+  valid: boolean;
+  /** Top-level keys found when the manifest is malformed (missing mcpServers). */
+  foundKeys?: string[];
+}
+
+async function findManifestFiles(cacheDir: string): Promise<string[]> {
+  const results: string[] = [];
+  let marketplaces: string[];
+  try {
+    marketplaces = await fs.readdir(cacheDir);
+  } catch {
+    return results;
+  }
+  for (const marketplace of marketplaces) {
+    const marketplaceDir = path.join(cacheDir, marketplace);
+    let plugins: string[];
+    try {
+      plugins = await fs.readdir(marketplaceDir);
+    } catch {
+      continue;
+    }
+    for (const plugin of plugins) {
+      const pluginDir = path.join(marketplaceDir, plugin);
+      let versions: string[];
+      try {
+        versions = await fs.readdir(pluginDir);
+      } catch {
+        continue;
+      }
+      for (const version of versions) {
+        const candidate = path.join(pluginDir, version, ".mcp.json");
+        try {
+          await fs.access(candidate);
+          results.push(candidate);
+        } catch {
+          // no manifest at this version path
+        }
+      }
+    }
+  }
+  return results;
+}
+
+/**
+ * Scans all .mcp.json files under the plugin cache directory and validates
+ * that each has the canonical `mcpServers` top-level key.
+ *
+ * Returns one result per manifest found. Malformed manifests are flagged but
+ * never throw — callers decide how to surface the warnings.
+ */
+export async function validatePluginCacheManifests(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<PluginManifestResult[]> {
+  const claudeConfigDir = resolveSharedClaudeConfigDir(env);
+  const cacheDir = path.join(claudeConfigDir, "plugins", "cache");
+  const manifestFiles = await findManifestFiles(cacheDir);
+  const results: PluginManifestResult[] = [];
+  for (const filePath of manifestFiles) {
+    let raw: string;
+    try {
+      raw = await fs.readFile(filePath, "utf-8");
+    } catch {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      results.push({ filePath, valid: false, foundKeys: [] });
+      continue;
+    }
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      results.push({ filePath, valid: false, foundKeys: [] });
+      continue;
+    }
+    const keys = Object.keys(parsed as Record<string, unknown>);
+    if (!keys.includes("mcpServers")) {
+      results.push({ filePath, valid: false, foundKeys: keys });
+    } else {
+      results.push({ filePath, valid: true });
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
## Context

Fleet root cause (PRO-4424): the `playwright/unknown/.mcp.json` manifest had a top-level `playwright` key instead of `mcpServers`. Claude silently failed to load any MCP server from it, causing all affected agents to enter `adapter_failed`. Kenji's host-side fix (PRO-4471) removed the malformed file. This PR adds the prevention layer so any future malformed manifest is caught and surfaced **before** Claude starts.

## What changed

### New: `plugin-cache-validation.ts`

`validatePluginCacheManifests(env)` — scans `$CLAUDE_CONFIG_DIR/plugins/cache/**/.mcp.json` and returns a result per manifest:
- `valid: true` — manifest has the `mcpServers` top-level key.
- `valid: false, foundKeys: [...]` — missing `mcpServers`; reports what keys were found.
- `valid: false, foundKeys: []` — JSON parse failure.

No throws. Returns an empty array if the cache directory does not exist.

### Modified: `execute.ts`

Calls `validatePluginCacheManifests` immediately before building the Claude argument list. For every invalid manifest it emits a `[paperclip] Warning: …` line on stderr naming the offending file and the keys that were found instead of `mcpServers`. The run continues — the gate surfaces the problem without blocking the agent from starting.

### New: `plugin-cache-validation.test.ts`

4 vitest cases covering:
1. Missing cache directory → empty result.
2. Well-formed manifest → valid.
3. Wrong-key manifest (the exact `playwright` regression shape) → invalid with `foundKeys`.
4. Unparseable JSON → invalid.
5. Mixed valid/invalid manifests → each flagged independently.

## Test plan

- [ ] `pnpm test --filter @paperclipai/adapter-claude-local` passes.
- [ ] Manual: place a malformed `.mcp.json` under `~/.claude/plugins/cache/test/bad/v0/.mcp.json` with `{"bad": {}}` — stderr should include the warning line naming that file.
- [ ] Confirm well-formed manifests produce no warnings.

## Related

- Root-cause: PRO-4424
- Host-side fix: PRO-4471
- Parent: PRO-4407

🤖 Generated with [Claude Code](https://claude.com/claude-code)