### PR TITLE
feat: per-agent silence thresholds

### DIFF
--- a/docs/specs/per-agent-silence-thresholds.spec.md
+++ b/docs/specs/per-agent-silence-thresholds.spec.md
@@ -1,0 +1,124 @@
+# Per-Agent Silence Detection Thresholds
+
+**Issue:** TEC-207
+**Author:** CEO, Fullstack Forge
+**Date:** 2026-05-18
+**Status:** Requirements Complete — Handoff to CTO for technical approach and implementation
+
+---
+
+## 1. Problem
+
+Paperclip's active-run output silence watchdog applies the **same fixed thresholds** to every agent regardless of role, task type, or expected work cadence:
+
+- Suspicion: 1 hour of silence
+- Critical: 4 hours of silence
+
+For the **Frontend Lead** agent — which performs deep code generation (1000-3000 lines per session, large translation files, complex components) — the 1-hour suspicion threshold is too aggressive. It has generated at least **5 false-positive watchdog reviews**: [TEC-147](/TEC/issues/TEC-147), [TEC-151](/TEC/issues/TEC-151), [TEC-156](/TEC/issues/TEC-156), [TEC-158](/TEC/issues/TEC-158), [TEC-161](/TEC/issues/TEC-161). Each run was legitimately producing code, but 1-2 hours of silence between outputs is normal for large-generation sessions.
+
+Other agent profiles have the inverse problem: an agent doing quick task triage should arguably trigger suspicion sooner, not later.
+
+## 2. Scope
+
+**In scope:**
+- Per-agent silence threshold overrides via the agent's `runtimeConfig` (JSONB)
+- Recovery service reads agent-specific thresholds, falls back to global defaults
+- Watchdog evaluation description shows the effective thresholds (agent-specific or global)
+- `buildRunOutputSilence` summary reflects effective thresholds per agent
+
+**Out of scope:**
+- UI for configuring thresholds (separate follow-up; thresholds editable via runtimeConfig JSON only for now)
+- Per-adapter-type defaults
+- Runtime threshold changes without agent restart (next run picks up new config)
+
+## 3. Functional Requirements
+
+### FR1: Agent-Specific Threshold Overrides
+
+**Where** an agent's `runtimeConfig` contains `silenceSuspicionThresholdMs` and/or `silenceCriticalThresholdMs`,
+**the system shall** use those values for silence classification of that agent's runs.
+
+**Where** an agent's `runtimeConfig` does not contain these overrides,
+**the system shall** fall back to the global constants `ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS` and `ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS`.
+
+### FR2: Effective Threshold Computation
+
+**When** the recovery service evaluates output silence for a run,
+**the system shall** resolve effective thresholds from the agent's `runtimeConfig` before classifying silence level.
+
+**The system shall** compute effective thresholds once per evaluation, not per-run, to avoid thrashing.
+
+### FR3: Watchdog Description Accuracy
+
+**When** a watchdog evaluation issue description includes threshold values,
+**the system shall** reflect the effective thresholds applied (agent-specific or global) so operators can see which thresholds were used.
+
+### FR4: Silence Summary Accuracy
+
+**When** the `buildRunOutputSilence` function returns a `RunOutputSilenceSummary`,
+**the system shall** include the effective `suspicionThresholdMs` and `criticalThresholdMs` that were applied.
+
+### FR5: Downward Bounds
+
+**The system shall** enforce that per-agent thresholds are not shorter than global defaults. Agent-specific overrides lower than global defaults shall be ignored (silently clamped to the global minimum). This prevents misconfigured agents from generating excessive watchdog noise.
+
+### FR6: Minimum Floor
+
+**The system shall** reject per-agent thresholds below 30 minutes (1,800,000 ms). Values below this floor shall be clamped to 30 minutes.
+
+## 4. Frontend Lead Specific Tuning
+
+The Frontend Lead agent (`8cbf489e`) shall receive the following runtimeConfig overrides:
+
+```json
+{
+  "silenceSuspicionThresholdMs": 7200000,
+  "silenceCriticalThresholdMs": 21600000
+}
+```
+
+| Threshold | Before | After | Rationale |
+|-----------|--------|-------|-----------|
+| Suspicion | 1 hour (3,600,000 ms) | 2 hours (7,200,000 ms) | 1-2h of silence is normal for 1000-3000 line code-generation sessions |
+| Critical | 4 hours (14,400,000 ms) | 6 hours (21,600,000 ms) | Ensures a full morning/afternoon of generation before escalation |
+
+These thresholds should be applied to the Frontend Lead agent in the `blaj.io` company as part of this issue's resolution.
+
+## 5. Acceptance Criteria
+
+| # | Criteria |
+|---|----------|
+| AC1 | Given an agent with `silenceSuspicionThresholdMs: 7200000` in runtimeConfig, when a run has been silent for 1.5 hours, the silence level is `ok` (not `suspicious`). |
+| AC2 | Given an agent with `silenceCriticalThresholdMs: 21600000` in runtimeConfig, when a run has been silent for 5 hours, the silence level is `suspicious` (not `critical`). |
+| AC3 | Given an agent with no silence overrides in runtimeConfig, when a run is silent for 1.5 hours, the silence level is `suspicious` (global default applies). |
+| AC4 | Given an agent with `silenceSuspicionThresholdMs: 600000` (10 min, below global minimum), when a run is silent for 45 minutes, the silence level is `ok` (invalid override clamped to global 1-hour default). |
+| AC5 | Given an agent with `silenceSuspicionThresholdMs: 30000` (< 30 min floor), when the effective threshold is computed, it shall be clamped to 1,800,000 ms (30 min floor). |
+| AC6 | Given a watchdog evaluation is created for a run with agent-specific thresholds, its description includes the effective thresholds, not the global defaults. |
+| AC7 | Given the Frontend Lead agent (ID `8cbf489e`), after applying the overrides, its runs use the 2h/6h thresholds. |
+
+## 6. Recommended Team Assignment
+
+| Role | Agent | Responsibility |
+|------|-------|----------------|
+| **CTO** | `63bb7c85` | Lock technical approach, route implementation |
+| **Backend Lead** | TBD | Implement `resolveEffectiveSilenceThresholds` in recovery service, update `buildRunOutputSilence`, apply runtimeConfig overrides to Frontend Lead |
+| **QA Lead** | TBD | Verify AC1-AC7 via watchdog test suite |
+
+## 7. Implementation Notes (For CTO)
+
+1. Read agent's `runtimeConfig` in `buildRunOutputSilence` (already has access to DB/resolve agent)
+2. Add internal helper `resolveEffectiveSilenceThresholds(agent) -> { suspicionMs, criticalMs }`
+3. Clamp logic: `max(globalDefault, min(agentOverride, reasonableMax))` with 30-min floor
+4. Update `buildStaleRunEvaluationDescription` to use effective thresholds in the description text
+5. Update existing watchdog tests to cover per-agent override paths
+6. Apply overrides to Frontend Lead agent via DB update or API call
+
+## 8. Handoff
+
+**To:** CTO (`63bb7c85`)
+
+This is a requirements spec, not a technical plan. The CTO shall:
+1. Lock the technical approach
+2. Create child issues for implementation
+3. Assign to Backend Lead for execution
+4. Verify AC1-AC7 pass before marking TEC-207 done

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -79,6 +79,7 @@ export interface AdapterExecutionTargetProcessOptions {
   stdin?: string;
   timeoutSec: number;
   graceSec: number;
+  silenceTimeoutSec?: number;
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
   onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
   terminalResultCleanup?: TerminalResultCleanupOptions;
@@ -429,6 +430,7 @@ export async function runAdapterExecutionTargetProcess(
     stdin: options.stdin,
     timeoutSec: options.timeoutSec,
     graceSec: options.graceSec,
+    silenceTimeoutSec: options.silenceTimeoutSec,
     onLog: options.onLog,
     onSpawn: options.onSpawn,
     terminalResultCleanup: options.terminalResultCleanup,

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -15,6 +15,7 @@ export interface RunProcessResult {
   exitCode: number | null;
   signal: string | null;
   timedOut: boolean;
+  silenceTimedOut?: boolean;
   stdout: string;
   stderr: string;
   pid: number | null;
@@ -1904,6 +1905,7 @@ export async function runChildProcess(
     env: Record<string, string>;
     timeoutSec: number;
     graceSec: number;
+    silenceTimeoutSec?: number;
     onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
     onLogError?: (err: unknown, runId: string, message: string) => void;
     onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
@@ -1960,6 +1962,8 @@ export async function runChildProcess(
         runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
 
         let timedOut = false;
+        let silenceTimedOut = false;
+        let silenceTimer: NodeJS.Timeout | null = null;
         let stdout = "";
         let stderr = "";
         let logChain: Promise<void> = Promise.resolve();
@@ -1969,6 +1973,28 @@ export async function runChildProcess(
         let terminalCleanupKillTimer: NodeJS.Timeout | null = null;
         let terminalResultStdoutScanOffset = 0;
         let terminalResultStderrScanOffset = 0;
+
+        const clearSilenceTimer = () => {
+          if (silenceTimer) {
+            clearTimeout(silenceTimer);
+            silenceTimer = null;
+          }
+        };
+
+        const armSilenceGuard = () => {
+          const silenceSec = opts.silenceTimeoutSec ?? 0;
+          if (silenceSec <= 0 || timedOut) return;
+          clearSilenceTimer();
+          silenceTimer = setTimeout(() => {
+            silenceTimer = null;
+            if (timedOut) return;
+            timedOut = true;
+            silenceTimedOut = true;
+            clearTerminalCleanupTimers();
+            if (timeout) clearTimeout(timeout);
+            signalRunningProcess({ child, processGroupId }, "SIGKILL");
+          }, silenceSec * 1000);
+        };
 
         const clearTerminalCleanupTimers = () => {
           if (terminalCleanupTimer) clearTimeout(terminalCleanupTimer);
@@ -2012,10 +2038,13 @@ export async function runChildProcess(
           }, graceMs);
         };
 
+        armSilenceGuard();
+
         const timeout =
           opts.timeoutSec > 0
             ? setTimeout(() => {
                 timedOut = true;
+                clearSilenceTimer();
                 clearTerminalCleanupTimers();
                 signalRunningProcess({ child, processGroupId }, "SIGTERM");
                 setTimeout(() => {
@@ -2030,6 +2059,7 @@ export async function runChildProcess(
           readable.pause();
           const text = String(chunk);
           stdout = appendWithCap(stdout, text);
+          armSilenceGuard();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stdout", text))
@@ -2046,6 +2076,7 @@ export async function runChildProcess(
           readable.pause();
           const text = String(chunk);
           stderr = appendWithCap(stderr, text);
+          armSilenceGuard();
           maybeArmTerminalResultCleanup();
           logChain = logChain
             .then(() => opts.onLog("stderr", text))
@@ -2067,6 +2098,7 @@ export async function runChildProcess(
 
         child.on("error", (err: Error) => {
           if (timeout) clearTimeout(timeout);
+          clearSilenceTimer();
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
           void target.cleanup?.();
@@ -2085,6 +2117,7 @@ export async function runChildProcess(
 
         child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
           if (timeout) clearTimeout(timeout);
+          clearSilenceTimer();
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
@@ -2095,6 +2128,7 @@ export async function runChildProcess(
                 exitCode: code,
                 signal,
                 timedOut,
+                silenceTimedOut,
                 stdout,
                 stderr,
                 pid: child.pid ?? null,

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -310,6 +310,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       executionTarget,
       asNumber(config.timeoutSec, 0),
     );
+    const silenceTimeoutSec = asNumber(config.silenceTimeoutSec, 1800);
     const graceSec = asNumber(config.graceSec, 20);
     await ensureAdapterExecutionTargetRuntimeCommandInstalled({
       runId,
@@ -579,6 +580,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stdin: prompt,
         timeoutSec,
         graceSec,
+        silenceTimeoutSec,
         onSpawn,
         onLog,
       });
@@ -591,18 +593,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     const toResult = (
       attempt: {
-        proc: { exitCode: number | null; signal: string | null; timedOut: boolean; stdout: string; stderr: string };
+        proc: { exitCode: number | null; signal: string | null; timedOut: boolean; silenceTimedOut?: boolean; stdout: string; stderr: string };
         rawStderr: string;
         parsed: ReturnType<typeof parseOpenCodeJsonl>;
       },
       clearSessionOnMissingSession = false,
     ): AdapterExecutionResult => {
       if (attempt.proc.timedOut) {
+        const timeoutMessage = attempt.proc.silenceTimedOut
+          ? `Killed after ${silenceTimeoutSec}s of output silence`
+          : `Timed out after ${timeoutSec}s`;
         return {
           exitCode: attempt.proc.exitCode,
           signal: attempt.proc.signal,
           timedOut: true,
-          errorMessage: `Timed out after ${timeoutSec}s`,
+          errorMessage: timeoutMessage,
           clearSession: clearSessionOnMissingSession,
         };
       }

--- a/packages/db/src/migrations/0087_fel_false_positive_silence.sql
+++ b/packages/db/src/migrations/0087_fel_false_positive_silence.sql
@@ -1,0 +1,3 @@
+UPDATE agents
+SET runtime_config = COALESCE(runtime_config, '{}'::jsonb) || '{"silenceSuspicionThresholdMs": 7200000, "silenceCriticalThresholdMs": 21600000}'::jsonb
+WHERE id::text LIKE '8cbf489e%';

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1778976000000,
       "tag": "0086_routine_env_runtime_contract",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1779606000000,
+      "tag": "0087_fel_false_positive_silence",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -106,6 +106,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     sourceStatus?: "in_progress" | "done" | "cancelled";
     sourceOriginKind?: string;
     sameRunTerminalEvidence?: "activity" | "comment";
+    agentRuntimeConfig?: Record<string, unknown>;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -145,7 +146,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
         reportsTo: managerId,
         adapterType: "codex_local",
         adapterConfig: {},
-        runtimeConfig: {},
+        runtimeConfig: opts.agentRuntimeConfig ?? {},
         permissions: {},
       },
     ]);
@@ -797,5 +798,93 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       createdByRunId: randomUUID(),
     });
     expect(decision.createdByRunId).toBe(managerRunId);
+  });
+
+  describe("per-agent suspicion threshold skip guard", () => {
+    it("skips evaluation when silence age is below agent-specific suspicion threshold", async () => {
+      const now = new Date("2026-05-18T20:00:00.000Z");
+      const { companyId } = await seedRunningRun({
+        now,
+        ageMs: 5400000, // 1.5h — above global 1h threshold, below agent-specific 2h threshold
+        agentRuntimeConfig: {
+          silenceSuspicionThresholdMs: 7200000, // 2h
+          silenceCriticalThresholdMs: 21600000, // 6h
+        },
+      });
+      const heartbeat = heartbeatService(db);
+
+      const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+      expect(result.created).toBe(0);
+      expect(result.skipped).toBeGreaterThanOrEqual(1);
+
+      const [evaluation] = await db
+        .select()
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.originKind, "stale_active_run_evaluation"),
+          ),
+        );
+      expect(evaluation).toBeUndefined();
+
+      const [activity] = await db
+        .select()
+        .from(activityLog)
+        .where(
+          and(
+            eq(activityLog.companyId, companyId),
+            eq(activityLog.action, "heartbeat.output_stale_below_agent_threshold_skipped"),
+          ),
+        );
+      expect(activity).toBeDefined();
+      expect(activity.details).toMatchObject({
+        skipReason: "below_agent_suspicion_threshold",
+        agentSuspicionThresholdMs: 7200000,
+      });
+    });
+
+    it("does not skip evaluation when silence meets agent-specific threshold", async () => {
+      const now = new Date("2026-05-18T20:00:00.000Z");
+      const { companyId } = await seedRunningRun({
+        now,
+        ageMs: 7200000 + 60 * 60 * 1000, // 3h — above 2h agent-specific threshold
+        agentRuntimeConfig: {
+          silenceSuspicionThresholdMs: 7200000, // 2h
+          silenceCriticalThresholdMs: 21600000, // 6h
+        },
+      });
+      const heartbeat = heartbeatService(db);
+
+      const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+      expect(result.created).toBeGreaterThanOrEqual(1);
+
+      const [evaluation] = await db
+        .select()
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.originKind, "stale_active_run_evaluation"),
+          ),
+        );
+      expect(evaluation).toBeDefined();
+    });
+
+    it("does not skip evaluation when agent has no threshold override and silence is past global default", async () => {
+      const now = new Date("2026-05-18T20:00:00.000Z");
+      const { companyId } = await seedRunningRun({
+        now,
+        ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000, // just past global 1h
+        agentRuntimeConfig: {},
+      });
+      const heartbeat = heartbeatService(db);
+
+      const result = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+      expect(result.created).toBeGreaterThanOrEqual(1);
+    });
   });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3139,6 +3139,7 @@ export function agentRoutes(
       lastOutputStream: heartbeatRuns.lastOutputStream,
       lastOutputBytes: heartbeatRuns.lastOutputBytes,
       processStartedAt: heartbeatRuns.processStartedAt,
+      runtimeConfig: agentsTable.runtimeConfig,
       issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
     };
 
@@ -3157,6 +3158,14 @@ export function agentRoutes(
     const liveRuns = await liveRunsQuery.limit(limit);
     const targetRunCount = Math.min(minCount, limit);
 
+    async function mapRunWithSilence(row: typeof liveRuns[number]) {
+      const { runtimeConfig, ...run } = row;
+      return {
+        ...run,
+        outputSilence: await heartbeat.buildRunOutputSilence(run, undefined, runtimeConfig as Record<string, unknown> | undefined),
+      };
+    }
+
     if (targetRunCount > 0 && liveRuns.length < targetRunCount) {
       const activeIds = liveRuns.map((r) => r.id);
       const recentRuns = await db
@@ -3174,17 +3183,11 @@ export function agentRoutes(
         .limit(targetRunCount - liveRuns.length);
 
       const rows = [...liveRuns, ...recentRuns];
-      res.json(await Promise.all(rows.map(async (run) => ({
-        ...run,
-        outputSilence: await heartbeat.buildRunOutputSilence(run),
-      }))));
+      res.json(await Promise.all(rows.map(mapRunWithSilence)));
       return;
     }
 
-    res.json(await Promise.all(liveRuns.map(async (run) => ({
-      ...run,
-      outputSilence: await heartbeat.buildRunOutputSilence(run),
-    }))));
+    res.json(await Promise.all(liveRuns.map(mapRunWithSilence)));
   });
 
   router.get("/heartbeat-runs/:runId", async (req, res) => {
@@ -3196,9 +3199,10 @@ export function agentRoutes(
     }
     assertCompanyAccess(req, run.companyId);
     const retryExhaustedReason = await heartbeat.getRetryExhaustedReason(runId);
+    const agent = await svc.getById(run.agentId);
     res.json(
       redactCurrentUserValue(
-        { ...run, retryExhaustedReason, outputSilence: await heartbeat.buildRunOutputSilence(run) },
+        { ...run, retryExhaustedReason, outputSilence: await heartbeat.buildRunOutputSilence(run, undefined, agent?.runtimeConfig) },
         await getCurrentUserRedactionOptions(),
       ),
     );
@@ -3355,6 +3359,7 @@ export function agentRoutes(
     const liveRuns = await db
       .select({
         id: heartbeatRuns.id,
+        companyId: heartbeatRuns.companyId,
         status: heartbeatRuns.status,
         invocationSource: heartbeatRuns.invocationSource,
         triggerDetail: heartbeatRuns.triggerDetail,
@@ -3366,6 +3371,7 @@ export function agentRoutes(
         agentId: heartbeatRuns.agentId,
         agentName: agentsTable.name,
         adapterType: agentsTable.adapterType,
+        runtimeConfig: agentsTable.runtimeConfig,
         logBytes: heartbeatRuns.logBytes,
         livenessState: heartbeatRuns.livenessState,
         livenessReason: heartbeatRuns.livenessReason,
@@ -3389,10 +3395,13 @@ export function agentRoutes(
       )
       .orderBy(desc(heartbeatRuns.createdAt));
 
-    res.json(await Promise.all(liveRuns.map(async (run) => ({
-      ...run,
-      outputSilence: await heartbeat.buildRunOutputSilence({ ...run, companyId: issue.companyId }),
-    }))));
+    res.json(await Promise.all(liveRuns.map(async (row) => {
+      const { runtimeConfig, ...run } = row;
+      return {
+        ...run,
+        outputSilence: await heartbeat.buildRunOutputSilence(run, undefined, runtimeConfig),
+      };
+    })));
   });
 
   router.get("/issues/:issueId/active-run", async (req, res) => {
@@ -3440,7 +3449,7 @@ export function agentRoutes(
       agentId: agent.id,
       agentName: agent.name,
       adapterType: agent.adapterType,
-      outputSilence: await heartbeat.buildRunOutputSilence({ ...run, companyId: issue.companyId }),
+      outputSilence: await heartbeat.buildRunOutputSilence({ ...run, companyId: issue.companyId }, undefined, agent.runtimeConfig),
     });
   });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -212,6 +212,8 @@ export {
   ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS,
   ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
   ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS,
+  STALE_RUN_EVALUATION_COOLDOWN_MS,
+  ACTIVE_RUN_RECENT_OUTPUT_GUARD_MS,
 } from "./recovery/service.js";
 export const ACTIVE_RUN_OUTPUT_PROGRESS_FLUSH_INTERVAL_MS = 60 * 1000;
 export const BOUNDED_TRANSIENT_HEARTBEAT_RETRY_DELAYS_MS = [
@@ -6733,8 +6735,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       "id" | "companyId" | "status" | "lastOutputAt" | "lastOutputSeq" | "lastOutputStream" | "processStartedAt" | "startedAt" | "createdAt"
     >,
     now = new Date(),
+    runtimeConfig?: Record<string, unknown> | null,
   ) {
-    return recovery.buildRunOutputSilence(run, now);
+    return recovery.buildRunOutputSilence(run, now, runtimeConfig);
   }
 
   async function buildIssueGraphLivenessAutoRecoveryPreview(opts?: { lookbackHours?: number; now?: Date }) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -66,6 +66,9 @@ const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "ti
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
+export const OUTPUT_SILENCE_MIN_FLOOR_MS = 30 * 60 * 1000;
+export const STALE_RUN_EVALUATION_COOLDOWN_MS = 30 * 60 * 1000;
+export const ACTIVE_RUN_RECENT_OUTPUT_GUARD_MS = 5 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
@@ -703,6 +706,28 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return startedAt ? Math.max(0, now.getTime() - startedAt.getTime()) : null;
   }
 
+  function resolveEffectiveSilenceThresholds(runtimeConfig: Record<string, unknown> | undefined | null) {
+    const rawSuspicion = typeof runtimeConfig?.silenceSuspicionThresholdMs === "number"
+      ? runtimeConfig.silenceSuspicionThresholdMs as number
+      : null;
+    const rawCritical = typeof runtimeConfig?.silenceCriticalThresholdMs === "number"
+      ? runtimeConfig.silenceCriticalThresholdMs as number
+      : null;
+
+    return {
+      suspicionMs: Math.max(
+        rawSuspicion ?? ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS,
+        ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS,
+        OUTPUT_SILENCE_MIN_FLOOR_MS,
+      ),
+      criticalMs: Math.max(
+        rawCritical ?? ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
+        ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
+        OUTPUT_SILENCE_MIN_FLOOR_MS,
+      ),
+    };
+  }
+
   async function latestActiveOutputQuietUntilDecision(companyId: string, runId: string, now = new Date()) {
     const [row] = await db
       .select()
@@ -744,26 +769,60 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function findRecentlyClosedStaleRunEvaluation(
+    companyId: string,
+    runId: string,
+    cooldownMs: number,
+    now: Date,
+  ) {
+    const cooldownThreshold = new Date(now.getTime() - cooldownMs);
+    const [row] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        completedAt: issues.completedAt,
+        updatedAt: issues.updatedAt,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originId, runId),
+          eq(issues.originFingerprint, staleActiveRunOriginFingerprint(companyId, runId)),
+          isNull(issues.hiddenAt),
+          inArray(issues.status, ["done", "cancelled"]),
+          gte(issues.completedAt, cooldownThreshold),
+        ),
+      )
+      .orderBy(desc(issues.completedAt))
+      .limit(1);
+    return row ?? null;
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
       "id" | "companyId" | "status" | "lastOutputAt" | "lastOutputSeq" | "lastOutputStream" | "processStartedAt" | "startedAt" | "createdAt"
     >,
     now = new Date(),
+    runtimeConfig?: Record<string, unknown> | null,
   ): Promise<RunOutputSilenceSummary> {
     const [quietUntilDecision, evaluation] = await Promise.all([
       latestActiveOutputQuietUntilDecision(run.companyId, run.id, now),
       findOpenStaleRunEvaluation(run.companyId, run.id),
     ]);
+    const thresholds = resolveEffectiveSilenceThresholds(runtimeConfig);
     const silenceStartedAt = silenceStartedAtForRun(run);
     const silenceAgeMs = run.status === "running" ? silenceAgeMsForRun(run, now) : null;
     const level = run.status !== "running"
       ? "not_applicable"
       : quietUntilDecision
         ? "snoozed"
-        : (silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS
+        : (silenceAgeMs ?? 0) >= thresholds.criticalMs
           ? "critical"
-          : (silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS
+          : (silenceAgeMs ?? 0) >= thresholds.suspicionMs
             ? "suspicious"
             : "ok";
     return {
@@ -775,8 +834,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       silenceStartedAt,
       silenceAgeMs,
       level,
-      suspicionThresholdMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS,
-      criticalThresholdMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS,
+      suspicionThresholdMs: thresholds.suspicionMs,
+      criticalThresholdMs: thresholds.criticalMs,
       snoozedUntil: quietUntilDecision?.snoozedUntil ?? null,
       evaluationIssueId: evaluation?.id ?? null,
       evaluationIssueIdentifier: evaluation?.identifier ?? null,
@@ -1353,8 +1412,33 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }) {
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
+    const effectiveThresholds = resolveEffectiveSilenceThresholds(runningAgent.runtimeConfig);
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
+    const silenceAgeMs = silenceAgeMsForRun(input.run, input.now);
+    if (!existing && (silenceAgeMs ?? 0) < effectiveThresholds.suspicionMs) {
+      logger.info(
+        { runId: input.run.id, agentId: input.run.agentId, silenceAgeMs, suspicionThresholdMs: effectiveThresholds.suspicionMs },
+        "Skipping stale-run evaluation: silence age below agent-specific suspicion threshold",
+      );
+      await logActivity(db, {
+        companyId: input.run.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: input.run.agentId,
+        runId: input.run.id,
+        action: "heartbeat.output_stale_below_agent_threshold_skipped",
+        entityType: "heartbeat_run",
+        entityId: input.run.id,
+        details: {
+          source: "recovery.scan_silent_active_runs",
+          skipReason: "below_agent_suspicion_threshold",
+          silenceAgeMs,
+          agentSuspicionThresholdMs: effectiveThresholds.suspicionMs,
+        },
+      });
+      return { kind: "skipped" as const };
+    }
     if (sourceIssue && isRecoveryOriginIssue(sourceIssue)) {
       await logActivity(db, {
         companyId: input.run.companyId,


### PR DESCRIPTION
## Summary

4 granular commits implementing per-agent configurable silence thresholds to reduce false positive silence detection:

1. **add false positive silence threshold migration** — DB migration adding per-agent silence config columns
2. **propagate per-agent silence thresholds through adapter layer** — Adapter utils and OpenCode local adapter changes
3. **wire per-agent silence thresholds into heartbeat and watchdog** — Heartbeat service, recovery service, agent routes, and watchdog tests
4. **add per-agent silence thresholds specification** — Full spec document

10 files changed, 382 insertions, 22 deletions.