### PR TITLE
fix: honor live external continuation recovery

### DIFF
--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -92,6 +92,59 @@ describe("issue validators", () => {
     ).toBe(false);
   });
 
+  it("allows recovery resolutions to return the source issue to in_progress only with explicit external continuation evidence", () => {
+    const parsed = resolveIssueRecoveryActionSchema.parse({
+      outcome: "false_positive",
+      sourceIssueStatus: "in_progress",
+      externalContinuation: {
+        nextCheckAt: "2026-05-09T20:30:00.000Z",
+        sourceRunId: "11111111-1111-4111-8111-111111111111",
+        pid: 567525,
+        logPath: "/tmp/oneshot-1779221563371.log",
+        notes: "External oneshot continuation is still running.",
+      },
+    });
+
+    expect(parsed).toMatchObject({
+      outcome: "false_positive",
+      sourceIssueStatus: "in_progress",
+      externalContinuation: {
+        sourceRunId: "11111111-1111-4111-8111-111111111111",
+        pid: 567525,
+        logPath: "/tmp/oneshot-1779221563371.log",
+      },
+    });
+
+    expect(
+      resolveIssueRecoveryActionSchema.safeParse({
+        outcome: "false_positive",
+        sourceIssueStatus: "in_progress",
+      }).success,
+    ).toBe(false);
+
+    expect(
+      resolveIssueRecoveryActionSchema.safeParse({
+        outcome: "false_positive",
+        sourceIssueStatus: "in_progress",
+        externalContinuation: {
+          nextCheckAt: "2026-05-09T20:30:00.000Z",
+          notes: "A scheduled check without continuation evidence is not enough.",
+        },
+      }).success,
+    ).toBe(false);
+
+    expect(
+      resolveIssueRecoveryActionSchema.safeParse({
+        outcome: "false_positive",
+        sourceIssueStatus: "in_review",
+        externalContinuation: {
+          nextCheckAt: "2026-05-09T20:30:00.000Z",
+          pid: 567525,
+        },
+      }).success,
+    ).toBe(false);
+  });
+
   it("allows cancelled recovery resolutions to atomically restore the source issue status", () => {
     expect(
       resolveIssueRecoveryActionSchema.parse({

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -272,21 +272,62 @@ const RESOLVE_ISSUE_RECOVERY_ACTION_OUTCOMES = [
   "cancelled",
 ] as const;
 
+const recoveryExternalContinuationSchema = z.object({
+  nextCheckAt: z.string().datetime(),
+  sourceRunId: z.string().uuid().optional().nullable(),
+  pid: z.number().int().positive().max(2_147_483_647).optional().nullable(),
+  logPath: z.string().trim().min(1).max(500).optional().nullable(),
+  externalRef: z.string().trim().min(1).max(500).optional().nullable(),
+  serviceName: z.string().trim().min(1).max(120).optional().nullable(),
+  notes: multilineTextSchema.pipe(z.string().trim().max(500)).optional().nullable(),
+  timeoutAt: z.string().datetime().optional().nullable(),
+  maxAttempts: z.number().int().positive().max(100).optional().nullable(),
+  recoveryPolicy: z.enum(ISSUE_EXECUTION_MONITOR_RECOVERY_POLICIES).optional().nullable(),
+}).strict().superRefine((value, ctx) => {
+  if (!value.sourceRunId && !value.pid && !value.logPath && !value.externalRef) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "External continuation evidence requires sourceRunId, pid, logPath, or externalRef",
+      path: ["externalRef"],
+    });
+  }
+});
+
 export const resolveIssueRecoveryActionSchema = z.object({
   actionId: z.string().uuid().optional(),
   outcome: z.enum(RESOLVE_ISSUE_RECOVERY_ACTION_OUTCOMES),
-  sourceIssueStatus: z.enum(["todo", "done", "in_review", "blocked"]),
+  sourceIssueStatus: z.enum(["todo", "in_progress", "done", "in_review", "blocked"]),
+  externalContinuation: recoveryExternalContinuationSchema.optional().nullable(),
   resolutionNote: multilineTextSchema.optional().nullable(),
 }).strict().superRefine((value, ctx) => {
+  if (value.sourceIssueStatus === "in_progress" && !value.externalContinuation) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Returning a recovery source issue to in_progress requires explicit externalContinuation evidence",
+      path: ["externalContinuation"],
+    });
+    return;
+  }
+
+  if (value.sourceIssueStatus !== "in_progress" && value.externalContinuation) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "External continuation evidence is only valid when sourceIssueStatus is in_progress",
+      path: ["externalContinuation"],
+    });
+    return;
+  }
+
   if (value.outcome === "restored") {
     if (
       value.sourceIssueStatus !== "todo" &&
+      value.sourceIssueStatus !== "in_progress" &&
       value.sourceIssueStatus !== "done" &&
       value.sourceIssueStatus !== "in_review"
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "Restored recovery actions must move the source issue to todo, done, or in_review",
+        message: "Restored recovery actions must move the source issue to todo, in_progress, done, or in_review",
         path: ["sourceIssueStatus"],
       });
     }
@@ -306,12 +347,13 @@ export const resolveIssueRecoveryActionSchema = z.object({
 
   if (value.outcome === "false_positive" || value.outcome === "cancelled") {
     if (
+      value.sourceIssueStatus !== "in_progress" &&
       value.sourceIssueStatus !== "done" &&
       value.sourceIssueStatus !== "in_review"
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "This recovery outcome requires sourceIssueStatus to be done or in_review",
+        message: "This recovery outcome requires sourceIssueStatus to be in_progress, done, or in_review",
         path: ["sourceIssueStatus"],
       });
     }

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -820,6 +820,70 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows.map((row) => row.blockerIssueId));
   }
 
+  function externalContinuationMonitorFields(input: {
+    nextCheckAt: Date;
+    attemptCount?: number;
+    timeoutAt?: Date | null;
+    maxAttempts?: number | null;
+  }) {
+    const nextCheckAt = input.nextCheckAt.toISOString();
+    const timeoutAt = input.timeoutAt?.toISOString() ?? null;
+    const attemptCount = input.attemptCount ?? 0;
+    const monitor = {
+      nextCheckAt,
+      notes: "External oneshot continuation is still running.",
+      scheduledBy: "board",
+      kind: "external_service",
+      serviceName: "external oneshot",
+      externalRef: "[redacted]",
+      timeoutAt,
+      maxAttempts: input.maxAttempts ?? null,
+      recoveryPolicy: "escalate_to_board",
+    };
+
+    return {
+      monitorNextCheckAt: input.nextCheckAt,
+      monitorWakeRequestedAt: null,
+      monitorAttemptCount: attemptCount,
+      monitorNotes: monitor.notes,
+      monitorScheduledBy: monitor.scheduledBy,
+      executionPolicy: {
+        mode: "normal",
+        commentRequired: true,
+        stages: [],
+        monitor,
+      },
+      executionState: {
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+        returnAssignee: null,
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: {
+          status: "scheduled",
+          nextCheckAt,
+          lastTriggeredAt: null,
+          attemptCount,
+          notes: monitor.notes,
+          scheduledBy: monitor.scheduledBy,
+          kind: monitor.kind,
+          serviceName: monitor.serviceName,
+          externalRef: monitor.externalRef,
+          timeoutAt,
+          maxAttempts: input.maxAttempts ?? null,
+          recoveryPolicy: monitor.recoveryPolicy,
+          clearedAt: null,
+          clearReason: null,
+        },
+      },
+    };
+  }
+
   async function seedQueuedIssueRunFixture() {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -2474,6 +2538,96 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const wakes = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
     expect(wakes.some((row) => row.reason === "run_liveness_continuation")).toBe(false);
   });
+
+  it("does not reassert stranded recovery while an external continuation monitor is active", async () => {
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db
+      .update(issues)
+      .set(externalContinuationMonitorFields({
+        nextCheckAt: new Date(Date.now() + 60 * 60 * 1000),
+      }))
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([]);
+
+    const [issue] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(issue).toMatchObject({
+      status: "in_progress",
+      monitorNotes: "External oneshot continuation is still running.",
+    });
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(eq(issueRecoveryActions.companyId, companyId), eq(issueRecoveryActions.sourceIssueId, issueId)));
+    expect(recoveryActions).toHaveLength(0);
+  });
+
+  it("recovers stranded work when external continuation monitor evidence is stale", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db
+      .update(issues)
+      .set(externalContinuationMonitorFields({
+        nextCheckAt: new Date(Date.now() - 60 * 1000),
+      }))
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      retryReason: "issue_continuation_needed",
+    });
+  });
+
+  it("does not treat arbitrary comments as external continuation liveness evidence", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorType: "system",
+      body: "External oneshot continuation is still running with PID 567525 and log /tmp/oneshot.log.",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      retryReason: "issue_continuation_needed",
+    });
+  });
+
   it("blocks stranded in-progress work after the continuation retry was already used", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -613,6 +613,90 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(await recoveryActionSvc.getActiveForIssue(companyId, sourceIssueId)).toBeNull();
   });
 
+  it("resolves an active recovery action by restoring the return owner with external continuation evidence", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    await db
+      .update(issues)
+      .set({ status: "blocked", assigneeAgentId: managerId, assigneeUserId: null })
+      .where(eq(issues.id, sourceIssueId));
+    const recoveryActionSvc = issueRecoveryActionService(db);
+    const action = await recoveryActionSvc.upsertSourceScoped({
+      companyId,
+      sourceIssueId,
+      kind: "stranded_assigned_issue",
+      ownerType: "agent",
+      ownerAgentId: managerId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+      cause: "stranded_assigned_issue",
+      fingerprint: "stranded-assigned:external-continuation",
+      evidence: { latestRunId: "run-1" },
+      nextAction: "Restore a live execution path.",
+      wakePolicy: { type: "manual" },
+    });
+    const app = createApp();
+    const sourceRunId = randomUUID();
+    const nextCheckAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
+    const resolved = await request(app)
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action.id,
+        outcome: "false_positive",
+        sourceIssueStatus: "in_progress",
+        resolutionNote: "External continuation is still live; do not redispatch.",
+        externalContinuation: {
+          nextCheckAt,
+          sourceRunId,
+          pid: 567525,
+          logPath: "/tmp/oneshot-1779221563371.log",
+          notes: "External oneshot continuation is still running.",
+        },
+      })
+      .expect(200);
+
+    expect(resolved.body.issue).toMatchObject({
+      id: sourceIssueId,
+      status: "in_progress",
+      assigneeAgentId: coderId,
+      assigneeUserId: null,
+      activeRecoveryAction: null,
+    });
+    expect(resolved.body.issue.monitorNextCheckAt).toBeTruthy();
+    expect(resolved.body.issue.monitorNotes).toBe("External oneshot continuation is still running.");
+    expect(resolved.body.issue.monitorScheduledBy).toBe("board");
+    expect(resolved.body.recoveryAction).toMatchObject({
+      id: action.id,
+      status: "resolved",
+      outcome: "false_positive",
+      evidence: {
+        latestRunId: "run-1",
+        externalContinuation: {
+          nextCheckAt,
+          sourceRunId,
+          pid: 567525,
+          logPath: "/tmp/oneshot-1779221563371.log",
+        },
+      },
+    });
+
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(sourceIssue).toMatchObject({
+      status: "in_progress",
+      assigneeAgentId: coderId,
+      assigneeUserId: null,
+      monitorNotes: "External oneshot continuation is still running.",
+      monitorScheduledBy: "board",
+    });
+    expect(sourceIssue?.monitorNextCheckAt?.toISOString()).toBe(nextCheckAt);
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+    expect(wakeups).toHaveLength(0);
+  });
+
   it("marks a recovery action stale when a blocked source issue is manually moved to todo", async () => {
     const { companyId, managerId, sourceIssueId } = await seedCompany();
     await db

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -46,6 +46,7 @@ import {
   type CompanySearchQuery,
   type CompanySearchResponse,
   type ExecutionWorkspace,
+  type ResolveIssueRecoveryAction,
   type IssueRelationIssueSummary,
   type SuccessfulRunHandoffState,
 } from "@paperclipai/shared";
@@ -588,6 +589,64 @@ function summarizeIssueMonitor(
     recoveryPolicy: policy?.monitor?.recoveryPolicy ?? state?.monitor?.recoveryPolicy ?? null,
     status: state?.monitor?.status ?? (policy?.monitor ? "scheduled" : null),
     clearReason: state?.monitor?.clearReason ?? null,
+  };
+}
+
+type ExternalContinuationResolution = NonNullable<ResolveIssueRecoveryAction["externalContinuation"]>;
+
+function externalContinuationRef(continuation: ExternalContinuationResolution) {
+  if (continuation.externalRef) return continuation.externalRef;
+  return [
+    continuation.sourceRunId ? `sourceRunId:${continuation.sourceRunId}` : null,
+    continuation.pid ? `pid:${continuation.pid}` : null,
+    continuation.logPath ? `logPath:${continuation.logPath}` : null,
+  ].filter((value): value is string => Boolean(value)).join(" ");
+}
+
+function externalContinuationExecutionPolicy(
+  continuation: ExternalContinuationResolution,
+  scheduledBy: "assignee" | "board",
+) {
+  return normalizeIssueExecutionPolicy({
+    monitor: {
+      nextCheckAt: continuation.nextCheckAt,
+      notes: continuation.notes ?? null,
+      scheduledBy,
+      kind: "external_service",
+      serviceName: continuation.serviceName ?? "external oneshot",
+      externalRef: externalContinuationRef(continuation),
+      timeoutAt: continuation.timeoutAt ?? null,
+      maxAttempts: continuation.maxAttempts ?? null,
+      recoveryPolicy: continuation.recoveryPolicy ?? "escalate_to_board",
+    },
+  });
+}
+
+function externalContinuationRecoveryEvidence(
+  continuation: ExternalContinuationResolution,
+  actor: ReturnType<typeof getActorInfo>,
+  recordedAt: Date,
+) {
+  return {
+    externalContinuation: {
+      nextCheckAt: continuation.nextCheckAt,
+      sourceRunId: continuation.sourceRunId ?? null,
+      pid: continuation.pid ?? null,
+      logPath: continuation.logPath ?? null,
+      externalRef: continuation.externalRef ?? null,
+      serviceName: continuation.serviceName ?? "external oneshot",
+      notes: continuation.notes ?? null,
+      timeoutAt: continuation.timeoutAt ?? null,
+      maxAttempts: continuation.maxAttempts ?? null,
+      recoveryPolicy: continuation.recoveryPolicy ?? "escalate_to_board",
+      recordedAt: recordedAt.toISOString(),
+      recordedBy: {
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+      },
+    },
   };
 }
 
@@ -2198,16 +2257,62 @@ export function issueRoutes(
       return;
     }
 
-    const { actionId, outcome, sourceIssueStatus, resolutionNote } = req.body;
+    const {
+      actionId,
+      outcome,
+      sourceIssueStatus,
+      externalContinuation,
+      resolutionNote,
+    } = req.body as ResolveIssueRecoveryAction;
     if (outcome === "false_positive" || outcome === "cancelled") {
       assertBoard(req);
     }
 
     const actor = getActorInfo(req);
-    const updateFields = sourceIssueStatus ? { status: sourceIssueStatus } : {};
+    const updateFields: Partial<typeof issueRows.$inferInsert> = sourceIssueStatus ? { status: sourceIssueStatus } : {};
+    let recoveryEvidence: Record<string, unknown> | undefined;
+    if (sourceIssueStatus === "in_progress") {
+      const nextCheckAt = new Date(externalContinuation!.nextCheckAt);
+      if (nextCheckAt.getTime() <= Date.now()) {
+        throw unprocessable("External continuation nextCheckAt must be in the future");
+      }
+
+      const returnOwnerAgentId = activeRecoveryAction?.returnOwnerAgentId ?? existing.assigneeAgentId;
+      if (!returnOwnerAgentId) {
+        throw unprocessable("External continuation recovery resolution requires a return owner agent");
+      }
+
+      const previousExecutionPolicy = normalizeIssueExecutionPolicy(existing.executionPolicy ?? null);
+      const nextExecutionPolicy = externalContinuationExecutionPolicy(
+        externalContinuation!,
+        actor.actorType === "user" ? "board" : "assignee",
+      );
+      const transition = applyIssueExecutionPolicyTransition({
+        issue: existing,
+        policy: nextExecutionPolicy,
+        previousPolicy: previousExecutionPolicy,
+        requestedStatus: "in_progress",
+        requestedAssigneePatch: {
+          assigneeAgentId: returnOwnerAgentId,
+          assigneeUserId: null,
+        },
+        actor: {
+          agentId: actor.agentId ?? null,
+          userId: actor.actorType === "user" ? actor.actorId : null,
+        },
+        monitorExplicitlyUpdated: true,
+      });
+      Object.assign(updateFields, transition.patch, {
+        status: "in_progress",
+        assigneeAgentId: returnOwnerAgentId,
+        assigneeUserId: null,
+        executionPolicy: nextExecutionPolicy,
+      });
+      recoveryEvidence = externalContinuationRecoveryEvidence(externalContinuation!, actor, new Date());
+    }
     await assertAgentInReviewReviewPath({
       existing,
-      updateFields,
+      updateFields: updateFields as Record<string, unknown>,
       actorType: req.actor.type,
     });
 
@@ -2237,7 +2342,7 @@ export function issueRoutes(
         const updatedIssue = await svc.update(
           id,
           {
-            status: sourceIssueStatus,
+            ...updateFields,
             actorAgentId: actor.agentId ?? null,
             actorUserId: actor.actorType === "user" ? actor.actorId : null,
           },
@@ -2255,6 +2360,7 @@ export function issueRoutes(
           status: actionStatus,
           outcome,
           resolutionNote: resolutionNote ?? null,
+          evidence: recoveryEvidence,
         },
         tx,
       );

--- a/server/src/services/issue-recovery-actions.ts
+++ b/server/src/services/issue-recovery-actions.ts
@@ -44,6 +44,7 @@ export type ResolveIssueRecoveryActionInput = {
   status: Extract<IssueRecoveryActionStatus, "resolved" | "cancelled">;
   outcome: IssueRecoveryActionOutcome;
   resolutionNote?: string | null;
+  evidence?: Record<string, unknown>;
 };
 
 function toReadModel(row: IssueRecoveryActionRow): IssueRecoveryAction {
@@ -271,15 +272,31 @@ export function issueRecoveryActionService(db: Db) {
       predicates.push(eq(issueRecoveryActions.id, input.actionId));
     }
 
+    const evidence = input.evidence === undefined
+      ? undefined
+      : await dbOrTx
+          .select({ evidence: issueRecoveryActions.evidence })
+          .from(issueRecoveryActions)
+          .where(and(...predicates))
+          .limit(1)
+          .then((rows) => ({
+            ...(rows[0]?.evidence ?? {}),
+            ...input.evidence,
+          }));
+    const updateFields: Partial<typeof issueRecoveryActions.$inferInsert> = {
+      status: input.status,
+      outcome: input.outcome,
+      resolutionNote: input.resolutionNote ?? null,
+      resolvedAt: now,
+      updatedAt: now,
+    };
+    if (evidence !== undefined) {
+      updateFields.evidence = evidence;
+    }
+
     const [updated] = await dbOrTx
       .update(issueRecoveryActions)
-      .set({
-        status: input.status,
-        outcome: input.outcome,
-        resolutionNote: input.resolutionNote ?? null,
-        resolvedAt: now,
-        updatedAt: now,
-      })
+      .set(updateFields)
       .where(and(...predicates))
       .returning();
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -312,6 +312,41 @@ function isRepeatedProductiveContinuationRecovery(latestRun: SuccessfulLatestIss
     isProductiveContinuationRun(latestRun);
 }
 
+function readMonitorDate(value: unknown) {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+  if (typeof value !== "string" || value.length === 0) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function readPositiveInteger(value: unknown) {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function hasPlausibleActiveScheduledMonitor(
+  issue: Pick<
+    typeof issues.$inferSelect,
+    "status" | "executionPolicy" | "executionState" | "monitorNextCheckAt" | "monitorAttemptCount"
+  >,
+  now: Date,
+) {
+  if (issue.status !== "in_progress") return false;
+  if (!issue.monitorNextCheckAt || issue.monitorNextCheckAt.getTime() <= now.getTime()) return false;
+
+  const policyMonitor = parseObject(parseObject(issue.executionPolicy).monitor);
+  const stateMonitor = parseObject(parseObject(issue.executionState).monitor);
+  if (readNonEmptyString(stateMonitor.status) === "cleared") return false;
+
+  const timeoutAt = readMonitorDate(policyMonitor.timeoutAt) ?? readMonitorDate(stateMonitor.timeoutAt);
+  if (timeoutAt && timeoutAt.getTime() <= now.getTime()) return false;
+
+  const maxAttempts = readPositiveInteger(policyMonitor.maxAttempts) ?? readPositiveInteger(stateMonitor.maxAttempts);
+  const attemptCount = issue.monitorAttemptCount ?? asNumber(stateMonitor.attemptCount, 0);
+  if (maxAttempts !== null && attemptCount >= maxAttempts) return false;
+
+  return true;
+}
+
 function parseLivenessIncidentKey(incidentKey: string | null | undefined) {
   if (!incidentKey) return null;
   return parseIssueGraphLivenessIncidentKey(incidentKey);
@@ -2382,6 +2417,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (hasPlausibleActiveScheduledMonitor(issue, new Date())) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through explicit issue ownership, recovery actions, and audit-safe dispositions.
> - The recovery subsystem is responsible for detecting stranded agent work and moving abandoned issues into an operator-visible recovery path.
> - Galleon’s Bosun workflow delegates real engineering through external `oneshot --bg` continuations that can outlive the Paperclip heartbeat run.
> - Recovery was treating those live external continuations as stranded because the source issue had no native live Paperclip execution run.
> - Prior comment-grace suppression was not durable: it could expire during long oneshots and arbitrary comments could briefly suppress recovery.
> - This pull request adds explicit external-continuation evidence to recovery-action resolution and teaches stranded recovery to honor only structured, still-valid continuation monitors.
> - The benefit is fewer false recovery loops without weakening recovery for genuinely abandoned issues.

## What Changed

- Added shared validation for `externalContinuation` recovery-action evidence.
- Allows `sourceIssueStatus: "in_progress"` only when explicit continuation evidence and a future monitor check are supplied.
- Records external continuation metadata on the source issue monitor state and in recovery-action evidence.
- Restores the source issue to the return owner when resolving a recovery action as an external continuation.
- Skips stranded-assigned recovery while the structured external-continuation monitor is still plausibly active.
- Added regression coverage for live continuation, stale continuation, and arbitrary-comment cases.

## Verification

- `pnpm run preflight:workspace-links` passed.
- `pnpm exec vitest run packages/shared/src/validators/issue.test.ts server/src/__tests__/issue-recovery-actions.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts` passed: 3 files, 94 tests.
- `pnpm --filter @paperclipai/shared typecheck` passed.
- `pnpm --filter @paperclipai/server typecheck` passed.
- `pnpm test:run` failed on one unrelated existing Better Auth cookie-prefix assertion: expected `paperclip-sat-worktree.session_token`, received `__Secure-paperclip-sat-worktree.session_token`.

## Risks

- Medium: this changes recovery semantics for a narrow source-scoped recovery path.
- Mitigation: `in_progress` recovery resolution is gated behind structured external-continuation evidence plus a future monitor check; arbitrary comments no longer suppress recovery.
- Deployment note: no service restart or deploy was performed from dappnode.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex CLI, GPT-5, code-editing/tool-use execution through oneshot; Hermes/Bosun performed recovery handoff and PR creation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
