### PR TITLE
Reconcile stale detached heartbeat runs

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -344,6 +344,13 @@ On startup and on the periodic recovery loop, Paperclip now does five things in 
 
 The stranded-work pass closes the gap where issue state survives a crash but the wake/run path does not. The silent-run scan covers the separate case where a live process exists but has stopped producing observable output. The productivity-review pass is later and separate; it reviews unusual progression patterns on assigned source issues, not stale run handles after a source issue already has a valid disposition.
 
+Detached local process handles are a special orphan-run case. When a `running` local-adapter run has `errorCode: process_detached`, Paperclip must distinguish an objectively live OS process from stale bookkeeping:
+
+- if the recorded PID or process group is still alive, the run remains active and cancellation stays board/manual/watchdog-controlled
+- if the server has no in-memory handle and the recorded PID/process group are both no longer alive, the reaper may bypass the normal `updatedAt` staleness delay, because timer/comment coalescing can refresh `updatedAt` without reviving the process
+
+Dead detached processes must still be reconciled through the normal heartbeat lifecycle: terminal run state, terminal wakeup state, lifecycle event, agent status finalization, lease/runtime cleanup, and issue execution release or promotion where applicable.
+
 ## 10. Silent Active-Run Watchdog
 
 An active run can still be unhealthy even when its process is `running`. Paperclip treats prolonged output silence as a watchdog signal, not as proof that the run is failed.

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -917,6 +917,92 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("keeps a detached local run active when the recorded pid is still alive", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId, wakeupRequestId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      includeIssue: false,
+      runErrorCode: "process_detached",
+      runError: `Lost in-memory process handle, but child pid ${child.pid} is still alive`,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns({ staleThresholdMs: 0 });
+    expect(result).toEqual({ reaped: 0, runIds: [] });
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(run?.errorCode).toBe("process_detached");
+    expect(run?.error).toContain(String(child.pid));
+
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, wakeupRequestId))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup?.status).toBe("claimed");
+  });
+
+  it("reconciles detached dead-pid runs even when the run was updated recently", async () => {
+    const { agentId, runId, wakeupRequestId } = await seedRunFixture({
+      agentStatus: "running",
+      processPid: 999_999_999,
+      processGroupId: 999_999_999,
+      processLossRetryCount: 1,
+      includeIssue: false,
+      runErrorCode: "process_detached",
+      runError: "Lost in-memory process handle, but child pid 999999999 is still alive",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns({
+      staleThresholdMs: 365 * 24 * 60 * 60 * 1000,
+    });
+    expect(result).toEqual({ reaped: 1, runIds: [runId] });
+
+    const [run, wakeup, agent, events] = await Promise.all([
+      heartbeat.getRun(runId),
+      db
+        .select()
+        .from(agentWakeupRequests)
+        .where(eq(agentWakeupRequests.id, wakeupRequestId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select()
+        .from(agents)
+        .where(eq(agents.id, agentId))
+        .then((rows) => rows[0] ?? null),
+      db
+        .select({
+          eventType: heartbeatRunEvents.eventType,
+          message: heartbeatRunEvents.message,
+        })
+        .from(heartbeatRunEvents)
+        .where(eq(heartbeatRunEvents.runId, runId)),
+    ]);
+
+    expect(run?.status).toBe("failed");
+    expect(run?.errorCode).toBe("process_lost");
+    expect(run?.finishedAt).toBeTruthy();
+    expect(run?.resultJson).toMatchObject({
+      stopReason: "process_lost",
+      timeoutConfigured: false,
+      timeoutFired: false,
+    });
+    expect(wakeup?.status).toBe("failed");
+    expect(agent?.status).toBe("error");
+    expect(
+      events.some(
+        (event) =>
+          event.eventType === "lifecycle" &&
+          event.message?.includes("Process lost"),
+      ),
+    ).toBe(true);
+  });
+
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       processPid: 999_999_999,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6581,15 +6581,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     for (const { run, adapterType, adapterConfig } of activeRuns) {
       if (runningProcesses.has(run.id) || activeRunExecutions.has(run.id)) continue;
 
+      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
+      const hasRecordedLocalProcess =
+        tracksLocalChild &&
+        ((typeof run.processPid === "number" && run.processPid > 0) ||
+          (typeof run.processGroupId === "number" && run.processGroupId > 0));
+      const processPidAlive = Boolean(
+        tracksLocalChild && run.processPid && isProcessAlive(run.processPid),
+      );
+      const processGroupAlive = Boolean(
+        tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId),
+      );
+      const staleDetachedDeadProcess =
+        run.errorCode === DETACHED_PROCESS_ERROR_CODE &&
+        hasRecordedLocalProcess &&
+        !processPidAlive &&
+        !processGroupAlive;
+
       // Apply staleness threshold to avoid false positives
-      if (staleThresholdMs > 0) {
+      if (staleThresholdMs > 0 && !staleDetachedDeadProcess) {
         const refTime = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
         if (now.getTime() - refTime < staleThresholdMs) continue;
       }
 
-      const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
-      const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
-      const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents by driving heartbeat runs through a backend lifecycle.
> - Local adapters can lose their in-memory child-process handle while the persisted heartbeat run remains `running`.
> - The orphan reaper already knows how to fail dead local processes through the heartbeat lifecycle, including wakeup status, lifecycle events, leases, agent status, and issue execution recovery.
> - A detached run marked `process_detached` can still have `updatedAt` refreshed by timer/comment coalescing even after the recorded PID is gone.
> - That fresh `updatedAt` prevents the existing stale-threshold gate from ever reaching the objective PID/PGID liveness check.
> - This pull request lets only objectively dead `process_detached` local runs bypass that stale-time gate while preserving protection for live PIDs/groups.
> - The benefit is that stale detached bookkeeping reconciles itself without manual database edits or board-only cancellation of truly running work.

## What Changed

- Detect `running` local-adapter runs with `errorCode: process_detached`, recorded PID/PGID evidence, and no live PID or process group before applying the normal `updatedAt` stale threshold.
- Keep live detached processes protected: if the PID or process group is alive, the reaper does not auto-fail the run before the normal lifecycle path allows it.
- Added focused integration tests for recent dead detached PIDs reconciling immediately and live detached PIDs remaining claimed/running.
- Documented the stale detached runtime rule in `doc/execution-semantics.md`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run preflight:workspace-links`
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`

## Risks

- Low behavioral risk: the bypass is limited to local adapters, `process_detached` runs, and rows with recorded process identity where both PID and process group are objectively not alive.
- The path reuses the existing orphan-run lifecycle instead of introducing direct database finalization.

## Model Used

- OpenAI Codex, GPT-5.5, command-line coding agent with tool use and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
