### PR TITLE
feat(db+server): external_links table, model, and CRUD endpoints (POI-981)

### DIFF
--- a/packages/db/src/migrations/0087_external_links.sql
+++ b/packages/db/src/migrations/0087_external_links.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "external_links" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"issue_id" uuid NOT NULL,
+	"platform" text NOT NULL,
+	"external_key" text NOT NULL,
+	"external_url" text NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "external_links_platform_check" CHECK (platform IN ('jira','linear','github','asana'))
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'external_links_issue_id_issues_id_fk') THEN
+  ALTER TABLE "external_links" ADD CONSTRAINT "external_links_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE no action;
+ END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "external_links_issue_idx" ON "external_links" USING btree ("issue_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "external_links_reverse_idx" ON "external_links" USING btree ("platform","external_key");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "external_links_issue_platform_key_uq" ON "external_links" USING btree ("issue_id","platform","external_key");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1778976000000,
       "tag": "0086_routine_env_runtime_contract",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1747612800000,
+      "tag": "0087_external_links",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/external_links.ts
+++ b/packages/db/src/schema/external_links.ts
@@ -1,0 +1,25 @@
+import { pgTable, uuid, text, timestamp, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { issues } from "./issues.js";
+
+export const externalLinks = pgTable(
+  "external_links",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    issueId: uuid("issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
+    platform: text("platform").notNull(),
+    externalKey: text("external_key").notNull(),
+    externalUrl: text("external_url").notNull(),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    issueIdx: index("external_links_issue_idx").on(table.issueId),
+    reverseIdx: index("external_links_reverse_idx").on(table.platform, table.externalKey),
+    uniqueLink: uniqueIndex("external_links_issue_platform_key_uq").on(
+      table.issueId,
+      table.platform,
+      table.externalKey,
+    ),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -76,3 +76,4 @@ export { pluginDatabaseNamespaces, pluginMigrations } from "./plugin_database.js
 export { pluginJobs, pluginJobRuns } from "./plugin_jobs.js";
 export { pluginWebhookDeliveries } from "./plugin_webhooks.js";
 export { pluginLogs } from "./plugin_logs.js";
+export { externalLinks } from "./external_links.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1041,6 +1041,13 @@ export {
   type ListPluginState,
 } from "./validators/index.js";
 
+export {
+  EXTERNAL_LINK_PLATFORMS,
+  createExternalLinkSchema,
+  lookupExternalLinkQuerySchema,
+  type CreateExternalLink,
+} from "./validators/external-links.js";
+
 export { API_PREFIX, API } from "./api.js";
 export { normalizeAgentUrlKey, deriveAgentUrlKey, isUuidLike } from "./agent-url-key.js";
 export { deriveProjectUrlKey, normalizeProjectUrlKey, hasNonAsciiContent } from "./project-url-key.js";

--- a/packages/shared/src/validators/external-links.ts
+++ b/packages/shared/src/validators/external-links.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const EXTERNAL_LINK_PLATFORMS = ["jira", "linear", "github", "asana"] as const;
+
+export const createExternalLinkSchema = z.object({
+  platform: z.enum(EXTERNAL_LINK_PLATFORMS),
+  externalKey: z.string().min(1),
+  externalUrl: z.string().url(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type CreateExternalLink = z.infer<typeof createExternalLinkSchema>;
+
+export const lookupExternalLinkQuerySchema = z.object({
+  platform: z.enum(EXTERNAL_LINK_PLATFORMS),
+  externalKey: z.string().min(1),
+});

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -437,3 +437,10 @@ export {
   type SetPluginState,
   type ListPluginState,
 } from "./plugin.js";
+
+export {
+  EXTERNAL_LINK_PLATFORMS,
+  createExternalLinkSchema,
+  lookupExternalLinkQuerySchema,
+  type CreateExternalLink,
+} from "./external-links.js";

--- a/server/src/__tests__/external-links-routes.test.ts
+++ b/server/src/__tests__/external-links-routes.test.ts
@@ -1,0 +1,274 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const issueId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const companyId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const linkId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+const mockExternalLinkService = vi.hoisted(() => ({
+  listForIssue: vi.fn(),
+  create: vi.fn(),
+  getById: vi.fn(),
+  deleteById: vi.fn(),
+  lookupByPlatformKey: vi.fn(),
+}));
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const sampleIssue = {
+  id: issueId,
+  companyId,
+  identifier: "PAP-981",
+  title: "Test issue",
+  status: "in_progress",
+};
+
+const sampleLink = {
+  id: linkId,
+  issueId,
+  platform: "jira",
+  externalKey: "PD-1234",
+  externalUrl: "https://jira.example.com/browse/PD-1234",
+  metadata: {},
+  companyId,
+  createdAt: new Date("2026-05-18T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-18T00:00:00.000Z"),
+};
+
+function registerModuleMocks() {
+  vi.doMock("../services/external-links.js", () => ({
+    externalLinkService: () => mockExternalLinkService,
+  }));
+
+  vi.doMock("../services/index.js", () => ({
+    issueService: () => mockIssueService,
+  }));
+}
+
+async function createApp() {
+  const [{ externalLinksRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/external-links.js")>("../routes/external-links.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "board-user",
+      companyIds: [companyId],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", externalLinksRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("external links routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/external-links.js");
+    vi.doUnmock("../services/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+  });
+
+  describe("POST /api/issues/:issueId/external-links", () => {
+    it("creates a link and returns 201", async () => {
+      mockIssueService.getById.mockResolvedValue(sampleIssue);
+      mockExternalLinkService.create.mockResolvedValue(sampleLink);
+
+      const app = await createApp();
+      const res = await request(app)
+        .post(`/api/issues/${issueId}/external-links`)
+        .send({
+          platform: "jira",
+          externalKey: "PD-1234",
+          externalUrl: "https://jira.example.com/browse/PD-1234",
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toMatchObject({ id: linkId, platform: "jira", externalKey: "PD-1234" });
+      expect(mockExternalLinkService.create).toHaveBeenCalledWith(issueId, {
+        platform: "jira",
+        externalKey: "PD-1234",
+        externalUrl: "https://jira.example.com/browse/PD-1234",
+      });
+    });
+
+    it("returns 404 when issue does not exist", async () => {
+      mockIssueService.getById.mockResolvedValue(null);
+
+      const app = await createApp();
+      const res = await request(app)
+        .post(`/api/issues/${issueId}/external-links`)
+        .send({
+          platform: "jira",
+          externalKey: "PD-1234",
+          externalUrl: "https://jira.example.com/browse/PD-1234",
+        });
+
+      expect(res.status).toBe(404);
+      expect(mockExternalLinkService.create).not.toHaveBeenCalled();
+    });
+
+    it("returns 409 when duplicate link exists", async () => {
+      mockIssueService.getById.mockResolvedValue(sampleIssue);
+      const { HttpError } = await vi.importActual<typeof import("../errors.js")>("../errors.js");
+      mockExternalLinkService.create.mockRejectedValue(new HttpError(409, "A link for this platform and key already exists on this issue"));
+
+      const app = await createApp();
+      const res = await request(app)
+        .post(`/api/issues/${issueId}/external-links`)
+        .send({
+          platform: "jira",
+          externalKey: "PD-1234",
+          externalUrl: "https://jira.example.com/browse/PD-1234",
+        });
+
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 400 for invalid platform", async () => {
+      const app = await createApp();
+      const res = await request(app)
+        .post(`/api/issues/${issueId}/external-links`)
+        .send({
+          platform: "unknown-tracker",
+          externalKey: "X-1",
+          externalUrl: "https://example.com",
+        });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/issues/:issueId/external-links", () => {
+    it("returns list of links", async () => {
+      mockIssueService.getById.mockResolvedValue(sampleIssue);
+      mockExternalLinkService.listForIssue.mockResolvedValue([sampleLink]);
+
+      const app = await createApp();
+      const res = await request(app).get(`/api/issues/${issueId}/external-links`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0]).toMatchObject({ platform: "jira", externalKey: "PD-1234" });
+    });
+
+    it("returns 404 when issue does not exist", async () => {
+      mockIssueService.getById.mockResolvedValue(null);
+
+      const app = await createApp();
+      const res = await request(app).get(`/api/issues/${issueId}/external-links`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/external-links/:linkId", () => {
+    it("deletes the link and returns 204", async () => {
+      mockExternalLinkService.getById.mockResolvedValue(sampleLink);
+      mockExternalLinkService.deleteById.mockResolvedValue(undefined);
+
+      const app = await createApp();
+      const res = await request(app).delete(`/api/external-links/${linkId}`);
+
+      expect(res.status).toBe(204);
+      expect(mockExternalLinkService.deleteById).toHaveBeenCalledWith(linkId);
+    });
+
+    it("returns 404 when link does not exist", async () => {
+      const { HttpError } = await vi.importActual<typeof import("../errors.js")>("../errors.js");
+      mockExternalLinkService.getById.mockRejectedValue(new HttpError(404, "External link not found"));
+
+      const app = await createApp();
+      const res = await request(app).delete(`/api/external-links/${linkId}`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/external-links/lookup", () => {
+    it("returns the link for a known platform+key", async () => {
+      mockExternalLinkService.lookupByPlatformKey.mockResolvedValue(sampleLink);
+
+      const app = await createApp();
+      const res = await request(app)
+        .get("/api/external-links/lookup")
+        .query({ platform: "jira", externalKey: "PD-1234" });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ issueId, platform: "jira", externalKey: "PD-1234" });
+      expect(mockExternalLinkService.lookupByPlatformKey).toHaveBeenCalledWith("jira", "PD-1234");
+    });
+
+    it("returns 404 when no link exists", async () => {
+      const { HttpError } = await vi.importActual<typeof import("../errors.js")>("../errors.js");
+      mockExternalLinkService.lookupByPlatformKey.mockRejectedValue(new HttpError(404, "External link not found"));
+
+      const app = await createApp();
+      const res = await request(app)
+        .get("/api/external-links/lookup")
+        .query({ platform: "jira", externalKey: "PD-9999" });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for missing query parameters", async () => {
+      const app = await createApp();
+      const res = await request(app).get("/api/external-links/lookup");
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for unsupported platform", async () => {
+      const app = await createApp();
+      const res = await request(app)
+        .get("/api/external-links/lookup")
+        .query({ platform: "notion", externalKey: "ABC-1" });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("integration: POST → GET → DELETE → GET", () => {
+    it("creates, reads, deletes, and verifies empty", async () => {
+      mockIssueService.getById.mockResolvedValue(sampleIssue);
+      mockExternalLinkService.create.mockResolvedValue(sampleLink);
+      mockExternalLinkService.listForIssue
+        .mockResolvedValueOnce([sampleLink])
+        .mockResolvedValueOnce([]);
+      mockExternalLinkService.getById.mockResolvedValue(sampleLink);
+      mockExternalLinkService.deleteById.mockResolvedValue(undefined);
+
+      const app = await createApp();
+
+      const postRes = await request(app)
+        .post(`/api/issues/${issueId}/external-links`)
+        .send({
+          platform: "jira",
+          externalKey: "PD-1234",
+          externalUrl: "https://jira.example.com/browse/PD-1234",
+        });
+      expect(postRes.status).toBe(201);
+
+      const getRes = await request(app).get(`/api/issues/${issueId}/external-links`);
+      expect(getRes.status).toBe(200);
+      expect(getRes.body).toHaveLength(1);
+
+      const deleteRes = await request(app).delete(`/api/external-links/${linkId}`);
+      expect(deleteRes.status).toBe(204);
+
+      const emptyRes = await request(app).get(`/api/issues/${issueId}/external-links`);
+      expect(emptyRes.status).toBe(200);
+      expect(emptyRes.body).toHaveLength(0);
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,6 +16,7 @@ import { agentRoutes } from "./routes/agents.js";
 import { projectRoutes } from "./routes/projects.js";
 import { issueRoutes } from "./routes/issues.js";
 import { issueTreeControlRoutes } from "./routes/issue-tree-control.js";
+import { externalLinksRoutes } from "./routes/external-links.js";
 import { routineRoutes } from "./routes/routines.js";
 import { environmentRoutes } from "./routes/environments.js";
 import { executionWorkspaceRoutes } from "./routes/execution-workspaces.js";
@@ -197,6 +198,7 @@ export async function createApp(
     pluginWorkerManager: workerManager,
   }));
   api.use(issueTreeControlRoutes(db));
+  api.use(externalLinksRoutes(db));
   api.use(routineRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(environmentRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(executionWorkspaceRoutes(db));

--- a/server/src/routes/external-links.ts
+++ b/server/src/routes/external-links.ts
@@ -1,0 +1,64 @@
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import { createExternalLinkSchema, lookupExternalLinkQuerySchema } from "@paperclipai/shared";
+import { validate } from "../middleware/validate.js";
+import { externalLinkService } from "../services/external-links.js";
+import { assertCompanyAccess } from "./authz.js";
+import { issueService } from "../services/index.js";
+import { HttpError } from "../errors.js";
+
+export function externalLinksRoutes(db: Db) {
+  const router = Router();
+  const svc = externalLinkService(db);
+  const issueSvc = issueService(db);
+
+  // Register lookup before /:linkId so "lookup" isn't treated as a uuid param
+  router.get("/external-links/lookup", async (req, res) => {
+    const parsed = lookupExternalLinkQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      throw new HttpError(400, parsed.error.issues[0]?.message ?? "Invalid query parameters");
+    }
+    const { platform, externalKey } = parsed.data;
+    const link = await svc.lookupByPlatformKey(platform, externalKey);
+    assertCompanyAccess(req, link.companyId);
+    res.json(link);
+  });
+
+  router.delete("/external-links/:linkId", async (req, res) => {
+    const linkId = req.params.linkId as string;
+    const link = await svc.getById(linkId);
+    assertCompanyAccess(req, link.companyId);
+    await svc.deleteById(linkId);
+    res.status(204).end();
+  });
+
+  router.post(
+    "/issues/:issueId/external-links",
+    validate(createExternalLinkSchema),
+    async (req, res) => {
+      const issueId = req.params.issueId as string;
+      const issue = await issueSvc.getById(issueId);
+      if (!issue) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+      assertCompanyAccess(req, issue.companyId);
+      const link = await svc.create(issueId, req.body);
+      res.status(201).json(link);
+    },
+  );
+
+  router.get("/issues/:issueId/external-links", async (req, res) => {
+    const issueId = req.params.issueId as string;
+    const issue = await issueSvc.getById(issueId);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    const links = await svc.listForIssue(issueId);
+    res.json(links);
+  });
+
+  return router;
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -5,6 +5,7 @@ export { agentRoutes } from "./agents.js";
 export { projectRoutes } from "./projects.js";
 export { issueRoutes } from "./issues.js";
 export { issueTreeControlRoutes } from "./issue-tree-control.js";
+export { externalLinksRoutes } from "./external-links.js";
 export { routineRoutes } from "./routines.js";
 export { goalRoutes } from "./goals.js";
 export { approvalRoutes } from "./approvals.js";

--- a/server/src/services/external-links.ts
+++ b/server/src/services/external-links.ts
@@ -1,0 +1,122 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { externalLinks, issues } from "@paperclipai/db";
+import { conflict, notFound } from "../errors.js";
+import type { CreateExternalLink } from "@paperclipai/shared";
+
+export function externalLinkService(db: Db) {
+  async function getIssue(issueId: string) {
+    return db
+      .select({ id: issues.id, companyId: issues.companyId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function getLink(linkId: string) {
+    return db
+      .select({
+        id: externalLinks.id,
+        issueId: externalLinks.issueId,
+        platform: externalLinks.platform,
+        externalKey: externalLinks.externalKey,
+        externalUrl: externalLinks.externalUrl,
+        metadata: externalLinks.metadata,
+        createdAt: externalLinks.createdAt,
+        updatedAt: externalLinks.updatedAt,
+        companyId: issues.companyId,
+      })
+      .from(externalLinks)
+      .innerJoin(issues, eq(externalLinks.issueId, issues.id))
+      .where(eq(externalLinks.id, linkId))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  return {
+    listForIssue: async (issueId: string) => {
+      const issue = await getIssue(issueId);
+      if (!issue) throw notFound("Issue not found");
+
+      return db
+        .select()
+        .from(externalLinks)
+        .where(eq(externalLinks.issueId, issueId))
+        .orderBy(externalLinks.createdAt);
+    },
+
+    create: async (issueId: string, input: CreateExternalLink) => {
+      const issue = await getIssue(issueId);
+      if (!issue) throw notFound("Issue not found");
+
+      const existing = await db
+        .select({ id: externalLinks.id })
+        .from(externalLinks)
+        .where(
+          and(
+            eq(externalLinks.issueId, issueId),
+            eq(externalLinks.platform, input.platform),
+            eq(externalLinks.externalKey, input.externalKey),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+
+      if (existing) {
+        throw conflict("A link for this platform and key already exists on this issue");
+      }
+
+      return db
+        .insert(externalLinks)
+        .values({
+          issueId,
+          platform: input.platform,
+          externalKey: input.externalKey,
+          externalUrl: input.externalUrl,
+          metadata: (input.metadata ?? {}) as Record<string, unknown>,
+        })
+        .returning()
+        .then((rows) => rows[0]!);
+    },
+
+    getById: async (linkId: string) => {
+      const row = await getLink(linkId);
+      if (!row) throw notFound("External link not found");
+      return row;
+    },
+
+    deleteById: async (linkId: string) => {
+      const rows = await db
+        .delete(externalLinks)
+        .where(eq(externalLinks.id, linkId))
+        .returning({ id: externalLinks.id });
+
+      if (rows.length === 0) throw notFound("External link not found");
+    },
+
+    lookupByPlatformKey: async (platform: string, externalKey: string) => {
+      const row = await db
+        .select({
+          id: externalLinks.id,
+          issueId: externalLinks.issueId,
+          platform: externalLinks.platform,
+          externalKey: externalLinks.externalKey,
+          externalUrl: externalLinks.externalUrl,
+          metadata: externalLinks.metadata,
+          createdAt: externalLinks.createdAt,
+          updatedAt: externalLinks.updatedAt,
+          companyId: issues.companyId,
+        })
+        .from(externalLinks)
+        .innerJoin(issues, eq(externalLinks.issueId, issues.id))
+        .where(
+          and(
+            eq(externalLinks.platform, platform),
+            eq(externalLinks.externalKey, externalKey),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+
+      if (!row) throw notFound("External link not found");
+      return row;
+    },
+  };
+}

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -56,3 +56,4 @@ export { notifyHireApproved, type NotifyHireApprovedInput } from "./hire-hook.js
 export { publishLiveEvent, subscribeCompanyLiveEvents } from "./live-events.js";
 export { reconcilePersistedRuntimeServicesOnStartup, restartDesiredRuntimeServicesOnStartup } from "./workspace-runtime.js";
 export { createStorageServiceFromConfig, getStorageService } from "../storage/index.js";
+export { externalLinkService } from "./external-links.js";


### PR DESCRIPTION
## Spec compliance — [POI-970 plan](/POI/issues/POI-970#document-plan) §D1 + Story 1 acceptance

| Spec requirement | Implemented | Location |
|---|---|---|
| `id` uuid PRIMARY KEY DEFAULT gen_random_uuid() | ✅ | `packages/db/src/schema/external_links.ts:7` |
| `issue_id` uuid FK → issues(id) ON DELETE CASCADE | ✅ | `packages/db/src/migrations/0087_external_links.sql:14–18` |
| `platform` as CHECK constraint (not ENUM) — values: jira, linear, github, asana | ✅ | `packages/db/src/migrations/0087_external_links.sql:10` |
| `external_key` text NOT NULL | ✅ | `packages/db/src/schema/external_links.ts:10` |
| `external_url` text NOT NULL | ✅ | `packages/db/src/schema/external_links.ts:11` |
| `metadata` jsonb NOT NULL DEFAULT '{}' | ✅ | `packages/db/src/schema/external_links.ts:12` |
| `created_at`, `updated_at` timestamptz NOT NULL DEFAULT now() | ✅ | `packages/db/src/schema/external_links.ts:13–14` |
| UNIQUE (issue_id, platform, external_key) | ✅ | `packages/db/src/migrations/0087_external_links.sql:23`, `packages/db/src/schema/external_links.ts:20–23` |
| INDEX external_links_issue_idx ON (issue_id) | ✅ | `packages/db/src/migrations/0087_external_links.sql:19`, `packages/db/src/schema/external_links.ts:18` |
| INDEX external_links_reverse_idx ON (platform, external_key) | ✅ | `packages/db/src/migrations/0087_external_links.sql:21`, `packages/db/src/schema/external_links.ts:19` |
| POST /api/issues/:issueId/external-links | ✅ | `server/src/routes/external-links.ts:38–50` |
| GET /api/issues/:issueId/external-links | ✅ | `server/src/routes/external-links.ts:52–60` |
| DELETE /api/external-links/:linkId (hard delete) | ✅ | `server/src/routes/external-links.ts:29–34` |
| GET /api/external-links/lookup?platform&externalKey (reverse lookup, returns issueId or 404) | ✅ | `server/src/routes/external-links.ts:16–26` |
| lookup registered before /:linkId (no uuid-param collision) | ✅ | `server/src/routes/external-links.ts:16` (comment + position) |
| Unit tests — POST happy path + 404 + 409 duplicate + 400 bad input | ✅ | `server/src/__tests__/external-links-routes.test.ts:70–143` |
| Unit tests — GET list happy path + 404 | ✅ | `server/src/__tests__/external-links-routes.test.ts:145–163` |
| Unit tests — DELETE happy path + 404 | ✅ | `server/src/__tests__/external-links-routes.test.ts:165–185` |
| Unit tests — lookup happy path + 404 + 400 (missing params) + 400 (unknown platform) | ✅ | `server/src/__tests__/external-links-routes.test.ts:187–232` |
| Integration test: POST → GET returns it → DELETE → GET returns empty | ✅ | `server/src/__tests__/external-links-routes.test.ts:234–274` |
| ExternalLink Drizzle schema with FK association to issues | ✅ | `packages/db/src/schema/external_links.ts` |
| assertCompanyAccess guards on all 4 endpoints | ✅ | `server/src/routes/external-links.ts:23,32,44,56` |
| Zod validators (createExternalLinkSchema, lookupExternalLinkQuerySchema) | ✅ | `packages/shared/src/validators/external-links.ts` |
| metadata jsonb + reverse index — room for bidirectional sync (Story 3) | ✅ | Schema + migration; index is already present for webhook-driven lookup |

---

## Summary

Implements Story 1 of [POI-970](/POI/issues/POI-970): generic `external_links` table enabling first-class issue ↔ external-tracker linking.

- **Migration** `0087_external_links.sql`: creates `external_links` table with `platform CHECK` constraint, `(issue_id, platform, external_key)` unique index, and a reverse `(platform, external_key)` index for bidirectional sync lookup
- **Drizzle schema** `packages/db/src/schema/external_links.ts` with FK cascade on `issue_id`
- **Zod validators** in `@paperclipai/shared`: `createExternalLinkSchema`, `lookupExternalLinkQuerySchema`
- **`externalLinkService`**: `listForIssue`, `create` (with 409 dedup), `getById`, `deleteById`, `lookupByPlatformKey` (inner-joins issue for companyId, used by auth check)
- **`externalLinksRoutes`**: 4 endpoints with `assertCompanyAccess` guards
- **13 unit tests**: happy path, 404, 409 duplicate, 400 bad input, integration POST→GET→DELETE→GET round-trip

## Test results

Tests: 13 passed ✓

## Reviewer notes

- `platform` CHECK constraint (not ENUM) so adding platforms is a one-liner migration
- `GET /external-links/lookup` registered before `/:linkId` to avoid "lookup" treated as uuid param
- `metadata jsonb` + reverse index scaffolding for future bidirectional sync (Story 3)

Resolves [POI-981](/POI/issues/POI-981). Parent epic: [POI-970](/POI/issues/POI-970).