### PR TITLE
fix(server): handle stale run_id FK violations from expired Cowork JWTs

### DIFF
--- a/packages/db/src/migrations/0087_drop_run_id_fk_soft_refs.sql
+++ b/packages/db/src/migrations/0087_drop_run_id_fk_soft_refs.sql
@@ -1,0 +1,10 @@
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'activity_log_run_id_heartbeat_runs_id_fk') THEN
+    ALTER TABLE "activity_log" DROP CONSTRAINT "activity_log_run_id_heartbeat_runs_id_fk";
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'issue_comments_created_by_run_id_heartbeat_runs_id_fk') THEN
+    ALTER TABLE "issue_comments" DROP CONSTRAINT "issue_comments_created_by_run_id_heartbeat_runs_id_fk";
+  END IF;
+END $$;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1778976000000,
       "tag": "0086_routine_env_runtime_contract",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1779062400000,
+      "tag": "0087_drop_run_id_fk_soft_refs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/activity_log.ts
+++ b/packages/db/src/schema/activity_log.ts
@@ -1,7 +1,6 @@
 import { pgTable, uuid, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 import { agents } from "./agents.js";
-import { heartbeatRuns } from "./heartbeat_runs.js";
 
 export const activityLog = pgTable(
   "activity_log",
@@ -14,7 +13,7 @@ export const activityLog = pgTable(
     entityType: text("entity_type").notNull(),
     entityId: text("entity_id").notNull(),
     agentId: uuid("agent_id").references(() => agents.id),
-    runId: uuid("run_id").references(() => heartbeatRuns.id),
+    runId: uuid("run_id"),
     details: jsonb("details").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/db/src/schema/issue_comments.ts
+++ b/packages/db/src/schema/issue_comments.ts
@@ -3,7 +3,6 @@ import { pgTable, uuid, text, timestamp, index, jsonb } from "drizzle-orm/pg-cor
 import { companies } from "./companies.js";
 import { issues } from "./issues.js";
 import { agents } from "./agents.js";
-import { heartbeatRuns } from "./heartbeat_runs.js";
 
 export const issueComments = pgTable(
   "issue_comments",
@@ -14,7 +13,7 @@ export const issueComments = pgTable(
     authorAgentId: uuid("author_agent_id").references(() => agents.id),
     authorUserId: text("author_user_id"),
     authorType: text("author_type").$type<IssueCommentAuthorType>(),
-    createdByRunId: uuid("created_by_run_id").references(() => heartbeatRuns.id, { onDelete: "set null" }),
+    createdByRunId: uuid("created_by_run_id"),
     body: text("body").notNull(),
     presentation: jsonb("presentation").$type<IssueCommentPresentation | null>(),
     metadata: jsonb("metadata").$type<IssueCommentMetadata | null>(),

--- a/server/src/__tests__/error-handler.test.ts
+++ b/server/src/__tests__/error-handler.test.ts
@@ -50,4 +50,35 @@ describe("errorHandler", () => {
     expect(res.err).toBe(err);
     expect(res.__errorContext?.error?.message).toBe("db exploded");
   });
+
+  it("returns 422 with foreign_key_violation reason for Postgres 23503 errors", () => {
+    const req = makeReq();
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+    const cause = Object.assign(new Error("FK constraint"), { code: "23503", detail: "Key (run_id)=(abc) is not present in table heartbeat_runs." });
+    const err = Object.assign(new Error("insert or update on table"), { cause });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Write rejected: a referenced entity does not exist",
+      reason: "foreign_key_violation",
+      detail: "Key (run_id)=(abc) is not present in table heartbeat_runs.",
+    });
+  });
+
+  it("returns 422 for 23503 errors with code on the error itself (not cause)", () => {
+    const req = makeReq();
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+    const err = Object.assign(new Error("FK violation"), { code: "23503", detail: "" });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "foreign_key_violation" }),
+    );
+  });
 });

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -62,6 +62,26 @@ export function errorHandler(
   }
 
   const rootError = err instanceof Error ? err : new Error(String(err));
+
+  // Postgres FK violation (23503) — stale run_id from expired Cowork/agent JWT.
+  // Return 422 with a descriptive body instead of a bare 500.
+  const pgCode = (rootError.cause as any)?.code ?? (rootError as any).code;
+  if (pgCode === "23503") {
+    const detail = (rootError.cause as any)?.detail ?? (rootError as any).detail ?? "";
+    attachErrorContext(
+      req,
+      res,
+      { message: rootError.message, stack: rootError.stack, name: rootError.name },
+      rootError,
+    );
+    res.status(422).json({
+      error: "Write rejected: a referenced entity does not exist",
+      reason: "foreign_key_violation",
+      detail,
+    });
+    return;
+  }
+
   attachErrorContext(
     req,
     res,

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -70,17 +70,38 @@ export async function logActivity(db: Db, input: LogActivityInput) {
   const redactedDetails = sanitizedDetails
     ? redactCurrentUserValue(sanitizedDetails, currentUserRedactionOptions)
     : null;
-  await db.insert(activityLog).values({
-    companyId: input.companyId,
-    actorType: input.actorType,
-    actorId: input.actorId,
-    action: input.action,
-    entityType: input.entityType,
-    entityId: input.entityId,
-    agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
-    details: redactedDetails,
-  });
+  try {
+    await db.insert(activityLog).values({
+      companyId: input.companyId,
+      actorType: input.actorType,
+      actorId: input.actorId,
+      action: input.action,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      agentId: input.agentId ?? null,
+      runId: input.runId ?? null,
+      details: redactedDetails,
+    });
+  } catch (e) {
+    // If a stale run_id causes a FK violation, retry without run attribution so the log entry
+    // is still recorded. This can happen when a Cowork-session JWT references a pruned run.
+    const pgCode = (e as any)?.cause?.code ?? (e as any)?.code;
+    if (pgCode === "23503" && input.runId) {
+      await db.insert(activityLog).values({
+        companyId: input.companyId,
+        actorType: input.actorType,
+        actorId: input.actorId,
+        action: input.action,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        agentId: input.agentId ?? null,
+        runId: null,
+        details: redactedDetails,
+      });
+    } else {
+      throw e;
+    }
+  }
 
   publishLiveEvent({
     companyId: input.companyId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5107,21 +5107,34 @@ export function issueService(db: Db) {
       const presentation = issueCommentPresentationSchema.nullable().parse(options?.presentation ?? null);
       const metadata = issueCommentMetadataSchema.nullable().parse(options?.metadata ?? null);
       const createdAt = options?.createdAt ? new Date(options.createdAt) : null;
+      const insertCommentValues = {
+        companyId: issue.companyId,
+        issueId,
+        authorAgentId: actor.agentId ?? null,
+        authorUserId: actor.userId ?? null,
+        authorType,
+        createdByRunId: actor.runId ?? null,
+        body: redactedBody,
+        presentation,
+        metadata,
+        ...(createdAt && !Number.isNaN(createdAt.getTime()) ? { createdAt } : {}),
+      };
+      // If a stale run_id causes a FK violation, retry with null run attribution so the comment
+      // is still posted. This can happen when a Cowork-session JWT references a pruned run.
       const [comment] = await db
         .insert(issueComments)
-        .values({
-          companyId: issue.companyId,
-          issueId,
-          authorAgentId: actor.agentId ?? null,
-          authorUserId: actor.userId ?? null,
-          authorType,
-          createdByRunId: actor.runId ?? null,
-          body: redactedBody,
-          presentation,
-          metadata,
-          ...(createdAt && !Number.isNaN(createdAt.getTime()) ? { createdAt } : {}),
-        })
-        .returning();
+        .values(insertCommentValues)
+        .returning()
+        .catch(async (e) => {
+          const pgCode = (e as any)?.cause?.code ?? (e as any)?.code;
+          if (pgCode === "23503" && insertCommentValues.createdByRunId) {
+            return db
+              .insert(issueComments)
+              .values({ ...insertCommentValues, createdByRunId: null })
+              .returning();
+          }
+          throw e;
+        });
 
       // Update issue's updatedAt so comment activity is reflected in recency sorting
       await db


### PR DESCRIPTION
## Summary

This PR upstreams the fix applied as a hotfix in JOIA-475 to compiled dist files. The hotfix patches are overwritten on `npm update paperclipai`; this makes the fix durable in source.

## Changes

- **AC1 (Schema):** Remove FK constraints on `run_id` / `created_by_run_id` from `activity_log` and `issue_comments` Drizzle schemas. Add migration `0087_drop_run_id_fk_soft_refs.sql`.
- **AC2 (`logActivity`):** Catch Postgres `23503` and retry INSERT with `runId: null`.
- **AC3 (`addComment`):** Catch Postgres `23503` and retry INSERT with `createdByRunId: null`.
- **AC4 (`errorHandler`):** Return HTTP 422 `{"error":"...","reason":"foreign_key_violation"}` for `23503` errors.

## Root cause

When a Cowork JWT expires mid-run, the run record is deleted before all activity/comment writes complete. The FK constraint on `run_id` / `created_by_run_id` then rejects the write with `23503`. The hotfix drops the FK constraints at the DB level and adds defensive retry logic in the application layer.

## Test coverage

Two new tests added to `server/src/__tests__/error-handler.test.ts` covering the 422 FK-violation path.