### PR TITLE
Add Hermes runtime identity lifecycle

### DIFF
--- a/docs/adapters/creating-an-adapter.md
+++ b/docs/adapters/creating-an-adapter.md
@@ -240,6 +240,12 @@ With these flags set, the Paperclip UI will automatically show the instructions 
 
 If capability flags are not set, the server falls back to legacy hardcoded lists for built-in adapter types. External adapters that omit the flags will default to `false` for all capabilities.
 
+## Runtime Identity Hooks
+
+Adapters that need one durable runtime profile per Paperclip agent can implement `ensureRuntimeIdentity`.
+
+The hook runs after Paperclip creates an agent and after adapter type/config changes. It must be idempotent. Return the adapter config and metadata Paperclip should persist. Do not delete runtime state from this hook.
+
 ## Skills Injection
 
 Make Paperclip skills discoverable to your agent runtime without writing to the agent's working directory:

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -12,6 +12,8 @@ export type {
   AdapterEnvironmentTestStatus,
   AdapterEnvironmentTestResult,
   AdapterEnvironmentTestContext,
+  AdapterRuntimeIdentityContext,
+  AdapterRuntimeIdentityResult,
   AdapterSkillSyncMode,
   AdapterSkillState,
   AdapterSkillOrigin,

--- a/packages/adapter-utils/src/runtime-identity-contract.test.ts
+++ b/packages/adapter-utils/src/runtime-identity-contract.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AdapterRuntimeIdentityContext,
+  AdapterRuntimeIdentityResult,
+  ServerAdapterModule,
+} from "./types.js";
+
+const runtimeIdentityAdapter: ServerAdapterModule = {
+  type: "test",
+  execute: async () => ({ exitCode: 0, signal: null, timedOut: false }),
+  testEnvironment: async () => ({
+    adapterType: "test",
+    status: "pass",
+    checks: [],
+    testedAt: new Date(0).toISOString(),
+  }),
+  ensureRuntimeIdentity: async (
+    ctx: AdapterRuntimeIdentityContext,
+  ): Promise<AdapterRuntimeIdentityResult> => ({
+    adapterConfig: ctx.adapterConfig,
+    metadata: ctx.metadata,
+    detail: { ok: true },
+  }),
+};
+
+describe("runtime identity adapter contract", () => {
+  it("allows server adapters to expose an idempotent runtime identity hook", async () => {
+    const result = await runtimeIdentityAdapter.ensureRuntimeIdentity?.({
+      companyId: "company-1",
+      companyName: "Acme",
+      agentId: "agent-1",
+      agentName: "Reviewer",
+      adapterType: "test",
+      adapterConfig: { env: { EXISTING: "1" } },
+      metadata: { existing: true },
+    });
+
+    expect(result?.detail).toEqual({ ok: true });
+  });
+
+  it("allows the initial null metadata state", async () => {
+    const result = await runtimeIdentityAdapter.ensureRuntimeIdentity?.({
+      companyId: "company-1",
+      companyName: "Acme",
+      agentId: "agent-1",
+      agentName: "Reviewer",
+      adapterType: "test",
+      adapterConfig: {},
+      metadata: null,
+    });
+
+    expect(result?.metadata).toBeNull();
+  });
+});

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -270,6 +270,23 @@ export interface HireApprovedHookResult {
   detail?: Record<string, unknown>;
 }
 
+export interface AdapterRuntimeIdentityContext {
+  companyId: string;
+  companyName: string;
+  agentId: string;
+  agentName: string;
+  adapterType: string;
+  adapterConfig: Record<string, unknown>;
+  metadata: Record<string, unknown> | null;
+}
+
+export interface AdapterRuntimeIdentityResult {
+  adapterConfig: Record<string, unknown>;
+  metadata: Record<string, unknown> | null;
+  detail?: Record<string, unknown>;
+  warnings?: string[];
+}
+
 // ---------------------------------------------------------------------------
 // Quota window types — used by adapters that can report provider quota/rate-limit state
 // ---------------------------------------------------------------------------
@@ -375,6 +392,13 @@ export interface ServerAdapterModule {
     payload: HireApprovedPayload,
     adapterConfig: Record<string, unknown>,
   ) => Promise<HireApprovedHookResult>;
+  /**
+   * Optional lifecycle hook that gives an adapter one stable runtime identity
+   * per Paperclip agent. The hook must be idempotent.
+   */
+  ensureRuntimeIdentity?: (
+    ctx: AdapterRuntimeIdentityContext,
+  ) => Promise<AdapterRuntimeIdentityResult>;
   /**
    * Optional: fetch live provider quota/rate-limit windows for this adapter.
    * Returns a ProviderQuotaResult so the server can aggregate across adapters

--- a/packages/shared/src/agent-runtime-identity.test.ts
+++ b/packages/shared/src/agent-runtime-identity.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import type { Agent, AgentRuntimeIdentity } from "./index.js";
+
+const runtimeIdentity: AgentRuntimeIdentity = {
+  adapter: "hermes_local",
+  profileSlug: "acme-reviewer",
+};
+
+const agent = {} as Agent;
+const profileSlug: string | undefined = agent.metadata?.runtimeIdentity?.profileSlug;
+
+describe("agent runtime identity type", () => {
+  it("allows agent metadata to expose a runtime identity profile slug", () => {
+    expect(runtimeIdentity.profileSlug).toBe("acme-reviewer");
+    expect(profileSlug).toBeUndefined();
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -314,6 +314,7 @@ export type {
   AgentChainOfCommandEntry,
   AgentDetail,
   AgentPermissions,
+  AgentRuntimeIdentity,
   AgentInstructionsBundleMode,
   AgentInstructionsFileSummary,
   AgentInstructionsFileDetail,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -24,6 +24,14 @@ export interface AgentRuntimeConfig extends Record<string, unknown> {
   modelProfiles?: Partial<Record<ModelProfileKey, AgentModelProfileConfig>>;
 }
 
+export interface AgentRuntimeIdentity {
+  adapter: string;
+  profileSlug?: string;
+  hermesHome?: string;
+  managedBy?: string;
+  createdAt?: string;
+}
+
 export type AgentInstructionsBundleMode = "managed" | "external";
 
 export interface AgentInstructionsFileSummary {
@@ -91,7 +99,7 @@ export interface Agent {
   pausedAt: Date | null;
   permissions: AgentPermissions;
   lastHeartbeatAt: Date | null;
-  metadata: Record<string, unknown> | null;
+  metadata: (Record<string, unknown> & { runtimeIdentity?: AgentRuntimeIdentity }) | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -77,6 +77,7 @@ export type {
   AgentModelProfileConfig,
   AgentPermissions,
   AgentRuntimeConfig,
+  AgentRuntimeIdentity,
   AgentInstructionsBundleMode,
   AgentInstructionsFileSummary,
   AgentInstructionsFileDetail,

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -480,6 +480,12 @@ describe("server adapter registry", () => {
     // Auth token is still injected.
     expect(patchedCtx.agent.adapterConfig.env.PAPERCLIP_API_KEY).toBe("agent-run-jwt");
   });
+
+  it("registers Hermes runtime identity support", () => {
+    const adapter = findServerAdapter("hermes_local");
+
+    expect(adapter?.ensureRuntimeIdentity).toEqual(expect.any(Function));
+  });
 });
 
 describe("resolveExternalAdapterRegistration", () => {

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { buildSandboxNpmInstallCommand } from "@paperclipai/adapter-utils";
 import type { ServerAdapterModule } from "../adapters/index.js";
 
@@ -485,6 +488,48 @@ describe("server adapter registry", () => {
     const adapter = findServerAdapter("hermes_local");
 
     expect(adapter?.ensureRuntimeIdentity).toEqual(expect.any(Function));
+  });
+
+  it("detects Hermes model defaults from HERMES_HOME config", async () => {
+    const hermesHome = await mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-detect-"));
+    await writeFile(
+      path.join(hermesHome, "config.yaml"),
+      [
+        "model:",
+        "  provider: openrouter",
+        "  default: anthropic/claude-sonnet-4",
+        "",
+      ].join("\n"),
+    );
+    const previousHermesHome = process.env.HERMES_HOME;
+    const previousHermesModel = process.env.HERMES_MODEL;
+    const previousHermesInferenceModel = process.env.HERMES_INFERENCE_MODEL;
+    process.env.HERMES_HOME = hermesHome;
+    delete process.env.HERMES_MODEL;
+    delete process.env.HERMES_INFERENCE_MODEL;
+    try {
+      await expect(detectAdapterModel("hermes_local")).resolves.toEqual({
+        model: "anthropic/claude-sonnet-4",
+        provider: "openrouter",
+        source: path.join(hermesHome, "config.yaml"),
+      });
+    } finally {
+      if (previousHermesHome === undefined) {
+        delete process.env.HERMES_HOME;
+      } else {
+        process.env.HERMES_HOME = previousHermesHome;
+      }
+      if (previousHermesModel === undefined) {
+        delete process.env.HERMES_MODEL;
+      } else {
+        process.env.HERMES_MODEL = previousHermesModel;
+      }
+      if (previousHermesInferenceModel === undefined) {
+        delete process.env.HERMES_INFERENCE_MODEL;
+      } else {
+        process.env.HERMES_INFERENCE_MODEL = previousHermesInferenceModel;
+      }
+    }
   });
 });
 

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -62,6 +62,7 @@ vi.mock("../services/environments.js", () => ({
 }));
 
 vi.mock("../adapters/index.js", () => ({
+  findActiveServerAdapter: mockFindServerAdapter,
   findServerAdapter: mockFindServerAdapter,
   listAdapterModels: vi.fn(),
 }));
@@ -92,6 +93,7 @@ function registerModuleMocks() {
   }));
 
   vi.doMock("../adapters/index.js", () => ({
+    findActiveServerAdapter: mockFindServerAdapter,
     findServerAdapter: mockFindServerAdapter,
     listAdapterModels: vi.fn(),
   }));

--- a/server/src/__tests__/hermes-agent-runtime-identity-routes.test.ts
+++ b/server/src/__tests__/hermes-agent-runtime-identity-routes.test.ts
@@ -291,5 +291,64 @@ describe("Hermes runtime identity routes", () => {
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body.adapterConfig.env.HERMES_HOME).toContain("/runtimes/hermes/profiles/");
     expect(res.body.metadata.runtimeIdentity.adapter).toBe("hermes_local");
+    expect(mockAgentService.update).toHaveBeenLastCalledWith(
+      existing.id,
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          env: expect.objectContaining({
+            HERMES_HOME: "/tmp/paperclip/runtimes/hermes/profiles/acme-reviewer",
+          }),
+        }),
+      }),
+      {
+        recordRevision: {
+          createdByAgentId: null,
+          createdByUserId: "local-board",
+          source: "adapter_runtime_identity_update",
+        },
+      },
+    );
+  });
+
+  it("does not overwrite existing metadata when runtime identity returns null metadata", async () => {
+    const existing = makeAgent({
+      adapterType: "hermes_local",
+      adapterConfig: {},
+      metadata: { existing: true },
+    });
+    let persistedAgent = existing;
+    mockAgentService.getById.mockResolvedValue(existing);
+    mockAgentService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+      persistedAgent = makeAgent({
+        ...persistedAgent,
+        ...patch,
+        adapterConfig: patch.adapterConfig ?? persistedAgent.adapterConfig,
+        ...(Object.prototype.hasOwnProperty.call(patch, "metadata") ? { metadata: patch.metadata } : {}),
+      });
+      return persistedAgent;
+    });
+    mockAdapter.ensureRuntimeIdentity.mockResolvedValueOnce({
+      adapterConfig: {
+        env: {
+          HERMES_HOME: "/tmp/paperclip/runtimes/hermes/profiles/acme-reviewer",
+        },
+      },
+      metadata: null,
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/agents/${existing.id}`)
+      .send({
+        adapterConfig: {
+          timeoutSec: 30,
+        },
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.metadata).toEqual({ existing: true });
+    const runtimeIdentityUpdate = mockAgentService.update.mock.calls.find((call) =>
+      call[2]?.recordRevision?.source === "adapter_runtime_identity_update",
+    );
+    expect(runtimeIdentityUpdate?.[1]).not.toHaveProperty("metadata");
   });
 });

--- a/server/src/__tests__/hermes-agent-runtime-identity-routes.test.ts
+++ b/server/src/__tests__/hermes-agent-runtime-identity-routes.test.ts
@@ -1,0 +1,295 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAgentService = vi.hoisted(() => ({
+  create: vi.fn(),
+  getById: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+  ensureMembership: vi.fn(),
+  setPrincipalPermission: vi.fn(),
+}));
+
+const mockApprovalService = vi.hoisted(() => ({
+  create: vi.fn(),
+  getById: vi.fn(),
+}));
+
+const mockBudgetService = vi.hoisted(() => ({
+  upsertPolicy: vi.fn(),
+}));
+
+const mockCompanySkillService = vi.hoisted(() => ({
+  listRuntimeSkillEntries: vi.fn(),
+  resolveRequestedSkillKeys: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(),
+}));
+
+const mockIssueApprovalService = vi.hoisted(() => ({
+  linkManyForApproval: vi.fn(),
+}));
+
+const mockSecretService = vi.hoisted(() => ({
+  normalizeAdapterConfigForPersistence: vi.fn(async (_companyId: string, config: Record<string, unknown>) => config),
+  resolveAdapterConfigForRuntime: vi.fn(async (_companyId: string, config: Record<string, unknown>) => ({ config })),
+  syncEnvBindingsForTarget: vi.fn(),
+}));
+
+const mockAgentInstructionsService = vi.hoisted(() => ({
+  materializeManagedBundle: vi.fn(),
+  getBundle: vi.fn(),
+  readFile: vi.fn(),
+  updateBundle: vi.fn(),
+  writeFile: vi.fn(),
+  deleteFile: vi.fn(),
+  exportFiles: vi.fn(),
+  ensureManagedBundle: vi.fn(),
+}));
+
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  getGeneral: vi.fn(async () => ({ censorUsernameInLogs: false })),
+}));
+
+const mockAdapter = vi.hoisted(() => ({
+  type: "hermes_local",
+  supportsInstructionsBundle: false,
+  requiresMaterializedRuntimeSkills: false,
+  ensureRuntimeIdentity: vi.fn(async (ctx: {
+    adapterConfig: Record<string, unknown>;
+    metadata: Record<string, unknown> | null;
+  }) => ({
+    adapterConfig: {
+      ...ctx.adapterConfig,
+      env: {
+        ...(ctx.adapterConfig.env as Record<string, unknown> | undefined),
+        HERMES_HOME: "/tmp/paperclip/runtimes/hermes/profiles/acme-reviewer",
+      },
+    },
+    metadata: {
+      ...(ctx.metadata ?? {}),
+      runtimeIdentity: {
+        adapter: "hermes_local",
+        profileSlug: "acme-reviewer",
+        hermesHome: "/tmp/paperclip/runtimes/hermes/profiles/acme-reviewer",
+      },
+    },
+  })),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+const mockTrackAgentCreated = vi.hoisted(() => vi.fn());
+const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentCreated: mockTrackAgentCreated,
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: mockGetTelemetryClient,
+}));
+
+vi.mock("../services/index.js", () => ({
+  agentService: () => mockAgentService,
+  agentInstructionsService: () => mockAgentInstructionsService,
+  accessService: () => mockAccessService,
+  approvalService: () => mockApprovalService,
+  companySkillService: () => mockCompanySkillService,
+  budgetService: () => mockBudgetService,
+  heartbeatService: () => mockHeartbeatService,
+  issueApprovalService: () => mockIssueApprovalService,
+  issueRecoveryActionService: () => ({}),
+  issueService: () => ({}),
+  logActivity: mockLogActivity,
+  secretService: () => mockSecretService,
+  syncInstructionsBundleConfigFromFilePath: vi.fn((_agent, config) => config),
+  workspaceOperationService: () => ({}),
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => mockInstanceSettingsService,
+}));
+
+vi.mock("../services/secrets.js", () => ({
+  secretService: () => mockSecretService,
+}));
+
+vi.mock("../services/environment-runtime.js", () => ({
+  environmentRuntimeService: () => ({}),
+}));
+
+vi.mock("../services/environments.js", () => ({
+  environmentService: () => ({ getById: vi.fn() }),
+}));
+
+vi.mock("../services/recovery/service.js", () => ({
+  recoveryService: () => ({}),
+}));
+
+vi.mock("../adapters/index.js", () => ({
+  detectAdapterModel: vi.fn(),
+  findActiveServerAdapter: vi.fn(() => mockAdapter),
+  findServerAdapter: vi.fn(() => mockAdapter),
+  listAdapterModels: vi.fn(),
+  listAdapterModelProfiles: vi.fn(async () => []),
+  refreshAdapterModels: vi.fn(),
+  requireServerAdapter: vi.fn(() => mockAdapter),
+}));
+
+function createDb() {
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => [
+          {
+            id: "company-1",
+            name: "Acme",
+            requireBoardApprovalForNewAgents: false,
+          },
+        ]),
+      })),
+    })),
+  };
+}
+
+function makeAgent(input: Record<string, unknown> = {}) {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    companyId: "company-1",
+    name: "Reviewer",
+    urlKey: "reviewer",
+    role: "engineer",
+    title: null,
+    icon: null,
+    status: "idle",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "process",
+    adapterConfig: {},
+    runtimeConfig: {},
+    defaultEnvironmentId: null,
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: { canCreateAgents: false },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...input,
+  };
+}
+
+async function createApp() {
+  const [{ agentRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes(createDb() as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("Hermes runtime identity routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAccessService.ensureMembership.mockResolvedValue(undefined);
+    mockAccessService.setPrincipalPermission.mockResolvedValue(undefined);
+    mockCompanySkillService.listRuntimeSkillEntries.mockResolvedValue([]);
+    mockCompanySkillService.resolveRequestedSkillKeys.mockResolvedValue([]);
+    mockGetTelemetryClient.mockReturnValue({ track: vi.fn() });
+    let persistedAgent: ReturnType<typeof makeAgent> | null = null;
+    mockAgentService.create.mockImplementation(async (_companyId: string, input: Record<string, unknown>) => {
+      persistedAgent = makeAgent({
+        ...input,
+        adapterConfig: input.adapterConfig ?? {},
+        runtimeConfig: input.runtimeConfig ?? {},
+      });
+      return persistedAgent;
+    });
+    mockAgentService.getById.mockImplementation(async () => persistedAgent ?? makeAgent());
+    mockAgentService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+      persistedAgent = makeAgent({
+        ...(persistedAgent ?? makeAgent()),
+        ...patch,
+        adapterConfig: patch.adapterConfig ?? (persistedAgent ?? makeAgent()).adapterConfig,
+        metadata: patch.metadata ?? (persistedAgent ?? makeAgent()).metadata,
+      });
+      return persistedAgent;
+    });
+  });
+
+  it("reconciles runtime identity when creating a Hermes agent", async () => {
+    const res = await request(await createApp())
+      .post("/api/companies/company-1/agents")
+      .send({
+        name: "Reviewer",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.body.adapterConfig.env.HERMES_HOME).toContain("/runtimes/hermes/profiles/");
+    expect(res.body.metadata.runtimeIdentity.profileSlug).toBe("acme-reviewer");
+  });
+
+  it("keeps agent creation non-fatal when runtime identity reconciliation fails", async () => {
+    mockAdapter.ensureRuntimeIdentity.mockRejectedValueOnce(new Error("disk full"));
+
+    const res = await request(await createApp())
+      .post("/api/companies/company-1/agents")
+      .send({
+        name: "Reviewer",
+        role: "engineer",
+        adapterType: "hermes_local",
+        adapterConfig: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.body.adapterConfig).toEqual({});
+    expect(res.body.metadata).toBeNull();
+  });
+
+  it("reconciles runtime identity when updating an agent to Hermes", async () => {
+    const existing = makeAgent({
+      adapterType: "process",
+      adapterConfig: { command: "node worker.js" },
+    });
+    mockAgentService.getById.mockResolvedValueOnce(existing);
+
+    const res = await request(await createApp())
+      .patch(`/api/agents/${existing.id}`)
+      .send({
+        adapterType: "hermes_local",
+        adapterConfig: {},
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.adapterConfig.env.HERMES_HOME).toContain("/runtimes/hermes/profiles/");
+    expect(res.body.metadata.runtimeIdentity.adapter).toBe("hermes_local");
+  });
+});

--- a/server/src/__tests__/hermes-runtime-identity.test.ts
+++ b/server/src/__tests__/hermes-runtime-identity.test.ts
@@ -61,6 +61,85 @@ describe("Hermes runtime identity", () => {
       .resolves.toContain("dashboard:");
   });
 
+  it("seeds a new profile from base Hermes model config without copying env secrets", async () => {
+    const instanceRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-profile-"));
+    const baseHermesHome = await mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-base-"));
+    await writeFile(
+      path.join(baseHermesHome, "config.yaml"),
+      [
+        "model:",
+        "  provider: openrouter",
+        "  default: anthropic/claude-sonnet-4",
+        "",
+        "dashboard:",
+        "  show_token_analytics: false",
+        "",
+      ].join("\n"),
+    );
+    await writeFile(path.join(baseHermesHome, ".env"), "ANTHROPIC_API_KEY=secret\n");
+
+    await ensureHermesRuntimeIdentity({
+      companyId: "company-1",
+      companyName: "Acme",
+      agentId: "agent-1",
+      agentName: "Reviewer",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+      metadata: null,
+      instanceRoot,
+      baseHermesHome,
+      env: {},
+      now: "2026-05-18T00:00:00.000Z",
+    });
+
+    const profileHome = path.join(instanceRoot, "runtimes", "hermes", "profiles", "acme-reviewer");
+    await expect(readFile(path.join(profileHome, "config.yaml"), "utf8")).resolves.toBe([
+      "model:",
+      "  provider: openrouter",
+      "  default: anthropic/claude-sonnet-4",
+      "",
+      "dashboard:",
+      "  show_token_analytics: true",
+      "",
+    ].join("\n"));
+    await expect(stat(path.join(profileHome, ".env"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("seeds a new profile from Hermes model environment defaults", async () => {
+    const instanceRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-profile-"));
+
+    await ensureHermesRuntimeIdentity({
+      companyId: "company-1",
+      companyName: "Acme",
+      agentId: "agent-1",
+      agentName: "Reviewer",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+      metadata: null,
+      instanceRoot,
+      env: {
+        HERMES_MODEL: "openai/gpt-5.2",
+        HERMES_PROVIDER: "openai",
+      },
+      now: "2026-05-18T00:00:00.000Z",
+    });
+
+    await expect(
+      readFile(
+        path.join(instanceRoot, "runtimes", "hermes", "profiles", "acme-reviewer", "config.yaml"),
+        "utf8",
+      ),
+    ).resolves.toBe([
+      "model:",
+      "  provider: openai",
+      "  default: openai/gpt-5.2",
+      "",
+      "dashboard:",
+      "  show_token_analytics: true",
+      "",
+    ].join("\n"));
+  });
+
   it("treats malformed adapter env as empty before patching Hermes home", async () => {
     const instanceRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-profile-"));
     const result = await ensureHermesRuntimeIdentity({

--- a/server/src/__tests__/hermes-runtime-identity.test.ts
+++ b/server/src/__tests__/hermes-runtime-identity.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  detectHermesRuntimeModelDefaults,
   ensureHermesRuntimeIdentity,
   deriveHermesProfileSlug,
 } from "../adapters/hermes-runtime-identity.js";
@@ -95,14 +96,37 @@ describe("Hermes runtime identity", () => {
     const profileHome = path.join(instanceRoot, "runtimes", "hermes", "profiles", "acme-reviewer");
     await expect(readFile(path.join(profileHome, "config.yaml"), "utf8")).resolves.toBe([
       "model:",
-      "  provider: openrouter",
-      "  default: anthropic/claude-sonnet-4",
+      "  provider: \"openrouter\"",
+      "  default: \"anthropic/claude-sonnet-4\"",
       "",
       "dashboard:",
       "  show_token_analytics: true",
       "",
     ].join("\n"));
     await expect(stat(path.join(profileHome, ".env"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("parses quoted Hermes config defaults without treating # as a comment", async () => {
+    const baseHermesHome = await mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-base-"));
+    const configPath = path.join(baseHermesHome, "config.yaml");
+    await writeFile(
+      configPath,
+      [
+        "model:",
+        "  provider: \"openrouter:chat\" # real comment",
+        "  default: \"anthropic/claude-sonnet-4 # primary\"",
+        "",
+      ].join("\n"),
+    );
+
+    await expect(detectHermesRuntimeModelDefaults({
+      baseHermesHome,
+      env: {},
+    })).resolves.toEqual({
+      model: "anthropic/claude-sonnet-4 # primary",
+      provider: "openrouter:chat",
+      source: configPath,
+    });
   });
 
   it("seeds a new profile from Hermes model environment defaults", async () => {
@@ -131,12 +155,43 @@ describe("Hermes runtime identity", () => {
       ),
     ).resolves.toBe([
       "model:",
-      "  provider: openai",
-      "  default: openai/gpt-5.2",
+      "  provider: \"openai\"",
+      "  default: \"openai/gpt-5.2\"",
       "",
       "dashboard:",
       "  show_token_analytics: true",
       "",
+    ].join("\n"));
+  });
+
+  it("quotes generated YAML model defaults", async () => {
+    const instanceRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-profile-"));
+
+    await ensureHermesRuntimeIdentity({
+      companyId: "company-1",
+      companyName: "Acme",
+      agentId: "agent-1",
+      agentName: "Reviewer",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+      metadata: null,
+      instanceRoot,
+      env: {
+        HERMES_MODEL: "openai/gpt-5.2 # primary",
+        HERMES_PROVIDER: "openai:compatible",
+      },
+      now: "2026-05-18T00:00:00.000Z",
+    });
+
+    await expect(
+      readFile(
+        path.join(instanceRoot, "runtimes", "hermes", "profiles", "acme-reviewer", "config.yaml"),
+        "utf8",
+      ),
+    ).resolves.toContain([
+      "model:",
+      "  provider: \"openai:compatible\"",
+      "  default: \"openai/gpt-5.2 # primary\"",
     ].join("\n"));
   });
 

--- a/server/src/__tests__/hermes-runtime-identity.test.ts
+++ b/server/src/__tests__/hermes-runtime-identity.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  ensureHermesRuntimeIdentity,
+  deriveHermesProfileSlug,
+} from "../adapters/hermes-runtime-identity.js";
+
+describe("Hermes runtime identity", () => {
+  it("derives a safe stable profile slug", () => {
+    expect(deriveHermesProfileSlug({
+      companyName: "Acme, Inc.",
+      agentName: "Head of Sales",
+      existingSlug: null,
+    })).toBe("acme-inc-head-of-sales");
+  });
+
+  it("reuses an existing managed profile slug", () => {
+    expect(deriveHermesProfileSlug({
+      companyName: "Renamed Company",
+      agentName: "Renamed Agent",
+      existingSlug: "acme-inc-head-of-sales",
+    })).toBe("acme-inc-head-of-sales");
+  });
+
+  it("adds a stable hash suffix when names exceed the slug length limit", () => {
+    const slug = deriveHermesProfileSlug({
+      companyName: "A Very Long Company Name ".repeat(8),
+      agentName: "A Very Long Agent Name ".repeat(8),
+      existingSlug: null,
+    });
+
+    expect(slug.length).toBeLessThanOrEqual(96);
+    expect(slug).toMatch(/-[a-f0-9]{8}$/);
+  });
+
+  it("creates a profile home and patches adapter env plus metadata", async () => {
+    const instanceRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-profile-"));
+    const result = await ensureHermesRuntimeIdentity({
+      companyId: "company-1",
+      companyName: "Acme",
+      agentId: "agent-1",
+      agentName: "Reviewer",
+      adapterType: "hermes_local",
+      adapterConfig: { env: { EXISTING: "1" } },
+      metadata: null,
+      instanceRoot,
+      now: "2026-05-18T00:00:00.000Z",
+    });
+
+    const identity = result.metadata?.runtimeIdentity as Record<string, unknown>;
+    expect(identity.profileSlug).toBe("acme-reviewer");
+    expect(identity.adapter).toBe("hermes_local");
+    expect(result.adapterConfig.env).toMatchObject({
+      EXISTING: "1",
+      HERMES_HOME: path.join(instanceRoot, "runtimes", "hermes", "profiles", "acme-reviewer"),
+    });
+    await expect(stat(path.join(instanceRoot, "runtimes", "hermes", "profiles", "acme-reviewer"))).resolves.toBeTruthy();
+    await expect(readFile(path.join(instanceRoot, "runtimes", "hermes", "profiles", "acme-reviewer", "config.yaml"), "utf8"))
+      .resolves.toContain("dashboard:");
+  });
+
+  it("treats malformed adapter env as empty before patching Hermes home", async () => {
+    const instanceRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-profile-"));
+    const result = await ensureHermesRuntimeIdentity({
+      companyId: "company-1",
+      companyName: "Acme",
+      agentId: "agent-1",
+      agentName: "Reviewer",
+      adapterType: "hermes_local",
+      adapterConfig: { env: "not-an-object" },
+      metadata: null,
+      instanceRoot,
+      now: "2026-05-18T00:00:00.000Z",
+    });
+
+    expect(result.adapterConfig.env).toEqual({
+      HERMES_HOME: path.join(instanceRoot, "runtimes", "hermes", "profiles", "acme-reviewer"),
+    });
+  });
+
+  it("is idempotent across repeated identity reconciliation", async () => {
+    const instanceRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-hermes-profile-"));
+    const first = await ensureHermesRuntimeIdentity({
+      companyId: "company-1",
+      companyName: "Acme",
+      agentId: "agent-1",
+      agentName: "Reviewer",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+      metadata: null,
+      instanceRoot,
+      now: "2026-05-18T00:00:00.000Z",
+    });
+    const configPath = path.join(instanceRoot, "runtimes", "hermes", "profiles", "acme-reviewer", "config.yaml");
+    await writeFile(configPath, "custom: true\n");
+
+    const second = await ensureHermesRuntimeIdentity({
+      companyId: "company-1",
+      companyName: "Renamed Acme",
+      agentId: "agent-1",
+      agentName: "Renamed Reviewer",
+      adapterType: "hermes_local",
+      adapterConfig: first.adapterConfig,
+      metadata: first.metadata,
+      instanceRoot,
+      now: "2026-05-19T00:00:00.000Z",
+    });
+
+    expect(second.metadata?.runtimeIdentity).toMatchObject({
+      profileSlug: "acme-reviewer",
+      hermesHome: path.join(instanceRoot, "runtimes", "hermes", "profiles", "acme-reviewer"),
+      createdAt: "2026-05-18T00:00:00.000Z",
+    });
+    await expect(readFile(configPath, "utf8")).resolves.toBe("custom: true\n");
+  });
+});

--- a/server/src/adapters/hermes-runtime-identity.ts
+++ b/server/src/adapters/hermes-runtime-identity.ts
@@ -1,0 +1,119 @@
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type {
+  AdapterRuntimeIdentityContext,
+  AdapterRuntimeIdentityResult,
+} from "@paperclipai/adapter-utils";
+import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+
+const MANAGED_BY = "paperclip.hermes_local.runtime_identity.v1";
+const SAFE_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,95}$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function slugPart(value: string): string {
+  const slug = value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-+/g, "-");
+  return slug || "unnamed";
+}
+
+function safeExistingSlug(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return SAFE_SLUG_RE.test(trimmed) ? trimmed : null;
+}
+
+function isNodeError(value: unknown): value is NodeJS.ErrnoException {
+  return value instanceof Error && "code" in value;
+}
+
+async function writeFileIfMissing(filePath: string, content: string): Promise<void> {
+  try {
+    await writeFile(filePath, content, { flag: "wx" });
+  } catch (err) {
+    if (isNodeError(err) && err.code === "EEXIST") return;
+    throw err;
+  }
+}
+
+export function deriveHermesProfileSlug(input: {
+  companyName: string;
+  agentName: string;
+  existingSlug: unknown;
+}): string {
+  const existing = safeExistingSlug(input.existingSlug);
+  if (existing) return existing;
+  const combined = `${slugPart(input.companyName)}-${slugPart(input.agentName)}`;
+  if (combined.length <= 96) return combined;
+  const digest = createHash("sha256").update(combined).digest("hex").slice(0, 8);
+  return `${combined.slice(0, 87).replace(/-+$/g, "")}-${digest}`;
+}
+
+export async function ensureHermesRuntimeIdentity(
+  ctx: AdapterRuntimeIdentityContext & {
+    instanceRoot?: string;
+    now?: string;
+  },
+): Promise<AdapterRuntimeIdentityResult> {
+  const metadata = isRecord(ctx.metadata) ? { ...ctx.metadata } : {};
+  const previousIdentity = isRecord(metadata.runtimeIdentity)
+    ? metadata.runtimeIdentity
+    : {};
+  const profileSlug = deriveHermesProfileSlug({
+    companyName: ctx.companyName,
+    agentName: ctx.agentName,
+    existingSlug: previousIdentity.profileSlug,
+  });
+  const instanceRoot = ctx.instanceRoot ?? resolvePaperclipInstanceRoot();
+  const hermesHome = path.join(instanceRoot, "runtimes", "hermes", "profiles", profileSlug);
+
+  await mkdir(hermesHome, { recursive: true });
+
+  const configPath = path.join(hermesHome, "config.yaml");
+  await writeFileIfMissing(
+    configPath,
+    [
+      "dashboard:",
+      "  show_token_analytics: true",
+      "",
+    ].join("\n"),
+  );
+
+  const adapterEnv = isRecord(ctx.adapterConfig.env)
+    ? { ...ctx.adapterConfig.env }
+    : {};
+  const adapterConfig = {
+    ...ctx.adapterConfig,
+    env: {
+      ...adapterEnv,
+      HERMES_HOME: hermesHome,
+    },
+  };
+
+  return {
+    adapterConfig,
+    metadata: {
+      ...metadata,
+      runtimeIdentity: {
+        ...previousIdentity,
+        adapter: "hermes_local",
+        profileSlug,
+        hermesHome,
+        managedBy: MANAGED_BY,
+        createdAt: typeof previousIdentity.createdAt === "string"
+          ? previousIdentity.createdAt
+          : ctx.now ?? new Date().toISOString(),
+      },
+    },
+    detail: { profileSlug, hermesHome },
+  };
+}

--- a/server/src/adapters/hermes-runtime-identity.ts
+++ b/server/src/adapters/hermes-runtime-identity.ts
@@ -83,13 +83,54 @@ function parseHermesModelDefaultsFromConfig(content: string, source: string): He
     if (!match) continue;
 
     const key = match[1];
-    const value = match[2].trim().replace(/\s+#.*$/, "").replace(/^['"]|['"]$/g, "");
+    const value = parseYamlScalarString(match[2]);
     if (key === "default") model = value;
     if (key === "provider") provider = value;
   }
 
   if (!model) return null;
   return { model, provider, source };
+}
+
+function parseYamlScalarString(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith("\"")) {
+    let escaped = false;
+    for (let index = 1; index < trimmed.length; index += 1) {
+      const char = trimmed[index];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === "\"") {
+        const quoted = trimmed.slice(0, index + 1);
+        try {
+          const parsed = JSON.parse(quoted);
+          if (typeof parsed === "string") return parsed;
+        } catch {
+          return quoted.slice(1, -1);
+        }
+      }
+    }
+  }
+  if (trimmed.startsWith("'")) {
+    let scalar = "";
+    for (let index = 1; index < trimmed.length; index += 1) {
+      const char = trimmed[index];
+      if (char === "'" && trimmed[index + 1] === "'") {
+        scalar += "'";
+        index += 1;
+        continue;
+      }
+      if (char === "'") return scalar;
+      scalar += char;
+    }
+  }
+  return trimmed.replace(/\s+#.*$/, "");
 }
 
 function modelDefaultsFromEnv(env: RuntimeIdentityEnv): HermesModelDefaults | null {
@@ -137,8 +178,8 @@ function buildManagedHermesConfig(modelDefaults: HermesModelDefaults | null): st
     ...(modelDefaults
       ? [
           "model:",
-          ...(modelDefaults.provider ? [`  provider: ${modelDefaults.provider}`] : []),
-          `  default: ${modelDefaults.model}`,
+          ...(modelDefaults.provider ? [`  provider: ${quoteYamlString(modelDefaults.provider)}`] : []),
+          `  default: ${quoteYamlString(modelDefaults.model)}`,
           "",
         ]
       : []),
@@ -146,6 +187,10 @@ function buildManagedHermesConfig(modelDefaults: HermesModelDefaults | null): st
     "  show_token_analytics: true",
     "",
   ].join("\n");
+}
+
+function quoteYamlString(value: string): string {
+  return JSON.stringify(value);
 }
 
 export function deriveHermesProfileSlug(input: {

--- a/server/src/adapters/hermes-runtime-identity.ts
+++ b/server/src/adapters/hermes-runtime-identity.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type {
   AdapterRuntimeIdentityContext,
@@ -10,8 +10,20 @@ import { resolvePaperclipInstanceRoot } from "../home-paths.js";
 const MANAGED_BY = "paperclip.hermes_local.runtime_identity.v1";
 const SAFE_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,95}$/;
 
+type RuntimeIdentityEnv = Record<string, string | undefined>;
+
+type HermesModelDefaults = {
+  model: string;
+  provider: string;
+  source: string;
+};
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
 function slugPart(value: string): string {
@@ -45,6 +57,97 @@ async function writeFileIfMissing(filePath: string, content: string): Promise<vo
   }
 }
 
+function parseHermesModelDefaultsFromConfig(content: string, source: string): HermesModelDefaults | null {
+  const lines = content.split("\n");
+  let inModelSection = false;
+  let model = "";
+  let provider = "";
+
+  for (const line of lines) {
+    const trimmedEnd = line.trimEnd();
+    const trimmed = trimmedEnd.trim();
+    const indent = line.length - line.trimStart().length;
+
+    if (/^model:\s*$/.test(trimmedEnd) && indent === 0) {
+      inModelSection = true;
+      continue;
+    }
+
+    if (inModelSection && indent === 0 && trimmed && !trimmed.startsWith("#")) {
+      inModelSection = false;
+    }
+
+    if (!inModelSection) continue;
+
+    const match = trimmedEnd.match(/^\s*(\w+)\s*:\s*(.+)$/);
+    if (!match) continue;
+
+    const key = match[1];
+    const value = match[2].trim().replace(/\s+#.*$/, "").replace(/^['"]|['"]$/g, "");
+    if (key === "default") model = value;
+    if (key === "provider") provider = value;
+  }
+
+  if (!model) return null;
+  return { model, provider, source };
+}
+
+function modelDefaultsFromEnv(env: RuntimeIdentityEnv): HermesModelDefaults | null {
+  const model = asNonEmptyString(env.HERMES_MODEL) ?? asNonEmptyString(env.HERMES_INFERENCE_MODEL);
+  if (!model) return null;
+  return {
+    model,
+    provider: asNonEmptyString(env.HERMES_PROVIDER) ?? asNonEmptyString(env.HERMES_INFERENCE_PROVIDER) ?? "",
+    source: "env",
+  };
+}
+
+async function modelDefaultsFromConfig(
+  baseHermesHome: string | null,
+  targetHermesHome?: string,
+): Promise<HermesModelDefaults | null> {
+  if (!baseHermesHome) return null;
+  const base = path.resolve(baseHermesHome);
+  if (targetHermesHome && base === path.resolve(targetHermesHome)) return null;
+
+  const configPath = path.join(base, "config.yaml");
+  try {
+    return parseHermesModelDefaultsFromConfig(await readFile(configPath, "utf8"), configPath);
+  } catch {
+    return null;
+  }
+}
+
+export async function detectHermesRuntimeModelDefaults(
+  options: {
+    baseHermesHome?: string | null;
+    env?: RuntimeIdentityEnv;
+  } = {},
+): Promise<HermesModelDefaults | null> {
+  const env = options.env ?? process.env;
+  const envDefaults = modelDefaultsFromEnv(env);
+  if (envDefaults) return envDefaults;
+  return await modelDefaultsFromConfig(
+    options.baseHermesHome ?? asNonEmptyString(env.HERMES_HOME) ?? asNonEmptyString(env.HERMES_DATA_ROOT),
+  );
+}
+
+function buildManagedHermesConfig(modelDefaults: HermesModelDefaults | null): string {
+  return [
+    ...(modelDefaults
+      ? [
+          "model:",
+          ...(modelDefaults.provider ? [`  provider: ${modelDefaults.provider}`] : []),
+          `  default: ${modelDefaults.model}`,
+          "",
+        ]
+      : []),
+    "dashboard:",
+    "  show_token_analytics: true",
+    "",
+  ].join("\n");
+}
+
 export function deriveHermesProfileSlug(input: {
   companyName: string;
   agentName: string;
@@ -62,6 +165,8 @@ export async function ensureHermesRuntimeIdentity(
   ctx: AdapterRuntimeIdentityContext & {
     instanceRoot?: string;
     now?: string;
+    baseHermesHome?: string;
+    env?: RuntimeIdentityEnv;
   },
 ): Promise<AdapterRuntimeIdentityResult> {
   const metadata = isRecord(ctx.metadata) ? { ...ctx.metadata } : {};
@@ -79,13 +184,17 @@ export async function ensureHermesRuntimeIdentity(
   await mkdir(hermesHome, { recursive: true });
 
   const configPath = path.join(hermesHome, "config.yaml");
+  const env = ctx.env ?? process.env;
+  let modelDefaults = modelDefaultsFromEnv(env);
+  if (!modelDefaults) {
+    modelDefaults = await modelDefaultsFromConfig(
+      ctx.baseHermesHome ?? asNonEmptyString(env.HERMES_HOME) ?? asNonEmptyString(env.HERMES_DATA_ROOT),
+      hermesHome,
+    );
+  }
   await writeFileIfMissing(
     configPath,
-    [
-      "dashboard:",
-      "  show_token_analytics: true",
-      "",
-    ].join("\n"),
+    buildManagedHermesConfig(modelDefaults),
   );
 
   const adapterEnv = isRecord(ctx.adapterConfig.env)

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -137,6 +137,7 @@ import {
   models as hermesModels,
 } from "hermes-paperclip-adapter";
 import { BUILTIN_ADAPTER_TYPES } from "./builtin-adapter-types.js";
+import { ensureHermesRuntimeIdentity } from "./hermes-runtime-identity.js";
 import { buildExternalAdapters } from "./plugin-loader.js";
 import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
 import { processAdapter } from "./process/index.js";
@@ -494,6 +495,7 @@ const hermesLocalAdapter: ServerAdapterModule = {
   supportsInstructionsBundle: false,
   requiresMaterializedRuntimeSkills: false,
   agentConfigurationDoc: hermesAgentConfigurationDoc,
+  ensureRuntimeIdentity: ensureHermesRuntimeIdentity,
   detectModel: () => detectModelFromHermes(),
 };
 

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -137,7 +137,10 @@ import {
   models as hermesModels,
 } from "hermes-paperclip-adapter";
 import { BUILTIN_ADAPTER_TYPES } from "./builtin-adapter-types.js";
-import { ensureHermesRuntimeIdentity } from "./hermes-runtime-identity.js";
+import {
+  detectHermesRuntimeModelDefaults,
+  ensureHermesRuntimeIdentity,
+} from "./hermes-runtime-identity.js";
 import { buildExternalAdapters } from "./plugin-loader.js";
 import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
 import { processAdapter } from "./process/index.js";
@@ -496,7 +499,10 @@ const hermesLocalAdapter: ServerAdapterModule = {
   requiresMaterializedRuntimeSkills: false,
   agentConfigurationDoc: hermesAgentConfigurationDoc,
   ensureRuntimeIdentity: ensureHermesRuntimeIdentity,
-  detectModel: () => detectModelFromHermes(),
+  detectModel: async () => {
+    const runtimeDefault = await detectHermesRuntimeModelDefaults();
+    return runtimeDefault ?? await detectModelFromHermes();
+  },
 };
 
 const adaptersByType = new Map<string, ServerAdapterModule>();

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1249,6 +1249,10 @@ export function agentRoutes(
   }>(
     agent: T,
     source: string,
+    actor?: {
+      createdByAgentId: string | null;
+      createdByUserId: string | null;
+    },
   ): Promise<T> {
     const adapter = findActiveServerAdapter(agent.adapterType);
     if (!adapter?.ensureRuntimeIdentity) return agent;
@@ -1302,16 +1306,23 @@ export function agentRoutes(
       adapterConfig: result.adapterConfig,
     });
 
+    const patch: {
+      adapterConfig: Record<string, unknown>;
+      metadata?: Record<string, unknown> | null;
+    } = {
+      adapterConfig: normalizedAdapterConfig,
+    };
+    if (result.metadata !== null) {
+      patch.metadata = result.metadata;
+    }
+
     const updated = await svc.update(
       agent.id,
-      {
-        adapterConfig: normalizedAdapterConfig,
-        metadata: result.metadata,
-      },
+      patch,
       {
         recordRevision: {
-          createdByAgentId: null,
-          createdByUserId: null,
+          createdByAgentId: actor?.createdByAgentId ?? null,
+          createdByUserId: actor?.createdByUserId ?? null,
           source,
         },
       },
@@ -2092,6 +2103,7 @@ export function agentRoutes(
 
     const requiresApproval = company.requireBoardApprovalForNewAgents;
     const status = requiresApproval ? "pending_approval" : "idle";
+    const actor = getActorInfo(req);
     const createdAgent = await svc.create(companyId, {
       ...normalizedHireInput,
       status,
@@ -2104,10 +2116,13 @@ export function agentRoutes(
     const agent = await ensureAdapterRuntimeIdentityForAgent(
       bundledAgent,
       "adapter_runtime_identity_hire",
+      {
+        createdByAgentId: actor.agentId,
+        createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+      },
     );
 
     let approval: Awaited<ReturnType<typeof approvalsSvc.getById>> | null = null;
-    const actor = getActorInfo(req);
 
     if (requiresApproval) {
       const requestedAdapterType = normalizedHireInput.adapterType ?? agent.adapterType;
@@ -2272,6 +2287,7 @@ export function agentRoutes(
       allowedSandboxProviders: allowedSandboxProvidersForAgent(createInput.adapterType),
     });
 
+    const actor = getActorInfo(req);
     const createdAgent = await svc.create(companyId, {
       ...createInput,
       adapterConfig: normalizedAdapterConfig,
@@ -2284,6 +2300,10 @@ export function agentRoutes(
     const agent = await ensureAdapterRuntimeIdentityForAgent(
       bundledAgent,
       "adapter_runtime_identity_create",
+      {
+        createdByAgentId: actor.agentId,
+        createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+      },
     );
     const agentEnv = asRecord(agent.adapterConfig)?.env;
     if (agentEnv) {
@@ -2294,7 +2314,6 @@ export function agentRoutes(
       );
     }
 
-    const actor = getActorInfo(req);
     await logActivity(db, {
       companyId,
       actorType: actor.actorType,
@@ -2773,6 +2792,10 @@ export function agentRoutes(
       agent = await ensureAdapterRuntimeIdentityForAgent(
         agent,
         "adapter_runtime_identity_update",
+        {
+          createdByAgentId: actor.agentId,
+          createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+        },
       );
       const agentEnv = asRecord(agent.adapterConfig)?.env;
       await secretsSvc.syncEnvBindingsForTarget?.(

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -32,6 +32,7 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { trackAgentCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
+import { logger } from "../middleware/logger.js";
 import {
   agentService,
   agentInstructionsService,
@@ -62,6 +63,7 @@ import type { AdapterExecutionTarget } from "@paperclipai/adapter-utils/executio
 import type {
   AdapterEnvironmentCheck,
   AdapterEnvironmentTestResult,
+  AdapterRuntimeIdentityResult,
 } from "@paperclipai/adapter-utils";
 import { secretService } from "../services/secrets.js";
 import {
@@ -1237,6 +1239,86 @@ export function agentRoutes(
     };
   }
 
+  async function ensureAdapterRuntimeIdentityForAgent<T extends {
+    id: string;
+    companyId: string;
+    name: string;
+    adapterType: string;
+    adapterConfig: unknown;
+    metadata?: unknown;
+  }>(
+    agent: T,
+    source: string,
+  ): Promise<T> {
+    const adapter = findActiveServerAdapter(agent.adapterType);
+    if (!adapter?.ensureRuntimeIdentity) return agent;
+
+    const company = await db
+      .select()
+      .from(companies)
+      .where(eq(companies.id, agent.companyId))
+      .then((rows) => rows[0] ?? null);
+    if (!company) {
+      logger.warn(
+        { agentId: agent.id, companyId: agent.companyId, adapterType: agent.adapterType },
+        "skipping adapter runtime identity because agent company was not found",
+      );
+      return agent;
+    }
+
+    let result: AdapterRuntimeIdentityResult;
+    try {
+      result = await adapter.ensureRuntimeIdentity({
+        companyId: agent.companyId,
+        companyName: company.name,
+        agentId: agent.id,
+        agentName: agent.name,
+        adapterType: agent.adapterType,
+        adapterConfig: asRecord(agent.adapterConfig) ?? {},
+        metadata: asRecord(agent.metadata),
+      });
+    } catch (err) {
+      logger.warn(
+        { err, agentId: agent.id, companyId: agent.companyId, adapterType: agent.adapterType },
+        "adapter runtime identity hook failed; continuing without runtime identity",
+      );
+      return agent;
+    }
+    if (result.warnings?.length) {
+      logger.warn(
+        {
+          agentId: agent.id,
+          companyId: agent.companyId,
+          adapterType: agent.adapterType,
+          warnings: result.warnings,
+        },
+        "adapter runtime identity hook completed with warnings",
+      );
+    }
+
+    const normalizedAdapterConfig = await normalizeMediatedAdapterConfigForPersistence({
+      companyId: agent.companyId,
+      adapterType: agent.adapterType,
+      adapterConfig: result.adapterConfig,
+    });
+
+    const updated = await svc.update(
+      agent.id,
+      {
+        adapterConfig: normalizedAdapterConfig,
+        metadata: result.metadata,
+      },
+      {
+        recordRevision: {
+          createdByAgentId: null,
+          createdByUserId: null,
+          source,
+        },
+      },
+    );
+    return (updated as T | null) ?? agent;
+  }
+
   async function resolveDesiredSkillAssignment(
     companyId: string,
     adapterType: string,
@@ -2016,7 +2098,13 @@ export function agentRoutes(
       spentMonthlyCents: 0,
       lastHeartbeatAt: null,
     });
-    const agent = await materializeDefaultInstructionsBundleForNewAgent(createdAgent, instructionsBundle);
+    const bundledAgent = await materializeDefaultInstructionsBundleForNewAgent(createdAgent, instructionsBundle);
+    // Pending hires keep runtime identity state so approval activation starts with
+    // the same adapter config; rejected hires are terminated without deleting it.
+    const agent = await ensureAdapterRuntimeIdentityForAgent(
+      bundledAgent,
+      "adapter_runtime_identity_hire",
+    );
 
     let approval: Awaited<ReturnType<typeof approvalsSvc.getById>> | null = null;
     const actor = getActorInfo(req);
@@ -2192,7 +2280,11 @@ export function agentRoutes(
       spentMonthlyCents: 0,
       lastHeartbeatAt: null,
     });
-    const agent = await materializeDefaultInstructionsBundleForNewAgent(createdAgent, instructionsBundle);
+    const bundledAgent = await materializeDefaultInstructionsBundleForNewAgent(createdAgent, instructionsBundle);
+    const agent = await ensureAdapterRuntimeIdentityForAgent(
+      bundledAgent,
+      "adapter_runtime_identity_create",
+    );
     const agentEnv = asRecord(agent.adapterConfig)?.env;
     if (agentEnv) {
       await secretsSvc.syncEnvBindingsForTarget?.(
@@ -2666,7 +2758,7 @@ export function agentRoutes(
     }
 
     const actor = getActorInfo(req);
-    const agent = await svc.update(id, patchData, {
+    let agent = await svc.update(id, patchData, {
       recordRevision: {
         createdByAgentId: actor.agentId,
         createdByUserId: actor.actorType === "user" ? actor.actorId : null,
@@ -2678,6 +2770,10 @@ export function agentRoutes(
       return;
     }
     if (touchesAdapterConfiguration) {
+      agent = await ensureAdapterRuntimeIdentityForAgent(
+        agent,
+        "adapter_runtime_identity_update",
+      );
       const agentEnv = asRecord(agent.adapterConfig)?.env;
       await secretsSvc.syncEnvBindingsForTarget?.(
         agent.companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies from a shared control plane.
> - The adapter layer lets Paperclip run local and external agent runtimes while keeping agent configuration, secrets, skills, and audit history in one place.
> - Hermes agents need their own durable runtime identity because a shared `HERMES_HOME` makes multiple Paperclip agents collide on one Hermes profile.
> - The runtime identity should inherit the instance-level Hermes model/provider defaults without copying `.env` secrets or baking model/provider into each agent adapter config.
> - Paperclip also needs to reconcile that identity during create/update flows and record the resulting adapter-config changes safely.
> - This pull request adds a Hermes runtime identity lifecycle, registry hook, model detection path, route integration, and documentation.
> - The benefit is that each Paperclip Hermes agent gets an isolated Hermes profile while still following the operator's default Hermes LLM setup.

## What Changed

- Added an optional `ensureRuntimeIdentity` adapter hook and Hermes implementation that creates deterministic per-agent profile homes under the Paperclip instance root.
- Seeded managed Hermes `config.yaml` files from default Hermes model/provider config while avoiding `.env` copying and quoting YAML scalar values safely.
- Updated agent create, hire, and adapter-config update routes to reconcile runtime identity, preserve existing metadata when adapters return `null`, and attribute runtime-identity config revisions to the triggering actor.
- Added Hermes runtime model detection from `HERMES_HOME` config through the adapter registry.
- Added tests for profile creation, idempotence, model-default inheritance, quoted YAML parsing, route reconciliation, null metadata preservation, audit attribution, and registry wiring.
- Documented runtime identity hooks in the adapter authoring guide.

## Verification

- [x] `pnpm vitest run server/src/__tests__/hermes-runtime-identity.test.ts server/src/__tests__/hermes-agent-runtime-identity-routes.test.ts server/src/__tests__/agent-instructions-routes.test.ts --reporter=verbose`
- [x] `pnpm vitest run server/src/__tests__/adapter-registry.test.ts packages/adapter-utils/src/runtime-identity-contract.test.ts --reporter=verbose`
- [x] `pnpm --filter @paperclipai/server typecheck`
- [x] `pnpm test:run:serialized -- --shard-index 2 --shard-count 4`
- [x] `git diff --check`
- [x] Claude Code review of the final diff: no blocking issues

## Risks

- Hermes profile config is created only if missing; existing profile configs are intentionally not rewritten, so operators with custom profile files keep control.
- Runtime identity reconciliation is non-fatal by design; if profile creation fails, agent creation/update continues and logs a warning rather than blocking unrelated adapter changes.
- The generic runtime-identity hook now omits metadata writes when an adapter returns `null`, preserving existing metadata for future adapters that do not manage metadata.
- ROADMAP.md was checked; this supports the bring-your-own-agent/local runtime direction without duplicating a listed core roadmap item.

## Model Used

- OpenAI Codex, GPT-5 coding agent in Codex CLI, with repository search, shell execution, GitHub CLI, and local test execution.
- Anthropic Claude Code CLI 2.1.141 was used as an independent review gate on the final diff; the CLI did not expose the backend model ID in command output.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A - no UI changes)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
