### PR TITLE
fix(ci): copy link-plugin-dev-sdk.mjs into Docker deps stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY packages/plugins/paperclip-plugin-fake-sandbox/package.json packages/plugin
 COPY packages/plugins/plugin-llm-wiki/package.json packages/plugins/plugin-llm-wiki/
 COPY packages/plugins/plugin-workspace-diff/package.json packages/plugins/plugin-workspace-diff/
 COPY patches/ patches/
+COPY scripts/link-plugin-dev-sdk.mjs scripts/
 
 RUN pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Releases ship via a Docker image built in the `build-and-push` CI workflow
> - A recent change added `plugin-workspace-diff` to the pnpm workspace; its `postinstall` hook calls `scripts/link-plugin-dev-sdk.mjs`
> - The Dockerfile's `deps` stage runs `pnpm install` before the full repo is copied, so the script was missing and `pnpm install` failed with `Cannot find module`
> - Sandbox-provider plugins have the same hook but are excluded from the pnpm workspace, so they were unaffected — this was specific to `plugin-workspace-diff`
> - This pull request copies `scripts/link-plugin-dev-sdk.mjs` into the `deps` stage alongside the package.json files
> - The benefit is restoring the `build-and-push` CI workflow with a minimal one-line change

## What Changed

- Add `COPY scripts/link-plugin-dev-sdk.mjs scripts/` to the Dockerfile's `deps` stage so the `plugin-workspace-diff` postinstall hook succeeds during `pnpm install`.

## Verification

- Reproduces the original failure on `master` by running `docker build --target deps .` — fails at `pnpm install` with `Cannot find module '/app/scripts/link-plugin-dev-sdk.mjs'`.
- With this patch, `docker build --target deps .` completes successfully through the `deps` stage.
- CI `build-and-push` job (previously failing on https://github.com/paperclipai/paperclip/actions/runs/26055610103/job/76602841176) should now pass.

## Risks

- Low risk. One-line addition that copies a single script earlier in the Docker build. No runtime behavior changes, no app code changes, no schema changes.

## Model Used

- Claude (Anthropic), model ID `claude-opus-4-7`, extended thinking enabled, 200K context. Used via Claude Code CLI with tool use (Bash, Read, Edit, Grep) running inside the Paperclip agent harness.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
