### PR TITLE
adapter-claude-local: quarantine poisoned session jsonl + force fresh session on retry

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.quarantine.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.quarantine.test.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { randomUUID } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { quarantinePoisonedJsonl } from "./execute.js";
+
+const TMP_DIRS: string[] = [];
+
+async function makeTmpDir() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-local-quarantine-"));
+  TMP_DIRS.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  while (TMP_DIRS.length > 0) {
+    const dir = TMP_DIRS.pop();
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+function poisonedJsonl(poisonId: string) {
+  const good = JSON.stringify({
+    type: "assistant",
+    message: {
+      id: "msg_01abc",
+      model: "claude-opus-4-7",
+      role: "assistant",
+      content: [{ type: "text", text: "Hello" }],
+    },
+  });
+  const synthetic = JSON.stringify({
+    type: "assistant",
+    message: {
+      id: poisonId,
+      model: "<synthetic>",
+      role: "assistant",
+      stop_reason: "stop_sequence",
+      stop_sequence: "",
+      content: [{ type: "text", text: "No response requested." }],
+    },
+  });
+  return `${good}\n${synthetic}\n`;
+}
+
+function cleanJsonl() {
+  return (
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        id: "msg_01good",
+        model: "claude-opus-4-7",
+        role: "assistant",
+        content: [{ type: "text", text: "All good." }],
+      },
+    }) + "\n"
+  );
+}
+
+describe("quarantinePoisonedJsonl", () => {
+  it("quarantines a poisoned jsonl matched by sessionId", async () => {
+    const tmpDir = await makeTmpDir();
+    const cwd = "/test/workspace/one";
+    const encodedCwd = cwd.replace(/\//g, "-");
+    const projectDir = path.join(tmpDir, "projects", encodedCwd);
+    await fs.mkdir(projectDir, { recursive: true });
+    const sessionId = randomUUID();
+    const poisonId = randomUUID();
+    const jsonlPath = path.join(projectDir, `${sessionId}.jsonl`);
+    await fs.writeFile(jsonlPath, poisonedJsonl(poisonId));
+
+    const runId = randomUUID();
+    const result = await quarantinePoisonedJsonl({
+      claudeConfigDir: tmpDir,
+      cwd,
+      sessionId,
+      runId,
+    });
+
+    expect(result?.quarantined).toBe(true);
+    expect(result?.poisonId).toBe(poisonId);
+    expect(result?.path).toBe(jsonlPath);
+    expect(result?.poisonedPath).toBe(`${jsonlPath}.poisoned-${runId}`);
+
+    await expect(fs.access(jsonlPath)).rejects.toThrow();
+    await expect(fs.access(result!.poisonedPath!)).resolves.toBeUndefined();
+  });
+
+  it("leaves a clean jsonl untouched", async () => {
+    const tmpDir = await makeTmpDir();
+    const cwd = "/test/workspace/two";
+    const encodedCwd = cwd.replace(/\//g, "-");
+    const projectDir = path.join(tmpDir, "projects", encodedCwd);
+    await fs.mkdir(projectDir, { recursive: true });
+    const sessionId = randomUUID();
+    const jsonlPath = path.join(projectDir, `${sessionId}.jsonl`);
+    await fs.writeFile(jsonlPath, cleanJsonl());
+
+    const result = await quarantinePoisonedJsonl({
+      claudeConfigDir: tmpDir,
+      cwd,
+      sessionId,
+      runId: randomUUID(),
+    });
+
+    expect(result?.quarantined).toBe(false);
+    await expect(fs.access(jsonlPath)).resolves.toBeUndefined();
+  });
+
+  it("falls back to the latest jsonl when no sessionId is given", async () => {
+    const tmpDir = await makeTmpDir();
+    const cwd = "/test/workspace/three";
+    const encodedCwd = cwd.replace(/\//g, "-");
+    const projectDir = path.join(tmpDir, "projects", encodedCwd);
+    await fs.mkdir(projectDir, { recursive: true });
+    const poisonId = randomUUID();
+    const latestPath = path.join(projectDir, `${randomUUID()}.jsonl`);
+    await fs.writeFile(latestPath, poisonedJsonl(poisonId));
+
+    const result = await quarantinePoisonedJsonl({
+      claudeConfigDir: tmpDir,
+      cwd,
+      sessionId: null,
+      runId: randomUUID(),
+    });
+
+    expect(result?.quarantined).toBe(true);
+    expect(result?.poisonId).toBe(poisonId);
+  });
+
+  it("does not quarantine a synthetic entry with a msg_* id", async () => {
+    const tmpDir = await makeTmpDir();
+    const cwd = "/test/workspace/four";
+    const encodedCwd = cwd.replace(/\//g, "-");
+    const projectDir = path.join(tmpDir, "projects", encodedCwd);
+    await fs.mkdir(projectDir, { recursive: true });
+    const sessionId = randomUUID();
+    const jsonlPath = path.join(projectDir, `${sessionId}.jsonl`);
+    const safeEntry = JSON.stringify({
+      type: "assistant",
+      message: {
+        id: `msg_${randomUUID().replace(/-/g, "")}`,
+        model: "<synthetic>",
+        role: "assistant",
+        content: [{ type: "text", text: "ok" }],
+      },
+    });
+    await fs.writeFile(jsonlPath, `${safeEntry}\n`);
+
+    const result = await quarantinePoisonedJsonl({
+      claudeConfigDir: tmpDir,
+      cwd,
+      sessionId,
+      runId: randomUUID(),
+    });
+
+    expect(result?.quarantined).toBe(false);
+    await expect(fs.access(jsonlPath)).resolves.toBeUndefined();
+  });
+
+  it("returns null when the project directory does not exist", async () => {
+    const tmpDir = await makeTmpDir();
+    const result = await quarantinePoisonedJsonl({
+      claudeConfigDir: tmpDir,
+      cwd: "/no/such/dir",
+      sessionId: null,
+      runId: randomUUID(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("skips already-quarantined files when scanning latest jsonl", async () => {
+    const tmpDir = await makeTmpDir();
+    const cwd = "/test/workspace/five";
+    const encodedCwd = cwd.replace(/\//g, "-");
+    const projectDir = path.join(tmpDir, "projects", encodedCwd);
+    await fs.mkdir(projectDir, { recursive: true });
+    // Latest by mtime is a `.poisoned-*` from a previous run — must be ignored.
+    const oldPoisoned = path.join(projectDir, `${randomUUID()}.jsonl.poisoned-prior-run`);
+    await fs.writeFile(oldPoisoned, poisonedJsonl(randomUUID()));
+    // The actual current jsonl is clean.
+    const currentPath = path.join(projectDir, `${randomUUID()}.jsonl`);
+    await fs.writeFile(currentPath, cleanJsonl());
+    // Bump mtime on the prior-poisoned file so it sorts newest.
+    const future = new Date(Date.now() + 60_000);
+    await fs.utimes(oldPoisoned, future, future);
+
+    const result = await quarantinePoisonedJsonl({
+      claudeConfigDir: tmpDir,
+      cwd,
+      sessionId: null,
+      runId: randomUUID(),
+    });
+
+    expect(result?.quarantined).toBe(false);
+    await expect(fs.access(currentPath)).resolves.toBeUndefined();
+    await expect(fs.access(oldPoisoned)).resolves.toBeUndefined();
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
@@ -123,6 +124,89 @@ function isBedrockAuth(env: Record<string, string>): boolean {
     env.CLAUDE_CODE_USE_BEDROCK === "true" ||
     hasNonEmptyEnvValue(env, "ANTHROPIC_BEDROCK_BASE_URL")
   );
+}
+
+interface QuarantineResult {
+  quarantined: boolean;
+  path?: string;
+  poisonedPath?: string;
+  poisonId?: string;
+  error?: string;
+}
+
+// Detect and quarantine a poisoned project-dir session jsonl before invoking
+// the Claude CLI. Claude Code 2.1.131 occasionally appends a synthetic
+// `assistant` entry whose `id` is a plain UUID instead of an Anthropic `msg_*`
+// id; the next CLI invocation replays that tail and Anthropic rejects with a
+// 400 on `diagnostics.previous_message_id` forever. We rename the file aside
+// so the CLI is forced to start a fresh session.
+export async function quarantinePoisonedJsonl(opts: {
+  claudeConfigDir: string;
+  cwd: string;
+  sessionId: string | null;
+  runId: string;
+}): Promise<QuarantineResult | null> {
+  try {
+    const home = process.env.HOME ?? "";
+    const configDir = opts.claudeConfigDir || `${home}/.claude`;
+    const encodedCwd = opts.cwd.replace(/\//g, "-");
+    const projectDir = `${configDir}/projects/${encodedCwd}`;
+
+    let targetPath: string | null = null;
+    if (opts.sessionId) {
+      const candidate = `${projectDir}/${opts.sessionId}.jsonl`;
+      try {
+        await fs.access(candidate);
+        targetPath = candidate;
+      } catch {
+        /* no file at the resume target */
+      }
+    }
+    if (!targetPath) {
+      let entries: string[];
+      try {
+        entries = await fs.readdir(projectDir);
+      } catch {
+        return null;
+      }
+      const jsonlFiles = entries.filter(
+        (e) => e.endsWith(".jsonl") && !e.includes(".poisoned-"),
+      );
+      if (jsonlFiles.length === 0) return null;
+      const stats = await Promise.all(
+        jsonlFiles.map(async (f) => ({
+          f,
+          mtime: (await fs.stat(`${projectDir}/${f}`)).mtimeMs,
+        })),
+      );
+      stats.sort((a, b) => b.mtime - a.mtime);
+      targetPath = `${projectDir}/${stats[0].f}`;
+    }
+
+    const raw = await fs.readFile(targetPath, "utf-8");
+    const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+    // Only the tail matters — the poisoned entry is what the CLI replays.
+    const tail = lines.slice(-60);
+    for (const line of tail) {
+      let entry: Record<string, unknown>;
+      try {
+        entry = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (entry.type !== "assistant") continue;
+      const msg = entry.message as Record<string, unknown> | undefined;
+      if (!msg || msg.model !== "<synthetic>") continue;
+      const id = typeof msg.id === "string" ? msg.id : "";
+      if (id.startsWith("msg_")) continue;
+      const poisonedPath = `${targetPath}.poisoned-${opts.runId}`;
+      await fs.rename(targetPath, poisonedPath);
+      return { quarantined: true, path: targetPath, poisonedPath, poisonId: id };
+    }
+    return { quarantined: false };
+  } catch (err) {
+    return { quarantined: false, error: String(err) };
+  }
 }
 
 function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
@@ -675,9 +759,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const buildClaudeArgs = (
     resumeSessionId: string | null,
     attemptInstructionsFilePath: string | undefined,
+    freshSessionId?: string | null,
   ) => {
     const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
-    if (resumeSessionId) args.push("--resume", resumeSessionId);
+    if (resumeSessionId) {
+      args.push("--resume", resumeSessionId);
+    } else if (freshSessionId) {
+      // Force a specific brand-new uuid so the CLI cannot land on a poisoned
+      // project-dir jsonl on retry.
+      args.push("--session-id", freshSessionId);
+    }
     args.push(...buildClaudeExecutionPermissionArgs({
       dangerouslySkipPermissions,
       targetIsSandbox: executionTargetIsSandbox,
@@ -718,9 +809,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       : `Claude exited with code ${proc.exitCode ?? -1}`;
   };
 
-  const runAttempt = async (resumeSessionId: string | null) => {
+  const runAttempt = async (
+    resumeSessionId: string | null,
+    freshSessionId?: string | null,
+  ) => {
     const attemptInstructionsFilePath = resumeSessionId ? undefined : effectiveInstructionsFilePath;
-    const args = buildClaudeArgs(resumeSessionId, attemptInstructionsFilePath);
+    const args = buildClaudeArgs(resumeSessionId, attemptInstructionsFilePath, freshSessionId);
     const commandNotes: string[] = [];
     if (!resumeSessionId) {
       commandNotes.push(`Using stable Claude prompt bundle ${promptBundle.bundleKey}.`);
@@ -765,7 +859,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
     const parsedStream = parseClaudeStreamJson(proc.stdout);
     const parsed = parsedStream.resultJson ?? parseJson(proc.stdout);
-    return { proc, parsedStream, parsed };
+    return {
+      proc,
+      parsedStream,
+      parsed,
+      resumeSessionId: resumeSessionId ?? null,
+      freshSessionId: freshSessionId ?? null,
+    };
   };
 
   const toAdapterResult = (
@@ -773,10 +873,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       proc: RunProcessResult;
       parsedStream: ReturnType<typeof parseClaudeStreamJson>;
       parsed: Record<string, unknown> | null;
+      resumeSessionId?: string | null;
+      freshSessionId?: string | null;
     },
     opts: { fallbackSessionId: string | null; clearSessionOnMissingSession?: boolean },
   ): AdapterExecutionResult => {
     const { proc, parsedStream, parsed } = attempt;
+    const attemptResumeSessionId = attempt.resumeSessionId ?? null;
+    const attemptFreshSessionId = attempt.freshSessionId ?? null;
     const loginMeta = detectClaudeLoginRequired({
       parsed,
       stdout: proc.stdout,
@@ -915,6 +1019,13 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       ...(transientUpstream ? { errorFamily: "transient_upstream" } : {}),
       ...(transientRetryNotBefore ? { retryNotBefore: transientRetryNotBefore.toISOString() } : {}),
       ...(transientRetryNotBefore ? { transientRetryNotBefore: transientRetryNotBefore.toISOString() } : {}),
+      // Record the resume/fresh session-id args we passed Claude so regressions
+      // on `diagnostics.previous_message_id` can be diagnosed without diffing
+      // project-dir jsonl tails.
+      commandArgs: {
+        usedResume: Boolean(attemptResumeSessionId),
+        sessionId: attemptResumeSessionId ?? attemptFreshSessionId ?? null,
+      },
     };
 
     return {
@@ -942,19 +1053,47 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   };
 
   try {
-    const initial = await runAttempt(sessionId ?? null);
+    // Quarantine a poisoned project-dir session jsonl before invoking the CLI.
+    // (Claude Code 2.1.131 occasionally appends a synthetic assistant entry
+    // with a non-`msg_*` id; the next CLI invocation replays it and Anthropic
+    // 400s on diagnostics.previous_message_id forever.) Remote targets manage
+    // their own ~/.claude state, so skip the local-fs scan there.
+    const claudeConfigDirForQuarantine =
+      env.CLAUDE_CONFIG_DIR ?? effectiveEnv.CLAUDE_CONFIG_DIR ?? "";
+    const quarantineResult = !executionTargetIsRemote
+      ? await quarantinePoisonedJsonl({
+          claudeConfigDir: claudeConfigDirForQuarantine,
+          cwd: effectiveExecutionCwd,
+          sessionId: sessionId ?? null,
+          runId,
+        })
+      : null;
+    if (quarantineResult?.quarantined) {
+      await onLog(
+        "stdout",
+        `[paperclip] Quarantined poisoned session jsonl "${quarantineResult.path}" (synthetic id: ${quarantineResult.poisonId}). Starting fresh session.\n`,
+      );
+    }
+    const effectiveSessionId = quarantineResult?.quarantined ? null : sessionId ?? null;
+
+    const initial = await runAttempt(effectiveSessionId);
+    // Drop the (exitCode !== 0) gate from the retry condition: the Anthropic
+    // Agent SDK 400 on previous_message_id surfaces with subtype=success and
+    // exitCode 0, so we rely on the detector regex as the source of truth. On
+    // retry, pass --session-id <fresh-uuid> (not just omit --resume) so the
+    // CLI cannot land on the same poisoned project-dir jsonl.
     if (
-      sessionId &&
+      effectiveSessionId &&
       !initial.proc.timedOut &&
-      (initial.proc.exitCode ?? 0) !== 0 &&
       initial.parsed &&
       isClaudeUnknownSessionError(initial.parsed)
     ) {
+      const freshSessionId = randomUUID();
       await onLog(
         "stdout",
-        `[paperclip] Claude resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+        `[paperclip] Claude resume session "${effectiveSessionId}" is unavailable; retrying with fresh session-id "${freshSessionId}".\n`,
       );
-      const retry = await runAttempt(null);
+      const retry = await runAttempt(null, freshSessionId);
       return toAdapterResult(retry, { fallbackSessionId: null, clearSessionOnMissingSession: true });
     }
 

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -1068,15 +1068,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           runId,
         })
       : null;
+    const effectiveSessionId = quarantineResult?.quarantined ? null : sessionId ?? null;
+    // When we just quarantined a poisoned jsonl, force a brand-new --session-id
+    // on the first attempt too. Otherwise the CLI's "no session arg" path can
+    // land on another stale jsonl in the same project dir (multiple prompt
+    // bundles, prior runs in the same cwd). Symmetric with the SDK-400 retry
+    // branch below.
+    const postQuarantineFreshSessionId = quarantineResult?.quarantined ? randomUUID() : null;
     if (quarantineResult?.quarantined) {
       await onLog(
         "stdout",
-        `[paperclip] Quarantined poisoned session jsonl "${quarantineResult.path}" (synthetic id: ${quarantineResult.poisonId}). Starting fresh session.\n`,
+        `[paperclip] Quarantined poisoned session jsonl "${quarantineResult.path}" (synthetic id: ${quarantineResult.poisonId}). Starting fresh session "${postQuarantineFreshSessionId}".\n`,
       );
     }
-    const effectiveSessionId = quarantineResult?.quarantined ? null : sessionId ?? null;
 
-    const initial = await runAttempt(effectiveSessionId);
+    const initial = await runAttempt(effectiveSessionId, postQuarantineFreshSessionId);
     // Drop the (exitCode !== 0) gate from the retry condition: the Anthropic
     // Agent SDK 400 on previous_message_id surfaces with subtype=success and
     // exitCode 0, so we rely on the detector regex as the source of truth. On

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractClaudeRetryNotBefore,
   isClaudeTransientUpstreamError,
+  isClaudeUnknownSessionError,
 } from "./parse.js";
 
 describe("isClaudeTransientUpstreamError", () => {
@@ -119,5 +120,51 @@ describe("extractClaudeRetryNotBefore", () => {
     expect(
       extractClaudeRetryNotBefore({ errorMessage: "Overloaded. Try again later." }, new Date()),
     ).toBeNull();
+  });
+});
+
+
+describe("isClaudeUnknownSessionError", () => {
+  it("matches the classic CLI message", () => {
+    expect(
+      isClaudeUnknownSessionError({
+        result: "Error: no conversation found with session id abc-123",
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeUnknownSessionError({
+        result: "Unknown session: abc-123",
+      }),
+    ).toBe(true);
+  });
+
+  it("matches the Anthropic Agent SDK 400 on previous_message_id", () => {
+    expect(
+      isClaudeUnknownSessionError({
+        result:
+          "API Error: 400 diagnostics.previous_message_id: must be the `id` from a prior assistant message",
+      }),
+    ).toBe(true);
+    expect(
+      isClaudeUnknownSessionError({
+        is_error: true,
+        errors: [
+          {
+            type: "invalid_request_error",
+            message:
+              "diagnostics.previous_message_id: must be from a prior assistant message in this conversation",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(
+      isClaudeUnknownSessionError({ result: "Overloaded. Try again later." }),
+    ).toBe(false);
+    expect(
+      isClaudeUnknownSessionError({ result: "" }),
+    ).toBe(false);
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -191,8 +191,16 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
     .map((msg) => msg.trim())
     .filter(Boolean);
 
+  // Also catch the Anthropic Agent SDK 400 on `diagnostics.previous_message_id`
+  // (Claude Code 2.1.131 occasionally writes a synthetic assistant entry to the
+  // project-dir session jsonl with a non-`msg_*` id; the next /v1/messages call
+  // sends that id as previous_message_id and the API rejects with 400). The SDK
+  // surfaces this with subtype=success and exitCode 0, so the detector regex
+  // (not exit code) is the source of truth for triggering a resume retry.
   return allMessages.some((msg) =>
-    /no conversation found with session id|unknown session|session .* not found/i.test(msg),
+    /no conversation found with session id|unknown session|session .* not found|previous_message_id[^\n]{0,160}?(must be the|from a prior)|400[^\n]{0,160}?previous_message_id/i.test(
+      msg,
+    ),
   );
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - `@paperclipai/adapter-claude-local` wraps the Claude Code CLI to run those agents and persists per-`(cwd, prompt-bundle)` session state under `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`
> - Claude Code 2.1.131 occasionally appends a synthetic `assistant` entry to that file whose `id` is a plain UUID (not an Anthropic `msg_*` id); the next `/v1/messages` call sends that UUID as `diagnostics.previous_message_id` and Anthropic rejects with HTTP 400
> - The existing resume-retry path in `execute.ts` did not save us: (a) the Anthropic Agent SDK surfaces that 400 with subtype=success and exitCode 0, so the `exitCode !== 0` gate skipped the retry; and (b) even when the retry fired, `runAttempt(null)` only meant "don't pass `--resume`" — the CLI still wrote to / picked up the same project-dir jsonl, so the next attempt 400'd on the same tail
> - This pull request hardens the adapter end-to-end: drop the exitCode gate, extend the detector regex to catch the SDK 400, quarantine the poisoned jsonl aside before each invocation, and on retry force a brand-new `--session-id <uuid>` so the CLI cannot land on the same file
> - The benefit is that affected runs self-heal on the next attempt instead of needing manual `mv …jsonl …jsonl.poisoned` operator intervention, and we record `commandArgs` in `resultJson` so future regressions can be diagnosed without diffing jsonl tails

## What Changed

- `parse.ts` — extend `isClaudeUnknownSessionError` regex to also match the Anthropic Agent SDK 400 on `diagnostics.previous_message_id` (`must be the …`, `from a prior …`, and `400 … previous_message_id` variants).
- `execute.ts` — drop the `(initial.proc.exitCode ?? 0) !== 0` gate from the resume-retry condition; the detector regex is now the source of truth.
- `execute.ts` — add and export `quarantinePoisonedJsonl()`. Before invoking the CLI it locates the project-dir jsonl (preferring the explicit resume target, else the most recently modified `.jsonl` that is not already `.poisoned-*`), scans the last 60 lines for an `assistant` entry with `model: "<synthetic>"` and a non-`msg_*` id, and if found renames the file to `<path>.poisoned-<runId>`. Skipped when `executionTargetIsRemote` (remote targets manage their own `~/.claude`).
- `execute.ts` — extend `buildClaudeArgs` and `runAttempt` with a `freshSessionId` parameter. On the SDK-400 retry branch, generate a `randomUUID()` and pass `--session-id <uuid>` instead of just omitting `--resume`, so the CLI cannot reattach to the poisoned project-dir jsonl.
- `execute.ts` — thread `resumeSessionId` and `freshSessionId` through the attempt object into `toAdapterResult`, and record `commandArgs: { usedResume: boolean, sessionId: string | null }` in `mergedResultJson` for regression diagnostics.
- Tests — 6 new `quarantinePoisonedJsonl` tests (positive match by session id, clean file untouched, fallback to latest jsonl, `msg_*` id is safe even with `<synthetic>` model, missing project dir returns null, `.poisoned-*` files are ignored when picking the latest jsonl). 3 new `isClaudeUnknownSessionError` tests covering the classic CLI message, the SDK 400 in two forms, and a negative case.

## Verification

```bash
cd packages/adapters/claude-local
pnpm typecheck
pnpm exec vitest run
# 4 test files, 23 tests passed (was 14)
```

Manual exercise: starting from a project dir containing a `.jsonl` whose tail has `{"type":"assistant","message":{"id":"<uuid>","model":"<synthetic>", ...}}` (the exact failure shape we observed in production), the adapter now logs `[paperclip] Quarantined poisoned session jsonl "…" …` on entry, renames the file to `…jsonl.poisoned-<runId>`, runs the attempt with a fresh session id, and writes `commandArgs.usedResume = false` into `resultJson`.

## Risks

- Low/medium. The new code path runs once per invocation but only reads the *tail* of a single jsonl (≤60 lines parsed) and only renames a file in a strictly-positive match — never deletes. A failure inside the helper is caught and downgraded to `{ quarantined: false, error: … }` so the CLI invocation still proceeds.
- The retry branch now also fires on exitCode 0 when the SDK 400 detector matches. The detector regex is narrow (`previous_message_id` near `must be the` / `from a prior`, or `400 … previous_message_id`) so the additional firings are confined to the case this PR is targeting. A successful run that legitimately mentions `previous_message_id` in its tool output is theoretically possible but unlikely in practice; if it ever does, the only consequence is one extra Claude invocation with a fresh session id.
- Skipped entirely when `executionTargetIsRemote`, so remote runners that manage their own `~/.claude` are unaffected.

## Model Used

- Claude — `claude-opus-4-7` (1M context window). Authored end-to-end with extended thinking and tool use (filesystem edits, pnpm test execution).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (server-side adapter only)
- [x] I have updated relevant documentation to reflect my changes — N/A; no user-facing docs reference the resume-retry internals
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge