### PR TITLE
fix(plugins): forward pluginDbId from tool dispatcher to registry

### DIFF
--- a/server/src/__tests__/plugin-tool-dispatcher.test.ts
+++ b/server/src/__tests__/plugin-tool-dispatcher.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+import { createPluginToolDispatcher } from "../services/plugin-tool-dispatcher.js";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+import type { ToolRunContext } from "@paperclipai/plugin-sdk";
+
+const PLUGIN_KEY = "test.plugin";
+const PLUGIN_DB_ID = "9c1b8f25-1cee-4f0c-8c39-7f1ed27e1234";
+
+function makeManifest(): PaperclipPluginManifestV1 {
+  return {
+    id: PLUGIN_KEY,
+    apiVersion: 1,
+    version: "0.0.1",
+    displayName: "Test Plugin",
+    description: "Test plugin for dispatcher unit tests",
+    author: "tests",
+    categories: ["automation"],
+    capabilities: ["agent.tools.register"],
+    entrypoints: { worker: "./worker.js" },
+    tools: [
+      {
+        name: "do-thing",
+        displayName: "Do Thing",
+        description: "Does a thing",
+        parametersSchema: { type: "object", properties: {} },
+      },
+    ],
+  } as PaperclipPluginManifestV1;
+}
+
+function makeRunContext(): ToolRunContext {
+  return {
+    agentId: "agent-a",
+    runId: "run-r",
+    companyId: "company-c",
+    projectId: "project-p",
+  };
+}
+
+describe("plugin-tool-dispatcher", () => {
+  it("routes workerManager.isRunning by the plugin DB id, not the package key", async () => {
+    // Stub that "recognizes" the worker ONLY when looked up by DB UUID,
+    // mirroring plugin-worker-manager's behavior where the workers Map is
+    // keyed by the DB UUID (set in plugin-loader's activatePlugin via
+    // `workerManager.startWorker(plugin.id, ...)`).
+    const isRunning = vi.fn((id: string) => id === PLUGIN_DB_ID);
+    const call = vi.fn(async (_id: string, _method: string, _params: unknown) => ({
+      content: "ok",
+    }));
+
+    const workerManager = {
+      isRunning,
+      call,
+      // Other methods unused by this code path; type-cast away the mismatch.
+    } as unknown as Parameters<typeof createPluginToolDispatcher>[0]["workerManager"];
+
+    const dispatcher = createPluginToolDispatcher({ workerManager });
+
+    // Mimic the plugin-loader call site: caller has both package key AND DB UUID.
+    // The dispatcher MUST persist the DB UUID so executeTool can later look up
+    // the worker correctly.
+    dispatcher.registerPluginTools(PLUGIN_KEY, makeManifest(), PLUGIN_DB_ID);
+
+    const result = await dispatcher.executeTool(
+      `${PLUGIN_KEY}:do-thing`,
+      { foo: "bar" },
+      makeRunContext(),
+    );
+
+    expect(result.pluginId).toBe(PLUGIN_KEY);
+    expect(result.toolName).toBe("do-thing");
+
+    expect(isRunning).toHaveBeenCalledWith(PLUGIN_DB_ID);
+    expect(isRunning).not.toHaveBeenCalledWith(PLUGIN_KEY);
+
+    expect(call).toHaveBeenCalledWith(PLUGIN_DB_ID, "executeTool", expect.objectContaining({
+      toolName: "do-thing",
+      parameters: { foo: "bar" },
+    }));
+  });
+
+  it("listTools exposes the plugin DB id, not the package key, as the descriptor pluginId", () => {
+    const workerManager = {
+      isRunning: () => true,
+      call: async () => ({ content: "ok" }),
+    } as unknown as Parameters<typeof createPluginToolDispatcher>[0]["workerManager"];
+
+    const dispatcher = createPluginToolDispatcher({ workerManager });
+    dispatcher.registerPluginTools(PLUGIN_KEY, makeManifest(), PLUGIN_DB_ID);
+
+    const descriptors = dispatcher.listToolsForAgent();
+    expect(descriptors).toHaveLength(1);
+    expect(descriptors[0].pluginId).toBe(PLUGIN_DB_ID);
+    expect(descriptors[0].name).toBe(`${PLUGIN_KEY}:do-thing`);
+  });
+});

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -1932,7 +1932,7 @@ export function pluginLoader(
       // ------------------------------------------------------------------
       const toolDeclarations = manifest.tools ?? [];
       if (toolDeclarations.length > 0) {
-        toolDispatcher.registerPluginTools(pluginKey, manifest);
+        toolDispatcher.registerPluginTools(pluginKey, manifest, pluginId);
         registered.tools = toolDeclarations.length;
 
         log.info(

--- a/server/src/services/plugin-tool-dispatcher.ts
+++ b/server/src/services/plugin-tool-dispatcher.ts
@@ -150,12 +150,20 @@ export interface PluginToolDispatcher {
    * This is called automatically when a plugin transitions to `ready`.
    * Can also be called manually for testing or recovery scenarios.
    *
-   * @param pluginId - The plugin's unique identifier
+   * @param pluginId - The plugin's package key (e.g. `"acme.linear"`),
+   *   used as the namespace prefix in tool names and as the unregister key.
    * @param manifest - The plugin manifest containing tool declarations
+   * @param pluginDbId - The plugin's database row UUID, used by `executeTool`
+   *   to look the worker up in `PluginWorkerManager` (whose workers Map is
+   *   keyed by the DB UUID, since `plugin-loader.activatePlugin` starts the
+   *   worker via `workerManager.startWorker(plugin.id, ...)`).
+   *   Omitting it causes tool execution to fail with "worker not running"
+   *   even when the worker is healthy.
    */
   registerPluginTools(
     pluginId: string,
     manifest: PaperclipPluginManifestV1,
+    pluginDbId: string,
   ): void;
 
   /**
@@ -429,8 +437,9 @@ export function createPluginToolDispatcher(
     registerPluginTools(
       pluginId: string,
       manifest: PaperclipPluginManifestV1,
+      pluginDbId: string,
     ): void {
-      registry.registerPlugin(pluginId, manifest);
+      registry.registerPlugin(pluginId, manifest, pluginDbId);
     },
 
     unregisterPluginTools(pluginId: string): void {


### PR DESCRIPTION
## TL;DR

`POST /api/plugins/tools/execute` returns `Cannot execute tool ... — worker for plugin "<key>" is not running` for every plugin, even when `GET /api/plugins/<key>/dashboard` reports the worker as healthy with a live pid. Bug survives container restart and `disable/enable` / `uninstall/install` cycles. Root cause is in `PluginToolDispatcher.registerPluginTools` not forwarding the plugin's DB UUID to the underlying `PluginToolRegistry`. Three-line fix + new test.

## Reproduction

1. Install any plugin that registers tools (e.g. `@acme/linear`).
2. Wait for plugin to reach `status: "ready"`. Verify worker is alive via `GET /api/plugins/<key>/dashboard` — it reports `worker.status: "running"` with a live pid.
3. Invoke any of the plugin's tools via `POST /api/plugins/tools/execute`:
   ```json
   {"tool": "acme.linear:list-issues", "parameters": {...}, "runContext": {...}}
   ```
4. Server responds with `400`: `Cannot execute tool "acme.linear:list-issues" — worker for plugin "acme.linear" is not running.`

This contradicts the dashboard endpoint's view of the same worker. Reproduces against every plugin and survives a full server process restart.

## Root cause

`PluginToolRegistry.registerPlugin` takes an optional third `pluginDbId` argument and falls back to `dbId = pluginDbId ?? pluginId` when it isn't provided. The first arg, `pluginId`, is the plugin's **package key** (e.g. `"acme.linear"`) — used as the namespace prefix in tool names and as the unregister key. The third arg is intended to be the plugin's **DB row UUID**, which is what `PluginWorkerManager.workers` Map is keyed on (since `plugin-loader.activatePlugin` starts the worker via `workerManager.startWorker(plugin.id, ...)`).

There are three call sites to `registry.registerPlugin` inside `plugin-tool-dispatcher.ts`:

| Line | Path | Passes DB UUID? |
| --- | --- | --- |
| 269 | `registerFromDb` (called from lifecycle event handler) | ✅ Yes — passes `plugin.id` |
| 333 | Dispatcher init (boot-time scan over `status='ready'` plugins) | ✅ Yes — passes `plugin.id` |
| 433 | `registerPluginTools` (called by `plugin-loader.activatePlugin`) | ❌ **No** — only two args |

The init path runs at boot and registers tools correctly. But then `plugin-loader.loadAll()` calls `activatePlugin` for each plugin, which calls `toolDispatcher.registerPluginTools(pluginKey, manifest)` — the buggy two-arg path. `registry.registerPlugin` clears the previous registration via `removePluginTools` and re-registers with `tool.pluginDbId = packageKey` (the fallback). The buggy path always runs last, so a restart doesn't help.

At execute time, `plugin-tool-registry.ts:406`:

```typescript
const dbId = tool.pluginDbId;       // <— package key, not DB UUID
if (!workerManager.isRunning(dbId)) {  // <— workers Map is keyed by UUID
  throw new Error(...);             // <— this fires for every plugin
}
```

This is why the dashboard endpoint (which uses `wm.getWorker(plugin.id)` — looking up by UUID directly) sees the worker, but `tools/execute` doesn't.

## Fix

Three changes, ~10 LoC excluding the test file:

- `server/src/services/plugin-tool-dispatcher.ts` — add `pluginDbId: string` as a required third parameter on both the interface and impl of `registerPluginTools`; forward it to `registry.registerPlugin(pluginId, manifest, pluginDbId)`. JSDoc updated to document the parameter ambiguity (the first arg's name `pluginId` historically refers to the package key here, not the DB UUID).
- `server/src/services/plugin-loader.ts:1935` — the sole caller passes the `pluginId` local variable (the DB UUID, set on line 1768 as `plugin.id`).

The `registry.registerPlugin` API is unchanged. Other call paths (`registerFromDb`, dispatcher init) were already passing the DB UUID correctly.

## Testing

New file `server/src/__tests__/plugin-tool-dispatcher.test.ts` with two tests:

1. **`routes workerManager.isRunning by the plugin DB id, not the package key`** — exercises the full register-then-execute flow with a stubbed `workerManager` that returns `true` only when called with the DB UUID. Before the fix this test fails with the exact production error string. After the fix it passes.
2. **`listTools exposes the plugin DB id, not the package key, as the descriptor pluginId`** — confirms `toAgentDescriptor` returns the correct `pluginId` field for consumers (e.g. agent service) that look it up.

Existing plugin tests verified clean:

```
Test Files  16 passed (16)
Tests       111 passed (111)
```

No other tests modified. No production callers of `registerPluginTools` other than the one site in `plugin-loader.ts`.

## Risk

- **API change:** `registerPluginTools` gains a required third parameter. The dispatcher interface is exported, but a code search across the server source found the single caller in `plugin-loader.activatePlugin`. Downstream consumers using the package would see a TypeScript compile error pointing them at the change; runtime behavior for callers correctly passing the DB UUID is unchanged.
- **Behavioral change:** Every plugin tool invocation now actually reaches the worker instead of failing pre-flight. This is the intended fix.
- **Migration:** None. No data shape changes, no DB migration, no manifest format changes. The fix applies on first server restart after deploy.

## Discovered downstream

The bug surfaced during an rf-collective adoption pilot for the `host.issueDocuments.upsert` methods introduced in #1074. The pilot plugin's tool registered fine (`plugin-loader` logged `"capabilities":["agent.tools.register","issue.documents.write"]`) but invocation always failed pre-flight at `workerManager.isRunning(dbId)`. Operator-side workarounds (server restart, plugin disable/enable, uninstall/reinstall) all failed because the loader-driven registration path always runs after them and overwrites any correct registration. Side note: a control case against a completely separate plugin (`rf-collective.iqengine:iqengine-status`) reproduced identically, confirming the bug is platform-wide rather than pilot-specific.
