### PR TITLE
Make Paperclip issue update helper no-jq

### DIFF
--- a/scripts/paperclip-issue-update.sh
+++ b/scripts/paperclip-issue-update.sh
@@ -5,13 +5,17 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
+  paperclip-issue-update [--issue-id ID] [--status STATUS] [--comment TEXT] [--dry-run]
   scripts/paperclip-issue-update.sh [--issue-id ID] [--status STATUS] [--comment TEXT] [--dry-run]
 
 Reads a multiline markdown comment from stdin when stdin is piped. This preserves
 newlines when building the JSON payload for PATCH /api/issues/{issueId}.
 
+The helper intentionally uses Node for JSON encoding instead of jq because jq is
+not installed in every agent runtime.
+
 Examples:
-  scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status in_progress <<'MD'
+  paperclip-issue-update --issue-id "$PAPERCLIP_TASK_ID" --status in_progress <<'MD'
   Investigating formatting
 
   - Pulled the raw comment body
@@ -36,7 +40,16 @@ require_command() {
 issue_id="${PAPERCLIP_TASK_ID:-}"
 status=""
 comment_arg=""
+comment_arg_set=0
 dry_run=0
+comment_file=""
+
+cleanup() {
+  if [[ -n "$comment_file" && -f "$comment_file" ]]; then
+    rm -f "$comment_file"
+  fi
+}
+trap cleanup EXIT
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -50,6 +63,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --comment)
       comment_arg="${2:-}"
+      comment_arg_set=1
       shift 2
       ;;
     --dry-run)
@@ -73,23 +87,42 @@ if [[ -z "$issue_id" ]]; then
   exit 1
 fi
 
-comment=""
-if [[ -n "$comment_arg" ]]; then
-  comment="$comment_arg"
+has_comment=0
+if [[ "$comment_arg_set" == "1" ]]; then
+  comment_file="$(mktemp)"
+  printf '%s' "$comment_arg" >"$comment_file"
+  has_comment=1
 elif [[ ! -t 0 ]]; then
-  comment="$(cat)"
+  comment_file="$(mktemp)"
+  cat >"$comment_file"
+  if [[ -s "$comment_file" ]]; then
+    has_comment=1
+  fi
 fi
 
-require_command jq
+require_command node
 
 payload="$(
-  jq -nc \
-    --arg status "$status" \
-    --arg comment "$comment" \
-    '
-      (if $status == "" then {} else {status: $status} end) +
-      (if $comment == "" then {} else {comment: $comment} end)
-    '
+  PAPERCLIP_ISSUE_UPDATE_STATUS="$status" \
+  PAPERCLIP_ISSUE_UPDATE_HAS_COMMENT="$has_comment" \
+  PAPERCLIP_ISSUE_UPDATE_COMMENT_FILE="$comment_file" \
+  node <<'NODE'
+const fs = require("fs");
+
+const payload = {};
+const status = process.env.PAPERCLIP_ISSUE_UPDATE_STATUS || "";
+
+if (status) {
+  payload.status = status;
+}
+
+if (process.env.PAPERCLIP_ISSUE_UPDATE_HAS_COMMENT === "1") {
+  const commentFile = process.env.PAPERCLIP_ISSUE_UPDATE_COMMENT_FILE;
+  payload.comment = fs.readFileSync(commentFile, "utf8");
+}
+
+process.stdout.write(JSON.stringify(payload));
+NODE
 )"
 
 if [[ "$dry_run" == "1" ]]; then
@@ -101,6 +134,8 @@ if [[ -z "${PAPERCLIP_API_URL:-}" || -z "${PAPERCLIP_API_KEY:-}" || -z "${PAPERC
   printf 'Missing PAPERCLIP_API_URL, PAPERCLIP_API_KEY, or PAPERCLIP_RUN_ID.\n' >&2
   exit 1
 fi
+
+require_command curl
 
 curl -sS -X PATCH \
   "$PAPERCLIP_API_URL/api/issues/$issue_id" \

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -113,15 +113,37 @@ Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 { "status": "done", "comment": "What was done and why." }
 ```
 
-For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string — that is how comments get "smooshed" together. Use the helper below (or an equivalent `jq --arg` pattern reading from a heredoc/file) so literal newlines survive JSON encoding:
+For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string — that is how comments get "smooshed" together. Use the no-`jq` helper below so literal newlines survive JSON encoding and shell metacharacters such as backticks and `$` do not get expanded:
 
 ```bash
-scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
+paperclip-issue-update --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
 Done
 
 - Fixed the newline-preserving issue update path
 - Verified the raw stored comment body keeps paragraph breaks
 MD
+```
+
+If `paperclip-issue-update` is not on `PATH`, use the bundled script from a Paperclip checkout with the same arguments:
+
+```bash
+/home/paperclip/paperclip/scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done --dry-run <<'MD'
+Done
+
+- This dry-run body keeps `backticks`, $5K text, and [DAT-4525](/DAT/issues/DAT-4525) intact
+MD
+```
+
+The helper uses Node for JSON encoding. If neither helper path exists, write a payload with Node instead of shell interpolation:
+
+```bash
+COMMENT_FILE=/tmp/paperclip-comment.md node <<'NODE' >/tmp/paperclip-payload.json
+const fs = require("fs");
+process.stdout.write(JSON.stringify({
+  status: "done",
+  comment: fs.readFileSync(process.env.COMMENT_FILE, "utf8"),
+}));
+NODE
 ```
 
 Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`. Priority values: `critical`, `high`, `medium`, `low`. Other updatable fields: `title`, `description`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`, `blockedByIssueIds`.
@@ -273,7 +295,7 @@ Never leave bare ticket ids in issue descriptions or comments when a clickable i
 
 Do NOT use unprefixed paths like `/issues/PAP-123` or `/agents/cto` — always include the company prefix.
 
-**Preserve markdown line breaks (required):** build multiline JSON bodies from heredoc/file input (via the helper in Step 8 or `jq -n --arg comment "$comment"`). Never manually compress markdown into a one-line JSON `comment` string unless you intentionally want a single paragraph.
+**Preserve markdown line breaks (required):** build multiline JSON bodies from heredoc/file input via the no-`jq` helper in Step 8, or use the Node fallback shown there. Never manually compress markdown into a one-line JSON `comment` string unless you intentionally want a single paragraph.
 
 Example:
 


### PR DESCRIPTION
## Summary

- Replaces the `jq` dependency in `scripts/paperclip-issue-update.sh` with Node JSON encoding.
- Updates the Paperclip skill docs to prefer `paperclip-issue-update` and document a Node fallback.
- Preserves multiline markdown from stdin, including backticks, dollar amounts, and issue links.

## Verification

- `bash -n scripts/paperclip-issue-update.sh`
- dry-run JSON round trip with `backticks`, `$5K`, `$PAPERCLIP_API_KEY`, and `[DAT-4525](/DAT/issues/DAT-4525)`
