### PR TITLE
feat(server): LLM intent parser for approval comment overrides (POI-979)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,6 +624,9 @@ importers:
 
   server:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.55.0
+        version: 0.55.1
       '@aws-sdk/client-s3':
         specifier: ^3.888.0
         version: 3.994.0
@@ -997,6 +1000,10 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.55.1':
+    resolution: {integrity: sha512-gjOMS4chmm8BxClKmCjNHmvf1FrO1Cn++CSX6K3YCZjz5JG4I9ZttQ/xEH4FBsz6HQyZvnUpiKlOAkmxaGmEaQ==}
+    hasBin: true
 
   '@anthropic-ai/sdk@0.81.0':
     resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
@@ -7449,6 +7456,8 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
+
+  '@anthropic-ai/sdk@0.55.1': {}
 
   '@anthropic-ai/sdk@0.81.0(zod@3.25.76)':
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -58,6 +58,7 @@
     "@paperclipai/db": "workspace:*",
     "@paperclipai/plugin-sdk": "workspace:*",
     "@paperclipai/shared": "workspace:*",
+    "@anthropic-ai/sdk": "^0.55.0",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "better-auth": "1.4.18",

--- a/server/src/llm/approval-intent/client.ts
+++ b/server/src/llm/approval-intent/client.ts
@@ -1,0 +1,57 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { PARSE_APPROVAL_OVERRIDE_TOOL, parseApprovalOverrideTool } from "./tools.js";
+
+// Model is spec-mandated — do not change to alias
+const MODEL = "claude-haiku-4-5-20251001";
+const TIMEOUT_MS = 5_000;
+
+export interface ToolUseResult {
+  action: "default" | "skip" | "transition" | "reassign";
+  transition?: string;
+  assignee?: string;
+  rawIntentSummary: string;
+}
+
+const SYSTEM_PROMPT = `You are an approval intent classifier for a code review system.
+Given a reviewer's comment on an approval request, classify their intent regarding Jira ticket handling.
+Use ONLY the parse_approval_override tool. Do not add prose outside the tool call.`;
+
+export async function callWithToolUse(comment: string): Promise<ToolUseResult> {
+  const client = new Anthropic();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const response = await client.messages.create(
+      {
+        model: MODEL,
+        max_tokens: 256,
+        system: SYSTEM_PROMPT,
+        tools: [parseApprovalOverrideTool],
+        tool_choice: { type: "tool", name: PARSE_APPROVAL_OVERRIDE_TOOL },
+        messages: [
+          {
+            role: "user",
+            content: `Approval comment: "${comment}"`,
+          },
+        ],
+      },
+      { signal: controller.signal },
+    );
+
+    const toolUseBlock = response.content.find((b) => b.type === "tool_use");
+    if (!toolUseBlock || toolUseBlock.type !== "tool_use") {
+      return { action: "default", rawIntentSummary: "<<no-tool-use>>" };
+    }
+
+    const input = toolUseBlock.input as Record<string, unknown>;
+    return {
+      action: (input.action as ToolUseResult["action"]) ?? "default",
+      transition: input.transition as string | undefined,
+      assignee: input.assignee as string | undefined,
+      rawIntentSummary: (input.rawIntentSummary as string) ?? "",
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/server/src/llm/approval-intent/parser.test.ts
+++ b/server/src/llm/approval-intent/parser.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { parseApprovalIntent } from "./parser.js";
+import * as clientModule from "./client.js";
+
+// --- Mock layer ---
+vi.mock("./client.js", () => ({
+  callWithToolUse: vi.fn(),
+}));
+
+const mockCallWithToolUse = vi.mocked(clientModule.callWithToolUse);
+
+describe("parseApprovalIntent (unit — mocked LLM)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    delete process.env.LLM_INTENT_PROVIDER;
+  });
+
+  afterEach(() => {
+    delete process.env.LLM_INTENT_PROVIDER;
+  });
+
+  it("returns default for empty comment without calling LLM", async () => {
+    const result = await parseApprovalIntent("");
+    expect(mockCallWithToolUse).not.toHaveBeenCalled();
+    expect(result.jira.action).toBe("default");
+    expect(result.rawIntentSummary).toBe("");
+  });
+
+  it("returns default for whitespace-only comment without calling LLM", async () => {
+    const result = await parseApprovalIntent("   ");
+    expect(mockCallWithToolUse).not.toHaveBeenCalled();
+    expect(result.jira.action).toBe("default");
+  });
+
+  it("returns default without calling LLM when LLM_INTENT_PROVIDER=noop", async () => {
+    process.env.LLM_INTENT_PROVIDER = "noop";
+    const result = await parseApprovalIntent("Please skip Jira");
+    expect(mockCallWithToolUse).not.toHaveBeenCalled();
+    expect(result.jira.action).toBe("default");
+  });
+
+  it("maps 'skip' action from LLM", async () => {
+    mockCallWithToolUse.mockResolvedValueOnce({
+      action: "skip",
+      rawIntentSummary: "Reviewer wants to skip Jira sync entirely.",
+    });
+    const result = await parseApprovalIntent("Don't touch Jira for this one.");
+    expect(result.jira.action).toBe("skip");
+    expect(result.rawIntentSummary).toBe("Reviewer wants to skip Jira sync entirely.");
+  });
+
+  it("maps 'transition' action with transition name from LLM", async () => {
+    mockCallWithToolUse.mockResolvedValueOnce({
+      action: "transition",
+      transition: "In Review",
+      rawIntentSummary: "Reviewer wants to move ticket to In Review status.",
+    });
+    const result = await parseApprovalIntent("Please move the ticket to In Review.");
+    expect(result.jira.action).toBe("transition");
+    expect(result.jira.transition).toBe("In Review");
+  });
+
+  it("maps 'reassign' action with assignee name from LLM", async () => {
+    mockCallWithToolUse.mockResolvedValueOnce({
+      action: "reassign",
+      assignee: "john.doe",
+      rawIntentSummary: "Reviewer wants to reassign the ticket to john.doe.",
+    });
+    const result = await parseApprovalIntent("Reassign this to john.doe please.");
+    expect(result.jira.action).toBe("reassign");
+    expect(result.jira.assignee).toBe("john.doe");
+  });
+
+  it("maps 'default' action from LLM (explicit LGTM)", async () => {
+    mockCallWithToolUse.mockResolvedValueOnce({
+      action: "default",
+      rawIntentSummary: "Reviewer approves with default Jira handling.",
+    });
+    const result = await parseApprovalIntent("LGTM!");
+    expect(result.jira.action).toBe("default");
+  });
+
+  it("returns <<llm-unavailable>> default when LLM call throws (timeout/network)", async () => {
+    mockCallWithToolUse.mockRejectedValueOnce(new Error("AbortError: The operation was aborted"));
+    const result = await parseApprovalIntent("Skip Jira please.");
+    expect(result.jira.action).toBe("default");
+    expect(result.rawIntentSummary).toBe("<<llm-unavailable>>");
+  });
+
+  it("returns <<llm-unavailable>> default when LLM call throws API error", async () => {
+    mockCallWithToolUse.mockRejectedValueOnce(new Error("503 Service Unavailable"));
+    const result = await parseApprovalIntent("Approved.");
+    expect(result.jira.action).toBe("default");
+    expect(result.rawIntentSummary).toBe("<<llm-unavailable>>");
+  });
+});
+
+// --- Live integration tests — skipped unless ANTHROPIC_API_KEY is set ---
+const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
+
+describe.skipIf(!hasApiKey)("parseApprovalIntent (integration — real LLM)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks(); // un-mock client so real SDK is used
+    delete process.env.LLM_INTENT_PROVIDER;
+  });
+
+  it("classifies 'LGTM' as default action", async () => {
+    const result = await parseApprovalIntent("LGTM!");
+    expect(result.jira.action).toBe("default");
+    expect(result.rawIntentSummary).toBeTruthy();
+  }, 15_000);
+
+  it("classifies explicit skip request", async () => {
+    const result = await parseApprovalIntent("Approved, but please skip the Jira update this time.");
+    expect(result.jira.action).toBe("skip");
+  }, 15_000);
+
+  it("classifies transition request", async () => {
+    const result = await parseApprovalIntent(
+      "Looks good to me. Please transition the ticket to Done.",
+    );
+    expect(result.jira.action).toBe("transition");
+    expect(result.jira.transition).toBeTruthy();
+  }, 15_000);
+});

--- a/server/src/llm/approval-intent/parser.ts
+++ b/server/src/llm/approval-intent/parser.ts
@@ -1,0 +1,50 @@
+import { callWithToolUse } from "./client.js";
+
+export interface ParsedOverride {
+  jira: {
+    action: "default" | "skip" | "transition" | "reassign";
+    transition?: string;
+    assignee?: string;
+  };
+  rawIntentSummary: string;
+}
+
+const DEFAULT_RESULT: ParsedOverride = {
+  jira: { action: "default" },
+  rawIntentSummary: "",
+};
+
+const UNAVAILABLE_RESULT: ParsedOverride = {
+  jira: { action: "default" },
+  rawIntentSummary: "<<llm-unavailable>>",
+};
+
+// LLM_INTENT_PROVIDER=noop short-circuits all LLM calls (used in CI)
+function isNoopProvider(): boolean {
+  return process.env.LLM_INTENT_PROVIDER === "noop";
+}
+
+export async function parseApprovalIntent(comment: string): Promise<ParsedOverride> {
+  if (!comment || !comment.trim()) {
+    return DEFAULT_RESULT;
+  }
+
+  if (isNoopProvider()) {
+    return DEFAULT_RESULT;
+  }
+
+  try {
+    const result = await callWithToolUse(comment);
+    return {
+      jira: {
+        action: result.action,
+        transition: result.transition,
+        assignee: result.assignee,
+      },
+      rawIntentSummary: result.rawIntentSummary,
+    };
+  } catch {
+    // LLM being unavailable must NEVER block approvals
+    return UNAVAILABLE_RESULT;
+  }
+}

--- a/server/src/llm/approval-intent/tools.ts
+++ b/server/src/llm/approval-intent/tools.ts
@@ -1,0 +1,36 @@
+import type Anthropic from "@anthropic-ai/sdk";
+
+export const PARSE_APPROVAL_OVERRIDE_TOOL = "parse_approval_override";
+
+export const parseApprovalOverrideTool: Anthropic.Tool = {
+  name: PARSE_APPROVAL_OVERRIDE_TOOL,
+  description:
+    "Parse an approval comment and extract the reviewer's intent for Jira ticket handling. Determine whether to use the default transition, skip Jira sync, perform a specific transition, or reassign to someone.",
+  input_schema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        enum: ["default", "skip", "transition", "reassign"],
+        description:
+          "'default' = follow the configured Jira transition; 'skip' = do not touch Jira at all; 'transition' = move to a specific status named in 'transition'; 'reassign' = change assignee to the person named in 'assignee'.",
+      },
+      transition: {
+        type: "string",
+        description:
+          "The target Jira status name when action is 'transition'. Omit for other actions.",
+      },
+      assignee: {
+        type: "string",
+        description:
+          "The name or username of the Jira assignee when action is 'reassign'. Omit for other actions.",
+      },
+      rawIntentSummary: {
+        type: "string",
+        description:
+          "A one-sentence natural language summary of the reviewer's intent, for audit logs.",
+      },
+    },
+    required: ["action", "rawIntentSummary"],
+  },
+};


### PR DESCRIPTION
## Summary

- Adds `@anthropic-ai/sdk` to the server package
- Implements `server/src/llm/approval-intent/` module with 4 files:
  - `tools.ts` — `parse_approval_override` tool schema (forces structured JSON via tool_choice)
  - `client.ts` — Anthropic SDK wrapper with 5s AbortController timeout
  - `parser.ts` — `parseApprovalIntent(comment)` with fast-path for empty comments and noop CI mode
  - `parser.test.ts` — 9 unit tests (mocked) + 3 live integration tests gated by `ANTHROPIC_API_KEY`

## Spec Compliance (POI-979 Story 4)

| Requirement | Status | Notes |
|---|---|---|
| Model: `claude-haiku-4-5-20251001` | ✅ | Spec-mandated model ID used verbatim |
| `tool_choice: {type:'tool', name: 'parse_approval_override'}` | ✅ | Forces structured output, no prose |
| Empty/whitespace → default, no LLM call | ✅ | Fast-path in `parser.ts` before LLM |
| 5s timeout → default (no throw) | ✅ | AbortController + catch returns `<<llm-unavailable>>` |
| LLM failure NEVER blocks approvals | ✅ | All errors return `{jira: {action: 'default'}}` |
| `LLM_INTENT_PROVIDER=noop` short-circuits for CI | ✅ | Checked in `parser.ts` before any LLM call |
| `ParsedOverride` TypeScript type | ✅ | Exported from `parser.ts` |
| Golden set: default, skip, transition, reassign | ✅ | All 4 actions covered in tests |
| Live integration tests gated by `ANTHROPIC_API_KEY` | ✅ | `describe.skipIf(!hasApiKey)` block |
| Vitest (not Jest) | ✅ | `vi.mock`, `vi.mocked`, `describe.skipIf` |

## Test Evidence

```
RUN  v3.2.4 /Users/erginaktas/Documents/Projects/paperclip/server

✓ src/llm/approval-intent/parser.test.ts (12 tests | 3 skipped) 2ms

Test Files  1 passed (1)
     Tests  9 passed | 3 skipped (12)
  Start at  18:34:39
  Duration  192ms
```

3 skipped = live integration tests (no `ANTHROPIC_API_KEY` in local env, correct behavior).

## TypeScript

Zero type errors in new files (`tsc --noEmit` output filtered to `llm/approval-intent` — no matches).

## Paperclip Task

POI-979 — Story 4: LLM intent parser (Claude Haiku tool-use)
Parent epic: POI-970 — Approve workflow: Jira sync + LLM-based override parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)