### PR TITLE
docs(skills): retire PARA Layers 1+2 in para-memory-files; replace with MemPalace

### DIFF
--- a/skills/para-memory-files/SKILL.md
+++ b/skills/para-memory-files/SKILL.md
@@ -1,104 +1,86 @@
 ---
 name: para-memory-files
 description: >
-  File-based memory system using Tiago Forte's PARA method. Use this skill whenever
-  you need to store, retrieve, update, or organize knowledge across sessions. Covers
-  three memory layers: (1) Knowledge graph in PARA folders with atomic YAML facts,
-  (2) Daily notes as raw timeline, (3) Tacit knowledge about user patterns. Also
-  handles planning files, memory decay, weekly synthesis, and recall via qmd.
-  Trigger on any memory operation: saving facts, writing daily notes, creating
-  entities, running weekly synthesis, recalling past context, or managing plans.
+  Tiny file-based memory for turn-0 rules that must apply before any tool call.
+  Use this skill ONLY for the small set of rules an agent must obey from the
+  first turn of a conversation (e.g. "never commit secrets", "always check X
+  before doing Y"). Everything else — durable facts, decisions, history,
+  cross-cutting context, code excerpts — belongs in the MemPalace and is
+  retrieved via `mempalace_search` / `mempalace_kg_query`. The PARA
+  knowledge-graph layer and daily-notes layer have been retired; only the
+  short `MEMORY.md` index remains, capped at ~150 lines.
 ---
 
-# PARA Memory Files
+# Agent Turn-0 Memory (formerly PARA Memory Files)
 
-Persistent, file-based memory organized by Tiago Forte's PARA method. Three layers: a knowledge graph, daily notes, and tacit knowledge. All paths are relative to `$AGENT_HOME`.
+**Scope:** this skill now covers ONE thing: a tiny, always-loaded `MEMORY.md`
+file of turn-0 rules. The previous PARA knowledge-graph (`life/`) and daily-notes
+(`memory/YYYY-MM-DD.md`) layers have been retired in favour of the MemPalace.
 
-## Three Memory Layers
+## What goes where
 
-### Layer 1: Knowledge Graph (`$AGENT_HOME/life/` -- PARA)
+| Need                                                        | Use                              |
+| ----------------------------------------------------------- | -------------------------------- |
+| Rules that must apply on turn 0 (every turn, every session) | `$AGENT_HOME/MEMORY.md` (this skill) |
+| Durable facts, decisions, history, code excerpts            | MemPalace drawers (`mempalace_add_drawer`) |
+| Recall a past decision, error, or design choice             | `mempalace_search`               |
+| Entity relationships (who owns what, dependencies, timing)  | `mempalace_kg_query`             |
+| Raw timeline of events                                      | MemPalace `mempalace_diary_write` (AAAK) |
 
-Entity-based storage. Each entity gets a folder with two tiers:
+If a piece of information does not need to be in context **every** turn, it
+does NOT belong in `MEMORY.md`. File it in the palace instead.
 
-1. `summary.md` -- quick context, load first.
-2. `items.yaml` -- atomic facts, load on demand.
+## The one remaining layer — `MEMORY.md`
+
+Path: `$AGENT_HOME/MEMORY.md`
+
+- **Cap: ~150 lines.** Every line costs tokens on every turn. Treat this as a
+  budget, not an aspiration.
+- **Turn-0 rules only.** Operating constraints, hard "always/never" rules, and
+  pointers the agent needs before it can act. Not facts, not history, not logs.
+- **No daily notes.** If you catch yourself writing a dated event, stop — that
+  is a MemPalace drawer, not a `MEMORY.md` entry.
+- **No entity knowledge graph.** Atomic facts about people, projects, or
+  companies go in the palace as drawers with verbatim content.
+
+Rule of thumb: if removing a line from `MEMORY.md` would not cause the agent to
+make a wrong call on its very first action, the line should not be there.
+
+## Memory Recall — search MemPalace first
+
+`qmd` is no longer required. For any cross-cutting recall question — "how does
+X work", "why did we choose Y", "did we hit this error before", "who owns Z" —
+use MemPalace as the first layer:
 
 ```text
-$AGENT_HOME/life/
-  projects/          # Active work with clear goals/deadlines
-    <name>/
-      summary.md
-      items.yaml
-  areas/             # Ongoing responsibilities, no end date
-    people/<name>/
-    companies/<name>/
-  resources/         # Reference material, topics of interest
-    <topic>/
-  archives/          # Inactive items from the other three
-  index.md
+mempalace_search        # semantic search across drawers, returns the WHY + WHERE
+mempalace_kg_query      # entity relationships, ownership, dependencies, timelines
+mempalace_kg_timeline   # when did this happen / what changed in this entity
+mempalace_get_drawer    # full content of a known drawer
 ```
 
-**PARA rules:**
-
-- **Projects** -- active work with a goal or deadline. Move to archives when complete.
-- **Areas** -- ongoing (people, companies, responsibilities). No end date.
-- **Resources** -- reference material, topics of interest.
-- **Archives** -- inactive items from any category.
-
-**Fact rules:**
-
-- Save durable facts immediately to `items.yaml`.
-- Weekly: rewrite `summary.md` from active facts.
-- Never delete facts. Supersede instead (`status: superseded`, add `superseded_by`).
-- When an entity goes inactive, move its folder to `$AGENT_HOME/life/archives/`.
-
-**When to create an entity:**
-
-- Mentioned 3+ times, OR
-- Direct relationship to the user (family, coworker, partner, client), OR
-- Significant project or company in the user's life.
-- Otherwise, note it in daily notes.
-
-For the atomic fact YAML schema and memory decay rules, see [references/schemas.md](references/schemas.md).
-
-### Layer 2: Daily Notes (`$AGENT_HOME/memory/YYYY-MM-DD.md`)
-
-Raw timeline of events -- the "when" layer.
-
-- Write continuously during conversations.
-- Extract durable facts to Layer 1 during heartbeats.
-
-### Layer 3: Tacit Knowledge (`$AGENT_HOME/MEMORY.md`)
-
-How the user operates -- patterns, preferences, lessons learned.
-
-- Not facts about the world; facts about the user.
-- Update whenever you learn new operating patterns.
-
-## Write It Down -- No Mental Notes
-
-Memory does not survive session restarts. Files do.
-
-- Want to remember something -> WRITE IT TO A FILE.
-- "Remember this" -> update `$AGENT_HOME/memory/YYYY-MM-DD.md` or the relevant entity file.
-- Learn a lesson -> update AGENTS.md, TOOLS.md, or the relevant skill file.
-- Make a mistake -> document it so future-you does not repeat it.
-- On-disk text files are always better than holding it in temporary context.
-
-## Memory Recall -- Use qmd
-
-Use `qmd` rather than grepping files:
-
-```bash
-qmd query "what happened at Christmas"   # Semantic search with reranking
-qmd search "specific phrase"              # BM25 keyword search
-qmd vsearch "conceptual question"         # Pure vector similarity
-```
-
-Index your personal folder: `qmd index $AGENT_HOME`
-
-Vectors + BM25 + reranking finds things even when the wording differs.
+Filing is just as important as searching. When you solve a non-obvious bug,
+make an architecture trade-off, or learn a hidden constraint, call
+`mempalace_add_drawer` with VERBATIM content (error messages, decisions,
+quotes) — do not summarise. The palace's WHY is what makes future recall useful.
 
 ## Planning
 
-Keep plans in timestamped files in `plans/` at the project root (outside personal memory so other agents can access them). Use `qmd` to search plans. Plans go stale -- if a newer plan exists, do not confuse yourself with an older version. If you notice staleness, update the file to note what it is supersededBy.
+Keep plans where the user / board / other agents can see them — issue
+documents on the relevant Paperclip issue (key `plan`), not in personal memory.
+The `paperclip` skill covers the plan-document workflow.
+
+## What was retired and why
+
+- **Layer 1 (`life/` PARA tree with `summary.md` + `items.yaml`)** — superseded
+  by MemPalace drawers and the knowledge graph. Atomic facts now live in
+  drawers with semantic search instead of folder-scoped YAML.
+- **Layer 2 (`memory/YYYY-MM-DD.md` daily notes)** — superseded by
+  `mempalace_diary_write` (AAAK dialect) at session end, which is searchable
+  and timeline-queryable.
+- **`qmd` recall** — superseded by `mempalace_search` /
+  `mempalace_kg_query`, which return the WHY alongside the WHERE.
+
+Existing `life/` and `memory/` trees from older agents are read-only history.
+Do not write new content into them; migrate anything still useful into the
+palace and leave the old files as-is.

--- a/skills/para-memory-files/references/schemas.md
+++ b/skills/para-memory-files/references/schemas.md
@@ -1,35 +1,57 @@
-# Schemas and Memory Decay
+# MEMORY.md Curation
 
-## Atomic Fact Schema (items.yaml)
+> The PARA `life/items.yaml` knowledge graph and its atomic-fact schema have
+> been retired. Atomic facts now live as MemPalace drawers, not as YAML rows in
+> a personal folder. The schema and access-tracking metadata below described
+> that retired system and no longer apply.
+>
+> This file now covers only one thing: how to keep `MEMORY.md` small and
+> useful, since it is the single remaining file-memory surface.
 
-```yaml
-- id: entity-001
-  fact: "The actual fact"
-  category: relationship | milestone | status | preference
-  timestamp: "YYYY-MM-DD"
-  source: "YYYY-MM-DD"
-  status: active # active | superseded
-  superseded_by: null # e.g. entity-002
-  related_entities:
-    - companies/acme
-    - people/jeff
-  last_accessed: "YYYY-MM-DD"
-  access_count: 0
-```
+## What `MEMORY.md` is for
 
-## Memory Decay
+`MEMORY.md` is a tiny, always-loaded file at `$AGENT_HOME/MEMORY.md`. Every
+line in it costs prompt tokens on every turn of every session. Use it ONLY for
+rules and pointers the agent needs before its first tool call — never for
+facts, history, or logs (those go in the MemPalace).
 
-Facts decay in retrieval priority over time so stale info does not crowd out recent context.
+## Curation rules
 
-**Access tracking:** When a fact is used in conversation, bump `access_count` and set `last_accessed` to today. During heartbeat extraction, scan the session for referenced entity facts and update their access metadata.
+- **Hard cap: ~150 lines.** When the file approaches this size, prune before
+  adding.
+- **Turn-0 test.** For each line, ask: "If this line were missing, would the
+  agent make a wrong call on its very first action this session?" If no,
+  delete the line.
+- **No dated entries.** Daily events, run logs, and conversation summaries
+  belong in `mempalace_diary_write`, not here.
+- **No relationship trees.** "X owns Y", "A depends on B", "person P works on
+  project Q" are knowledge-graph facts — file them with `mempalace_kg_add`.
+- **No code excerpts.** Verbatim code, error messages, and decision context go
+  in MemPalace drawers via `mempalace_add_drawer`.
+- **No "might be useful someday" entries.** If you cannot name the very next
+  decision a line will inform, it does not earn the per-turn token cost.
 
-**Recency tiers (for summary.md rewriting):**
+## When you outgrow the cap
 
-- **Hot** (accessed in last 7 days) -- include prominently in summary.md.
-- **Warm** (8-30 days ago) -- include at lower priority.
-- **Cold** (30+ days or never accessed) -- omit from summary.md. Still in items.yaml, retrievable on demand.
-- High `access_count` resists decay -- frequently used facts stay warm longer.
+If `MEMORY.md` keeps trying to grow past ~150 lines, that is a signal that
+content is in the wrong layer — not that the cap is wrong. Walk the file and
+move each oversized entry to its proper home:
 
-**Weekly synthesis:** Sort by recency tier, then by access_count within tier. Cold facts drop out of the summary but remain in items.yaml. Accessing a cold fact reheats it.
+| Found in `MEMORY.md`                  | Move to                              |
+| ------------------------------------- | ------------------------------------ |
+| Dated events, "what happened today"   | `mempalace_diary_write`              |
+| "Why we chose X over Y" decisions     | `mempalace_add_drawer` (decisions room) |
+| Atomic facts about people / projects  | `mempalace_kg_add`                   |
+| Long code snippets or error traces    | `mempalace_add_drawer`               |
+| Pointers ("see file Z") with no rule  | Delete — the agent can search        |
 
-No deletion. Decay only affects retrieval priority via summary.md curation. The full record always lives in items.yaml.
+## What this file used to contain
+
+For historical context: earlier versions of this skill described an atomic
+fact YAML schema (`items.yaml`) with `id`, `category`, `timestamp`, `status`,
+`superseded_by`, `last_accessed`, and `access_count` fields, plus a
+hot/warm/cold decay model for rewriting per-entity `summary.md` files weekly.
+That entire system has been replaced by MemPalace drawers + semantic search;
+no decay model is needed because the palace ranks by relevance at query time.
+Existing `life/` trees from older agents are read-only history — do not write
+new YAML facts there.


### PR DESCRIPTION
## Summary

The `para-memory-files` skill currently describes a full three-layer PARA memory system (knowledge graph in `life/`, daily notes in `memory/YYYY-MM-DD.md`, tacit knowledge in `MEMORY.md`) backed by `qmd` semantic recall. That system has been superseded by the [MemPalace](https://github.com/paperclipai/paperclip) semantic memory backend for agents that have it available.

This PR retires Layers 1+2 and updates both skill files to reflect the new, minimal scope:

### `skills/para-memory-files/SKILL.md`
- Reframes the skill to cover **one thing only**: a tiny `MEMORY.md` capped at ~150 lines for turn-0 rules.
- Adds a **what-goes-where table** routing durable facts, decisions, history, and code excerpts to `mempalace_add_drawer`; entity relationships to `mempalace_kg_add`; recall to `mempalace_search` / `mempalace_kg_query`.
- Replaces the `qmd` recall section with MemPalace tool usage examples.
- Documents what was retired and why (no silent deletion).

### `skills/para-memory-files/references/schemas.md`
- Replaces the atomic-fact YAML schema (`items.yaml`) and hot/warm/cold decay-model documentation with **MEMORY.md curation rules**: hard 150-line cap, turn-0 test, and a triage table for moving oversized entries to their proper MemPalace layer.
- Preserves historical context for the retired system (existing `life/` trees from older agents remain read-only).

## Motivation

Agents using both `para-memory-files` and a MemPalace instance were receiving conflicting instructions: the old skill told them to write atomic YAML facts and daily notes to personal folders, while the MemPalace protocol told them to file drawers instead. This caused duplicate writes and inflated `MEMORY.md` files. The fix is to narrow this skill's scope to what it uniquely provides (always-loaded turn-0 rules) and route everything else to the palace.

## Test plan
- [ ] Review `SKILL.md` for correctness of the what-goes-where table and MemPalace tool names.
- [ ] Review `references/schemas.md` for correctness of the curation rules and triage table.
- [ ] Confirm no references to `qmd`, `items.yaml`, or `life/` folder writes remain (the historical-context section is intentional and clearly marked).
- [ ] Spot-check that an agent following the new SKILL.md would not try to create `life/` folders or `memory/YYYY-MM-DD.md` files.