### PR TITLE
fix: system-authored comments display as 'You' instead of 'Paperclip'

### DIFF
--- a/ui/src/lib/issue-chat-messages.ts
+++ b/ui/src/lib/issue-chat-messages.ts
@@ -365,7 +365,7 @@ function authorNameForComment(
     return agentMap?.get(authorAgentId)?.name ?? (options?.isSystemNotice ? "Paperclip" : authorAgentId.slice(0, 8));
   }
   const authorUserId = comment.authorUserId ?? null;
-  if (!authorUserId) return "You";
+  if (!authorUserId) return options?.isSystemNotice ? "Paperclip" : "You";
   const userLabel = userLabelMap?.get(authorUserId)?.trim();
   if (userLabel) return userLabel;
   return formatAssigneeUserLabel(authorUserId, currentUserId, userLabelMap) ?? "You";


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The issue chat thread renders comments from agents, users, and the system itself  
> - When Paperclip's internal recovery system posts a comment (e.g., stranded issue recovery), it creates a comment with `author_type: "system"`, no agent ID, and no user ID
> - The UI function `authorNameForComment` falls back to `"You"` when both author IDs are null
> - This PR returns `"Paperclip"` instead for system notices
> - The benefit: system comments are clearly attributed to Paperclip, not the logged-in viewer

## What Changed

- `ui/src/lib/issue-chat-messages.ts`: In `authorNameForComment`, the null-userId fallback now checks `options?.isSystemNotice` and returns `"Paperclip"` instead of `"You"` for system-authored comments. One-line change.

## Verification

- 82/82 existing tests pass (issue-chat-messages 20, IssueChatThreadSystemNotice 11, IssueChatThread 51)
- Manual repro: view any issue with a system-authored comment (stranded issue recovery moves issue to blocked). Before: author "You". After: author "Paperclip".

## Risks

Low risk. One-line change. Only affects system-authored comments with no user/agent ID. The `isSystemNotice` flag is already computed upstream (`comment.authorType === "system"`) and passed into this function.

## Model Used

zai/glm-5.1 (200K context). Investigation and code tracing assisted by the model.

## Checklist

- [x] Thinking path included
- [x] Model specified
- [x] Checked ROADMAP.md — bug fix, not a feature
- [x] Tests pass locally (82/82)
- [x] Risks documented
- [x] Will address all reviewer comments