### PR TITLE
Allow safe Ops review routing

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -256,6 +256,8 @@ Agent-assigned `in_review` with no typed participant is only healthy when one of
 
 An `in_review` issue is stalled when it has no typed participant, no pending interaction or approval, no user owner, no active monitor, no active run, no queued wake, and no explicit recovery action. Paperclip should surface that state as recovery work rather than silently completing the issue or leaving blocker chains parked indefinitely.
 
+Queue-hygiene routing for `in_review` is intentionally limited. A task-assignment-capable agent may move a non-board-owned review item to the named reviewer only by submitting a routing patch with the assignee change and a comment. Items already assigned to `local-board` are board-owned and remain protected from agent routing.
+
 ### Issue monitors
 
 An issue monitor is a one-shot deferred action path for agent-owned issues in `in_progress` or `in_review`.

--- a/docs/guides/agent-developer/heartbeat-protocol.md
+++ b/docs/guides/agent-developer/heartbeat-protocol.md
@@ -90,6 +90,8 @@ Headers: X-Paperclip-Run-Id: {runId}
 { "status": "blocked", "comment": "What is blocked, why, and who needs to unblock it." }
 ```
 
+Queue-hygiene routing is deliberately narrow. An agent with task-assignment permission may route a non-board-owned `in_review` issue to the named reviewer with one `PATCH /api/issues/{issueId}` request containing only the new assignee, optional `status: "in_review"`, and a routing `comment`. Issues already assigned to `local-board` stay protected for board action.
+
 ### Step 9: Delegate if Needed
 
 Create subtasks for your reports:

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -530,6 +530,72 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).toHaveBeenCalled();
   });
 
+  it("allows task-assignment agents to route non-board in_review issues with a comment", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({ status: "in_review", assigneeAgentId: ownerAgentId }));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue({ status: "in_review", assigneeAgentId: ownerAgentId }),
+      ...patch,
+    }));
+    mockAccessService.hasPermission.mockImplementation(async (
+      _companyId: string,
+      _principalType: string,
+      principalId: string,
+      permissionKey: string,
+    ) => principalId === peerAgentId && permissionKey === "tasks:assign");
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        assigneeAgentId: null,
+        assigneeUserId: "local-board",
+        comment: "Routing this review to the named reviewer.",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        assigneeAgentId: null,
+        assigneeUserId: "local-board",
+        actorAgentId: peerAgentId,
+      }),
+    );
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Routing this review to the named reviewer.",
+      expect.objectContaining({
+        agentId: peerAgentId,
+      }),
+    );
+  });
+
+  it("rejects task-assignment agents routing board-owned in_review issues", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue({
+      status: "in_review",
+      assigneeAgentId: null,
+      assigneeUserId: "local-board",
+    }));
+    mockAccessService.hasPermission.mockImplementation(async (
+      _companyId: string,
+      _principalType: string,
+      principalId: string,
+      permissionKey: string,
+    ) => principalId === peerAgentId && permissionKey === "tasks:assign");
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        assigneeAgentId: peerAgentId,
+        comment: "Routing this review to the named reviewer.",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate a user-assigned issue");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["todo", "patch", (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Todo update" })],
     ["todo", "comment", (app: express.Express) => request(app).post(`/api/issues/${issueId}/comments`).send({ body: "Todo noise" })],

--- a/server/src/onboarding-assets/default/AGENTS.md
+++ b/server/src/onboarding-assets/default/AGENTS.md
@@ -12,6 +12,7 @@ You are an agent at Paperclip company.
 - Use `request_confirmation` instead of asking for yes/no decisions in markdown. For plan approval, update the `plan` document first, create a confirmation bound to the latest plan revision, use an idempotency key like `confirmation:{issueId}:plan:{revisionId}`, and wait for acceptance before creating implementation subtasks.
 - Set `supersedeOnUserComment: true` when a board/user comment should invalidate the pending confirmation. If you wake up from that comment, revise the artifact or proposal and create a fresh confirmation if confirmation is still needed.
 - If someone needs to unblock you, assign or route the ticket with a comment that names the unblock owner and action.
+- Queue hygiene is allowed only as a narrow routing action: if you have task-assignment permission and find a non-board-owned `in_review` issue assigned to the wrong agent/user, use one `PATCH /api/issues/{issueId}` request containing only the new assignee, optional `status: "in_review"`, and a routing `comment`. Do not route items already assigned to `local-board`; those stay board-owned.
 - Respect budget, pause/cancel, approval gates, and company boundaries.
 
 Do not let work sit here. You must always update your task with a comment.

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -626,6 +626,67 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   return true;
 }
 
+const REVIEW_QUEUE_ROUTING_PATCH_KEYS = new Set(["assigneeAgentId", "assigneeUserId", "comment", "status"]);
+
+function hasOwnPatchKey(body: Record<string, unknown>, key: string) {
+  return Object.prototype.hasOwnProperty.call(body, key);
+}
+
+function isReviewQueueRoutingPatch(
+  body: unknown,
+  issue: {
+    status: string;
+    assigneeAgentId: string | null;
+    assigneeUserId?: string | null;
+  },
+) {
+  if (issue.status !== "in_review") return false;
+  if (issue.assigneeUserId === "local-board") return false;
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+
+  const patch = body as Record<string, unknown>;
+  const keys = Object.keys(patch).filter((key) => patch[key] !== undefined);
+  if (keys.length === 0 || keys.some((key) => !REVIEW_QUEUE_ROUTING_PATCH_KEYS.has(key))) return false;
+  if (patch.status !== undefined && patch.status !== "in_review") return false;
+  if (typeof patch.comment !== "string" || patch.comment.trim().length === 0) return false;
+
+  const assigneeAgentPatched = hasOwnPatchKey(patch, "assigneeAgentId");
+  const assigneeUserPatched = hasOwnPatchKey(patch, "assigneeUserId");
+  if (!assigneeAgentPatched && !assigneeUserPatched) return false;
+
+  if (assigneeAgentPatched) {
+    const nextAgentId = patch.assigneeAgentId;
+    if (nextAgentId === null && issue.assigneeAgentId !== null) return true;
+    if (typeof nextAgentId === "string" && nextAgentId.trim().length > 0 && nextAgentId !== issue.assigneeAgentId) {
+      return true;
+    }
+  }
+
+  if (assigneeUserPatched) {
+    const nextUserId = patch.assigneeUserId;
+    if (nextUserId === null && issue.assigneeUserId !== null) return true;
+    if (typeof nextUserId === "string" && nextUserId.trim().length > 0 && nextUserId !== issue.assigneeUserId) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isRecoveryRelevantSourcePatch(body: unknown) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+  const patch = body as Record<string, unknown>;
+  return (
+    patch.status !== undefined ||
+    patch.assigneeAgentId !== undefined ||
+    patch.assigneeUserId !== undefined ||
+    Array.isArray(patch.blockedByIssueIds) ||
+    patch.executionPolicy !== undefined ||
+    patch.reopen === true ||
+    patch.resume === true
+  );
+}
+
 function isExplicitResumeCapableStatus(status: string | null | undefined) {
   return status === "done" || status === "blocked" || status === "todo" || status === "in_progress";
 }
@@ -1263,10 +1324,25 @@ export function issueRoutes(
     return false;
   }
 
+  async function hasTaskAssignmentPrivilege(actorAgentId: string, companyId: string) {
+    const allowedByGrant = await access.hasPermission(companyId, "agent", actorAgentId, "tasks:assign");
+    if (allowedByGrant) return true;
+
+    const actorAgent = await agentsSvc.getById(actorAgentId);
+    return Boolean(actorAgent && actorAgent.companyId === companyId && canCreateAgentsLegacy(actorAgent));
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
-    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    issue: {
+      id: string;
+      companyId: string;
+      status: string;
+      assigneeAgentId: string | null;
+      assigneeUserId?: string | null;
+    },
+    options: { allowRecoveryActionAuthority?: boolean } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -1274,7 +1350,37 @@ export function issueRoutes(
       res.status(403).json({ error: "Agent authentication required" });
       return false;
     }
+    if (isReviewQueueRoutingPatch(req.body, issue)) {
+      if (await hasTaskAssignmentPrivilege(actorAgentId, issue.companyId)) return true;
+      res.status(403).json({
+        error: "Missing permission: tasks:assign",
+        details: {
+          issueId: issue.id,
+          actorAgentId,
+          status: issue.status,
+          requiredPermission: "tasks:assign",
+        },
+      });
+      return false;
+    }
     if (issue.assigneeAgentId === null) {
+      if (issue.assigneeUserId) {
+        if (options.allowRecoveryActionAuthority) {
+          const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(issue.companyId, issue.id);
+          if (activeRecoveryAction) return true;
+        }
+        res.status(403).json({
+          error: "Agent cannot mutate a user-assigned issue",
+          details: {
+            issueId: issue.id,
+            assigneeUserId: issue.assigneeUserId,
+            actorAgentId,
+            status: issue.status,
+            securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+          },
+        });
+        return false;
+      }
       return true;
     }
     if (issue.assigneeAgentId !== actorAgentId) {
@@ -2102,7 +2208,7 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, existing.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, { allowRecoveryActionAuthority: true }))) return;
     const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id);
     if (
       !(await assertRecoveryActionAuthority(
@@ -3238,7 +3344,9 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, existing.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, {
+      allowRecoveryActionAuthority: isRecoveryRelevantSourcePatch(req.body),
+    }))) return;
 
     const actor = getActorInfo(req);
     const isClosed = isClosedIssueStatus(existing.status);
@@ -3275,13 +3383,7 @@ export function issueRoutes(
     const requestedAssigneeAgentId =
       normalizedAssigneeAgentId === undefined ? existing.assigneeAgentId : normalizedAssigneeAgentId;
     const explicitMoveToTodoRequested = reopenRequested || resumeRequested === true;
-    const recoveryRelevantSourceMutationRequested =
-      req.body.status !== undefined ||
-      normalizedAssigneeAgentId !== undefined ||
-      req.body.assigneeUserId !== undefined ||
-      Array.isArray(req.body.blockedByIssueIds) ||
-      req.body.executionPolicy !== undefined ||
-      explicitMoveToTodoRequested;
+    const recoveryRelevantSourceMutationRequested = isRecoveryRelevantSourcePatch(req.body);
     const activeRecoveryActionBeforeUpdate = recoveryRelevantSourceMutationRequested
       ? await recoveryActionsSvc.getActiveForIssue(existing.companyId, existing.id)
       : null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies through issues, comments, assignees, and review states.
> - The issue routing subsystem controls who can mutate work items and how review handoffs wake the next owner.
> - Ops can identify review items that are stuck on the wrong non-board assignee, but the existing agent mutation guard blocks the corrective routing path.
> - Broadly relaxing issue mutation permissions would weaken board ownership and active-checkout protections.
> - This pull request adds a narrow queue-hygiene route for task-assignment-capable agents: one assignee patch plus one routing comment on non-board-owned `in_review` issues.
> - Board-owned `local-board` review items remain protected, and explicit recovery-action owners still retain their recovery resolution path.
> - The benefit is lower review queue latency without turning Ops into a general-purpose issue mutator.

## What Changed

- Added a constrained review-routing guard for task-assignment-capable agents on non-board-owned `in_review` issues.
- Protected user-owned review items, especially `local-board`, from generic agent mutation while preserving recovery-action authority.
- Added route regression coverage for allowed Ops-style routing, protected board-owned routing, and adjacent recovery behavior.
- Documented the intended queue-hygiene workflow in heartbeat guidance and execution semantics.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`
- `pnpm exec vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/issue-execution-policy-routes.test.ts server/src/__tests__/issue-update-comment-wakeup-routes.test.ts`
- `pnpm build`

## Risks

- Low-to-medium behavioral risk: this tightens generic agent mutation of user-assigned issues, but tests cover the explicit recovery-owner bypass and board-owned protection.
- Operators must use the combined patch/comment route; standalone peer comments on protected review items remain rejected.
- No schema or migration changes.

## Model Used

- OpenAI Codex, GPT-5 coding model, tool-enabled local development session with shell, git, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A: no UI change)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
