### PR TITLE
Add shell-safe Paperclip comment helpers

### DIFF
--- a/docs/guides/agent-developer/comments-and-communication.md
+++ b/docs/guides/agent-developer/comments-and-communication.md
@@ -7,6 +7,17 @@ Comments on issues are the primary communication channel between agents. Every s
 
 ## Posting Comments
 
+When posting from a shell, prefer the repository helpers with stdin/heredoc input. This preserves markdown line breaks and prevents shell-looking text from being expanded while building JSON:
+
+```bash
+scripts/paperclip-issue-comment.sh --issue-id "$PAPERCLIP_TASK_ID" <<'MD'
+Update
+
+- Completed the JWT signing change
+- Literal examples like $(command), ${VAR}, and `code` remain data here
+MD
+```
+
 ```
 POST /api/issues/{issueId}/comments
 { "body": "## Update\n\nCompleted JWT signing.\n\n- Added RS256 support\n- Tests passing\n- Still need refresh token logic" }
@@ -18,6 +29,19 @@ You can also add a comment when updating an issue:
 PATCH /api/issues/{issueId}
 { "status": "done", "comment": "Implemented login endpoint with JWT auth." }
 ```
+
+For shell-driven status updates, use stdin/heredoc as well:
+
+```bash
+scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
+Done
+
+- Implemented login endpoint with JWT auth
+- Verified the synthetic $() / ${VAR} / `code` regression stays literal
+MD
+```
+
+Avoid manually embedding multiline markdown, backticks, `$()`, or `${VAR}` examples inside double-quoted shell JSON. If you need raw API access, build the JSON with a file or `jq --arg body "$body"` from heredoc-captured content.
 
 ## Comment Style
 

--- a/scripts/paperclip-comment-helpers.test.mjs
+++ b/scripts/paperclip-comment-helpers.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import test from "node:test";
+
+function runHelper(script, args, input) {
+  return execFileSync("bash", [script, ...args], {
+    cwd: new URL("..", import.meta.url),
+    encoding: "utf8",
+    input,
+  }).trim();
+}
+
+test("issue update helper preserves stdin markdown with shell-looking text", () => {
+  const body = [
+    "Update",
+    "",
+    "- Synthetic command text: $(printf DO_NOT_RUN)",
+    "- Synthetic env text: ${SYNTHETIC_SECRET}",
+    "- Inline code: `echo no`",
+  ].join("\n");
+
+  const raw = runHelper(
+    "scripts/paperclip-issue-update.sh",
+    ["--issue-id", "issue-123", "--status", "in_progress", "--dry-run"],
+    body,
+  );
+  const payload = JSON.parse(raw);
+
+  assert.equal(payload.status, "in_progress");
+  assert.equal(payload.comment, body);
+});
+
+test("issue comment helper preserves stdin markdown with shell-looking text", () => {
+  const body = [
+    "Comment",
+    "",
+    "- Synthetic command text: $(printf DO_NOT_RUN)",
+    "- Synthetic env text: ${SYNTHETIC_SECRET}",
+    "- Inline code: `echo no`",
+  ].join("\n");
+
+  const raw = runHelper(
+    "scripts/paperclip-issue-comment.sh",
+    ["--issue-id", "issue-123", "--dry-run"],
+    body,
+  );
+  const payload = JSON.parse(raw);
+
+  assert.deepEqual(payload, { body });
+});
+
+test("inline update comments reject shell-expansion-looking text", () => {
+  const result = spawnSync(
+    "bash",
+    [
+      "scripts/paperclip-issue-update.sh",
+      "--issue-id",
+      "issue-123",
+      "--comment",
+      "synthetic $(printf DO_NOT_RUN)",
+      "--dry-run",
+    ],
+    {
+      cwd: new URL("..", import.meta.url),
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Refusing shell-risky --comment content/);
+});
+
+test("inline comment bodies reject shell-expansion-looking text", () => {
+  const result = spawnSync(
+    "bash",
+    [
+      "scripts/paperclip-issue-comment.sh",
+      "--issue-id",
+      "issue-123",
+      "--body",
+      "synthetic ${SYNTHETIC_SECRET}",
+      "--dry-run",
+    ],
+    {
+      cwd: new URL("..", import.meta.url),
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Refusing shell-risky --body content/);
+});

--- a/scripts/paperclip-issue-comment.sh
+++ b/scripts/paperclip-issue-comment.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/paperclip-issue-comment.sh [--issue-id ID] [--body TEXT] [--dry-run]
+
+Posts a comment to POST /api/issues/{issueId}/comments. Prefer stdin/heredoc
+input for comment bodies; it preserves newlines and avoids accidental shell
+expansion in inline JSON or double-quoted shell strings.
+
+Examples:
+  scripts/paperclip-issue-comment.sh --issue-id "$PAPERCLIP_TASK_ID" <<'MD'
+  Update
+
+  - Verified the comment body keeps line breaks
+  - Literal examples like $(command), ${VAR}, and `code` remain data
+  MD
+
+  scripts/paperclip-issue-comment.sh --issue-id "$PAPERCLIP_TASK_ID" --dry-run <<'MD'
+  Dry-run comment
+  MD
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'Missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+guard_inline_body() {
+  local value="$1"
+  if [[ "$value" == *$'\n'* || "$value" == *'$('* || "$value" == *'${'* || "$value" == *'`'* ]]; then
+    cat >&2 <<'EOF'
+Refusing shell-risky --body content.
+
+Pass multiline or shell-looking markdown via stdin/heredoc instead, for example:
+
+  scripts/paperclip-issue-comment.sh --issue-id "$PAPERCLIP_TASK_ID" <<'MD'
+  Update
+
+  - Literal examples like $(command), ${VAR}, and `code` remain data here.
+  MD
+EOF
+    exit 2
+  fi
+}
+
+issue_id="${PAPERCLIP_TASK_ID:-}"
+body_arg=""
+body_from_arg=0
+dry_run=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue-id)
+      issue_id="${2:-}"
+      shift 2
+      ;;
+    --body)
+      body_arg="${2:-}"
+      body_from_arg=1
+      shift 2
+      ;;
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$issue_id" ]]; then
+  printf 'Missing issue id. Pass --issue-id or set PAPERCLIP_TASK_ID.\n' >&2
+  exit 1
+fi
+
+body=""
+if [[ "$body_from_arg" == "1" ]]; then
+  guard_inline_body "$body_arg"
+  body="$body_arg"
+elif [[ ! -t 0 ]]; then
+  body="$(cat)"
+fi
+
+if [[ -z "$body" ]]; then
+  printf 'Missing comment body. Pass --body or pipe stdin.\n' >&2
+  exit 1
+fi
+
+require_command jq
+
+payload="$(jq -nc --arg body "$body" '{body: $body}')"
+
+if [[ "$dry_run" == "1" ]]; then
+  printf '%s\n' "$payload"
+  exit 0
+fi
+
+if [[ -z "${PAPERCLIP_API_URL:-}" || -z "${PAPERCLIP_API_KEY:-}" || -z "${PAPERCLIP_RUN_ID:-}" ]]; then
+  printf 'Missing PAPERCLIP_API_URL, PAPERCLIP_API_KEY, or PAPERCLIP_RUN_ID.\n' >&2
+  exit 1
+fi
+
+curl -sS -X POST \
+  "$PAPERCLIP_API_URL/api/issues/$issue_id/comments" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H 'Content-Type: application/json' \
+  --data-binary "$payload"

--- a/scripts/paperclip-issue-update.sh
+++ b/scripts/paperclip-issue-update.sh
@@ -9,6 +9,10 @@ Usage:
 
 Reads a multiline markdown comment from stdin when stdin is piped. This preserves
 newlines when building the JSON payload for PATCH /api/issues/{issueId}.
+Prefer stdin/heredoc input for comments. The --comment argument is rejected when
+it contains newlines or shell-expansion-looking markdown such as $(), ${}, or
+backticks because those are easy to expand accidentally in shell commands before
+this helper receives them.
 
 Examples:
   scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status in_progress <<'MD'
@@ -33,9 +37,28 @@ require_command() {
   fi
 }
 
+guard_inline_comment() {
+  local value="$1"
+  if [[ "$value" == *$'\n'* || "$value" == *'$('* || "$value" == *'${'* || "$value" == *'`'* ]]; then
+    cat >&2 <<'EOF'
+Refusing shell-risky --comment content.
+
+Pass multiline or shell-looking markdown via stdin/heredoc instead, for example:
+
+  scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status in_progress <<'MD'
+  Update
+
+  - Literal examples like $(command), ${VAR}, and `code` remain data here.
+  MD
+EOF
+    exit 2
+  fi
+}
+
 issue_id="${PAPERCLIP_TASK_ID:-}"
 status=""
 comment_arg=""
+comment_from_arg=0
 dry_run=0
 
 while [[ $# -gt 0 ]]; do
@@ -50,6 +73,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --comment)
       comment_arg="${2:-}"
+      comment_from_arg=1
       shift 2
       ;;
     --dry-run)
@@ -74,7 +98,8 @@ if [[ -z "$issue_id" ]]; then
 fi
 
 comment=""
-if [[ -n "$comment_arg" ]]; then
+if [[ "$comment_from_arg" == "1" ]]; then
+  guard_inline_comment "$comment_arg"
   comment="$comment_arg"
 elif [[ ! -t 0 ]]; then
   comment="$(cat)"

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -113,7 +113,7 @@ Headers: X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 { "status": "done", "comment": "What was done and why." }
 ```
 
-For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string — that is how comments get "smooshed" together. Use the helper below (or an equivalent `jq --arg` pattern reading from a heredoc/file) so literal newlines survive JSON encoding:
+For multiline markdown comments, do **not** hand-inline the markdown into a one-line JSON string — that is how comments get "smooshed" together and can accidentally expand shell/runtime text before Paperclip receives it. Use the helpers below (or an equivalent `jq --arg` pattern reading from a heredoc/file) so literal newlines, `$()`, `${VAR}`, and backticks remain data:
 
 ```bash
 scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status done <<'MD'
@@ -123,6 +123,18 @@ Done
 - Verified the raw stored comment body keeps paragraph breaks
 MD
 ```
+
+To add a comment without changing issue status, use:
+
+```bash
+scripts/paperclip-issue-comment.sh --issue-id "$PAPERCLIP_TASK_ID" <<'MD'
+Update
+
+- Literal examples like $(command), ${VAR}, and `code` remain data here.
+MD
+```
+
+The helper `--comment` and `--body` inline arguments are only for short plain text. They reject newlines and shell-expansion-looking content; use stdin/heredoc for markdown, code examples, environment variable names, command substitutions, or anything copied from a runtime.
 
 Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled`. Priority values: `critical`, `high`, `medium`, `low`. Other updatable fields: `title`, `description`, `priority`, `assigneeAgentId`, `projectId`, `goalId`, `parentId`, `billingCode`, `blockedByIssueIds`.
 


### PR DESCRIPTION
## Summary

Implements [ITO-187](/ITO/issues/ITO-187): shell-safe helper paths and documentation for Paperclip issue comments/status updates after the published-comment credential exposure follow-up.

- Adds `scripts/paperclip-issue-comment.sh` for safe `POST /api/issues/:id/comments` bodies via stdin/heredoc.
- Strengthens `scripts/paperclip-issue-update.sh` so inline `--comment` rejects newlines and shell-expansion-looking markdown; heredoc/stdin remains the safe path.
- Documents the safe pattern in the Paperclip skill and agent developer comments guide.
- Adds synthetic regression coverage only; no exposed comment body or secret value is copied.

## Verification

- `bash -n scripts/paperclip-issue-update.sh scripts/paperclip-issue-comment.sh`
- `node --test scripts/paperclip-comment-helpers.test.mjs`

## Diff Stat

```text
 .../agent-developer/comments-and-communication.md  |  24 ++++
 scripts/paperclip-comment-helpers.test.mjs         |  92 ++++++++++++++++
 scripts/paperclip-issue-comment.sh                 | 122 +++++++++++++++++++++
 scripts/paperclip-issue-update.sh                  |  27 ++++-
 skills/paperclip/SKILL.md                          |  14 ++-
 5 files changed, 277 insertions(+), 2 deletions(-)
```

## Raw Diff Excerpt

```diff
+guard_inline_comment() {
+  local value="$1"
+  if [[ "$value" == *$'\n'* || "$value" == *'$('* || "$value" == *'${'* || "$value" == *'`'* ]]; then
+    cat >&2 <<'EOF'
+Refusing shell-risky --comment content.
+
+Pass multiline or shell-looking markdown via stdin/heredoc instead, for example:
+
+  scripts/paperclip-issue-update.sh --issue-id "$PAPERCLIP_TASK_ID" --status in_progress <<'MD'
+  Update
+
+  - Literal examples like $(command), ${VAR}, and `code` remain data here.
+  MD
+EOF
+    exit 2
+  fi
+}
```

```diff
+test("issue update helper preserves stdin markdown with shell-looking text", () => {
+  const body = [
+    "Update",
+    "",
+    "- Synthetic command text: $(printf DO_NOT_RUN)",
+    "- Synthetic env text: ${SYNTHETIC_SECRET}",
+    "- Inline code: `echo no`",
+  ].join("\n");
+
+  const raw = runHelper(
+    "scripts/paperclip-issue-update.sh",
+    ["--issue-id", "issue-123", "--status", "in_progress", "--dry-run"],
+    body,
+  );
+  const payload = JSON.parse(raw);
+
+  assert.equal(payload.status, "in_progress");
+  assert.equal(payload.comment, body);
+});
+```
+
+```diff
+curl -sS -X POST \
+  "$PAPERCLIP_API_URL/api/issues/$issue_id/comments" \
+  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
+  -H 'Content-Type: application/json' \
+  --data-binary "$payload"
+```
