### PR TITLE
fix(productivity-review): exempt long_active_duration for blocked/interaction-aware issues

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -8,6 +8,8 @@ import {
   createDb,
   heartbeatRuns,
   issueComments,
+  issueRelations,
+  issueThreadInteractions,
   issues,
 } from "@paperclipai/db";
 import {
@@ -51,7 +53,7 @@ describeEmbeddedPostgres("productivity review service", () => {
   });
 
   async function seedAssignedIssue(opts?: {
-    status?: "todo" | "in_progress";
+    status?: "todo" | "in_progress" | "blocked";
     startedAt?: Date;
     parentId?: string | null;
     originKind?: string;
@@ -111,6 +113,42 @@ describeEmbeddedPostgres("productivity review service", () => {
     });
 
     return { companyId, managerId, coderId, issueId, issuePrefix, createdAt };
+  }
+
+  async function addUnresolvedBlocker(
+    seeded: { companyId: string; issueId: string; issuePrefix: string },
+    opts?: { status?: "todo" | "in_progress" | "blocked" | "done" },
+  ) {
+    const blockerId = randomUUID();
+    await db.insert(issues).values({
+      id: blockerId,
+      companyId: seeded.companyId,
+      title: "Upstream blocker",
+      status: opts?.status ?? "in_progress",
+      priority: "medium",
+      issueNumber: 900,
+      identifier: `${seeded.issuePrefix}-900`,
+    });
+    await db.insert(issueRelations).values({
+      companyId: seeded.companyId,
+      issueId: blockerId,
+      relatedIssueId: seeded.issueId,
+      type: "blocks",
+    });
+    return blockerId;
+  }
+
+  async function addPendingConfirmation(seeded: { companyId: string; issueId: string }) {
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      payload: { version: 1, prompt: "Confirm before proceeding" },
+    });
+    return interactionId;
   }
 
   async function insertRuns(input: {
@@ -358,6 +396,116 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(review?.description).toContain("Primary trigger: `long_active_duration`");
     expect(review?.priority).toBe("medium");
     expect(hold.held).toBe(false);
+  });
+
+  it("exempts long_active_duration while the source issue has an unresolved first-class blocker", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+    await addUnresolvedBlocker(seeded);
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("exempts long_active_duration while a pending request_confirmation interaction is open", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+    const interactionId = await addPendingConfirmation(seeded);
+    const service = productivityReviewService(db);
+
+    const exempt = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    expect(exempt.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+
+    // Exemption is keyed on `pending` specifically — once resolved the clock runs.
+    await db
+      .update(issueThreadInteractions)
+      .set({ status: "accepted" })
+      .where(eq(issueThreadInteractions.id, interactionId));
+    const resumed = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    expect(resumed.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
+  });
+
+  it("still fires long_active_duration for a bare blocked issue with no blocker or interaction", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "blocked",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
+  });
+
+  it("leaves no_comment_streak unaffected when the long_active_duration exemption applies", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+    await addUnresolvedBlocker(seeded);
+    await addPendingConfirmation(seeded);
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `no_comment_streak`");
+  });
+
+  it("leaves high_churn unaffected when the long_active_duration exemption applies", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+    await addUnresolvedBlocker(seeded);
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 10,
+      now,
+      withRunComments: true,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `high_churn`");
   });
 
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -7,6 +7,7 @@ import {
   costEvents,
   heartbeatRuns,
   issueComments,
+  issueThreadInteractions,
   issues,
   projects,
 } from "@paperclipai/db";
@@ -471,12 +472,39 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       ACTIVE_RUN_STATUSES.includes(run.status as (typeof ACTIVE_RUN_STATUSES)[number]),
     ).length;
     const activeStartedAt = sourceIssue.startedAt ?? sourceIssue.executionLockedAt ?? null;
-    const elapsedMs = sourceIssue.status === "in_progress" && activeStartedAt
+    // Active episode also runs for `blocked` issues so a bare `blocked` status
+    // (no first-class blocker, no pending request_confirmation) cannot escape the
+    // long_active_duration detector entirely.
+    const elapsedMs = (sourceIssue.status === "in_progress" || sourceIssue.status === "blocked") && activeStartedAt
       ? Math.max(0, now.getTime() - activeStartedAt.getTime())
       : null;
 
+    // long_active_duration is exempt while the issue has a legitimate reason to
+    // wait: one or more unresolved first-class blockers, or a pending
+    // request_confirmation interaction on the thread. Scoped to
+    // long_active_duration ONLY — noComment and highChurn still evaluate
+    // (CEO guardrail). It is NOT keyed on status === 'blocked'.
+    const [dependencyReadiness, hasPendingConfirmation] = await Promise.all([
+      issuesSvc.getDependencyReadiness(sourceIssue.id),
+      db
+        .select({ id: issueThreadInteractions.id })
+        .from(issueThreadInteractions)
+        .where(
+          and(
+            eq(issueThreadInteractions.companyId, sourceIssue.companyId),
+            eq(issueThreadInteractions.issueId, sourceIssue.id),
+            eq(issueThreadInteractions.kind, "request_confirmation"),
+            eq(issueThreadInteractions.status, "pending"),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows.length > 0),
+    ]);
+    const longActiveExempt = dependencyReadiness.unresolvedBlockerCount > 0 || hasPendingConfirmation;
+
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    const longActive =
+      !longActiveExempt && elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||
@@ -773,7 +801,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           opts?.companyId ? eq(issues.companyId, opts.companyId) : undefined,
           isNull(issues.hiddenAt),
           isNull(issues.assigneeUserId),
-          inArray(issues.status, ["todo", "in_progress"]),
+          // `blocked` included so a `blocked` issue still runs through the
+          // detector — exemption is decided per-issue in collectEvidence, not by
+          // status. A bare `blocked` with no blocker/interaction is not exempt.
+          inArray(issues.status, ["todo", "in_progress", "blocked"]),
           sql`${issues.assigneeAgentId} is not null`,
           sql`${issues.originKind} <> ${PRODUCTIVITY_REVIEW_ORIGIN_KIND}`,
         ),


### PR DESCRIPTION
## Summary

Fixes MAT-622 (child of MAT-620; CEO-approved runtime fix MAT-618 #1).

The `long_active_duration` productivity trigger was firing on issues that were legitimately waiting on unresolved blockers or pending board/user confirmations, producing spammy productivity reviews and forcing agents to re-acknowledge work they could not advance.

This PR:

1. **Exempts `long_active_duration`** when the source issue has either:
   - one or more unresolved first-class blockers (`blockedByIssueIds`), OR
   - a `pending` `request_confirmation` interaction on its thread.
2. **Leaves `no_comment_streak` and `high_churn` untouched** (CEO guardrail).
3. **Guardrail — candidate scan:** extends the productivity scan to also include `status = 'blocked'` (alongside `todo`, `in_progress`) and computes `elapsedMs` for `blocked` issues. Rationale: a bare `blocked` status with no blocker/interaction must not be a free pass to dodge oversight. With this change:
   - bare `blocked` (no blocker, no interaction) → not exempt → clock runs → still trips `long_active_duration`.
   - `blocked` WITH a real blocker/interaction → exempt.

## Files

- `server/src/services/productivity-review.ts`
- `server/src/__tests__/productivity-review-service.test.ts` (+5 tests covering all 4 acceptance cases)

## Test plan

- [x] `pnpm --filter @paperclipai/server test productivity-review-service` → 16/16 pass
- [x] `pnpm --filter @paperclipai/server exec tsc --noEmit` → exit 0
- [ ] CI green on this PR

## Acceptance (from MAT-622)

- [x] Issue with ≥1 unresolved first-class blocker → `long_active_duration` does not fire regardless of elapsed time.
- [x] Issue with a pending `request_confirmation` interaction → same.
- [x] Bare `blocked` issue (no blocker, no interaction) → `long_active_duration` still fires past threshold.
- [x] `no_comment_streak` and `high_churn` unaffected in all cases.
- [x] Unit tests added.

Closes MAT-622.