### PR TITLE
fix(claude-local): remove exit-code gate blocking fresh-session retry on code-0 errors

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -943,10 +943,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   try {
     const initial = await runAttempt(sessionId ?? null);
+    // Retry with a fresh session on unknown-session / invalid-previous_message_id errors.
+    // The exit-code check is intentionally omitted: when context compaction passes an ID
+    // that doesn't start with "msg_", the Claude CLI exits with code 0 (it successfully
+    // reported the 400 response) but is_error:true appears in the parsed stream.
+    // Gating on exitCode != 0 caused all such runs to stall instead of falling back.
     if (
       sessionId &&
       !initial.proc.timedOut &&
-      (initial.proc.exitCode ?? 0) !== 0 &&
       initial.parsed &&
       isClaudeUnknownSessionError(initial.parsed)
     ) {


### PR DESCRIPTION
## Problem

When context compaction passes an invalid `previous_message_id` to the Claude API, the API returns a 400 but the Claude CLI exits with code 0 (it successfully reported the error). The old session-retry guard:

```ts
if (
  sessionId &&
  !initial.proc.timedOut &&
  (initial.proc.exitCode ?? 0) !== 0 &&   // ← WRONG: blocks retry when exitCode is 0
  initial.parsed &&
  isClaudeUnknownSessionError(initial.parsed)
)
```

evaluated `false` because `exitCode === 0`, so the fresh-session fallback never fired. This caused every such run to stall with an unrecoverable session error.

## Fix

Remove the `(initial.proc.exitCode ?? 0) !== 0 &&` guard. `isClaudeUnknownSessionError()` inspects the parsed result JSON directly; the exit-code pre-check was redundant and wrong for the case where the CLI exits 0 after reporting the API error.

A comment block is added to explain the invariant so this does not regress.

## Context

- Observed in the May 14–15 run failure spike (TDA-5239)
- Hotfix was applied to the running compiled JS on May 16
- This PR fixes the upstream TypeScript source to prevent regression on adapter reinstall/update