### PR TITLE
fix(recovery): skip successfulRunHandoff corrective wake on [ROUTINE:SILENT] completions

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -139,6 +139,7 @@ import {
   findExistingRunLivenessContinuationWake,
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
   readContinuationAttempt,
+  commentHasRoutineSilentSentinel,
 } from "./recovery/index.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
 import {
@@ -4163,6 +4164,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       existingWake,
       budgetBlock,
       pauseHold,
+      hasRoutineSilentComment,
     ] = await Promise.all([
       issue
         ? db
@@ -4288,6 +4290,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issue
         ? treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id)
         : Promise.resolve(null),
+      issue
+        ? db
+          .select({ body: issueComments.body })
+          .from(issueComments)
+          .where(
+            and(
+              eq(issueComments.companyId, run.companyId),
+              eq(issueComments.issueId, issue.id),
+              eq(issueComments.createdByRunId, run.id),
+            ),
+          )
+          .then((rows) => rows.some((r) => commentHasRoutineSilentSentinel(r.body)))
+        : Promise.resolve(false),
     ]);
 
     const decision = decideSuccessfulRunHandoff({
@@ -4305,6 +4320,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       hasPauseHold: Boolean(pauseHold),
       budgetBlocked: Boolean(budgetBlock),
       idempotentWakeExists: Boolean(existingWake),
+      hasRoutineSilentComment: Boolean(hasRoutineSilentComment),
     });
 
     if (decision.kind !== "enqueue" || !issue) return;

--- a/server/src/services/recovery/index.ts
+++ b/server/src/services/recovery/index.ts
@@ -57,6 +57,7 @@ export {
   decideSuccessfulRunHandoff,
   findExistingFinishSuccessfulRunHandoffWake,
   isSuccessfulRunHandoffRequiredNoticeBody,
+  commentHasRoutineSilentSentinel,
 } from "./successful-run-handoff.js";
 export type {
   SuccessfulRunHandoffNotice,

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -87,6 +87,13 @@ describe("successful run handoff decision", () => {
     expect(decision.instruction).toContain("record an explicit continuation path");
   });
 
+  it("does not queue when a [ROUTINE:SILENT] sentinel comment was posted by this run", () => {
+    expect(decide({ hasRoutineSilentComment: true })).toEqual({
+      kind: "skip",
+      reason: "run produced [ROUTINE:SILENT] sentinel — routine scan completed without issue action",
+    });
+  });
+
   it("does not queue when the issue already has a valid disposition", () => {
     expect(decide({ issue: { ...issue, status: "done" } as any })).toEqual({
       kind: "skip",

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -74,6 +74,12 @@ export function noticeMetadataReferencesRecoveryAction(
   );
 }
 
+export const ROUTINE_SILENT_SENTINEL = "[ROUTINE:SILENT]";
+
+export function commentHasRoutineSilentSentinel(body: string) {
+  return body.includes(ROUTINE_SILENT_SENTINEL);
+}
+
 export type SuccessfulRunHandoffDecision =
   | {
       kind: "enqueue";
@@ -344,10 +350,12 @@ export function decideSuccessfulRunHandoff(input: {
   hasPauseHold: boolean;
   budgetBlocked: boolean;
   idempotentWakeExists: boolean;
+  hasRoutineSilentComment?: boolean;
 }): SuccessfulRunHandoffDecision {
   const { run, issue, agent } = input;
 
   if (run.status !== "succeeded") return { kind: "skip", reason: "source run did not succeed" };
+  if (input.hasRoutineSilentComment) return { kind: "skip", reason: "run produced [ROUTINE:SILENT] sentinel — routine scan completed without issue action" };
   if (isCorrectiveHandoffRun(run)) return { kind: "skip", reason: "source run is already a corrective handoff run" };
   if (isIssueMonitorMaintenanceRun(run)) return { kind: "skip", reason: "issue monitor run owns its own recovery path" };
   if (run.issueCommentStatus === "retry_queued" || run.issueCommentStatus === "retry_exhausted") {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies — routine scan agents are a core automated workflow
> - The recovery subsystem uses `successfulRunHandoff` to detect runs that succeeded but left issues without a valid disposition, then spawns corrective wakes
> - Routine scan agents post a `[ROUTINE:SILENT]` sentinel comment and PATCH issue status to `done` — these are valid terminal actions for a scan routine
> - The handoff classifier was not aware of the sentinel, so it saw "productive run, issue still in_progress" and triggered a corrective wake anyway
> - The corrective run reopened the issue and spawned another corrective run, creating an infinite budget-burning loop (MAI-3148 observed 10 corrective runs in 1hr)
> - This PR adds a sentinel-aware early-exit guard: if any run-scoped comment contains `[ROUTINE:SILENT]`, skip the corrective handoff entirely
> - The benefit is zero-cost termination of the loop for all routine scan completions without affecting non-routine handoff recovery

## What Changed

- `server/src/services/recovery/successful-run-handoff.ts`: added `ROUTINE_SILENT_SENTINEL` constant, `commentHasRoutineSilentSentinel()` helper, `hasRoutineSilentComment?` optional param to `decideSuccessfulRunHandoff()` with early `skip` guard before any other checks
- `server/src/services/heartbeat.ts`: queries run-scoped `issueComments` for the sentinel in the parallel pre-decision fetch; passes `hasRoutineSilentComment` to `decideSuccessfulRunHandoff()`
- `server/src/services/recovery/index.ts`: re-exports `commentHasRoutineSilentSentinel`
- `server/src/services/recovery/successful-run-handoff.test.ts`: adds test case asserting `hasRoutineSilentComment: true` → `kind: "skip"` with correct reason string

## Verification

```bash
npx vitest run server/src/services/recovery/successful-run-handoff.test.ts
# 15/15 pass
```

Manual: routine scan agent with `[ROUTINE:SILENT]` in comment body no longer triggers corrective run after this change is live. Verified on local instance — the loop that produced 10 corrective runs in 1hr (MAI-3148) does not recur.

## Risks

- Low risk: the `hasRoutineSilentComment` param is optional (defaults falsy), so all existing call sites that don't pass it are unaffected
- The query is run-scoped (`createdByRunId = run.id`), so it only inspects comments posted by the current run — no cross-run false positives
- Sentinel check is `includes()` on the full comment body, which is broad but intentional: any comment from that run containing `[ROUTINE:SILENT]` is a valid terminal signal

## Model Used

- Provider: Anthropic
- Model ID: `claude-sonnet-4-6`
- Context window: 200k tokens
- Capabilities: tool use, code execution, agentic workflows

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge