### PR TITLE
feat(server): LET-411 pilot-reporting renderers (B6-prep)

### DIFF
--- a/server/src/services/sandbox/pilot-reporting/README.md
+++ b/server/src/services/sandbox/pilot-reporting/README.md
@@ -1,0 +1,135 @@
+# pilot-reporting
+
+Phase 4A-S4 B6-prep helpers (LET-411 under parent LET-365).
+
+These are two **pure** Markdown renderers — they take a typed input bundle
+and return a string. They do no I/O: no HTTP, no DB, no document upsert, no
+secret-store read, no provider transport. CI runs them without any E2B
+credential.
+
+The renderers will be consumed by LET-371 (B6) when the 2-week E2B pilot
+starts. LET-371 owns the live wiring (daily-job scheduler, status-page
+poller, document-upsert call). This package only ships the deterministic
+building blocks.
+
+## Components
+
+### `renderDailySnapshot(input)`
+
+Markdown snapshot of one UTC pilot day. Renders the row set defined in
+LET-371 §"Daily Command Center snapshot":
+
+- Day-to-date / month-to-date spend vs. 20 / 200 USD hard caps.
+- Lease success rate (running tally), p95 cold start, p95 lease-ready.
+- Isolation incidents (always reported, default 0).
+- Raw-secret leaks (always reported, default 0).
+- Vendor uptime from the E2B status page.
+- Kill-switch state per layer.
+- Banner section that surfaces cap breaches, isolation/leak counts ≥ 1,
+  tripped/manual-disable switches, and vendor uptime dips below 99.5%.
+
+Output is suitable to drop into a comment body. **LET-411 does not post
+snapshots**; LET-371's daily-job caller takes the string and posts on
+LET-365 at 00:05 UTC.
+
+### `renderExitCriteriaReport(input)` + `evaluateExitCriteria(input)`
+
+Markdown body for the mandatory issue document
+`phase-4a-s4-pilot-exit-criteria-YYYY-MM-DD`. Evaluation pass also
+returned separately so callers can branch (pass → ADR §7 gate issue for
+Phase 4B / fail → revert + incident + ADR addendum) without re-parsing the
+rendered Markdown.
+
+The renderer covers every row in LET-371 §"Exit-criteria report":
+
+- Per-criterion evaluation table (lease success rate, p95 cold start,
+  p95 lease-ready, isolation incidents, raw-secret leaks, monthly cost,
+  vendor uptime, operator confidence).
+- Daily snapshot tally.
+- Incident log (isolation + raw-secret), green-log placeholder when empty.
+- Total cost vs cap with day-of-close + month-state.
+- Vendor uptime computed across the pilot window.
+- Operator-confidence comments from the three required reviewers
+  (`Architect`, `QA Validator`, `Hermes Orchestrator`).
+- Recommendation block (pass → Phase 4B / fail → revert + escalate).
+- Optional early-halt section when the pilot stopped before the
+  scheduled window end.
+
+**LET-411 does not upsert documents**; LET-371's document-upserter takes
+the string and writes it to the issue document store.
+
+## Inputs
+
+All inputs are defined in `./types.ts`. The shapes are the integration
+seam between this prep work and B2 / B3:
+
+| Field | Shipped by | Notes |
+|---|---|---|
+| `BillingCounterSnapshot` | LET-367 (B2 counter store) | `dayState` / `monthState` are pre-resolved by the caller via `resolveCapState`. |
+| `ProviderStatusSnapshot.killSwitches` | LET-368 (B3 panel read-model) | Layer ids: `sandbox_provider`, `billing_cap`, `isolation_guard`, `secret_egress_guard`. |
+| `VendorStatusPageSnapshot` | E2B status-page poll | Caller fetches; renderer never makes a network call. |
+| `LeaseLatencyAggregate` | Paperclip lease history for provider `e2b` | Caller aggregates success/failure + p95. |
+| `IsolationIncidentReport` / `SecretLeakReport` | Operator-curated incident log | Renderer truncates summaries at 240 chars. |
+| `OperatorConfidenceComment` | LET-365 comment scrape | Caller maps comment id + role + verdict. |
+
+When LET-367 / LET-368 ship a shape that diverges from what is declared
+here, add a thin adapter in the LET-371 caller — **do not mutate the
+shipped B2 / B3 shapes for this prep work** (per LET-411 AC #4). File a
+`Component-inputs-gap` comment on LET-411 in that case so the seam evolves
+with eyes on it.
+
+## LET-371 integration seam
+
+LET-371 wires two callers — both live behind the post-G2 boundary:
+
+1. **Daily-job caller** (LET-371-owned)
+   - Cron: 00:05 UTC.
+   - Project from live B2 / B3 / status-page / lease-history into a
+     `DailySnapshotInput`.
+   - Call `renderDailySnapshot(input)`.
+   - Post the string as a comment on LET-365.
+2. **Document-upserter caller** (LET-371-owned)
+   - Fires at pilot end (week 2) or on early-halt trigger.
+   - Project pilot-window aggregates into an `ExitCriteriaInput`.
+   - Call `renderExitCriteriaReport(input)` + branch on
+     `evaluateExitCriteria(input).overall`.
+   - Upsert the rendered body as the issue document with key
+     `phase-4a-s4-pilot-exit-criteria-YYYY-MM-DD`.
+
+Both callers stamp `truthLabel: "preview"` until Andrii's G2
+(`confirmation:LET-365:canary-flag-flip:rev1`) is accepted. After G2, the
+caller flips to `truthLabel: "live"`. The renderer surfaces this label in
+the snapshot / report header so a stub-driven artifact can never be
+confused with a live-pilot artifact.
+
+## Constraints (LET-411)
+
+- Zero key requirement. No `secrets/sandbox/e2b/apiKey/pilot` resolve.
+- No live HTTP from this package.
+- Components do not initialise any provider transport.
+- Fail-closed boundary preserved — `truthLabel` defaults to `preview`.
+- Raw secrets never persisted in code, tests, logs, comments, or PR
+  description.
+
+## Tests
+
+Tests live as `*.test.ts` siblings (`daily-snapshot.test.ts`,
+`exit-criteria-report.test.ts`) per the existing server convention. They
+cover the state cases LET-411 names: within-cap, soft-cap,
+hard-cap auto-disable, isolation incident, secret leak, vendor uptime
+dip, green pass, cost-breach halt, isolation-incident halt, latency
+failure, no-sample / no-data placeholder behaviour.
+
+Run them with:
+
+```
+pnpm --filter @paperclipai/server vitest run src/services/sandbox/pilot-reporting
+```
+
+Note on path: LET-411 spec calls for tests under
+`server/test/services/sandbox/pilot-reporting/`, but this repo
+discovers tests via `*.test.ts` siblings under `src/` (see
+`server/vitest.config.ts` — there is no `server/test/` tree). Tests are
+filed alongside the renderers so vitest picks them up without config
+changes; this matches LET-410's
+`packages/shared/src/harness-reliability/classifier.test.ts` layout.

--- a/server/src/services/sandbox/pilot-reporting/daily-snapshot.test.ts
+++ b/server/src/services/sandbox/pilot-reporting/daily-snapshot.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  projectBillingSnapshot,
+  renderDailySnapshot,
+  resolveCapState,
+  successRate,
+} from "./daily-snapshot.js";
+import type {
+  DailySnapshotInput,
+  KillSwitchState,
+  ProviderStatusSnapshot,
+  VendorStatusPageSnapshot,
+} from "./types.js";
+
+function armedSwitches(): KillSwitchState[] {
+  return [
+    { layer: "sandbox_provider", state: "armed", changedAt: "2026-05-18T00:00:00Z", reason: null },
+    { layer: "billing_cap", state: "armed", changedAt: "2026-05-18T00:00:00Z", reason: null },
+    { layer: "isolation_guard", state: "armed", changedAt: "2026-05-18T00:00:00Z", reason: null },
+    { layer: "secret_egress_guard", state: "armed", changedAt: "2026-05-18T00:00:00Z", reason: null },
+  ];
+}
+
+function baseVendor(): VendorStatusPageSnapshot {
+  return {
+    vendor: "e2b",
+    capturedAt: "2026-05-18T00:05:00Z",
+    uptimeRatio: 0.999,
+    activeIncidentIds: [],
+    statusText: "All systems operational",
+  };
+}
+
+function baseProviderStatus(): ProviderStatusSnapshot {
+  return {
+    capturedAt: "2026-05-18T00:05:00Z",
+    killSwitches: armedSwitches(),
+    lastLease: {
+      leaseId: "lease-1",
+      provider: "e2b",
+      outcome: "success",
+      completedAt: "2026-05-17T23:50:00Z",
+      coldStartMs: 320,
+      leaseReadyMs: 1100,
+    },
+  };
+}
+
+function withinCapInput(overrides: Partial<DailySnapshotInput> = {}): DailySnapshotInput {
+  return {
+    utcDay: "2026-05-18",
+    pilotId: "phase-4a-s4-e2b-pilot",
+    billing: projectBillingSnapshot({
+      utcDay: "2026-05-18",
+      dayToDateCents: 250,
+      monthToDateCents: 4500,
+      dailyHardCapCents: 2000,
+      monthlyHardCapCents: 20000,
+      dailySoftCapCents: 1500,
+      monthlySoftCapCents: 15000,
+    }),
+    providerStatus: baseProviderStatus(),
+    vendor: baseVendor(),
+    leaseTally: {
+      successCount: 47,
+      failureCount: 1,
+      coldStartP95Ms: 330,
+      leaseReadyP95Ms: 1200,
+    },
+    isolationIncidents: [],
+    secretLeaks: [],
+    truthLabel: "preview",
+    ...overrides,
+  };
+}
+
+describe("renderDailySnapshot", () => {
+  it("produces the green within-cap snapshot with no banners", () => {
+    const out = renderDailySnapshot(withinCapInput());
+    expect(out).toContain("# phase-4a-s4-e2b-pilot — daily snapshot (2026-05-18 UTC)");
+    expect(out).toContain("Truth label: `preview`");
+    expect(out).toContain("Day-to-date spend | $2.50 | $20.00 | ✅ within");
+    expect(out).toContain("Month-to-date spend | $45.00 | $200.00 | ✅ within");
+    expect(out).toContain("Lease success rate (running tally) | 97.92%");
+    expect(out).toContain("p95 cold start | 330 ms");
+    expect(out).toContain("Isolation incidents | 0");
+    expect(out).toContain("Raw-secret leaks | 0");
+    expect(out).toContain("sandbox_provider | ✅ armed");
+    expect(out).not.toContain("Action banners");
+  });
+
+  it("flags soft-cap state without auto-disabling", () => {
+    const input = withinCapInput({
+      billing: projectBillingSnapshot({
+        utcDay: "2026-05-18",
+        dayToDateCents: 1600,
+        monthToDateCents: 16000,
+        dailyHardCapCents: 2000,
+        monthlyHardCapCents: 20000,
+        dailySoftCapCents: 1500,
+        monthlySoftCapCents: 15000,
+      }),
+    });
+    const out = renderDailySnapshot(input);
+    expect(out).toContain("⚠️ soft cap");
+    expect(out).toContain("Soft cap reached — operator warning");
+    expect(out).not.toContain("HARD CAP REACHED");
+  });
+
+  it("flags hard-cap auto-disable as the lead banner", () => {
+    const input = withinCapInput({
+      billing: projectBillingSnapshot({
+        utcDay: "2026-05-18",
+        dayToDateCents: 2000,
+        monthToDateCents: 17000,
+        dailyHardCapCents: 2000,
+        monthlyHardCapCents: 20000,
+        dailySoftCapCents: 1500,
+        monthlySoftCapCents: 15000,
+      }),
+    });
+    const out = renderDailySnapshot(input);
+    expect(out).toContain("🛑 hard cap (auto-disabled)");
+    expect(out).toContain("HARD CAP REACHED — provider auto-disabled by B2");
+  });
+
+  it("flags isolation incidents and surfaces detail rows", () => {
+    const input = withinCapInput({
+      isolationIncidents: [
+        {
+          id: "iso-1",
+          detectedAt: "2026-05-18T03:14:00Z",
+          summary: "Provider returned cross-tenant filesystem handle",
+          link: "https://example.invalid/LET-365#iso-1",
+        },
+      ],
+    });
+    const out = renderDailySnapshot(input);
+    expect(out).toContain("Isolation incidents | 1");
+    expect(out).toContain("### Isolation incident detail");
+    expect(out).toContain("`iso-1`");
+    expect(out).toContain("isolation incident(s) flagged this window");
+  });
+
+  it("flags raw-secret leak detections", () => {
+    const input = withinCapInput({
+      secretLeaks: [
+        {
+          id: "leak-7",
+          detectedAt: "2026-05-18T04:00:00Z",
+          summary: "API key reflected in provider audit log",
+        },
+      ],
+    });
+    const out = renderDailySnapshot(input);
+    expect(out).toContain("Raw-secret leaks | 1");
+    expect(out).toContain("### Raw-secret leak detail");
+    expect(out).toContain("raw-secret leak(s) flagged this window");
+  });
+
+  it("warns when vendor uptime dips below 99.5%", () => {
+    const input = withinCapInput({
+      vendor: { ...baseVendor(), uptimeRatio: 0.991, activeIncidentIds: ["e2b-2026-05-18-A"] },
+    });
+    const out = renderDailySnapshot(input);
+    expect(out).toContain("Uptime (window): 99.10%");
+    expect(out).toContain("Vendor uptime 99.10% is below the 99.5% exit threshold");
+    expect(out).toContain("Vendor reports 1 active incident(s)");
+  });
+
+  it("renders no-samples placeholder when lease tally is empty", () => {
+    const input = withinCapInput({
+      leaseTally: {
+        successCount: 0,
+        failureCount: 0,
+        coldStartP95Ms: null,
+        leaseReadyP95Ms: null,
+      },
+    });
+    const out = renderDailySnapshot(input);
+    expect(out).toContain("Lease success rate (running tally) | _no samples_");
+    expect(out).toContain("p95 cold start | _no samples_");
+  });
+});
+
+describe("helpers", () => {
+  it("resolveCapState moves through within → soft → hard", () => {
+    expect(resolveCapState(0, 100, 50)).toBe("within");
+    expect(resolveCapState(50, 100, 50)).toBe("soft_cap");
+    expect(resolveCapState(100, 100, 50)).toBe("hard_cap_disabled");
+    expect(resolveCapState(120, 100, 50)).toBe("hard_cap_disabled");
+    expect(resolveCapState(60, 100, null)).toBe("within");
+  });
+
+  it("successRate handles zero-sample and ratio cases", () => {
+    expect(successRate({ successCount: 0, failureCount: 0, coldStartP95Ms: null, leaseReadyP95Ms: null })).toBeNull();
+    expect(successRate({ successCount: 95, failureCount: 5, coldStartP95Ms: null, leaseReadyP95Ms: null })).toBe(0.95);
+  });
+});

--- a/server/src/services/sandbox/pilot-reporting/daily-snapshot.ts
+++ b/server/src/services/sandbox/pilot-reporting/daily-snapshot.ts
@@ -1,0 +1,250 @@
+import type {
+  BillingCounterSnapshot,
+  CapState,
+  DailySnapshotInput,
+  IsolationIncidentReport,
+  KillSwitchState,
+  LeaseLatencyAggregate,
+  SecretLeakReport,
+  VendorStatusPageSnapshot,
+} from "./types.js";
+
+const SUMMARY_TRUNCATE = 240;
+
+/**
+ * Pure renderer for the Phase 4A-S4 daily Command Center snapshot.
+ *
+ * Inputs are typed against the projected B2 counter / B3 panel / status-page
+ * shapes. Output is a Markdown string suitable for posting as a comment on
+ * LET-365 (LET-371 owns the posting). This function does no I/O.
+ */
+export function renderDailySnapshot(input: DailySnapshotInput): string {
+  const lines: string[] = [];
+  lines.push(`# ${input.pilotId} — daily snapshot (${input.utcDay} UTC)`);
+  lines.push("");
+  lines.push(`> Truth label: \`${input.truthLabel}\` — ${truthLabelExplain(input.truthLabel)}`);
+  lines.push("");
+
+  lines.push("## Spend vs cap");
+  lines.push("");
+  lines.push("| Metric | Value | Cap | State |");
+  lines.push("|---|---|---|---|");
+  lines.push(spendRow("Day-to-date spend", input.billing.dayToDateCents, input.billing.dailyHardCapCents, input.billing.dayState));
+  lines.push(spendRow("Month-to-date spend", input.billing.monthToDateCents, input.billing.monthlyHardCapCents, input.billing.monthState));
+  lines.push("");
+
+  lines.push("## Lease health");
+  lines.push("");
+  lines.push("| Metric | Value |");
+  lines.push("|---|---|");
+  lines.push(`| Lease success rate (running tally) | ${formatRate(successRate(input.leaseTally))} |`);
+  lines.push(`| Lease attempts (success / failure) | ${input.leaseTally.successCount} / ${input.leaseTally.failureCount} |`);
+  lines.push(`| p95 cold start | ${formatMs(input.leaseTally.coldStartP95Ms)} |`);
+  lines.push(`| p95 lease-ready latency | ${formatMs(input.leaseTally.leaseReadyP95Ms)} |`);
+  lines.push("");
+
+  lines.push("## Safety counters");
+  lines.push("");
+  lines.push("| Metric | Count |");
+  lines.push("|---|---|");
+  lines.push(`| Isolation incidents | ${input.isolationIncidents.length} |`);
+  lines.push(`| Raw-secret leaks | ${input.secretLeaks.length} |`);
+  if (input.isolationIncidents.length > 0) {
+    lines.push("");
+    lines.push("### Isolation incident detail");
+    for (const incident of input.isolationIncidents) {
+      lines.push(`- ${formatIncident(incident)}`);
+    }
+  }
+  if (input.secretLeaks.length > 0) {
+    lines.push("");
+    lines.push("### Raw-secret leak detail");
+    for (const leak of input.secretLeaks) {
+      lines.push(`- ${formatLeak(leak)}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Vendor health (E2B status page)");
+  lines.push("");
+  lines.push(formatVendor(input.vendor));
+  lines.push("");
+
+  lines.push("## Kill-switch state per layer");
+  lines.push("");
+  lines.push("| Layer | State | Changed at | Reason |");
+  lines.push("|---|---|---|---|");
+  for (const layer of input.providerStatus.killSwitches) {
+    lines.push(killSwitchRow(layer));
+  }
+  if (input.providerStatus.killSwitches.length === 0) {
+    lines.push("| _no layers reported_ |  |  |  |");
+  }
+  lines.push("");
+
+  const banners = buildBanners(input);
+  if (banners.length > 0) {
+    lines.push("## Action banners");
+    lines.push("");
+    for (const banner of banners) {
+      lines.push(`- ${banner}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+function truthLabelExplain(label: "preview" | "live"): string {
+  return label === "live"
+    ? "live pilot data — G2 has fired and the live provider is enabled."
+    : "preview / stub data — G2 has NOT fired yet; counters and vendor poll are mocked.";
+}
+
+function spendRow(
+  label: string,
+  cents: number,
+  capCents: number,
+  state: CapState,
+): string {
+  return `| ${label} | ${formatUsd(cents)} | ${formatUsd(capCents)} | ${formatCapState(state)} |`;
+}
+
+function killSwitchRow(layer: KillSwitchState): string {
+  const reason = layer.reason ?? "";
+  const changedAt = layer.changedAt ?? "";
+  return `| ${layer.layer} | ${formatLayerState(layer.state)} | ${changedAt} | ${escapeCell(reason)} |`;
+}
+
+function buildBanners(input: DailySnapshotInput): string[] {
+  const banners: string[] = [];
+
+  if (input.billing.dayState === "hard_cap_disabled" || input.billing.monthState === "hard_cap_disabled") {
+    banners.push("🛑 **HARD CAP REACHED — provider auto-disabled by B2.** Operator must investigate before re-enable.");
+  } else if (input.billing.dayState === "soft_cap" || input.billing.monthState === "soft_cap") {
+    banners.push("⚠️ Soft cap reached — operator warning, traffic continues.");
+  }
+
+  if (input.isolationIncidents.length > 0) {
+    banners.push(`🛑 **${input.isolationIncidents.length} isolation incident(s) flagged this window.** Exit criterion requires 0 — escalate immediately.`);
+  }
+  if (input.secretLeaks.length > 0) {
+    banners.push(`🛑 **${input.secretLeaks.length} raw-secret leak(s) flagged this window.** Exit criterion requires 0 — escalate immediately.`);
+  }
+
+  for (const layer of input.providerStatus.killSwitches) {
+    if (layer.state === "tripped") {
+      banners.push(`🛑 Kill switch \`${layer.layer}\` is **tripped** — traffic halted on this layer.`);
+    } else if (layer.state === "manual_disable") {
+      banners.push(`⏸️ Kill switch \`${layer.layer}\` is **manually disabled** — operator intent.`);
+    }
+  }
+
+  if (input.vendor.uptimeRatio !== null && input.vendor.uptimeRatio < 0.995) {
+    banners.push(`⚠️ Vendor uptime ${formatRate(input.vendor.uptimeRatio)} is below the 99.5% exit threshold — flag in incident log if the dip persists.`);
+  }
+  if (input.vendor.activeIncidentIds.length > 0) {
+    banners.push(`ℹ️ Vendor reports ${input.vendor.activeIncidentIds.length} active incident(s): ${input.vendor.activeIncidentIds.join(", ")}.`);
+  }
+  return banners;
+}
+
+function formatVendor(vendor: VendorStatusPageSnapshot): string {
+  const uptime = vendor.uptimeRatio === null ? "_unknown_" : formatRate(vendor.uptimeRatio);
+  const status = vendor.statusText ? ` — ${escapeCell(vendor.statusText)}` : "";
+  const incidents = vendor.activeIncidentIds.length === 0
+    ? "no active incidents"
+    : `active incidents: ${vendor.activeIncidentIds.join(", ")}`;
+  return `- Vendor: \`${vendor.vendor}\`\n- Uptime (window): ${uptime}\n- Captured at: ${vendor.capturedAt}\n- ${incidents}${status}`;
+}
+
+function formatIncident(incident: IsolationIncidentReport): string {
+  const link = incident.link ? ` ([link](${incident.link}))` : "";
+  return `\`${incident.id}\` — ${escapeCell(truncate(incident.summary, SUMMARY_TRUNCATE))} (detected ${incident.detectedAt})${link}`;
+}
+
+function formatLeak(leak: SecretLeakReport): string {
+  const link = leak.link ? ` ([link](${leak.link}))` : "";
+  return `\`${leak.id}\` — ${escapeCell(truncate(leak.summary, SUMMARY_TRUNCATE))} (detected ${leak.detectedAt})${link}`;
+}
+
+function formatCapState(state: CapState): string {
+  switch (state) {
+    case "within":
+      return "✅ within";
+    case "soft_cap":
+      return "⚠️ soft cap";
+    case "hard_cap_disabled":
+      return "🛑 hard cap (auto-disabled)";
+  }
+}
+
+function formatLayerState(state: KillSwitchState["state"]): string {
+  switch (state) {
+    case "armed":
+      return "✅ armed";
+    case "tripped":
+      return "🛑 tripped";
+    case "manual_disable":
+      return "⏸️ manual disable";
+  }
+}
+
+export function successRate(tally: LeaseLatencyAggregate): number | null {
+  const total = tally.successCount + tally.failureCount;
+  if (total === 0) return null;
+  return tally.successCount / total;
+}
+
+function formatRate(rate: number | null): string {
+  if (rate === null) return "_no samples_";
+  return `${(rate * 100).toFixed(2)}%`;
+}
+
+function formatMs(value: number | null): string {
+  if (value === null) return "_no samples_";
+  return `${value} ms`;
+}
+
+function formatUsd(cents: number): string {
+  const dollars = cents / 100;
+  return `$${dollars.toFixed(2)}`;
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+// Re-export a couple of helpers callers need when projecting billing state.
+export function resolveCapState(currentCents: number, hardCapCents: number, softCapCents: number | null | undefined): CapState {
+  if (currentCents >= hardCapCents) return "hard_cap_disabled";
+  if (softCapCents != null && currentCents >= softCapCents) return "soft_cap";
+  return "within";
+}
+
+export function projectBillingSnapshot(args: {
+  utcDay: string;
+  dayToDateCents: number;
+  monthToDateCents: number;
+  dailyHardCapCents: number;
+  monthlyHardCapCents: number;
+  dailySoftCapCents?: number | null;
+  monthlySoftCapCents?: number | null;
+}): BillingCounterSnapshot {
+  return {
+    utcDay: args.utcDay,
+    dayToDateCents: args.dayToDateCents,
+    monthToDateCents: args.monthToDateCents,
+    dailyHardCapCents: args.dailyHardCapCents,
+    monthlyHardCapCents: args.monthlyHardCapCents,
+    dailySoftCapCents: args.dailySoftCapCents ?? null,
+    monthlySoftCapCents: args.monthlySoftCapCents ?? null,
+    dayState: resolveCapState(args.dayToDateCents, args.dailyHardCapCents, args.dailySoftCapCents),
+    monthState: resolveCapState(args.monthToDateCents, args.monthlyHardCapCents, args.monthlySoftCapCents),
+  };
+}

--- a/server/src/services/sandbox/pilot-reporting/exit-criteria-report.test.ts
+++ b/server/src/services/sandbox/pilot-reporting/exit-criteria-report.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateExitCriteria, renderExitCriteriaReport } from "./exit-criteria-report.js";
+import { projectBillingSnapshot } from "./daily-snapshot.js";
+import { PILOT_EXIT_CRITERIA_DEFAULTS, type ExitCriteriaInput, type OperatorConfidenceComment } from "./types.js";
+
+function goCommentForRole(role: string): OperatorConfidenceComment {
+  return {
+    role,
+    operator: `${role} Operator`,
+    verdict: "go",
+    postedAt: "2026-06-01T12:00:00Z",
+    commentId: `comment-${role.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`,
+    excerpt: `${role} approves Phase 4B graduation.`,
+  };
+}
+
+function greenInput(overrides: Partial<ExitCriteriaInput> = {}): ExitCriteriaInput {
+  return {
+    pilotId: "phase-4a-s4-e2b-pilot",
+    windowStartUtcDay: "2026-05-18",
+    windowEndUtcDay: "2026-06-01",
+    windowLeaseTally: {
+      successCount: 980,
+      failureCount: 20,
+      coldStartP95Ms: 450,
+      leaseReadyP95Ms: 1400,
+    },
+    finalBilling: projectBillingSnapshot({
+      utcDay: "2026-06-01",
+      dayToDateCents: 500,
+      monthToDateCents: 18000,
+      dailyHardCapCents: 2000,
+      monthlyHardCapCents: 20000,
+    }),
+    vendorUptimeRatio: 0.998,
+    dailyTally: [
+      {
+        utcDay: "2026-05-18",
+        leaseSuccessRate: 0.99,
+        coldStartP95Ms: 410,
+        daySpendCents: 250,
+        monthToDateCents: 250,
+        isolationIncidents: 0,
+        secretLeaks: 0,
+        vendorUptimeRatio: 0.999,
+        capState: "within",
+      },
+    ],
+    isolationIncidents: [],
+    secretLeaks: [],
+    operatorConfidenceComments: [
+      goCommentForRole("Architect"),
+      goCommentForRole("QA Validator"),
+      goCommentForRole("Hermes Orchestrator"),
+    ],
+    thresholds: PILOT_EXIT_CRITERIA_DEFAULTS,
+    truthLabel: "preview",
+    ...overrides,
+  };
+}
+
+describe("evaluateExitCriteria", () => {
+  it("returns pass for a fully green pilot", () => {
+    const result = evaluateExitCriteria(greenInput());
+    expect(result.overall).toBe("pass");
+    expect(result.failedIds).toEqual([]);
+    expect(result.perCriterion.map((r) => r.id)).toEqual([
+      "lease_success_rate",
+      "cold_start_p95",
+      "lease_ready_p95",
+      "isolation_incidents",
+      "secret_leaks",
+      "monthly_cost",
+      "vendor_uptime",
+      "operator_confidence",
+    ]);
+  });
+
+  it("fails when monthly cost breaches the hard cap", () => {
+    const result = evaluateExitCriteria(greenInput({
+      finalBilling: projectBillingSnapshot({
+        utcDay: "2026-06-01",
+        dayToDateCents: 500,
+        monthToDateCents: 21000,
+        dailyHardCapCents: 2000,
+        monthlyHardCapCents: 20000,
+      }),
+    }));
+    expect(result.overall).toBe("fail");
+    expect(result.failedIds).toContain("monthly_cost");
+  });
+
+  it("fails when an isolation incident is logged", () => {
+    const result = evaluateExitCriteria(greenInput({
+      isolationIncidents: [{ id: "iso-1", detectedAt: "2026-05-20T10:00:00Z", summary: "cross-tenant FS" }],
+    }));
+    expect(result.overall).toBe("fail");
+    expect(result.failedIds).toContain("isolation_incidents");
+  });
+
+  it("fails when p95 latency breaches threshold", () => {
+    const result = evaluateExitCriteria(greenInput({
+      windowLeaseTally: {
+        successCount: 980,
+        failureCount: 20,
+        coldStartP95Ms: 600,
+        leaseReadyP95Ms: 1800,
+      },
+    }));
+    expect(result.overall).toBe("fail");
+    expect(result.failedIds).toEqual(expect.arrayContaining(["cold_start_p95", "lease_ready_p95"]));
+  });
+
+  it("fails when operator confidence is missing or non-go", () => {
+    const noOps = evaluateExitCriteria(greenInput({ operatorConfidenceComments: [] }));
+    expect(noOps.failedIds).toContain("operator_confidence");
+
+    const partial = evaluateExitCriteria(greenInput({
+      operatorConfidenceComments: [
+        goCommentForRole("Architect"),
+        { ...goCommentForRole("QA Validator"), verdict: "no_go" },
+        goCommentForRole("Hermes Orchestrator"),
+      ],
+    }));
+    expect(partial.failedIds).toContain("operator_confidence");
+  });
+
+  it("reports no_data when sample sets are empty", () => {
+    const result = evaluateExitCriteria(greenInput({
+      windowLeaseTally: { successCount: 0, failureCount: 0, coldStartP95Ms: null, leaseReadyP95Ms: null },
+      vendorUptimeRatio: null,
+    }));
+    expect(result.overall).toBe("fail");
+    expect(result.failedIds).toEqual(expect.arrayContaining([
+      "lease_success_rate",
+      "cold_start_p95",
+      "lease_ready_p95",
+      "vendor_uptime",
+    ]));
+  });
+});
+
+describe("renderExitCriteriaReport", () => {
+  it("renders the pass recommendation block for a green pilot", () => {
+    const md = renderExitCriteriaReport(greenInput());
+    expect(md).toContain("# phase-4a-s4-e2b-pilot — exit-criteria report");
+    expect(md).toContain("Truth label: `preview`");
+    expect(md).toContain("Pilot window: 2026-05-18 → 2026-06-01");
+    expect(md).toContain("✅ **PASS — graduate to Phase 4B.**");
+    expect(md).toContain("Open a new ADR §7 gate issue");
+    expect(md).not.toContain("⛔ Early halt");
+    expect(md).toContain("| Lease success rate | ≥ 95.00% | 98.00% | ✅ pass");
+  });
+
+  it("renders the fail recommendation when cost breach triggers a halt", () => {
+    const md = renderExitCriteriaReport(greenInput({
+      earlyHalt: {
+        triggeredAt: "2026-05-26T18:30:00Z",
+        trigger: "cost_breach",
+        summary: "Monthly hard cap reached on day 9",
+        incidentLink: "https://example.invalid/LET-365#incident-1",
+      },
+      finalBilling: projectBillingSnapshot({
+        utcDay: "2026-05-26",
+        dayToDateCents: 2000,
+        monthToDateCents: 21000,
+        dailyHardCapCents: 2000,
+        monthlyHardCapCents: 20000,
+      }),
+    }));
+    expect(md).toContain("⛔ Early halt");
+    expect(md).toContain("Trigger: `cost_breach`");
+    expect(md).toContain("🛑 **FAIL — revert and escalate.**");
+    expect(md).toContain("`monthly_cost`");
+    expect(md).toContain("Flip `SANDBOX_PROVIDER_ALLOW_LIVE` back to `false`");
+  });
+
+  it("renders the fail recommendation when an isolation incident halts the pilot", () => {
+    const md = renderExitCriteriaReport(greenInput({
+      earlyHalt: {
+        triggeredAt: "2026-05-22T09:00:00Z",
+        trigger: "isolation_incident",
+        summary: "Cross-tenant filesystem handle detected",
+      },
+      isolationIncidents: [{
+        id: "iso-1",
+        detectedAt: "2026-05-22T08:55:00Z",
+        summary: "Cross-tenant FS handle leaked across leases",
+        link: "https://example.invalid/LET-365#iso-1",
+      }],
+    }));
+    expect(md).toContain("Trigger: `isolation_incident`");
+    expect(md).toContain("### Isolation incidents");
+    expect(md).toContain("`iso-1`");
+    expect(md).toContain("🛑 **FAIL — revert and escalate.**");
+    expect(md).toContain("`isolation_incidents`");
+  });
+
+  it("renders the fail recommendation when latency exceeds the threshold", () => {
+    const md = renderExitCriteriaReport(greenInput({
+      windowLeaseTally: {
+        successCount: 950,
+        failureCount: 50,
+        coldStartP95Ms: 700,
+        leaseReadyP95Ms: 1700,
+      },
+    }));
+    expect(md).toContain("🛑 **FAIL — revert and escalate.**");
+    expect(md).toContain("`cold_start_p95`");
+    expect(md).toContain("`lease_ready_p95`");
+  });
+
+  it("formats the daily-snapshot tally and incident log", () => {
+    const md = renderExitCriteriaReport(greenInput({
+      dailyTally: [
+        {
+          utcDay: "2026-05-18",
+          leaseSuccessRate: 0.99,
+          coldStartP95Ms: 410,
+          daySpendCents: 250,
+          monthToDateCents: 250,
+          isolationIncidents: 0,
+          secretLeaks: 0,
+          vendorUptimeRatio: 0.999,
+          capState: "within",
+        },
+        {
+          utcDay: "2026-05-19",
+          leaseSuccessRate: 0.97,
+          coldStartP95Ms: 430,
+          daySpendCents: 350,
+          monthToDateCents: 600,
+          isolationIncidents: 0,
+          secretLeaks: 0,
+          vendorUptimeRatio: 1,
+          capState: "within",
+        },
+      ],
+    }));
+    expect(md).toContain("| 2026-05-18 | 99.00% | 410 ms | $2.50 | $2.50 | 0 | 0 | 99.90% | `within` |");
+    expect(md).toContain("| 2026-05-19 | 97.00% | 430 ms | $3.50 | $6.00 | 0 | 0 | 100.00% | `within` |");
+    expect(md).toContain("### Isolation incidents");
+    expect(md).toContain("_None — green log._");
+    expect(md).toContain("### Raw-secret leaks");
+  });
+});

--- a/server/src/services/sandbox/pilot-reporting/exit-criteria-report.ts
+++ b/server/src/services/sandbox/pilot-reporting/exit-criteria-report.ts
@@ -1,0 +1,352 @@
+import { successRate } from "./daily-snapshot.js";
+import type {
+  DailySnapshotTallyEntry,
+  ExitCriteriaInput,
+  ExitCriteriaThresholds,
+  IsolationIncidentReport,
+  LeaseLatencyAggregate,
+  OperatorConfidenceComment,
+  SecretLeakReport,
+} from "./types.js";
+
+export type ExitCriterionId =
+  | "lease_success_rate"
+  | "cold_start_p95"
+  | "lease_ready_p95"
+  | "isolation_incidents"
+  | "secret_leaks"
+  | "monthly_cost"
+  | "vendor_uptime"
+  | "operator_confidence";
+
+export type ExitCriterionVerdict = "pass" | "fail" | "no_data";
+
+export type ExitCriterionEvaluation = {
+  id: ExitCriterionId;
+  label: string;
+  threshold: string;
+  actual: string;
+  verdict: ExitCriterionVerdict;
+  detail?: string | null;
+};
+
+export type ExitCriteriaEvaluation = {
+  perCriterion: ExitCriterionEvaluation[];
+  overall: "pass" | "fail";
+  /** Set when overall = "fail"; lists the criterion ids that failed. */
+  failedIds: ExitCriterionId[];
+};
+
+const REQUIRED_OPERATOR_ROLES = ["Architect", "QA Validator", "Hermes Orchestrator"] as const;
+
+/**
+ * Evaluate every exit-criteria row against the thresholds. Pure function
+ * over its inputs — the caller (LET-371) decides what to do with the
+ * verdict (pass → ADR §7 issue, fail → revert + incident + ADR addendum).
+ */
+export function evaluateExitCriteria(input: ExitCriteriaInput): ExitCriteriaEvaluation {
+  const t = input.thresholds;
+  const tallyRate = successRate(input.windowLeaseTally);
+  const perCriterion: ExitCriterionEvaluation[] = [];
+
+  perCriterion.push({
+    id: "lease_success_rate",
+    label: "Lease success rate",
+    threshold: `≥ ${formatRate(t.leaseSuccessRateMin)}`,
+    actual: formatRate(tallyRate),
+    verdict: tallyRate === null ? "no_data" : tallyRate >= t.leaseSuccessRateMin ? "pass" : "fail",
+    detail: tallyAsText(input.windowLeaseTally),
+  });
+
+  perCriterion.push(thresholdMaxMs(
+    "cold_start_p95",
+    "p95 cold start",
+    input.windowLeaseTally.coldStartP95Ms,
+    t.coldStartP95MsMax,
+  ));
+  perCriterion.push(thresholdMaxMs(
+    "lease_ready_p95",
+    "End-to-end lease-ready latency p95",
+    input.windowLeaseTally.leaseReadyP95Ms,
+    t.leaseReadyP95MsMax,
+  ));
+
+  const isoCount = input.isolationIncidents.length;
+  perCriterion.push({
+    id: "isolation_incidents",
+    label: "Isolation incidents",
+    threshold: `≤ ${t.isolationIncidentsMax}`,
+    actual: String(isoCount),
+    verdict: isoCount <= t.isolationIncidentsMax ? "pass" : "fail",
+  });
+
+  const leakCount = input.secretLeaks.length;
+  perCriterion.push({
+    id: "secret_leaks",
+    label: "Raw-secret leaks",
+    threshold: `≤ ${t.secretLeaksMax}`,
+    actual: String(leakCount),
+    verdict: leakCount <= t.secretLeaksMax ? "pass" : "fail",
+  });
+
+  const monthCents = input.finalBilling.monthToDateCents;
+  perCriterion.push({
+    id: "monthly_cost",
+    label: "Monthly cost",
+    threshold: `≤ ${formatUsd(t.monthlyHardCapCents)} hard cap`,
+    actual: formatUsd(monthCents),
+    verdict: monthCents > t.monthlyHardCapCents || input.finalBilling.monthState === "hard_cap_disabled" ? "fail" : "pass",
+    detail: `month state: ${input.finalBilling.monthState}`,
+  });
+
+  perCriterion.push({
+    id: "vendor_uptime",
+    label: "Vendor uptime",
+    threshold: `≥ ${formatRate(t.vendorUptimeMin)}`,
+    actual: formatRate(input.vendorUptimeRatio),
+    verdict: input.vendorUptimeRatio === null ? "no_data" : input.vendorUptimeRatio >= t.vendorUptimeMin ? "pass" : "fail",
+  });
+
+  perCriterion.push(operatorConfidenceVerdict(input.operatorConfidenceComments));
+
+  const failedIds = perCriterion
+    .filter((row) => row.verdict === "fail" || row.verdict === "no_data")
+    .map((row) => row.id);
+  return {
+    perCriterion,
+    overall: failedIds.length === 0 ? "pass" : "fail",
+    failedIds,
+  };
+}
+
+/**
+ * Pure renderer. Produces the Markdown body for the
+ * `phase-4a-s4-pilot-exit-criteria-YYYY-MM-DD` issue document. The caller
+ * (LET-371) takes this string and upserts it; this function never touches
+ * the document store.
+ */
+export function renderExitCriteriaReport(input: ExitCriteriaInput): string {
+  const evaluation = evaluateExitCriteria(input);
+  const lines: string[] = [];
+
+  lines.push(`# ${input.pilotId} — exit-criteria report`);
+  lines.push("");
+  lines.push(`> Truth label: \`${input.truthLabel}\` — ${truthLabelExplain(input.truthLabel)}`);
+  lines.push(`> Pilot window: ${input.windowStartUtcDay} → ${input.windowEndUtcDay} (UTC, inclusive)`);
+  lines.push("");
+
+  if (input.earlyHalt) {
+    lines.push("## ⛔ Early halt");
+    lines.push("");
+    lines.push(`- Triggered at: ${input.earlyHalt.triggeredAt}`);
+    lines.push(`- Trigger: \`${input.earlyHalt.trigger}\``);
+    lines.push(`- Summary: ${escapeCell(input.earlyHalt.summary)}`);
+    if (input.earlyHalt.incidentLink) {
+      lines.push(`- Incident link: ${input.earlyHalt.incidentLink}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("## Exit criteria");
+  lines.push("");
+  lines.push("| Criterion | Threshold | Actual | Verdict | Notes |");
+  lines.push("|---|---|---|---|---|");
+  for (const row of evaluation.perCriterion) {
+    lines.push(`| ${row.label} | ${row.threshold} | ${row.actual} | ${verdictBadge(row.verdict)} | ${escapeCell(row.detail ?? "")} |`);
+  }
+  lines.push("");
+
+  lines.push("## Total cost vs cap");
+  lines.push("");
+  lines.push(`- Month-to-date spend at close: ${formatUsd(input.finalBilling.monthToDateCents)}`);
+  lines.push(`- Monthly hard cap: ${formatUsd(input.finalBilling.monthlyHardCapCents)} (state: \`${input.finalBilling.monthState}\`)`);
+  lines.push(`- Day-of-close spend: ${formatUsd(input.finalBilling.dayToDateCents)} of ${formatUsd(input.finalBilling.dailyHardCapCents)} (state: \`${input.finalBilling.dayState}\`)`);
+  lines.push("");
+
+  lines.push("## Vendor uptime");
+  lines.push("");
+  lines.push(`- Window uptime: ${formatRate(input.vendorUptimeRatio)} (threshold ≥ ${formatRate(input.thresholds.vendorUptimeMin)})`);
+  lines.push("");
+
+  lines.push("## Daily snapshot tally");
+  lines.push("");
+  if (input.dailyTally.length === 0) {
+    lines.push("_No daily snapshots recorded._");
+  } else {
+    lines.push("| UTC day | Success rate | p95 cold start | Day spend | MTD spend | Iso. inc. | Leaks | Vendor uptime | Cap state |");
+    lines.push("|---|---|---|---|---|---|---|---|---|");
+    for (const row of input.dailyTally) {
+      lines.push(dailyTallyRow(row));
+    }
+  }
+  lines.push("");
+
+  lines.push("## Incident log");
+  lines.push("");
+  lines.push("### Isolation incidents");
+  lines.push(incidentBlock(input.isolationIncidents));
+  lines.push("");
+  lines.push("### Raw-secret leaks");
+  lines.push(leakBlock(input.secretLeaks));
+  lines.push("");
+
+  lines.push("## Operator-confidence comments");
+  lines.push("");
+  lines.push(operatorConfidenceBlock(input.operatorConfidenceComments));
+  lines.push("");
+
+  lines.push("## Recommendation");
+  lines.push("");
+  lines.push(recommendationBlock(evaluation, input));
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function thresholdMaxMs(
+  id: ExitCriterionId,
+  label: string,
+  actual: number | null,
+  max: number,
+): ExitCriterionEvaluation {
+  return {
+    id,
+    label,
+    threshold: `≤ ${max} ms`,
+    actual: actual === null ? "_no samples_" : `${actual} ms`,
+    verdict: actual === null ? "no_data" : actual <= max ? "pass" : "fail",
+  };
+}
+
+function operatorConfidenceVerdict(comments: ReadonlyArray<OperatorConfidenceComment>): ExitCriterionEvaluation {
+  const byRole = new Map<string, OperatorConfidenceComment>();
+  for (const comment of comments) {
+    // Last comment per role wins — operators may amend their verdict.
+    byRole.set(comment.role, comment);
+  }
+  const missing: string[] = [];
+  const nonGo: string[] = [];
+  for (const role of REQUIRED_OPERATOR_ROLES) {
+    const comment = byRole.get(role);
+    if (!comment) {
+      missing.push(role);
+      continue;
+    }
+    if (comment.verdict !== "go") {
+      nonGo.push(`${role}=${comment.verdict}`);
+    }
+  }
+  const detail = missing.length === 0 && nonGo.length === 0
+    ? `${REQUIRED_OPERATOR_ROLES.length}/${REQUIRED_OPERATOR_ROLES.length} go`
+    : `missing: [${missing.join(", ")}]; non-go: [${nonGo.join(", ")}]`;
+  return {
+    id: "operator_confidence",
+    label: "Operator confidence",
+    threshold: `${REQUIRED_OPERATOR_ROLES.join(" + ")} each post a written "go"`,
+    actual: detail,
+    verdict: missing.length === 0 && nonGo.length === 0 ? "pass" : "fail",
+  };
+}
+
+function recommendationBlock(evaluation: ExitCriteriaEvaluation, input: ExitCriteriaInput): string {
+  if (evaluation.overall === "pass" && !input.earlyHalt) {
+    return [
+      "✅ **PASS — graduate to Phase 4B.**",
+      "",
+      "- Open a new ADR §7 gate issue for the Phase 4B rollout.",
+      "- Carry the lease-success-rate, cold-start p95, lease-ready p95, monthly spend, and vendor uptime numbers above into the gate issue as the prior-phase evidence.",
+      "- Keep the kill-switch, billing cap, isolation guard, and secret-egress guard layers armed through the rollout.",
+    ].join("\n");
+  }
+  const failedList = evaluation.failedIds.length === 0
+    ? "_early halt (no per-criterion failure)_"
+    : evaluation.failedIds.map((id) => `\`${id}\``).join(", ");
+  return [
+    "🛑 **FAIL — revert and escalate.**",
+    "",
+    `- Failed criteria: ${failedList}`,
+    "- Flip `SANDBOX_PROVIDER_ALLOW_LIVE` back to `false` for the pilot agent role.",
+    "- Write a Phase 4A-S4 incident on LET-365 referencing this report.",
+    "- Append an ADR addendum capturing the failure mode and next-step decision (extend pilot vs. abandon E2B vs. switch provider).",
+  ].join("\n");
+}
+
+function dailyTallyRow(row: DailySnapshotTallyEntry): string {
+  return [
+    `| ${row.utcDay}`,
+    formatRate(row.leaseSuccessRate),
+    row.coldStartP95Ms === null ? "_no samples_" : `${row.coldStartP95Ms} ms`,
+    formatUsd(row.daySpendCents),
+    formatUsd(row.monthToDateCents),
+    String(row.isolationIncidents),
+    String(row.secretLeaks),
+    formatRate(row.vendorUptimeRatio),
+    `\`${row.capState}\` |`,
+  ].join(" | ");
+}
+
+function incidentBlock(incidents: ReadonlyArray<IsolationIncidentReport>): string {
+  if (incidents.length === 0) return "_None — green log._";
+  return incidents.map((incident) => {
+    const link = incident.link ? ` ([link](${incident.link}))` : "";
+    return `- \`${incident.id}\` (${incident.detectedAt}) — ${escapeCell(truncate(incident.summary, 240))}${link}`;
+  }).join("\n");
+}
+
+function leakBlock(leaks: ReadonlyArray<SecretLeakReport>): string {
+  if (leaks.length === 0) return "_None — green log._";
+  return leaks.map((leak) => {
+    const link = leak.link ? ` ([link](${leak.link}))` : "";
+    return `- \`${leak.id}\` (${leak.detectedAt}) — ${escapeCell(truncate(leak.summary, 240))}${link}`;
+  }).join("\n");
+}
+
+function operatorConfidenceBlock(comments: ReadonlyArray<OperatorConfidenceComment>): string {
+  if (comments.length === 0) return "_No operator-confidence comments recorded._";
+  const rows = comments.map((c) => {
+    const excerpt = c.excerpt ? ` — ${escapeCell(truncate(c.excerpt, 240))}` : "";
+    return `- **${c.role}** (${c.operator}) — \`${c.verdict}\` at ${c.postedAt} (comment \`${c.commentId}\`)${excerpt}`;
+  });
+  return rows.join("\n");
+}
+
+function verdictBadge(verdict: ExitCriterionVerdict): string {
+  switch (verdict) {
+    case "pass":
+      return "✅ pass";
+    case "fail":
+      return "🛑 fail";
+    case "no_data":
+      return "⚠️ no data";
+  }
+}
+
+function tallyAsText(tally: LeaseLatencyAggregate): string {
+  return `${tally.successCount} success / ${tally.failureCount} failure`;
+}
+
+function truthLabelExplain(label: "preview" | "live"): string {
+  return label === "live"
+    ? "live pilot data — G2 has fired."
+    : "preview / stub data — G2 has NOT fired yet.";
+}
+
+function formatRate(rate: number | null): string {
+  if (rate === null) return "_no samples_";
+  return `${(rate * 100).toFixed(2)}%`;
+}
+
+function formatUsd(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function escapeCell(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}…`;
+}
+
+export type { ExitCriteriaThresholds };

--- a/server/src/services/sandbox/pilot-reporting/index.ts
+++ b/server/src/services/sandbox/pilot-reporting/index.ts
@@ -1,0 +1,35 @@
+export {
+  PILOT_REPORTING_SCHEMA_VERSION,
+  PILOT_EXIT_CRITERIA_DEFAULTS,
+  type BillingCounterSnapshot,
+  type CapState,
+  type DailySnapshotInput,
+  type DailySnapshotTallyEntry,
+  type ExitCriteriaInput,
+  type ExitCriteriaThresholds,
+  type IsolationIncidentReport,
+  type KillSwitchLayerState,
+  type KillSwitchState,
+  type LeaseLatencyAggregate,
+  type OperatorConfidenceComment,
+  type ProviderLayerId,
+  type ProviderStatusSnapshot,
+  type SecretLeakReport,
+  type VendorStatusPageSnapshot,
+} from "./types.js";
+
+export {
+  renderDailySnapshot,
+  successRate,
+  resolveCapState,
+  projectBillingSnapshot,
+} from "./daily-snapshot.js";
+
+export {
+  renderExitCriteriaReport,
+  evaluateExitCriteria,
+  type ExitCriterionId,
+  type ExitCriterionVerdict,
+  type ExitCriterionEvaluation,
+  type ExitCriteriaEvaluation,
+} from "./exit-criteria-report.js";

--- a/server/src/services/sandbox/pilot-reporting/types.ts
+++ b/server/src/services/sandbox/pilot-reporting/types.ts
@@ -1,0 +1,232 @@
+/**
+ * Pure input shapes consumed by the Phase 4A-S4 pilot-reporting components.
+ *
+ * These shapes are the integration seam between LET-411 (this prep work) and
+ * LET-371 (the B6 pilot orchestration). They are intentionally narrow and
+ * provider-agnostic: callers project from the live B2 counter store
+ * (LET-367), the live B3 panel read-model (LET-368), the E2B status-page
+ * poll, and the Paperclip lease history into these typed bundles. The
+ * renderers themselves never reach across the seam — no I/O, no provider
+ * transport, no secret-store read.
+ *
+ * If LET-367 / LET-368 ship a shape that diverges from what is declared here,
+ * the LET-411 caller adds a thin adapter (see README) instead of mutating
+ * the shipped shapes.
+ */
+
+export const PILOT_REPORTING_SCHEMA_VERSION = 1 as const;
+
+export type CapState = "within" | "soft_cap" | "hard_cap_disabled";
+
+export type KillSwitchLayerState = "armed" | "tripped" | "manual_disable";
+
+export type ProviderLayerId =
+  | "sandbox_provider"
+  | "billing_cap"
+  | "isolation_guard"
+  | "secret_egress_guard";
+
+export type KillSwitchState = {
+  /** Layer identifier as exposed by the B3 panel read-model. */
+  layer: ProviderLayerId;
+  /** Current state. `tripped` and `manual_disable` both halt traffic. */
+  state: KillSwitchLayerState;
+  /** ISO timestamp of last state change, if recorded. */
+  changedAt?: string | null;
+  /** Operator-supplied reason for `tripped` / `manual_disable`. */
+  reason?: string | null;
+};
+
+/**
+ * Projection from the B2 counter store. Spend is in whole USD cents to avoid
+ * float rounding in the renderer; callers convert.
+ */
+export type BillingCounterSnapshot = {
+  /** UTC day the day-to-date counter represents (YYYY-MM-DD). */
+  utcDay: string;
+  /** Day-to-date spend in USD cents. */
+  dayToDateCents: number;
+  /** Month-to-date spend in USD cents. */
+  monthToDateCents: number;
+  /** Hard daily cap in USD cents. From B2 config; pilot frozen at 20 USD. */
+  dailyHardCapCents: number;
+  /** Hard monthly cap in USD cents. From B2 config; pilot frozen at 200 USD. */
+  monthlyHardCapCents: number;
+  /** Soft daily cap — operator warning threshold. */
+  dailySoftCapCents?: number | null;
+  /** Soft monthly cap — operator warning threshold. */
+  monthlySoftCapCents?: number | null;
+  /** Resolved day/month state after applying the caps. */
+  dayState: CapState;
+  monthState: CapState;
+};
+
+/**
+ * Projection from the B3 panel read-model. Layer states drive the
+ * Command Center "kill-switch state per layer" row in the snapshot.
+ */
+export type ProviderStatusSnapshot = {
+  /** Capture timestamp (ISO). */
+  capturedAt: string;
+  /** Per-layer kill-switch state. */
+  killSwitches: ReadonlyArray<KillSwitchState>;
+  /** Last lease attempt metadata, if a lease was recorded in this window. */
+  lastLease?: {
+    leaseId: string;
+    provider: "e2b" | string;
+    outcome: "success" | "failure";
+    completedAt: string;
+    coldStartMs?: number | null;
+    leaseReadyMs?: number | null;
+  } | null;
+};
+
+/**
+ * Vendor-side health from polling the E2B status-page. Callers fetch and
+ * project; the renderer never makes a network call.
+ */
+export type VendorStatusPageSnapshot = {
+  /** Vendor name — `"e2b"` for the pilot. */
+  vendor: string;
+  /** Capture timestamp (ISO). */
+  capturedAt: string;
+  /** Vendor uptime over the reported window, 0..1. `null` when unknown. */
+  uptimeRatio: number | null;
+  /** Vendor-reported incident IDs that overlap the reporting window. */
+  activeIncidentIds: ReadonlyArray<string>;
+  /** Free-text status. Renderer surfaces it as the vendor health note. */
+  statusText?: string | null;
+};
+
+export type LeaseLatencyAggregate = {
+  successCount: number;
+  failureCount: number;
+  /** p95 provider cold-start latency in ms. `null` when no samples. */
+  coldStartP95Ms: number | null;
+  /** p95 end-to-end lease-ready latency in ms. `null` when no samples. */
+  leaseReadyP95Ms: number | null;
+};
+
+export type IsolationIncidentReport = {
+  /** Stable incident id (issue identifier, log id, or operator-assigned). */
+  id: string;
+  /** ISO timestamp the incident was detected. */
+  detectedAt: string;
+  /** One-line operator summary. Renderer truncates at 240 chars. */
+  summary: string;
+  /** Optional pointer back to the issue/comment where the incident lives. */
+  link?: string | null;
+};
+
+export type SecretLeakReport = {
+  id: string;
+  detectedAt: string;
+  /** One-line operator summary. Never contains the raw secret. */
+  summary: string;
+  link?: string | null;
+};
+
+/** Bundle the daily-snapshot generator consumes. */
+export type DailySnapshotInput = {
+  /** Logical pilot day this snapshot represents (YYYY-MM-DD, UTC). */
+  utcDay: string;
+  /** Pilot identifier used in headings (e.g. `phase-4a-s4-e2b-pilot`). */
+  pilotId: string;
+  billing: BillingCounterSnapshot;
+  providerStatus: ProviderStatusSnapshot;
+  vendor: VendorStatusPageSnapshot;
+  /** Running lease tally as of the snapshot capture. */
+  leaseTally: LeaseLatencyAggregate;
+  /** Isolation incidents detected during the reporting window. */
+  isolationIncidents: ReadonlyArray<IsolationIncidentReport>;
+  /** Raw-secret leak detections during the reporting window. */
+  secretLeaks: ReadonlyArray<SecretLeakReport>;
+  /**
+   * `preview` until Andrii G2 fires and the live provider is enabled, then
+   * `live`. The renderer surfaces this label in the snapshot header so
+   * downstream readers can never confuse a stub-driven snapshot with a
+   * live-pilot one.
+   */
+  truthLabel: "preview" | "live";
+};
+
+/** Exit-criteria thresholds frozen from LET-371 §"Exit criteria". */
+export type ExitCriteriaThresholds = {
+  leaseSuccessRateMin: number; // 0..1, e.g. 0.95
+  coldStartP95MsMax: number; // e.g. 500
+  leaseReadyP95MsMax: number; // e.g. 1500
+  isolationIncidentsMax: number; // 0
+  secretLeaksMax: number; // 0
+  monthlyHardCapCents: number; // 20000 (= USD 200)
+  vendorUptimeMin: number; // 0.995
+};
+
+export type OperatorConfidenceComment = {
+  /** Role label, e.g. `Architect`, `QA Validator`, `Hermes Orchestrator`. */
+  role: string;
+  /** Display name of the operator who posted the comment. */
+  operator: string;
+  /** Verdict captured from the comment body. */
+  verdict: "go" | "no_go" | "abstain";
+  /** ISO timestamp of the comment. */
+  postedAt: string;
+  /** Pointer back to the LET-365 comment id (UUID). */
+  commentId: string;
+  /** Optional free-text excerpt for the report body (renderer truncates). */
+  excerpt?: string | null;
+};
+
+export type DailySnapshotTallyEntry = {
+  utcDay: string;
+  leaseSuccessRate: number | null;
+  coldStartP95Ms: number | null;
+  daySpendCents: number;
+  monthToDateCents: number;
+  isolationIncidents: number;
+  secretLeaks: number;
+  vendorUptimeRatio: number | null;
+  capState: CapState;
+};
+
+export type ExitCriteriaInput = {
+  /** Pilot identifier, e.g. `phase-4a-s4-e2b-pilot`. */
+  pilotId: string;
+  /** Pilot window (ISO date strings, inclusive UTC days). */
+  windowStartUtcDay: string;
+  windowEndUtcDay: string;
+  /** Aggregates across the full pilot window. */
+  windowLeaseTally: LeaseLatencyAggregate;
+  /** Final billing snapshot at window close. */
+  finalBilling: BillingCounterSnapshot;
+  /** Vendor uptime computed across the pilot window, 0..1. */
+  vendorUptimeRatio: number | null;
+  /** All daily snapshot tally rows for the pilot window. */
+  dailyTally: ReadonlyArray<DailySnapshotTallyEntry>;
+  /** Incident log — empty in a green pilot. */
+  isolationIncidents: ReadonlyArray<IsolationIncidentReport>;
+  secretLeaks: ReadonlyArray<SecretLeakReport>;
+  /** Operator-confidence comments — must be 3 `go` for a clean pass. */
+  operatorConfidenceComments: ReadonlyArray<OperatorConfidenceComment>;
+  /** Threshold bundle (frozen from LET-371). */
+  thresholds: ExitCriteriaThresholds;
+  /** Optional explicit halt event if the pilot stopped early. */
+  earlyHalt?: {
+    triggeredAt: string;
+    trigger: "cost_breach" | "isolation_incident" | "latency_failure" | "secret_leak" | "operator_halt";
+    summary: string;
+    incidentLink?: string | null;
+  } | null;
+  /** `preview` until G2 fires, then `live`. */
+  truthLabel: "preview" | "live";
+};
+
+/** Frozen defaults that the Phase 4A-S4 pilot has approved. */
+export const PILOT_EXIT_CRITERIA_DEFAULTS: ExitCriteriaThresholds = {
+  leaseSuccessRateMin: 0.95,
+  coldStartP95MsMax: 500,
+  leaseReadyP95MsMax: 1500,
+  isolationIncidentsMax: 0,
+  secretLeaksMax: 0,
+  monthlyHardCapCents: 20000,
+  vendorUptimeMin: 0.995,
+};


### PR DESCRIPTION
## Summary

Phase 4A-S4 **B6-prep** under parent LET-365. Adds two pure Markdown renderers under `server/src/services/sandbox/pilot-reporting/` that LET-371 (B6) will consume when the 2-week E2B pilot starts. Zero key dependency — CI runs without any E2B credential.

- `renderDailySnapshot(input)` — Command Center daily snapshot (spend vs cap, lease health, safety counters, vendor uptime, kill-switch state per layer, action banners).
- `renderExitCriteriaReport(input)` + `evaluateExitCriteria(input)` — body for the `phase-4a-s4-pilot-exit-criteria-YYYY-MM-DD` issue document with per-criterion verdict table, daily tally, incident log, operator-confidence aggregation, and pass/fail recommendation block.

Both components are pure functions over their inputs — no I/O, no HTTP, no provider transport, no secret-store read. **LET-411 does not post the snapshot and does not upsert the document**; the LET-371-owned callers wire those in after Andrii G2 (`confirmation:LET-365:canary-flag-flip:rev1`) is accepted. `truthLabel` defaults to `preview` so stub-driven artifacts can never be confused with live-pilot artifacts.

## Files

- `server/src/services/sandbox/pilot-reporting/types.ts` — typed integration seam (B2 counters, B3 panel, status-page poll, lease history, operator confidence, exit thresholds).
- `server/src/services/sandbox/pilot-reporting/daily-snapshot.ts` — Component 1 renderer + cap-state helpers.
- `server/src/services/sandbox/pilot-reporting/exit-criteria-report.ts` — Component 2 renderer + evaluator.
- `server/src/services/sandbox/pilot-reporting/{daily-snapshot,exit-criteria-report}.test.ts` — 20 tests covering all named states.
- `server/src/services/sandbox/pilot-reporting/README.md` — interface docs + LET-371 integration seam.
- `server/src/services/sandbox/pilot-reporting/index.ts` — public re-exports.

## Test plan

- [x] `pnpm exec vitest run src/services/sandbox/pilot-reporting` → 20/20 pass (within-cap, soft-cap, hard-cap auto-disable, isolation incident, secret leak, vendor uptime dip, green pass, cost-breach halt, isolation-incident halt, latency failure, operator-confidence missing/non-go, no-data placeholders).
- [x] `pnpm run typecheck` — no new errors in `pilot-reporting/`. Listed `tsc` errors (`adapter-grok-local`, `environment-runtime.ts`, `plugin-environment-driver.ts`, `plugin-host-services.ts`) are pre-existing on `origin/master` and unrelated to this PR.
- [ ] Reviewers: Claude Reviewer + QA Validator per project pull-request policy.

## Canonical-shell handoff

- **Target zone:** none — server-side pure helpers, no UI surface.
- **Route / nav impact:** none.
- **Truth labels:** renderer output is `preview` until G2 fires, then the LET-371 caller flips to `live`. Renderer surfaces the label in the snapshot / report header.
- **Branch / PR / master / release:** branch `enterprise-agent-os/LET-411` off `origin/master`; PR targets `master`; no release-window dependency.
- **Tests / QA / Claude evidence:** vitest run above, full repo typecheck delta clean for new files, README documents the LET-371 caller seam.

## Constraints honoured

- Zero key requirement. No `secrets/sandbox/e2b/apiKey/pilot` resolve. No live HTTP.
- Fail-closed boundary preserved — no provider transport initialised.
- Preview/stub label stays on the rendered surfaces; no UI changed.
- Raw secrets never persisted in code, tests, logs, comments, or this PR description.
- No production deploy/restart, no prod DB migration apply.

## What this PR does NOT do

- Does not post any snapshot comment on LET-365.
- Does not upsert any pilot-exit-criteria document.
- Does not orchestrate the pilot.
- Does not call E2B.
- Does not change the kill-switch, flag, or any gate.

LET-371 (B6) remains blocked on LET-370 (B5) + Andrii G2. This child runs in parallel and produces the building blocks B6 will need on pilot start.

Refs: LET-411, parent LET-365, plan doc `phase-4a-s4-e2b-pilot-execution-plan-2026-05-17` §11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)