### PR TITLE
feat(shared+server): Jira key extractor + externalRefs on issues (POI-971)

### DIFF
--- a/packages/db/src/migrations/0087_external_links.sql
+++ b/packages/db/src/migrations/0087_external_links.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS "external_links" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"issue_id" uuid NOT NULL,
+	"platform" text NOT NULL,
+	"external_key" text NOT NULL,
+	"external_url" text NOT NULL,
+	"metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "external_links_platform_check" CHECK (platform IN ('jira','linear','github','asana'))
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'external_links_issue_id_issues_id_fk') THEN
+  ALTER TABLE "external_links" ADD CONSTRAINT "external_links_issue_id_issues_id_fk" FOREIGN KEY ("issue_id") REFERENCES "public"."issues"("id") ON DELETE cascade ON UPDATE no action;
+ END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "external_links_issue_idx" ON "external_links" USING btree ("issue_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "external_links_reverse_idx" ON "external_links" USING btree ("platform","external_key");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "external_links_issue_platform_key_uq" ON "external_links" USING btree ("issue_id","platform","external_key");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1778976000000,
       "tag": "0086_routine_env_runtime_contract",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1747612800000,
+      "tag": "0087_external_links",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/external_links.ts
+++ b/packages/db/src/schema/external_links.ts
@@ -1,0 +1,25 @@
+import { pgTable, uuid, text, timestamp, jsonb, index, uniqueIndex } from "drizzle-orm/pg-core";
+import { issues } from "./issues.js";
+
+export const externalLinks = pgTable(
+  "external_links",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    issueId: uuid("issue_id").notNull().references(() => issues.id, { onDelete: "cascade" }),
+    platform: text("platform").notNull(),
+    externalKey: text("external_key").notNull(),
+    externalUrl: text("external_url").notNull(),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    issueIdx: index("external_links_issue_idx").on(table.issueId),
+    reverseIdx: index("external_links_reverse_idx").on(table.platform, table.externalKey),
+    uniqueLink: uniqueIndex("external_links_issue_platform_key_uq").on(
+      table.issueId,
+      table.platform,
+      table.externalKey,
+    ),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -76,3 +76,4 @@ export { pluginDatabaseNamespaces, pluginMigrations } from "./plugin_database.js
 export { pluginJobs, pluginJobRuns } from "./plugin_jobs.js";
 export { pluginWebhookDeliveries } from "./plugin_webhooks.js";
 export { pluginLogs } from "./plugin_logs.js";
+export { externalLinks } from "./external_links.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -648,6 +648,8 @@ export {
   type IssueReferenceMatch,
 } from "./issue-references.js";
 
+export { extractJiraKey, extractAllJiraKeys } from "./jira-key.js";
+
 export {
   sidebarOrderPreferenceSchema,
   upsertSidebarOrderPreferenceSchema,
@@ -1045,7 +1047,11 @@ export {
   EXTERNAL_LINK_PLATFORMS,
   createExternalLinkSchema,
   lookupExternalLinkQuerySchema,
+  issueExternalRefsSchema,
+  issueExternalRefsJiraSchema,
   type CreateExternalLink,
+  type IssueExternalRefs,
+  type IssueExternalRefsJira,
 } from "./validators/external-links.js";
 
 export { API_PREFIX, API } from "./api.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1041,6 +1041,13 @@ export {
   type ListPluginState,
 } from "./validators/index.js";
 
+export {
+  EXTERNAL_LINK_PLATFORMS,
+  createExternalLinkSchema,
+  lookupExternalLinkQuerySchema,
+  type CreateExternalLink,
+} from "./validators/external-links.js";
+
 export { API_PREFIX, API } from "./api.js";
 export { normalizeAgentUrlKey, deriveAgentUrlKey, isUuidLike } from "./agent-url-key.js";
 export { deriveProjectUrlKey, normalizeProjectUrlKey, hasNonAsciiContent } from "./project-url-key.js";

--- a/packages/shared/src/jira-key.test.ts
+++ b/packages/shared/src/jira-key.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { extractJiraKey, extractAllJiraKeys } from "./jira-key.js";
+
+describe("extractJiraKey", () => {
+  it("extracts a standard Jira key from plain text", () => {
+    expect(extractJiraKey("Fixes PD-123 in production")).toBe("PD-123");
+  });
+
+  it("extracts a 4-digit key", () => {
+    expect(extractJiraKey("see PD-1234 for context")).toBe("PD-1234");
+  });
+
+  it("returns null when no key is present", () => {
+    expect(extractJiraKey("no ticket referenced here")).toBeNull();
+    expect(extractJiraKey("")).toBeNull();
+  });
+
+  it("returns the first key when multiple are present", () => {
+    expect(extractJiraKey("PD-100 and PD-200 both apply")).toBe("PD-100");
+  });
+
+  it("does not match lowercase", () => {
+    expect(extractJiraKey("pd-123 should not match")).toBeNull();
+  });
+
+  it("does not match keys that start with a digit", () => {
+    expect(extractJiraKey("1AB-99 is not a valid key")).toBeNull();
+  });
+
+  it("does not match project prefixes longer than 10 chars", () => {
+    expect(extractJiraKey("TOOLONGPREFIX-1 should not match")).toBeNull();
+  });
+});
+
+describe("extractAllJiraKeys", () => {
+  it("returns all unique keys in order", () => {
+    expect(extractAllJiraKeys("PD-100 and PD-200 and PD-100 again")).toEqual(["PD-100", "PD-200"]);
+  });
+
+  it("returns empty array when no keys found", () => {
+    expect(extractAllJiraKeys("nothing here")).toEqual([]);
+  });
+});

--- a/packages/shared/src/jira-key.ts
+++ b/packages/shared/src/jira-key.ts
@@ -1,0 +1,30 @@
+// Matches standard Jira key format: PROJECT-123
+const JIRA_KEY_REGEX = /\b([A-Z][A-Z0-9]{1,9}-\d+)\b/g;
+
+/**
+ * Extracts the first Jira issue key found in the given text.
+ * Returns null when no key is found.
+ * v1 label-based fallback — use externalRefs.jira.key when available.
+ */
+export function extractJiraKey(text: string): string | null {
+  const match = JIRA_KEY_REGEX.exec(text);
+  JIRA_KEY_REGEX.lastIndex = 0;
+  return match ? (match[1] ?? null) : null;
+}
+
+/**
+ * Extracts all unique Jira issue keys found in the given text.
+ */
+export function extractAllJiraKeys(text: string): string[] {
+  const keys: string[] = [];
+  let match: RegExpExecArray | null;
+  JIRA_KEY_REGEX.lastIndex = 0;
+  while ((match = JIRA_KEY_REGEX.exec(text)) !== null) {
+    const key = match[1];
+    if (key && !keys.includes(key)) {
+      keys.push(key);
+    }
+  }
+  JIRA_KEY_REGEX.lastIndex = 0;
+  return keys;
+}

--- a/packages/shared/src/validators/external-links.ts
+++ b/packages/shared/src/validators/external-links.ts
@@ -15,3 +15,20 @@ export const lookupExternalLinkQuerySchema = z.object({
   platform: z.enum(EXTERNAL_LINK_PLATFORMS),
   externalKey: z.string().min(1),
 });
+
+// Structured externalRefs field used on issue create/update/read payloads.
+// Each platform entry is optional and nullable (null = remove the link).
+export const issueExternalRefsJiraSchema = z.object({
+  key: z.string().min(1),
+  externalUrl: z.string().url(),
+  projectKey: z.string().optional().nullable(),
+  instanceUrl: z.string().url().optional().nullable(),
+});
+
+export type IssueExternalRefsJira = z.infer<typeof issueExternalRefsJiraSchema>;
+
+export const issueExternalRefsSchema = z.object({
+  jira: issueExternalRefsJiraSchema.nullable().optional(),
+}).optional().nullable();
+
+export type IssueExternalRefs = z.infer<typeof issueExternalRefsSchema>;

--- a/packages/shared/src/validators/external-links.ts
+++ b/packages/shared/src/validators/external-links.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const EXTERNAL_LINK_PLATFORMS = ["jira", "linear", "github", "asana"] as const;
+
+export const createExternalLinkSchema = z.object({
+  platform: z.enum(EXTERNAL_LINK_PLATFORMS),
+  externalKey: z.string().min(1),
+  externalUrl: z.string().url(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export type CreateExternalLink = z.infer<typeof createExternalLinkSchema>;
+
+export const lookupExternalLinkQuerySchema = z.object({
+  platform: z.enum(EXTERNAL_LINK_PLATFORMS),
+  externalKey: z.string().min(1),
+});

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -442,5 +442,9 @@ export {
   EXTERNAL_LINK_PLATFORMS,
   createExternalLinkSchema,
   lookupExternalLinkQuerySchema,
+  issueExternalRefsSchema,
+  issueExternalRefsJiraSchema,
   type CreateExternalLink,
+  type IssueExternalRefs,
+  type IssueExternalRefsJira,
 } from "./external-links.js";

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -437,3 +437,10 @@ export {
   type SetPluginState,
   type ListPluginState,
 } from "./plugin.js";
+
+export {
+  EXTERNAL_LINK_PLATFORMS,
+  createExternalLinkSchema,
+  lookupExternalLinkQuerySchema,
+  type CreateExternalLink,
+} from "./external-links.js";

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -27,6 +27,7 @@ import {
   MODEL_PROFILE_KEYS,
 } from "../constants.js";
 import { multilineTextSchema } from "./text.js";
+import { issueExternalRefsSchema } from "./external-links.js";
 
 export const issueBlockedInboxStateSchema = z.enum([
   "needs_attention",
@@ -390,6 +391,7 @@ const createIssueBaseSchema = z.object({
   executionWorkspacePreference: z.enum(ISSUE_EXECUTION_WORKSPACE_PREFERENCES).optional().nullable(),
   executionWorkspaceSettings: issueExecutionWorkspaceSettingsSchema.optional().nullable(),
   labelIds: z.array(z.string().uuid()).optional(),
+  externalRefs: issueExternalRefsSchema,
 });
 
 export const createIssueInputSchema = createIssueBaseSchema.extend({

--- a/server/src/__tests__/external-links-routes.test.ts
+++ b/server/src/__tests__/external-links-routes.test.ts
@@ -1,0 +1,274 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const issueId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const companyId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const linkId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+const mockExternalLinkService = vi.hoisted(() => ({
+  listForIssue: vi.fn(),
+  create: vi.fn(),
+  getById: vi.fn(),
+  deleteById: vi.fn(),
+  lookupByPlatformKey: vi.fn(),
+}));
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const sampleIssue = {
+  id: issueId,
+  companyId,
+  identifier: "PAP-981",
+  title: "Test issue",
+  status: "in_progress",
+};
+
+const sampleLink = {
+  id: linkId,
+  issueId,
+  platform: "jira",
+  externalKey: "PD-1234",
+  externalUrl: "https://jira.example.com/browse/PD-1234",
+  metadata: {},
+  companyId,
+  createdAt: new Date("2026-05-18T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-18T00:00:00.000Z"),
+};
+
+function registerModuleMocks() {
+  vi.doMock("../services/external-links.js", () => ({
+    externalLinkService: () => mockExternalLinkService,
+  }));
+
+  vi.doMock("../services/index.js", () => ({
+    issueService: () => mockIssueService,
+  }));
+}
+
+async function createApp() {
+  const [{ externalLinksRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/external-links.js")>("../routes/external-links.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "board-user",
+      companyIds: [companyId],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", externalLinksRoutes({} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("external links routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../services/external-links.js");
+    vi.doUnmock("../services/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+  });
+
+  describe("POST /api/issues/:issueId/external-links", () => {
+    it("creates a link and returns 201", async () => {
+      mockIssueService.getById.mockResolvedValue(sampleIssue);
+      mockExternalLinkService.create.mockResolvedValue(sampleLink);
+
+      const app = await createApp();
+      const res = await request(app)
+        .post(`/api/issues/${issueId}/external-links`)
+        .send({
+          platform: "jira",
+          externalKey: "PD-1234",
+          externalUrl: "https://jira.example.com/browse/PD-1234",
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toMatchObject({ id: linkId, platform: "jira", externalKey: "PD-1234" });
+      expect(mockExternalLinkService.create).toHaveBeenCalledWith(issueId, {
+        platform: "jira",
+        externalKey: "PD-1234",
+        externalUrl: "https://jira.example.com/browse/PD-1234",
+      });
+    });
+
+    it("returns 404 when issue does not exist", async () => {
+      mockIssueService.getById.mockResolvedValue(null);
+
+      const app = await createApp();
+      const res = await request(app)
+        .post(`/api/issues/${issueId}/external-links`)
+        .send({
+          platform: "jira",
+          externalKey: "PD-1234",
+          externalUrl: "https://jira.example.com/browse/PD-1234",
+        });
+
+      expect(res.status).toBe(404);
+      expect(mockExternalLinkService.create).not.toHaveBeenCalled();
+    });
+
+    it("returns 409 when duplicate link exists", async () => {
+      mockIssueService.getById.mockResolvedValue(sampleIssue);
+      const { HttpError } = await vi.importActual<typeof import("../errors.js")>("../errors.js");
+      mockExternalLinkService.create.mockRejectedValue(new HttpError(409, "A link for this platform and key already exists on this issue"));
+
+      const app = await createApp();
+      const res = await request(app)
+        .post(`/api/issues/${issueId}/external-links`)
+        .send({
+          platform: "jira",
+          externalKey: "PD-1234",
+          externalUrl: "https://jira.example.com/browse/PD-1234",
+        });
+
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 400 for invalid platform", async () => {
+      const app = await createApp();
+      const res = await request(app)
+        .post(`/api/issues/${issueId}/external-links`)
+        .send({
+          platform: "unknown-tracker",
+          externalKey: "X-1",
+          externalUrl: "https://example.com",
+        });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /api/issues/:issueId/external-links", () => {
+    it("returns list of links", async () => {
+      mockIssueService.getById.mockResolvedValue(sampleIssue);
+      mockExternalLinkService.listForIssue.mockResolvedValue([sampleLink]);
+
+      const app = await createApp();
+      const res = await request(app).get(`/api/issues/${issueId}/external-links`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0]).toMatchObject({ platform: "jira", externalKey: "PD-1234" });
+    });
+
+    it("returns 404 when issue does not exist", async () => {
+      mockIssueService.getById.mockResolvedValue(null);
+
+      const app = await createApp();
+      const res = await request(app).get(`/api/issues/${issueId}/external-links`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("DELETE /api/external-links/:linkId", () => {
+    it("deletes the link and returns 204", async () => {
+      mockExternalLinkService.getById.mockResolvedValue(sampleLink);
+      mockExternalLinkService.deleteById.mockResolvedValue(undefined);
+
+      const app = await createApp();
+      const res = await request(app).delete(`/api/external-links/${linkId}`);
+
+      expect(res.status).toBe(204);
+      expect(mockExternalLinkService.deleteById).toHaveBeenCalledWith(linkId);
+    });
+
+    it("returns 404 when link does not exist", async () => {
+      const { HttpError } = await vi.importActual<typeof import("../errors.js")>("../errors.js");
+      mockExternalLinkService.getById.mockRejectedValue(new HttpError(404, "External link not found"));
+
+      const app = await createApp();
+      const res = await request(app).delete(`/api/external-links/${linkId}`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("GET /api/external-links/lookup", () => {
+    it("returns the link for a known platform+key", async () => {
+      mockExternalLinkService.lookupByPlatformKey.mockResolvedValue(sampleLink);
+
+      const app = await createApp();
+      const res = await request(app)
+        .get("/api/external-links/lookup")
+        .query({ platform: "jira", externalKey: "PD-1234" });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ issueId, platform: "jira", externalKey: "PD-1234" });
+      expect(mockExternalLinkService.lookupByPlatformKey).toHaveBeenCalledWith("jira", "PD-1234");
+    });
+
+    it("returns 404 when no link exists", async () => {
+      const { HttpError } = await vi.importActual<typeof import("../errors.js")>("../errors.js");
+      mockExternalLinkService.lookupByPlatformKey.mockRejectedValue(new HttpError(404, "External link not found"));
+
+      const app = await createApp();
+      const res = await request(app)
+        .get("/api/external-links/lookup")
+        .query({ platform: "jira", externalKey: "PD-9999" });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 400 for missing query parameters", async () => {
+      const app = await createApp();
+      const res = await request(app).get("/api/external-links/lookup");
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for unsupported platform", async () => {
+      const app = await createApp();
+      const res = await request(app)
+        .get("/api/external-links/lookup")
+        .query({ platform: "notion", externalKey: "ABC-1" });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("integration: POST → GET → DELETE → GET", () => {
+    it("creates, reads, deletes, and verifies empty", async () => {
+      mockIssueService.getById.mockResolvedValue(sampleIssue);
+      mockExternalLinkService.create.mockResolvedValue(sampleLink);
+      mockExternalLinkService.listForIssue
+        .mockResolvedValueOnce([sampleLink])
+        .mockResolvedValueOnce([]);
+      mockExternalLinkService.getById.mockResolvedValue(sampleLink);
+      mockExternalLinkService.deleteById.mockResolvedValue(undefined);
+
+      const app = await createApp();
+
+      const postRes = await request(app)
+        .post(`/api/issues/${issueId}/external-links`)
+        .send({
+          platform: "jira",
+          externalKey: "PD-1234",
+          externalUrl: "https://jira.example.com/browse/PD-1234",
+        });
+      expect(postRes.status).toBe(201);
+
+      const getRes = await request(app).get(`/api/issues/${issueId}/external-links`);
+      expect(getRes.status).toBe(200);
+      expect(getRes.body).toHaveLength(1);
+
+      const deleteRes = await request(app).delete(`/api/external-links/${linkId}`);
+      expect(deleteRes.status).toBe(204);
+
+      const emptyRes = await request(app).get(`/api/issues/${issueId}/external-links`);
+      expect(emptyRes.status).toBe(200);
+      expect(emptyRes.body).toHaveLength(0);
+    });
+  });
+});

--- a/server/src/__tests__/issue-external-refs-routes.test.ts
+++ b/server/src/__tests__/issue-external-refs-routes.test.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { companies, createDb, issues } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping issue externalRefs route tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("issue externalRefs routes", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-external-refs-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = {
+        type: "board",
+        userId: "board-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: true,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any));
+    app.use(errorHandler);
+    return app;
+  }
+
+  it("PATCH sets externalRefs.jira and GET returns it", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme Corp",
+      issuePrefix: "ACM",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: 1,
+      identifier: "ACM-1",
+      title: "Jira link test issue",
+      status: "todo",
+      priority: "medium",
+      createdByUserId: "board-user-1",
+    });
+
+    const app = createApp(companyId);
+
+    // PATCH sets jira link
+    const patch = await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        externalRefs: {
+          jira: {
+            key: "PD-1234",
+            externalUrl: "https://jira.example.com/browse/PD-1234",
+            projectKey: "PD",
+          },
+        },
+      });
+
+    expect(patch.status, JSON.stringify(patch.body)).toBe(200);
+    expect(patch.body.externalRefs).toMatchObject({
+      jira: { key: "PD-1234", externalUrl: "https://jira.example.com/browse/PD-1234", projectKey: "PD" },
+    });
+
+    // GET returns the same externalRefs
+    const read = await request(app).get(`/api/issues/${issueId}`);
+    expect(read.status).toBe(200);
+    expect(read.body.externalRefs).toMatchObject({
+      jira: { key: "PD-1234", externalUrl: "https://jira.example.com/browse/PD-1234" },
+    });
+  });
+
+  it("PATCH with jira=null removes the Jira link", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme Corp 2",
+      issuePrefix: "ACM2",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: 2,
+      identifier: "ACM2-2",
+      title: "Jira link removal test",
+      status: "todo",
+      priority: "medium",
+      createdByUserId: "board-user-1",
+    });
+
+    const app = createApp(companyId);
+
+    // First set a jira link
+    await request(app).patch(`/api/issues/${issueId}`).send({
+      externalRefs: {
+        jira: { key: "PD-9999", externalUrl: "https://jira.example.com/browse/PD-9999" },
+      },
+    });
+
+    // Then remove it
+    const remove = await request(app).patch(`/api/issues/${issueId}`).send({
+      externalRefs: { jira: null },
+    });
+    expect(remove.status, JSON.stringify(remove.body)).toBe(200);
+    expect(remove.body.externalRefs).toBeNull();
+
+    // Verify GET also returns null
+    const read = await request(app).get(`/api/issues/${issueId}`);
+    expect(read.body.externalRefs).toBeNull();
+  });
+
+  it("PATCH updates externalRefs.jira when key already exists (upsert)", async () => {
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme Corp 3",
+      issuePrefix: "ACM3",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      issueNumber: 3,
+      identifier: "ACM3-3",
+      title: "Jira upsert test",
+      status: "todo",
+      priority: "medium",
+      createdByUserId: "board-user-1",
+    });
+
+    const app = createApp(companyId);
+
+    // First set
+    await request(app).patch(`/api/issues/${issueId}`).send({
+      externalRefs: {
+        jira: { key: "PD-100", externalUrl: "https://jira.example.com/browse/PD-100" },
+      },
+    });
+
+    // Upsert same key with new URL
+    const upsert = await request(app).patch(`/api/issues/${issueId}`).send({
+      externalRefs: {
+        jira: { key: "PD-100", externalUrl: "https://updated.example.com/browse/PD-100" },
+      },
+    });
+    expect(upsert.status, JSON.stringify(upsert.body)).toBe(200);
+    expect(upsert.body.externalRefs?.jira?.externalUrl).toBe("https://updated.example.com/browse/PD-100");
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,6 +16,7 @@ import { agentRoutes } from "./routes/agents.js";
 import { projectRoutes } from "./routes/projects.js";
 import { issueRoutes } from "./routes/issues.js";
 import { issueTreeControlRoutes } from "./routes/issue-tree-control.js";
+import { externalLinksRoutes } from "./routes/external-links.js";
 import { routineRoutes } from "./routes/routines.js";
 import { environmentRoutes } from "./routes/environments.js";
 import { executionWorkspaceRoutes } from "./routes/execution-workspaces.js";
@@ -197,6 +198,7 @@ export async function createApp(
     pluginWorkerManager: workerManager,
   }));
   api.use(issueTreeControlRoutes(db));
+  api.use(externalLinksRoutes(db));
   api.use(routineRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(environmentRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(executionWorkspaceRoutes(db));

--- a/server/src/routes/external-links.ts
+++ b/server/src/routes/external-links.ts
@@ -1,0 +1,64 @@
+import { Router } from "express";
+import type { Db } from "@paperclipai/db";
+import { createExternalLinkSchema, lookupExternalLinkQuerySchema } from "@paperclipai/shared";
+import { validate } from "../middleware/validate.js";
+import { externalLinkService } from "../services/external-links.js";
+import { assertCompanyAccess } from "./authz.js";
+import { issueService } from "../services/index.js";
+import { HttpError } from "../errors.js";
+
+export function externalLinksRoutes(db: Db) {
+  const router = Router();
+  const svc = externalLinkService(db);
+  const issueSvc = issueService(db);
+
+  // Register lookup before /:linkId so "lookup" isn't treated as a uuid param
+  router.get("/external-links/lookup", async (req, res) => {
+    const parsed = lookupExternalLinkQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      throw new HttpError(400, parsed.error.issues[0]?.message ?? "Invalid query parameters");
+    }
+    const { platform, externalKey } = parsed.data;
+    const link = await svc.lookupByPlatformKey(platform, externalKey);
+    assertCompanyAccess(req, link.companyId);
+    res.json(link);
+  });
+
+  router.delete("/external-links/:linkId", async (req, res) => {
+    const linkId = req.params.linkId as string;
+    const link = await svc.getById(linkId);
+    assertCompanyAccess(req, link.companyId);
+    await svc.deleteById(linkId);
+    res.status(204).end();
+  });
+
+  router.post(
+    "/issues/:issueId/external-links",
+    validate(createExternalLinkSchema),
+    async (req, res) => {
+      const issueId = req.params.issueId as string;
+      const issue = await issueSvc.getById(issueId);
+      if (!issue) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+      assertCompanyAccess(req, issue.companyId);
+      const link = await svc.create(issueId, req.body);
+      res.status(201).json(link);
+    },
+  );
+
+  router.get("/issues/:issueId/external-links", async (req, res) => {
+    const issueId = req.params.issueId as string;
+    const issue = await issueSvc.getById(issueId);
+    if (!issue) {
+      res.status(404).json({ error: "Issue not found" });
+      return;
+    }
+    assertCompanyAccess(req, issue.companyId);
+    const links = await svc.listForIssue(issueId);
+    res.json(links);
+  });
+
+  return router;
+}

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -5,6 +5,7 @@ export { agentRoutes } from "./agents.js";
 export { projectRoutes } from "./projects.js";
 export { issueRoutes } from "./issues.js";
 export { issueTreeControlRoutes } from "./issue-tree-control.js";
+export { externalLinksRoutes } from "./external-links.js";
 export { routineRoutes } from "./routines.js";
 export { goalRoutes } from "./goals.js";
 export { approvalRoutes } from "./approvals.js";

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -109,6 +109,7 @@ import {
 } from "../services/issue-execution-policy.js";
 import { parseIssueExecutionWorkspaceSettings } from "../services/execution-workspace-policy.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { externalLinkService } from "../services/external-links.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -857,6 +858,7 @@ export function issueRoutes(
   const documentsSvc = documentService(db);
   const issueReferencesSvc = issueReferenceService(db);
   const issueThreadInteractionsSvc = issueThreadInteractionService(db);
+  const externalLinksSvc = externalLinkService(db);
   const routinesSvc = routineService(db, {
     pluginWorkerManager: opts.pluginWorkerManager,
   });
@@ -2052,7 +2054,20 @@ export function issueRoutes(
     const currentExecutionWorkspace = issue.executionWorkspaceId
       ? await executionWorkspacesSvc.getById(issue.executionWorkspaceId)
       : null;
-    const workProducts = await workProductsSvc.listForIssue(issue.id);
+    const [workProducts, jiraLink] = await Promise.all([
+      workProductsSvc.listForIssue(issue.id),
+      externalLinksSvc.getJiraLink(issue.id),
+    ]);
+    const externalRefs = jiraLink
+      ? {
+          jira: {
+            key: jiraLink.externalKey,
+            externalUrl: jiraLink.externalUrl,
+            projectKey: (jiraLink.metadata as Record<string, unknown>)?.projectKey as string | null ?? null,
+            instanceUrl: (jiraLink.metadata as Record<string, unknown>)?.instanceUrl as string | null ?? null,
+          },
+        }
+      : null;
     res.json({
       ...issue,
       goalId: goal?.id ?? issue.goalId,
@@ -2072,6 +2087,7 @@ export function issueRoutes(
       mentionedProjects,
       currentExecutionWorkspace,
       workProducts,
+      externalRefs,
     });
   });
 
@@ -3259,6 +3275,7 @@ export function issueRoutes(
       resume: resumeRequested,
       interrupt: interruptRequested,
       hiddenAt: hiddenAtRaw,
+      externalRefs: externalRefsInput,
       ...updateFields
     } = req.body;
     const shouldCancelActiveRunForCancelledStatus =
@@ -4138,7 +4155,27 @@ export function issueRoutes(
       }
     })();
 
-    res.json({ ...issueResponse, comment });
+    // Handle externalRefs.jira upsert/delete
+    if (externalRefsInput !== undefined) {
+      if (externalRefsInput?.jira != null) {
+        await externalLinksSvc.upsertJiraLink(id, externalRefsInput.jira);
+      } else if (externalRefsInput?.jira === null) {
+        await externalLinksSvc.deleteJiraLinks(id);
+      }
+    }
+    const jiraLink = await externalLinksSvc.getJiraLink(id);
+    const externalRefs = jiraLink
+      ? {
+          jira: {
+            key: jiraLink.externalKey,
+            externalUrl: jiraLink.externalUrl,
+            projectKey: (jiraLink.metadata as Record<string, unknown>)?.projectKey as string | null ?? null,
+            instanceUrl: (jiraLink.metadata as Record<string, unknown>)?.instanceUrl as string | null ?? null,
+          },
+        }
+      : null;
+
+    res.json({ ...issueResponse, comment, externalRefs });
   });
 
   router.delete("/issues/:id", async (req, res) => {

--- a/server/src/services/external-links.ts
+++ b/server/src/services/external-links.ts
@@ -1,8 +1,8 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { externalLinks, issues } from "@paperclipai/db";
 import { conflict, notFound } from "../errors.js";
-import type { CreateExternalLink } from "@paperclipai/shared";
+import type { CreateExternalLink, IssueExternalRefsJira } from "@paperclipai/shared";
 
 export function externalLinkService(db: Db) {
   async function getIssue(issueId: string) {
@@ -90,6 +90,49 @@ export function externalLinkService(db: Db) {
         .returning({ id: externalLinks.id });
 
       if (rows.length === 0) throw notFound("External link not found");
+    },
+
+    // Upsert the Jira external link for an issue. Used by PATCH /issues/:id externalRefs.
+    upsertJiraLink: async (issueId: string, input: IssueExternalRefsJira) => {
+      const metadata: Record<string, unknown> = {};
+      if (input.projectKey) metadata.projectKey = input.projectKey;
+      if (input.instanceUrl) metadata.instanceUrl = input.instanceUrl;
+
+      await db
+        .insert(externalLinks)
+        .values({
+          issueId,
+          platform: "jira",
+          externalKey: input.key,
+          externalUrl: input.externalUrl,
+          metadata,
+        })
+        .onConflictDoUpdate({
+          target: [externalLinks.issueId, externalLinks.platform, externalLinks.externalKey],
+          set: {
+            externalUrl: input.externalUrl,
+            metadata: sql`excluded.metadata`,
+            updatedAt: sql`now()`,
+          },
+        });
+    },
+
+    // Remove all Jira links for an issue. Used when externalRefs.jira is set to null.
+    deleteJiraLinks: async (issueId: string) => {
+      await db
+        .delete(externalLinks)
+        .where(and(eq(externalLinks.issueId, issueId), eq(externalLinks.platform, "jira")));
+    },
+
+    // Returns the first Jira link for an issue, or null.
+    getJiraLink: async (issueId: string) => {
+      return db
+        .select()
+        .from(externalLinks)
+        .where(and(eq(externalLinks.issueId, issueId), eq(externalLinks.platform, "jira")))
+        .orderBy(externalLinks.createdAt)
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
     },
 
     lookupByPlatformKey: async (platform: string, externalKey: string) => {

--- a/server/src/services/external-links.ts
+++ b/server/src/services/external-links.ts
@@ -1,0 +1,122 @@
+import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { externalLinks, issues } from "@paperclipai/db";
+import { conflict, notFound } from "../errors.js";
+import type { CreateExternalLink } from "@paperclipai/shared";
+
+export function externalLinkService(db: Db) {
+  async function getIssue(issueId: string) {
+    return db
+      .select({ id: issues.id, companyId: issues.companyId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  async function getLink(linkId: string) {
+    return db
+      .select({
+        id: externalLinks.id,
+        issueId: externalLinks.issueId,
+        platform: externalLinks.platform,
+        externalKey: externalLinks.externalKey,
+        externalUrl: externalLinks.externalUrl,
+        metadata: externalLinks.metadata,
+        createdAt: externalLinks.createdAt,
+        updatedAt: externalLinks.updatedAt,
+        companyId: issues.companyId,
+      })
+      .from(externalLinks)
+      .innerJoin(issues, eq(externalLinks.issueId, issues.id))
+      .where(eq(externalLinks.id, linkId))
+      .then((rows) => rows[0] ?? null);
+  }
+
+  return {
+    listForIssue: async (issueId: string) => {
+      const issue = await getIssue(issueId);
+      if (!issue) throw notFound("Issue not found");
+
+      return db
+        .select()
+        .from(externalLinks)
+        .where(eq(externalLinks.issueId, issueId))
+        .orderBy(externalLinks.createdAt);
+    },
+
+    create: async (issueId: string, input: CreateExternalLink) => {
+      const issue = await getIssue(issueId);
+      if (!issue) throw notFound("Issue not found");
+
+      const existing = await db
+        .select({ id: externalLinks.id })
+        .from(externalLinks)
+        .where(
+          and(
+            eq(externalLinks.issueId, issueId),
+            eq(externalLinks.platform, input.platform),
+            eq(externalLinks.externalKey, input.externalKey),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+
+      if (existing) {
+        throw conflict("A link for this platform and key already exists on this issue");
+      }
+
+      return db
+        .insert(externalLinks)
+        .values({
+          issueId,
+          platform: input.platform,
+          externalKey: input.externalKey,
+          externalUrl: input.externalUrl,
+          metadata: (input.metadata ?? {}) as Record<string, unknown>,
+        })
+        .returning()
+        .then((rows) => rows[0]!);
+    },
+
+    getById: async (linkId: string) => {
+      const row = await getLink(linkId);
+      if (!row) throw notFound("External link not found");
+      return row;
+    },
+
+    deleteById: async (linkId: string) => {
+      const rows = await db
+        .delete(externalLinks)
+        .where(eq(externalLinks.id, linkId))
+        .returning({ id: externalLinks.id });
+
+      if (rows.length === 0) throw notFound("External link not found");
+    },
+
+    lookupByPlatformKey: async (platform: string, externalKey: string) => {
+      const row = await db
+        .select({
+          id: externalLinks.id,
+          issueId: externalLinks.issueId,
+          platform: externalLinks.platform,
+          externalKey: externalLinks.externalKey,
+          externalUrl: externalLinks.externalUrl,
+          metadata: externalLinks.metadata,
+          createdAt: externalLinks.createdAt,
+          updatedAt: externalLinks.updatedAt,
+          companyId: issues.companyId,
+        })
+        .from(externalLinks)
+        .innerJoin(issues, eq(externalLinks.issueId, issues.id))
+        .where(
+          and(
+            eq(externalLinks.platform, platform),
+            eq(externalLinks.externalKey, externalKey),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+
+      if (!row) throw notFound("External link not found");
+      return row;
+    },
+  };
+}

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -56,3 +56,4 @@ export { notifyHireApproved, type NotifyHireApprovedInput } from "./hire-hook.js
 export { publishLiveEvent, subscribeCompanyLiveEvents } from "./live-events.js";
 export { reconcilePersistedRuntimeServicesOnStartup, restartDesiredRuntimeServicesOnStartup } from "./workspace-runtime.js";
 export { createStorageServiceFromConfig, getStorageService } from "../storage/index.js";
+export { externalLinkService } from "./external-links.js";


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for development teams; those teams also use Jira for human-visible tracking
> - Issue ↔ Jira link traceability is needed so agents can cross-reference Paperclip issues with their Jira counterparts
> - The `external_links` table (POI-981, same branch base) provides normalized per-platform link storage, but the issue create/update/read API had no way to set or read a Jira link in a single call
> - Agents and API clients need a single-field `externalRefs.jira` on `PATCH /issues/:id` to set the Jira key alongside other issue updates, and `GET /issues/:id` to read it back — separate round-trips to `/external-links` endpoints are fragile for automated pipelines
> - This PR adds: (1) a v1 regex extractor `extractJiraKey` for issues that carry the key only in their text; (2) an `externalRefs` field wired into both the issue PATCH write path (upsert via `ON CONFLICT DO UPDATE`) and the GET read path; (3) `issueExternalRefsSchema` exported from `@paperclipai/shared` for typed client usage
> - The benefit is that any agent or client can now set `{ externalRefs: { jira: { key: "PD-1234", externalUrl: "..." } } }` on an issue update and immediately read it back from `GET /issues/:id` without extra round-trips

## What Changed

- **`packages/shared/src/jira-key.ts`** — new `extractJiraKey(text)` and `extractAllJiraKeys(text)` utilities; regex covers any `[A-Z][A-Z0-9]{1,9}-\d+` format
- **`packages/shared/src/jira-key.test.ts`** — 9 unit tests: match, 4-digit key, no-match, first-of-multiple, lowercase rejection, digit-start rejection, prefix-too-long rejection; all unique-keys de-dupe
- **`packages/shared/src/validators/external-links.ts`** — `issueExternalRefsJiraSchema` and `issueExternalRefsSchema` added; exported from shared `index.ts` and `validators/index.ts`
- **`packages/shared/src/validators/issue.ts`** — `createIssueBaseSchema` extended with optional `externalRefs` field; flows to `updateIssueSchema.partial()` automatically
- **`server/src/services/external-links.ts`** — three new service methods: `upsertJiraLink` (INSERT ON CONFLICT DO UPDATE), `deleteJiraLinks`, `getJiraLink`
- **`server/src/routes/issues.ts`** — `externalLinkService` instantiated; `GET /issues/:id` includes `externalRefs` in parallel fetch; `PATCH /issues/:id` extracts `externalRefs` from body and applies upsert/delete before response
- **`server/src/__tests__/issue-external-refs-routes.test.ts`** — 3 embedded-postgres integration tests: set + read, remove (`jira=null`), and upsert same key

## Verification

```bash
# Unit tests (shared package)
cd packages/shared && npx vitest run
# → 99 passed (15 suites), including 9 new jira-key tests

# Integration tests
cd server && npx vitest run src/__tests__/issue-external-refs-routes.test.ts
# → 3 passed

# External links routes (regression)
cd server && npx vitest run src/__tests__/external-links-routes.test.ts
# → 13 passed
```

Manual round-trip:
```bash
# Set Jira link via PATCH
PATCH /api/issues/:id  { "externalRefs": { "jira": { "key": "PD-1234", "externalUrl": "https://..." } } }
# GET /api/issues/:id → response includes externalRefs.jira.key = "PD-1234"

# Remove via PATCH
PATCH /api/issues/:id  { "externalRefs": { "jira": null } }
# GET /api/issues/:id → response.externalRefs = null
```

## Risks

- **Migration**: No new migration required; uses `external_links` table from POI-981 (migration 0087). This PR must be merged after or alongside POI-981.
- **Upsert behavior**: The ON CONFLICT DO UPDATE on `(issueId, platform, externalKey)` means the URL and metadata are always overwritten with the latest value. This is intentional for idempotent agent writes.
- **`externalRefs` on list endpoints**: This PR only adds `externalRefs` to the single-issue `GET /issues/:id` endpoint. Bulk list endpoints (`GET /companies/:id/issues`) do not include it — adding it there would require a join on potentially large result sets and is deferred.
- Low risk overall: additive schema change (optional field), no migrations, existing tests unaffected.

## Model Used

- Provider: Anthropic
- Model ID: claude-sonnet-4-6
- Context window: 200K
- Mode: standard tool-use, no extended thinking

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (backend only)
- [ ] I have updated relevant documentation to reflect my changes — N/A (self-documenting)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge