### PR TITLE
feat: deduplicate child issues on matching originFingerprint

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3159,3 +3159,96 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     expect(row).toEqual({ executionRunId: null, executionLockedAt: null });
   });
 });
+
+describeEmbeddedPostgres("issueService.findByOriginFingerprint", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let companyId!: string;
+  let parentId!: string;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-fingerprint-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seed() {
+    companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Test Co",
+      issuePrefix: "TC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    const parent = await svc.create(companyId, { title: "Parent issue" });
+    parentId = parent.id;
+  }
+
+  it("returns null when no matching issue exists", async () => {
+    await seed();
+    const result = await svc.findByOriginFingerprint(companyId, parentId, "my-task-slug");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fingerprint is 'default' (no dedup for default)", async () => {
+    await seed();
+    await svc.create(companyId, { parentId, title: "Child", originFingerprint: "default" });
+    const result = await svc.findByOriginFingerprint(companyId, parentId, "default");
+    // findByOriginFingerprint CAN return rows for "default" — dedup guard lives in the route.
+    // This test simply confirms the service lookup works for any fingerprint string.
+    expect(result).not.toBeNull();
+  });
+
+  it("returns the existing issue when a non-cancelled child with the same fingerprint exists", async () => {
+    await seed();
+    const child = await svc.create(companyId, { parentId, title: "Child", originFingerprint: "my-task-slug" });
+    const found = await svc.findByOriginFingerprint(companyId, parentId, "my-task-slug");
+    expect(found?.id).toBe(child.id);
+    expect(found?.title).toBe("Child");
+  });
+
+  it("returns null when the only matching issue is cancelled", async () => {
+    await seed();
+    const child = await svc.create(companyId, { parentId, title: "Child", originFingerprint: "my-task-slug" });
+    await svc.update(child.id, { status: "cancelled" });
+    const result = await svc.findByOriginFingerprint(companyId, parentId, "my-task-slug");
+    expect(result).toBeNull();
+  });
+
+  it("does not cross company boundaries", async () => {
+    await seed();
+    const otherCompanyId = randomUUID();
+    await db.insert(companies).values({
+      id: otherCompanyId,
+      name: "Other Co",
+      issuePrefix: "OC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    // create a parent in the other company, then a child with the same fingerprint
+    const otherParent = await svc.create(otherCompanyId, { title: "Other parent" });
+    await svc.create(otherCompanyId, { parentId: otherParent.id, title: "Other child", originFingerprint: "my-task-slug" });
+    // lookup against our company should return null
+    const result = await svc.findByOriginFingerprint(companyId, parentId, "my-task-slug");
+    expect(result).toBeNull();
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3003,6 +3003,20 @@ export function issueRoutes(
     }
     await assertIssueEnvironmentSelection(companyId, req.body.executionWorkspaceSettings?.environmentId);
 
+    const { originFingerprint, parentId } = req.body;
+    if (originFingerprint && originFingerprint !== "default" && parentId) {
+      const existing = await svc.findByOriginFingerprint(companyId, parentId, originFingerprint);
+      if (existing) {
+        const referenceSummary = await issueReferencesSvc.listIssueReferenceSummary(existing.id);
+        res.status(200).json({
+          ...existing,
+          relatedWork: referenceSummary,
+          referencedIssueIdentifiers: referenceSummary.outbound.map((item) => item.issue.identifier ?? item.issue.id),
+        });
+        return;
+      }
+    }
+
     const actor = getActorInfo(req);
     const executionPolicy = applyActorMonitorScheduledBy(
       normalizeIssueExecutionPolicy(req.body.executionPolicy),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -3765,6 +3765,24 @@ export function issueService(db: Db) {
       return getIssueByIdentifier(identifier);
     },
 
+    findByOriginFingerprint: async (companyId: string, parentId: string, originFingerprint: string) => {
+      const row = await db
+        .select()
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.parentId, parentId),
+            eq(issues.originFingerprint, originFingerprint),
+            ne(issues.status, "cancelled"),
+          ),
+        )
+        .then((rows) => rows[0] ?? null);
+      if (!row) return null;
+      const [enriched] = await withIssueLabels(db, [row]);
+      return enriched;
+    },
+
     getCurrentScheduledRetry: async (issueId: string) => {
       const issue = await db
         .select({ id: issues.id, companyId: issues.companyId })


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; agents create child issues to delegate parallel work
> - The issue-creation route (`POST /api/companies/:companyId/issues`) has no deduplication — every POST produces a new issue
> - Agent heartbeats are idempotent by design: if a heartbeat fires twice (liveness recovery, rapid-fire loop) the same child issues are created multiple times, wasting tokens and triggering redundant parallel work
> - The `originFingerprint` field already exists on issues for exactly this kind of idempotency key, but nothing enforces uniqueness server-side
> - This PR adds a service method `findByOriginFingerprint` and a pre-insert guard in the route: if an explicit (non-`"default"`) fingerprint matches a non-cancelled child under the same parent + company, return the existing issue (HTTP 200) instead of inserting a duplicate
> - The benefit is that agents can set `originFingerprint: "{parentId}-{task-slug}"` and be safe from self-duplication across retries

## What Changed

- **`server/src/services/issues.ts`** — adds `findByOriginFingerprint(companyId, parentId, originFingerprint)` that returns the first non-cancelled matching issue or `null`
- **`server/src/routes/issues.ts`** — adds a pre-creation dedup guard on `POST /companies/:companyId/issues`: if `originFingerprint` is set, non-`"default"`, and `parentId` is present, check for an existing match and return HTTP 200 with the existing issue payload instead of creating a duplicate
- **`server/src/__tests__/issues-service.test.ts`** — adds `describeEmbeddedPostgres("issueService.findByOriginFingerprint")` with 5 cases: null when no match, non-null on match, null when only match is cancelled, default fingerprint passthrough, cross-company isolation

## Verification

```bash
pnpm --filter @paperclipai/server exec vitest run --testNamePattern="findByOriginFingerprint"
# → 5 passed
pnpm --filter @paperclipai/server typecheck
# → no errors
```

Manual: POST the same issue twice with `originFingerprint: "parent-id-task-slug"` and `parentId` set — second call returns HTTP 200 with the original issue. POST with `originFingerprint: "default"` — second call creates a new issue (backwards compatible).

## Risks

- Low risk: the guard only activates when `originFingerprint !== "default"` and `parentId` is present. All existing callers that omit `originFingerprint` (defaults to `"default"`) are unaffected.
- Cancelled issues are excluded from dedup so agents can retry a failed/cancelled subtask with the same fingerprint.
- No schema migration needed — `originFingerprint` column and its index already exist.

## Model Used

- Provider: Anthropic  
- Model ID: `claude-sonnet-4-6`  
- Tool use enabled; no extended thinking

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (not applicable — server-only change)
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge