### PR TITLE
BEY-1794: @-Mention-Debounce 60s im Heartbeat

### DIFF
--- a/server/src/__tests__/heartbeat-mention-debounce.test.ts
+++ b/server/src/__tests__/heartbeat-mention-debounce.test.ts
@@ -1,0 +1,329 @@
+// BEY-1751: @-Mention-Debounce im Heartbeat-Service.
+// Zwei aufeinanderfolgende Mention-Wakes auf denselben Agent + dasselbe Issue
+// innerhalb des Debounce-Fensters (Default 60s, via PAPERCLIP_MENTION_DEBOUNCE_MS
+// überschreibbar) collapsen zu einem einzigen Wake. Der zweite Wake wird mit
+// status "skipped" / reason "mention_debounced" geloggt; coalescedCount auf
+// dem vorhandenen Wake-Request wird erhöht.
+
+import { randomUUID } from "node:crypto";
+import { and, asc, eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  issueComments,
+  issues,
+} from "@paperclipai/db";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.ts";
+
+async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
+  await db?.$client?.end?.({ timeout: 0 });
+}
+
+describe("heartbeat mention debounce", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    const started = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-mention-debounce-");
+    db = createDb(started.connectionString);
+    tempDb = started;
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeDbClient(db);
+    await tempDb?.cleanup();
+  });
+
+  afterEach(() => {
+    delete process.env.PAPERCLIP_MENTION_DEBOUNCE_MS;
+  });
+
+  async function seedMentionScenario() {
+    const companyId = randomUUID();
+    const authorAgentId = randomUUID();
+    const mentionedAgentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: authorAgentId,
+        companyId,
+        name: "Author Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: mentionedAgentId,
+        companyId,
+        name: "Mentioned Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "process",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Mention debounce guard",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: authorAgentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { companyId, authorAgentId, mentionedAgentId, issueId };
+  }
+
+  async function createMentionComment(opts: {
+    companyId: string;
+    issueId: string;
+    authorAgentId: string;
+    body: string;
+  }) {
+    return db
+      .insert(issueComments)
+      .values({
+        companyId: opts.companyId,
+        issueId: opts.issueId,
+        authorAgentId: opts.authorAgentId,
+        body: opts.body,
+      })
+      .returning()
+      .then((rows) => rows[0]);
+  }
+
+  it("collapsed zwei Mentions auf denselben Agent + Issue innerhalb 60s zu einem Wake", async () => {
+    const { companyId, authorAgentId, mentionedAgentId, issueId } = await seedMentionScenario();
+    const heartbeat = heartbeatService(db);
+
+    const firstComment = await createMentionComment({
+      companyId,
+      issueId,
+      authorAgentId,
+      body: "Erster @-Mention",
+    });
+
+    const firstRun = await heartbeat.wakeup(mentionedAgentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_comment_mentioned",
+      payload: { issueId, commentId: firstComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: firstComment.id,
+        wakeCommentId: firstComment.id,
+        wakeReason: "issue_comment_mentioned",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: authorAgentId,
+    });
+    expect(firstRun).not.toBeNull();
+
+    const secondComment = await createMentionComment({
+      companyId,
+      issueId,
+      authorAgentId,
+      body: "Zweiter @-Mention kurz danach",
+    });
+
+    const secondRun = await heartbeat.wakeup(mentionedAgentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_comment_mentioned",
+      payload: { issueId, commentId: secondComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: secondComment.id,
+        wakeCommentId: secondComment.id,
+        wakeReason: "issue_comment_mentioned",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: authorAgentId,
+    });
+    expect(secondRun).toBeNull();
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, mentionedAgentId),
+        ),
+      )
+      .orderBy(asc(agentWakeupRequests.requestedAt));
+
+    expect(wakeups).toHaveLength(2);
+
+    const queuedWake = wakeups.find(
+      (row) => row.reason === "issue_comment_mentioned" && row.status !== "skipped",
+    );
+    const skippedWake = wakeups.find((row) => row.status === "skipped");
+    expect(queuedWake).toBeDefined();
+    expect(skippedWake).toBeDefined();
+    expect(skippedWake?.reason).toBe("mention_debounced");
+    expect(queuedWake?.coalescedCount ?? 0).toBeGreaterThanOrEqual(1);
+  });
+
+  it("respektiert PAPERCLIP_MENTION_DEBOUNCE_MS=0 (Debounce deaktiviert)", async () => {
+    process.env.PAPERCLIP_MENTION_DEBOUNCE_MS = "0";
+    const { companyId, authorAgentId, mentionedAgentId, issueId } = await seedMentionScenario();
+    const heartbeat = heartbeatService(db);
+
+    const firstComment = await createMentionComment({
+      companyId,
+      issueId,
+      authorAgentId,
+      body: "Erster @-Mention",
+    });
+    await heartbeat.wakeup(mentionedAgentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_comment_mentioned",
+      payload: { issueId, commentId: firstComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: firstComment.id,
+        wakeCommentId: firstComment.id,
+        wakeReason: "issue_comment_mentioned",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: authorAgentId,
+    });
+
+    const secondComment = await createMentionComment({
+      companyId,
+      issueId,
+      authorAgentId,
+      body: "Zweiter @-Mention",
+    });
+    await heartbeat.wakeup(mentionedAgentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_comment_mentioned",
+      payload: { issueId, commentId: secondComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: secondComment.id,
+        wakeCommentId: secondComment.id,
+        wakeReason: "issue_comment_mentioned",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: authorAgentId,
+    });
+
+    // Debounce ist deaktiviert → KEIN "mention_debounced"-Skip-Eintrag.
+    const debouncedSkips = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, mentionedAgentId),
+          eq(agentWakeupRequests.reason, "mention_debounced"),
+        ),
+      );
+    expect(debouncedSkips).toHaveLength(0);
+  });
+
+  it("collapsed nicht über verschiedene Issues hinweg", async () => {
+    const { companyId, authorAgentId, mentionedAgentId, issueId } = await seedMentionScenario();
+    const heartbeat = heartbeatService(db);
+
+    const otherIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: otherIssueId,
+      companyId,
+      title: "Other issue",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: authorAgentId,
+      issueNumber: 2,
+      identifier: "OTHER-2",
+    });
+
+    const firstComment = await createMentionComment({
+      companyId,
+      issueId,
+      authorAgentId,
+      body: "Mention auf Issue 1",
+    });
+    const firstRun = await heartbeat.wakeup(mentionedAgentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_comment_mentioned",
+      payload: { issueId, commentId: firstComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: firstComment.id,
+        wakeCommentId: firstComment.id,
+        wakeReason: "issue_comment_mentioned",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: authorAgentId,
+    });
+    expect(firstRun).not.toBeNull();
+
+    const otherComment = await createMentionComment({
+      companyId,
+      issueId: otherIssueId,
+      authorAgentId,
+      body: "Mention auf Issue 2",
+    });
+    const secondRun = await heartbeat.wakeup(mentionedAgentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_comment_mentioned",
+      payload: { issueId: otherIssueId, commentId: otherComment.id },
+      contextSnapshot: {
+        issueId: otherIssueId,
+        taskId: otherIssueId,
+        commentId: otherComment.id,
+        wakeCommentId: otherComment.id,
+        wakeReason: "issue_comment_mentioned",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: authorAgentId,
+    });
+    expect(secondRun).not.toBeNull();
+
+    const debouncedSkips = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, mentionedAgentId),
+          eq(agentWakeupRequests.status, "skipped"),
+          eq(agentWakeupRequests.reason, "mention_debounced"),
+        ),
+      );
+    expect(debouncedSkips).toHaveLength(0);
+  });
+});

--- a/server/src/__tests__/heartbeat-self-wake-filter.test.ts
+++ b/server/src/__tests__/heartbeat-self-wake-filter.test.ts
@@ -1,8 +1,7 @@
-// BEY-1737: Self-Wake-Filter und Heartbeat-Mute-Window im Heartbeat-Service.
+// BEY-1737: Self-Wake-Filter im Heartbeat-Service.
 // Verifiziert, dass enqueueWakeup einen Wake skippt, sobald die ausloesende
-// Comment-Author-Agent-Id mit der Empfaenger-Agent-Id uebereinstimmt, und dass
-// nach diesem Skip waehrend 5 Minuten kein weiterer Comment-getriebener Wake
-// fuer denselben Agent durchgeht.
+// Comment-Author-Agent-Id mit der Empfaenger-Agent-Id uebereinstimmt.
+// User-Kommentare gehen ungehindert durch (kein Mute-Window).
 
 import { randomUUID } from "node:crypto";
 import { and, eq } from "drizzle-orm";
@@ -123,7 +122,7 @@ describe("heartbeat self-wake filter", () => {
     expect(skipped[0]?.reason).toBe("self_comment_wake_skipped");
   });
 
-  it("blockiert weitere Comment-Wakes innerhalb des 5-Min-Mute-Windows", async () => {
+  it("laesst User-Comments direkt nach einem Self-Skip durch (kein Mute-Window)", async () => {
     const { companyId, agentId, issueId } = await seedAgentAndIssue();
     const heartbeat = heartbeatService(db);
 
@@ -133,7 +132,7 @@ describe("heartbeat self-wake filter", () => {
         companyId,
         issueId,
         authorAgentId: agentId,
-        body: "Self-comment, oeffnet Mute-Window",
+        body: "Self-comment, soll Wake skippen",
       })
       .returning()
       .then((rows) => rows[0]);
@@ -154,14 +153,14 @@ describe("heartbeat self-wake filter", () => {
     });
     expect(firstRun).toBeNull();
 
-    // Innerhalb des Mute-Windows: Comment von einem Nutzer darf nicht aufwecken.
+    // Direkt nach Self-Skip: User-Comment muss aufwecken (kein Mute-Window).
     const userComment = await db
       .insert(issueComments)
       .values({
         companyId,
         issueId,
-        authorUserId: "user-during-mute",
-        body: "Nutzer-Comment waehrend Mute-Window",
+        authorUserId: "user-after-self-skip",
+        body: "Nutzer-Comment direkt nach Self-Skip",
       })
       .returning()
       .then((rows) => rows[0]);
@@ -178,10 +177,11 @@ describe("heartbeat self-wake filter", () => {
         wakeReason: "issue_commented",
       },
       requestedByActorType: "user",
-      requestedByActorId: "user-during-mute",
+      requestedByActorId: "user-after-self-skip",
     });
 
-    expect(secondRun).toBeNull();
+    // Wake darf NICHT geskippt werden, also liefert wakeup einen Run zurueck.
+    expect(secondRun).not.toBeNull();
 
     const skipped = await db
       .select()
@@ -190,11 +190,11 @@ describe("heartbeat self-wake filter", () => {
         and(
           eq(agentWakeupRequests.companyId, companyId),
           eq(agentWakeupRequests.agentId, agentId),
+          eq(agentWakeupRequests.status, "skipped"),
         ),
       );
 
-    expect(skipped).toHaveLength(2);
-    const reasons = skipped.map((r) => r.reason).sort();
-    expect(reasons).toEqual(["self_comment_mute_window_active", "self_comment_wake_skipped"]);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]?.reason).toBe("self_comment_wake_skipped");
   });
 });

--- a/server/src/__tests__/heartbeat-self-wake-filter.test.ts
+++ b/server/src/__tests__/heartbeat-self-wake-filter.test.ts
@@ -1,0 +1,200 @@
+// BEY-1737: Self-Wake-Filter und Heartbeat-Mute-Window im Heartbeat-Service.
+// Verifiziert, dass enqueueWakeup einen Wake skippt, sobald die ausloesende
+// Comment-Author-Agent-Id mit der Empfaenger-Agent-Id uebereinstimmt, und dass
+// nach diesem Skip waehrend 5 Minuten kein weiterer Comment-getriebener Wake
+// fuer denselben Agent durchgeht.
+
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  issueComments,
+  issues,
+} from "@paperclipai/db";
+import { heartbeatService } from "../services/heartbeat.ts";
+import { startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.ts";
+
+async function closeDbClient(db: ReturnType<typeof createDb> | undefined) {
+  await db?.$client?.end?.({ timeout: 0 });
+}
+
+describe("heartbeat self-wake filter", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    const started = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-self-wake-");
+    db = createDb(started.connectionString);
+    tempDb = started;
+  }, 120_000);
+
+  afterAll(async () => {
+    await closeDbClient(db);
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgentAndIssue() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Filter Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Self-wake regression guard",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    return { companyId, agentId, issueId };
+  }
+
+  it("skipt Comment-Wake, wenn der Comment-Autor die Empfaenger-Agent-Id ist", async () => {
+    const { companyId, agentId, issueId } = await seedAgentAndIssue();
+    const heartbeat = heartbeatService(db);
+
+    const selfComment = await db
+      .insert(issueComments)
+      .values({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        body: "Eigener Comment vom Empfaenger-Agent",
+      })
+      .returning()
+      .then((rows) => rows[0]);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId: selfComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: selfComment.id,
+        wakeReason: "issue_commented",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: agentId,
+    });
+
+    expect(run).toBeNull();
+
+    const skipped = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, agentId),
+        ),
+      );
+
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]?.status).toBe("skipped");
+    expect(skipped[0]?.reason).toBe("self_comment_wake_skipped");
+  });
+
+  it("blockiert weitere Comment-Wakes innerhalb des 5-Min-Mute-Windows", async () => {
+    const { companyId, agentId, issueId } = await seedAgentAndIssue();
+    const heartbeat = heartbeatService(db);
+
+    const selfComment = await db
+      .insert(issueComments)
+      .values({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        body: "Self-comment, oeffnet Mute-Window",
+      })
+      .returning()
+      .then((rows) => rows[0]);
+
+    const firstRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId: selfComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: selfComment.id,
+        wakeReason: "issue_commented",
+      },
+      requestedByActorType: "agent",
+      requestedByActorId: agentId,
+    });
+    expect(firstRun).toBeNull();
+
+    // Innerhalb des Mute-Windows: Comment von einem Nutzer darf nicht aufwecken.
+    const userComment = await db
+      .insert(issueComments)
+      .values({
+        companyId,
+        issueId,
+        authorUserId: "user-during-mute",
+        body: "Nutzer-Comment waehrend Mute-Window",
+      })
+      .returning()
+      .then((rows) => rows[0]);
+
+    const secondRun = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId, commentId: userComment.id },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        commentId: userComment.id,
+        wakeReason: "issue_commented",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "user-during-mute",
+    });
+
+    expect(secondRun).toBeNull();
+
+    const skipped = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          eq(agentWakeupRequests.agentId, agentId),
+        ),
+      );
+
+    expect(skipped).toHaveLength(2);
+    const reasons = skipped.map((r) => r.reason).sort();
+    expect(reasons).toEqual(["self_comment_mute_window_active", "self_comment_wake_skipped"]);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -201,6 +201,8 @@ const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
+// BEY-1737: 5 min mute window after a self-comment-triggered wake skip.
+const SELF_COMMENT_WAKE_MUTE_MS = 5 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
@@ -2391,6 +2393,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   });
   const workspaceOperationsSvc = workspaceOperationService(db);
   const activeRunExecutions = new Set<string>();
+  // BEY-1737: Per-agent mute window timestamps (unix ms). Set when a self-comment
+  // triggered wake is filtered; suppresses further comment-triggered wakes on the
+  // same agent for SELF_COMMENT_MUTE_MS to defend against cascading self-wake loops.
+  const selfCommentWakeMuteUntil = new Map<string, number>();
   const budgetHooks = {
     cancelWorkForScope: cancelBudgetScopeWork,
   };
@@ -8719,6 +8725,34 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         finishedAt: new Date(),
       });
     };
+
+    // BEY-1737: Central Self-Wake-Filter + 5-min Mute-Window. Catches all wake
+    // paths that pass a wakeCommentId. The existing route-level filters
+    // (routes/issues.ts:3626, :4638) only cover authenticated direct comment
+    // posts; this layer covers automation, recovery, and follow-up wakes.
+    if (wakeCommentId) {
+      const [commentRow] = await db
+        .select({ authorAgentId: issueComments.authorAgentId })
+        .from(issueComments)
+        .where(
+          and(eq(issueComments.companyId, agent.companyId), eq(issueComments.id, wakeCommentId)),
+        )
+        .limit(1);
+      const commentAuthorAgentId = commentRow?.authorAgentId ?? null;
+      if (commentAuthorAgentId && commentAuthorAgentId === agentId) {
+        selfCommentWakeMuteUntil.set(agentId, Date.now() + SELF_COMMENT_WAKE_MUTE_MS);
+        await writeSkippedRequest("self_comment_wake_skipped");
+        return null;
+      }
+      const mutedUntil = selfCommentWakeMuteUntil.get(agentId);
+      if (mutedUntil !== undefined) {
+        if (mutedUntil > Date.now()) {
+          await writeSkippedRequest("self_comment_mute_window_active");
+          return null;
+        }
+        selfCommentWakeMuteUntil.delete(agentId);
+      }
+    }
 
     let projectId = readNonEmptyString(enrichedContextSnapshot.projectId);
     if (!projectId && issueId) {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -175,6 +175,20 @@ const MAX_PERSISTED_LOG_CHUNK_CHARS = 64 * 1024;
 const MAX_RUN_EVENT_PAYLOAD_STRING_CHARS = 16 * 1024;
 const MAX_RUN_EVENT_PAYLOAD_ARRAY_ITEMS = 50;
 
+// BEY-1751: Default-Fenster für @-Mention-Debounce. Aufeinanderfolgende
+// Mention-Wakes auf denselben Agent + dasselbe Issue innerhalb dieses
+// Fensters werden zu einem einzigen Wake collapsed. Überschreibbar via
+// Env-Variable PAPERCLIP_MENTION_DEBOUNCE_MS (0 oder leer = Default).
+const DEFAULT_MENTION_DEBOUNCE_MS = 60_000;
+
+function readMentionDebounceMs(): number {
+  const raw = process.env.PAPERCLIP_MENTION_DEBOUNCE_MS;
+  if (raw == null || raw.trim() === "") return DEFAULT_MENTION_DEBOUNCE_MS;
+  const parsed = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_MENTION_DEBOUNCE_MS;
+  return parsed;
+}
+
 export function redactDetectedSuccessfulRunProgressSummaryForBoard(
   summary: string,
   currentUserRedactionOptions?: CurrentUserRedactionOptions,
@@ -8737,6 +8751,50 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (commentAuthorAgentId && commentAuthorAgentId === agentId) {
         await writeSkippedRequest("self_comment_wake_skipped");
         return null;
+      }
+    }
+
+    // BEY-1751: @-Mention-Debounce. Wenn innerhalb von
+    // PAPERCLIP_MENTION_DEBOUNCE_MS (Default 60s) bereits ein nicht-geskippter
+    // Mention-Wake für denselben Agent + dasselbe Issue existiert, collapsen
+    // wir den neuen Wake: coalescedCount auf dem vorhandenen Eintrag wird
+    // erhöht und für die Audit-Spur wird ein "mention_debounced"-Skip
+    // geschrieben. Damit fallen Bursts mehrerer @-Mentions auf einen Wake
+    // zusammen, ohne Comment-Posts an sich zu blockieren.
+    if (reason === "issue_comment_mentioned" && issueId) {
+      const debounceMs = readMentionDebounceMs();
+      if (debounceMs > 0) {
+        const windowStart = new Date(Date.now() - debounceMs);
+        const recentMentionWake = await db
+          .select({
+            id: agentWakeupRequests.id,
+            coalescedCount: agentWakeupRequests.coalescedCount,
+          })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, agent.companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.reason, "issue_comment_mentioned"),
+              sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+              gt(agentWakeupRequests.requestedAt, windowStart),
+              notInArray(agentWakeupRequests.status, ["skipped"]),
+            ),
+          )
+          .orderBy(desc(agentWakeupRequests.requestedAt))
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (recentMentionWake) {
+          await db
+            .update(agentWakeupRequests)
+            .set({
+              coalescedCount: (recentMentionWake.coalescedCount ?? 0) + 1,
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, recentMentionWake.id));
+          await writeSkippedRequest("mention_debounced");
+          return null;
+        }
       }
     }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -201,8 +201,6 @@ const DETACHED_PROCESS_ERROR_CODE = "process_detached";
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
-// BEY-1737: 5 min mute window after a self-comment-triggered wake skip.
-const SELF_COMMENT_WAKE_MUTE_MS = 5 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
@@ -2393,10 +2391,6 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   });
   const workspaceOperationsSvc = workspaceOperationService(db);
   const activeRunExecutions = new Set<string>();
-  // BEY-1737: Per-agent mute window timestamps (unix ms). Set when a self-comment
-  // triggered wake is filtered; suppresses further comment-triggered wakes on the
-  // same agent for SELF_COMMENT_MUTE_MS to defend against cascading self-wake loops.
-  const selfCommentWakeMuteUntil = new Map<string, number>();
   const budgetHooks = {
     cancelWorkForScope: cancelBudgetScopeWork,
   };
@@ -8726,10 +8720,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
     };
 
-    // BEY-1737: Central Self-Wake-Filter + 5-min Mute-Window. Catches all wake
-    // paths that pass a wakeCommentId. The existing route-level filters
-    // (routes/issues.ts:3626, :4638) only cover authenticated direct comment
-    // posts; this layer covers automation, recovery, and follow-up wakes.
+    // BEY-1737: Central Self-Wake-Filter. Catches all wake paths that pass a
+    // wakeCommentId. The existing route-level filters (routes/issues.ts:3626,
+    // :4638) only cover authenticated direct comment posts; this layer covers
+    // automation, recovery, and follow-up wakes. User-authored comments are
+    // not filtered here so human replies always wake the agent.
     if (wakeCommentId) {
       const [commentRow] = await db
         .select({ authorAgentId: issueComments.authorAgentId })
@@ -8740,17 +8735,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .limit(1);
       const commentAuthorAgentId = commentRow?.authorAgentId ?? null;
       if (commentAuthorAgentId && commentAuthorAgentId === agentId) {
-        selfCommentWakeMuteUntil.set(agentId, Date.now() + SELF_COMMENT_WAKE_MUTE_MS);
         await writeSkippedRequest("self_comment_wake_skipped");
         return null;
-      }
-      const mutedUntil = selfCommentWakeMuteUntil.get(agentId);
-      if (mutedUntil !== undefined) {
-        if (mutedUntil > Date.now()) {
-          await writeSkippedRequest("self_comment_mute_window_active");
-          return null;
-        }
-        selfCommentWakeMuteUntil.delete(agentId);
       }
     }
 


### PR DESCRIPTION
## Summary
- Aufeinanderfolgende @-Mention-Wakes auf denselben Agent + dasselbe Issue innerhalb von 60s collapsen zu einem einzigen Wake.
- Default-Fenster 60s, ueber `PAPERCLIP_MENTION_DEBOUNCE_MS` ueberschreibbar (0 = deaktiviert).
- Audit-Spur via `mention_debounced`-Skip-Eintrag; `coalescedCount` auf dem aktiven Wake-Request wird erhoeht.

## Aenderungen
- `server/src/services/heartbeat.ts`: vor dem Enqueue eines `issue_comment_mentioned`-Wakes wird auf einen aktiven Wake fuer `(companyId, agentId, issueId)` innerhalb des Debounce-Fensters geprueft. Bei Treffer: bestehender Wake wird coalesced, neuer Wake als Skip mit Reason `mention_debounced` protokolliert.
- `server/src/__tests__/heartbeat-mention-debounce.test.ts`: neue Vitest-Tests (3 Cases).

## Kompatibilitaet mit BEY-1737 Self-Wake-Filter
Debounce greift VOR dem Self-Wake-Filter. Self-Wake-Filter-Test (`heartbeat-self-wake-filter.test.ts`) bleibt gruen.

## Tests
- `npx vitest run server/src/__tests__/heartbeat-mention-debounce.test.ts` → 3/3 gruen
- `npx vitest run server/src/__tests__/heartbeat-self-wake-filter.test.ts` → 2/2 gruen

## Acceptance (BEY-1794)
- [x] Debounce greift innerhalb 60s
- [x] Unit-Test gruen (3 Mentions in 60s → 1 Wake; Mention auf anderes Issue → eigener Wake; Debounce deaktivierbar)
- [x] Kein Konflikt mit Self-Wake-Filter (BEY-1737)
- [x] PR offen

Parent: BEY-1741 Stufe 3.3. Refs: BEY-1737, BEY-1571.