### PR TITLE
fix(redaction): Preserve semver payload values

### DIFF
--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -46,7 +46,7 @@ describe("redaction", () => {
 
   it("redacts jwt-looking values even when key name is not sensitive", () => {
     const input = {
-      session: "aaa.bbb.ccc",
+      session: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
       normal: "plain",
     };
 
@@ -54,6 +54,22 @@ describe("redaction", () => {
 
     expect(result.session).toBe(REDACTED_EVENT_VALUE);
     expect(result.normal).toBe("plain");
+  });
+
+  it("preserves semver strings in structured payloads", () => {
+    const result = redactEventPayload({
+      target_version: "v0.0.0",
+      version: "1.2.3",
+      prerelease: "v2.0.0-beta.1+build.5",
+      token: "v0.0.0",
+    });
+
+    expect(result).toEqual({
+      target_version: "v0.0.0",
+      version: "1.2.3",
+      prerelease: "v2.0.0-beta.1+build.5",
+      token: REDACTED_EVENT_VALUE,
+    });
   });
 
   it("redacts payload objects while preserving null", () => {

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -7,7 +7,7 @@ const SECRET_PAYLOAD_KEY_RE = new RegExp(SECRET_FIELD_NAME_PATTERN, "i");
 const COMMAND_PAYLOAD_KEY_RE =
   /(^command$|^cmd$|command[-_]?line|resolved[-_]?command|PAPERCLIP_RESOLVED_COMMAND)/i;
 const COMMAND_ARGS_PAYLOAD_KEY_RE = /^(commandArgs|command_?args|argv)$/i;
-const JWT_VALUE_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+)?$/;
+const JWT_VALUE_RE = /^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?$/;
 const CLI_SECRET_FLAG_RE = new RegExp(String.raw`^-{1,2}${SECRET_FIELD_NAME_PATTERN}$`, "i");
 const JSON_SECRET_FIELD_TEXT_RE = new RegExp(
   String.raw`((?:"|')?${SECRET_FIELD_NAME_PATTERN}(?:"|')?\s*:\s*(?:"|'))[^"'` + "`" + String.raw`\r\n]+((?:"|'))`,


### PR DESCRIPTION
## Summary

- tighten structured JWT redaction so short dotted semver values such as `v0.0.0` are not treated as tokens
- preserve approval payload version fields while still redacting real JWT-shaped values and sensitive keys such as `token`
- add regression coverage for semver payload values and a realistic JWT fixture

Fixes #6335

## Tests

- `pnpm exec vitest run server/src/__tests__/redaction.test.ts`
- `node cli/node_modules/tsx/dist/cli.mjs --input-type=module` smoke check for semver/JWT/token output
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check`
