### PR TITLE
fix(adapter-claude-local): restore settingsContents in prompt bundle key and execute

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -455,10 +455,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       );
     }
   }
+  let agentSettingsContents: string | null = null;
+  if (agentHome) {
+    const agentSettingsPath = path.join(agentHome, ".claude", "settings.json");
+    agentSettingsContents = await fs.readFile(agentSettingsPath, "utf-8").catch(() => null);
+  }
   const promptBundle = await prepareClaudePromptBundle({
     companyId: agent.companyId,
     skills: claudeSkillEntries.filter((entry) => desiredSkillNames.has(entry.key)),
     instructionsContents: combinedInstructionsContents,
+    settingsContents: agentSettingsContents,
     onLog,
   });
   const useManagedRemoteClaudeConfig =

--- a/packages/adapters/claude-local/src/server/prompt-cache.ts
+++ b/packages/adapters/claude-local/src/server/prompt-cache.ts
@@ -88,6 +88,7 @@ async function hashPathContents(
 async function buildClaudePromptBundleKey(input: {
   skills: SkillEntry[];
   instructionsContents: string | null;
+  settingsContents: string | null;
 }): Promise<string> {
   const hash = createHash("sha256");
   hash.update("paperclip-claude-prompt-bundle:v1\n");
@@ -103,6 +104,14 @@ async function buildClaudePromptBundleKey(input: {
   for (const entry of sortedSkills) {
     hash.update(`skill:${entry.key}:${entry.runtimeName}\n`);
     await hashPathContents(entry.source, hash, entry.runtimeName, new Set<string>());
+  }
+
+  if (input.settingsContents) {
+    hash.update("settings\n");
+    hash.update(input.settingsContents);
+    hash.update("\n");
+  } else {
+    hash.update("settings:none\n");
   }
 
   return hash.digest("hex");
@@ -135,12 +144,14 @@ export async function prepareClaudePromptBundle(input: {
   companyId: string;
   skills: SkillEntry[];
   instructionsContents: string | null;
+  settingsContents: string | null;
   onLog: AdapterExecutionContext["onLog"];
 }): Promise<ClaudePromptBundle> {
-  const { companyId, skills, instructionsContents, onLog } = input;
+  const { companyId, skills, instructionsContents, settingsContents, onLog } = input;
   const bundleKey = await buildClaudePromptBundleKey({
     skills,
     instructionsContents,
+    settingsContents,
   });
   const rootDir = path.join(resolveManagedClaudePromptCacheRoot(process.env, companyId), bundleKey);
   const skillsHome = path.join(rootDir, ".claude", "skills");
@@ -163,6 +174,11 @@ export async function prepareClaudePromptBundle(input: {
     : null;
   if (instructionsFilePath && instructionsContents) {
     await ensureReadableFile(instructionsFilePath, instructionsContents);
+  }
+
+  if (settingsContents) {
+    const settingsPath = path.join(rootDir, ".claude", "settings.json");
+    await ensureReadableFile(settingsPath, settingsContents);
   }
 
   return {


### PR DESCRIPTION
## Summary

The `2026.517.0` release dropped `settingsContents` from both `buildClaudePromptBundleKey` and `prepareClaudePromptBundle` in `prompt-cache.ts`, and from the `execute.ts` call site. This caused new pcache bundles to be written without a permission deny list in the bundle directory, creating a security regression (SEV-010).

The fix was present in `2026.416.0` (April release) but was lost in the May 17 release.

## Changes

**`prompt-cache.ts`**
- Add `settingsContents: string | null` parameter to `buildClaudePromptBundleKey`
- Include `settingsContents` in the SHA-256 hash after the skills loop
- Add `settingsContents: string | null` parameter to `prepareClaudePromptBundle`
- Write the agent settings file into the bundle directory when `settingsContents` is provided

**`execute.ts`**
- Read the agent settings file from `agentHome` before calling `prepareClaudePromptBundle`
- Pass it as `settingsContents` to `prepareClaudePromptBundle`

## Verification

`grep settingsContents` returns 8 hits in `prompt-cache.ts` and 1 hit in `execute.ts`.

The diff exactly matches the monkey-patch that was applied as an emergency workaround to local npx caches following the regression.