### PR TITLE
fix: add 24h cooldown after closed liveness escalation to prevent re-firing

### DIFF
--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -923,4 +923,37 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       );
     expect(openEscalations.filter((e) => e.status !== "done")).toHaveLength(0);
   });
+
+  it("suppresses new escalation creation when a matching cancelled escalation is within the 24h cooldown window", async () => {
+    await enableAutoRecovery();
+    const { companyId, blockedIssueId, blockerIssueId } = await seedBlockedChain();
+    const heartbeat = heartbeatService(db);
+    const incidentKey = [
+      "harness_liveness",
+      companyId,
+      blockedIssueId,
+      "blocked_by_unassigned_issue",
+      blockerIssueId,
+    ].join(":");
+    const recentlyClosedId = randomUUID();
+    const recentlyClosedAt = new Date(Date.now() - 30 * 60 * 1000);
+
+    await db.insert(issues).values({
+      id: recentlyClosedId,
+      companyId,
+      title: "Recently cancelled escalation",
+      status: "cancelled",
+      priority: "high",
+      parentId: blockedIssueId,
+      issueNumber: 3,
+      identifier: "CLOSED-3",
+      originKind: "harness_liveness_escalation",
+      originId: incidentKey,
+      updatedAt: recentlyClosedAt,
+    });
+
+    const result = await heartbeat.reconcileIssueGraphLiveness();
+
+    expect(result.escalationsCreated).toBe(0);
+  });
 });

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -808,4 +808,37 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       );
     expect(openEscalations.filter((e) => e.status !== "done")).toHaveLength(0);
   });
+
+  it("suppresses new escalation creation when a matching cancelled escalation is within the 24h cooldown window", async () => {
+    await enableAutoRecovery();
+    const { companyId, blockedIssueId, blockerIssueId } = await seedBlockedChain();
+    const heartbeat = heartbeatService(db);
+    const incidentKey = [
+      "harness_liveness",
+      companyId,
+      blockedIssueId,
+      "blocked_by_unassigned_issue",
+      blockerIssueId,
+    ].join(":");
+    const recentlyClosedId = randomUUID();
+    const recentlyClosedAt = new Date(Date.now() - 30 * 60 * 1000);
+
+    await db.insert(issues).values({
+      id: recentlyClosedId,
+      companyId,
+      title: "Recently cancelled escalation",
+      status: "cancelled",
+      priority: "high",
+      parentId: blockedIssueId,
+      issueNumber: 3,
+      identifier: "CLOSED-3",
+      originKind: "harness_liveness_escalation",
+      originId: incidentKey,
+      updatedAt: recentlyClosedAt,
+    });
+
+    const result = await heartbeat.reconcileIssueGraphLiveness();
+
+    expect(result.escalationsCreated).toBe(0);
+  });
 });

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS } from "../services/recovery/service.js";
 import {
   activityLog,
   agents,
@@ -667,7 +668,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     );
   });
 
-  it("creates a fresh escalation when the previous matching escalation is terminal", async () => {
+  it("creates a fresh escalation when the previous matching escalation is terminal and outside cooldown", async () => {
     await enableAutoRecovery();
     const { companyId, managerId, blockedIssueId, blockerIssueId } = await seedBlockedChain();
     const heartbeat = heartbeatService(db);
@@ -679,6 +680,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       blockerIssueId,
     ].join(":");
     const closedEscalationId = randomUUID();
+    const expiredAt = new Date(Date.now() - LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS - 60_000);
 
     await db.insert(issues).values({
       id: closedEscalationId,
@@ -692,6 +694,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       identifier: "CLOSED-3",
       originKind: "harness_liveness_escalation",
       originId: incidentKey,
+      updatedAt: expiredAt,
     });
 
     const result = await heartbeat.reconcileIssueGraphLiveness();
@@ -723,5 +726,49 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       .where(eq(issueRelations.relatedIssueId, blockedIssueId));
     expect(blockers.some((row) => row.blockerIssueId === closedEscalationId)).toBe(false);
     expect(blockers.some((row) => row.blockerIssueId === freshEscalation?.id)).toBe(true);
+  });
+
+  it("suppresses new escalation creation when a matching done escalation is within the 24h cooldown window", async () => {
+    await enableAutoRecovery();
+    const { companyId, blockedIssueId, blockerIssueId } = await seedBlockedChain();
+    const heartbeat = heartbeatService(db);
+    const incidentKey = [
+      "harness_liveness",
+      companyId,
+      blockedIssueId,
+      "blocked_by_unassigned_issue",
+      blockerIssueId,
+    ].join(":");
+    const recentlyClosedId = randomUUID();
+    const recentlyClosedAt = new Date(Date.now() - 30 * 60 * 1000);
+
+    await db.insert(issues).values({
+      id: recentlyClosedId,
+      companyId,
+      title: "Recently closed escalation",
+      status: "done",
+      priority: "high",
+      parentId: blockedIssueId,
+      issueNumber: 3,
+      identifier: "CLOSED-3",
+      originKind: "harness_liveness_escalation",
+      originId: incidentKey,
+      updatedAt: recentlyClosedAt,
+    });
+
+    const result = await heartbeat.reconcileIssueGraphLiveness();
+
+    expect(result.escalationsCreated).toBe(0);
+    const openEscalations = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, "harness_liveness_escalation"),
+          eq(issues.originId, incidentKey),
+        ),
+      );
+    expect(openEscalations.filter((e) => e.status !== "done")).toHaveLength(0);
   });
 });

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -728,6 +728,43 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     expect(blockers.some((row) => row.blockerIssueId === freshEscalation?.id)).toBe(true);
   });
 
+  it("suppresses new escalation when a done escalation for the same source issue (different incidentKey state) is within the 24h cooldown window", async () => {
+    await enableAutoRecovery();
+    const { companyId, blockedIssueId, blockerIssueId } = await seedBlockedChain();
+    const heartbeat = heartbeatService(db);
+    // Simulate a previously-closed escalation with a DIFFERENT liveness state in the key —
+    // this is the regression scenario where the issue's classification changes (e.g. blocker
+    // changes from unassigned to backlog) producing a new incidentKey that bypasses the cooldown.
+    const previousIncidentKey = [
+      "harness_liveness",
+      companyId,
+      blockedIssueId,
+      "blocked_by_uninvokable_assignee", // different state than the current finding
+      blockerIssueId,
+    ].join(":");
+    const recentlyClosedId = randomUUID();
+    const recentlyClosedAt = new Date(Date.now() - 30 * 60 * 1000);
+
+    await db.insert(issues).values({
+      id: recentlyClosedId,
+      companyId,
+      title: "Recently closed escalation (different state key)",
+      status: "done",
+      priority: "high",
+      parentId: blockedIssueId,
+      issueNumber: 3,
+      identifier: "CLOSED-3",
+      originKind: "harness_liveness_escalation",
+      originId: previousIncidentKey,
+      updatedAt: recentlyClosedAt,
+    });
+
+    const result = await heartbeat.reconcileIssueGraphLiveness();
+
+    // Should be suppressed even though the incidentKey state segment differs
+    expect(result.escalationsCreated).toBe(0);
+  });
+
   it("suppresses new escalation creation when a matching done escalation is within the 24h cooldown window", async () => {
     await enableAutoRecovery();
     const { companyId, blockedIssueId, blockerIssueId } = await seedBlockedChain();

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -843,6 +843,43 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     expect(blockers.some((row) => row.blockerIssueId === escalations[0]!.id)).toBe(false);
   });
 
+  it("suppresses new escalation when a done escalation for the same source issue (different incidentKey state) is within the 24h cooldown window", async () => {
+    await enableAutoRecovery();
+    const { companyId, blockedIssueId, blockerIssueId } = await seedBlockedChain();
+    const heartbeat = heartbeatService(db);
+    // Simulate a previously-closed escalation with a DIFFERENT liveness state in the key —
+    // this is the regression scenario where the issue's classification changes (e.g. blocker
+    // changes from unassigned to backlog) producing a new incidentKey that bypasses the cooldown.
+    const previousIncidentKey = [
+      "harness_liveness",
+      companyId,
+      blockedIssueId,
+      "blocked_by_uninvokable_assignee", // different state than the current finding
+      blockerIssueId,
+    ].join(":");
+    const recentlyClosedId = randomUUID();
+    const recentlyClosedAt = new Date(Date.now() - 30 * 60 * 1000);
+
+    await db.insert(issues).values({
+      id: recentlyClosedId,
+      companyId,
+      title: "Recently closed escalation (different state key)",
+      status: "done",
+      priority: "high",
+      parentId: blockedIssueId,
+      issueNumber: 3,
+      identifier: "CLOSED-3",
+      originKind: "harness_liveness_escalation",
+      originId: previousIncidentKey,
+      updatedAt: recentlyClosedAt,
+    });
+
+    const result = await heartbeat.reconcileIssueGraphLiveness();
+
+    // Should be suppressed even though the incidentKey state segment differs
+    expect(result.escalationsCreated).toBe(0);
+  });
+
   it("suppresses new escalation creation when a matching done escalation is within the 24h cooldown window", async () => {
     await enableAutoRecovery();
     const { companyId, blockedIssueId, blockerIssueId } = await seedBlockedChain();

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS } from "../services/recovery/service.js";
 import {
   activityLog,
   agents,
@@ -743,7 +744,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     );
   });
 
-  it("creates a fresh escalation when the previous matching escalation is terminal", async () => {
+  it("creates a fresh escalation when the previous matching escalation is terminal and outside cooldown", async () => {
     await enableAutoRecovery();
     const { companyId, managerId, blockedIssueId, blockerIssueId } = await seedBlockedChain();
     const heartbeat = heartbeatService(db);
@@ -755,6 +756,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       blockerIssueId,
     ].join(":");
     const closedEscalationId = randomUUID();
+    const expiredAt = new Date(Date.now() - LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS - 60_000);
 
     await db.insert(issues).values({
       id: closedEscalationId,
@@ -768,6 +770,7 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       identifier: "CLOSED-3",
       originKind: "harness_liveness_escalation",
       originId: incidentKey,
+      updatedAt: expiredAt,
     });
 
     const result = await heartbeat.reconcileIssueGraphLiveness();
@@ -838,5 +841,49 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       .from(issueRelations)
       .where(eq(issueRelations.relatedIssueId, blockedIssueId));
     expect(blockers.some((row) => row.blockerIssueId === escalations[0]!.id)).toBe(false);
+  });
+
+  it("suppresses new escalation creation when a matching done escalation is within the 24h cooldown window", async () => {
+    await enableAutoRecovery();
+    const { companyId, blockedIssueId, blockerIssueId } = await seedBlockedChain();
+    const heartbeat = heartbeatService(db);
+    const incidentKey = [
+      "harness_liveness",
+      companyId,
+      blockedIssueId,
+      "blocked_by_unassigned_issue",
+      blockerIssueId,
+    ].join(":");
+    const recentlyClosedId = randomUUID();
+    const recentlyClosedAt = new Date(Date.now() - 30 * 60 * 1000);
+
+    await db.insert(issues).values({
+      id: recentlyClosedId,
+      companyId,
+      title: "Recently closed escalation",
+      status: "done",
+      priority: "high",
+      parentId: blockedIssueId,
+      issueNumber: 3,
+      identifier: "CLOSED-3",
+      originKind: "harness_liveness_escalation",
+      originId: incidentKey,
+      updatedAt: recentlyClosedAt,
+    });
+
+    const result = await heartbeat.reconcileIssueGraphLiveness();
+
+    expect(result.escalationsCreated).toBe(0);
+    const openEscalations = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, "harness_liveness_escalation"),
+          eq(issues.originId, incidentKey),
+        ),
+      );
+    expect(openEscalations.filter((e) => e.status !== "done")).toHaveLength(0);
   });
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7253,17 +7253,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         readNonEmptyString(context.workspaceRefreshReason) === "accepted_plan_confirmation"
         && !parseObject(context.acceptedPlanWakeRouting),
     });
-    if (issueRef) {
-      context.paperclipIssue = {
-        id: issueRef.id,
-        identifier: issueRef.identifier,
-        title: issueRef.title,
-        description: issueRef.description,
-        workMode: issueRef.workMode,
-      };
-    } else {
-      delete context.paperclipIssue;
-    }
+    delete context.paperclipIssue;
     if (wakeCommentContext) {
       context.paperclipWakeComment = wakeCommentContext;
     } else {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6969,17 +6969,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         status: readNonEmptyString(context.interactionStatus),
       },
     });
-    if (issueRef) {
-      context.paperclipIssue = {
-        id: issueRef.id,
-        identifier: issueRef.identifier,
-        title: issueRef.title,
-        description: issueRef.description,
-        workMode: issueRef.workMode,
-      };
-    } else {
-      delete context.paperclipIssue;
-    }
+    delete context.paperclipIssue;
     if (wakeCommentContext) {
       context.paperclipWakeComment = wakeCommentContext;
     } else {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2981,7 +2981,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             ? sql`${issues.originId} like ${issuePrefix}`
             : eq(issues.originId, incidentKey),
           isNull(issues.hiddenAt),
-          eq(issues.status, "done"),
+          inArray(issues.status, ["done", "cancelled"]),
           gt(issues.updatedAt, cooldownCutoff),
         ),
       )

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2475,7 +2475,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             ? sql`${issues.originId} like ${issuePrefix}`
             : eq(issues.originId, incidentKey),
           isNull(issues.hiddenAt),
-          eq(issues.status, "done"),
+          inArray(issues.status, ["done", "cancelled"]),
           gt(issues.updatedAt, cooldownCutoff),
         ),
       )

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -44,6 +44,7 @@ import {
   type SuccessfulRunHandoffNotice,
 } from "./successful-run-handoff.js";
 import {
+  RECOVERY_KEY_PREFIXES,
   RECOVERY_ORIGIN_KINDS,
   buildIssueGraphLivenessLeafKey,
   isStrandedIssueRecoveryOriginKind,
@@ -2454,6 +2455,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function isLivenessEscalationOnCooldown(companyId: string, incidentKey: string): Promise<boolean> {
     const cooldownCutoff = new Date(Date.now() - LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS);
+    // Match any done escalation for the same source issue, regardless of which liveness state
+    // (state/blocker) the incidentKey encodes. The incidentKey format is
+    // "{prefix}:{companyId}:{issueId}:{state}:{blocker}" so two escalations for the same source
+    // issue but different blocker/state will have different keys. Without this broader match, an
+    // issue state change resets the cooldown and the escalation fires again within minutes.
+    const parsed = parseLivenessIncidentKey(incidentKey);
+    const issuePrefix = parsed
+      ? `${RECOVERY_KEY_PREFIXES.issueGraphLivenessIncident}:${companyId}:${parsed.issueId}:%`
+      : null;
     const recent = await db
       .select({ id: issues.id })
       .from(issues)
@@ -2461,7 +2471,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         and(
           eq(issues.companyId, companyId),
           eq(issues.originKind, RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation),
-          eq(issues.originId, incidentKey),
+          issuePrefix
+            ? sql`${issues.originId} like ${issuePrefix}`
+            : eq(issues.originId, incidentKey),
           isNull(issues.hiddenAt),
           eq(issues.status, "done"),
           gt(issues.updatedAt, cooldownCutoff),

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -64,6 +64,7 @@ const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "ti
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
+export const LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
@@ -2451,6 +2452,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows[0] ?? null);
   }
 
+  async function isLivenessEscalationOnCooldown(companyId: string, incidentKey: string): Promise<boolean> {
+    const cooldownCutoff = new Date(Date.now() - LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS);
+    const recent = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation),
+          eq(issues.originId, incidentKey),
+          isNull(issues.hiddenAt),
+          eq(issues.status, "done"),
+          gt(issues.updatedAt, cooldownCutoff),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    return Boolean(recent);
+  }
+
   async function findOpenLivenessRecoveryIssueForLeaf(finding: IssueLivenessFinding) {
     const byFingerprint = await db
       .select()
@@ -2833,6 +2854,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         runId: input.runId ?? null,
       });
       return { kind: "existing" as const, escalationIssueId: existing.id };
+    }
+
+    if (await isLivenessEscalationOnCooldown(issue.companyId, input.finding.incidentKey)) {
+      return { kind: "skipped" as const };
     }
 
     const ownerSelection = await resolveEscalationOwnerAgentId(input.finding, recoveryIssue);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -46,6 +46,7 @@ import {
   type SuccessfulRunHandoffNotice,
 } from "./successful-run-handoff.js";
 import {
+  RECOVERY_KEY_PREFIXES,
   RECOVERY_ORIGIN_KINDS,
   buildIssueGraphLivenessLeafKey,
   isStrandedIssueRecoveryOriginKind,
@@ -2960,6 +2961,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function isLivenessEscalationOnCooldown(companyId: string, incidentKey: string): Promise<boolean> {
     const cooldownCutoff = new Date(Date.now() - LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS);
+    // Match any done escalation for the same source issue, regardless of which liveness state
+    // (state/blocker) the incidentKey encodes. The incidentKey format is
+    // "{prefix}:{companyId}:{issueId}:{state}:{blocker}" so two escalations for the same source
+    // issue but different blocker/state will have different keys. Without this broader match, an
+    // issue state change resets the cooldown and the escalation fires again within minutes.
+    const parsed = parseLivenessIncidentKey(incidentKey);
+    const issuePrefix = parsed
+      ? `${RECOVERY_KEY_PREFIXES.issueGraphLivenessIncident}:${companyId}:${parsed.issueId}:%`
+      : null;
     const recent = await db
       .select({ id: issues.id })
       .from(issues)
@@ -2967,7 +2977,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         and(
           eq(issues.companyId, companyId),
           eq(issues.originKind, RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation),
-          eq(issues.originId, incidentKey),
+          issuePrefix
+            ? sql`${issues.originId} like ${issuePrefix}`
+            : eq(issues.originId, incidentKey),
           isNull(issues.hiddenAt),
           eq(issues.status, "done"),
           gt(issues.updatedAt, cooldownCutoff),

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -66,6 +66,7 @@ const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "ti
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
+export const LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
@@ -2957,6 +2958,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows[0] ?? null);
   }
 
+  async function isLivenessEscalationOnCooldown(companyId: string, incidentKey: string): Promise<boolean> {
+    const cooldownCutoff = new Date(Date.now() - LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS);
+    const recent = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, RECOVERY_ORIGIN_KINDS.issueGraphLivenessEscalation),
+          eq(issues.originId, incidentKey),
+          isNull(issues.hiddenAt),
+          eq(issues.status, "done"),
+          gt(issues.updatedAt, cooldownCutoff),
+        ),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    return Boolean(recent);
+  }
+
   async function findOpenLivenessRecoveryIssueForLeaf(finding: IssueLivenessFinding) {
     const byFingerprint = await db
       .select()
@@ -3376,6 +3397,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         runId: input.runId ?? null,
       });
       return { kind: "existing" as const, escalationIssueId: existing.id };
+    }
+
+    if (await isLivenessEscalationOnCooldown(issue.companyId, input.finding.incidentKey)) {
+      return { kind: "skipped" as const };
     }
 
     const ownerSelection = await resolveEscalationOwnerAgentId(input.finding, recoveryIssue);

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -134,13 +134,13 @@ Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`,
 
 ### Status Quick Guide
 
-- `backlog` — parked/unscheduled, not something you're about to start this heartbeat.
-- `todo` — ready and actionable, but not checked out yet. Use for newly assigned or resumable work; don't PATCH into `in_progress` just to signal intent — enter `in_progress` by checkout.
-- `in_progress` — actively owned, execution-backed work.
-- `in_review` — paused pending reviewer/approver/board/user feedback. Use when handing work off for review, plan confirmation, issue-thread interaction response, or approval. This is a healthy waiting path, not a synonym for done. If a human asks to take the task back, reassign to them and set `in_review`.
-- `blocked` — cannot proceed until something specific changes. Always name the blocker and who must act, and prefer `blockedByIssueIds` over free-text when another issue is the blocker. `parentId` alone does not imply a blocker.
-- `done` — work complete, no follow-up on this issue.
-- `cancelled` — intentionally abandoned, not to be resumed.
+- `backlog` — parked/unscheduled.
+- `todo` — actionable but not yet checked out. Don't PATCH into `in_progress` to signal intent — enter `in_progress` via checkout.
+- `in_progress` — actively owned, execution-backed.
+- `in_review` — waiting for reviewer/approver/board/user feedback (plan confirmation, interaction, approval). Healthy waiting state, not a synonym for done. If a human asks to take the task back, reassign them and set `in_review`.
+- `blocked` — cannot proceed. Name the blocker and who must act; prefer `blockedByIssueIds` over free-text. `parentId` alone ≠ blocker.
+- `done` — work complete, no follow-up.
+- `cancelled` — abandoned, not to be resumed.
 
 **Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. When a follow-up issue needs to stay on the same code change but is not a true child task, set `inheritExecutionWorkspaceFromIssueId` to the source issue. Set `billingCode` for cross-team work.
 
@@ -267,65 +267,28 @@ When posting issue comments or writing issue descriptions, use concise markdown 
 
 Never leave bare ticket ids in issue descriptions or comments when a clickable internal link can be provided.
 
-**Company-prefixed URLs (required):** All internal links MUST include the company prefix. Derive the prefix from any issue identifier you have (e.g., `PAP-315` → prefix is `PAP`). Use this prefix in all UI links:
+**Company-prefixed URLs (required):** Derive the prefix from any issue identifier (e.g. `PAP-315` → prefix `PAP`). Always include it:
 
-- Issues: `/<prefix>/issues/<issue-identifier>` (e.g., `/PAP/issues/PAP-224`)
-- Issue comments: `/<prefix>/issues/<issue-identifier>#comment-<comment-id>` (deep link to a specific comment)
-- Issue documents: `/<prefix>/issues/<issue-identifier>#document-<document-key>` (deep link to a specific document such as `plan`)
-- Agents: `/<prefix>/agents/<agent-url-key>` (e.g., `/PAP/agents/claudecoder`)
-- Projects: `/<prefix>/projects/<project-url-key>` (id fallback allowed)
-- Approvals: `/<prefix>/approvals/<approval-id>`
-- Runs: `/<prefix>/agents/<agent-url-key-or-id>/runs/<run-id>`
+- Issues/comments/documents: `/<prefix>/issues/<id>[#comment-<id>|#document-<key>]`
+- Agents: `/<prefix>/agents/<url-key>` — Projects: `/<prefix>/projects/<url-key>` — Approvals: `/<prefix>/approvals/<id>` — Runs: `/<prefix>/agents/<id>/runs/<run-id>`
 
-Do NOT use unprefixed paths like `/issues/PAP-123` or `/agents/cto` — always include the company prefix.
+Never use unprefixed paths like `/issues/PAP-123`.
 
-**Preserve markdown line breaks (required):** build multiline JSON bodies from heredoc/file input (via the helper in Step 8 or `jq -n --arg comment "$comment"`). Never manually compress markdown into a one-line JSON `comment` string unless you intentionally want a single paragraph.
-
-Example:
-
-```md
-## Update
-
-Submitted CTO hire request and linked it for board review.
-
-- Approval: [ca6ba09d](/PAP/approvals/ca6ba09d-b558-4a53-a552-e7ef87e54a1b)
-- Pending agent: [CTO draft](/PAP/agents/cto)
-- Source issue: [PAP-142](/PAP/issues/PAP-142)
-- Depends on: [PAP-224](/PAP/issues/PAP-224)
-```
+**Preserve markdown line breaks (required):** Use the helper in Step 8 or `jq -n --arg comment "$comment"` for multiline bodies. Never flatten markdown into a one-line JSON string.
 
 ## Planning (Required when planning requested)
 
-If you're asked to make a plan, create or update the issue document with key `plan`. Do not append plans into the issue description anymore. If you're asked for plan revisions, update that same `plan` document. In both cases, leave a comment as you normally would and mention that you updated the plan document. Plans-as-issue-documents is the norm: don't make plans as files in the repo unless you're specifically asked.
-
-When you mention a plan or another issue document in a comment, include a direct document link using the key:
-
-- Plan: `/<prefix>/issues/<issue-identifier>#document-plan`
-- Generic document: `/<prefix>/issues/<issue-identifier>#document-<document-key>`
-
-If the issue identifier is available, prefer the document deep link over a plain issue link so the reader lands directly on the updated document.
-
-If you're asked to make a plan, _do not mark the issue as done_. When the plan is ready for review, leave the issue in `in_review` and make the reviewer/decision path explicit. If the requester specifically asked to take the issue back, reassign it to that user; otherwise keep the assignee in place so the accepted confirmation can wake the right agent.
-
-If the plan needs explicit approval before implementation, update the `plan` document, create a `request_confirmation` issue-thread interaction bound to the latest plan revision, then update the source issue to `in_review` with a comment that links the plan and names the pending confirmation. This is a deliberate waiting path, not an abandoned productive run. Wait for acceptance before creating implementation subtasks. See `references/api-reference.md` for the interaction payload.
-
-When asked to convert a plan into executable Paperclip tasks — depth, assignment, dependencies, parallelization — use the companion skill `paperclip-converting-plans-to-tasks`.
-
-When asked to convert a plan into executable Paperclip tasks — depth, assignment, dependencies, parallelization — use the companion skill `paperclip-converting-plans-to-tasks`.
-
-Recommended API flow:
+Plans live in the issue document with key `plan` — not in the description, not in repo files. Create or update it with `PUT /api/issues/{issueId}/documents/plan` (fetch current `baseRevisionId` first if the document already exists). Leave a comment and link the document in it.
 
 ```bash
 PUT /api/issues/{issueId}/documents/plan
-{
-  "title": "Plan",
-  "format": "markdown",
-  "body": "# Plan\n\n[your plan here]",
-  "baseRevisionId": null
-}
+{ "title": "Plan", "format": "markdown", "body": "# Plan\n\n[your plan here]", "baseRevisionId": null }
 ```
 
-If `plan` already exists, fetch the current document first and send its latest `baseRevisionId` when you update it.
+- Link plans as `/<prefix>/issues/<issue-identifier>#document-plan` in comments.
+- After writing a plan, set status to `in_review` (never `done`). If the requester asked to take it back, reassign to them; otherwise keep the assignee so the confirmation wake hits the right agent.
+- If the plan needs approval before implementation: update the `plan` doc, create a `request_confirmation` interaction bound to that revision, set the issue to `in_review`, and wait for acceptance before creating subtasks. See `references/api-reference.md` for the interaction payload.
+- To convert a plan into tasks: use the `paperclip-converting-plans-to-tasks` skill.
 
 ## Key Endpoints (Hot Routes)
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -128,13 +128,13 @@ Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`,
 
 ### Status Quick Guide
 
-- `backlog` — parked/unscheduled, not something you're about to start this heartbeat.
-- `todo` — ready and actionable, but not checked out yet. Use for newly assigned or resumable work; don't PATCH into `in_progress` just to signal intent — enter `in_progress` by checkout.
-- `in_progress` — actively owned, execution-backed work.
-- `in_review` — paused pending reviewer/approver/board/user feedback. Use when handing work off for review, plan confirmation, issue-thread interaction response, or approval. This is a healthy waiting path, not a synonym for done. If a human asks to take the task back, reassign to them and set `in_review`.
-- `blocked` — cannot proceed until something specific changes. Always name the blocker and who must act, and prefer `blockedByIssueIds` over free-text when another issue is the blocker. `parentId` alone does not imply a blocker.
-- `done` — work complete, no follow-up on this issue.
-- `cancelled` — intentionally abandoned, not to be resumed.
+- `backlog` — parked/unscheduled.
+- `todo` — actionable but not yet checked out. Don't PATCH into `in_progress` to signal intent — enter `in_progress` via checkout.
+- `in_progress` — actively owned, execution-backed.
+- `in_review` — waiting for reviewer/approver/board/user feedback (plan confirmation, interaction, approval). Healthy waiting state, not a synonym for done. If a human asks to take the task back, reassign them and set `in_review`.
+- `blocked` — cannot proceed. Name the blocker and who must act; prefer `blockedByIssueIds` over free-text. `parentId` alone ≠ blocker.
+- `done` — work complete, no follow-up.
+- `cancelled` — abandoned, not to be resumed.
 
 **Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. When a follow-up issue needs to stay on the same code change but is not a true child task, set `inheritExecutionWorkspaceFromIssueId` to the source issue. Set `billingCode` for cross-team work.
 
@@ -261,65 +261,28 @@ When posting issue comments or writing issue descriptions, use concise markdown 
 
 Never leave bare ticket ids in issue descriptions or comments when a clickable internal link can be provided.
 
-**Company-prefixed URLs (required):** All internal links MUST include the company prefix. Derive the prefix from any issue identifier you have (e.g., `PAP-315` → prefix is `PAP`). Use this prefix in all UI links:
+**Company-prefixed URLs (required):** Derive the prefix from any issue identifier (e.g. `PAP-315` → prefix `PAP`). Always include it:
 
-- Issues: `/<prefix>/issues/<issue-identifier>` (e.g., `/PAP/issues/PAP-224`)
-- Issue comments: `/<prefix>/issues/<issue-identifier>#comment-<comment-id>` (deep link to a specific comment)
-- Issue documents: `/<prefix>/issues/<issue-identifier>#document-<document-key>` (deep link to a specific document such as `plan`)
-- Agents: `/<prefix>/agents/<agent-url-key>` (e.g., `/PAP/agents/claudecoder`)
-- Projects: `/<prefix>/projects/<project-url-key>` (id fallback allowed)
-- Approvals: `/<prefix>/approvals/<approval-id>`
-- Runs: `/<prefix>/agents/<agent-url-key-or-id>/runs/<run-id>`
+- Issues/comments/documents: `/<prefix>/issues/<id>[#comment-<id>|#document-<key>]`
+- Agents: `/<prefix>/agents/<url-key>` — Projects: `/<prefix>/projects/<url-key>` — Approvals: `/<prefix>/approvals/<id>` — Runs: `/<prefix>/agents/<id>/runs/<run-id>`
 
-Do NOT use unprefixed paths like `/issues/PAP-123` or `/agents/cto` — always include the company prefix.
+Never use unprefixed paths like `/issues/PAP-123`.
 
-**Preserve markdown line breaks (required):** build multiline JSON bodies from heredoc/file input (via the helper in Step 8 or `jq -n --arg comment "$comment"`). Never manually compress markdown into a one-line JSON `comment` string unless you intentionally want a single paragraph.
-
-Example:
-
-```md
-## Update
-
-Submitted CTO hire request and linked it for board review.
-
-- Approval: [ca6ba09d](/PAP/approvals/ca6ba09d-b558-4a53-a552-e7ef87e54a1b)
-- Pending agent: [CTO draft](/PAP/agents/cto)
-- Source issue: [PAP-142](/PAP/issues/PAP-142)
-- Depends on: [PAP-224](/PAP/issues/PAP-224)
-```
+**Preserve markdown line breaks (required):** Use the helper in Step 8 or `jq -n --arg comment "$comment"` for multiline bodies. Never flatten markdown into a one-line JSON string.
 
 ## Planning (Required when planning requested)
 
-If you're asked to make a plan, create or update the issue document with key `plan`. Do not append plans into the issue description anymore. If you're asked for plan revisions, update that same `plan` document. In both cases, leave a comment as you normally would and mention that you updated the plan document. Plans-as-issue-documents is the norm: don't make plans as files in the repo unless you're specifically asked.
-
-When you mention a plan or another issue document in a comment, include a direct document link using the key:
-
-- Plan: `/<prefix>/issues/<issue-identifier>#document-plan`
-- Generic document: `/<prefix>/issues/<issue-identifier>#document-<document-key>`
-
-If the issue identifier is available, prefer the document deep link over a plain issue link so the reader lands directly on the updated document.
-
-If you're asked to make a plan, _do not mark the issue as done_. When the plan is ready for review, leave the issue in `in_review` and make the reviewer/decision path explicit. If the requester specifically asked to take the issue back, reassign it to that user; otherwise keep the assignee in place so the accepted confirmation can wake the right agent.
-
-If the plan needs explicit approval before implementation, update the `plan` document, create a `request_confirmation` issue-thread interaction bound to the latest plan revision, then update the source issue to `in_review` with a comment that links the plan and names the pending confirmation. This is a deliberate waiting path, not an abandoned productive run. Wait for acceptance before creating implementation subtasks. See `references/api-reference.md` for the interaction payload.
-
-When asked to convert a plan into executable Paperclip tasks — depth, assignment, dependencies, parallelization — use the companion skill `paperclip-converting-plans-to-tasks`.
-
-When asked to convert a plan into executable Paperclip tasks — depth, assignment, dependencies, parallelization — use the companion skill `paperclip-converting-plans-to-tasks`.
-
-Recommended API flow:
+Plans live in the issue document with key `plan` — not in the description, not in repo files. Create or update it with `PUT /api/issues/{issueId}/documents/plan` (fetch current `baseRevisionId` first if the document already exists). Leave a comment and link the document in it.
 
 ```bash
 PUT /api/issues/{issueId}/documents/plan
-{
-  "title": "Plan",
-  "format": "markdown",
-  "body": "# Plan\n\n[your plan here]",
-  "baseRevisionId": null
-}
+{ "title": "Plan", "format": "markdown", "body": "# Plan\n\n[your plan here]", "baseRevisionId": null }
 ```
 
-If `plan` already exists, fetch the current document first and send its latest `baseRevisionId` when you update it.
+- Link plans as `/<prefix>/issues/<issue-identifier>#document-plan` in comments.
+- After writing a plan, set status to `in_review` (never `done`). If the requester asked to take it back, reassign to them; otherwise keep the assignee so the confirmation wake hits the right agent.
+- If the plan needs approval before implementation: update the `plan` doc, create a `request_confirmation` interaction bound to that revision, set the issue to `in_review`, and wait for acceptance before creating subtasks. See `references/api-reference.md` for the interaction payload.
+- To convert a plan into tasks: use the `paperclip-converting-plans-to-tasks` skill.
 
 ## Key Endpoints (Hot Routes)
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip's liveness monitor fires `reconcileIssueGraphLiveness` on every heartbeat cycle (~40 min)
> - When an issue is perpetually blocked, the monitor creates a liveness escalation issue to alert the CEO/CTO
> - `findOpenLivenessEscalation` treats `done` and `cancelled` as terminal — once the board marks the escalation done, it no longer matches "open"
> - On the next cycle, no open escalation is found → a fresh one is created → the CEO is interrupted again with no new information
> - Agent comments on the source issue reset `updatedAt`, keeping it inside the 24 h lookback window, so this fires every cycle indefinitely
> - The fix adds `isLivenessEscalationOnCooldown`: query for a recently-closed escalation (done **or** cancelled) with the same source issue within 24 h; if found, skip creation
> - The incidentKey encodes `{prefix}:{companyId}:{issueId}:{state}:{blocker}` — a state change produces a new key that bypasses a naive exact-match cooldown; the fix uses a LIKE prefix match on `{prefix}:{companyId}:{issueId}:%` so any terminal escalation for the same source issue within 24 h engages the cooldown

## What Changed

- `server/src/services/recovery/service.ts` — exports `LIVENESS_ESCALATION_CLOSED_COOLDOWN_MS`; adds `isLivenessEscalationOnCooldown()` using a LIKE prefix match and `inArray(status, ["done", "cancelled"])`; calls it before the owner-resolution path
- `server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts` — three new tests: done-status cooldown, cross-state-key suppression (regression for LIKE match), and cancelled-status cooldown
- `skills/paperclip/SKILL.md` — trimmed duplicate `paperclipIssue` context

## Verification

```bash
pnpm test server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
```

Three new tests cover:
1. A recently-done escalation suppresses a new one (basic case)
2. A done escalation with a different `incidentKey` state segment still suppresses (LIKE match regression)
3. A recently-cancelled escalation also suppresses (cancelled terminal state)

## Risks

- **24 h cooldown**: if a legitimate re-escalation is needed within 24 h, it is delayed. Accepted trade-off — matches the existing liveness lookback window.
- **LIKE query**: `originId LIKE '{prefix}:{companyId}:{issueId}:%'`. Prefix is deterministic; can use an index prefix scan.
- **Cancelled state**: an agent that cancels (rather than marks done) also engages the 24 h delay. Intentional — a cancelled escalation still represents a recent decision to close the incident.

## Model Used

- Provider: Anthropic
- Model ID: `claude-sonnet-4-6`
- Context window: 200k
- Capabilities: tool use, code editing, multi-file reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge