### PR TITLE
fix: skip pinned chat mirrors in productivity reviews

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -55,6 +55,8 @@ describeEmbeddedPostgres("productivity review service", () => {
     startedAt?: Date;
     parentId?: string | null;
     originKind?: string;
+    title?: string;
+    description?: string | null;
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
@@ -97,7 +99,8 @@ describeEmbeddedPostgres("productivity review service", () => {
     await db.insert(issues).values({
       id: issueId,
       companyId,
-      title: "Implement data import",
+      title: opts?.title ?? "Implement data import",
+      description: opts?.description ?? null,
       status: opts?.status ?? "in_progress",
       priority: "medium",
       assigneeAgentId: coderId,
@@ -358,6 +361,30 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(review?.description).toContain("Primary trigger: `long_active_duration`");
     expect(review?.priority).toBe("medium");
     expect(hold.held).toBe(false);
+  });
+
+  it("skips pinned chat mirror issues while preserving normal long-active reviews", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const pinned = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+      title: "[PIN OPEN] CEO-Jason chat mirror target - Coding Agent",
+      description: "Deliberately pinned chat mirror ticket that stays open by design.",
+    });
+    const normal = await seedAssignedIssue({
+      status: "in_progress",
+      startedAt: new Date(now.getTime() - 7 * 60 * 60 * 1000),
+    });
+    const service = productivityReviewService(db);
+
+    const pinnedResult = await service.reconcileProductivityReviews({ now, companyId: pinned.companyId });
+    const normalResult = await service.reconcileProductivityReviews({ now, companyId: normal.companyId });
+
+    expect(pinnedResult.created).toBe(0);
+    expect(pinnedResult.skipped).toBe(1);
+    expect(await listProductivityReviews(pinned.companyId)).toHaveLength(0);
+    expect(normalResult.created).toBe(1);
+    expect(await listProductivityReviews(normal.companyId)).toHaveLength(1);
   });
 
   it("creates a high-churn review even when every sampled run has a progress comment", async () => {

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -200,6 +200,12 @@ function formatTrigger(trigger: ProductivityReviewTrigger) {
   return "Long active duration";
 }
 
+function isPinnedChatMirrorIssue(issue: Pick<IssueRow, "title" | "description">) {
+  const title = issue.title.trim().toLowerCase();
+  const description = issue.description?.toLowerCase() ?? "";
+  return title.startsWith("[pin open]") && (title.includes("chat mirror") || description.includes("chat mirror"));
+}
+
 export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: EnqueueWakeup }) {
   const issuesSvc = issueService(db);
   const budgets = budgetService(db);
@@ -797,6 +803,10 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     const prefixCache = new Map<string, string>();
     for (const candidate of candidates) {
       if (!candidate.assigneeAgentId) {
+        result.skipped += 1;
+        continue;
+      }
+      if (isPinnedChatMirrorIssue(candidate)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The productivity review service watches assigned issues for stalled or high-churn execution patterns.
> - Some issues are deliberately long-lived because they are pinned chat mirror tickets, not stalled implementation work.
> - Those pinned mirrors have been producing false-positive terminal productivity review children.
> - This pull request adds a narrow suppression for issues explicitly marked as pinned chat mirrors.
> - It keeps normal long-active productivity reviews for ordinary todo/in_progress issues.
> - The benefit is less review noise without changing chat routing or weakening ordinary productivity review coverage.

## What Changed

- Added `isPinnedChatMirrorIssue` in `server/src/services/productivity-review.ts`.
- Suppresses productivity-review creation only when the title starts with `[PIN OPEN]` and either title or description contains `chat mirror`.
- Added a regression test proving a pinned chat mirror is skipped while a normal long-active issue still creates a review.
- Diff stat: `2 files changed, 38 insertions(+), 1 deletion(-)`.

Relevant raw diff excerpt:

```diff
+function isPinnedChatMirrorIssue(issue: Pick<IssueRow, "title" | "description">) {
+  const title = issue.title.trim().toLowerCase();
+  const description = issue.description?.toLowerCase() ?? "";
+  return title.startsWith("[pin open]") && (title.includes("chat mirror") || description.includes("chat mirror"));
+}
...
+      if (isPinnedChatMirrorIssue(candidate)) {
+        result.skipped += 1;
+        continue;
+      }
```

## Verification

- `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/__tests__/productivity-review-service.test.ts`
- Result after rebasing onto current `origin/master`: 1 test file passed, 12 tests passed.

## Risks

- Low risk. The suppression requires both an explicit `[PIN OPEN]` title prefix and a `chat mirror` marker, so unrelated pinned work still receives normal productivity reviews.
- No migrations, routing changes, chat bridge changes, or lockfile changes.

## Model Used

- OpenAI GPT-5 via Codex local coding agent, with tool use and medium reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
