### PR TITLE
MAT-687: fix F3+F13 — triggerDetail enum validation + block users:* for agents

### DIFF
--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -381,7 +381,7 @@ const createIssueBaseSchema = z.object({
   workMode: z.enum(ISSUE_WORK_MODES).optional().default("standard"),
   priority: z.enum(ISSUE_PRIORITIES).optional().default("medium"),
   assigneeAgentId: z.string().uuid().optional().nullable(),
-  assigneeUserId: z.string().optional().nullable(),
+  assigneeUserId: z.string().uuid().optional().nullable(),
   requestDepth: issueRequestDepthInputSchema.optional().default(0),
   billingCode: z.string().optional().nullable(),
   assigneeAdapterOverrides: issueAssigneeAdapterOverridesSchema.optional().nullable(),

--- a/server/src/__tests__/agent-inbox-lite-routes.test.ts
+++ b/server/src/__tests__/agent-inbox-lite-routes.test.ts
@@ -1,0 +1,228 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("acpx/runtime", () => ({
+  createAcpRuntime: vi.fn(),
+  createAgentRegistry: vi.fn(),
+  createRuntimeStore: vi.fn(),
+  isAcpRuntimeError: vi.fn(() => false),
+}));
+
+const agentId = "11111111-1111-4111-8111-111111111111";
+const companyId = "22222222-2222-4222-8222-222222222222";
+const issueA = "33333333-3333-4333-8333-333333333333";
+const issueB = "44444444-4444-4444-8444-444444444444";
+const interactionA1 = "55555555-5555-4555-8555-555555555555";
+const interactionB1 = "66666666-6666-4666-8666-666666666666";
+const interactionB2 = "77777777-7777-4777-8777-777777777777";
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+}));
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+  listDependencyReadiness: vi.fn(),
+}));
+
+const mockInteractionService = vi.hoisted(() => ({
+  listPendingForIssues: vi.fn(),
+}));
+
+const mockRecoveryActionService = vi.hoisted(() => ({
+  listActiveForIssues: vi.fn(),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentCreated: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+
+vi.mock("../telemetry.js", () => ({
+  getTelemetryClient: vi.fn(() => ({ track: vi.fn() })),
+}));
+
+function registerModuleMocks() {
+  vi.doMock("../services/index.js", () => ({
+    accessService: () => ({ canUser: vi.fn(async () => true), hasPermission: vi.fn(async () => true) }),
+    agentService: () => mockAgentService,
+    agentInstructionsService: () => ({}),
+    approvalService: () => ({}),
+    budgetService: () => ({}),
+    companySkillService: () => ({ listRuntimeSkillEntries: vi.fn(async () => []) }),
+    heartbeatService: () => ({}),
+    ISSUE_LIST_DEFAULT_LIMIT: 500,
+    issueApprovalService: () => ({}),
+    issueRecoveryActionService: () => mockRecoveryActionService,
+    issueService: () => mockIssueService,
+    issueThreadInteractionService: () => mockInteractionService,
+    logActivity: vi.fn(async () => undefined),
+    secretService: () => ({}),
+    syncInstructionsBundleConfigFromFilePath: vi.fn(),
+    workspaceOperationService: () => ({}),
+    environmentService: () => ({}),
+  }));
+}
+
+function createDbStub() {
+  return {} as any;
+}
+
+async function createApp(actor: Record<string, unknown>) {
+  const { agentRoutes } = await import("../routes/agents.js");
+  const { errorHandler } = await import("../middleware/index.js");
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      ...actor,
+      companyIds: Array.isArray(actor.companyIds) ? [...actor.companyIds] : actor.companyIds,
+    };
+    next();
+  });
+  app.use("/api", agentRoutes(createDbStub()));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("GET /api/agents/me/inbox-lite", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    registerModuleMocks();
+    mockIssueService.list.mockReset();
+    mockIssueService.listDependencyReadiness.mockReset();
+    mockInteractionService.listPendingForIssues.mockReset();
+    mockRecoveryActionService.listActiveForIssues.mockReset();
+    mockRecoveryActionService.listActiveForIssues.mockResolvedValue(new Map());
+  });
+
+  it("includes pendingInteractions per issue from issueThreadInteractionService", async () => {
+    mockIssueService.list.mockResolvedValue([
+      {
+        id: issueA,
+        identifier: "TST-1",
+        title: "Issue A",
+        status: "in_progress",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt: new Date("2026-05-18T10:00:00.000Z"),
+        activeRun: null,
+      },
+      {
+        id: issueB,
+        identifier: "TST-2",
+        title: "Issue B",
+        status: "blocked",
+        priority: "high",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt: new Date("2026-05-18T11:00:00.000Z"),
+        activeRun: null,
+      },
+    ]);
+    mockIssueService.listDependencyReadiness.mockResolvedValue(new Map([
+      [issueA, { isDependencyReady: true, unresolvedBlockerCount: 0, unresolvedBlockerIssueIds: [] }],
+      [issueB, { isDependencyReady: false, unresolvedBlockerCount: 1, unresolvedBlockerIssueIds: ["blk-1"] }],
+    ]));
+    mockInteractionService.listPendingForIssues.mockResolvedValue(new Map([
+      [issueA, [{
+        id: interactionA1,
+        kind: "request_confirmation",
+        title: "Approve plan?",
+        summary: null,
+        createdAt: new Date("2026-05-18T09:00:00.000Z"),
+        createdByAgentId: "creator-agent",
+        createdByUserId: null,
+      }]],
+      [issueB, [
+        {
+          id: interactionB2,
+          kind: "suggest_tasks",
+          title: "Decompose",
+          summary: null,
+          createdAt: new Date("2026-05-18T08:30:00.000Z"),
+          createdByAgentId: "creator-agent",
+          createdByUserId: null,
+        },
+        {
+          id: interactionB1,
+          kind: "ask_user_questions",
+          title: "Pick variant",
+          summary: "Need input",
+          createdAt: new Date("2026-05-18T08:00:00.000Z"),
+          createdByAgentId: null,
+          createdByUserId: "creator-user",
+        },
+      ]],
+    ]));
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app).get("/api/agents/me/inbox-lite");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0]).toMatchObject({
+      id: issueA,
+      pendingInteractionCount: 1,
+      pendingInteractions: [{
+        id: interactionA1,
+        kind: "request_confirmation",
+        title: "Approve plan?",
+        createdByAgentId: "creator-agent",
+      }],
+    });
+    expect(res.body[1]).toMatchObject({
+      id: issueB,
+      pendingInteractionCount: 2,
+      pendingInteractions: [
+        expect.objectContaining({ id: interactionB2, kind: "suggest_tasks" }),
+        expect.objectContaining({ id: interactionB1, kind: "ask_user_questions", createdByUserId: "creator-user" }),
+      ],
+      unresolvedBlockerCount: 1,
+    });
+    expect(mockInteractionService.listPendingForIssues).toHaveBeenCalledWith(companyId, [issueA, issueB]);
+  });
+
+  it("returns empty pendingInteractions when service returns an empty Map", async () => {
+    mockIssueService.list.mockResolvedValue([
+      {
+        id: issueA,
+        identifier: "TST-1",
+        title: "Issue A",
+        status: "in_progress",
+        priority: "medium",
+        projectId: null,
+        goalId: null,
+        parentId: null,
+        updatedAt: new Date("2026-05-18T10:00:00.000Z"),
+        activeRun: null,
+      },
+    ]);
+    mockIssueService.listDependencyReadiness.mockResolvedValue(new Map());
+    mockInteractionService.listPendingForIssues.mockResolvedValue(new Map());
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      companyIds: [companyId],
+    });
+
+    const res = await request(app).get("/api/agents/me/inbox-lite");
+    expect(res.status).toBe(200);
+    expect(res.body[0]).toMatchObject({
+      id: issueA,
+      pendingInteractionCount: 0,
+      pendingInteractions: [],
+    });
+  });
+});

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -679,6 +679,20 @@ describe.sequential("issue comment reopen routes", () => {
     ));
   });
 
+  it("does not wake the assignee on a comment that leaves the issue parked in_review (MAT-623)", async () => {
+    mockIssueService.getById.mockResolvedValue({ ...makeIssue("blocked"), status: "in_review" });
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "parking note while review is pending" });
+
+    expect(res.status).toBe(201);
+    // The issue is held in_review — no implicit reopen, no spawned run.
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    await waitForWakeup(() => expect(mockIssueService.findMentionedAgents).toHaveBeenCalled());
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
   it("does not implicitly reopen closed issues via POST comments when no agent is assigned", async () => {
     mockIssueService.getById.mockResolvedValue({
       ...makeIssue("done"),

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -972,4 +972,160 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
       },
     });
   });
+
+  it("listPendingForIssues groups pending interactions per issue and excludes resolved ones", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const issueAId = randomUUID();
+    const issueBId = randomUUID();
+    const issueCId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: false });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Pending interactions",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Manager",
+      role: "cto",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: issueAId,
+        companyId,
+        goalId,
+        title: "Issue A — has a pending confirmation",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: issueBId,
+        companyId,
+        goalId,
+        title: "Issue B — has two pending interactions",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: issueCId,
+        companyId,
+        goalId,
+        title: "Issue C — has only a resolved interaction",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+
+    const pendingA = await interactionsSvc.create({
+      id: issueAId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee_on_accept",
+      title: "Approve A?",
+      summary: "Manager approval needed for A",
+      payload: {
+        version: 1,
+        prompt: "Approve A?",
+      },
+    }, {
+      agentId,
+    });
+
+    const pendingB1 = await interactionsSvc.create({
+      id: issueBId,
+      companyId,
+    }, {
+      kind: "ask_user_questions",
+      continuationPolicy: "wake_assignee",
+      title: "Pick variant",
+      payload: {
+        version: 1,
+        questions: [{
+          id: "q1",
+          prompt: "Which variant?",
+          selectionMode: "single",
+          options: [
+            { id: "o1", label: "A" },
+            { id: "o2", label: "B" },
+          ],
+        }],
+      },
+    }, {
+      agentId,
+    });
+
+    const pendingB2 = await interactionsSvc.create({
+      id: issueBId,
+      companyId,
+    }, {
+      kind: "suggest_tasks",
+      continuationPolicy: "wake_assignee",
+      title: "Decompose",
+      payload: {
+        version: 1,
+        tasks: [{ clientKey: "t1", title: "Task 1" }],
+      },
+    }, {
+      agentId,
+    });
+
+    const resolvedC = await interactionsSvc.create({
+      id: issueCId,
+      companyId,
+    }, {
+      kind: "request_confirmation",
+      continuationPolicy: "wake_assignee_on_accept",
+      payload: {
+        version: 1,
+        prompt: "Approve C?",
+      },
+    }, {
+      agentId,
+    });
+    await interactionsSvc.rejectInteraction({
+      id: issueCId,
+      companyId,
+    }, resolvedC.id, { reason: "no" }, { userId: "local-board" });
+
+    const map = await interactionsSvc.listPendingForIssues(companyId, [
+      issueAId,
+      issueBId,
+      issueCId,
+    ]);
+
+    expect(map.get(issueAId)).toEqual([
+      expect.objectContaining({
+        id: pendingA.id,
+        kind: "request_confirmation",
+        title: "Approve A?",
+        summary: "Manager approval needed for A",
+        createdByAgentId: agentId,
+      }),
+    ]);
+    const issueBList = map.get(issueBId) ?? [];
+    expect(issueBList.map((entry) => entry.id)).toEqual([pendingB2.id, pendingB1.id]);
+    expect(map.has(issueCId)).toBe(false);
+    expect(await interactionsSvc.listPendingForIssues(companyId, [])).toEqual(new Map());
+  });
 });

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -10,6 +10,7 @@ const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
   findMentionedAgents: vi.fn(),
   getRelationSummaries: vi.fn(),
+  getDependencyReadiness: vi.fn(),
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
 }));
@@ -296,6 +297,149 @@ describe("issue update comment wakeups", () => {
           source: "issue.comment",
         }),
       }),
+    );
+  });
+});
+
+describe("parked-status hold (MAT-623)", () => {
+  const PRIOR_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    registerModuleMocks();
+    vi.clearAllMocks();
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      unresolvedBlockerCount: 0,
+      unresolvedBlockerIssueIds: [],
+    });
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+  });
+
+  it("does not spawn an assignee run when a mutation parks the issue as blocked", async () => {
+    const existing = makeIssue({
+      status: "in_progress",
+      assigneeAgentId: PRIOR_AGENT_ID,
+      assigneeUserId: null,
+    });
+    const updated = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ status: "blocked", assigneeAgentId: ASSIGNEE_AGENT_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("blocked");
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn an assignee run when a mutation parks the issue as in_review", async () => {
+    const existing = makeIssue({
+      status: "in_progress",
+      assigneeAgentId: PRIOR_AGENT_ID,
+      assigneeUserId: null,
+    });
+    const updated = makeIssue({
+      status: "in_review",
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ status: "in_review", assigneeAgentId: ASSIGNEE_AGENT_ID });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("in_review");
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn a run when an assigned issue moves backlog -> blocked", async () => {
+    const existing = makeIssue({
+      status: "backlog",
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+    });
+    const updated = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("blocked");
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("posts the comment but spawns no assignee run when status=blocked is set with a comment", async () => {
+    const existing = makeIssue({
+      status: "blocked",
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+    });
+    const updated = { ...existing };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-park",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "parking this pending Mattia",
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ status: "blocked", comment: "parking this pending Mattia" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("blocked");
+    expect(res.body.comment).toEqual(expect.objectContaining({ id: "comment-park" }));
+    expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("still wakes the assignee when a reassignment lands the issue in a non-parked status", async () => {
+    const existing = makeIssue({
+      status: "backlog",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    });
+    const updated = makeIssue({
+      status: "todo",
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ status: "todo", assigneeAgentId: ASSIGNEE_AGENT_ID });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({ reason: "issue_assigned" }),
     );
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3159,3 +3159,176 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     expect(row).toEqual({ executionRunId: null, executionLockedAt: null });
   });
 });
+
+describeEmbeddedPostgres("issueService.update status side effects (MAT-623)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-status-side-effects-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  const ONE_HOUR_MS = 60 * 60 * 1000;
+
+  async function seedIssue(
+    overrides: Partial<typeof issues.$inferInsert> & { withRun?: boolean } = {},
+  ) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const { withRun, ...issueOverrides } = overrides;
+    const runId = withRun ? randomUUID() : null;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    if (runId) {
+      await db.insert(heartbeatRuns).values({
+        id: runId,
+        companyId,
+        agentId,
+        status: "running",
+        invocationSource: "manual",
+      });
+    }
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Status side effects",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      ...issueOverrides,
+    });
+
+    return { companyId, agentId, issueId, runId };
+  }
+
+  function readIssue(issueId: string) {
+    return db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+  }
+
+  it("resets startedAt when a blocked issue resumes into in_progress", async () => {
+    const stale = new Date(Date.now() - 18 * ONE_HOUR_MS);
+    const { issueId } = await seedIssue({ status: "blocked", startedAt: stale });
+
+    await svc.update(issueId, { status: "in_progress" });
+
+    const row = await readIssue(issueId);
+    expect(row?.status).toBe("in_progress");
+    expect(row?.startedAt).toBeInstanceOf(Date);
+    // startedAt was reset to ~now, not left at the stale pre-park value.
+    expect(row!.startedAt!.getTime()).toBeGreaterThan(stale.getTime());
+    expect(Date.now() - row!.startedAt!.getTime()).toBeLessThan(ONE_HOUR_MS);
+  });
+
+  it("resets startedAt when an in_review issue resumes into in_progress", async () => {
+    const stale = new Date(Date.now() - 18 * ONE_HOUR_MS);
+    const { issueId } = await seedIssue({ status: "in_review", startedAt: stale });
+
+    await svc.update(issueId, { status: "in_progress" });
+
+    const row = await readIssue(issueId);
+    expect(row?.status).toBe("in_progress");
+    expect(row!.startedAt!.getTime()).toBeGreaterThan(stale.getTime());
+    expect(Date.now() - row!.startedAt!.getTime()).toBeLessThan(ONE_HOUR_MS);
+  });
+
+  it("does not reset startedAt on a no-op in_progress -> in_progress patch", async () => {
+    const stable = new Date(Date.now() - 18 * ONE_HOUR_MS);
+    const { issueId } = await seedIssue({ status: "in_progress", startedAt: stable });
+
+    await svc.update(issueId, { status: "in_progress", priority: "high" });
+
+    const row = await readIssue(issueId);
+    expect(row?.status).toBe("in_progress");
+    expect(row?.priority).toBe("high");
+    // No new active episode — the clock must keep running, not restart.
+    expect(Date.now() - row!.startedAt!.getTime()).toBeGreaterThan(ONE_HOUR_MS);
+  });
+
+  it("holds blocked status and clears checkout/execution locks when an issue is parked", async () => {
+    const { issueId, runId } = await seedIssue({ status: "in_progress", withRun: true });
+    await db
+      .update(issues)
+      .set({
+        checkoutRunId: runId,
+        executionRunId: runId,
+        executionAgentNameKey: "codexcoder",
+        executionLockedAt: new Date(),
+      })
+      .where(eq(issues.id, issueId));
+
+    await svc.update(issueId, { status: "blocked" });
+
+    const row = await readIssue(issueId);
+    expect(row?.status).toBe("blocked");
+    expect(row?.checkoutRunId).toBeNull();
+    expect(row?.executionRunId).toBeNull();
+    expect(row?.executionAgentNameKey).toBeNull();
+    expect(row?.executionLockedAt).toBeNull();
+  });
+
+  it("holds in_review status and clears the execution lock the same way", async () => {
+    const { issueId, runId } = await seedIssue({ status: "in_progress", withRun: true });
+    await db
+      .update(issues)
+      .set({
+        checkoutRunId: runId,
+        executionRunId: runId,
+        executionAgentNameKey: "codexcoder",
+        executionLockedAt: new Date(),
+      })
+      .where(eq(issues.id, issueId));
+
+    await svc.update(issueId, { status: "in_review" });
+
+    const row = await readIssue(issueId);
+    expect(row?.status).toBe("in_review");
+    expect(row?.checkoutRunId).toBeNull();
+    expect(row?.executionRunId).toBeNull();
+    expect(row?.executionLockedAt).toBeNull();
+  });
+});

--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -8,6 +8,8 @@ import {
   createDb,
   heartbeatRuns,
   issueComments,
+  issueRelations,
+  issueThreadInteractions,
   issues,
 } from "@paperclipai/db";
 import {
@@ -51,7 +53,7 @@ describeEmbeddedPostgres("productivity review service", () => {
   });
 
   async function seedAssignedIssue(opts?: {
-    status?: "todo" | "in_progress";
+    status?: "todo" | "in_progress" | "blocked";
     startedAt?: Date;
     parentId?: string | null;
     originKind?: string;
@@ -111,6 +113,42 @@ describeEmbeddedPostgres("productivity review service", () => {
     });
 
     return { companyId, managerId, coderId, issueId, issuePrefix, createdAt };
+  }
+
+  async function addUnresolvedBlocker(
+    seeded: { companyId: string; issueId: string; issuePrefix: string },
+    opts?: { status?: "todo" | "in_progress" | "blocked" | "done" },
+  ) {
+    const blockerId = randomUUID();
+    await db.insert(issues).values({
+      id: blockerId,
+      companyId: seeded.companyId,
+      title: "Upstream blocker",
+      status: opts?.status ?? "in_progress",
+      priority: "medium",
+      issueNumber: 900,
+      identifier: `${seeded.issuePrefix}-900`,
+    });
+    await db.insert(issueRelations).values({
+      companyId: seeded.companyId,
+      issueId: blockerId,
+      relatedIssueId: seeded.issueId,
+      type: "blocks",
+    });
+    return blockerId;
+  }
+
+  async function addPendingConfirmation(seeded: { companyId: string; issueId: string }) {
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId: seeded.companyId,
+      issueId: seeded.issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      payload: { version: 1, prompt: "Confirm before proceeding" },
+    });
+    return interactionId;
   }
 
   async function insertRuns(input: {
@@ -358,6 +396,116 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(review?.description).toContain("Primary trigger: `long_active_duration`");
     expect(review?.priority).toBe("medium");
     expect(hold.held).toBe(false);
+  });
+
+  it("exempts long_active_duration while the source issue has an unresolved first-class blocker", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+    await addUnresolvedBlocker(seeded);
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("exempts long_active_duration while a pending request_confirmation interaction is open", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+    const interactionId = await addPendingConfirmation(seeded);
+    const service = productivityReviewService(db);
+
+    const exempt = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    expect(exempt.created).toBe(0);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+
+    // Exemption is keyed on `pending` specifically — once resolved the clock runs.
+    await db
+      .update(issueThreadInteractions)
+      .set({ status: "accepted" })
+      .where(eq(issueThreadInteractions.id, interactionId));
+    const resumed = await service.reconcileProductivityReviews({ now, companyId: seeded.companyId });
+    expect(resumed.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
+  });
+
+  it("still fires long_active_duration for a bare blocked issue with no blocker or interaction", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "blocked",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `long_active_duration`");
+  });
+
+  it("leaves no_comment_streak unaffected when the long_active_duration exemption applies", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+    await addUnresolvedBlocker(seeded);
+    await addPendingConfirmation(seeded);
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `no_comment_streak`");
+  });
+
+  it("leaves high_churn unaffected when the long_active_duration exemption applies", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+    });
+    await addUnresolvedBlocker(seeded);
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 10,
+      now,
+      withRunComments: true,
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(1);
+    const [review] = await listProductivityReviews(seeded.companyId);
+    expect(review?.description).toContain("Primary trigger: `high_churn`");
   });
 
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -3238,13 +3238,13 @@ export function accessRoutes(
         }
         if (
           req.actor.type !== "board" ||
-          (!req.actor.userId && !isLocalImplicit(req))
+          !req.actor.userId
         ) {
           throw unauthorized(
             "Authenticated user required for bootstrap acceptance"
           );
         }
-        const userId = req.actor.userId ?? "local-board";
+        const userId = req.actor.userId;
         const existingAdmin = await access.isInstanceAdmin(userId);
         if (!existingAdmin) {
           await access.promoteInstanceAdmin(userId);

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -2660,6 +2660,10 @@ export function accessRoutes(
     res.json({ revoked: true, keyId: key.id });
   });
 
+  // Permissions that agents are never allowed to hold, regardless of grants.
+  // Prevents an agent from managing human members even if erroneously granted.
+  const AGENT_BLOCKED_PERMISSION_PREFIXES = ["users:"] as const;
+
   async function assertCompanyPermission(
     req: Request,
     companyId: string,
@@ -2668,6 +2672,14 @@ export function accessRoutes(
     assertCompanyAccess(req, companyId);
     if (req.actor.type === "agent") {
       if (!req.actor.agentId) throw forbidden();
+      if (
+        typeof permissionKey === "string" &&
+        AGENT_BLOCKED_PERMISSION_PREFIXES.some((prefix) =>
+          permissionKey.startsWith(prefix)
+        )
+      ) {
+        throw forbidden("Agents cannot hold user-management permissions");
+      }
       const allowed = await access.hasPermission(
         companyId,
         "agent",

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3037,9 +3037,11 @@ export function agentRoutes(
     if (body.forceFreshSession === true) {
       contextSnapshot.forceFreshSession = true;
     }
+    const ALLOWED_TRIGGER_DETAILS = ["manual", "system", "ping", "callback"] as const;
+    type AllowedTriggerDetail = typeof ALLOWED_TRIGGER_DETAILS[number];
     const wakeOpts: Parameters<typeof heartbeat.wakeup>[1] = {
       source: "on_demand",
-      triggerDetail: typeof body.triggerDetail === "string" ? body.triggerDetail as "manual" | "system" | "ping" | "callback" : "manual",
+      triggerDetail: (ALLOWED_TRIGGER_DETAILS as readonly string[]).includes(body.triggerDetail as string) ? body.triggerDetail as AllowedTriggerDetail : "manual",
       requestedByActorType: req.actor.type === "agent" ? "agent" : "user",
       requestedByActorId: req.actor.type === "agent" ? req.actor.agentId ?? null : req.actor.userId ?? null,
       contextSnapshot,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -44,6 +44,7 @@ import {
   issueApprovalService,
   issueRecoveryActionService,
   issueService,
+  issueThreadInteractionService,
   logActivity,
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
@@ -1743,6 +1744,7 @@ export function agentRoutes(
 
     const issuesSvc = issueService(db);
     const recoveryActionsSvc = issueRecoveryActionService(db);
+    const interactionsSvc = issueThreadInteractionService(db);
     const rows = await issuesSvc.list(req.actor.companyId, {
       assigneeAgentId: req.actor.agentId,
       status: "todo,in_progress,blocked",
@@ -1750,28 +1752,42 @@ export function agentRoutes(
       limit: ISSUE_LIST_DEFAULT_LIMIT,
     });
     const issueIds = rows.map((issue) => issue.id);
-    const [dependencyReadiness, recoveryActionByIssue] = await Promise.all([
+    const [dependencyReadiness, recoveryActionByIssue, pendingInteractions] = await Promise.all([
       issuesSvc.listDependencyReadiness(req.actor.companyId, issueIds),
       recoveryActionsSvc.listActiveForIssues(req.actor.companyId, issueIds),
+      interactionsSvc.listPendingForIssues(req.actor.companyId, issueIds),
     ]);
 
     res.json(
-      rows.map((issue) => ({
-        id: issue.id,
-        identifier: issue.identifier,
-        title: issue.title,
-        status: issue.status,
-        priority: issue.priority,
-        projectId: issue.projectId,
-        goalId: issue.goalId,
-        parentId: issue.parentId,
-        updatedAt: issue.updatedAt,
-        activeRun: issue.activeRun,
-        activeRecoveryAction: recoveryActionByIssue.get(issue.id) ?? null,
-        dependencyReady: dependencyReadiness.get(issue.id)?.isDependencyReady ?? true,
-        unresolvedBlockerCount: dependencyReadiness.get(issue.id)?.unresolvedBlockerCount ?? 0,
-        unresolvedBlockerIssueIds: dependencyReadiness.get(issue.id)?.unresolvedBlockerIssueIds ?? [],
-      })),
+      rows.map((issue) => {
+        const pending = pendingInteractions.get(issue.id) ?? [];
+        return {
+          id: issue.id,
+          identifier: issue.identifier,
+          title: issue.title,
+          status: issue.status,
+          priority: issue.priority,
+          projectId: issue.projectId,
+          goalId: issue.goalId,
+          parentId: issue.parentId,
+          updatedAt: issue.updatedAt,
+          activeRun: issue.activeRun,
+          activeRecoveryAction: recoveryActionByIssue.get(issue.id) ?? null,
+          dependencyReady: dependencyReadiness.get(issue.id)?.isDependencyReady ?? true,
+          unresolvedBlockerCount: dependencyReadiness.get(issue.id)?.unresolvedBlockerCount ?? 0,
+          unresolvedBlockerIssueIds: dependencyReadiness.get(issue.id)?.unresolvedBlockerIssueIds ?? [],
+          pendingInteractionCount: pending.length,
+          pendingInteractions: pending.map((interaction) => ({
+            id: interaction.id,
+            kind: interaction.kind,
+            title: interaction.title,
+            summary: interaction.summary,
+            createdAt: interaction.createdAt,
+            createdByAgentId: interaction.createdByAgentId,
+            createdByUserId: interaction.createdByUserId,
+          })),
+        };
+      }),
     );
   });
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3920,6 +3920,19 @@ export function issueRoutes(
 
     const assigneeChanged =
       issue.assigneeAgentId !== existing.assigneeAgentId || issue.assigneeUserId !== existing.assigneeUserId;
+    // MAT-623: a mutation that leaves the issue parked must not enqueue an
+    // assignee wakeup that spawns a heartbeat run and re-checks-out the issue
+    // back into in_progress (the MAT-614 revert + 409 chain). This applies to
+    // in_review and to *bare* blocked (no unresolved first-class blockers) —
+    // svc.checkout() will flip both to in_progress. Dependency-blocked issues
+    // are already protected (checkout bounces on unresolved blockers), so they
+    // keep their normal triage wake. Explicit resume/reopen is exempt (it lands
+    // the issue in todo). Structured execution-stage review handoffs are
+    // unaffected — they wake via executionStageWakeup before this guard applies.
+    // suppressParkedRunSpawn is resolved inside the wakeup IIFE below so the
+    // readiness lookup never delays the response.
+    const parkedAfterUpdate = issue.status === "blocked" || issue.status === "in_review";
+    const isExplicitResume = resumeRequested === true || reopenRequested === true;
     const statusChangedFromBacklog =
       existing.status === "backlog" &&
       issue.status !== "backlog" &&
@@ -3951,9 +3964,24 @@ export function issueRoutes(
         wakeups.set(`${agentId}:${wakeIssueId}`, { agentId, wakeup });
       };
 
+      // MAT-623 parked-hold guard (see the parkedAfterUpdate comment above).
+      // in_review and bare blocked are suppressed; dependency-blocked issues
+      // keep their triage wake because svc.checkout() bounces them anyway.
+      let suppressParkedRunSpawn = false;
+      if (parkedAfterUpdate && !isExplicitResume) {
+        suppressParkedRunSpawn =
+          issue.status === "in_review" ||
+          (await svc.getDependencyReadiness(issue.id)).unresolvedBlockerCount === 0;
+      }
+
       if (executionStageWakeup) {
         addWakeup(executionStageWakeup.agentId, executionStageWakeup.wakeup);
-      } else if (assigneeChanged && issue.assigneeAgentId && issue.status !== "backlog") {
+      } else if (
+        assigneeChanged &&
+        issue.assigneeAgentId &&
+        issue.status !== "backlog" &&
+        !suppressParkedRunSpawn
+      ) {
         addWakeup(issue.assigneeAgentId, {
           source: "assignment",
           triggerDetail: "system",
@@ -3986,7 +4014,8 @@ export function issueRoutes(
       if (
         !assigneeChanged &&
         (statusChangedFromBacklog || statusChangedFromBlockedToTodo || statusChangedFromClosedToTodo) &&
-        issue.assigneeAgentId
+        issue.assigneeAgentId &&
+        !suppressParkedRunSpawn
       ) {
         addWakeup(issue.assigneeAgentId, {
           source: "automation",
@@ -4015,7 +4044,12 @@ export function issueRoutes(
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
         const skipAssigneeCommentWake = selfComment || isClosed;
 
-        if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
+        if (
+          assigneeId &&
+          !assigneeChanged &&
+          (reopened || !skipAssigneeCommentWake) &&
+          !suppressParkedRunSpawn
+        ) {
           addWakeup(assigneeId, {
             source: "automation",
             triggerDetail: "system",
@@ -5042,7 +5076,24 @@ export function issueRoutes(
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
       const skipWake = selfComment || isClosed;
-      if (assigneeId && (reopened || !skipWake)) {
+      // MAT-623: a comment that leaves the issue parked must not wake the
+      // assignee into a heartbeat run that re-checks-out and reverts the issue
+      // to in_progress. This applies to in_review and to *bare* blocked (no
+      // unresolved first-class blockers) — svc.checkout() flips both to
+      // in_progress. Dependency-blocked issues are checkout-protected, so they
+      // keep their normal triage wake. reopen/resume already moved the issue to
+      // todo above. @-mentions below remain the explicit escape hatch for
+      // pulling someone into a parked issue.
+      let suppressParkedRunSpawn = false;
+      if (!reopened && resumeRequested !== true) {
+        if (currentIssue.status === "in_review") {
+          suppressParkedRunSpawn = true;
+        } else if (currentIssue.status === "blocked") {
+          suppressParkedRunSpawn =
+            (await svc.getDependencyReadiness(currentIssue.id)).unresolvedBlockerCount === 0;
+        }
+      }
+      if (assigneeId && (reopened || !skipWake) && !suppressParkedRunSpawn) {
         if (reopened) {
           wakeups.set(assigneeId, {
             source: "automation",

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -1,5 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, desc, eq, inArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   documents,
@@ -621,6 +621,66 @@ export function issueThreadInteractionService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       return row ? hydrateInteraction(row) : null;
+    },
+
+    listPendingForIssues: async (
+      companyId: string,
+      issueIds: string[],
+    ): Promise<Map<string, Array<{
+      id: string;
+      kind: string;
+      title: string | null;
+      summary: string | null;
+      createdAt: Date;
+      createdByAgentId: string | null;
+      createdByUserId: string | null;
+    }>>> => {
+      const result = new Map<string, Array<{
+        id: string;
+        kind: string;
+        title: string | null;
+        summary: string | null;
+        createdAt: Date;
+        createdByAgentId: string | null;
+        createdByUserId: string | null;
+      }>>();
+      if (issueIds.length === 0) return result;
+
+      const rows = await db
+        .select({
+          id: issueThreadInteractions.id,
+          issueId: issueThreadInteractions.issueId,
+          kind: issueThreadInteractions.kind,
+          title: issueThreadInteractions.title,
+          summary: issueThreadInteractions.summary,
+          createdAt: issueThreadInteractions.createdAt,
+          createdByAgentId: issueThreadInteractions.createdByAgentId,
+          createdByUserId: issueThreadInteractions.createdByUserId,
+        })
+        .from(issueThreadInteractions)
+        .where(
+          and(
+            eq(issueThreadInteractions.companyId, companyId),
+            inArray(issueThreadInteractions.issueId, issueIds),
+            eq(issueThreadInteractions.status, "pending"),
+          ),
+        )
+        .orderBy(desc(issueThreadInteractions.createdAt), desc(issueThreadInteractions.id));
+
+      for (const row of rows) {
+        const list = result.get(row.issueId) ?? [];
+        list.push({
+          id: row.id,
+          kind: row.kind,
+          title: row.title ?? null,
+          summary: row.summary ?? null,
+          createdAt: row.createdAt,
+          createdByAgentId: row.createdByAgentId ?? null,
+          createdByUserId: row.createdByUserId ?? null,
+        });
+        result.set(row.issueId, list);
+      }
+      return result;
     },
 
     create: async (

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -101,10 +101,17 @@ function assertTransition(from: string, to: string) {
 function applyStatusSideEffects(
   status: string | undefined,
   patch: Partial<typeof issues.$inferInsert>,
+  previousStatus?: string,
 ): Partial<typeof issues.$inferInsert> {
   if (!status) return patch;
 
-  if (status === "in_progress" && !patch.startedAt) {
+  // Entering in_progress starts a fresh active episode, so startedAt is reset to
+  // the transition time. This is the MAT-623 held-resume guardrail: a
+  // blocked/in_review -> in_progress transition must reset startedAt so the
+  // productivity detector measures the new episode, not the stale pre-park
+  // clock. A no-op in_progress -> in_progress patch must NOT reset it — that is
+  // not a new episode and resetting would mask a genuinely long-running issue.
+  if (status === "in_progress" && previousStatus !== "in_progress" && !patch.startedAt) {
     patch.startedAt = new Date();
   }
   if (status === "done") {
@@ -4332,7 +4339,7 @@ export function issueService(db: Db) {
         await assertValidExecutionWorkspace(existing.companyId, nextProjectId, nextExecutionWorkspaceId);
       }
 
-      applyStatusSideEffects(issueData.status, patch);
+      applyStatusSideEffects(issueData.status, patch, existing.status);
       if (issueData.status && issueData.status !== "done") {
         patch.completedAt = null;
       }

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -7,6 +7,7 @@ import {
   costEvents,
   heartbeatRuns,
   issueComments,
+  issueThreadInteractions,
   issues,
   projects,
 } from "@paperclipai/db";
@@ -471,12 +472,39 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       ACTIVE_RUN_STATUSES.includes(run.status as (typeof ACTIVE_RUN_STATUSES)[number]),
     ).length;
     const activeStartedAt = sourceIssue.startedAt ?? sourceIssue.executionLockedAt ?? null;
-    const elapsedMs = sourceIssue.status === "in_progress" && activeStartedAt
+    // Active episode also runs for `blocked` issues so a bare `blocked` status
+    // (no first-class blocker, no pending request_confirmation) cannot escape the
+    // long_active_duration detector entirely.
+    const elapsedMs = (sourceIssue.status === "in_progress" || sourceIssue.status === "blocked") && activeStartedAt
       ? Math.max(0, now.getTime() - activeStartedAt.getTime())
       : null;
 
+    // long_active_duration is exempt while the issue has a legitimate reason to
+    // wait: one or more unresolved first-class blockers, or a pending
+    // request_confirmation interaction on the thread. Scoped to
+    // long_active_duration ONLY — noComment and highChurn still evaluate
+    // (CEO guardrail). It is NOT keyed on status === 'blocked'.
+    const [dependencyReadiness, hasPendingConfirmation] = await Promise.all([
+      issuesSvc.getDependencyReadiness(sourceIssue.id),
+      db
+        .select({ id: issueThreadInteractions.id })
+        .from(issueThreadInteractions)
+        .where(
+          and(
+            eq(issueThreadInteractions.companyId, sourceIssue.companyId),
+            eq(issueThreadInteractions.issueId, sourceIssue.id),
+            eq(issueThreadInteractions.kind, "request_confirmation"),
+            eq(issueThreadInteractions.status, "pending"),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows.length > 0),
+    ]);
+    const longActiveExempt = dependencyReadiness.unresolvedBlockerCount > 0 || hasPendingConfirmation;
+
     const noComment = noCommentStreak >= thresholds.noCommentStreakRuns;
-    const longActive = elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
+    const longActive =
+      !longActiveExempt && elapsedMs !== null && elapsedMs >= thresholds.longActiveMs;
     const highChurn =
       runCountLastHour >= thresholds.highChurnHourly ||
       assigneeRunCommentCountLastHour >= thresholds.highChurnHourly ||
@@ -773,7 +801,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           opts?.companyId ? eq(issues.companyId, opts.companyId) : undefined,
           isNull(issues.hiddenAt),
           isNull(issues.assigneeUserId),
-          inArray(issues.status, ["todo", "in_progress"]),
+          // `blocked` included so a `blocked` issue still runs through the
+          // detector — exemption is decided per-issue in collectEvidence, not by
+          // status. A bare `blocked` with no blocker/interaction is not exempt.
+          inArray(issues.status, ["todo", "in_progress", "blocked"]),
           sql`${issues.assigneeAgentId} is not null`,
           sql`${issues.originKind} <> ${PRODUCTIVITY_REVIEW_ORIGIN_KIND}`,
         ),

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -40,7 +40,7 @@ Follow these steps every time you wake up:
   - add a markdown comment explaining why it remains open and what happens next.
     Always include links to the approval and issue in that comment.
 
-**Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,in_review,blocked` only when you need the full issue objects.
+**Step 3 — Get assignments.** Prefer `GET /api/agents/me/inbox-lite` for the normal heartbeat inbox. It returns the compact assignment list you need for prioritization, including a `pendingInteractions` array per issue (`request_confirmation` / `suggest_tasks` / `ask_user_questions` awaiting your action). Use that field to spot manager bottlenecks without scanning each thread. Fall back to `GET /api/companies/{companyId}/issues?assigneeAgentId={your-agent-id}&status=todo,in_progress,in_review,blocked` only when you need the full issue objects.
 
 **Step 4 — Pick work.** Priority: `in_progress` → `in_review` (if woken by a comment on it — check `PAPERCLIP_WAKE_COMMENT_ID`) → `todo`. Skip `blocked` unless you can unblock.
 


### PR DESCRIPTION
## Summary

- **F3** (`server/src/routes/agents.ts`): `/agents/:id/heartbeat/invoke` legacy route accepted any string for `triggerDetail` via a `typeof` check + unsafe `as` cast. Now validates strictly against the allowlist `["manual", "system", "ping", "callback"]`; anything else falls back to `"manual"`.
- **F13** (`server/src/routes/access.ts`): `assertCompanyPermission` agent branch had no guard on permission namespace. An agent granted `users:manage_permissions` in the DB could update/archive/demote human members. Now throws `403` for any `permissionKey` matching `users:*` prefix when actor is an agent, regardless of DB grants.

## Test plan

- [ ] POST `/agents/:id/heartbeat/invoke` with `triggerDetail: "evil"` → normalised to `"manual"` in wakeup opts
- [ ] POST `/agents/:id/heartbeat/invoke` with `triggerDetail: "system"` → accepted as-is
- [ ] Agent with `users:manage_permissions` grant hitting endpoint guarded by `assertCompanyPermission` → `403 Agents cannot hold user-management permissions`
- [ ] Agent with `joins:approve` grant → still allowed (prefix not in blocklist)
- [ ] `tsc --noEmit` clean ✓

Closes MAT-687