### PR TITLE
ci(docker): install openjdk-21 + maven in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG USER_UID=1000
 ARG USER_GID=1000
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates gosu curl gh git wget ripgrep python3 \
+       openjdk-21-jdk-headless maven \
   && rm -rf /var/lib/apt/lists/* \
   && corepack enable
 


### PR DESCRIPTION
## Summary

Adds `openjdk-21-jdk-headless` + `maven` to the base-stage apt-install line in `Dockerfile`. One-line change, inherited by `deps`, `build`, and `production` stages.

## Why

`claude_local`-adapter agents working on Java/Spring projects cannot run `mvn`, `javac`, or `./mvnw` locally — the runtime container ships only Node + python3 + a small CLI toolchain (`ca-certificates gosu curl gh git wget ripgrep python3` in the base stage; `openssh-client jq` in production). The unprivileged `node` user can't `apt-get install` at runtime (dpkg lock denied, no `sudo`).

Effect on real heartbeats: an agent assigned a Java change edits files but only PR CI exercises the code, turning every typo into a ~10-minute CI round-trip instead of seconds. Observed downstream at Standard Power on [SPC-4198 / SPC-4196](https://work.standardpower.co/SPC/issues/SPC-4198) — BackendEngineer agent landed an OpenAPI DTO rename without local `mvn test` because the heartbeat env has no JDK.

## Trade-off

- Base image grows by ~350 MB (openjdk-21-jdk-headless) + ~10 MB (maven). Headless variant skips AWT/Swing GUI deps, so this is the minimum useful JDK install.
- JDK 21 chosen because it's the default `openjdk-N` on Debian trixie (matches `node:lts-trixie-slim` base) and it's what `eclipse-temurin-21` Spring-Boot images ship. Trixie also has `openjdk-17-jdk-headless` if a smaller / LTS-stable runtime is preferred — happy to swap.

## Alternatives considered

- **Per-workspace SDKMAN install** at heartbeat start: avoids the image-size hit but pays 1–2 min boot tax per heartbeat and complicates `PATH` for every adapter. Rejected.
- **Build-arg opt-in (`ARG WITH_JDK=false`)**: keeps image lean for non-Java users but means every Java-adopter has to rebuild; for a hosted product where users don't build their own image, that's not useful. Rejected.

## Test plan

- [ ] CI builds the image cleanly with the new apt package.
- [ ] `docker run --rm <image> java -version` returns `openjdk version "21.x"`.
- [ ] `docker run --rm <image> mvn -v` returns Maven 3.9+ / Java 21.
- [ ] In a `claude_local` agent heartbeat against a Spring-Boot pom (`<java.version>21</java.version>`), `mvn -q compile` and `mvn -q test` complete locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)