### PR TITLE
fix: restore null-assignee issues filter contract

### DIFF
--- a/docs/plans/2026-05-18-fma-1880-null-assignee-filter-restoration.md
+++ b/docs/plans/2026-05-18-fma-1880-null-assignee-filter-restoration.md
@@ -1,0 +1,19 @@
+# FMA-1880 null-assignee issues filter restoration
+
+## Scope
+
+Restore the documented `assigneeAgentId=null` contract on Paperclip issue list routes so orphan sweeps can query unassigned issues without a client-side fallback.
+
+## Plan
+
+1. Add route regression coverage for `GET /api/companies/:companyId/issues` and `GET /api/companies/:companyId/issues/count`:
+   - literal `"null"` normalizes to `assigneeAgentId: null`
+   - malformed values return `422`
+   - duplicate query values return `422`
+2. Add service regression coverage proving:
+   - `assigneeAgentId: null` maps to `IS NULL`
+   - UUID assignee filtering still works
+   - count mirrors list semantics
+3. Implement a route helper that accepts exactly one assignee query token and only allows UUIDs or the literal `"null"`.
+4. Update issue service filter semantics so `undefined` means no filter, `null` means unassigned, and a string means exact assignee match.
+5. Run focused Vitest coverage for the new route and service regressions.

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -1,0 +1,235 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIssueService = vi.hoisted(() => ({
+  list: vi.fn(),
+  count: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  companySearchService: () => ({ search: vi.fn(async () => ({ results: [] })) }),
+  accessService: () => ({
+    canUser: vi.fn(async () => true),
+    hasPermission: vi.fn(async () => true),
+  }),
+  agentService: () => ({
+    getById: vi.fn(async () => null),
+    resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({
+      ambiguous: false,
+      agent: { id: raw },
+    })),
+  }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+  }),
+  goalService: () => ({ getById: vi.fn(async () => null), getDefaultCompanyGoal: vi.fn(async () => null) }),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+    getRun: vi.fn(async () => null),
+    getActiveRunForAgent: vi.fn(async () => null),
+    cancelRun: vi.fn(async () => null),
+  }),
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => ["company-1"]),
+  }),
+  issueApprovalService: () => ({ listApprovalsForIssue: vi.fn(async () => []), unlink: vi.fn(async () => undefined) }),
+  issueRecoveryActionService: () => ({
+    getActiveForIssue: vi.fn(async () => null),
+    listActiveForIssues: vi.fn(async () => new Map()),
+  }),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueService: () => mockIssueService,
+  issueThreadInteractionService: () => ({
+    expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+    expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+  }),
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({}),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({}),
+  ISSUE_LIST_DEFAULT_LIMIT: 500,
+  ISSUE_LIST_MAX_LIMIT: 1000,
+  clampIssueListLimit: (value: number) => Math.min(1000, Math.max(1, Math.floor(value))),
+}));
+
+vi.mock("../services/feedback.js", () => ({
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+  }),
+}));
+
+vi.mock("../services/environments.js", () => ({
+  environmentService: () => ({ getById: vi.fn(async () => null) }),
+}));
+
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: {
+        censorUsernameInLogs: false,
+        feedbackDataSharingPreference: "prompt",
+      },
+    })),
+    listCompanyIds: vi.fn(async () => ["company-1"]),
+  }),
+}));
+
+vi.mock("../services/company-search-rate-limit.js", () => ({
+  createCompanySearchRateLimiter: () => ({
+    consume: () => ({
+      allowed: true,
+      limit: 20,
+      remaining: 19,
+      retryAfterSeconds: 0,
+    }),
+  }),
+}));
+
+vi.mock("../services/issue-assignment-wakeup.js", () => ({
+  queueIssueAssignmentWakeup: vi.fn(),
+}));
+
+vi.mock("../services/recovery/successful-run-handoff.js", () => ({
+  listSuccessfulRunHandoffStates: vi.fn(async () => new Map()),
+}));
+
+async function createApp() {
+  const [{ errorHandler }, { issueRoutes }] = await Promise.all([
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+  ]);
+
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("issue list assigneeAgentId route handling", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockIssueService.list.mockReset();
+    mockIssueService.count.mockReset();
+  });
+
+  it("normalizes assigneeAgentId='null' to an explicit null-assignee filter", async () => {
+    mockIssueService.list.mockResolvedValue([]);
+
+    const res = await request(await createApp())
+      .get("/api/companies/company-1/issues")
+      .query({ status: "todo", assigneeAgentId: "null", limit: "20" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        status: "todo",
+        assigneeAgentId: null,
+      }),
+    );
+  });
+
+  it("returns 422 for malformed assigneeAgentId instead of 500", async () => {
+    mockIssueService.list.mockResolvedValue([]);
+
+    const res = await request(await createApp())
+      .get("/api/companies/company-1/issues")
+      .query({ status: "todo", assigneeAgentId: "bad", limit: "20" });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toEqual({ error: "assigneeAgentId must be a UUID or 'null'" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 for duplicate assigneeAgentId query values", async () => {
+    mockIssueService.list.mockResolvedValue([]);
+
+    const res = await request(await createApp())
+      .get("/api/companies/company-1/issues")
+      .query({
+        status: "todo",
+        assigneeAgentId: [
+          "11111111-1111-4111-8111-111111111111",
+          "22222222-2222-4222-8222-222222222222",
+        ],
+        limit: "20",
+      } as any);
+
+    expect(res.status).toBe(422);
+    expect(res.body).toEqual({ error: "assigneeAgentId must be a UUID or 'null'" });
+    expect(mockIssueService.list).not.toHaveBeenCalled();
+  });
+
+  it("applies the same null normalization on issues/count", async () => {
+    mockIssueService.count.mockResolvedValue(3);
+
+    const res = await request(await createApp())
+      .get("/api/companies/company-1/issues/count")
+      .query({ attention: "blocked", assigneeAgentId: "null" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ count: 3 });
+    expect(mockIssueService.count).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        attention: "blocked",
+        assigneeAgentId: null,
+      }),
+    );
+  });
+
+  it("returns 422 for malformed assigneeAgentId on issues/count", async () => {
+    mockIssueService.count.mockResolvedValue(0);
+
+    const res = await request(await createApp())
+      .get("/api/companies/company-1/issues/count")
+      .query({ attention: "blocked", assigneeAgentId: "bad" });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toEqual({ error: "assigneeAgentId must be a UUID or 'null'" });
+    expect(mockIssueService.count).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1412,6 +1412,116 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
   });
 });
 
+describeEmbeddedPostgres("issueService assigneeAgentId filters", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-assignee-filter-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
+    await db.delete(goals);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("treats assigneeAgentId null as an explicit unassigned filter", async () => {
+    const companyId = randomUUID();
+    const firstAgentId = randomUUID();
+    const secondAgentId = randomUUID();
+    const unassignedIssueId = randomUUID();
+    const firstAssignedIssueId = randomUUID();
+    const secondAssignedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `A${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: firstAgentId,
+        companyId,
+        name: "FirstAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: secondAgentId,
+        companyId,
+        name: "SecondAgent",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(issues).values([
+      {
+        id: unassignedIssueId,
+        companyId,
+        title: "Unassigned todo",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: firstAssignedIssueId,
+        companyId,
+        title: "Assigned to first",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: firstAgentId,
+      },
+      {
+        id: secondAssignedIssueId,
+        companyId,
+        title: "Assigned to second",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: secondAgentId,
+      },
+    ]);
+
+    await expect(svc.list(companyId, { status: "todo", assigneeAgentId: null }))
+      .resolves.toEqual([
+        expect.objectContaining({ id: unassignedIssueId, assigneeAgentId: null }),
+      ]);
+    await expect(svc.count(companyId, { status: "todo", assigneeAgentId: null })).resolves.toBe(1);
+    await expect(svc.list(companyId, { status: "todo", assigneeAgentId: firstAgentId }))
+      .resolves.toEqual([
+        expect.objectContaining({ id: firstAssignedIssueId, assigneeAgentId: firstAgentId }),
+      ]);
+  });
+});
+
 describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
   let db!: ReturnType<typeof createDb>;
   let svc!: ReturnType<typeof issueService>;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1161,6 +1161,19 @@ export function issueRoutes(
     return parsed;
   }
 
+  const assigneeAgentIdQuerySchema = z.string().uuid();
+
+  function parseAssigneeAgentIdQuery(value: unknown): string | null | undefined {
+    if (value === undefined) return undefined;
+    if (Array.isArray(value) || typeof value !== "string") {
+      throw unprocessable("assigneeAgentId must be a UUID or 'null'");
+    }
+    const trimmed = value.trim();
+    if (trimmed === "null") return null;
+    if (assigneeAgentIdQuerySchema.safeParse(trimmed).success) return trimmed;
+    throw unprocessable("assigneeAgentId must be a UUID or 'null'");
+  }
+
   async function runSingleFileUpload(req: Request, res: Response, fileSizeLimit: number) {
     const upload = multer({
       storage: multer.memoryStorage(),
@@ -1710,11 +1723,12 @@ export function issueRoutes(
       return;
     }
     const offset = parsedOffset ?? 0;
+    const assigneeAgentId = parseAssigneeAgentIdQuery(req.query.assigneeAgentId);
 
     const result = await svc.list(companyId, {
       attention: attention === "blocked" ? "blocked" : undefined,
       status: req.query.status as string | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
+      assigneeAgentId,
       participantAgentId: req.query.participantAgentId as string | undefined,
       assigneeUserId,
       touchedByUserId,
@@ -1779,11 +1793,12 @@ export function issueRoutes(
       res.status(400).json({ error: "issues/count does not accept limit or offset" });
       return;
     }
+    const assigneeAgentId = parseAssigneeAgentIdQuery(req.query.assigneeAgentId);
 
     const count = await svc.count(companyId, {
       attention: "blocked",
       status: req.query.status as string | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
+      assigneeAgentId,
       participantAgentId: req.query.participantAgentId as string | undefined,
       assigneeUserId: req.query.assigneeUserId as string | undefined,
       projectId: req.query.projectId as string | undefined,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -216,7 +216,7 @@ export function deriveIssueCommentRunLogAttribution(
 export interface IssueFilters {
   attention?: "blocked";
   status?: string;
-  assigneeAgentId?: string;
+  assigneeAgentId?: string | null;
   participantAgentId?: string;
   assigneeUserId?: string;
   touchedByUserId?: string;
@@ -2520,7 +2520,13 @@ async function blockedInboxIssueConditions(
       conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]!) : inArray(issues.status, statuses));
     }
   }
-  if (filters?.assigneeAgentId) conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
+  if (filters?.assigneeAgentId !== undefined) {
+    conditions.push(
+      filters.assigneeAgentId === null
+        ? isNull(issues.assigneeAgentId)
+        : eq(issues.assigneeAgentId, filters.assigneeAgentId),
+    );
+  }
   if (filters?.participantAgentId) conditions.push(participatedByAgentCondition(companyId, filters.participantAgentId));
   if (filters?.assigneeUserId) conditions.push(eq(issues.assigneeUserId, filters.assigneeUserId));
   if (touchedByUserId) conditions.push(touchedByUserCondition(companyId, touchedByUserId));
@@ -3451,8 +3457,12 @@ export function issueService(db: Db) {
         const statuses = filters.status.split(",").map((s) => s.trim());
         conditions.push(statuses.length === 1 ? eq(issues.status, statuses[0]) : inArray(issues.status, statuses));
       }
-      if (filters?.assigneeAgentId) {
-        conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
+      if (filters?.assigneeAgentId !== undefined) {
+        conditions.push(
+          filters.assigneeAgentId === null
+            ? isNull(issues.assigneeAgentId)
+            : eq(issues.assigneeAgentId, filters.assigneeAgentId),
+        );
       }
       if (filters?.participantAgentId) {
         conditions.push(participatedByAgentCondition(companyId, filters.participantAgentId));
@@ -3633,7 +3643,13 @@ export function issueService(db: Db) {
         if (statuses.length === 1) conditions.push(eq(issues.status, statuses[0]!));
         else if (statuses.length > 1) conditions.push(inArray(issues.status, statuses));
       }
-      if (filters?.assigneeAgentId) conditions.push(eq(issues.assigneeAgentId, filters.assigneeAgentId));
+      if (filters?.assigneeAgentId !== undefined) {
+        conditions.push(
+          filters.assigneeAgentId === null
+            ? isNull(issues.assigneeAgentId)
+            : eq(issues.assigneeAgentId, filters.assigneeAgentId),
+        );
+      }
       if (filters?.assigneeUserId) conditions.push(eq(issues.assigneeUserId, filters.assigneeUserId));
       if (filters?.projectId) conditions.push(eq(issues.projectId, filters.projectId));
       if (filters?.workspaceId) {


### PR DESCRIPTION
## Summary
- restore `assigneeAgentId=null` parsing on issues list/count routes
- treat `assigneeAgentId: null` as `IS NULL` in the issues service instead of no filter
- add focused route and service regressions for null, malformed, duplicate, and UUID assignee filters

## Testing
- pnpm vitest run server/src/__tests__/issue-list-assignee-filter-routes.test.ts
- pnpm vitest run server/src/__tests__/issues-service.test.ts -t "assigneeAgentId"
