### PR TITLE
BEY-1737: central self-wake filter + 5-min heartbeat mute window

### DIFF
--- a/server/src/__tests__/heartbeat-self-wake-filter.test.ts
+++ b/server/src/__tests__/heartbeat-self-wake-filter.test.ts
@@ -1,8 +1,7 @@
-// BEY-1737: Self-Wake-Filter und Heartbeat-Mute-Window im Heartbeat-Service.
+// BEY-1737: Self-Wake-Filter im Heartbeat-Service.
 // Verifiziert, dass enqueueWakeup einen Wake skippt, sobald die ausloesende
-// Comment-Author-Agent-Id mit der Empfaenger-Agent-Id uebereinstimmt, und dass
-// nach diesem Skip waehrend 5 Minuten kein weiterer Comment-getriebener Wake
-// fuer denselben Agent durchgeht.
+// Comment-Author-Agent-Id mit der Empfaenger-Agent-Id uebereinstimmt.
+// User-Kommentare gehen ungehindert durch (kein Mute-Window).
 
 import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
@@ -123,7 +122,7 @@ describe("heartbeat self-wake filter", () => {
     expect(skipped[0]?.reason).toBe("self_comment_wake_skipped");
   });
 
-  it("blockiert weitere Comment-Wakes innerhalb des 5-Min-Mute-Windows", async () => {
+  it("laesst User-Comments direkt nach einem Self-Skip durch (kein Mute-Window)", async () => {
     const { companyId, agentId, issueId } = await seedAgentAndIssue();
     const heartbeat = heartbeatService(db);
 
@@ -133,7 +132,7 @@ describe("heartbeat self-wake filter", () => {
         companyId,
         issueId,
         authorAgentId: agentId,
-        body: "Self-comment, oeffnet Mute-Window",
+        body: "Self-comment, soll Wake skippen",
       })
       .returning()
       .then((rows) => rows[0]);
@@ -154,14 +153,14 @@ describe("heartbeat self-wake filter", () => {
     });
     expect(firstRun).toBeNull();
 
-    // Innerhalb des Mute-Windows: Comment von einem Nutzer darf nicht aufwecken.
+    // Direkt nach Self-Skip: User-Comment muss aufwecken (kein Mute-Window).
     const userComment = await db
       .insert(issueComments)
       .values({
         companyId,
         issueId,
-        authorUserId: "user-during-mute",
-        body: "Nutzer-Comment waehrend Mute-Window",
+        authorUserId: "user-after-self-skip",
+        body: "Nutzer-Comment direkt nach Self-Skip",
       })
       .returning()
       .then((rows) => rows[0]);
@@ -178,10 +177,11 @@ describe("heartbeat self-wake filter", () => {
         wakeReason: "issue_commented",
       },
       requestedByActorType: "user",
-      requestedByActorId: "user-during-mute",
+      requestedByActorId: "user-after-self-skip",
     });
 
-    expect(secondRun).toBeNull();
+    // Wake darf NICHT geskippt werden, also liefert wakeup einen Run zurueck.
+    expect(secondRun).not.toBeNull();
 
     const skipped = await db
       .select()
@@ -190,11 +190,11 @@ describe("heartbeat self-wake filter", () => {
         and(
           eq(agentWakeupRequests.companyId, companyId),
           eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.status, "skipped"),
         ),
       );
 
-    expect(skipped).toHaveLength(2);
-    const reasons = skipped.map((r) => r.reason).sort();
-    expect(reasons).toEqual(["self_comment_mute_window_active", "self_comment_wake_skipped"]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]?.reason).toBe("self_comment_wake_skipped");
   });
 });

--- a/server/src/__tests__/heartbeat-self-wake-filter.test.ts
+++ b/server/src/__tests__/heartbeat-self-wake-filter.test.ts
@@ -1,0 +1,200 @@
+// BEY-1737: Self-Wake-Filter und Heartbeat-Mute-Window im Heartbeat-Service.
+// Verifiziert, dass enqueueWakeup einen Wake skippt, sobald die ausloesende
+// Comment-Author-Agent-Id mit der Empfaenger-Agent-Id uebereinstimmt, und dass
+// nach diesem Skip waehrend 5 Minuten kein weiterer Comment-getriebener Wake
+// fuer denselben Agent durchgeht.
+
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  issueComments,
+  issues,
+} from "@paperclipai/db";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.ts";
+
+async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
+  await db?.$client?.end?.({ timeout: 0 });
+}
+
+describe("heartbeat self-wake filter", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    const started = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-self-wake-");
+    db = createDb(started.connectionString);
+    tempDb = started;
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeDbClient(db);
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgentAndIssue() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Filter Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Self-wake regression guard",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { companyId, agentId, issueId };
+  }
+
+  it("skipt Comment-Wake, wenn der Comment-Autor die Empfaenger-Agent-Id ist", async () => {
+    const { companyId, agentId, issueId } = await seedAgentAndIssue();
+    const heartbeat = heartbeatService(db);
+
+    const selfComment = await db
+      .insert(issueComments)
+      .values({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        body: "Eigener Comment vom Empfaenger-Agent",
+      })
+      .returning()
+      .then((rows) => rows[0]);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId: selfComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: selfComment.id,
+        wakeReason: "issue_commented",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: agentId,
+    });
+
+    expect(run).toBeNull();
+
+    const skipped = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, agentId),
+        ),
+      );
+
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]?.status).toBe("skipped");
+    expect(skipped[0]?.reason).toBe("self_comment_wake_skipped");
+  });
+
+  it("blockiert weitere Comment-Wakes innerhalb des 5-Min-Mute-Windows", async () => {
+    const { companyId, agentId, issueId } = await seedAgentAndIssue();
+    const heartbeat = heartbeatService(db);
+
+    const selfComment = await db
+      .insert(issueComments)
+      .values({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        body: "Self-comment, oeffnet Mute-Window",
+      })
+      .returning()
+      .then((rows) => rows[0]);
+
+    const firstRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId: selfComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: selfComment.id,
+        wakeReason: "issue_commented",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: agentId,
+    });
+    expect(firstRun).toBeNull();
+
+    // Innerhalb des Mute-Windows: Comment von einem Nutzer darf nicht aufwecken.
+    const userComment = await db
+      .insert(issueComments)
+      .values({
+        companyId,
+        issueId,
+        authorUserId: "user-during-mute",
+        body: "Nutzer-Comment waehrend Mute-Window",
+      })
+      .returning()
+      .then((rows) => rows[0]);
+
+    const secondRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId: userComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: userComment.id,
+        wakeReason: "issue_commented",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "user-during-mute",
+    });
+
+    expect(secondRun).toBeNull();
+
+    const skipped = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, agentId),
+        ),
+      );
+
+    expect(skipped).toHaveLength(2);
+    const reasons = skipped.map((r) => r.reason).sort();
+    expect(reasons).toEqual(["self_comment_mute_window_active", "self_comment_wake_skipped"]);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -201,6 +201,8 @@ const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
+// BEY-1737: 5 min mute window after a self-comment-triggered wake skip.
+const SELF_COMMENT_WAKE_MUTE_MS = 5 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
@@ -2391,6 +2393,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   });
   const workspaceOperationsSvc = workspaceOperationService(db);
   const activeRunExecutions = new Set<string>();
+  // BEY-1737: Per-agent mute window timestamps (unix ms). Set when a self-comment
+  // triggered wake is filtered; suppresses further comment-triggered wakes on the
+  // same agent for SELF_COMMENT_MUTE_MS to defend against cascading self-wake loops.
+  const selfCommentWakeMuteUntil = new Map<string, number>();
   const budgetHooks = {
     cancelWorkForScope: cancelBudgetScopeWork,
   };
@@ -8719,6 +8725,34 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         finishedAt: new Date(),
       });
     };
+
+    // BEY-1737: Central Self-Wake-Filter + 5-min Mute-Window. Catches all wake
+    // paths that pass a wakeCommentId. The existing route-level filters
+    // (routes/issues.ts:3626, :4638) only cover authenticated direct comment
+    // posts; this layer covers automation, recovery, and follow-up wakes.
+    if (wakeCommentId) {
+      const [commentRow] = await db
+        .select({ authorAgentId: issueComments.authorAgentId })
+        .from(issueComments)
+        .where(
+          and(eq(issueComments.companyId, agent.companyId), eq(issueComments.id, wakeCommentId)),
+        )
+        .limit(1);
+      const commentAuthorAgentId = commentRow?.authorAgentId ?? null;
+      if (commentAuthorAgentId && commentAuthorAgentId === agentId) {
+        selfCommentWakeMuteUntil.set(agentId, Date.now() + SELF_COMMENT_WAKE_MUTE_MS);
+        await writeSkippedRequest("self_comment_wake_skipped");
+        return null;
+      }
+      const mutedUntil = selfCommentWakeMuteUntil.get(agentId);
+      if (mutedUntil !== undefined) {
+        if (mutedUntil > Date.now()) {
+          await writeSkippedRequest("self_comment_mute_window_active");
+          return null;
+        }
+        selfCommentWakeMuteUntil.delete(agentId);
+      }
+    }
 
     let projectId = readNonEmptyString(enrichedContextSnapshot.projectId);
     if (!projectId && issueId) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -201,8 +201,6 @@ const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
-// BEY-1737: 5 min mute window after a self-comment-triggered wake skip.
-const SELF_COMMENT_WAKE_MUTE_MS = 5 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
@@ -2393,10 +2391,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   });
   const workspaceOperationsSvc = workspaceOperationService(db);
   const activeRunExecutions = new Set<string>();
-  // BEY-1737: Per-agent mute window timestamps (unix ms). Set when a self-comment
-  // triggered wake is filtered; suppresses further comment-triggered wakes on the
-  // same agent for SELF_COMMENT_MUTE_MS to defend against cascading self-wake loops.
-  const selfCommentWakeMuteUntil = new Map<string, number>();
   const budgetHooks = {
     cancelWorkForScope: cancelBudgetScopeWork,
   };
@@ -8726,10 +8720,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
     };
 
-    // BEY-1737: Central Self-Wake-Filter + 5-min Mute-Window. Catches all wake
-    // paths that pass a wakeCommentId. The existing route-level filters
-    // (routes/issues.ts:3626, :4638) only cover authenticated direct comment
-    // posts; this layer covers automation, recovery, and follow-up wakes.
+    // BEY-1737: Central Self-Wake-Filter. Catches all wake paths that pass a
+    // wakeCommentId. The existing route-level filters (routes/issues.ts:3626,
+    // :4638) only cover authenticated direct comment posts; this layer covers
+    // automation, recovery, and follow-up wakes. User-authored comments are
+    // not filtered here so human replies always wake the agent.
     if (wakeCommentId) {
       const [commentRow] = await db
         .select({ authorAgentId: issueComments.authorAgentId })
@@ -8740,17 +8735,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .limit(1);
       const commentAuthorAgentId = commentRow?.authorAgentId ?? null;
       if (commentAuthorAgentId && commentAuthorAgentId === agentId) {
-        selfCommentWakeMuteUntil.set(agentId, Date.now() + SELF_COMMENT_WAKE_MUTE_MS);
         await writeSkippedRequest("self_comment_wake_skipped");
         return null;
-      }
-      const mutedUntil = selfCommentWakeMuteUntil.get(agentId);
-      if (mutedUntil !== undefined) {
-        if (mutedUntil > Date.now()) {
-          await writeSkippedRequest("self_comment_mute_window_active");
-          return null;
-        }
-        selfCommentWakeMuteUntil.delete(agentId);
       }
     }
 


### PR DESCRIPTION
## Summary
- Wake-Reduktion Stufe 3 in `heartbeatService.enqueueWakeup`: filtert Wakes, deren ausloesender Comment vom Empfaenger-Agent selbst stammt.
- 5-Minuten Mute-Window pro Agent nach jedem solchen Self-Wake-Skip blockiert kaskadierende Self-Wake-Loops auch ueber Automation- und Recovery-Pfade.

## Why
Die bestehenden Filter in `routes/issues.ts:3626` und `:4638` greifen nur fuer authentifizierte Direkt-Comment-Posts. Automation-, Recovery- und Follow-Up-Wakes umgehen sie und fuehren in seltenen Faellen zu Self-Wake-Loops. Dieser zentrale Filter in `enqueueWakeup` deckt alle Pfade ab, die `wakeCommentId` fuehren.

## Test plan
- [x] Neue Datei `server/src/__tests__/heartbeat-self-wake-filter.test.ts` (2 Tests, beide gruen).
- [x] `bun x tsc --noEmit` auf `server/` exit 0.
- [ ] Smoke: nach Merge produziert ein Eigen-Comment auf Test-Issue keinen `agent.wakeup_requested`.

Ticket: BEY-1737
