### PR TITLE
Fix templates.js build issue in plugin-llm-wiki

### DIFF
--- a/packages/plugins/plugin-llm-wiki/esbuild.config.mjs
+++ b/packages/plugins/plugin-llm-wiki/esbuild.config.mjs
@@ -5,7 +5,10 @@ const presets = createPluginBundlerPresets({ uiEntry: "src/ui/index.tsx" });
 const watch = process.argv.includes("--watch");
 
 const workerCtx = await esbuild.context(presets.esbuild.worker);
-const manifestCtx = await esbuild.context(presets.esbuild.manifest);
+const manifestCtx = await esbuild.context({
+  ...presets.esbuild.manifest,
+  entryPoints: [...(presets.esbuild.manifest.entryPoints ?? []), "src/templates.ts"],
+});
 const uiCtx = await esbuild.context(presets.esbuild.ui);
 
 if (watch) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The plugin-llm-wiki subsystem is responsible for managing AI interactions.
> - A runtime module-not-found error occurred due to templates.ts not being compiled.
> - This issue arises from the manifest esbuild preset not including templates.ts as an entry point.
> - This pull request adds templates.ts as an entry point in the esbuild configuration.
> - The benefit is resolving the runtime error and ensuring proper module loading.

## What Changed

- Added templates.ts as an entry point in the esbuild configuration for the plugin-llm-wiki.

## Verification

- Build the plugin using the updated esbuild configuration and verify that dist/templates.js is emitted without errors.

## Risks

- Low risk; primarily affects the build process without altering runtime behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

None — human-authored.

## Checklist

- [ ] I have included a thinking path that traces from project context to this change
- [ ] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [ ] I have updated relevant documentation to reflect my changes
- [ ] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge

