### PR TITLE
Remove planning badge from inbox issue rows (PAP-9691)

### DIFF
--- a/tests/e2e/planning-mode-visual-verification.spec.ts
+++ b/tests/e2e/planning-mode-visual-verification.spec.ts
@@ -119,7 +119,7 @@ test("captures planning mode UI for desktop and mobile", async ({ page }) => {
 
   await page.goto(`/${companyPrefix}/issues`);
   await expect(page.locator(issueLinkSelector)).toBeVisible();
-  await expect(page.locator(issueLinkSelector)).toContainText("Planning");
+  await expect(page.locator(issueLinkSelector)).not.toContainText("Planning");
   await page.screenshot({
     path: `${screenshotDir}/desktop-planning-row-${timestamp}.png`,
     fullPage: true,
@@ -149,7 +149,7 @@ test("captures planning mode UI for desktop and mobile", async ({ page }) => {
 
   await page.goto(`/${companyPrefix}/issues`);
   await expect(page.locator(issueLinkSelector)).toBeVisible();
-  await expect(page.locator(issueLinkSelector)).toContainText("Planning");
+  await expect(page.locator(issueLinkSelector)).not.toContainText("Planning");
   await page.screenshot({
     path: `${screenshotDir}/mobile-planning-row-${timestamp}.png`,
     fullPage: true,

--- a/ui/src/components/IssueRow.test.tsx
+++ b/ui/src/components/IssueRow.test.tsx
@@ -228,7 +228,7 @@ describe("IssueRow", () => {
     });
   });
 
-  it("renders planning mode marker for planning work mode issues", () => {
+  it("does not render a planning mode marker for planning work mode issues", () => {
     const root = createRoot(container);
 
     act(() => {
@@ -237,8 +237,7 @@ describe("IssueRow", () => {
 
     const link = container.querySelector("[data-inbox-issue-link]") as HTMLAnchorElement | null;
     expect(link).not.toBeNull();
-    expect(link?.textContent).toContain("Planning");
-    expect(link?.textContent?.match(/Planning/g)).toHaveLength(1);
+    expect(link?.textContent).not.toContain("Planning");
 
     act(() => {
       root.unmount();

--- a/ui/src/components/IssueRow.tsx
+++ b/ui/src/components/IssueRow.tsx
@@ -85,14 +85,6 @@ export function IssueRow({
       {checklistStepNumber}.
     </span>
   ) : null;
-  const planningModeIndicator = issue.workMode === "planning" ? (
-    <span
-      className="ml-1.5 inline-flex shrink-0 items-center rounded-full border border-amber-500/60 bg-amber-500/15 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300"
-      title="This issue is in planning mode."
-    >
-      Planning
-    </span>
-  ) : null;
   const recoveryAction = issue.activeRecoveryAction ?? null;
   const recoveryIndicator = recoveryAction ? renderRecoveryChip(recoveryAction, selected) : null;
   const parkedBlockerIndicator = hasAssignedBacklogBlocker(issue.blockedBy) ? (
@@ -156,7 +148,6 @@ export function IssueRow({
               {recoveryIndicator}
             </>
           )}
-          {planningModeIndicator}
           {mobileMeta ? (
             <>
               <span className="text-xs text-muted-foreground sm:hidden" aria-hidden="true">


### PR DESCRIPTION
## Summary

- Removes the amber "Planning" pill from inbox / issue-list rows in `IssueRow`
- Updates the focused IssueRow test to assert the badge is no longer rendered
- Per [PAP-9691](https://paperclip.ing/PAP/issues/PAP-9691): user just doesn't want to see the badge in list rows

The underlying `issue.workMode === "planning"` data, the issue detail composer toggle, and the server/plugin/heartbeat work-mode contract introduced in #5353 are all untouched. Planning mode still functions; the list-row indicator is just gone.

## Test plan

- [x] `pnpm exec vitest run --project @paperclipai/ui ui/src/components/IssueRow.test.tsx` (11 passed)
- [ ] Visual: open `/PAP/inbox` with a planning-mode issue assigned and confirm no amber Planning pill on the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)