### PR TITLE
fix(plugin-sdk): wrap caller-supplied taskKey inside required plugin prefix so sessions remain visible to sendMessage/list/close

### DIFF
--- a/server/src/__tests__/plugin-orchestration-apis.test.ts
+++ b/server/src/__tests__/plugin-orchestration-apis.test.ts
@@ -2,10 +2,11 @@ import { randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { and, eq } from "drizzle-orm";
+import { and, eq, like } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
+  agentTaskSessions,
   agentWakeupRequests,
   agents,
   companies,
@@ -65,6 +66,7 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     await db.delete(costEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
+    await db.delete(agentTaskSessions);
     await db.delete(issueRelations);
     await db.delete(issues);
     await db.delete(pluginManagedResources);
@@ -673,5 +675,73 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
       cachedInputTokens: 3,
       outputTokens: 6,
     });
+  });
+
+  it("agentSessions.create wraps a caller-supplied taskKey in the plugin prefix so sendMessage/list/close can find it", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.missions", createEventBusStub());
+
+    const session = await services.agentSessions.create({
+      agentId,
+      companyId,
+      taskKey: "discord-thread-123",
+      reason: "test custom taskKey wrapping",
+    });
+
+    // The stored taskKey must be wrapped inside the prefix
+    const [stored] = await db
+      .select()
+      .from(agentTaskSessions)
+      .where(eq(agentTaskSessions.id, session.sessionId));
+    expect(stored?.taskKey).toBe("plugin:paperclip.missions:session:discord-thread-123");
+
+    // And it must be findable by the same LIKE filter sendMessage/list/close use
+    const findable = await db
+      .select()
+      .from(agentTaskSessions)
+      .where(
+        and(
+          eq(agentTaskSessions.id, session.sessionId),
+          eq(agentTaskSessions.companyId, companyId),
+          like(agentTaskSessions.taskKey, "plugin:paperclip.missions:session:%"),
+        ),
+      )
+      .then((rows) => rows[0] ?? null);
+    expect(findable).not.toBeNull();
+  });
+
+  it("agentSessions.create does not double-prefix an already-prefixed taskKey", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.missions", createEventBusStub());
+
+    const session = await services.agentSessions.create({
+      agentId,
+      companyId,
+      taskKey: "plugin:paperclip.missions:session:already-prefixed",
+      reason: "test no double-prefix",
+    });
+
+    const [stored] = await db
+      .select()
+      .from(agentTaskSessions)
+      .where(eq(agentTaskSessions.id, session.sessionId));
+    expect(stored?.taskKey).toBe("plugin:paperclip.missions:session:already-prefixed");
+  });
+
+  it("agentSessions.create with no taskKey produces a default prefixed key (backwards compatible)", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const services = buildHostServices(db, "plugin-record-id", "paperclip.missions", createEventBusStub());
+
+    const session = await services.agentSessions.create({
+      agentId,
+      companyId,
+      reason: "test default key generation",
+    });
+
+    const [stored] = await db
+      .select()
+      .from(agentTaskSessions)
+      .where(eq(agentTaskSessions.id, session.sessionId));
+    expect(stored?.taskKey).toMatch(/^plugin:paperclip\.missions:session:[0-9a-f-]{36}$/);
   });
 });

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -1946,7 +1946,14 @@ export function buildHostServices(
         await ensurePluginAvailableForCompany(companyId);
         const agent = await agents.getById(params.agentId);
         requireInCompany("Agent", agent, companyId);
-        const taskKey = params.taskKey ?? `plugin:${pluginKey}:session:${randomUUID()}`;
+        // Wrap any caller-supplied taskKey inside the required prefix so
+        // sendMessage/list/close (which filter on `plugin:${pluginKey}:session:%`)
+        // can still find the session. Without this, a custom taskKey orphans the
+        // session — sendMessage immediately throws `Session not found`.
+        const rawTaskKey = params.taskKey ?? randomUUID();
+        const taskKey = rawTaskKey.startsWith(`plugin:${pluginKey}:session:`)
+          ? rawTaskKey
+          : `plugin:${pluginKey}:session:${rawTaskKey}`;
 
         const row = await db
           .insert(agentTaskSessionsTable)


### PR DESCRIPTION
Closes #6156.

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Plugins extend that orchestration through the Plugin SDK, which exposes `agents.sessions.*` as a session API for plugin-driven agent interactions (Telegram, Discord, etc.)
> - Plugins create sessions via `sessions.create()` and refer back to them via `sessions.sendMessage()`, `sessions.list()`, and `sessions.close()`
> - But `create` honored an arbitrary caller-supplied `taskKey` verbatim, while the three consumer ops hard-filter on `taskKey LIKE 'plugin:${pluginKey}:session:%'`
> - This means any plugin that passes a meaningful `taskKey` (e.g. `discord-thread-${threadId}` for cross-restart session lookup) creates a session that's immediately invisible to its own `sendMessage` calls — the session is orphaned, `sendMessage` throws `Session not found: <uuid>`
> - This PR wraps the caller's `taskKey` inside the required prefix so all four ops agree on the lookup pattern
> - The benefit is the documented `agents.sessions.*` API becomes usable for plugins that need stable, meaningful taskKeys

## What Changed

- `server/src/services/plugin-host-services.ts:1949` — `agentSessions.create` now wraps any caller-supplied `taskKey` inside the required `plugin:${pluginKey}:session:` prefix. Backwards-compatible for callers that pass no `taskKey` (still gets `plugin:${pluginKey}:session:${randomUUID()}`). Already-prefixed values are not double-wrapped (defensive `startsWith` check).
- `server/src/__tests__/plugin-orchestration-apis.test.ts` — three new integration tests (embedded-postgres backed, matches existing file pattern):
  - `wraps a caller-supplied taskKey in the plugin prefix so sendMessage/list/close can find it` — proves the fix end-to-end by re-running the same `LIKE` filter the consumer ops use.
  - `does not double-prefix an already-prefixed taskKey` — guards the new prefix-detection branch.
  - `with no taskKey produces a default prefixed key (backwards compatible)` — guards existing default behavior.
- Test cleanup now includes `agentTaskSessions` deletion in the `afterEach` so the new tests don't leave rows for subsequent runs.

## Verification

**Test:**

```
$ npx pnpm --filter @paperclipai/server exec vitest run src/__tests__/plugin-orchestration-apis.test.ts
 ✓ src/__tests__/plugin-orchestration-apis.test.ts (12 tests) 1163ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

12/12 pass (was 9 before; added 3 new). Sanity-checked by reverting the fix temporarily — the "wraps custom taskKey" test fails with `expected 'discord-thread-123' to be 'plugin:paperclip.missions:session:discord-thread-123'`. With the fix, all green.

**Typecheck:**

```
$ npx pnpm --filter @paperclipai/server typecheck
EXIT=0
```

**End-to-end (downstream reproducer):**

Reproduced upstream symptom against PaperClip v2026.403.0 with `mvanhorn/paperclip-plugin-discord` v0.9.1's `/acp spawn` flow (which passes `taskKey: \`discord-thread-${threadId}\`` to `sessions.create`). Before this fix: plugin worker logs `host handler error method=agents.sessions.sendMessage err: "Session not found: <uuid>"` followed by `Native session create failed, trying ACP fallback transport=acp`. After this fix: `transport=native`, agent receives prompt, replies in the spawned thread.

## Risks

**Low risk.** The change is a string-wrapping addition inside the `taskKey` defaulting line. All current callsites of `sessions.create` either pass no `taskKey` (unchanged) or pass an unprefixed custom value (which previously orphaned silently — now becomes findable).

Edge case considered and tested: if a future caller passes an already-prefixed `taskKey` (e.g. while migrating off a defensive workaround), `startsWith` check prevents double-prefixing.

No DB migration. No API contract change for the plugin SDK (the `taskKey` parameter still accepts arbitrary strings; the wrapping happens server-side). Plugins that worked correctly before continue to work; plugins that were silently broken by this bug now work.

## Model Used

- Provider: Anthropic
- Model: claude-opus-4-7 (Opus 4.7, 1M context window)
- Mode: agentic coding with tool use (Read/Edit/Bash); no extended thinking mode used for this change
- Role: surfaced the root cause via downstream reproducer, drafted the fix + tests, wrote the PR body

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (plugin-orchestration-apis.test.ts: 12/12)
- [x] I have added or updated tests where applicable (3 new tests cover the fix + guards)
- [ ] If this change affects the UI, I have included before/after screenshots (n/a — server-only)
- [x] I have updated relevant documentation to reflect my changes (no doc references the bug; SDK README is consistent with the fixed behavior — `sessions.create` accepts `taskKey` and downstream ops find it)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge