### PR TITLE
fix(gemini-local): pipe prompt via stdin to avoid Windows 8191-char cmd-line limit

### DIFF
--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -445,7 +445,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     }
   }
   const commandNotes = (() => {
-    const notes: string[] = ["Prompt is passed to Gemini via --prompt for non-interactive execution."];
+    const notes: string[] = ["Prompt is passed to Gemini via stdin; --prompt flag is empty to trigger non-interactive mode without exceeding Windows cmd-line limits."];
     notes.push("Added --approval-mode yolo for unattended execution.");
     if (executionTargetIsRemote) {
       notes.push("Set GEMINI_CLI_TRUST_WORKSPACE=true for remote headless execution.");
@@ -514,7 +514,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       args.push("--sandbox=none");
     }
     if (extraArgs.length > 0) args.push(...extraArgs);
-    args.push("--prompt", prompt);
+    // Pass empty --prompt to trigger non-interactive mode; actual prompt is piped via stdin
+    // to avoid the Windows 8191-char command-line limit when heartbeat context is large.
+    args.push("--prompt", "");
     return args;
   };
 
@@ -526,9 +528,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         command: resolvedCommand,
         cwd: effectiveExecutionCwd,
         commandNotes,
-        commandArgs: args.map((value, index) => (
-          index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
-        )),
+        commandArgs: [...args, `<stdin: prompt ${prompt.length} chars>`],
         env: loggedEnv,
         prompt,
         promptMetrics,
@@ -539,6 +539,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
       cwd,
       env,
+      stdin: prompt,
       timeoutSec,
       graceSec,
       onSpawn,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents across multiple CLI adapters (claude-local, gemini-local, codex-local, etc.)
> - The gemini-local adapter spawns the Gemini CLI with `--prompt <full_heartbeat_context>` as a CLI argument
> - On Windows, the total command-line length is hard-limited to 8191 characters
> - Heartbeat context (agent instructions + wake payload + task markdown) routinely exceeds 100KB
> - This causes instant "The command line is too long." failures — 25/40 runs failed in production with 10 agents
> - Gemini CLI's own `--prompt` help states it is "Appended to input on stdin (if any)" → stdin is supported
> - The claude-local adapter already uses `stdin: prompt` with `--print -`; codex also uses stdin-based input
> - This pull request switches gemini-local to the same pattern: empty `--prompt ""` (keeps non-interactive mode) + actual prompt via stdin
> - The benefit is that CLI args stay short on all platforms and macOS/Linux see no regression

## What Changed

- `packages/adapters/gemini-local/src/server/execute.ts`: Replace `args.push("--prompt", prompt)` with `args.push("--prompt", "")` and add `stdin: prompt` to `runAdapterExecutionTargetProcess` options
- Update `commandNotes` to reflect stdin delivery method
- Update `commandArgs` in `onMeta` logging to show `<stdin: prompt N chars>` instead of masking the last arg

## Verification

**Repro (before this fix — Windows only):**
```
gemini --output-format stream-json --approval-mode yolo --sandbox=none --prompt "<100KB+ heartbeat>"
# → "The command line is too long."
```

**After this fix:**
```
echo "<100KB+ heartbeat>" | gemini --output-format stream-json --approval-mode yolo --sandbox=none --prompt ""
# → runs successfully; prompt read from stdin
```

**macOS/Linux regression check:** stdin is universal; `--prompt ""` is a valid empty-string flag that triggers non-interactive mode. No behaviour change on Unix.

**Pattern parity:** Matches `claude-local` adapter (`stdin: prompt` + short args) and codex adapter (stdin-based input).

**Windows production evidence (before fix):** 25/40 gemini agent runs failed with cmd-too-long; all 10 agents had to be rolled back to claude_local.