### PR TITLE
fix(plugins): enforce scoped-API body limit pre-parse (MAT-666 F7)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,4 +1,9 @@
-import express, { Router, type Request as ExpressRequest } from "express";
+import express, {
+  Router,
+  type Request as ExpressRequest,
+  type Response as ExpressResponse,
+  type NextFunction,
+} from "express";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -38,7 +43,11 @@ import { llmRoutes } from "./routes/llms.js";
 import { authRoutes } from "./routes/auth.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
-import { pluginRoutes } from "./routes/plugins.js";
+import {
+  pluginRoutes,
+  PLUGIN_API_BODY_LIMIT_BYTES,
+  PLUGIN_SCOPED_API_PATH_REGEX,
+} from "./routes/plugins.js";
 import { adapterRoutes } from "./routes/adapters.js";
 import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
@@ -137,13 +146,29 @@ export async function createApp(
 ) {
   const app = express();
 
-  app.use(express.json({
+  const captureRawBody = (req: ExpressRequest, _res: ExpressResponse, buf: Buffer) => {
+    (req as unknown as { rawBody: Buffer }).rawBody = buf;
+  };
+  // MAT-666 F7: scoped plugin-API routes get a dedicated parser with a tighter
+  // pre-parse limit than the default 10mb parser. express.json() rejects
+  // payloads exceeding the limit with a 413 PayloadTooLargeError before
+  // buffering, so oversize bodies on `/api/plugins/:pluginId/api/...` never
+  // reach the route handler.
+  const pluginScopedApiJsonParser = express.json({
+    limit: PLUGIN_API_BODY_LIMIT_BYTES,
+    verify: captureRawBody,
+  });
+  const defaultJsonParser = express.json({
     // Company import/export payloads can inline full portable packages.
     limit: "10mb",
-    verify: (req, _res, buf) => {
-      (req as unknown as { rawBody: Buffer }).rawBody = buf;
-    },
-  }));
+    verify: captureRawBody,
+  });
+  app.use((req: ExpressRequest, res: ExpressResponse, next: NextFunction) => {
+    if (PLUGIN_SCOPED_API_PATH_REGEX.test(req.path)) {
+      return pluginScopedApiJsonParser(req, res, next);
+    }
+    return defaultJsonParser(req, res, next);
+  });
   app.use(httpLogger);
   const privateHostnameGateEnabled = shouldEnablePrivateHostnameGuard({
     deploymentMode: opts.deploymentMode,

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -140,7 +140,14 @@ interface PluginHealthCheckResult {
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const PLUGIN_API_BODY_LIMIT_BYTES = 1_000_000;
+// MAT-666 F7: scoped plugin-API JSON body limit. Enforced pre-parse by a
+// dedicated express.json() instance mounted in app.ts on the scoped API path
+// prefix, so oversize payloads are rejected with 413 before the parser
+// buffers them.
+export const PLUGIN_API_BODY_LIMIT_BYTES = 1_000_000;
+// Matches `/api/plugins/<id>/api` and `/api/plugins/<id>/api/<...>`. Used by
+// the app-level JSON-parser dispatcher to apply the scoped-API limit.
+export const PLUGIN_SCOPED_API_PATH_REGEX = /^\/api\/plugins\/[^/]+\/api(?:\/|$)/;
 const PLUGIN_SCOPED_API_RESPONSE_HEADER_ALLOWLIST = new Set([
   "cache-control",
   "etag",
@@ -1486,8 +1493,15 @@ export function pluginRoutes(
         return;
       }
       const requestBody = req.body ?? null;
-      const bodySize = Buffer.byteLength(JSON.stringify(requestBody));
-      if (bodySize > PLUGIN_API_BODY_LIMIT_BYTES) {
+      // MAT-666 F7: primary limit enforced pre-parse by the dedicated
+      // express.json() instance mounted in app.ts (PLUGIN_API_BODY_LIMIT_BYTES),
+      // which rejects oversize payloads with 413 before they are buffered into
+      // memory. Defense-in-depth fallback below uses the raw payload size
+      // captured by the parser's `verify` hook so the count reflects bytes
+      // actually received rather than `JSON.stringify(req.body)`, which can
+      // drift from the wire size.
+      const rawBodyLength = (req as unknown as { rawBody?: Buffer }).rawBody?.length ?? 0;
+      if (rawBodyLength > PLUGIN_API_BODY_LIMIT_BYTES) {
         res.status(413).json({ error: "Plugin API request body is too large" });
         return;
       }


### PR DESCRIPTION
The post-parse `Buffer.byteLength(JSON.stringify(req.body))` check at routes/plugins.ts:1490 runs only after `express.json({limit: "10mb"})` has already buffered the payload. An attacker can spam ~10 MiB JSON documents at /api/plugins/:id/api/* and exhaust memory before the 413 ever fires. The JSON.stringify size also drifts from wire size, so the in-handler count is unreliable as a limit.

Mount a dedicated `express.json({limit: PLUGIN_API_BODY_LIMIT_BYTES})` parser dispatched at app-level on the path regex
`/^\/api\/plugins\/[^/]+\/api(?:\/|$)/`. Express rejects oversize payloads with 413 PayloadTooLargeError before buffering. Existing import/export routes keep the 10mb default parser.

Keep the in-handler check as defense-in-depth (e.g. tests that mount the router directly bypass the app-level dispatcher), but switch it to `req.rawBody.length` so the count reflects actual wire bytes.

## Thinking Path

<!--
  Required. Trace your reasoning from the top of the project down to this
  specific change. Start with what Paperclip is, then narrow through the
  subsystem, the problem, and why this PR exists. Use blockquote style.
  Aim for 5–8 steps. See CONTRIBUTING.md for full examples.
-->

> - Paperclip orchestrates AI agents for zero-human companies
> - [Which subsystem or capability is involved]
> - [What problem or gap exists]
> - [Why it needs to be addressed]
> - This pull request ...
> - The benefit is ...

## What Changed

<!-- Bullet list of concrete changes. One bullet per logical unit. -->

-

## Verification

<!--
  How can a reviewer confirm this works? Include test commands, manual
  steps, or both. For UI changes, include before/after screenshots.
-->

-

## Risks

<!--
  What could go wrong? Mention migration safety, breaking changes,
  behavioral shifts, or "Low risk" if genuinely minor.
-->

-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

-

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
