### PR TITLE
heartbeat: kill detached child after 5-min grace (RED-1279)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -917,6 +917,72 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeup?.status).toBe("claimed");
   });
 
+  it("respects the detached grace window before killing an already-flagged detached pid", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      includeIssue: false,
+      runErrorCode: "process_detached",
+      runError: `Lost in-memory process handle, but child pid ${child.pid} is still alive`,
+    });
+
+    // Pretend the detached flag was set ~1 minute ago (well inside the 5-minute grace window).
+    await db
+      .update(heartbeatRuns)
+      .set({ updatedAt: new Date(Date.now() - 60_000) })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(0);
+    expect(isPidAlive(child.pid ?? -1)).toBe(true);
+
+    const run = await heartbeat.getRun(runId);
+    expect(run?.status).toBe("running");
+    expect(run?.errorCode).toBe("process_detached");
+  });
+
+  it.skipIf(process.platform === "win32")("kills a detached child after the grace window expires and queues a retry", async () => {
+    const child = spawnAliveProcess();
+    childProcesses.add(child);
+    expect(child.pid).toBeTypeOf("number");
+
+    const { agentId, runId } = await seedRunFixture({
+      processPid: child.pid ?? null,
+      runErrorCode: "process_detached",
+      runError: `Lost in-memory process handle, but child pid ${child.pid} is still alive`,
+    });
+
+    // Push updatedAt past the 5-minute kill grace window.
+    await db
+      .update(heartbeatRuns)
+      .set({ updatedAt: new Date(Date.now() - 6 * 60_000) })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    expect(await waitForPidExit(child.pid ?? -1, 2_000)).toBe(true);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+
+    const failedRun = runs.find((row) => row.id === runId);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_lost");
+    expect(retryRun?.status).toBe("queued");
+    expect(retryRun?.retryOfRunId).toBe(runId);
+  });
+
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       processPid: 999_999_999,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -198,6 +198,7 @@ const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
 const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+const DETACHED_PROCESS_KILL_GRACE_MS = 5 * 60 * 1000;
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -6590,6 +6591,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const tracksLocalChild = isTrackedLocalChildProcessAdapter(adapterType);
       const processPidAlive = tracksLocalChild && run.processPid && isProcessAlive(run.processPid);
       const processGroupAlive = tracksLocalChild && run.processGroupId && isProcessGroupAlive(run.processGroupId);
+      let killedDetachedMainPid = false;
       if (processPidAlive) {
         if (run.errorCode !== DETACHED_PROCESS_ERROR_CODE) {
           const detachedMessage = `Lost in-memory process handle, but child pid ${run.processPid} is still alive`;
@@ -6608,12 +6610,31 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               },
             });
           }
+          continue;
         }
-        continue;
+        // Already flagged process_detached on a prior tick. clearDetachedRunWarning
+        // would have unset the errorCode if the child checked back in, so getting
+        // here means the child is wedged. Give it a grace window for a recovering
+        // server to re-attach, then kill it and let the existing process-loss
+        // finalization path take over below.
+        const detachedSinceMs = run.updatedAt ? new Date(run.updatedAt).getTime() : now.getTime();
+        const detachedMs = now.getTime() - detachedSinceMs;
+        if (detachedMs < DETACHED_PROCESS_KILL_GRACE_MS) {
+          continue;
+        }
+        logger.warn(
+          { runId: run.id, processPid: run.processPid, processGroupId: run.processGroupId, detachedMs },
+          "killing detached child process after grace window",
+        );
+        await terminateHeartbeatRunProcess({
+          pid: run.processPid,
+          processGroupId: run.processGroupId,
+        });
+        killedDetachedMainPid = true;
       }
 
       let descendantOnlyCleanup = false;
-      if (processGroupAlive) {
+      if (!killedDetachedMainPid && processGroupAlive) {
         descendantOnlyCleanup = true;
         await terminateHeartbeatRunProcess({
           pid: run.processPid,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6617,7 +6617,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // here means the child is wedged. Give it a grace window for a recovering
         // server to re-attach, then kill it and let the existing process-loss
         // finalization path take over below.
-        const detachedSinceMs = run.updatedAt ? new Date(run.updatedAt).getTime() : now.getTime();
+        const detachedSinceMs = run.updatedAt ? new Date(run.updatedAt).getTime() : 0;
         const detachedMs = now.getTime() - detachedSinceMs;
         if (detachedMs < DETACHED_PROCESS_KILL_GRACE_MS) {
           continue;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents and runs their work as local child processes the server tracks via an in-memory `runningProcesses` map
> - The heartbeat reaper (`server/src/services/heartbeat.ts::reapOrphanedRuns`) is what reconciles that in-memory state against the database when the server restarts and the map is wiped
> - When the reaper finds an alive child pid that isn't in the map, it sets `errorCode = process_detached` — but on every subsequent tick it just `continue`s, never killing the child; the only recovery path requires the wedged child to call back into the API, which it cannot do
> - Real-world impact: CTO opencode_local adapter sat hung for 2–7h windows multiple times this week, blocking a cascade of recovery tickets (see [RED-1279](/RED/issues/RED-1279))
> - This pull request adds a 5-minute grace window after the detached flag is set; if `clearDetachedRunWarning` does not unset the flag in that window, the reaper kills the child and falls through to the existing `process_lost` finalization path (failed status, retry enqueue, lease release, lifecycle event)
> - The benefit is that detached children can no longer wedge indefinitely; the system self-heals within ~6 min of any restart-induced detachment

## What Changed

- `server/src/services/heartbeat.ts`: in `reapOrphanedRuns()`, when the alive child pid already carries `process_detached`, compare `now - run.updatedAt` against a new `DETACHED_PROCESS_KILL_GRACE_MS = 5 * 60_000`. Inside the window → `continue` (give a recovering server a chance to re-attach). Past the window → `terminateHeartbeatRunProcess({ pid, processGroupId })` and fall through to the existing finalization path.
- `server/src/services/heartbeat.ts`: introduce `killedDetachedMainPid` so the downstream `processGroupAlive` branch does not also classify the cleanup as "descendant-only" — the `process_lost` lifecycle event stays correctly labeled.
- `server/src/services/heartbeat.ts`: null-`updatedAt` fallback uses `0` (epoch), matching the precedent two lines above, so a missing timestamp resolves to "very long ago" and the kill fires rather than silently never firing (per Greptile review on this PR).
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: two new tests covering the within-grace (no kill) and post-grace (kill + retry queued) paths.

## Verification

- `pnpm typecheck` clean in `server`
- `pnpm exec vitest run src/__tests__/heartbeat-process-recovery.test.ts` — **46/46 pass** locally; same suite green on PR CI
- New tests asserted explicitly:
  - `respects the detached grace window before killing an already-flagged detached pid` — alive child, `updatedAt` 1 min ago → `reaped === 0`, pid still alive, run stays `running`/`process_detached`
  - `kills a detached child after the grace window expires and queues a retry` — alive child, `updatedAt` 6 min ago → pid killed (`waitForPidExit` confirms), source run finalized `failed`/`process_lost`, retry run queued with `retryOfRunId`
- Full CI rollup on the prior commit: 14/14 green (policy, typecheck, server tests, workspace tests, build, canary dry run, e2e, verify, Greptile, Snyk)

## Risks

- **Grace tuning:** 5 minutes is comfortably longer than the reaper tick interval and any reasonable server restart window. Shorter values could race with a server that is mid-restart and about to re-attach; longer values prolong the original hang. 5 min matches the comparable stale-threshold guard elsewhere in this function.
- **Behavioral shift:** previously detached children effectively never died; now they die ~5 min after detachment. This is the intended behavior shift. The existing `clearDetachedRunWarning` path still wins if the child checks back in inside the window.
- **Process-lost vs descendant-only labeling:** `killedDetachedMainPid` is explicitly set before the downstream `processGroupAlive` branch is consulted, so downstream classification stays consistent. Verified by the new tests' assertion that `errorCode === "process_lost"` (not "descendant cleanup only").
- **Low blast radius:** change is gated entirely behind `processPidAlive && errorCode === process_detached` — a code path that today guarantees indefinite hang. Worst-case regression is "we kill a child we could have re-attached to," which is the same outcome as the existing dead-pid path that already works.

Tracking: [RED-1279](/RED/issues/RED-1279) (parent: [RED-1231](/RED/issues/RED-1231), root cause: [RED-1270](/RED/issues/RED-1270)).

🤖 Generated with [Paperclip](https://paperclip.ing)
