### PR TITLE
fix(heartbeat): auto-clear agent error status when subprocess exits code 0

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2933,4 +2933,55 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
     expect(runs).toHaveLength(1);
   });
+
+  it("clears agent error status to idle when subprocess exits 0 even if run was pre-terminated as failed by recovery", async () => {
+    // Scenario: process-loss recovery marks a run "failed" before the subprocess
+    // exits. The subprocess then exits cleanly (exit code 0). Without the fix,
+    // the latestRun.status === "failed" check causes outcome="failed" and the
+    // agent stays stuck in "error". With the fix, subprocessExitCode=0 overrides
+    // the transition to "idle".
+    const { companyId, agentId, runId } = await seedQueuedIssueRunFixture();
+
+    // Put the agent into "error" to simulate a previous failure.
+    await db
+      .update(agents)
+      .set({ status: "error", updatedAt: new Date() })
+      .where(eq(agents.id, agentId));
+
+    // Mock: simulate process-loss recovery pre-terminating the run as "failed"
+    // while the subprocess is still executing, then returning exit code 0.
+    mockAdapterExecute.mockImplementationOnce(async (ctx: { runId: string }) => {
+      await db
+        .update(heartbeatRuns)
+        .set({
+          status: "failed",
+          error: "process_lost: pid not alive (simulated recovery)",
+          errorCode: "process_lost",
+          finishedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(heartbeatRuns.id, ctx.runId));
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Subprocess exited cleanly despite run pre-termination.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.resumeQueuedRuns();
+    await waitForRunToSettle(heartbeat, runId, 5_000);
+    await waitForHeartbeatIdle(db, 5_000);
+
+    const agent = await db
+      .select({ status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0] ?? null);
+    expect(agent?.status).toBe("idle");
+  });
 });

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2940,13 +2940,23 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     // the latestRun.status === "failed" check causes outcome="failed" and the
     // agent stays stuck in "error". With the fix, subprocessExitCode=0 overrides
     // the transition to "idle".
-    const { companyId, agentId, runId } = await seedQueuedIssueRunFixture();
+    const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();
 
     // Put the agent into "error" to simulate a previous failure.
     await db
       .update(agents)
       .set({ status: "error", updatedAt: new Date() })
       .where(eq(agents.id, agentId));
+
+    // Set the issue to "in_review" so that releaseIssueExecutionAndPromote does not
+    // enqueue a recovery run when the simulated run is marked failed. If the issue
+    // stays "in_progress", the recovery loop starts a new run immediately, putting
+    // the agent into "running" before finalizeAgentStatus fires — which prevents the
+    // exit-code-0 override from being reached.
+    await db
+      .update(issues)
+      .set({ status: "in_review", updatedAt: new Date() })
+      .where(eq(issues.id, issueId));
 
     // Mock: simulate process-loss recovery pre-terminating the run as "failed"
     // while the subprocess is still executing, then returning exit code 0.

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6182,6 +6182,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   async function finalizeAgentStatus(
     agentId: string,
     outcome: "succeeded" | "failed" | "cancelled" | "timed_out",
+    opts?: { subprocessExitCode?: number | null },
   ) {
     const existing = await getAgent(agentId);
     if (!existing) return;
@@ -6193,12 +6194,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const isFirstHeartbeat = !existing.lastHeartbeatAt;
 
     const runningCount = await countRunningRunsForAgent(agentId);
-    const nextStatus =
+    let nextStatus: "running" | "idle" | "error" =
       runningCount > 0
         ? "running"
         : outcome === "succeeded" || outcome === "cancelled"
           ? "idle"
           : "error";
+
+    // If the subprocess exited cleanly (exit code 0) but the run was pre-terminated
+    // as "failed" by process-loss recovery before the subprocess finished, still
+    // transition the agent from "error" to "idle" so the successful work is recognised.
+    // The gate on existing.status === "error" prevents this from masking a first-run
+    // failure where the agent was "running" when finalizeAgentStatus was called.
+    if (nextStatus === "error" && opts?.subprocessExitCode === 0 && existing.status === "error") {
+      nextStatus = "idle";
+    }
 
     const updated = await db
       .update(agents)
@@ -7961,7 +7971,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           }
         }
       }
-      await finalizeAgentStatus(agent.id, outcome);
+      await finalizeAgentStatus(agent.id, outcome, { subprocessExitCode: adapterResult.exitCode ?? null });
     } catch (err) {
       const message = redactCurrentUserText(
         err instanceof Error ? err.message : "Unknown adapter failure",


### PR DESCRIPTION
## Summary

Fixes [PRO-4483](/PRO/issues/PRO-4483). Filed from [PRO-4482](/PRO/issues/PRO-4482) resolution.

### Root cause

When process-loss recovery pre-terminates a run as `"failed"` before the subprocess finishes executing, the outcome determination in `heartbeat.ts` checks `latestRun.status` first. If the run is already in a terminal state (`"failed"`), the outcome is set to `"failed"` regardless of `adapterResult.exitCode`. This caused `finalizeAgentStatus` to leave the agent in `"error"` even when the subprocess actually exited cleanly with code 0.

**Evidence**: Rafael Torres and Cassandra Holm remained in `"error"` after the playwright fix because their runs were pre-terminated by the watchdog before the fixed subprocess exited 0.

### Fix

Extend `finalizeAgentStatus()` with an optional `{ subprocessExitCode }` parameter. When the computed `nextStatus` would be `"error"` but `subprocessExitCode === 0` and the agent was **already in `"error"`**, override the transition to `"idle"`.

The `existing.status === "error"` gate ensures this does not affect first-run failures (the agent would be in `"running"` at that point, not `"error"`).

Only the **normal-completion call site** (after `adapter.execute()` returns) passes `subprocessExitCode`. All recovery and catch paths leave `opts` undefined so the override never fires there.

### Changes

- `server/src/services/heartbeat.ts` — extend `finalizeAgentStatus` signature; add override; update call site
- `server/src/__tests__/heartbeat-process-recovery.test.ts` — new test: agent in `error` → run pre-terminated as `failed` by recovery → subprocess exits 0 → assert agent transitions to `idle`

### No schema changes

The fix is entirely in-process logic. No DB migrations needed.

## Test plan

- [ ] New test passes: `clears agent error status to idle when subprocess exits 0 even if run was pre-terminated as failed by recovery`
- [ ] Existing `heartbeat-process-recovery` tests continue to pass (no regressions on error-transition paths)
- [ ] `heartbeat-runtime-state` tests continue to pass