### PR TITLE
recovery: skip handoff for routine pickup own-issue comments

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -140,6 +140,7 @@ import {
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
   readContinuationAttempt,
 } from "./recovery/index.js";
+import type { SuccessfulRunHandoffEvidenceInput } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
 import {
   recoveryAssigneeAdapterOverrides,
@@ -4073,6 +4074,82 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return `[${label}](/${prefix}/issues/${label})`;
   }
 
+  async function collectSuccessfulRunHandoffEvidence(
+    run: typeof heartbeatRuns.$inferSelect,
+    issueId: string,
+  ): Promise<SuccessfulRunHandoffEvidenceInput> {
+    const [
+      ownCommentStats,
+      otherCommentStats,
+      documentStats,
+      workProductStats,
+      eventStats,
+    ] = await Promise.all([
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(issueComments)
+        .where(
+          and(
+            eq(issueComments.companyId, run.companyId),
+            eq(issueComments.createdByRunId, run.id),
+            eq(issueComments.issueId, issueId),
+          ),
+        )
+        .then((rows) => rows[0]),
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(issueComments)
+        .where(
+          and(
+            eq(issueComments.companyId, run.companyId),
+            eq(issueComments.createdByRunId, run.id),
+            sql`${issueComments.issueId} <> ${issueId}`,
+          ),
+        )
+        .then((rows) => rows[0]),
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(documentRevisions)
+        .where(
+          and(
+            eq(documentRevisions.companyId, run.companyId),
+            eq(documentRevisions.createdByRunId, run.id),
+          ),
+        )
+        .then((rows) => rows[0]),
+      db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(issueWorkProducts)
+        .where(
+          and(
+            eq(issueWorkProducts.companyId, run.companyId),
+            eq(issueWorkProducts.createdByRunId, run.id),
+          ),
+        )
+        .then((rows) => rows[0]),
+      db
+        .select({
+          count: sql<number>`count(*) filter (where ${heartbeatRunEvents.eventType} not in ('lifecycle', 'adapter.invoke', 'error'))::int`,
+        })
+        .from(heartbeatRunEvents)
+        .where(
+          and(
+            eq(heartbeatRunEvents.companyId, run.companyId),
+            eq(heartbeatRunEvents.runId, run.id),
+          ),
+        )
+        .then((rows) => rows[0]),
+    ]);
+
+    return {
+      ownIssueCommentsCreated: ownCommentStats?.count ?? 0,
+      otherIssueCommentsCreated: otherCommentStats?.count ?? 0,
+      documentRevisionsCreated: documentStats?.count ?? 0,
+      workProductsCreated: workProductStats?.count ?? 0,
+      toolOrActionEventsCreated: eventStats?.count ?? 0,
+    };
+  }
+
   async function buildDetectedSuccessfulRunProgressSummary(run: typeof heartbeatRuns.$inferSelect) {
     const resultJson = parseObject(run.resultJson);
     const candidates = [
@@ -4140,6 +4217,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeUserId: issues.assigneeUserId,
         executionState: issues.executionState,
         projectId: issues.projectId,
+        originKind: issues.originKind,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -4152,6 +4230,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       : null;
     const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
     const detectedProgressSummary = await buildDetectedSuccessfulRunProgressSummary(run);
+    const runEvidence = issue ? await collectSuccessfulRunHandoffEvidence(run, issue.id) : null;
 
     const [
       activeExecutionPath,
@@ -4297,6 +4376,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       livenessState: run.livenessState as RunLivenessState | null,
       detectedProgressSummary,
       taskKey,
+      runEvidence,
       hasActiveExecutionPath: Boolean(activeExecutionPath),
       hasQueuedWake: Boolean(queuedWake),
       hasPendingInteractionOrApproval: Boolean(pendingInteraction || pendingApproval),

--- a/server/src/services/recovery/index.ts
+++ b/server/src/services/recovery/index.ts
@@ -59,6 +59,7 @@ export {
   isSuccessfulRunHandoffRequiredNoticeBody,
 } from "./successful-run-handoff.js";
 export type {
+  SuccessfulRunHandoffEvidenceInput,
   SuccessfulRunHandoffNotice,
   SuccessfulRunHandoffDecision,
 } from "./successful-run-handoff.js";

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -309,7 +309,7 @@ describe("successful run handoff decision", () => {
     });
   });
 
-  it("still enqueues for routine-execution pickup that produced cross-issue progress", () => {
+  it("still enqueues for routine-execution pickup with non-bookkeeping tool/action events", () => {
     const routineIssue = { ...issue, originKind: "routine_execution" } as any;
     const decision = decide({
       issue: routineIssue,

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -292,6 +292,68 @@ describe("successful run handoff decision", () => {
     expect(noticeMetadataReferencesRecoveryAction(notice.metadata, "88888888-8888-4888-8888-888888888888")).toBe(false);
   });
 
+  it("skips routine-execution pickup whose only evidence is a comment on its own issue", () => {
+    const routineIssue = { ...issue, originKind: "routine_execution" } as any;
+    expect(decide({
+      issue: routineIssue,
+      runEvidence: {
+        ownIssueCommentsCreated: 1,
+        otherIssueCommentsCreated: 0,
+        documentRevisionsCreated: 0,
+        workProductsCreated: 0,
+        toolOrActionEventsCreated: 0,
+      },
+    })).toEqual({
+      kind: "skip",
+      reason: "routine pickup own-issue comment is not productive evidence",
+    });
+  });
+
+  it("still enqueues for routine-execution pickup that produced cross-issue progress", () => {
+    const routineIssue = { ...issue, originKind: "routine_execution" } as any;
+    const decision = decide({
+      issue: routineIssue,
+      runEvidence: {
+        ownIssueCommentsCreated: 1,
+        otherIssueCommentsCreated: 0,
+        documentRevisionsCreated: 0,
+        workProductsCreated: 0,
+        toolOrActionEventsCreated: 3,
+      },
+    });
+    expect(decision.kind).toBe("enqueue");
+  });
+
+  it("still enqueues for routine-execution pickup that commented on a different issue", () => {
+    const routineIssue = { ...issue, originKind: "routine_execution" } as any;
+    const decision = decide({
+      issue: routineIssue,
+      runEvidence: {
+        ownIssueCommentsCreated: 1,
+        otherIssueCommentsCreated: 1,
+        documentRevisionsCreated: 0,
+        workProductsCreated: 0,
+        toolOrActionEventsCreated: 0,
+      },
+    });
+    expect(decision.kind).toBe("enqueue");
+  });
+
+  it("does not skip non-routine issues even when only own-issue comments exist", () => {
+    const manualIssue = { ...issue, originKind: "manual" } as any;
+    const decision = decide({
+      issue: manualIssue,
+      runEvidence: {
+        ownIssueCommentsCreated: 1,
+        otherIssueCommentsCreated: 0,
+        documentRevisionsCreated: 0,
+        workProductsCreated: 0,
+        toolOrActionEventsCreated: 0,
+      },
+    });
+    expect(decision.kind).toBe("enqueue");
+  });
+
   it("recognizes new notices and legacy markdown headings for fallback deduplication", () => {
     expect(isSuccessfulRunHandoffRequiredNoticeBody(SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY)).toBe(true);
     expect(isSuccessfulRunHandoffRequiredNoticeBody("## Successful run missing issue disposition\n\nold body")).toBe(true);

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -45,8 +45,26 @@ export function isIdempotentFinishSuccessfulRunHandoffWakeStatus(status: string)
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
 type IssueRow = Pick<
   typeof issues.$inferSelect,
-  "id" | "companyId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId" | "executionState"
+  | "id"
+  | "companyId"
+  | "identifier"
+  | "title"
+  | "status"
+  | "assigneeAgentId"
+  | "assigneeUserId"
+  | "executionState"
+  | "originKind"
 >;
+
+const ROUTINE_EXECUTION_ORIGIN_KIND = "routine_execution";
+
+export interface SuccessfulRunHandoffEvidenceInput {
+  ownIssueCommentsCreated: number;
+  otherIssueCommentsCreated: number;
+  documentRevisionsCreated: number;
+  workProductsCreated: number;
+  toolOrActionEventsCreated: number;
+}
 type AgentRow = Pick<typeof agents.$inferSelect, "id" | "companyId" | "status">;
 type NoticeIssue = Pick<typeof issues.$inferSelect, "id" | "identifier" | "title" | "status">;
 type NoticeRun = Pick<typeof heartbeatRuns.$inferSelect, "id" | "status">;
@@ -303,6 +321,23 @@ function isProductiveSuccessfulRun(input: {
   return Boolean(input.detectedProgressSummary);
 }
 
+function isRoutineExecutionIssue(issue: IssueRow): boolean {
+  return issue.originKind === ROUTINE_EXECUTION_ORIGIN_KIND;
+}
+
+function onlyEvidenceIsOwnIssueComment(
+  evidence: SuccessfulRunHandoffEvidenceInput | null | undefined,
+): boolean {
+  if (!evidence) return false;
+  if (evidence.ownIssueCommentsCreated <= 0) return false;
+  return (
+    evidence.otherIssueCommentsCreated === 0 &&
+    evidence.documentRevisionsCreated === 0 &&
+    evidence.workProductsCreated === 0 &&
+    evidence.toolOrActionEventsCreated === 0
+  );
+}
+
 export function buildSuccessfulRunHandoffInstruction(input: {
   issueIdentifier: string | null;
   sourceRunId: string;
@@ -336,6 +371,7 @@ export function decideSuccessfulRunHandoff(input: {
   livenessState: RunLivenessState | null;
   detectedProgressSummary: string | null;
   taskKey: string | null;
+  runEvidence?: SuccessfulRunHandoffEvidenceInput | null;
   hasActiveExecutionPath: boolean;
   hasQueuedWake: boolean;
   hasPendingInteractionOrApproval: boolean;
@@ -366,6 +402,12 @@ export function decideSuccessfulRunHandoff(input: {
   if (issue.executionState) return { kind: "skip", reason: "issue has execution policy state" };
   if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
     return { kind: "skip", reason: `agent status ${agent.status} is not invokable` };
+  }
+  if (isRoutineExecutionIssue(issue) && onlyEvidenceIsOwnIssueComment(input.runEvidence)) {
+    return {
+      kind: "skip",
+      reason: "routine pickup own-issue comment is not productive evidence",
+    };
   }
   if (!isProductiveSuccessfulRun(input)) {
     return { kind: "skip", reason: "successful run did not produce handoff-relevant progress" };


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The recovery subsystem includes a "successful run handoff" sweep that detects when a `succeeded` run leaves an issue in `in_progress` with no visible next step, and enqueues a one-shot corrective handoff wake to force the agent to record a valid disposition
> - Pickup-routine empty-queue runs post a single status comment on their own routine-execution issue and exit — `decideSuccessfulRunHandoff` treats that one comment as productive evidence (`livenessState=advanced` from the comment count → `isProductiveSuccessfulRun → true`), enqueues a corrective handoff, exhausts the single retry, and escalates the execution issue to `blocked` + recovery owner
> - Downstream the recovery owner / CEO route the action back, and the next routine tick reopens the same loop — burning heartbeats and producing the `feedback_pickup_routine_empty_queue_needs_monitor.md` workaround on the Noya CRM fork
> - This pull request adds an early skip branch in `decideSuccessfulRunHandoff`: when the issue's `originKind` is `routine_execution` and the run's only evidence is comment(s) on its own issue (no document revisions, work products, cross-issue comments, or non-bookkeeping tool/action events), the decision returns `{ kind: "skip", reason: "routine pickup own-issue comment is not productive evidence" }`
> - The benefit is that pickup routines no longer self-escalate when their queue is empty; the routine cron fires again at its next scheduled tick anyway, so no liveness signal is lost

## What Changed

- `server/src/services/recovery/successful-run-handoff.ts`
  - `IssueRow` now also picks `originKind`.
  - New `SuccessfulRunHandoffEvidenceInput` type and new optional `runEvidence` field on the `decideSuccessfulRunHandoff` input (existing callers that don't pass it keep working).
  - New helpers: `isRoutineExecutionIssue(issue)`, `onlyEvidenceIsOwnIssueComment(evidence)`.
  - New skip branch placed **before** `isProductiveSuccessfulRun`: only fires when both helpers match.
- `server/src/services/heartbeat.ts`
  - `handleSuccessfulRunHandoff` selects `originKind` and threads a `runEvidence` payload computed by a new `collectSuccessfulRunHandoffEvidence(run, issueId)` helper (own-issue comments, cross-issue comments, document revisions, work products, and non-bookkeeping `heartbeat_run_events` counts — five parallel queries).
- `server/src/services/recovery/index.ts`
  - Re-exports the new `SuccessfulRunHandoffEvidenceInput` type.
- `server/src/services/recovery/successful-run-handoff.test.ts`
  - 4 new tests: the new skip path + 3 regression cases (non-bookkeeping tool/action events still enqueue, cross-issue comments still enqueue, non-routine origins still enqueue).

## Verification

- `pnpm vitest run server/src/services/recovery/successful-run-handoff.test.ts` — 18/18 pass (4 new + 14 existing).
- `pnpm tsc --noEmit -p server/tsconfig.json` — same 39 pre-existing errors as `origin/master` (routines schema drift + missing `@paperclipai/adapter-grok-local`); zero new errors on the changed surfaces. Verified by stashing the diff and re-running on bare master.
- Greptile review (commit `7c0f77d9`): SUCCESS, Confidence 4/5; the one functional concern (misleading test title) is addressed in commit `5304ebb2`.
- Snyk `security/snyk (cryppadotta)`: SUCCESS.

## Risks

- **Low risk.** The skip predicate is strictly tighter than the existing `isProductiveSuccessfulRun` short-circuit: it only fires when the issue is a routine-execution origin AND the evidence shape is exactly own-issue comments with nothing else. Any cross-issue PATCH, document revision, work product, or non-bookkeeping tool event keeps the existing enqueue behaviour.
- The `runEvidence` field is optional; old call sites and tests that don't set it keep the current code path (the helper returns `false` when evidence is missing).
- `collectSuccessfulRunHandoffEvidence` adds five parallel DB queries per `handleSuccessfulRunHandoff` invocation. Those queries are all indexed on `(company_id, created_by_run_id)` / `(company_id, run_id)` already used by `buildRunLivenessInput`, so the cost is comparable.
- No schema migration, no behaviour change for non-routine issues.

## Model Used

- Provider: Anthropic Claude
- Model ID: `claude-opus-4-7`
- Context window: ~200k tokens
- Mode: standard agentic tool-use loop (no extended thinking)
- Capabilities used: code search/edit (Read/Grep/Edit), local test/typecheck runs (Bash), and Paperclip control-plane API calls for issue disposition. No code execution sandbox.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only)
- [x] I have updated relevant documentation to reflect my changes (no user-facing docs touched; behaviour change is internal recovery-sweep predicate)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

## Out of scope

- The routine-side workaround (Option A: `in_review` + monitor on the Noya CRM fork) stays in place as belt-and-braces while this lands.
- Other handoff-escalation predicates (`hasOpenRecoveryIssue`, `hasExplicitBlockerPath`, etc.) are unchanged.

Blocks: NOY-8466 (Noya CRM).
