### PR TITLE
fix(access): allow grant updates on agent-principal memberships

### DIFF
--- a/server/src/__tests__/company-member-permissions-route.test.ts
+++ b/server/src/__tests__/company-member-permissions-route.test.ts
@@ -236,7 +236,7 @@ describe("PATCH /companies/:companyId/members/:memberId/permissions", () => {
     // would surface as a 404 here. The guard itself succeeded — that's what
     // this test asserts — so we accept either 200 or 404 from the trailing
     // lookup, but never 403 from the guard.
-    expect(res.status).not.toBe(403);
+    expect([200, 404]).toContain(res.status);
     expect(mockAccessService.archiveMember).toHaveBeenCalledWith(
       companyId,
       humanMemberId,
@@ -256,5 +256,37 @@ describe("PATCH /companies/:companyId/members/:memberId/permissions", () => {
     expect(res.status).toBe(403);
     expect(res.body.error).toContain("owners cannot be removed");
     expect(mockAccessService.archiveMember).not.toHaveBeenCalled();
+  });
+
+  // Regression for PR #6358 feedback: the grant-update relaxation must only
+  // apply to PATCH /permissions. The other two PATCH routes still rely on
+  // loadCompanyMemberRecords (human-only) after they mutate, so they have to
+  // reject agent principals at the guard — before any DB mutation runs.
+  it("rejects PATCH /members/:memberId for an agent-principal member at the guard (no DB write)", async () => {
+    mockAccessService.getMemberById.mockResolvedValue(agentMember);
+
+    const app = createApp(localImplicitBoardActor);
+
+    const res = await request(app)
+      .patch(`/api/companies/${companyId}/members/${agentMemberId}`)
+      .send({ status: "suspended" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("Only human company members can be removed");
+    expect(mockAccessService.setMemberPermissions).not.toHaveBeenCalled();
+  });
+
+  it("rejects PATCH /members/:memberId/role-and-grants for an agent-principal member at the guard (no DB write)", async () => {
+    mockAccessService.getMemberById.mockResolvedValue(agentMember);
+
+    const app = createApp(localImplicitBoardActor);
+
+    const res = await request(app)
+      .patch(`/api/companies/${companyId}/members/${agentMemberId}/role-and-grants`)
+      .send({ status: "active", grants: [] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("Only human company members can be removed");
+    expect(mockAccessService.setMemberPermissions).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/company-member-permissions-route.test.ts
+++ b/server/src/__tests__/company-member-permissions-route.test.ts
@@ -1,0 +1,260 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { accessRoutes } from "../routes/access.js";
+import { errorHandler } from "../middleware/index.js";
+
+const companyId = "11111111-1111-4111-8111-111111111111";
+const agentMemberId = "22222222-2222-4222-8222-222222222222";
+const agentId = "33333333-3333-4333-8333-333333333333";
+const humanMemberId = "44444444-4444-4444-8444-444444444444";
+const humanUserId = "55555555-5555-4555-8555-555555555555";
+const ownerMemberId = "66666666-6666-4666-8666-666666666666";
+const ownerUserId = "77777777-7777-4777-8777-777777777777";
+
+const agentMember = {
+  id: agentMemberId,
+  companyId,
+  principalType: "agent" as const,
+  principalId: agentId,
+  status: "active" as const,
+  membershipRole: "member",
+  createdAt: new Date("2026-05-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+};
+
+const humanMember = {
+  id: humanMemberId,
+  companyId,
+  principalType: "user" as const,
+  principalId: humanUserId,
+  status: "active" as const,
+  membershipRole: "operator",
+  createdAt: new Date("2026-05-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+};
+
+const ownerMember = {
+  id: ownerMemberId,
+  companyId,
+  principalType: "user" as const,
+  principalId: ownerUserId,
+  status: "active" as const,
+  membershipRole: "owner",
+  createdAt: new Date("2026-05-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+};
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+  isInstanceAdmin: vi.fn(),
+  getMembership: vi.fn(),
+  getMemberById: vi.fn(),
+  setMemberPermissions: vi.fn(),
+  archiveMember: vi.fn(),
+  listPrincipalGrants: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => mockAccessService,
+  agentService: () => ({ getById: vi.fn() }),
+  boardAuthService: () => ({
+    createChallenge: vi.fn(),
+    resolveBoardAccess: vi.fn(),
+    assertCurrentBoardKey: vi.fn(),
+    revokeBoardApiKey: vi.fn(),
+  }),
+  deduplicateAgentName: vi.fn(),
+  logActivity: mockLogActivity,
+  notifyHireApproved: vi.fn(),
+}));
+
+function createDbStub() {
+  // The PATCH /permissions route only re-queries memberships via
+  // loadCompanyMemberRecords on the human path, so an empty result set is fine
+  // here — tests that hit that branch supply their own member via the mocked
+  // getMemberById return value.
+  return {
+    select() {
+      return {
+        from() {
+          const query = {
+            where() {
+              return query;
+            },
+            orderBy() {
+              return Promise.resolve([]);
+            },
+            then(resolve: (rows: unknown[]) => unknown) {
+              return Promise.resolve(resolve([]));
+            },
+          };
+          return query;
+        },
+      };
+    },
+  };
+}
+
+function createApp(actor: Express.Request["actor"]) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = actor;
+    next();
+  });
+  app.use(
+    "/api",
+    accessRoutes(createDbStub() as never, {
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    }),
+  );
+  app.use(errorHandler);
+  return app;
+}
+
+const localImplicitBoardActor = {
+  type: "board",
+  userId: "local-board-user",
+  source: "local_implicit",
+  isInstanceAdmin: true,
+  companyIds: [companyId],
+} as unknown as Express.Request["actor"];
+
+describe("PATCH /companies/:companyId/members/:memberId/permissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccessService.canUser.mockResolvedValue(true);
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAccessService.isInstanceAdmin.mockResolvedValue(false);
+    mockAccessService.getMembership.mockResolvedValue({
+      id: "owner-self",
+      companyId,
+      principalType: "user",
+      principalId: "local-board-user",
+      status: "active",
+      membershipRole: "owner",
+    });
+    mockAccessService.setMemberPermissions.mockImplementation(
+      async (_companyId: string, memberId: string) => {
+        if (memberId === agentMemberId) return agentMember;
+        if (memberId === humanMemberId) return humanMember;
+        if (memberId === ownerMemberId) return ownerMember;
+        return null;
+      },
+    );
+    mockAccessService.archiveMember.mockResolvedValue(null);
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+  });
+
+  it("allows updating grants on an active agent-principal member", async () => {
+    mockAccessService.getMemberById.mockResolvedValue(agentMember);
+    mockAccessService.listPrincipalGrants.mockResolvedValue([
+      {
+        id: "grant-1",
+        companyId,
+        principalType: "agent",
+        principalId: agentId,
+        permissionKey: "tasks:manage_active_checkouts",
+        scope: null,
+        grantedByUserId: null,
+        createdAt: new Date("2026-05-19T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-19T00:00:00.000Z"),
+      },
+    ]);
+
+    const app = createApp(localImplicitBoardActor);
+
+    const res = await request(app)
+      .patch(`/api/companies/${companyId}/members/${agentMemberId}/permissions`)
+      .send({
+        grants: [{ permissionKey: "tasks:manage_active_checkouts", scope: null }],
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: agentMemberId,
+      principalType: "agent",
+      principalId: agentId,
+      grants: [
+        expect.objectContaining({ permissionKey: "tasks:manage_active_checkouts" }),
+      ],
+    });
+    expect(mockAccessService.setMemberPermissions).toHaveBeenCalledWith(
+      companyId,
+      agentMemberId,
+      [{ permissionKey: "tasks:manage_active_checkouts", scope: null }],
+      "local-board-user",
+    );
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "company_member.permissions_updated",
+        details: expect.objectContaining({
+          principalType: "agent",
+          grantCount: 1,
+        }),
+      }),
+    );
+  });
+
+  it("still blocks archive (destructive) operations on agent-principal members", async () => {
+    mockAccessService.getMemberById.mockResolvedValue(agentMember);
+
+    const app = createApp(localImplicitBoardActor);
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/members/${agentMemberId}/archive`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("Only human company members can be removed");
+    expect(mockAccessService.archiveMember).not.toHaveBeenCalled();
+  });
+
+  it("still allows archive on a regular human operator", async () => {
+    mockAccessService.getMemberById.mockResolvedValue(humanMember);
+    mockAccessService.archiveMember.mockResolvedValue({
+      member: humanMember,
+      reassignedIssueCount: 0,
+    });
+
+    const app = createApp(localImplicitBoardActor);
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/members/${humanMemberId}/archive`)
+      .send({});
+
+    // The route still tries to look up the archived record via
+    // loadCompanyMemberRecords, which our minimal db stub does not back; that
+    // would surface as a 404 here. The guard itself succeeded — that's what
+    // this test asserts — so we accept either 200 or 404 from the trailing
+    // lookup, but never 403 from the guard.
+    expect(res.status).not.toBe(403);
+    expect(mockAccessService.archiveMember).toHaveBeenCalledWith(
+      companyId,
+      humanMemberId,
+      expect.objectContaining({ reassignment: null }),
+    );
+  });
+
+  it("still blocks archive of a human owner via the protected-member guard", async () => {
+    mockAccessService.getMemberById.mockResolvedValue(ownerMember);
+
+    const app = createApp(localImplicitBoardActor);
+
+    const res = await request(app)
+      .post(`/api/companies/${companyId}/members/${ownerMemberId}/archive`)
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("owners cannot be removed");
+    expect(mockAccessService.archiveMember).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -45,7 +45,7 @@ import {
   updateUserCompanyAccessSchema,
   PERMISSION_KEYS
 } from "@paperclipai/shared";
-import type { DeploymentExposure, DeploymentMode, HumanCompanyMembershipRole, PermissionKey } from "@paperclipai/shared";
+import type { DeploymentExposure, DeploymentMode, HumanCompanyMembershipRole, PermissionKey, PrincipalType } from "@paperclipai/shared";
 import {
   forbidden,
   conflict,
@@ -1090,7 +1090,15 @@ async function getProtectedMemberReason(
     operation?: "archive" | "update";
   },
 ): Promise<string | null> {
-  if (member.principalType !== "user") return "Only human company members can be removed.";
+  const operation = opts?.operation ?? "update";
+  if (member.principalType !== "user") {
+    // Non-human (e.g. agent) memberships: allow grant/permission updates so
+    // callers with users:manage_permissions can adjust scoped grants on agents
+    // through the API. Destructive operations (archive/remove) still go through
+    // human-only flows today and remain blocked here.
+    if (operation === "archive") return "Only human company members can be removed.";
+    return null;
+  }
   if (req.actor.type !== "board") return "Board access is required to remove members.";
   if (member.principalId === req.actor.userId) return "You cannot remove yourself.";
   const isTargetInstanceAdmin = opts?.instanceAdminUserIds
@@ -4293,9 +4301,22 @@ export function accessRoutes(
         entityType: "company_membership",
         entityId: memberId,
         details: {
+          principalType: updated.principalType,
           grantCount: req.body.grants?.length ?? 0,
         },
       });
+      if (updated.principalType !== "user") {
+        const grants = await access.listPrincipalGrants(
+          companyId,
+          updated.principalType as PrincipalType,
+          updated.principalId,
+        );
+        res.json({
+          ...updated,
+          grants,
+        });
+        return;
+      }
       const member = (await loadCompanyMemberRecords(db, companyId)).find(
         (entry) => entry.id === memberId,
       );

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1087,17 +1087,19 @@ async function getProtectedMemberReason(
   opts?: {
     actorRole?: HumanCompanyMembershipRole | null;
     instanceAdminUserIds?: ReadonlySet<string>;
-    operation?: "archive" | "update";
+    operation?: "archive" | "update" | "update-grants";
   },
 ): Promise<string | null> {
   const operation = opts?.operation ?? "update";
   if (member.principalType !== "user") {
-    // Non-human (e.g. agent) memberships: allow grant/permission updates so
-    // callers with users:manage_permissions can adjust scoped grants on agents
-    // through the API. Destructive operations (archive/remove) still go through
-    // human-only flows today and remain blocked here.
-    if (operation === "archive") return "Only human company members can be removed.";
-    return null;
+    // Non-human (e.g. agent) memberships: only the explicit "update-grants"
+    // path is allowed, so callers with users:manage_permissions can adjust
+    // scoped grants on agent principals through PATCH /permissions. The
+    // default "update" and "archive" paths still call loadCompanyMemberRecords
+    // (human-only) after mutating, which would leak inconsistent state for
+    // agent members — keep them blocked here.
+    if (operation === "update-grants") return null;
+    return "Only human company members can be removed.";
   }
   if (req.actor.type !== "board") return "Board access is required to remove members.";
   if (member.principalId === req.actor.userId) return "You cannot remove yourself.";
@@ -1130,7 +1132,7 @@ async function assertCanManageCompanyMember(
   access: ReturnType<typeof accessService>,
   companyId: string,
   member: { principalId: string; principalType: string; membershipRole: string | null },
-  operation: "archive" | "update" = "update",
+  operation: "archive" | "update" | "update-grants" = "update",
 ) {
   const reason = await getProtectedMemberReason(req, access, companyId, member, { operation });
   if (reason) throw forbidden(reason);
@@ -4285,7 +4287,7 @@ export function accessRoutes(
       await assertCompanyPermission(req, companyId, "users:manage_permissions");
       const memberToUpdate = await access.getMemberById(companyId, memberId);
       if (!memberToUpdate) throw notFound("Member not found");
-      await assertCanManageCompanyMember(req, access, companyId, memberToUpdate);
+      await assertCanManageCompanyMember(req, access, companyId, memberToUpdate, "update-grants");
       const updated = await access.setMemberPermissions(
         companyId,
         memberId,
@@ -4293,6 +4295,18 @@ export function accessRoutes(
         req.actor.userId ?? null
       );
       if (!updated) throw notFound("Member not found");
+      // For agent principals we read back grants directly because
+      // loadCompanyMemberRecords is human-only. Do the readback before
+      // writing the activity log so a readback failure does not leave a
+      // duplicate log row on the inevitable client retry.
+      let agentGrants: Awaited<ReturnType<typeof access.listPrincipalGrants>> | null = null;
+      if (updated.principalType !== "user") {
+        agentGrants = await access.listPrincipalGrants(
+          companyId,
+          updated.principalType as PrincipalType,
+          updated.principalId,
+        );
+      }
       await logActivity(db, {
         companyId,
         actorType: "user",
@@ -4305,15 +4319,10 @@ export function accessRoutes(
           grantCount: req.body.grants?.length ?? 0,
         },
       });
-      if (updated.principalType !== "user") {
-        const grants = await access.listPrincipalGrants(
-          companyId,
-          updated.principalType as PrincipalType,
-          updated.principalId,
-        );
+      if (agentGrants !== null) {
         res.json({
           ...updated,
-          grants,
+          grants: agentGrants,
         });
         return;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Company access control is the subsystem that decides which human and agent principals can receive operational grants.
> - Agent-principal memberships already exist and are used for local agents such as QA and Reviewer.
> - The member-permissions API rejected every non-user membership through the protected-member guard, even for non-destructive grant updates.
> - MAT-121 had to bypass the API with a direct embedded-Postgres grant insert, which is fragile and skips the intended permission workflow.
> - This pull request scopes the guard so `PATCH /members/:memberId/permissions` can update grants for agent-principal memberships while destructive/archive paths and unrelated member mutation routes remain blocked.
> - The benefit is that future agent grants can use the supported API path instead of direct database bootstrap workarounds.

## What Changed

- Added an explicit `"update-grants"` protected-member operation and made only `PATCH /api/companies/:companyId/members/:memberId/permissions` opt into it.
- Kept the default member update/archive guard strict for agent-principal memberships, including `PATCH /members/:memberId` and `PATCH /members/:memberId/role-and-grants`.
- Updated the permissions handler to return non-user membership records plus `listPrincipalGrants` readback directly, because `loadCompanyMemberRecords` is intentionally human-only.
- Moved grant readback before the activity-log write so a readback failure does not create duplicate `company_member.permissions_updated` rows on retry.
- Added focused tests for agent-principal grant update, protected archive behavior, regular human archive behavior, and the two unrelated PATCH member routes staying blocked for agent principals.
- Tightened the archive happy-path assertion to accept only the two expected statuses from the minimal DB stub.

## Verification

- [x] `pnpm exec vitest run src/__tests__/company-member-permissions-route.test.ts` — 6/6 passing after Greptile follow-up.
- [x] `pnpm exec vitest run src/__tests__/{access-service,access-validators,company-user-directory-route}.test.ts` — 8/8 passing after Greptile follow-up.
- [x] GitHub Actions on this PR are green: policy, typecheck/release registry, server tests, workspace tests, build, serialized server suites, canary dry run, e2e, verify, and Snyk.
- [x] Greptile follow-up review on commit `590d1ad3` says all findings are resolved and LGTM.
- [ ] Manual local API smoke against the patched server: grant a harmless permission to an agent-principal member via `PATCH /api/companies/<companyId>/members/<agent-member-id>/permissions`, then remove it via the same API. This cannot be completed against the currently installed `paperclipai@2026.428.0` package because it still has the old guard.

## Risks

- Low migration risk: no schema changes and no data migration.
- Main behavioral risk is accidentally allowing broader agent-member mutation than intended; this is mitigated by the explicit `"update-grants"` operation token and regression tests proving the other two PATCH member routes still 403 before DB writes.
- `PATCH /permissions` still requires the existing `users:manage_permissions` gate, so this does not create a new unauthenticated or low-privilege grant path.
- Manual end-to-end API verification is still pending until the patched server is run locally from source or published upstream.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude Opus 4.7 via Claude Code, 1M context, with shell/file-edit tool use for the implementation and tests.
- OpenAI Codex (GPT-5) via Paperclip heartbeat for PR hygiene and template update only; no code changes in this PR body update.

## Checklist

- [x] I have included a thinking path that traces from project context to this change.
- [x] I have specified the model used (with version and capability details).
- [x] I have checked ROADMAP.md and confirmed this PR is a targeted bug fix that does not duplicate planned core feature work.
- [x] I have run tests locally and they pass.
- [x] I have added or updated tests where applicable.
- [x] If this change affects the UI, I have included before/after screenshots. Not applicable: API/server-only change.
- [x] I have updated relevant documentation to reflect my changes. Not applicable beyond this PR description: no user-facing docs change.
- [x] I have considered and documented any risks above.
- [x] I will address all Greptile and reviewer comments before requesting merge.

Refs MAT-148, MAT-121.
