### PR TITLE
fix(release): publish modal plugin from ci

### DIFF
--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -117,7 +117,7 @@
   {
     "dir": "packages/plugins/sandbox-providers/modal",
     "name": "@paperclipai/plugin-modal",
-    "publishFromCi": false
+    "publishFromCi": true
   },
   {
     "dir": "ui",


### PR DESCRIPTION
## Thinking Path

> - Paperclip keeps its core release process declarative through `scripts/release-package-manifest.json`, which decides which packages CI is allowed to publish.
> - The Modal sandbox provider now exists as a first-party plugin package under `packages/plugins/sandbox-providers/modal`.
> - The original Modal PR intentionally left `publishFromCi` disabled until the package had been published and the registry bootstrap concern was cleared.
> - The latest reviewer comment confirms that bootstrap step is complete, so the remaining gap is only release automation configuration.
> - This pull request flips the Modal manifest entry to `publishFromCi: true` so future CI-driven releases can publish `@paperclipai/plugin-modal` the same way the other releasable packages do.
> - The benefit is that Modal releases no longer require a manual exception in the release pipeline.

## What Changed

- Updated the `@paperclipai/plugin-modal` entry in `scripts/release-package-manifest.json` to set `publishFromCi` to `true`.

## Verification

- Ran `node -e 'const m=require("./scripts/release-package-manifest.json"); const e=m.find(x=>x.name==="@paperclipai/plugin-modal"); if(!e||e.publishFromCi!==true){throw new Error("modal publishFromCi not true")}; console.log(JSON.stringify(e))'`

## Risks

- Low risk. This only changes release-manifest metadata; the main failure mode is CI attempting to publish the Modal package before registry credentials or release conditions are ready.

## Model Used

- OpenAI Codex local agent, GPT-5-based coding model in the Codex runtime (exact deployment model ID not exposed in this workspace), with tool use and shell execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
