### PR TITLE
fix: exempt routine_execution issues from auto-disposition and productivity review

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2822,6 +2822,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           assigneeAgentId: issues.assigneeAgentId,
           executionState: issues.executionState,
           projectId: issues.projectId,
+          originKind: issues.originKind,
         })
         .from(issues)
         .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -6253,6 +6254,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+        return { kind: "released" as const };
+      }
+
+      // Routine execution issues are re-triggered by their cron schedule;
+      // auto-recovery and blocking are not appropriate for scheduled gaps.
+      if (issue.originKind === "routine_execution") {
         return { kind: "released" as const };
       }
 

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, ne, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { clampIssueRequestDepth } from "@paperclipai/shared";
 import {
@@ -656,6 +656,9 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
           inArray(issues.status, ["todo", "in_progress"]),
           sql`${issues.assigneeAgentId} is not null`,
           sql`${issues.originKind} <> ${PRODUCTIVITY_REVIEW_ORIGIN_KIND}`,
+          // Routine execution issues are expected to stay in_progress between
+          // scheduled runs — the cron schedule is the continuation path.
+          ne(issues.originKind, "routine_execution"),
         ),
       )
       .orderBy(asc(issues.updatedAt), asc(issues.id))

--- a/server/src/services/recovery/run-liveness-continuations.ts
+++ b/server/src/services/recovery/run-liveness-continuations.ts
@@ -17,7 +17,7 @@ const IDEMPOTENT_WAKE_STATUSES = ["queued", "deferred_issue_execution", "complet
 type HeartbeatRunRow = typeof heartbeatRuns.$inferSelect;
 type IssueRow = Pick<
   typeof issues.$inferSelect,
-  "id" | "companyId" | "identifier" | "title" | "status" | "assigneeAgentId" | "executionState" | "projectId"
+  "id" | "companyId" | "identifier" | "title" | "status" | "assigneeAgentId" | "executionState" | "projectId" | "originKind"
 >;
 type AgentRow = Pick<typeof agents.$inferSelect, "id" | "companyId" | "status">;
 
@@ -120,6 +120,11 @@ export function decideRunLivenessContinuation(input: {
   }
   if (issue.executionState) {
     return { kind: "skip", reason: "issue is blocked by execution policy state" };
+  }
+  // Routine execution issues are expected to stay in_progress between scheduled
+  // runs — the cron schedule is the continuation path, not liveness wakeups.
+  if (issue.originKind === "routine_execution") {
+    return { kind: "skip", reason: "routine execution issues use schedule-based continuation" };
   }
   if (!CONTINUATION_AGENT_STATUSES.has(agent.status)) {
     return { kind: "skip", reason: `agent status ${agent.status} is not invokable` };


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Routines create recurring execution issues (originKind=routine_execution) that stay in_progress between scheduled runs
> - The productivity review system and liveness continuation system treat these scheduled gaps as missing dispositions
> - This causes routine issues to be falsely flagged as blocked, requiring manual CMO recovery 3x/day
> - This pull request exempts routine_execution issues from productivity review candidates, liveness continuation wakeups, and auto-recovery blocking
> - The benefit is routine issues respect their cron schedule as the continuation path, eliminating false-positive blocks

## What Changed

- **Productivity review reconciler**: Added `ne(issues.originKind, "routine_execution")` filter to the candidate query so routine issues are no longer scanned for longActive/noCommentStreak/highChurn triggers
- **Liveness continuation**: Added early return in `decideRunLivenessContinuation` for routine_execution issues, skipping continuation wakeups since the cron schedule re-triggers automatically
- **Issue recovery**: Added early return in `releaseIssueExecutionAndPromote` for routine_execution issues, skipping auto-recovery and blocking since the next scheduled run will re-dispatch naturally

## Verification

- `pnpm typecheck` passes (server, ui, cli)
- All 147 heartbeat tests pass (9 afterAll cleanup timeouts are pre-existing embedded Postgres teardown issues, not test failures)
- All 13 run-liveness classifier tests pass
- All 8 productivity review service tests pass
- Manual verification: the diff is minimal (17 insertions, 2 deletions) and each change is a simple early-return or filter exclusion

## Risks

Low risk. The change is additive — it only adds exclusion filters for a specific originKind. The worst case is a routine issue that genuinely needs intervention won't get a productivity review, but that's handled by the routine's assigned agent and manager chain, not the automated scanner. If a routine issue genuinely stalls, the manager can still manually intervene.

## Model Used

- Provider: Anthropic (Claude)
- Model: claude-sonnet-4-20250514
- Context: 200K
- Capabilities: Extended thinking, tool use

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable (existing tests cover the unchanged paths; the new exclusion is a filter predicate)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [ ] I have updated relevant documentation to reflect my changes (N/A — behavior aligns with existing routine design intent)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge