### PR TITLE
fix(plugin): raise environmentProbe RPC timeout to 120s for cold-start sandboxes

### DIFF
--- a/server/src/services/plugin-environment-driver.ts
+++ b/server/src/services/plugin-environment-driver.ts
@@ -182,7 +182,7 @@ export async function probePluginEnvironmentDriver(input: {
     companyId: input.companyId,
     environmentId: input.environmentId,
     config: input.config.driverConfig,
-  });
+  }, 120_000);
 
   return {
     ok: result.ok,
@@ -227,7 +227,7 @@ export async function probePluginSandboxProviderDriver(input: {
     companyId: input.companyId,
     environmentId: input.environmentId,
     config: driverConfig,
-  });
+  }, 120_000);
 
   return {
     ok: result.ok,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Companies provision execution environments via sandbox provider plugins (Modal, Daytona, E2B, etc.)
> - At provision time, the server probes each plugin's environment / sandbox-provider driver over a worker RPC to validate config
> - `workerManager.call()` defaults to a 30s timeout, but cold-start sandboxes — Modal in particular — take ~31s to boot
> - Result: every fresh Modal environment probe fails with a worker RPC timeout, blocking environment provisioning end-to-end
> - This PR passes `timeoutMs=120_000` to the two probe call sites (`probePluginEnvironmentDriver`, `probePluginSandboxProviderDriver`)
> - The benefit is Modal — and any future provider with similar cold-start latency — can be successfully probed without false-negative timeout failures

## What Changed

- Pass `timeoutMs=120_000` to `workerManager.call()` in `probePluginEnvironmentDriver` (`server/src/services/plugin-environment-driver.ts`)
- Pass `timeoutMs=120_000` to `workerManager.call()` in `probePluginSandboxProviderDriver` (same file)

## Verification

- Targeted unit tests:
  ```
  pnpm --filter @paperclipai/server exec vitest run \
    src/__tests__/plugin-environment-driver-seam.test.ts \
    src/__tests__/heartbeat-plugin-environment.test.ts
  ```
  5/5 tests pass.
- Manual: provision a fresh Modal sandbox environment from the UI. Previously failed with a worker RPC timeout at ~30s; now succeeds.

## Risks

- Low risk. The change only raises a per-call timeout (default 30s → explicit 120s) on two probe call sites. Fast providers are unaffected since probe completes well below either bound. Worst case: a genuinely hung worker now blocks the probe for 120s instead of 30s before giving up — still bounded, and only on the provision-time probe path (not the heartbeat/run path).

## Model Used

- Provider: Anthropic
- Model: `claude-opus-4-7` (Claude Opus 4.7, 1M context window)
- Capabilities: extended thinking, tool use, code execution
- Scope of AI assistance: the underlying 4-line code change was human-authored by the committer; this PR (verification commands, message structuring, and submission) was prepared with Claude per the `paperclip-dev` skill.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — n/a, this is a per-call timeout configuration bump; existing tests cover the probe call path
- [x] If this change affects the UI, I have included before/after screenshots — n/a, no UI change
- [ ] I have updated relevant documentation to reflect my changes — n/a, the timeout is an internal worker-RPC tuning value with no documented contract
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
