### PR TITLE
fix(codex-local): require explicit codex executable path

### DIFF
--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -72,7 +72,7 @@ Core fields:
 - search (boolean, optional): run codex with --search
 - fastMode (boolean, optional): enable Codex Fast mode; supported on GPT-5.4 and passed through for manual model IDs
 - dangerouslyBypassApprovalsAndSandbox (boolean, optional): run with bypass flag
-- command (string, optional): defaults to "codex"
+- command (string, required): absolute path to the Codex executable; Paperclip no longer falls back to shell PATH lookup at runtime
 - extraArgs (string[], optional): additional CLI args
 - env (object, optional): KEY=VALUE environment variables
 - workspaceStrategy (object, optional): execution workspace strategy; currently supports { type: "git_worktree", baseRef?, branchTemplate?, worktreeParentDir? }

--- a/packages/adapters/codex-local/src/server/codex-command.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-command.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  assertCodexCommandReadyForExecution,
+  codexCommandConfigError,
+  resolveDefaultCodexCommand,
+} from "./codex-command.js";
+
+describe("resolveDefaultCodexCommand", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prefers PAPERCLIP_CODEX_COMMAND when it points to an executable", () => {
+    vi.stubEnv("PAPERCLIP_CODEX_COMMAND", process.execPath);
+
+    expect(resolveDefaultCodexCommand()).toBe(process.execPath);
+  });
+
+  it("falls back to a PATH-resolved absolute executable when no override is set", async () => {
+    vi.stubEnv("PAPERCLIP_CODEX_COMMAND", "");
+    vi.stubEnv("CODEX_COMMAND", "");
+    vi.stubEnv("CODEX_BIN", "");
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-command-"));
+    const commandPath = path.join(root, process.platform === "win32" ? "codex.cmd" : "codex");
+    await fs.writeFile(commandPath, process.platform === "win32" ? "@echo off\r\n" : "#!/bin/sh\n", "utf8");
+    if (process.platform !== "win32") {
+      await fs.chmod(commandPath, 0o755);
+    }
+    vi.stubEnv("PATH", root);
+
+    const resolved = resolveDefaultCodexCommand();
+    expect(path.isAbsolute(resolved)).toBe(true);
+    expect(["codex", "codex.cmd", "codex.exe"]).toContain(path.basename(resolved).toLowerCase());
+
+    await fs.rm(root, { recursive: true, force: true });
+  });
+});
+
+describe("assertCodexCommandReadyForExecution", () => {
+  it("accepts an absolute executable path", () => {
+    expect(assertCodexCommandReadyForExecution(process.execPath)).toBe(process.execPath);
+  });
+
+  it("rejects missing or relative commands", () => {
+    expect(() => assertCodexCommandReadyForExecution("")).toThrow(codexCommandConfigError());
+    expect(() => assertCodexCommandReadyForExecution("codex")).toThrow(codexCommandConfigError());
+  });
+});

--- a/packages/adapters/codex-local/src/server/codex-command.ts
+++ b/packages/adapters/codex-local/src/server/codex-command.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const CODEX_COMMAND_EXAMPLE =
+  process.platform === "win32" ? "C:\\Program Files\\Codex\\codex.cmd" : "/opt/homebrew/bin/codex";
+
+function nonEmpty(value: string | undefined): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function pathExts(env: NodeJS.ProcessEnv): string[] {
+  if (process.platform !== "win32") return [""];
+  return (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM")
+    .split(";")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function canExecute(candidate: string): boolean {
+  try {
+    fs.accessSync(candidate, process.platform === "win32" ? fs.constants.F_OK : fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveFromPath(command: string, env: NodeJS.ProcessEnv): string | null {
+  const pathValue = nonEmpty(env.PATH) ?? nonEmpty(env.Path) ?? nonEmpty(process.env.PATH) ?? "";
+  if (!pathValue) return null;
+
+  const entries = pathValue.split(path.delimiter).map((entry) => entry.trim()).filter(Boolean);
+  const exts = pathExts(env);
+  const hasExtension = process.platform === "win32" && path.extname(command).length > 0;
+
+  for (const entry of entries) {
+    const candidates =
+      process.platform === "win32"
+        ? hasExtension
+          ? [path.join(entry, command)]
+          : exts.map((ext) => path.join(entry, `${command}${ext}`))
+        : [path.join(entry, command)];
+    for (const candidate of candidates) {
+      if (canExecute(candidate)) return candidate;
+    }
+  }
+
+  return null;
+}
+
+function resolveKnownCodexCandidate(env: NodeJS.ProcessEnv): string | null {
+  const configuredCandidate =
+    nonEmpty(env.PAPERCLIP_CODEX_COMMAND) ??
+    nonEmpty(env.CODEX_COMMAND) ??
+    nonEmpty(env.CODEX_BIN);
+  if (configuredCandidate) {
+    const resolved = path.isAbsolute(configuredCandidate)
+      ? configuredCandidate
+      : path.resolve(configuredCandidate);
+    if (canExecute(resolved)) return resolved;
+  }
+
+  const platformCandidates =
+    process.platform === "darwin"
+      ? ["/opt/homebrew/bin/codex", "/usr/local/bin/codex"]
+      : process.platform === "linux"
+        ? ["/usr/local/bin/codex", "/usr/bin/codex"]
+        : [];
+  for (const candidate of platformCandidates) {
+    if (canExecute(candidate)) return candidate;
+  }
+
+  return resolveFromPath("codex", env);
+}
+
+export function resolveDefaultCodexCommand(env: NodeJS.ProcessEnv = process.env): string {
+  return resolveKnownCodexCandidate(env) ?? "";
+}
+
+export function codexCommandConfigError(configKey = "adapterConfig.command"): string {
+  return `codex_local requires ${configKey} to be an absolute path to the Codex executable. PATH lookup is no longer used at runtime. Example: ${CODEX_COMMAND_EXAMPLE}`;
+}
+
+export function assertCodexCommandReadyForExecution(
+  command: unknown,
+  configKey = "adapterConfig.command",
+): string {
+  const trimmed = typeof command === "string" ? command.trim() : "";
+  if (!trimmed || !path.isAbsolute(trimmed)) {
+    throw new Error(codexCommandConfigError(configKey));
+  }
+  return trimmed;
+}

--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -113,7 +113,7 @@ describe("codex remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: process.execPath,
+        command: "/opt/homebrew/bin/codex",
         env: {
           CODEX_HOME: codexHomeDir,
         },
@@ -231,7 +231,7 @@ describe("codex remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: process.execPath,
+        command: "/opt/homebrew/bin/codex",
         env: {
           CODEX_HOME: codexHomeDir,
         },
@@ -302,7 +302,7 @@ describe("codex remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: process.execPath,
+        command: "/opt/homebrew/bin/codex",
         env: {
           CODEX_HOME: codexHomeDir,
         },
@@ -375,7 +375,7 @@ describe("codex remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: process.execPath,
+        command: "/opt/homebrew/bin/codex",
         env: {
           CODEX_HOME: codexHomeDir,
         },

--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -113,7 +113,7 @@ describe("codex remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: "codex",
+        command: process.execPath,
         env: {
           CODEX_HOME: codexHomeDir,
         },
@@ -231,7 +231,7 @@ describe("codex remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: "codex",
+        command: process.execPath,
         env: {
           CODEX_HOME: codexHomeDir,
         },
@@ -302,7 +302,7 @@ describe("codex remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: "codex",
+        command: process.execPath,
         env: {
           CODEX_HOME: codexHomeDir,
         },
@@ -375,7 +375,7 @@ describe("codex remote execution", () => {
         taskKey: null,
       },
       config: {
-        command: "codex",
+        command: process.execPath,
         env: {
           CODEX_HOME: codexHomeDir,
         },

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -48,6 +48,7 @@ import { pathExists, prepareManagedCodexHome, resolveManagedCodexHomeDir, resolv
 import { resolveCodexDesiredSkillNames } from "./skills.js";
 import { buildCodexExecArgs } from "./codex-args.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
+import { assertCodexCommandReadyForExecution } from "./codex-command.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const CODEX_ROLLOUT_NOISE_RE =
@@ -289,7 +290,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     config.promptTemplate,
     DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   );
-  const command = asString(config.command, "codex");
+  const command = assertCodexCommandReadyForExecution(config.command);
   const model = asString(config.model, "");
 
   const workspaceContext = parseObject(context.paperclipWorkspace);

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -1,6 +1,11 @@
 export { execute, ensureCodexSkillsInjected } from "./execute.js";
 export { listCodexSkills, syncCodexSkills } from "./skills.js";
 export { testEnvironment } from "./test.js";
+export {
+  assertCodexCommandReadyForExecution,
+  codexCommandConfigError,
+  resolveDefaultCodexCommand,
+} from "./codex-command.js";
 export { parseCodexJsonl, isCodexTransientUpstreamError, isCodexUnknownSessionError } from "./parse.js";
 export {
   getQuotaWindows,

--- a/packages/adapters/codex-local/src/server/test.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/test.remote.test.ts
@@ -107,7 +107,7 @@ describe("codex remote environment diagnostics", () => {
       companyId: "company-1",
       adapterType: "codex_local",
       config: {
-        command: "codex",
+        command: process.execPath,
       },
       executionTarget: remoteTarget,
       environmentName: "QA SSH",
@@ -174,7 +174,7 @@ describe("codex remote environment diagnostics", () => {
       companyId: "company-1",
       adapterType: "codex_local",
       config: {
-        command: "codex",
+        command: process.execPath,
         env: {
           OPENAI_API_KEY: "sk-test",
         },

--- a/packages/adapters/codex-local/src/server/test.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/test.remote.test.ts
@@ -107,7 +107,7 @@ describe("codex remote environment diagnostics", () => {
       companyId: "company-1",
       adapterType: "codex_local",
       config: {
-        command: process.execPath,
+        command: "/opt/homebrew/bin/codex",
       },
       executionTarget: remoteTarget,
       environmentName: "QA SSH",
@@ -174,7 +174,7 @@ describe("codex remote environment diagnostics", () => {
       companyId: "company-1",
       adapterType: "codex_local",
       config: {
-        command: process.execPath,
+        command: "/opt/homebrew/bin/codex",
         env: {
           OPENAI_API_KEY: "sk-test",
         },

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -227,11 +227,11 @@ export async function testEnvironment(
   if (!checks.some((check) => check.code === "codex_command_not_absolute")) {
     try {
       await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
-    checks.push({
-      code: "codex_command_resolvable",
-      level: "info",
-      message: `Command is executable: ${command}`,
-    });
+      checks.push({
+        code: "codex_command_resolvable",
+        level: "info",
+        message: `Command is executable: ${command}`,
+      });
     } catch (err) {
       checks.push({
         code: "codex_command_unresolvable",

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -25,6 +25,7 @@ import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 import { codexHomeDir, readCodexAuthInfo } from "./quota.js";
 import { buildCodexExecArgs } from "./codex-args.js";
 import { prepareManagedCodexHome } from "./codex-home.js";
+import { assertCodexCommandReadyForExecution } from "./codex-command.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -213,19 +214,32 @@ export async function testEnvironment(
   });
   if (installCheck) checks.push(installCheck);
   try {
-    await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
+    assertCodexCommandReadyForExecution(command);
+  } catch (err) {
+    checks.push({
+      code: "codex_command_not_absolute",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command || undefined,
+    });
+  }
+
+  if (!checks.some((check) => check.code === "codex_command_not_absolute")) {
+    try {
+      await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
     checks.push({
       code: "codex_command_resolvable",
       level: "info",
       message: `Command is executable: ${command}`,
     });
-  } catch (err) {
-    checks.push({
-      code: "codex_command_unresolvable",
-      level: "error",
-      message: err instanceof Error ? err.message : "Command is not executable",
-      detail: command,
-    });
+    } catch (err) {
+      checks.push({
+        code: "codex_command_unresolvable",
+        level: "error",
+        message: err instanceof Error ? err.message : "Command is not executable",
+        detail: command || undefined,
+      });
+    }
   }
 
   const configOpenAiKey = env.OPENAI_API_KEY;
@@ -261,7 +275,10 @@ export async function testEnvironment(
   }
 
   const canRunProbe =
-    checks.every((check) => check.code !== "codex_cwd_invalid" && check.code !== "codex_command_unresolvable");
+    checks.every((check) =>
+      check.code !== "codex_cwd_invalid"
+      && check.code !== "codex_command_unresolvable"
+      && check.code !== "codex_command_not_absolute");
   if (canRunProbe) {
     if (!commandLooksLike(command, "codex")) {
       checks.push({

--- a/server/src/__tests__/codex-local-adapter-environment.test.ts
+++ b/server/src/__tests__/codex-local-adapter-environment.test.ts
@@ -38,6 +38,17 @@ describe("codex_local environment diagnostics", () => {
     await fs.rm(path.dirname(cwd), { recursive: true, force: true });
   });
 
+  it("fails fast when command is missing or not absolute", async () => {
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: {},
+    });
+
+    expect(result.status).toBe("fail");
+    expect(result.checks.some((check) => check.code === "codex_command_not_absolute")).toBe(true);
+  });
+
   it("emits codex_native_auth_present when ~/.codex/auth.json exists and OPENAI_API_KEY is unset", async () => {
     const root = path.join(
       os.tmpdir(),
@@ -124,11 +135,10 @@ describe("codex_local environment diagnostics", () => {
         companyId: "company-1",
         adapterType: "codex_local",
         config: {
-          command: "codex",
+          command: fakeCodex,
           cwd,
           env: {
             OPENAI_API_KEY: "test-key",
-            PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
           },
         },
       });

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -247,20 +247,16 @@ describe("codex execute", () => {
     }
   });
 
-  it("logs HOME and the resolved executable path in invocation metadata", async () => {
+  it("logs HOME and the configured executable path in invocation metadata", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-execute-meta-"));
     const workspace = path.join(root, "workspace");
-    const binDir = path.join(root, "bin");
-    const commandPath = path.join(binDir, "codex");
+    const commandPath = path.join(root, "codex");
     const capturePath = path.join(root, "capture.json");
     await fs.mkdir(workspace, { recursive: true });
-    await fs.mkdir(binDir, { recursive: true });
     await writeFakeCodexCommand(commandPath);
 
     const previousHome = process.env.HOME;
-    const previousPath = process.env.PATH;
     process.env.HOME = root;
-    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ""}`;
 
     let loggedCommand: string | null = null;
     let loggedEnv: Record<string, string> = {};
@@ -281,7 +277,7 @@ describe("codex execute", () => {
           taskKey: null,
         },
         config: {
-          command: "codex",
+          command: commandPath,
           cwd: workspace,
           env: {
             PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
@@ -305,8 +301,6 @@ describe("codex execute", () => {
     } finally {
       if (previousHome === undefined) delete process.env.HOME;
       else process.env.HOME = previousHome;
-      if (previousPath === undefined) delete process.env.PATH;
-      else process.env.PATH = previousPath;
       await fs.rm(root, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents across local and remote execution adapters, so adapter launch semantics need to be deterministic and debuggable.
> - The `codex_local` adapter is the Codex execution path inside that runtime layer.
> - This adapter previously tolerated `command: "codex"` and relied on ambient shell PATH lookup at execution time.
> - That makes runtime behavior host-dependent and undermines hardening work meant to make Codex launches explicit and reproducible.
> - This pull request moves the runtime contract to an explicit absolute executable path, while still keeping setup and diagnostics able to discover likely defaults for operators.
> - It also preserves newer upstream remote-target/runtime behavior and fixes the environment-test error classification so config mistakes are reported structurally rather than by fragile message matching.
> - The benefit is a mergeable upstream hardening change with clearer operator guidance and safer failure modes for misconfigured `codex_local` agents.

## What Changed

- Added `codex-command.ts` to centralize Codex executable validation and default-path discovery helpers.
- Changed `codex_local` runtime execution to require an absolute `command` path instead of falling back to shell PATH lookup.
- Exported the new command helpers from the codex-local server entrypoint.
- Updated adapter environment and execution tests to use explicit executable paths.
- Fixed environment-test classification so `codex_command_not_absolute` is emitted from the validation branch directly instead of by matching a full error string.
- Rebased the branch onto current `master` so the PR is mergeable against upstream runtime changes.

## Verification

- `corepack pnpm vitest run packages/adapters/codex-local/src/server/codex-command.test.ts`
- Attempted: `corepack pnpm run preflight:workspace-links && corepack pnpm vitest run packages/adapters/codex-local/src/server/codex-command.test.ts server/src/__tests__/codex-local-adapter-environment.test.ts server/src/__tests__/codex-local-execute.test.ts`
- The second command is currently blocked in the detached worktree by workspace package-link resolution (`ERR_MODULE_NOT_FOUND` for `@paperclipai/shared` during `preflight:workspace-links`) before the server suites execute.

## Risks

- Breaking change: existing `codex_local` configs that still set `command: "codex"` or any relative path will now fail fast until they are updated to an absolute executable path.
- Verification in this detached worktree is partially constrained by workspace-link drift in the harnessed test environment, so reviewers should rely on CI for the broader server-suite signal after mergeable head update.

> Checked `ROADMAP.md` and did not find overlapping planned core work for this codex_local command-path hardening.

## Model Used

- OpenAI GPT-5 Codex agent with terminal/tool execution in the local Paperclip workspace.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
