### PR TITLE
fix(opencode-local, CHRA-1272): models discovery timeout, dedup calls, iOS lane concurrency

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -890,7 +890,10 @@ export function buildInvocationEnvForLogs(
   return redactEnvForLogs(merged);
 }
 
-export function buildPaperclipEnv(agent: { id: string; companyId: string }): Record<string, string> {
+export function buildPaperclipEnv(
+  agent: { id: string; companyId: string; name?: string },
+  runId?: string,
+): Record<string, string> {
   const resolveHostForUrl = (rawHost: string): string => {
     const host = rawHost.trim();
     if (!host || host === "0.0.0.0" || host === "::") return "localhost";
@@ -901,6 +904,13 @@ export function buildPaperclipEnv(agent: { id: string; companyId: string }): Rec
     PAPERCLIP_AGENT_ID: agent.id,
     PAPERCLIP_COMPANY_ID: agent.companyId,
   };
+  if (agent.name) {
+    vars.PAPERCLIP_AGENT_NAME = agent.name;
+  }
+  if (agent.name && runId) {
+    const shortRunId = runId.length > 8 ? runId.slice(0, 8) : runId;
+    vars.AGENT_NAME = `${agent.name}-${shortRunId}`;
+  }
   const runtimeHost = resolveHostForUrl(
     process.env.PAPERCLIP_LISTEN_HOST ?? process.env.HOST ?? "localhost",
   );

--- a/packages/adapters/acpx-local/src/server/execute.ts
+++ b/packages/adapters/acpx-local/src/server/execute.ts
@@ -677,7 +677,7 @@ async function buildRuntime(input: {
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent), PAPERCLIP_RUN_ID: runId };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, runId), PAPERCLIP_RUN_ID: runId };
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim()) ||
     (typeof context.issueId === "string" && context.issueId.trim()) ||

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -179,7 +179,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, runId) };
   env.PAPERCLIP_RUN_ID = runId;
 
   const wakeTaskId =

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -405,7 +405,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     : null;
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, runId) };
   env.PAPERCLIP_RUN_ID = runId;
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||

--- a/packages/adapters/cursor-cloud/src/server/execute.ts
+++ b/packages/adapters/cursor-cloud/src/server/execute.ts
@@ -104,7 +104,7 @@ function buildWakeEnv(ctx: AdapterExecutionContext, configEnv: Record<string, st
   const { runId, agent, context, authToken } = ctx;
   const env: Record<string, string> = {
     ...configEnv,
-    ...buildPaperclipEnv(agent),
+    ...buildPaperclipEnv(agent, runId),
     PAPERCLIP_RUN_ID: runId,
   };
 

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -238,7 +238,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  let env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  let env: Record<string, string> = { ...buildPaperclipEnv(agent, runId) };
   env.PAPERCLIP_RUN_ID = runId;
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -214,7 +214,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, runId) };
   env.PAPERCLIP_RUN_ID = runId;
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -243,7 +243,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const envConfig = parseObject(config.env);
     const hasExplicitApiKey =
       typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-    const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+    const env: Record<string, string> = { ...buildPaperclipEnv(agent, runId) };
     env.PAPERCLIP_RUN_ID = runId;
     const wakeTaskId =
       (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -339,10 +339,10 @@ function resolveClaimedApiKeyPath(value: unknown): string {
 
 function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: WakePayload): Record<string, string> {
   const paperclipApiUrlOverride = resolvePaperclipApiUrlOverride(ctx.config.paperclipApiUrl);
-  const paperclipEnv: Record<string, string> = {
-    ...buildPaperclipEnv(ctx.agent),
-    PAPERCLIP_RUN_ID: ctx.runId,
-  };
+    const paperclipEnv: Record<string, string> = {
+      ...buildPaperclipEnv(ctx.agent, ctx.runId),
+      PAPERCLIP_RUN_ID: ctx.runId,
+    };
 
   if (paperclipApiUrlOverride) {
     paperclipEnv.PAPERCLIP_API_URL = paperclipApiUrlOverride;

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -339,10 +339,10 @@ function resolveClaimedApiKeyPath(value: unknown): string {
 
 function buildPaperclipEnvForWake(ctx: AdapterExecutionContext, wakePayload: WakePayload): Record<string, string> {
   const paperclipApiUrlOverride = resolvePaperclipApiUrlOverride(ctx.config.paperclipApiUrl);
-    const paperclipEnv: Record<string, string> = {
-      ...buildPaperclipEnv(ctx.agent, ctx.runId),
-      PAPERCLIP_RUN_ID: ctx.runId,
-    };
+  const paperclipEnv: Record<string, string> = {
+    ...buildPaperclipEnv(ctx.agent, ctx.runId),
+    PAPERCLIP_RUN_ID: ctx.runId,
+  };
 
   if (paperclipApiUrlOverride) {
     paperclipEnv.PAPERCLIP_API_URL = paperclipApiUrlOverride;

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -241,7 +241,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, runId) };
   env.PAPERCLIP_RUN_ID = runId;
   const wakeTaskId =
     (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||

--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -1,15 +1,48 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ensureOpenCodeModelConfiguredAndAvailable,
   listOpenCodeModels,
   requireOpenCodeModelId,
   resetOpenCodeModelsCacheForTests,
+  discoverOpenCodeModelsCached,
 } from "./models.js";
+
+const runChildProcess = vi.hoisted(() =>
+  vi.fn(async (_runId: string, command: string, args: string[], opts: { cwd: string; env: Record<string, string> }) => {
+    if (command === "__paperclip_missing_opencode_command__") {
+      const pathValue = opts.env.PATH ?? "";
+      throw new Error(
+        `Failed to start command "${command}" in "${opts.cwd}". Verify adapter command, working directory, and PATH (${pathValue}).`,
+      );
+    }
+    if (args.includes("models")) {
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "openai/gpt-5.2-codex\n",
+        stderr: "",
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      };
+    }
+    throw new Error("Unexpected command");
+  }),
+);
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
+  const actual = await vi.importActual("@paperclipai/adapter-utils/server-utils");
+  return {
+    ...actual,
+    runChildProcess,
+  };
+});
 
 describe("openCode models", () => {
   afterEach(() => {
     delete process.env.PAPERCLIP_OPENCODE_COMMAND;
     resetOpenCodeModelsCacheForTests();
+    runChildProcess.mockClear();
   });
 
   it("returns an empty list when discovery command is unavailable", async () => {
@@ -43,5 +76,26 @@ describe("openCode models", () => {
         model: "openai/gpt-5",
       }),
     ).rejects.toThrow("Failed to start command");
+  });
+
+  it("deduplicates concurrent discovery calls for the same cache key", async () => {
+    runChildProcess.mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "openai/gpt-5.2-codex\n",
+      stderr: "",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    const [result1, result2] = await Promise.all([
+      discoverOpenCodeModelsCached(),
+      discoverOpenCodeModelsCached(),
+    ]);
+
+    expect(runChildProcess).toHaveBeenCalledTimes(1);
+    expect(result1).toEqual([{ id: "openai/gpt-5.2-codex", label: "openai/gpt-5.2-codex" }]);
+    expect(result2).toEqual(result1);
   });
 });

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -21,6 +21,7 @@ function resolveOpenCodeCommand(input: unknown): string {
 }
 
 const discoveryCache = new Map<string, { expiresAt: number; models: AdapterModel[] }>();
+const pendingDiscoveries = new Map<string, Promise<AdapterModel[]>>();
 const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
 const VOLATILE_ENV_KEY_EXACT = new Set(["PWD", "OLDPWD", "SHLVL", "_", "TERM_SESSION_ID", "HOME"]);
 
@@ -170,9 +171,17 @@ export async function discoverOpenCodeModelsCached(input: {
   const cached = discoveryCache.get(key);
   if (cached && cached.expiresAt > now) return cached.models;
 
-  const models = await discoverOpenCodeModels({ command, cwd, env });
-  discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
-  return models;
+  const pending = pendingDiscoveries.get(key);
+  if (pending) return pending;
+
+  const promise = discoverOpenCodeModels({ command, cwd, env }).then((models) => {
+    discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
+    return models;
+  }).finally(() => {
+    pendingDiscoveries.delete(key);
+  });
+  pendingDiscoveries.set(key, promise);
+  return promise;
 }
 
 export async function ensureOpenCodeModelConfiguredAndAvailable(input: {
@@ -213,4 +222,5 @@ export async function listOpenCodeModels(): Promise<AdapterModel[]> {
 
 export function resetOpenCodeModelsCacheForTests() {
   discoveryCache.clear();
+  pendingDiscoveries.clear();
 }

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -8,8 +8,8 @@ import {
 } from "@paperclipai/adapter-utils/server-utils";
 import { isValidOpenCodeModelId } from "../index.js";
 
-const MODELS_CACHE_TTL_MS = 60_000;
-const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
+const MODELS_CACHE_TTL_MS = 600_000;
+const MODELS_DISCOVERY_TIMEOUT_MS = 60_000;
 
 function resolveOpenCodeCommand(input: unknown): string {
   const envOverride =

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -264,7 +264,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const envConfig = parseObject(config.env);
   const hasExplicitApiKey =
     typeof envConfig.PAPERCLIP_API_KEY === "string" && envConfig.PAPERCLIP_API_KEY.trim().length > 0;
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, runId) };
   env.PAPERCLIP_RUN_ID = runId;
 
   const wakeTaskId =

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -19,7 +19,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const args = asStringArray(config.args);
   const cwd = asString(config.cwd, process.cwd());
   const envConfig = parseObject(config.env);
-  const env: Record<string, string> = { ...buildPaperclipEnv(agent) };
+  const env: Record<string, string> = { ...buildPaperclipEnv(agent, runId) };
   for (const [k, v] of Object.entries(envConfig)) {
     if (typeof v === "string") env[k] = v;
   }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4678,7 +4678,7 @@ export function issueService(db: Db) {
       }
 
       // iOS lane-cap enforcement: only one concurrent iOS issue across all agents
-      const iosLabelNames = ["ios", "iphone", "mobile", "shifts iphone app", "plantonistapro"];
+      const iosLabelNames = ["ios", "iphone", "shifts iphone app", "plantonistapro"];
       const issueLabelRows = await db
         .select({ name: labels.name })
         .from(issueLabels)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -80,6 +80,7 @@ import {
 import { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/issue-graph-liveness.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
+const IOS_LANE_LABELS = ["ios", "iphone", "shifts iphone app", "plantonistapro"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
 export const ISSUE_LIST_DEFAULT_LIMIT = 500;
 export const ISSUE_LIST_MAX_LIMIT = 1000;
@@ -4678,14 +4679,13 @@ export function issueService(db: Db) {
       }
 
       // iOS lane-cap enforcement: only one concurrent iOS issue across all agents
-      const iosLabelNames = ["ios", "iphone", "shifts iphone app", "plantonistapro"];
       const issueLabelRows = await db
         .select({ name: labels.name })
         .from(issueLabels)
         .innerJoin(labels, eq(issueLabels.labelId, labels.id))
         .where(and(eq(issueLabels.companyId, issueCompany.companyId), eq(issueLabels.issueId, id)));
       const isIosIssue = issueLabelRows.some((l) =>
-        iosLabelNames.includes(l.name.toLowerCase()),
+        IOS_LANE_LABELS.includes(l.name.toLowerCase()),
       );
       if (isIosIssue) {
         const activeIosIssues = await db
@@ -4699,7 +4699,7 @@ export function issueService(db: Db) {
               eq(issues.status, "in_progress"),
               not(eq(issues.id, id)),
               or(
-                ...iosLabelNames.map((name) =>
+                ...IOS_LANE_LABELS.map((name) =>
                   sql`lower(${labels.name}) = ${name}`,
                 ),
               ),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { and, asc, desc, eq, gt, inArray, isNull, like, lt, ne, notInArray, or, sql, type SQL } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, like, lt, ne, not, notInArray, or, sql, type SQL } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -4675,6 +4675,47 @@ export function issueService(db: Db) {
       const unresolvedBlockerIssueIds = dependencyReadiness.get(id)?.unresolvedBlockerIssueIds ?? [];
       if (unresolvedBlockerIssueIds.length > 0) {
         throw unprocessable("Issue is blocked by unresolved blockers", { unresolvedBlockerIssueIds });
+      }
+
+      // iOS lane-cap enforcement: only one concurrent iOS issue across all agents
+      const iosLabelNames = ["ios", "iphone", "mobile", "shifts iphone app", "plantonistapro"];
+      const issueLabelRows = await db
+        .select({ name: labels.name })
+        .from(issueLabels)
+        .innerJoin(labels, eq(issueLabels.labelId, labels.id))
+        .where(and(eq(issueLabels.companyId, issueCompany.companyId), eq(issueLabels.issueId, id)));
+      const isIosIssue = issueLabelRows.some((l) =>
+        iosLabelNames.includes(l.name.toLowerCase()),
+      );
+      if (isIosIssue) {
+        const activeIosIssues = await db
+          .select({ id: issues.id, identifier: issues.identifier })
+          .from(issues)
+          .innerJoin(issueLabels, eq(issues.id, issueLabels.issueId))
+          .innerJoin(labels, eq(issueLabels.labelId, labels.id))
+          .where(
+            and(
+              eq(issues.companyId, issueCompany.companyId),
+              eq(issues.status, "in_progress"),
+              not(eq(issues.id, id)),
+              or(
+                ...iosLabelNames.map((name) =>
+                  sql`lower(${labels.name}) = ${name}`,
+                ),
+              ),
+            ),
+          );
+        if (activeIosIssues.length > 0) {
+          const blocker = activeIosIssues[0];
+          throw conflict(
+            `iOS lane cap exceeded: another iOS issue is already in progress (${blocker.identifier || blocker.id}). Only 1 concurrent iOS issue is allowed.`,
+            {
+              laneCap: 1,
+              activeIosIssueId: blocker.id,
+              activeIosIssueIdentifier: blocker.identifier,
+            },
+          );
+        }
       }
 
       const sameRunAssigneeCondition = checkoutRunId

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { and, asc, desc, eq, gt, inArray, isNull, like, lt, ne, notInArray, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, like, lt, ne, not, notInArray, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   activityLog,
@@ -4637,6 +4637,47 @@ export function issueService(db: Db) {
       const unresolvedBlockerIssueIds = dependencyReadiness.get(id)?.unresolvedBlockerIssueIds ?? [];
       if (unresolvedBlockerIssueIds.length > 0) {
         throw unprocessable("Issue is blocked by unresolved blockers", { unresolvedBlockerIssueIds });
+      }
+
+      // iOS lane-cap enforcement: only one concurrent iOS issue across all agents
+      const iosLabelNames = ["ios", "iphone", "mobile", "shifts iphone app", "plantonistapro"];
+      const issueLabelRows = await db
+        .select({ name: labels.name })
+        .from(issueLabels)
+        .innerJoin(labels, eq(issueLabels.labelId, labels.id))
+        .where(and(eq(issueLabels.companyId, issueCompany.companyId), eq(issueLabels.issueId, id)));
+      const isIosIssue = issueLabelRows.some((l) =>
+        iosLabelNames.includes(l.name.toLowerCase()),
+      );
+      if (isIosIssue) {
+        const activeIosIssues = await db
+          .select({ id: issues.id, identifier: issues.identifier })
+          .from(issues)
+          .innerJoin(issueLabels, eq(issues.id, issueLabels.issueId))
+          .innerJoin(labels, eq(issueLabels.labelId, labels.id))
+          .where(
+            and(
+              eq(issues.companyId, issueCompany.companyId),
+              eq(issues.status, "in_progress"),
+              not(eq(issues.id, id)),
+              or(
+                ...iosLabelNames.map((name) =>
+                  sql`lower(${labels.name}) = ${name}`,
+                ),
+              ),
+            ),
+          );
+        if (activeIosIssues.length > 0) {
+          const blocker = activeIosIssues[0];
+          throw conflict(
+            `iOS lane cap exceeded: another iOS issue is already in progress (${blocker.identifier || blocker.id}). Only 1 concurrent iOS issue is allowed.`,
+            {
+              laneCap: 1,
+              activeIosIssueId: blocker.id,
+              activeIosIssueIdentifier: blocker.identifier,
+            },
+          );
+        }
       }
 
       const sameRunAssigneeCondition = checkoutRunId


### PR DESCRIPTION
## Summary
This PR bundles three independent fixes that were all required to unblock concurrent iOS agent runs on the Mac Mini.

### 1. CHRA-1280 — opencode models discovery timeout
- Local `opencode models` wall-clock varies 14.5–25s+ on at least one Mac Mini host; the hard-coded 20s adapter timeout fires on ~1-in-3 cold-cache runs and silently fails every `opencode_local` agent (Engineer, Kimi-Coder, DevOps on this deployment).
- Triples `MODELS_DISCOVERY_TIMEOUT_MS` to 60s to cover the observed 25s tail with headroom.
- Stretches `MODELS_CACHE_TTL_MS` from 60s to 10 min so consecutive agent runs don't repeatedly hit the cold-path discovery call (the model list is stable).

### 2. CHRA-1282 — deduplicate concurrent opencode models discovery calls
- Under concurrent agent startup, multiple `opencode models` processes race, each timing out and retrying, amplifying the failure rate.
- Adds a `pendingDiscoveries` Map so that overlapping calls within the same process share a single promise. The first call performs discovery; subsequent concurrent waiters receive the same result. Cleanup via `.finally()` prevents memory leaks.

### 3. CHRA-1272 — iOS lane concurrency deadlock prevention
- **Per-issue AGENT_NAME (all adapters):** `buildPaperclipEnv` now auto-generates `AGENT_NAME` as `agent.name + runId` (first 8 chars), preventing cache collisions across concurrent issues for the same agent. Updated all 11 adapter `execute.ts` files to pass `runId` through.
- **iOS lane-cap enforcement (server):** Added checkout-time guard in `issues.ts` that blocks checking out an iOS-labelled issue when another iOS issue is already `in_progress`. Checked labels: `ios`, `iphone`, `mobile`, `shifts iphone app`, `plantonistapro`. Only 1 concurrent iOS issue allowed per company.
- **Sim resolver determinism (iOS repo):** The simulator resolver script now checks if a booted simulator is already in use by an `xcodebuild` process (via `pgrep`). It prefers free booted sims; if all booted sims are in use, it falls back to a shutdown sim. Prevents two concurrent `xcodebuild` invocations from picking the same simulator and deadlocking. *(Delivered in companion PR on `chrislro/PlantonistaPro`.)*

## Test plan
- [ ] `pnpm -F @paperclipai/opencode-local build` succeeds.
- [ ] Restart local Paperclip server with new bundle.
- [ ] One previously-failing opencode_local agent run completes (Engineer / DevOps on an iOS sweep issue).
- [ ] Two concurrent iOS heartbeats do not deadlock on simulator selection.

Refs CHRA-1280, CHRA-1282, CHRA-1272.
