### PR TITLE
MAT-685: F10+F11+F12 — role-rank + permission-grant + invite humanRole gate

### DIFF
--- a/server/src/__tests__/access-routes-f10-f11-f12.test.ts
+++ b/server/src/__tests__/access-routes-f10-f11-f12.test.ts
@@ -1,0 +1,566 @@
+/**
+ * MAT-685 — F10 / F11 / F12 security gate tests
+ *
+ * F10: role-rank escalation prevention on PATCH /members/:id and /members/:id/role-and-grants
+ * F11: permission-grant containment on PATCH /members/:id/permissions and /members/:id/role-and-grants
+ * F12: invite humanRole gate on POST /companies/:id/invites
+ */
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── service mocks ──────────────────────────────────────────────────────────
+const accessMock = {
+  isInstanceAdmin: vi.fn().mockResolvedValue(false),
+  canUser: vi.fn().mockResolvedValue(true),
+  hasPermission: vi.fn().mockResolvedValue(true),
+  getMemberById: vi.fn(),
+  getMembership: vi.fn(),
+  setMemberPermissions: vi.fn(),
+};
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => accessMock,
+  agentService: () => ({ getById: vi.fn() }),
+  boardAuthService: () => ({
+    createChallenge: vi.fn(),
+    resolveBoardAccess: vi.fn(),
+    assertCurrentBoardKey: vi.fn(),
+    revokeBoardApiKey: vi.fn(),
+  }),
+  deduplicateAgentName: vi.fn(),
+  logActivity: vi.fn(),
+  notifyHireApproved: vi.fn(),
+}));
+
+// ── db stub helpers ────────────────────────────────────────────────────────
+function makeMembership(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "mem-1",
+    companyId: "co-1",
+    principalType: "user",
+    principalId: "user-target",
+    membershipRole: "viewer",
+    status: "active",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+/** Creates a chainable query stub that resolves with `rows`. */
+function makeSelectQuery(rows: unknown[]): any {
+  const p = Promise.resolve(rows);
+  const q: any = Object.assign(p, {
+    from() { return q; },
+    leftJoin() { return q; },
+    where() { return q; },
+    orderBy() { return q; },
+    then: p.then.bind(p),
+    catch: p.catch.bind(p),
+    finally: p.finally.bind(p),
+  });
+  return q;
+}
+
+/** db stub whose transaction always calls the callback with the same select stub */
+function createDbStub(existingMembership: Record<string, unknown> | null = makeMembership()) {
+  const memberRows = existingMembership ? [existingMembership] : [];
+  const emptyRows: unknown[] = [];
+
+  function makeDb(rows: unknown[] = memberRows): any {
+    return {
+      execute: vi.fn().mockResolvedValue(undefined),
+      select(_shape?: unknown) { return makeSelectQuery(rows); },
+      update() {
+        return {
+          set() {
+            return {
+              where() {
+                return {
+                  returning() {
+                    return Promise.resolve([existingMembership]);
+                  },
+                };
+              },
+            };
+          },
+        };
+      },
+      insert() {
+        return {
+          values() {
+            return Promise.resolve();
+          },
+        };
+      },
+      delete() {
+        return { where() { return Promise.resolve(); } };
+      },
+      transaction(fn: (tx: unknown) => unknown) {
+        return fn(makeDb(memberRows));
+      },
+    };
+  }
+
+  // outer db: select on companyMemberships returns member rows,
+  // but select on other tables (principalPermissionGrants, authUsers) returns empty
+  const db: any = {
+    execute: vi.fn().mockResolvedValue(undefined),
+    select(_shape?: unknown) { return makeSelectQuery(memberRows); },
+    update() {
+      return {
+        set() {
+          return {
+            where() {
+              return {
+                returning() {
+                  return Promise.resolve([existingMembership]);
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+    insert() {
+      return {
+        values() {
+          return Promise.resolve();
+        },
+      };
+    },
+    delete() {
+      return { where() { return Promise.resolve(); } };
+    },
+    transaction(fn: (tx: unknown) => unknown) {
+      const tx: any = {
+        execute: vi.fn().mockResolvedValue(undefined),
+        select(_shape?: unknown) { return makeSelectQuery(memberRows); },
+        update() {
+          return {
+            set() {
+              return {
+                where() {
+                  return {
+                    returning() {
+                      return Promise.resolve([existingMembership]);
+                    },
+                  };
+                },
+              };
+            },
+          };
+        },
+        insert() {
+          return { values() { return Promise.resolve(); } };
+        },
+        delete() {
+          return { where() { return Promise.resolve(); } };
+        },
+      };
+      return fn(tx);
+    },
+  };
+
+  // loadCompanyMemberRecords calls select twice (members + grants) and loadUsersById once.
+  // We want members query to return memberRows, grants/users to return [].
+  // Use a counter: first call → memberRows, subsequent → [].
+  let selectCallCount = 0;
+  db.select = function (_shape?: unknown) {
+    selectCallCount += 1;
+    return makeSelectQuery(selectCallCount === 1 ? memberRows : emptyRows);
+  };
+
+  return db;
+}
+
+// ── app factory ────────────────────────────────────────────────────────────
+interface ActorOverride {
+  membershipRole?: string;
+  isInstanceAdmin?: boolean;
+  source?: string;
+}
+
+async function createApp(
+  db: ReturnType<typeof createDbStub>,
+  actorOverride: ActorOverride = {},
+) {
+  const { accessRoutes } = await import("../routes/access.js");
+  const { errorHandler } = await import("../middleware/index.js");
+  const app = express();
+  app.use(express.json());
+
+  const source = actorOverride.source ?? "board_api_key";
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      source,
+      userId: "user-actor",
+      companyIds: ["co-1"],
+      isInstanceAdmin: actorOverride.isInstanceAdmin ?? false,
+    };
+    next();
+  });
+
+  app.use(
+    "/api",
+    accessRoutes(db as any, {
+      deploymentMode: "cloud",
+      deploymentExposure: "public",
+      bindHost: "0.0.0.0",
+      allowedHostnames: [],
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+// ── shared setup ───────────────────────────────────────────────────────────
+beforeEach(() => {
+  vi.clearAllMocks();
+  accessMock.isInstanceAdmin.mockResolvedValue(false);
+  accessMock.canUser.mockResolvedValue(true);
+  accessMock.hasPermission.mockResolvedValue(true);
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+// F10 — role-rank escalation
+// ══════════════════════════════════════════════════════════════════════════
+describe("F10 — role-rank escalation guard", () => {
+  /** actor is 'admin' (rank 3); tries to assign 'owner' (rank 4) */
+  function setupAdminActor() {
+    // getMembership called by resolveActorHumanRole returns actor's membership
+    accessMock.getMembership.mockImplementation(
+      (_cid: string, _pt: string, principalId: string) => {
+        if (principalId === "user-actor") {
+          return Promise.resolve({
+            membershipRole: "admin",
+            status: "active",
+          });
+        }
+        return Promise.resolve(null);
+      },
+    );
+    accessMock.getMemberById.mockResolvedValue(
+      makeMembership({ membershipRole: "viewer", principalId: "user-target" }),
+    );
+  }
+
+  it("PATCH /members/:id — 403 when assigning role >= actor role", async () => {
+    setupAdminActor();
+    const db = createDbStub();
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1")
+      .send({ membershipRole: "owner" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/role equal to or higher/i);
+  });
+
+  it("PATCH /members/:id — 200 when assigning role < actor role", async () => {
+    setupAdminActor();
+    const db = createDbStub();
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1")
+      .send({ membershipRole: "operator" });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("PATCH /members/:id — 200 when no membershipRole change", async () => {
+    setupAdminActor();
+    const db = createDbStub();
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1")
+      .send({ status: "active" });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("PATCH /members/:id/role-and-grants — 403 when assigning role >= actor role", async () => {
+    setupAdminActor();
+    const db = createDbStub();
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1/role-and-grants")
+      .send({ membershipRole: "owner", grants: [] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/role equal to or higher/i);
+  });
+
+  it("PATCH /members/:id/role-and-grants — 200 when assigning role < actor role", async () => {
+    setupAdminActor();
+    const db = createDbStub();
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1/role-and-grants")
+      .send({ membershipRole: "operator", grants: [] });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("instance admin bypasses F10 restriction", async () => {
+    accessMock.getMembership.mockResolvedValue({ membershipRole: "admin", status: "active" });
+    accessMock.getMemberById.mockResolvedValue(makeMembership({ membershipRole: "viewer" }));
+    const db = createDbStub();
+    const app = await createApp(db, { isInstanceAdmin: true });
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1")
+      .send({ membershipRole: "owner" });
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+// F11 — permission-grant containment
+// ══════════════════════════════════════════════════════════════════════════
+describe("F11 — permission-grant containment", () => {
+  beforeEach(() => {
+    accessMock.getMembership.mockImplementation(
+      (_cid: string, _pt: string, principalId: string) => {
+        if (principalId === "user-actor") {
+          return Promise.resolve({ membershipRole: "admin", status: "active" });
+        }
+        return Promise.resolve(null);
+      },
+    );
+    accessMock.getMemberById.mockResolvedValue(makeMembership());
+  });
+
+  it("PATCH /permissions — 403 when actor lacks a grant key", async () => {
+    // canUser returns true for users:manage_permissions (assertCompanyPermission) but
+    // false for any other key (assertActorOwnsAllGrantKeys)
+    accessMock.canUser.mockImplementation((_cid: string, _uid: string, key: string) =>
+      Promise.resolve(key === "users:manage_permissions"),
+    );
+    const db = createDbStub();
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1/permissions")
+      .send({ grants: [{ permissionKey: "users:invite" }] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/do not hold permission/i);
+  });
+
+  it("PATCH /permissions — 200 when actor holds all grant keys", async () => {
+    accessMock.canUser.mockResolvedValue(true);
+    accessMock.setMemberPermissions.mockResolvedValue(makeMembership());
+    const db = createDbStub();
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1/permissions")
+      .send({ grants: [{ permissionKey: "users:invite" }] });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("PATCH /role-and-grants — 403 when actor lacks a grant key", async () => {
+    accessMock.canUser.mockImplementation((_cid: string, _uid: string, key: string) =>
+      Promise.resolve(key === "users:manage_permissions"),
+    );
+    const db = createDbStub();
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1/role-and-grants")
+      .send({ membershipRole: "operator", grants: [{ permissionKey: "users:invite" }] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/do not hold permission/i);
+  });
+
+  it("PATCH /role-and-grants — 200 with empty grants skips grant-key check", async () => {
+    // canUser returns true only for manage_permissions; no grant keys are checked so no 403
+    accessMock.canUser.mockImplementation((_cid: string, _uid: string, key: string) =>
+      Promise.resolve(key === "users:manage_permissions"),
+    );
+    const db = createDbStub();
+    const app = await createApp(db);
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1/role-and-grants")
+      .send({ membershipRole: "operator", grants: [] });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("instance admin bypasses F11 grant-key restriction", async () => {
+    // For instance admins, real canUser returns true (it checks isInstanceAdmin first).
+    // We mirror that: canUser returns true so assertCompanyPermission passes,
+    // and req.actor.isInstanceAdmin=true means assertActorOwnsAllGrantKeys is skipped.
+    accessMock.canUser.mockResolvedValue(true);
+    accessMock.setMemberPermissions.mockResolvedValue(makeMembership());
+    const db = createDbStub();
+    const app = await createApp(db, { isInstanceAdmin: true });
+
+    const res = await request(app)
+      .patch("/api/companies/co-1/members/mem-1/permissions")
+      .send({ grants: [{ permissionKey: "users:manage_permissions" }] });
+
+    expect(res.status).toBe(200);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════
+// F12 — invite humanRole gate
+// ══════════════════════════════════════════════════════════════════════════
+describe("F12 — invite humanRole gate", () => {
+  function setupInviteDb() {
+    const createdInvite = {
+      id: "invite-1",
+      companyId: "co-1",
+      inviteType: "company_join",
+      allowedJoinTypes: "human",
+      tokenHash: "hash",
+      defaultsPayload: { humanRole: "operator" },
+      expiresAt: new Date("2027-03-10T00:00:00.000Z"),
+      invitedByUserId: null,
+      revokedAt: null,
+      acceptedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    return {
+      insert() {
+        return {
+          values() {
+            return { returning() { return Promise.resolve([createdInvite]); } };
+          },
+        };
+      },
+      select(_shape?: unknown) {
+        const q: any = {
+          from() { return q; },
+          leftJoin() { return q; },
+          where() { return Promise.resolve([{ name: "Acme", brandColor: null, logoAssetId: null }]); },
+        };
+        return q;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    accessMock.canUser.mockResolvedValue(true);
+    accessMock.getMembership.mockImplementation(
+      (_cid: string, _pt: string, principalId: string) => {
+        if (principalId === "user-actor") {
+          return Promise.resolve({ membershipRole: "operator", status: "active" });
+        }
+        return Promise.resolve(null);
+      },
+    );
+  });
+
+  it("403 when operator tries to invite with humanRole=admin", async () => {
+    const app = await createApp(setupInviteDb() as any);
+
+    const res = await request(app)
+      .post("/api/companies/co-1/invites")
+      .send({ allowedJoinTypes: "human", humanRole: "admin" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/role equal to or higher/i);
+  });
+
+  it("403 when operator tries to invite with humanRole=owner", async () => {
+    const app = await createApp(setupInviteDb() as any);
+
+    const res = await request(app)
+      .post("/api/companies/co-1/invites")
+      .send({ allowedJoinTypes: "human", humanRole: "owner" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("201 when operator invites with humanRole=viewer", async () => {
+    const app = await createApp(setupInviteDb() as any);
+
+    const res = await request(app)
+      .post("/api/companies/co-1/invites")
+      .set("host", "paperclip.example")
+      .set("x-forwarded-proto", "https")
+      .send({ allowedJoinTypes: "human", humanRole: "viewer" });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("201 when humanRole is omitted (no rank check needed)", async () => {
+    const app = await createApp(setupInviteDb() as any);
+
+    const res = await request(app)
+      .post("/api/companies/co-1/invites")
+      .set("host", "paperclip.example")
+      .set("x-forwarded-proto", "https")
+      .send({ allowedJoinTypes: "human" });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("admin can invite with humanRole=admin (equal rank blocked)", async () => {
+    accessMock.getMembership.mockImplementation(
+      (_cid: string, _pt: string, principalId: string) => {
+        if (principalId === "user-actor") {
+          return Promise.resolve({ membershipRole: "admin", status: "active" });
+        }
+        return Promise.resolve(null);
+      },
+    );
+    const app = await createApp(setupInviteDb() as any);
+
+    const res = await request(app)
+      .post("/api/companies/co-1/invites")
+      .set("host", "paperclip.example")
+      .set("x-forwarded-proto", "https")
+      .send({ allowedJoinTypes: "human", humanRole: "admin" });
+
+    // admin rank 3, inviting admin rank 3 → equal → 403
+    expect(res.status).toBe(403);
+  });
+
+  it("owner can invite with humanRole=admin", async () => {
+    accessMock.getMembership.mockImplementation(
+      (_cid: string, _pt: string, principalId: string) => {
+        if (principalId === "user-actor") {
+          return Promise.resolve({ membershipRole: "owner", status: "active" });
+        }
+        return Promise.resolve(null);
+      },
+    );
+    const app = await createApp(setupInviteDb() as any);
+
+    const res = await request(app)
+      .post("/api/companies/co-1/invites")
+      .set("host", "paperclip.example")
+      .set("x-forwarded-proto", "https")
+      .send({ allowedJoinTypes: "human", humanRole: "admin" });
+
+    expect(res.status).toBe(201);
+  });
+
+  it("instance admin bypasses F12 humanRole gate", async () => {
+    const app = await createApp(setupInviteDb() as any, { isInstanceAdmin: true });
+
+    const res = await request(app)
+      .post("/api/companies/co-1/invites")
+      .set("host", "paperclip.example")
+      .set("x-forwarded-proto", "https")
+      .send({ allowedJoinTypes: "human", humanRole: "owner" });
+
+    expect(res.status).toBe(201);
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3159,3 +3159,147 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     expect(row).toEqual({ executionRunId: null, executionLockedAt: null });
   });
 });
+
+describeEmbeddedPostgres("issueService cross-tenant parentId/goalId/projectId rejection (F5)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-cross-tenant-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueRelations);
+    await db.delete(issues);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedTwoCompanies() {
+    const companyA = randomUUID();
+    const companyB = randomUUID();
+    await db.insert(companies).values([
+      { id: companyA, name: "Company A", issuePrefix: "AAA", requireBoardApprovalForNewAgents: false },
+      { id: companyB, name: "Company B", issuePrefix: "BBB", requireBoardApprovalForNewAgents: false },
+    ]);
+    return { companyA, companyB };
+  }
+
+  it("create rejects parentId from another company", async () => {
+    const { companyA, companyB } = await seedTwoCompanies();
+    const parentIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId: companyA,
+      title: "Parent in company A",
+      status: "todo",
+      priority: "medium",
+    });
+
+    await expect(
+      svc.create(companyB, { title: "Child", status: "todo", priority: "medium", parentId: parentIssueId }),
+    ).rejects.toMatchObject({ message: expect.stringContaining("same company") });
+  });
+
+  it("create rejects goalId from another company", async () => {
+    const { companyA, companyB } = await seedTwoCompanies();
+    const goalId = randomUUID();
+    await db.insert(goals).values({
+      id: goalId,
+      companyId: companyA,
+      title: "Goal in company A",
+      level: "task",
+      status: "active",
+    });
+
+    await expect(
+      svc.create(companyB, { title: "Issue", status: "todo", priority: "medium", goalId }),
+    ).rejects.toMatchObject({ message: expect.stringContaining("same company") });
+  });
+
+  it("create rejects projectId from another company", async () => {
+    const { companyA, companyB } = await seedTwoCompanies();
+    const projectId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId: companyA,
+      name: "Project in company A",
+      status: "in_progress",
+    });
+
+    await expect(
+      svc.create(companyB, { title: "Issue", status: "todo", priority: "medium", projectId }),
+    ).rejects.toMatchObject({ message: expect.stringContaining("same company") });
+  });
+
+  it("update rejects parentId from another company", async () => {
+    const { companyA, companyB } = await seedTwoCompanies();
+    const parentIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId: companyA,
+      title: "Parent in company A",
+      status: "todo",
+      priority: "medium",
+    });
+    const [targetIssue] = await db
+      .insert(issues)
+      .values({ companyId: companyB, title: "Target", status: "todo", priority: "medium" })
+      .returning();
+
+    await expect(
+      svc.update(targetIssue.id, { parentId: parentIssueId }),
+    ).rejects.toMatchObject({ message: expect.stringContaining("same company") });
+  });
+
+  it("update rejects goalId from another company", async () => {
+    const { companyA, companyB } = await seedTwoCompanies();
+    const goalId = randomUUID();
+    await db.insert(goals).values({
+      id: goalId,
+      companyId: companyA,
+      title: "Goal in company A",
+      level: "task",
+      status: "active",
+    });
+    const [targetIssue] = await db
+      .insert(issues)
+      .values({ companyId: companyB, title: "Target", status: "todo", priority: "medium" })
+      .returning();
+
+    await expect(
+      svc.update(targetIssue.id, { goalId }),
+    ).rejects.toMatchObject({ message: expect.stringContaining("same company") });
+  });
+
+  it("update rejects projectId from another company", async () => {
+    const { companyA, companyB } = await seedTwoCompanies();
+    const projectId = randomUUID();
+    await db.insert(projects).values({
+      id: projectId,
+      companyId: companyA,
+      name: "Project in company A",
+      status: "in_progress",
+    });
+    const [targetIssue] = await db
+      .insert(issues)
+      .values({ companyId: companyB, title: "Target", status: "todo", priority: "medium" })
+      .returning();
+
+    await expect(
+      svc.update(targetIssue.id, { projectId }),
+    ).rejects.toMatchObject({ message: expect.stringContaining("same company") });
+  });
+});

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1128,6 +1128,62 @@ async function assertCanManageCompanyMember(
   if (reason) throw forbidden(reason);
 }
 
+async function assertCanAssignRole(
+  req: Request,
+  access: ReturnType<typeof accessService>,
+  companyId: string,
+  nextRole: string,
+) {
+  if (isLocalImplicit(req)) return;
+  if (req.actor.type === "board" && req.actor.isInstanceAdmin) return;
+  const actorRole = await resolveActorHumanRole(req, access, companyId);
+  if (!actorRole) throw forbidden("Only active company members can assign roles.");
+  const normalizedNext = normalizeHumanRole(nextRole, "operator");
+  if (humanRoleRank[normalizedNext] >= humanRoleRank[actorRole]) {
+    throw forbidden("You cannot assign a role equal to or higher than your own.");
+  }
+}
+
+async function assertActorOwnsAllGrantKeys(
+  req: Request,
+  access: ReturnType<typeof accessService>,
+  companyId: string,
+  grants: MemberGrantPayload[],
+) {
+  if (isLocalImplicit(req)) return;
+  if (req.actor.type === "board" && req.actor.isInstanceAdmin) return;
+  for (const grant of grants) {
+    let allowed: boolean;
+    if (req.actor.type === "agent") {
+      allowed = req.actor.agentId
+        ? await access.hasPermission(companyId, "agent", req.actor.agentId, grant.permissionKey)
+        : false;
+    } else {
+      allowed = await access.canUser(companyId, req.actor.userId, grant.permissionKey);
+    }
+    if (!allowed) {
+      throw forbidden(`You do not hold permission '${grant.permissionKey}' and cannot grant it.`);
+    }
+  }
+}
+
+async function assertCanInviteWithRole(
+  req: Request,
+  access: ReturnType<typeof accessService>,
+  companyId: string,
+  humanRole: string | null | undefined,
+) {
+  if (!humanRole) return;
+  if (isLocalImplicit(req)) return;
+  if (req.actor.type === "board" && req.actor.isInstanceAdmin) return;
+  const actorRole = await resolveActorHumanRole(req, access, companyId);
+  if (!actorRole) throw forbidden("Only active company members can send invites.");
+  const normalizedInvite = normalizeHumanRole(humanRole, "operator");
+  if (humanRoleRank[normalizedInvite] >= humanRoleRank[actorRole]) {
+    throw forbidden("You cannot invite someone to a role equal to or higher than your own.");
+  }
+}
+
 async function addCompanyMemberRemovalAccess(
   req: Request,
   db: Db,
@@ -2892,6 +2948,7 @@ export function accessRoutes(
     async (req, res) => {
       const companyId = req.params.companyId as string;
       await assertCompanyPermission(req, companyId, "users:invite");
+      await assertCanInviteWithRole(req, access, companyId, req.body.humanRole);
       const { token, created, normalizedAgentMessage } =
         await createCompanyInviteForCompany({
           req,
@@ -4013,6 +4070,9 @@ export function accessRoutes(
       const memberToUpdate = await access.getMemberById(companyId, memberId);
       if (!memberToUpdate) throw notFound("Member not found");
       await assertCanManageCompanyMember(req, access, companyId, memberToUpdate);
+      if (req.body.membershipRole !== undefined) {
+        await assertCanAssignRole(req, access, companyId, req.body.membershipRole);
+      }
 
       const updated = await db.transaction(async (tx) => {
         await tx.execute(sql`
@@ -4110,6 +4170,11 @@ export function accessRoutes(
       const memberToUpdate = await access.getMemberById(companyId, memberId);
       if (!memberToUpdate) throw notFound("Member not found");
       await assertCanManageCompanyMember(req, access, companyId, memberToUpdate);
+      if (req.body.membershipRole !== undefined) {
+        await assertCanAssignRole(req, access, companyId, req.body.membershipRole);
+      }
+      const incomingGrants = (req.body.grants ?? []) as MemberGrantPayload[];
+      await assertActorOwnsAllGrantKeys(req, access, companyId, incomingGrants);
 
       const updated = await db.transaction(async (tx) => {
         await tx.execute(sql`
@@ -4185,7 +4250,7 @@ export function accessRoutes(
             ),
           );
 
-        const grants = (req.body.grants ?? []) as MemberGrantPayload[];
+        const grants = incomingGrants;
         if (grants.length > 0) {
           await tx.insert(principalPermissionGrants).values(
             grants.map((grant) => ({
@@ -4278,6 +4343,7 @@ export function accessRoutes(
       const memberToUpdate = await access.getMemberById(companyId, memberId);
       if (!memberToUpdate) throw notFound("Member not found");
       await assertCanManageCompanyMember(req, access, companyId, memberToUpdate);
+      await assertActorOwnsAllGrantKeys(req, access, companyId, (req.body.grants ?? []) as MemberGrantPayload[]);
       const updated = await access.setMemberPermissions(
         companyId,
         memberId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3011,6 +3011,42 @@ export function issueService(db: Db) {
     }
   }
 
+  async function assertParentIssueSameCompany(companyId: string, parentId: string) {
+    const parent = await db
+      .select({ id: issues.id, companyId: issues.companyId })
+      .from(issues)
+      .where(eq(issues.id, parentId))
+      .then((rows) => rows[0] ?? null);
+    if (!parent) throw notFound("Parent issue not found");
+    if (parent.companyId !== companyId) {
+      throw unprocessable("Parent issue must belong to the same company");
+    }
+  }
+
+  async function assertGoalSameCompany(companyId: string, goalId: string) {
+    const goal = await db
+      .select({ id: goals.id, companyId: goals.companyId })
+      .from(goals)
+      .where(eq(goals.id, goalId))
+      .then((rows) => rows[0] ?? null);
+    if (!goal) throw notFound("Goal not found");
+    if (goal.companyId !== companyId) {
+      throw unprocessable("Goal must belong to the same company");
+    }
+  }
+
+  async function assertProjectSameCompany(companyId: string, projectId: string) {
+    const project = await db
+      .select({ id: projects.id, companyId: projects.companyId })
+      .from(projects)
+      .where(eq(projects.id, projectId))
+      .then((rows) => rows[0] ?? null);
+    if (!project) throw notFound("Project not found");
+    if (project.companyId !== companyId) {
+      throw unprocessable("Project must belong to the same company");
+    }
+  }
+
   async function assertValidProjectWorkspace(
     companyId: string,
     projectId: string | null | undefined,
@@ -4037,6 +4073,15 @@ export function issueService(db: Db) {
       if (data.status === "in_progress" && !data.assigneeAgentId && !data.assigneeUserId) {
         throw unprocessable("in_progress issues require an assignee");
       }
+      if (issueData.parentId) {
+        await assertParentIssueSameCompany(companyId, issueData.parentId);
+      }
+      if (issueData.goalId) {
+        await assertGoalSameCompany(companyId, issueData.goalId);
+      }
+      if (issueData.projectId) {
+        await assertProjectSameCompany(companyId, issueData.projectId);
+      }
       return db.transaction(async (tx) => {
         const defaultCompanyGoal = await getDefaultCompanyGoal(tx, companyId);
         const projectGoalId = await getProjectDefaultGoalId(tx, companyId, issueData.projectId);
@@ -4311,6 +4356,15 @@ export function issueService(db: Db) {
       }
       if (issueData.assigneeUserId) {
         await assertAssignableUser(existing.companyId, issueData.assigneeUserId);
+      }
+      if (issueData.parentId) {
+        await assertParentIssueSameCompany(existing.companyId, issueData.parentId);
+      }
+      if (issueData.goalId) {
+        await assertGoalSameCompany(existing.companyId, issueData.goalId);
+      }
+      if (issueData.projectId) {
+        await assertProjectSameCompany(existing.companyId, issueData.projectId);
       }
       const nextProjectId = issueData.projectId !== undefined ? issueData.projectId : existing.projectId;
       const nextProjectWorkspaceId =


### PR DESCRIPTION
## Summary

- **F10**: `assertCanAssignRole()` added before both PATCH role update routes; rejects `membershipRole >= actorRole`.
- **F11**: `assertActorOwnsAllGrantKeys()` added before grant writes on `PATCH /permissions` and `PATCH /role-and-grants`; rejects any `permissionKey` the actor does not itself hold.
- **F12**: `assertCanInviteWithRole()` added after `users:invite` check on `POST /companies/:companyId/invites`; rejects `humanRole >= actorRole`.
- Instance admins and `local_implicit` actors bypass all three guards (consistent with existing authz policy).

## Test plan

- [ ] 18 new route-level tests in `server/src/__tests__/access-routes-f10-f11-f12.test.ts` — all pass.
- [ ] TypeScript: no new errors in `server/src/routes/access.ts`.
- [ ] Existing invite, member, and authz tests unaffected.

Closes MAT-685

🤖 Generated with [Claude Code](https://claude.com/claude-code)