### PR TITLE
fix: detect issue-prefix collisions through drizzle's error cause chain

### DIFF
--- a/server/src/services/companies.test.ts
+++ b/server/src/services/companies.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { isIssuePrefixConflict } from "./companies.js";
+
+// Shapes mirror what the runtime drivers actually produce:
+// - drizzle-orm DrizzleQueryError sets `.cause` to the original driver error
+// - postgres-js PostgresError exposes the constraint as `.constraint_name`
+// - node-postgres exposes it as `.constraint`
+const pgError = (over: Record<string, unknown> = {}) => ({
+  code: "23505",
+  constraint_name: "companies_issue_prefix_idx",
+  ...over,
+});
+const drizzleWrap = (cause: unknown) => ({
+  name: "DrizzleQueryError",
+  message: "Failed query: insert into \"companies\" ...",
+  cause,
+});
+
+describe("isIssuePrefixConflict", () => {
+  it("detects the conflict through a drizzle cause chain (postgres-js)", () => {
+    expect(isIssuePrefixConflict(drizzleWrap(pgError()))).toBe(true);
+  });
+
+  it("detects the conflict on a bare postgres error", () => {
+    expect(isIssuePrefixConflict(pgError())).toBe(true);
+  });
+
+  it("accepts node-postgres style `.constraint`", () => {
+    expect(
+      isIssuePrefixConflict(
+        drizzleWrap(pgError({ constraint_name: undefined, constraint: "companies_issue_prefix_idx" })),
+      ),
+    ).toBe(true);
+  });
+
+  it("walks more than one wrapper layer (bounded)", () => {
+    expect(isIssuePrefixConflict(drizzleWrap(drizzleWrap(pgError())))).toBe(true);
+  });
+
+  it("does not retry a 23505 from a different constraint", () => {
+    expect(
+      isIssuePrefixConflict(drizzleWrap(pgError({ constraint_name: "companies_name_idx" }))),
+    ).toBe(false);
+  });
+
+  it("does not match non-unique-violation errors", () => {
+    expect(isIssuePrefixConflict(drizzleWrap(pgError({ code: "25P02" })))).toBe(false);
+  });
+
+  it("is safe on null, primitives, and cause-less errors", () => {
+    expect(isIssuePrefixConflict(null)).toBe(false);
+    expect(isIssuePrefixConflict(undefined)).toBe(false);
+    expect(isIssuePrefixConflict("boom")).toBe(false);
+    expect(isIssuePrefixConflict(new Error("no cause"))).toBe(false);
+  });
+
+  it("terminates on a self-referential cause chain", () => {
+    const cyclic: { cause?: unknown } = {};
+    cyclic.cause = cyclic;
+    expect(isIssuePrefixConflict(cyclic)).toBe(false);
+  });
+});

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -32,6 +32,42 @@ import {
 import { notFound, unprocessable } from "../errors.js";
 import { environmentService } from "./environments.js";
 
+const ISSUE_PREFIX_CONFLICT_CONSTRAINT = "companies_issue_prefix_idx";
+
+/**
+ * True when `error` represents a unique-constraint violation on the company
+ * issue-prefix index.
+ *
+ * drizzle-orm wraps the driver error in a DrizzleQueryError whose `.cause`
+ * is the original PostgresError, so the SQLSTATE/constraint metadata is not
+ * on the top-level error. We walk a bounded cause chain rather than checking
+ * a fixed depth so a future drizzle version that adds an intermediate
+ * wrapper doesn't silently reintroduce the swallow-as-HTTP-500 bug.
+ *
+ * node-postgres exposes the constraint as `.constraint`; postgres-js (the
+ * driver in use here) exposes it as `.constraint_name` — accept either.
+ */
+export function isIssuePrefixConflict(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current != null; depth += 1) {
+    if (typeof current !== "object") break;
+    const e = current as {
+      code?: string;
+      constraint?: string;
+      constraint_name?: string;
+      cause?: unknown;
+    };
+    if (
+      e.code === "23505"
+      && (e.constraint ?? e.constraint_name) === ISSUE_PREFIX_CONFLICT_CONSTRAINT
+    ) {
+      return true;
+    }
+    current = e.cause;
+  }
+  return false;
+}
+
 export function companyService(db: Db) {
   const ISSUE_PREFIX_FALLBACK = "CMP";
   const environmentsSvc = environmentService(db);
@@ -124,19 +160,11 @@ export function companyService(db: Db) {
     return "A".repeat(attempt - 1);
   }
 
-  function isIssuePrefixConflict(error: unknown) {
-    const constraint = typeof error === "object" && error !== null && "constraint" in error
-      ? (error as { constraint?: string }).constraint
-      : typeof error === "object" && error !== null && "constraint_name" in error
-        ? (error as { constraint_name?: string }).constraint_name
-        : undefined;
-    return typeof error === "object"
-      && error !== null
-      && "code" in error
-      && (error as { code?: string }).code === "23505"
-      && constraint === "companies_issue_prefix_idx";
-  }
-
+  // Precondition: must run on an auto-committing connection, NOT inside a
+  // db.transaction(). On a prefix collision the failed INSERT would abort an
+  // enclosing transaction (PG 25P02); the retry's next INSERT would then fail
+  // with the abort error instead of retrying. The sole caller (the create
+  // route) runs outside a transaction.
   async function createCompanyWithUniquePrefix(data: typeof companies.$inferInsert) {
     const base = deriveIssuePrefixBase(data.name);
     let suffix = 1;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; companies are the top-level tenant and every one needs a unique issue prefix.
> - Company creation lives in `server/src/services/companies.ts`; `createCompanyWithUniquePrefix` derives a 3-letter prefix from the name and is designed to retry with a longer candidate on a unique-constraint collision.
> - In practice the retry never fires: creating a company whose name derives an already-taken prefix returns HTTP 500 instead of falling back to the next prefix.
> - Root cause: `drizzle-orm` wraps the driver error in a `DrizzleQueryError` whose `.cause` holds the real `PostgresError`. `isIssuePrefixConflict` only inspected the top-level error, so it never matched SQLSTATE `23505` / the constraint name and re-threw.
> - This needs addressing because it's a hard user-facing failure on a core flow — a real instance hit it (an existing `Realty` company owned prefix `REA`; creating `Realty Services` 500'd).
> - This pull request makes the conflict check walk a bounded error cause chain and accept both driver field names, so the existing retry loop works as intended.
> - The benefit is company creation degrades gracefully to the next free prefix instead of returning an opaque 500.

## What Changed

- Hoisted `isIssuePrefixConflict` to module scope (pure predicate, captured nothing from the closure) and exported it so it is unit-testable.
- Replaced the top-level-only error inspection with a **bounded cause-chain walk** (depth 5), so the wrapped `PostgresError` is found — and a future drizzle version that adds a wrapper layer cannot silently reintroduce the regression.
- Accept both `.constraint` (node-postgres) and `.constraint_name` (postgres-js, the driver actually in use).
- Documented the non-transactional precondition of `createCompanyWithUniquePrefix` (a failed INSERT inside an enclosing transaction would abort it with PG `25P02` and defeat the retry).
- Added `server/src/services/companies.test.ts` — 8 cases.

## Verification

Reproduction before the fix (instance where `Realty` already owns prefix `REA`):

```
[12:08:06] ERROR: POST /api/companies 500 — Failed query: insert into "companies" (...)
params: Realty Services,REA,0
  "type": "DrizzleQueryError",
  caused by: PostgresError: duplicate key value violates unique constraint
  "companies_issue_prefix_idx"
    at createCompanyWithUniquePrefix (.../services/companies.ts:96:30)
```

After the fix, the same input creates the company with prefix `REAA`.

Automated:

- `pnpm typecheck` — clean for the changed files
- `pnpm vitest run src/services/companies.test.ts` — 8/8 passing

The 8 tests cover: drizzle-wrapped cause, bare postgres error, multi-layer
cause, node-postgres `.constraint`, non-matching `23505` (different
constraint → not retried), non-unique-violation SQLSTATE, null/primitive/
cause-less inputs, and a cyclic cause chain (termination).

## Risks

- **Low risk.** No schema/migration changes. No API or behavioral change outside the collision path — the retry loop, prefix derivation, and success path are unchanged. The only behavioral delta is that a prefix collision now succeeds with the next candidate instead of returning 500 (the originally intended behavior).
- A non-prefix `23505` (e.g. a future unique constraint elsewhere) is explicitly **not** retried — it still re-throws, so this cannot turn an unrelated error into a hot loop.

> `suffixForAttempt` produces `REA → REAA → REAAA` (repeated `A`s). Functional but unpolished; a numeric scheme (`REA2`, `REA3`) would read better. Deliberately left as a separate follow-up to keep this PR a focused crash fix — not core roadmap work.

## Model Used

Anthropic Claude. Implementation, root-cause analysis, and the regression
tests were produced with **`claude-sonnet-4-6`** (Sonnet 4.6). An independent
review pass (separate context, not self-approval) was run via a
code-reviewer subagent, and the final review/commit phase used
**`claude-opus-4-7`** (Opus 4.7, 1M context). Tool use and local code
execution (typecheck + vitest) were used to verify claims; extended
reasoning enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (this is a crash bugfix, not core feature work)
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — no UI change)
- [x] I have updated relevant documentation to reflect my changes (added JSDoc on the exported predicate and an inline precondition comment)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
