### PR TITLE
MAT-624: surface pending manager-agent interactions on inbox-lite

### DIFF
--- a/server/src/__tests__/agent-inbox-lite-routes.test.ts
+++ b/server/src/__tests__/agent-inbox-lite-routes.test.ts
@@ -1,0 +1,228 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("acpx/runtime", () => ({
+  createAcpRuntime: vi.fn(),
+  createAgentRegistry: vi.fn(),
+  createRuntimeStore: vi.fn(),
+  isAcpRuntimeError: vi.fn(() => false),
+}));
+
+const agentId = "11111111-1111-4111-8111-111111111111";
+const companyId = "22222222-2222-4222-8222-222222222222";
+const issueA = "33333333-3333-4333-8333-333333333333";
+const issueB = "44444444-4444-4444-8444-444444444444";
+const interactionA1 = "55555555-5555-4555-8555-555555555555";
+const interactionB1 = "66666666-6666-4666-8666-666666666666";
+const interactionB2 = "77777777-7777-4777-8777-777777777777";
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+  listDependencyReadiness: vi.fn(),
+}));
+
+const mockInteractionService = vi.hoisted(() => ({
+  listPendingForIssues: vi.fn(),
+}));
+
+const mockRecoveryActionService = vi.hoisted(() => ({
+  listActiveForIssues: vi.fn(),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentCreated: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => ({ canUser: vi.fn(async () => true), hasPermission: vi.fn(async () => true) }),
+    agentService: () => mockAgentService,
+    agentInstructionsService: () => ({}),
+    approvalService: () => ({}),
+    budgetService: () => ({}),
+    companySkillService: () => ({ listRuntimeSkillEntries: vi.fn(async () => []) }),
+    heartbeatService: () => ({}),
+    ISSUE_LIST_DEFAULT_LIMIT: 500,
+    issueApprovalService: () => ({}),
+    issueRecoveryActionService: () => mockRecoveryActionService,
+    issueService: () => mockIssueService,
+    issueThreadInteractionService: () => mockInteractionService,
+    logActivity: vi.fn(async () => undefined),
+    secretService: () => ({}),
+    syncInstructionsBundleConfigFromFilePath: vi.fn(),
+    workspaceOperationService: () => ({}),
+    environmentService: () => ({}),
+  }));
+}
+
+function createDbStub() {
+  return {} as any;
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const { agentRoutes } = await import("../routes/agents.js");
+  const { errorHandler } = await import("../middleware/index.js");
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      ...actor,
+      companyIds: Array.isArray(actor.companyIds) ? [...actor.companyIds] : actor.companyIds,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes(createDbStub()));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("GET /api/agents/me/inbox-lite", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    registerModuleMocks();
+    mockIssueService.list.mockReset();
+    mockIssueService.listDependencyReadiness.mockReset();
+    mockInteractionService.listPendingForIssues.mockReset();
+    mockRecoveryActionService.listActiveForIssues.mockReset();
+    mockRecoveryActionService.listActiveForIssues.mockResolvedValue(new Map());
+  });
+
+  it("includes pendingInteractions per issue from issueThreadInteractionService", async () => {
+    mockIssueService.list.mockResolvedValue([
+      {
+        id: issueA,
+        identifier: "TST-1",
+        title: "Issue A",
+        status: "in_progress",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt: new Date("2026-05-18T10:00:00.000Z"),
+        activeRun: null,
+      },
+      {
+        id: issueB,
+        identifier: "TST-2",
+        title: "Issue B",
+        status: "blocked",
+        priority: "high",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt: new Date("2026-05-18T11:00:00.000Z"),
+        activeRun: null,
+      },
+    ]);
+    mockIssueService.listDependencyReadiness.mockResolvedValue(new Map([
+      [issueA, { isDependencyReady: true, unresolvedBlockerCount: 0, unresolvedBlockerIssueIds: [] }],
+      [issueB, { isDependencyReady: false, unresolvedBlockerCount: 1, unresolvedBlockerIssueIds: ["blk-1"] }],
+    ]));
+    mockInteractionService.listPendingForIssues.mockResolvedValue(new Map([
+      [issueA, [{
+        id: interactionA1,
+        kind: "request_confirmation",
+        title: "Approve plan?",
+        summary: null,
+        createdAt: new Date("2026-05-18T09:00:00.000Z"),
+        createdByAgentId: "creator-agent",
+        createdByUserId: null,
+      }]],
+      [issueB, [
+        {
+          id: interactionB2,
+          kind: "suggest_tasks",
+          title: "Decompose",
+          summary: null,
+          createdAt: new Date("2026-05-18T08:30:00.000Z"),
+          createdByAgentId: "creator-agent",
+          createdByUserId: null,
+        },
+        {
+          id: interactionB1,
+          kind: "ask_user_questions",
+          title: "Pick variant",
+          summary: "Need input",
+          createdAt: new Date("2026-05-18T08:00:00.000Z"),
+          createdByAgentId: null,
+          createdByUserId: "creator-user",
+        },
+      ]],
+    ]));
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app).get("/api/agents/me/inbox-lite");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0]).toMatchObject({
+      id: issueA,
+      pendingInteractionCount: 1,
+      pendingInteractions: [{
+        id: interactionA1,
+        kind: "request_confirmation",
+        title: "Approve plan?",
+        createdByAgentId: "creator-agent",
+      }],
+    });
+    expect(res.body[1]).toMatchObject({
+      id: issueB,
+      pendingInteractionCount: 2,
+      pendingInteractions: [
+        expect.objectContaining({ id: interactionB2, kind: "suggest_tasks" }),
+        expect.objectContaining({ id: interactionB1, kind: "ask_user_questions", createdByUserId: "creator-user" }),
+      ],
+      unresolvedBlockerCount: 1,
+    });
+    expect(mockInteractionService.listPendingForIssues).toHaveBeenCalledWith(companyId, [issueA, issueB]);
+  });
+
+  it("returns empty pendingInteractions when service returns an empty Map", async () => {
+    mockIssueService.list.mockResolvedValue([
+      {
+        id: issueA,
+        identifier: "TST-1",
+        title: "Issue A",
+        status: "in_progress",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt: new Date("2026-05-18T10:00:00.000Z"),
+        activeRun: null,
+      },
+    ]);
+    mockIssueService.listDependencyReadiness.mockResolvedValue(new Map());
+    mockInteractionService.listPendingForIssues.mockResolvedValue(new Map());
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app).get("/api/agents/me/inbox-lite");
+    expect(res.status).toBe(200);
+    expect(res.body[0]).toMatchObject({
+      id: issueA,
+      pendingInteractionCount: 0,
+      pendingInteractions: [],
+    });
+  });
+});

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -972,4 +972,160 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       },
     });
   });
+
+  it("listPendingForIssues groups pending interactions per issue and excludes resolved ones", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueAId = randomUUID();
+    const issueBId = randomUUID();
+    const issueCId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Pending interactions",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Manager",
+      role: "cto",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: issueAId,
+        companyId,
+        goalId,
+        title: "Issue A — has a pending confirmation",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: issueBId,
+        companyId,
+        goalId,
+        title: "Issue B — has two pending interactions",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: issueCId,
+        companyId,
+        goalId,
+        title: "Issue C — has only a resolved interaction",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    const pendingA = await interactionsSvc.create({
+      id: issueAId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee_on_accept",
+      title: "Approve A?",
+      summary: "Manager approval needed for A",
+      payload: {
+        version: 1,
+        prompt: "Approve A?",
+      },
+    }, {
+      agentId,
+    });
+
+    const pendingB1 = await interactionsSvc.create({
+      id: issueBId,
+      companyId,
+    }, {
+      kind: "ask_user_questions",
+      continuationPolicy: "wake_assignee",
+      title: "Pick variant",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "q1",
+          prompt: "Which variant?",
+          selectionMode: "single",
+          options: [
+            { id: "o1", label: "A" },
+            { id: "o2", label: "B" },
+          ],
+        }],
+      },
+    }, {
+      agentId,
+    });
+
+    const pendingB2 = await interactionsSvc.create({
+      id: issueBId,
+      companyId,
+    }, {
+      kind: "suggest_tasks",
+      continuationPolicy: "wake_assignee",
+      title: "Decompose",
+      payload: {
+        version: 1,
+        tasks: [{ clientKey: "t1", title: "Task 1" }],
+      },
+    }, {
+      agentId,
+    });
+
+    const resolvedC = await interactionsSvc.create({
+      id: issueCId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee_on_accept",
+      payload: {
+        version: 1,
+        prompt: "Approve C?",
+      },
+    }, {
+      agentId,
+    });
+    await interactionsSvc.rejectInteraction({
+      id: issueCId,
+      companyId,
+    }, resolvedC.id, { reason: "no" }, { userId: "local-board" });
+
+    const map = await interactionsSvc.listPendingForIssues(companyId, [
+      issueAId,
+      issueBId,
+      issueCId,
+    ]);
+
+    expect(map.get(issueAId)).toEqual([
+      expect.objectContaining({
+        id: pendingA.id,
+        kind: "request_confirmation",
+        title: "Approve A?",
+        summary: "Manager approval needed for A",
+        createdByAgentId: agentId,
+      }),
+    ]);
+    const issueBList = map.get(issueBId) ?? [];
+    expect(issueBList.map((entry) => entry.id)).toEqual([pendingB2.id, pendingB1.id]);
+    expect(map.has(issueCId)).toBe(false);
+    expect(await interactionsSvc.listPendingForIssues(companyId, [])).toEqual(new Map());
+  });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -44,6 +44,7 @@ import {
   issueApprovalService,
   issueRecoveryActionService,
   issueService,
+  issueThreadInteractionService,
   logActivity,
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
@@ -1743,6 +1744,7 @@ export function agentRoutes(
 
     const issuesSvc = issueService(db);
     const recoveryActionsSvc = issueRecoveryActionService(db);
+    const interactionsSvc = issueThreadInteractionService(db);
     const rows = await issuesSvc.list(req.actor.companyId, {
       assigneeAgentId: req.actor.agentId,
       status: "todo,in_progress,blocked",
@@ -1750,28 +1752,42 @@ export function agentRoutes(
       limit: ISSUE_LIST_DEFAULT_LIMIT,
     });
     const issueIds = rows.map((issue) => issue.id);
-    const [dependencyReadiness, recoveryActionByIssue] = await Promise.all([
+    const [dependencyReadiness, recoveryActionByIssue, pendingInteractions] = await Promise.all([
       issuesSvc.listDependencyReadiness(req.actor.companyId, issueIds),
       recoveryActionsSvc.listActiveForIssues(req.actor.companyId, issueIds),
+      interactionsSvc.listPendingForIssues(req.actor.companyId, issueIds),
     ]);
 
     res.json(
-      rows.map((issue) => ({
-        id: issue.id,
-        identifier: issue.identifier,
-        title: issue.title,
-        status: issue.status,
-        priority: issue.priority,
-        projectId: issue.projectId,
-        goalId: issue.goalId,
-        parentId: issue.parentId,
-        updatedAt: issue.updatedAt,
-        activeRun: issue.activeRun,
-        activeRecoveryAction: recoveryActionByIssue.get(issue.id) ?? null,
-        dependencyReady: dependencyReadiness.get(issue.id)?.isDependencyReady ?? true,
-        unresolvedBlockerCount: dependencyReadiness.get(issue.id)?.unresolvedBlockerCount ?? 0,
-        unresolvedBlockerIssueIds: dependencyReadiness.get(issue.id)?.unresolvedBlockerIssueIds ?? [],
-      })),
+      rows.map((issue) => {
+        const pending = pendingInteractions.get(issue.id) ?? [];
+        return {
+          id: issue.id,
+          identifier: issue.identifier,
+          title: issue.title,
+          status: issue.status,
+          priority: issue.priority,
+          projectId: issue.projectId,
+          goalId: issue.goalId,
+          parentId: issue.parentId,
+          updatedAt: issue.updatedAt,
+          activeRun: issue.activeRun,
+          activeRecoveryAction: recoveryActionByIssue.get(issue.id) ?? null,
+          dependencyReady: dependencyReadiness.get(issue.id)?.isDependencyReady ?? true,
+          unresolvedBlockerCount: dependencyReadiness.get(issue.id)?.unresolvedBlockerCount ?? 0,
+          unresolvedBlockerIssueIds: dependencyReadiness.get(issue.id)?.unresolvedBlockerIssueIds ?? [],
+          pendingInteractionCount: pending.length,
+          pendingInteractions: pending.map((interaction) => ({
+            id: interaction.id,
+            kind: interaction.kind,
+            title: interaction.title,
+            summary: interaction.summary,
+            createdAt: interaction.createdAt,
+            createdByAgentId: interaction.createdByAgentId,
+            createdByUserId: interaction.createdByUserId,
+          })),
+        };
+      }),
     );
   });
 

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1,5 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   documents,
@@ -621,6 +621,66 @@ export function issueThreadInteractionService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       return row ? hydrateInteraction(row) : null;
+    },
+
+    listPendingForIssues: async (
+      companyId: string,
+      issueIds: string[],
+    ): Promise<Map<string, Array<{
+      id: string;
+      kind: string;
+      title: string | null;
+      summary: string | null;
+      createdAt: Date;
+      createdByAgentId: string | null;
+      createdByUserId: string | null;
+    }>>> => {
+      const result = new Map<string, Array<{
+        id: string;
+        kind: string;
+        title: string | null;
+        summary: string | null;
+        createdAt: Date;
+        createdByAgentId: string | null;
+        createdByUserId: string | null;
+      }>>();
+      if (issueIds.length === 0) return result;
+
+      const rows = await db
+        .select({
+          id: issueThreadInteractions.id,
+          issueId: issueThreadInteractions.issueId,
+          kind: issueThreadInteractions.kind,
+          title: issueThreadInteractions.title,
+          summary: issueThreadInteractions.summary,
+          createdAt: issueThreadInteractions.createdAt,
+          createdByAgentId: issueThreadInteractions.createdByAgentId,
+          createdByUserId: issueThreadInteractions.createdByUserId,
+        })
+        .from(issueThreadInteractions)
+        .where(
+          and(
+            eq(issueThreadInteractions.companyId, companyId),
+            inArray(issueThreadInteractions.issueId, issueIds),
+            eq(issueThreadInteractions.status, "pending"),
+          ),
+        )
+        .orderBy(desc(issueThreadInteractions.createdAt), desc(issueThreadInteractions.id));
+
+      for (const row of rows) {
+        const list = result.get(row.issueId) ?? [];
+        list.push({
+          id: row.id,
+          kind: row.kind,
+          title: row.title ?? null,
+          summary: row.summary ?? null,
+          createdAt: row.createdAt,
+          createdByAgentId: row.createdByAgentId ?? null,
+          createdByUserId: row.createdByUserId ?? null,
+        });
+        result.set(row.issueId, list);
+      }
+      return result;
     },
 
     create: async (

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -40,7 +40,7 @@ Follow these steps every time you wake up:
   - add a markdown comment explaining why it remains open and what happens next.
     Always include links to the approval and issue in that comment.
 
-**Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,in_review,blocked` only when you need the full issue objects.
+**Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization, including a `pendingInteractions` array per issue (`request_confirmation` / `suggest_tasks` / `ask_user_questions` awaiting your action). Use that field to spot manager bottlenecks without scanning each thread. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,in_review,blocked` only when you need the full issue objects.
 
 **Step 4 — Pick work.** Priority: `in_progress` → `in_review` (if woken by a comment on it — check `PAPERCLIP_WAKE_COMMENT_ID`) → `todo`. Skip `blocked` unless you can unblock.
 


### PR DESCRIPTION
## Summary

Adds a compact `pendingInteractions` array (and `pendingInteractionCount`) per issue in the `GET /api/agents/me/inbox-lite` response. The new field lists `request_confirmation`, `suggest_tasks`, and `ask_user_questions` interactions in status `pending` on each issue the agent owns, so manager bottlenecks are visible directly from the heartbeat inbox without requiring a productivity-review issue.

This is the deferred Fix #3 from MAT-618 / MAT-620.

## Why

Fixes #1 + #2 (MAT-620) stop the productivity-review re-fire loop at the source. Fix #3 is a smaller visibility win: when an issue sits in \`in_progress\` / \`in_review\` / \`blocked\` because a manager has not yet answered a pending interaction, the manager's heartbeat inbox now surfaces it explicitly instead of forcing the manager to open each thread.

## Approach

- New service method `issueThreadInteractionService.listPendingForIssues(companyId, issueIds)` returning `Map<issueId, Array<{ id, kind, title, summary, createdAt, createdByAgentId, createdByUserId }>>`. One grouped query against the existing `issue_thread_interactions_company_issue_status_idx` index — no new indexes, no per-row queries.
- `inbox-lite` route runs the dependency-readiness query and the new pending-interactions query in `Promise.all`, then attaches `pendingInteractionCount` and `pendingInteractions` to each row of the existing payload.
- Field shape kept compact (id / kind / title / summary / createdAt / createdBy*) so hot-path response size stays small. Most issues will have zero pending interactions and the array will simply be empty.

## Tests

- `server/src/__tests__/issue-thread-interactions-service.test.ts` — added \`listPendingForIssues\` integration test against embedded Postgres covering: grouping per issue, ordering by createdAt desc, exclusion of resolved interactions, empty input.
- `server/src/__tests__/agent-inbox-lite-routes.test.ts` (new) — route-level test verifying the wiring and that an empty Map produces \`pendingInteractionCount: 0\`.

\`pnpm --filter @paperclipai/server typecheck\` and the new test files both pass locally.

## Refs

- Source defect: [MAT-618](https://example/MAT-618)
- Companion runtime fixes (Fix #1 + #2): MAT-620 / MAT-622 / MAT-623
- This PR closes: MAT-624

## Test plan

- [ ] Hit `/api/agents/me/inbox-lite` as a manager agent with at least one pending `request_confirmation` on an owned issue, confirm `pendingInteractions[0].kind === "request_confirmation"`.
- [ ] Resolve the interaction (accept/reject/answer), re-fetch, confirm it disappears from the array and count drops to 0.
- [ ] Confirm no measurable regression in inbox-lite latency on a company with many issues (single grouped query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)