### PR TITLE
Fix ITO-256 review handoff mutation guard

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -76,6 +76,15 @@ const mockHeartbeatService = vi.hoisted(() => ({
   getActiveRunForAgent: vi.fn(async () => null),
   cancelRun: vi.fn(async () => null),
 }));
+const mockTxInsertValues = vi.hoisted(() => vi.fn(async () => undefined));
+const mockTx = vi.hoisted(() => ({
+  insert: vi.fn(() => ({
+    values: mockTxInsertValues,
+  })),
+}));
+const mockDb = vi.hoisted(() => ({
+  transaction: vi.fn(async (callback: (tx: typeof mockTx) => unknown) => callback(mockTx)),
+}));
 
 function registerRouteMocks() {
   vi.doMock("@paperclipai/shared/telemetry", () => ({
@@ -180,6 +189,34 @@ function makeIssue(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeExecutionReviewIssue(overrides: Record<string, unknown> = {}) {
+  return makeIssue({
+    status: "in_review",
+    assigneeAgentId: ownerAgentId,
+    executionPolicy: {
+      stages: [
+        {
+          id: "88888888-8888-4888-8888-888888888888",
+          type: "review",
+          participants: [{ type: "agent", agentId: peerAgentId }],
+        },
+      ],
+    },
+    executionState: {
+      status: "pending",
+      currentStageId: "88888888-8888-4888-8888-888888888888",
+      currentStageIndex: 0,
+      currentStageType: "review",
+      currentParticipant: { type: "agent", agentId: peerAgentId },
+      returnAssignee: { type: "agent", agentId: ownerAgentId },
+      completedStageIds: [],
+      lastDecisionId: null,
+      lastDecisionOutcome: null,
+    },
+    ...overrides,
+  });
+}
+
 function makeAgent(id: string, overrides: Record<string, unknown> = {}) {
   return {
     id,
@@ -193,7 +230,7 @@ function makeAgent(id: string, overrides: Record<string, unknown> = {}) {
 
 function createRunContextDb(contextSnapshot: Record<string, unknown> = {}) {
   return {
-    transaction: async (callback: (tx: Record<string, never>) => Promise<unknown>) => callback({}),
+    transaction: async (callback: (tx: typeof mockTx) => Promise<unknown>) => callback(mockTx),
     select: vi.fn(() => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
@@ -332,6 +369,9 @@ describe("agent issue mutation checkout ownership", () => {
     mockHeartbeatService.getActiveRunForAgent.mockResolvedValue(null);
     mockHeartbeatService.cancelRun.mockReset();
     mockHeartbeatService.cancelRun.mockResolvedValue(null);
+    mockDb.transaction.mockClear();
+    mockTx.insert.mockClear();
+    mockTxInsertValues.mockClear();
     mockIssueService.remove.mockReset();
     mockIssueService.removeAttachment.mockReset();
     mockIssueService.update.mockReset();
@@ -710,6 +750,90 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it("allows the active execution reviewer to add a handoff comment on a stale-assigned in-review issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeExecutionReviewIssue());
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Approved: source handoff recorded from the linked QA review." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).toHaveBeenCalledWith(
+      issueId,
+      "Approved: source handoff recorded from the linked QA review.",
+      expect.objectContaining({
+        agentId: peerAgentId,
+        runId: "66666666-6666-4666-8666-666666666666",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("allows the active execution reviewer to complete the review decision on a stale-assigned issue", async () => {
+    mockIssueService.getById.mockResolvedValue(makeExecutionReviewIssue());
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeExecutionReviewIssue(),
+      ...patch,
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", comment: "Approved: source handoff complete." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({
+        status: "done",
+        actorAgentId: peerAgentId,
+      }),
+      mockTx,
+    );
+  });
+
+  it("rejects active execution reviewer handoff without an agent run id", async () => {
+    mockIssueService.getById.mockResolvedValue(makeExecutionReviewIssue());
+
+    const res = await request(await createApp(peerActor({ runId: "" })))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done", comment: "Approved, but missing run id." });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(401);
+    expect(res.body.error).toBe("Agent run id required");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+    expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "delete issue",
+      (app: express.Express) => request(app).delete(`/api/issues/${issueId}`),
+      () => expect(mockIssueService.remove).not.toHaveBeenCalled(),
+    ],
+    [
+      "document upsert",
+      (app: express.Express) =>
+        request(app).put(`/api/issues/${issueId}/documents/plan`).send({ format: "markdown", body: "# unrelated" }),
+      () => expect(mockDocumentService.upsertIssueDocument).not.toHaveBeenCalled(),
+    ],
+    [
+      "title patch",
+      (app: express.Express) => request(app).patch(`/api/issues/${issueId}`).send({ title: "Unrelated reviewer edit" }),
+      () => expect(mockIssueService.update).not.toHaveBeenCalled(),
+    ],
+  ])("rejects active execution reviewer unrelated %s mutation on a stale-assigned issue", async (_name, sendRequest, assertNotMutated) => {
+    mockIssueService.getById.mockResolvedValue(makeExecutionReviewIssue());
+
+    const res = await sendRequest(await createApp(peerActor()));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+    assertNotMutated();
   });
 
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1267,7 +1267,8 @@ export function issueRoutes(
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
-    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null; executionState?: unknown },
+    options: { allowExecutionReviewHandoff?: boolean } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -1281,6 +1282,15 @@ export function issueRoutes(
     if (issue.assigneeAgentId !== actorAgentId) {
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
+      }
+      const executionState = parseIssueExecutionState(issue.executionState);
+      const isCurrentExecutionParticipant =
+        issue.status === "in_review" &&
+        executionState?.status === "pending" &&
+        executionState.currentParticipant?.type === "agent" &&
+        executionState.currentParticipant.agentId === actorAgentId;
+      if (options.allowExecutionReviewHandoff && isCurrentExecutionParticipant) {
+        return !!requireAgentRunId(req, res);
       }
       if (issue.status === "in_progress") {
         res.status(409).json({
@@ -1411,6 +1421,23 @@ export function issueRoutes(
       },
     });
     return false;
+  }
+
+  function isExecutionReviewDecisionPatchBody(body: unknown) {
+    if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+    const patch = body as Record<string, unknown>;
+    const keys = Object.keys(patch);
+    if (!keys.every((key) => key === "status" || key === "comment")) return false;
+    if (patch.status !== "done" && patch.status !== "in_progress") return false;
+    return typeof patch.comment === "string" && patch.comment.trim().length > 0;
+  }
+
+  function isExecutionReviewHandoffCommentBody(body: unknown) {
+    if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+    const input = body as Record<string, unknown>;
+    const keys = Object.keys(input);
+    if (!keys.every((key) => key === "body")) return false;
+    return typeof input.body === "string" && input.body.trim().length > 0;
   }
 
   function assertStructuredCommentFieldsAllowed(
@@ -3327,7 +3354,9 @@ export function issueRoutes(
     }
     assertCompanyAccess(req, existing.companyId);
     assertNoAgentHostWorkspaceCommandMutation(req, collectIssueWorkspaceCommandPaths(req.body));
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, {
+      allowExecutionReviewHandoff: isExecutionReviewDecisionPatchBody(req.body),
+    }))) return;
     if (!(await assertCheapRecoveryIssueAssigneeProfileAllowed(req, res, existing, req.body))) return;
 
     const actor = getActorInfo(req);
@@ -4954,7 +4983,9 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
-    if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, issue, {
+      allowExecutionReviewHandoff: isExecutionReviewHandoffCommentBody(req.body),
+    }))) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
       metadata: req.body.metadata,


### PR DESCRIPTION
## Summary

Fixes ITO-256 by adding a narrow review-handoff path through the agent issue mutation guard.

The revised change allows an agent to pass the cross-agent mutation guard only when all of these are true:
- target issue is `in_review`
- target issue has parsed execution state with `status === "pending"`
- `executionState.currentParticipant` is an agent and matches the calling agent
- the route explicitly opted into review-handoff semantics
- the calling agent has a run id, preserving run audit linkage via the existing `requireAgentRunId` path

The route opt-in is deliberately narrow:
- `PATCH /api/issues/:id` only for `{ status: "done" | "in_progress", comment: non-empty string }`
- `POST /api/issues/:id/comments` only for a plain `{ body: non-empty string }` handoff comment

Ordinary cross-agent mutation still follows the existing active-checkout override / conflict / forbidden paths. Representative unrelated reviewer mutations are covered as denied.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts` passed: 20 tests
- `pnpm --filter @paperclipai/server typecheck` passed

## Diff Stat

```text
 .../issue-agent-mutation-ownership-routes.test.ts  | 126 ++++++++++++++++++++-
 server/src/routes/issues.ts                        |  37 +++++-
 2 files changed, 159 insertions(+), 4 deletions(-)
```

## Raw Guard Diff Excerpt

```diff
@@
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
-    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null; executionState?: unknown },
+    options: { allowExecutionReviewHandoff?: boolean } = {},
   ) {
@@
     if (issue.assigneeAgentId !== actorAgentId) {
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
         return true;
       }
+      const executionState = parseIssueExecutionState(issue.executionState);
+      const isCurrentExecutionParticipant =
+        issue.status === "in_review" &&
+        executionState?.status === "pending" &&
+        executionState.currentParticipant?.type === "agent" &&
+        executionState.currentParticipant.agentId === actorAgentId;
+      if (options.allowExecutionReviewHandoff && isCurrentExecutionParticipant) {
+        return !!requireAgentRunId(req, res);
+      }
       if (issue.status === "in_progress") {
```

```diff
+  function isExecutionReviewDecisionPatchBody(body: unknown) {
+    if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+    const patch = body as Record<string, unknown>;
+    const keys = Object.keys(patch);
+    if (!keys.every((key) => key === "status" || key === "comment")) return false;
+    if (patch.status !== "done" && patch.status !== "in_progress") return false;
+    return typeof patch.comment === "string" && patch.comment.trim().length > 0;
+  }
+
+  function isExecutionReviewHandoffCommentBody(body: unknown) {
+    if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+    const input = body as Record<string, unknown>;
+    const keys = Object.keys(input);
+    if (!keys.every((key) => key === "body")) return false;
+    return typeof input.body === "string" && input.body.trim().length > 0;
+  }
```

## Review Notes

Security-sensitive surface: this changes API authorization behavior. The follow-up revision addresses QA's first review by proving active reviewers are still denied unrelated issue delete, document upsert, and title patch mutations, while allowed handoff comment / review decision paths still work and missing run id is rejected.
