### PR TITLE
fix(recovery): skip handoff and stranded-issue escalation when issue has future scheduled monitor

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4139,6 +4139,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeAgentId: issues.assigneeAgentId,
         assigneeUserId: issues.assigneeUserId,
         executionState: issues.executionState,
+        executionPolicy: issues.executionPolicy,
+        monitorNextCheckAt: issues.monitorNextCheckAt,
         projectId: issues.projectId,
       })
       .from(issues)

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -280,6 +280,42 @@ function isAgentInvokable(agent: typeof agents.$inferSelect | null | undefined) 
   return Boolean(agent && !["paused", "terminated", "pending_approval"].includes(agent.status));
 }
 
+function readIssueMonitorRecord(issue: typeof issues.$inferSelect): Record<string, unknown> | null {
+  const state = issue.executionState as Record<string, unknown> | null;
+  const policy = issue.executionPolicy as Record<string, unknown> | null;
+  const stateMonitor = state?.monitor as Record<string, unknown> | null;
+  const policyMonitor = policy?.monitor as Record<string, unknown> | null;
+  return stateMonitor ?? policyMonitor ?? null;
+}
+
+/**
+ * Returns true when the issue has a future scheduled monitor checkpoint.
+ *
+ * Issues backed by a scheduled routine or an external-service monitor declare
+ * their next wake via monitorNextCheckAt (the authoritative DB column) or via
+ * executionPolicy/executionState monitor.nextCheckAt.  While that checkpoint is
+ * in the future the issue has a live continuation path — recovery actions must
+ * not treat it as stranded and must not escalate it to blocked.
+ */
+function issueHasFutureScheduledMonitor(issue: typeof issues.$inferSelect, nowMs = Date.now()): boolean {
+  // Authoritative DB-indexed column — set whenever the issue scheduler syncs monitor state.
+  const dbNextAt = issue.monitorNextCheckAt;
+  if (dbNextAt !== null && dbNextAt !== undefined) {
+    const dbMs = dbNextAt instanceof Date ? dbNextAt.getTime() : new Date(dbNextAt as string).getTime();
+    if (!Number.isNaN(dbMs) && dbMs > nowMs) return true;
+  }
+
+  // Fallback: read from the monitor blob in executionState (preferred) or executionPolicy.
+  const monitor = readIssueMonitorRecord(issue);
+  if (monitor?.nextCheckAt) {
+    const rawAt = monitor.nextCheckAt as string | Date;
+    const monMs = rawAt instanceof Date ? rawAt.getTime() : new Date(rawAt).getTime();
+    if (!Number.isNaN(monMs) && monMs > nowMs) return true;
+  }
+
+  return false;
+}
+
 function isStrandedIssueRecoveryIssue(issue: Pick<typeof issues.$inferSelect, "originKind">) {
   return isStrandedIssueRecoveryOriginKind(issue.originKind);
 }
@@ -2382,6 +2418,15 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      // Skip issues that have a future scheduled monitor continuation — the next
+      // monitor check or routine tick is the declared live path, so recovery would
+      // be a false positive.  This mirrors the hasScheduledMonitor guard used by
+      // the liveness graph classifier for blocked/in_review issues.
+      if (issueHasFutureScheduledMonitor(issue)) {
         result.skipped += 1;
         continue;
       }

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -30,6 +30,8 @@ const issue = {
   assigneeAgentId: "agent-1",
   assigneeUserId: null,
   executionState: null,
+  executionPolicy: null,
+  monitorNextCheckAt: null,
 } as any;
 
 const agent = {
@@ -176,6 +178,49 @@ describe("successful run handoff decision", () => {
       kind: "skip",
       reason: "issue monitor run owns its own recovery path",
     });
+  });
+
+  it("does not queue when the issue has a future monitorNextCheckAt (routine-backed continuation)", () => {
+    // Regression guard for: routine-backed in_progress issues were getting incorrectly
+    // flagged as missing-disposition and escalated to blocked between routine ticks.
+    // A future monitorNextCheckAt means the issue has a live scheduled continuation path.
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000).toISOString(); // 1 hour from now
+    expect(decide({
+      issue: { ...issue, monitorNextCheckAt: futureDate, executionPolicy: null } as any,
+    })).toEqual({
+      kind: "skip",
+      reason: "issue has a future scheduled monitor continuation path",
+    });
+  });
+
+  it("does not queue when executionPolicy.monitor.nextCheckAt is in the future (routine-backed, DB column not yet synced)", () => {
+    const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(); // 24 hours from now
+    expect(decide({
+      issue: {
+        ...issue,
+        monitorNextCheckAt: null,
+        executionPolicy: {
+          mode: "normal",
+          monitor: {
+            kind: "external_service",
+            nextCheckAt: futureDate,
+            serviceName: "routine:ba937eda-9871-4761-9491-e69fbf5f0e37",
+          },
+        },
+      } as any,
+    })).toEqual({
+      kind: "skip",
+      reason: "issue has a future scheduled monitor continuation path",
+    });
+  });
+
+  it("does queue when monitorNextCheckAt is in the past (overdue monitor)", () => {
+    const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1 hour ago
+    const decision = decide({
+      issue: { ...issue, monitorNextCheckAt: pastDate, executionPolicy: null } as any,
+    });
+    // Overdue monitor = no live path; handoff should still fire if all other checks pass.
+    expect(decision.kind).toBe("enqueue");
   });
 
   it("uses a stable one-attempt idempotency key", () => {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -45,7 +45,16 @@ export function isIdempotentFinishSuccessfulRunHandoffWakeStatus(status: string)
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
 type IssueRow = Pick<
   typeof issues.$inferSelect,
-  "id" | "companyId" | "identifier" | "title" | "status" | "assigneeAgentId" | "assigneeUserId" | "executionState"
+  | "id"
+  | "companyId"
+  | "identifier"
+  | "title"
+  | "status"
+  | "assigneeAgentId"
+  | "assigneeUserId"
+  | "executionState"
+  | "executionPolicy"
+  | "monitorNextCheckAt"
 >;
 type AgentRow = Pick<typeof agents.$inferSelect, "id" | "companyId" | "status">;
 type NoticeIssue = Pick<typeof issues.$inferSelect, "id" | "identifier" | "title" | "status">;
@@ -282,6 +291,37 @@ function readString(value: unknown) {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function readDateMs(value: unknown): number | null {
+  if (!(typeof value === "string" || value instanceof Date)) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+/**
+ * Returns true when the issue has a scheduled continuation path via its monitor
+ * fields — either the DB-level monitorNextCheckAt column or the executionPolicy
+ * monitor's nextCheckAt — and that checkpoint is still in the future.
+ *
+ * Routine-backed issues (e.g. ones driven by a daily scheduled routine) only
+ * need a handoff disposition once the current monitoring window has passed.
+ * Firing a corrective-handoff wake before that time would incorrectly mark the
+ * issue "missing disposition" and trigger a blocked/recovery cycle.
+ */
+function hasScheduledMonitorContinuation(issue: IssueRow, nowMs = Date.now()): boolean {
+  // Prefer the DB-indexed column (monitorNextCheckAt) which is always authoritative.
+  const dbNextMs = readDateMs(issue.monitorNextCheckAt);
+  if (dbNextMs !== null && dbNextMs > nowMs) return true;
+
+  // Fall back to the executionPolicy monitor's nextCheckAt so we catch issues
+  // whose monitor was declared in policy but whose DB column hasn't been synced yet.
+  const policyMonitor = readRecord(readRecord(issue.executionPolicy)?.monitor);
+  const policyNextMs = readDateMs(policyMonitor.nextCheckAt);
+  if (policyNextMs !== null && policyNextMs > nowMs) return true;
+
+  return false;
+}
+
 function isCorrectiveHandoffRun(run: HeartbeatRunRow) {
   const context = readRecord(run.contextSnapshot);
   return context.handoffRequired === true ||
@@ -364,6 +404,9 @@ export function decideSuccessfulRunHandoff(input: {
   if (issue.assigneeUserId) return { kind: "skip", reason: "issue is human-owned" };
   if (issue.status !== "in_progress") return { kind: "skip", reason: `issue status ${issue.status} is a valid disposition` };
   if (issue.executionState) return { kind: "skip", reason: "issue has execution policy state" };
+  if (hasScheduledMonitorContinuation(issue)) {
+    return { kind: "skip", reason: "issue has a future scheduled monitor continuation path" };
+  }
   if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") {
     return { kind: "skip", reason: `agent status ${agent.status} is not invokable` };
   }


### PR DESCRIPTION
## Summary

Fixes the recovery loop for routine-backed issues. When an issue has a scheduled monitor check in the future, the system should skip the handoff and stranded-issue escalation logic to prevent false recovery attempts.

## Changes

- 4 files changed, 136 insertions
- Prevents recovery from interrupting issues with valid scheduled monitor continuations

## Testing

Branch tested locally. The fix ensures recovery does not falsely escalate issues that have legitimate future monitor checks scheduled.

## Related

- Paperclip MIL-29
- Paperclip MIL-30

Created by GitHubOps agent.