### PR TITLE
security(plugin-webhook-ingest): collapse pre-dispatch errors to single 404 (MAT-669, audit §F10)

### DIFF
--- a/server/src/__tests__/plugin-webhook-ingest-errors.test.ts
+++ b/server/src/__tests__/plugin-webhook-ingest-errors.test.ts
@@ -1,0 +1,178 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockRegistry = vi.hoisted(() => ({
+  getById: vi.fn(),
+  getByKey: vi.fn(),
+}));
+
+const mockLifecycle = vi.hoisted(() => ({
+  load: vi.fn(),
+  upgrade: vi.fn(),
+  unload: vi.fn(),
+  enable: vi.fn(),
+  disable: vi.fn(),
+}));
+
+vi.mock("../services/plugin-registry.js", () => ({
+  pluginRegistryService: () => mockRegistry,
+}));
+
+vi.mock("../services/plugin-lifecycle.js", () => ({
+  pluginLifecycleManager: () => mockLifecycle,
+}));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: vi.fn(),
+}));
+
+vi.mock("../services/live-events.js", () => ({
+  publishGlobalLiveEvent: vi.fn(),
+}));
+
+const pluginId = "11111111-1111-4111-8111-111111111111";
+const endpointKey = "github-push";
+
+async function createApp(routeOverrides: {
+  db?: unknown;
+  webhookDeps?: unknown;
+} = {}) {
+  const [{ pluginRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/plugins.js"),
+    import("../middleware/index.js"),
+  ]);
+
+  const loader = { installPlugin: vi.fn() };
+
+  const app = express();
+  app.use(express.json());
+  app.use("/api", pluginRoutes(
+    (routeOverrides.db ?? {}) as never,
+    loader as never,
+    undefined,
+    routeOverrides.webhookDeps as never,
+    undefined,
+    undefined,
+  ));
+  app.use(errorHandler);
+
+  return app;
+}
+
+function workerManagerStub() {
+  return {
+    workerManager: {
+      call: vi.fn(),
+    },
+  };
+}
+
+describe.sequential("MAT-669 webhook ingest error responses", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns generic 404 when plugin does not exist", async () => {
+    mockRegistry.getById.mockResolvedValue(null);
+    mockRegistry.getByKey.mockResolvedValue(null);
+    const app = await createApp({ webhookDeps: workerManagerStub() });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/webhooks/${endpointKey}`)
+      .send({ event: "push" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "webhook not delivered" });
+  });
+
+  it("returns generic 404 when plugin is not in ready state", async () => {
+    mockRegistry.getById.mockResolvedValue({
+      id: pluginId,
+      status: "disabled",
+      manifestJson: {
+        capabilities: ["webhooks.receive"],
+        webhooks: [{ endpointKey }],
+      },
+    });
+    const app = await createApp({ webhookDeps: workerManagerStub() });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/webhooks/${endpointKey}`)
+      .send({ event: "push" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "webhook not delivered" });
+    expect(res.body.error).not.toMatch(/disabled|ready|status/i);
+  });
+
+  it("returns generic 404 when plugin manifest is missing", async () => {
+    mockRegistry.getById.mockResolvedValue({
+      id: pluginId,
+      status: "ready",
+      manifestJson: null,
+    });
+    const app = await createApp({ webhookDeps: workerManagerStub() });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/webhooks/${endpointKey}`)
+      .send({ event: "push" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "webhook not delivered" });
+    expect(res.body.error).not.toMatch(/manifest/i);
+  });
+
+  it("returns generic 404 when plugin lacks webhooks.receive capability", async () => {
+    mockRegistry.getById.mockResolvedValue({
+      id: pluginId,
+      status: "ready",
+      manifestJson: {
+        capabilities: ["tools.invoke"],
+        webhooks: [{ endpointKey }],
+      },
+    });
+    const app = await createApp({ webhookDeps: workerManagerStub() });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/webhooks/${endpointKey}`)
+      .send({ event: "push" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "webhook not delivered" });
+    expect(res.body.error).not.toMatch(/capabilit|webhooks\.receive/i);
+  });
+
+  it("returns generic 404 when endpointKey is not declared by the plugin", async () => {
+    mockRegistry.getById.mockResolvedValue({
+      id: pluginId,
+      status: "ready",
+      manifestJson: {
+        capabilities: ["webhooks.receive"],
+        webhooks: [{ endpointKey: "stripe-charge" }],
+      },
+    });
+    const app = await createApp({ webhookDeps: workerManagerStub() });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/webhooks/${endpointKey}`)
+      .send({ event: "push" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "webhook not delivered" });
+    expect(res.body.error).not.toMatch(/declared|endpointKey/i);
+  });
+
+  it("does not dispatch to the worker on any rejection path", async () => {
+    const deps = workerManagerStub();
+    mockRegistry.getById.mockResolvedValue(null);
+    mockRegistry.getByKey.mockResolvedValue(null);
+    const app = await createApp({ webhookDeps: deps });
+
+    await request(app)
+      .post(`/api/plugins/${pluginId}/webhooks/${endpointKey}`)
+      .send({ event: "push" });
+
+    expect(deps.workerManager.call).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -47,6 +47,7 @@ import {
 import { pluginRegistryService } from "../services/plugin-registry.js";
 import { pluginLifecycleManager } from "../services/plugin-lifecycle.js";
 import { getPluginUiContributionMetadata, pluginLoader } from "../services/plugin-loader.js";
+import { logger } from "../middleware/logger.js";
 import { logActivity } from "../services/activity-log.js";
 import { publishGlobalLiveEvent } from "../services/live-events.js";
 import { issueService } from "../services/issues.js";
@@ -2259,8 +2260,12 @@ export function pluginRoutes(
    *
    * Response: `{ deliveryId: string, status: string }`
    * Errors:
-   * - 404 if plugin not found or endpointKey not declared
-   * - 400 if plugin is not in ready state or lacks webhooks.receive capability
+   * - 404 with body `{ error: "webhook not delivered" }` for every
+   *   pre-dispatch rejection (plugin missing, not ready, manifest missing,
+   *   webhooks.receive capability missing, or endpointKey not declared).
+   *   The real cause is logged server-side and never returned to the
+   *   anonymous caller — see audit §F10 / MAT-669: distinct error strings
+   *   used to leak plugin-ID lifecycle to unauthenticated probes.
    * - 502 if the worker is unavailable or the RPC call fails
    */
   router.post("/plugins/:pluginId/webhooks/:endpointKey", async (req, res) => {
@@ -2270,34 +2275,45 @@ export function pluginRoutes(
     }
 
     const { pluginId, endpointKey } = req.params;
+    const webhookLog = logger.child({
+      service: "plugin-webhook-ingest",
+      pluginId,
+      endpointKey,
+    });
+    const rejectNotDelivered = (
+      reason: string,
+      details?: Record<string, unknown>,
+    ) => {
+      webhookLog.warn(
+        { reason, ...(details ?? {}) },
+        "Webhook delivery rejected before dispatch",
+      );
+      res.status(404).json({ error: "webhook not delivered" });
+    };
 
     // Step 1: Resolve the plugin
     const plugin = await resolvePlugin(registry, pluginId);
     if (!plugin) {
-      res.status(404).json({ error: "Plugin not found" });
+      rejectNotDelivered("plugin_not_found");
       return;
     }
 
     // Step 2: Validate the plugin is in 'ready' state
     if (plugin.status !== "ready") {
-      res.status(400).json({
-        error: `Plugin is not ready (current status: ${plugin.status})`,
-      });
+      rejectNotDelivered("plugin_not_ready", { status: plugin.status });
       return;
     }
 
     // Step 3: Validate the plugin has webhooks.receive capability
     const manifest = plugin.manifestJson;
     if (!manifest) {
-      res.status(400).json({ error: "Plugin manifest is missing" });
+      rejectNotDelivered("manifest_missing");
       return;
     }
 
     const capabilities = manifest.capabilities ?? [];
     if (!capabilities.includes("webhooks.receive")) {
-      res.status(400).json({
-        error: "Plugin does not have the webhooks.receive capability",
-      });
+      rejectNotDelivered("capability_missing");
       return;
     }
 
@@ -2307,9 +2323,7 @@ export function pluginRoutes(
       (w) => w.endpointKey === endpointKey,
     );
     if (!webhookDecl) {
-      res.status(404).json({
-        error: `Webhook endpoint '${endpointKey}' is not declared by this plugin`,
-      });
+      rejectNotDelivered("endpoint_not_declared");
       return;
     }
 


### PR DESCRIPTION
## Summary

Closes anonymous-callable plugin-webhook lifecycle leak surfaced by MAT-642 audit §F10 (tracked as MAT-669).

Collapses **five** distinct pre-dispatch error strings on `POST /api/plugins/:pluginId/webhooks/:endpointKey` into a single opaque response:

```
404 { "error": "webhook not delivered" }
```

Real cause is recorded server-side with a structured `reason` enum via `logger.child({ service: "plugin-webhook-ingest", pluginId, endpointKey })`:

| reason                  | previous leak                                                       |
| ----------------------- | ------------------------------------------------------------------- |
| `plugin_not_found`      | `404 Plugin not found` — anon plugin-id oracle                      |
| `plugin_not_ready`      | `400 Plugin is not ready (current status: <enum>)` — lifecycle leak |
| `manifest_missing`      | `400 Plugin manifest is missing` — install-state leak               |
| `capability_missing`    | `400 Plugin does not have the webhooks.receive capability`          |
| `endpoint_not_declared` | `404 Webhook endpoint '<key>' is not declared by this plugin`       |

### Out of scope

- `501` (feature disabled) and `502` (worker dispatch failure) untouched — they do not leak plugin lifecycle state, and `502` is already gated by successful pre-dispatch validation.
- Timing-based existence inference is acknowledged in JSDoc as a known residual; mitigation belongs to a separate hardening pass.

### Why anonymous

The route MUST be anonymous: external providers (GitHub, Linear, Stripe, …) call it without board auth. Signature verification is the plugin's responsibility.

## Test plan

- [x] `server/src/__tests__/plugin-webhook-ingest-errors.test.ts` — 6/6 vitest cases pass: every rejection path returns the same body and never matches the old leaky tokens; worker is never dispatched on rejection paths.
- [ ] Manual probe against a deployed instance: `curl -s -o - -w '%{http_code}\n' -X POST $URL/api/plugins/nonexistent/webhooks/anything` — should yield `404 {"error":"webhook not delivered"}`.