### PR TITLE
feat(recovery): GOV-4 recovery storm cap — 2-strike park on repeated adapter error class

### DIFF
--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -603,6 +603,137 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     );
   });
 
+  // GOV-4 scenario (c): gemini cmd-too-long 3 times → 0 debris tickets, 1 park comment
+  it("parks the recovery issue when the same error class hits the 2-strike cap (scenario c: gemini cmd-too-long x3)", async () => {
+    await enableAutoRecovery();
+    const companyId = randomUUID();
+    const managerId = randomUUID();
+    const geminiAgentId = randomUUID();
+    const blockedIssueId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values([
+      {
+        id: managerId,
+        companyId,
+        name: "CTO",
+        role: "cto",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: false } },
+        permissions: {},
+      },
+      {
+        id: geminiAgentId,
+        companyId,
+        name: "GeminiCoder",
+        role: "engineer",
+        // paused → blocked_by_uninvokable_assignee finding fires for blockerIssue
+        status: "paused",
+        pauseReason: "manual",
+        reportsTo: managerId,
+        adapterType: "gemini_local",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: false } },
+        permissions: {},
+      },
+    ]);
+
+    await db.insert(issues).values([
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked work item",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: managerId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Gemini recovery issue stalled with cmd-too-long",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: geminiAgentId,
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+      },
+    ]);
+
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+
+    // Seed 3 failed runs with command_line_too_long for the gemini agent on the blocker issue.
+    const runBase = { companyId, agentId: geminiAgentId, invocationSource: "assignment", triggerDetail: "system" } as const;
+    for (let i = 0; i < 3; i++) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        ...runBase,
+        status: "failed",
+        errorCode: "command_line_too_long",
+        error: "gemini: E2BIG — argument list too long",
+        contextSnapshot: { issueId: blockerIssueId, taskId: blockerIssueId },
+        startedAt: new Date(Date.now() - (30 - i * 5) * 60 * 1000),
+        finishedAt: new Date(Date.now() - (25 - i * 5) * 60 * 1000),
+      });
+    }
+
+    const heartbeat = heartbeatService(db);
+
+    // First reconcile: storm cap fires → 0 escalation issues, 1 park comment
+    const first = await heartbeat.reconcileIssueGraphLiveness();
+    expect(first.stormCapped).toBe(1);
+    expect(first.escalationsCreated).toBe(0);
+
+    const escalationsAfterFirst = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "harness_liveness_escalation")));
+    expect(escalationsAfterFirst).toHaveLength(0);
+
+    const commentsAfterFirst = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, blockerIssueId));
+    expect(commentsAfterFirst).toHaveLength(1);
+    expect(commentsAfterFirst[0]?.body).toContain("Recovery storm cap applied");
+    expect(commentsAfterFirst[0]?.body).toContain("command_line_too_long");
+    expect(commentsAfterFirst[0]?.body).toContain("PARKED");
+    expect(commentsAfterFirst[0]?.body).toContain("Bulk adapter swap: **disabled**");
+
+    const parkedAgent = await db
+      .select({ status: agents.status, pauseReason: agents.pauseReason })
+      .from(agents)
+      .where(eq(agents.id, geminiAgentId))
+      .then((rows) => rows[0] ?? null);
+    expect(parkedAgent?.pauseReason).toBe("recovery_park");
+
+    // Second reconcile: idempotency guard → still 0 escalation issues, still 1 comment
+    const second = await heartbeat.reconcileIssueGraphLiveness();
+    expect(second.escalationsCreated).toBe(0);
+
+    const commentsAfterSecond = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, blockerIssueId));
+    expect(commentsAfterSecond).toHaveLength(1);
+  });
+
   it("creates a fresh escalation when the previous matching escalation is terminal", async () => {
     await enableAutoRecovery();
     const { companyId, managerId, blockedIssueId, blockerIssueId } = await seedBlockedChain();
@@ -659,5 +790,68 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
       .where(eq(issueRelations.relatedIssueId, blockedIssueId));
     expect(blockers.some((row) => row.blockerIssueId === closedEscalationId)).toBe(false);
     expect(blockers.some((row) => row.blockerIssueId === freshEscalation?.id)).toBe(true);
+  });
+
+  // GOV-4 scenario (c): storm cap — same error class 3 times → debris=0, 1 park comment
+  it("storm cap: cmd-too-long 3 runs → 0 escalation tickets, 1 park comment, agent paused", async () => {
+    await enableAutoRecovery();
+    const { companyId, managerId, coderId, blockedIssueId, blockerIssueId } = await seedBlockedChain();
+
+    // Simulate 3 failed heartbeat runs for coderId on blockerIssueId with command_line_too_long
+    const now = new Date();
+    const runIds = [randomUUID(), randomUUID(), randomUUID()];
+    for (const runId of runIds) {
+      await db.insert(heartbeatRuns).values({
+        id: runId,
+        companyId,
+        agentId: coderId,
+        status: "failed",
+        errorCode: "command_line_too_long",
+        error: "E2BIG: argument list too long",
+        contextSnapshot: { issueId: blockerIssueId },
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileIssueGraphLiveness();
+
+    // Storm cap should fire: no new escalation tickets created
+    expect(result.escalationsCreated).toBe(0);
+    expect(result.stormCapped).toBe(1);
+
+    // No escalation issues should exist
+    const escalations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "harness_liveness_escalation")));
+    expect(escalations).toHaveLength(0);
+
+    // Exactly 1 park comment should be on the blocker (recovery) issue
+    const comments = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, blockerIssueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]!.body).toContain("Recovery storm cap applied");
+    expect(comments[0]!.body).toContain("command_line_too_long");
+
+    // Agent should be paused with recovery_park reason
+    const agent = await db
+      .select({ status: agents.status, pauseReason: agents.pauseReason })
+      .from(agents)
+      .where(eq(agents.id, coderId))
+      .then((rows) => rows[0] ?? null);
+    expect(agent?.status).toBe("paused");
+    expect(agent?.pauseReason).toBe("recovery_park");
+
+    // Second reconciliation should NOT add another park comment (idempotent)
+    await heartbeat.reconcileIssueGraphLiveness();
+    const commentsAfterSecondRun = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.issueId, blockerIssueId));
+    expect(commentsAfterSecondRun).toHaveLength(1);
   });
 });

--- a/server/src/__tests__/recovery-classifiers.test.ts
+++ b/server/src/__tests__/recovery-classifiers.test.ts
@@ -5,9 +5,12 @@ import {
   RECOVERY_KEY_PREFIXES,
   RECOVERY_ORIGIN_KINDS,
   RECOVERY_REASON_KINDS,
+  STORM_CAP_MAX_FAILS,
+  STORM_CAP_WINDOW_MS,
   buildIssueGraphLivenessIncidentKey,
   buildIssueGraphLivenessLeafKey,
   buildRunLivenessContinuationIdempotencyKey,
+  classifyAdapterErrorClass,
   classifyIssueGraphLiveness,
   decideRunLivenessContinuation,
   isStrandedIssueRecoveryOriginKind,
@@ -150,5 +153,61 @@ describe("recovery classifier boundary", () => {
     expect(isStrandedIssueRecoveryOriginKind("harness_liveness_escalation")).toBe(false);
     expect(isStrandedIssueRecoveryOriginKind("manual")).toBe(false);
     expect(isStrandedIssueRecoveryOriginKind(null)).toBe(false);
+  });
+});
+
+describe("adapter error class classifier (GOV-4)", () => {
+  it("exports stable storm cap constants", () => {
+    expect(STORM_CAP_WINDOW_MS).toBe(60 * 60 * 1000);
+    expect(STORM_CAP_MAX_FAILS).toBe(2);
+  });
+
+  it("falls back to adapter_failed for null, undefined, and empty codes", () => {
+    expect(classifyAdapterErrorClass(null)).toBe("adapter_failed");
+    expect(classifyAdapterErrorClass(undefined)).toBe("adapter_failed");
+    expect(classifyAdapterErrorClass("")).toBe("adapter_failed");
+    expect(classifyAdapterErrorClass("UNKNOWN_CODE_XYZ")).toBe("adapter_failed");
+    expect(classifyAdapterErrorClass("adapter_failed")).toBe("adapter_failed");
+  });
+
+  it("classifies command_line_too_long variants", () => {
+    expect(classifyAdapterErrorClass("command_line_too_long")).toBe("command_line_too_long");
+    expect(classifyAdapterErrorClass("COMMAND_LINE_TOO_LONG")).toBe("command_line_too_long");
+    expect(classifyAdapterErrorClass("E2BIG")).toBe("command_line_too_long");
+    expect(classifyAdapterErrorClass("e2big")).toBe("command_line_too_long");
+    expect(classifyAdapterErrorClass("arg_too_long")).toBe("command_line_too_long");
+    expect(classifyAdapterErrorClass("argument_too_long")).toBe("command_line_too_long");
+    expect(classifyAdapterErrorClass("cmdline_overflow")).toBe("command_line_too_long");
+  });
+
+  it("classifies auth_quota variants", () => {
+    expect(classifyAdapterErrorClass("auth_error")).toBe("auth_quota");
+    expect(classifyAdapterErrorClass("quota_exceeded")).toBe("auth_quota");
+    expect(classifyAdapterErrorClass("rate_limit")).toBe("auth_quota");
+    expect(classifyAdapterErrorClass("rate_limit_exceeded")).toBe("auth_quota");
+    expect(classifyAdapterErrorClass("permission_denied")).toBe("auth_quota");
+    expect(classifyAdapterErrorClass("unauthorized")).toBe("auth_quota");
+    expect(classifyAdapterErrorClass("forbidden")).toBe("auth_quota");
+  });
+
+  it("classifies timeout variants", () => {
+    expect(classifyAdapterErrorClass("timeout")).toBe("timeout");
+    expect(classifyAdapterErrorClass("TIMEOUT")).toBe("timeout");
+    expect(classifyAdapterErrorClass("timed_out")).toBe("timeout");
+    expect(classifyAdapterErrorClass("request_timed_out")).toBe("timeout");
+  });
+
+  it("classifies test_failure variants", () => {
+    expect(classifyAdapterErrorClass("test_failure")).toBe("test_failure");
+    expect(classifyAdapterErrorClass("test_failed")).toBe("test_failure");
+    expect(classifyAdapterErrorClass("assertion_failed")).toBe("test_failure");
+    expect(classifyAdapterErrorClass("assert_error")).toBe("test_failure");
+  });
+
+  it("classifies deploy_mismatch variants", () => {
+    expect(classifyAdapterErrorClass("deploy_mismatch")).toBe("deploy_mismatch");
+    expect(classifyAdapterErrorClass("version_mismatch")).toBe("deploy_mismatch");
+    expect(classifyAdapterErrorClass("deploy_error")).toBe("deploy_mismatch");
+    expect(classifyAdapterErrorClass("deploy_failed")).toBe("deploy_mismatch");
   });
 });

--- a/server/src/services/recovery/index.ts
+++ b/server/src/services/recovery/index.ts
@@ -14,8 +14,13 @@ export type {
 } from "./origins.js";
 export {
   classifyIssueGraphLiveness,
+  classifyAdapterErrorClass,
+  ADAPTER_ERROR_CLASS_RECOMMENDED_ACTIONS,
+  STORM_CAP_WINDOW_MS,
+  STORM_CAP_MAX_FAILS,
 } from "./issue-graph-liveness.js";
 export type {
+  AdapterErrorClass,
   IssueGraphLivenessInput,
   IssueLivenessAgentInput,
   IssueLivenessDependencyPathEntry,

--- a/server/src/services/recovery/issue-graph-liveness.ts
+++ b/server/src/services/recovery/issue-graph-liveness.ts
@@ -1,5 +1,93 @@
 import { buildIssueGraphLivenessIncidentKey } from "./origins.js";
 
+// ---------------------------------------------------------------------------
+// Adapter error class fingerprint (GOV-4)
+// ---------------------------------------------------------------------------
+
+export type AdapterErrorClass =
+  | "adapter_failed"
+  | "command_line_too_long"
+  | "auth_quota"
+  | "timeout"
+  | "test_failure"
+  | "deploy_mismatch";
+
+export const STORM_CAP_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+export const STORM_CAP_MAX_FAILS = 2;
+
+export const ADAPTER_ERROR_CLASS_RECOMMENDED_ACTIONS: Record<AdapterErrorClass, string> = {
+  adapter_failed:
+    "Check adapter configuration and logs, then reassign or restart the agent.",
+  command_line_too_long:
+    "Reduce command-line arguments or switch to a prompt-based adapter. Bulk adapter swap is disabled for this class.",
+  auth_quota:
+    "Verify credentials and quota limits, clear the block, then resume the agent.",
+  timeout:
+    "Increase the adapter timeout limit or reduce workload per heartbeat.",
+  test_failure:
+    "Review and fix the failing test suite before resuming.",
+  deploy_mismatch:
+    "Align deployment versions between adapter and target, then retry.",
+};
+
+/**
+ * Classify a raw errorCode string into one of the six AdapterErrorClass
+ * buckets.  Falls back to "adapter_failed" for unknown codes.
+ */
+export function classifyAdapterErrorClass(
+  errorCode: string | null | undefined,
+): AdapterErrorClass {
+  if (!errorCode) return "adapter_failed";
+  const code = errorCode.toLowerCase();
+
+  if (
+    code.includes("command_line_too_long") ||
+    code.includes("e2big") ||
+    code.includes("arg_too_long") ||
+    code.includes("argument_too_long") ||
+    code.includes("cmdline_overflow")
+  ) {
+    return "command_line_too_long";
+  }
+
+  if (
+    code.includes("auth") ||
+    code.includes("quota") ||
+    code.includes("rate_limit") ||
+    code.includes("permission_denied") ||
+    code.includes("unauthorized") ||
+    code.includes("forbidden")
+  ) {
+    return "auth_quota";
+  }
+
+  if (code === "timeout" || code.includes("timed_out")) {
+    return "timeout";
+  }
+
+  if (
+    code.includes("test_failure") ||
+    code.includes("test_failed") ||
+    code.includes("assertion_failed") ||
+    code.includes("assert_error")
+  ) {
+    return "test_failure";
+  }
+
+  if (
+    code.includes("deploy_mismatch") ||
+    code.includes("version_mismatch") ||
+    code.includes("deploy_error") ||
+    code.includes("deploy_failed")
+  ) {
+    return "deploy_mismatch";
+  }
+
+  return "adapter_failed";
+}
+
+// ---------------------------------------------------------------------------
+
 export type IssueLivenessSeverity = "warning" | "critical";
 
 export type IssueLivenessState =

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -40,6 +40,11 @@ import {
 } from "./origins.js";
 import {
   classifyIssueGraphLiveness,
+  classifyAdapterErrorClass,
+  ADAPTER_ERROR_CLASS_RECOMMENDED_ACTIONS,
+  STORM_CAP_WINDOW_MS,
+  STORM_CAP_MAX_FAILS,
+  type AdapterErrorClass,
   type IssueLivenessFinding,
 } from "./issue-graph-liveness.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
@@ -2259,6 +2264,148 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return updated;
   }
 
+  // ---------------------------------------------------------------------------
+  // Storm cap (GOV-4): 2-strike park — prevent recovery storm
+  // ---------------------------------------------------------------------------
+
+  async function loadRecentFailedRunsForIssue(
+    companyId: string,
+    agentId: string,
+    issueId: string,
+  ): Promise<Array<{ errorCode: string | null }>> {
+    const cutoff = new Date(Date.now() - STORM_CAP_WINDOW_MS);
+    return db
+      .select({ errorCode: heartbeatRuns.errorCode })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, companyId),
+          eq(heartbeatRuns.agentId, agentId),
+          inArray(heartbeatRuns.status, ["failed", "timed_out", "cancelled"]),
+          gt(heartbeatRuns.createdAt, cutoff),
+          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+        ),
+      )
+      .limit(50);
+  }
+
+  function detectStormCapHit(
+    runs: Array<{ errorCode: string | null }>,
+  ): { hit: false } | { hit: true; errorClass: AdapterErrorClass; count: number } {
+    const countByClass = new Map<AdapterErrorClass, number>();
+    for (const run of runs) {
+      const cls = classifyAdapterErrorClass(run.errorCode);
+      countByClass.set(cls, (countByClass.get(cls) ?? 0) + 1);
+    }
+    for (const [cls, count] of countByClass.entries()) {
+      if (count >= STORM_CAP_MAX_FAILS) {
+        return { hit: true, errorClass: cls, count };
+      }
+    }
+    return { hit: false };
+  }
+
+  function buildStormCapParkedComment(input: {
+    agentId: string;
+    recoveryIssue: typeof issues.$inferSelect;
+    errorClass: AdapterErrorClass;
+    failCount: number;
+    prefix: string;
+  }): string {
+    const issueLink = issueUiLink(
+      { identifier: input.recoveryIssue.identifier, id: input.recoveryIssue.id },
+      input.prefix,
+    );
+    const action = ADAPTER_ERROR_CLASS_RECOMMENDED_ACTIONS[input.errorClass];
+    const isCmdTooLong = input.errorClass === "command_line_too_long";
+    const lines = [
+      `**Recovery storm cap applied** — \`${input.agentId}\` failed ${input.failCount} times in the last hour with error class \`${input.errorClass}\`.`,
+      "",
+      "Creating another recovery ticket would cause a recovery storm. This issue is now **PARKED** pending manual review.",
+      "",
+      `- Error class: \`${input.errorClass}\``,
+      `- Failure count (last 1h): ${input.failCount}`,
+      `- Agent: \`${input.agentId}\``,
+      `- Issue: ${issueLink}`,
+    ];
+    if (isCmdTooLong) {
+      lines.push("- Bulk adapter swap: **disabled** for `command_line_too_long` class");
+    }
+    lines.push("", `**Required action:** ${action}`);
+    lines.push(
+      "",
+      "When the root cause is resolved, resume the agent and clear the `recovery_park` pause reason.",
+    );
+    return lines.join("\n");
+  }
+
+  async function checkAndApplyStormCap(input: {
+    issue: typeof issues.$inferSelect;
+    recoveryIssue: typeof issues.$inferSelect;
+    assigneeAgentId: string;
+    runId: string | null | undefined;
+  }): Promise<{ kind: "not_hit" } | { kind: "already_parked" } | { kind: "parked"; errorClass: AdapterErrorClass }> {
+    // Guard: command_line_too_long bulk adapter swap path is disabled.
+    // For ALL classes: if ≥2 failures in last 1h with same error class → park.
+    const recentRuns = await loadRecentFailedRunsForIssue(
+      input.issue.companyId,
+      input.assigneeAgentId,
+      input.recoveryIssue.id,
+    );
+    const cap = detectStormCapHit(recentRuns);
+    if (!cap.hit) return { kind: "not_hit" };
+
+    // Idempotency: if agent is already parked by a previous storm cap, skip comment.
+    const agent = await db
+      .select({ status: agents.status, pauseReason: agents.pauseReason })
+      .from(agents)
+      .where(eq(agents.id, input.assigneeAgentId))
+      .then((rows) => rows[0] ?? null);
+
+    if (agent?.pauseReason === "recovery_park") {
+      logger.info(
+        { agentId: input.assigneeAgentId, issueId: input.recoveryIssue.id, errorClass: cap.errorClass },
+        "storm cap: agent already parked, skipping duplicate comment",
+      );
+      return { kind: "already_parked" };
+    }
+
+    const prefix = await getCompanyIssuePrefix(input.issue.companyId);
+    const parkedComment = buildStormCapParkedComment({
+      agentId: input.assigneeAgentId,
+      recoveryIssue: input.recoveryIssue,
+      errorClass: cap.errorClass,
+      failCount: cap.count,
+      prefix,
+    });
+
+    await issuesSvc.addComment(
+      input.recoveryIssue.id,
+      parkedComment,
+      { runId: input.runId ?? null },
+    );
+
+    await db
+      .update(agents)
+      .set({ status: "paused", pauseReason: "recovery_park", pausedAt: new Date(), updatedAt: new Date() })
+      .where(eq(agents.id, input.assigneeAgentId));
+
+    logger.warn(
+      {
+        agentId: input.assigneeAgentId,
+        issueId: input.recoveryIssue.id,
+        sourceIssueId: input.issue.id,
+        errorClass: cap.errorClass,
+        failCount: cap.count,
+      },
+      "storm cap: recovery parked, agent paused with recovery_park",
+    );
+
+    return { kind: "parked", errorClass: cap.errorClass };
+  }
+
+  // ---------------------------------------------------------------------------
+
   async function createIssueGraphLivenessEscalation(input: {
     finding: IssueLivenessFinding;
     runId?: string | null;
@@ -2291,6 +2438,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         runId: input.runId ?? null,
       });
       return { kind: "existing" as const, escalationIssueId: existing.id };
+    }
+
+    // Storm cap: if same error class hit ≥2 times in last 1h for the recovery
+    // issue's assignee (or, when the recovery issue is unassigned, the source
+    // issue's assignee), park instead of spawning another debris ticket.
+    const stormCapAgentId = recoveryIssue.assigneeAgentId ?? issue.assigneeAgentId;
+    if (stormCapAgentId) {
+      const stormCapResult = await checkAndApplyStormCap({
+        issue,
+        recoveryIssue,
+        assigneeAgentId: stormCapAgentId,
+        runId: input.runId,
+      });
+      if (stormCapResult.kind === "parked" || stormCapResult.kind === "already_parked") {
+        return { kind: "storm_capped" as const };
+      }
     }
 
     const ownerSelection = await resolveEscalationOwnerAgentId(input.finding, recoveryIssue);
@@ -2453,6 +2616,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       skipped: 0,
       skippedAutoRecoveryDisabled: 0,
       skippedOutsideLookback: 0,
+      stormCapped: 0,
       obsoleteRecoveriesRetired: obsoleteRecoveryCleanup.retired,
       obsoleteRecoveriesActiveSkipped: obsoleteRecoveryCleanup.activeSkipped,
       obsoleteRecoveryBlockerRelationsRemoved: obsoleteRecoveryCleanup.blockerRelationsRemoved,
@@ -2484,6 +2648,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         result.existingEscalations += 1;
         result.issueIds.push(finding.issueId);
         result.escalationIssueIds.push(escalation.escalationIssueId);
+      } else if (escalation.kind === "storm_capped") {
+        result.stormCapped += 1;
+        result.skipped += 1;
       } else {
         result.skipped += 1;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2270,36 +2270,45 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
   async function loadRecentFailedRunsForIssue(
     companyId: string,
-    agentId: string,
+    agentId: string | null,
     issueId: string,
-  ): Promise<Array<{ errorCode: string | null }>> {
+  ): Promise<Array<{ errorCode: string | null; agentId: string }>> {
     const cutoff = new Date(Date.now() - STORM_CAP_WINDOW_MS);
+    const conditions = [
+      eq(heartbeatRuns.companyId, companyId),
+      inArray(heartbeatRuns.status, ["failed", "timed_out", "cancelled"]),
+      gt(heartbeatRuns.createdAt, cutoff),
+      sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+    ] as const;
     return db
-      .select({ errorCode: heartbeatRuns.errorCode })
+      .select({ errorCode: heartbeatRuns.errorCode, agentId: heartbeatRuns.agentId })
       .from(heartbeatRuns)
       .where(
-        and(
-          eq(heartbeatRuns.companyId, companyId),
-          eq(heartbeatRuns.agentId, agentId),
-          inArray(heartbeatRuns.status, ["failed", "timed_out", "cancelled"]),
-          gt(heartbeatRuns.createdAt, cutoff),
-          sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
-        ),
+        agentId
+          ? and(...conditions, eq(heartbeatRuns.agentId, agentId))
+          : and(...conditions),
       )
       .limit(50);
   }
 
   function detectStormCapHit(
-    runs: Array<{ errorCode: string | null }>,
-  ): { hit: false } | { hit: true; errorClass: AdapterErrorClass; count: number } {
-    const countByClass = new Map<AdapterErrorClass, number>();
+    runs: Array<{ errorCode: string | null; agentId: string }>,
+  ): { hit: false } | { hit: true; errorClass: AdapterErrorClass; count: number; hitAgentId: string } {
+    // Group by (agentId, errorClass) so a single agent's repeat failures trigger the cap.
+    const countByKey = new Map<string, { cls: AdapterErrorClass; count: number; agentId: string }>();
     for (const run of runs) {
       const cls = classifyAdapterErrorClass(run.errorCode);
-      countByClass.set(cls, (countByClass.get(cls) ?? 0) + 1);
+      const key = `${run.agentId}:${cls}`;
+      const existing = countByKey.get(key);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        countByKey.set(key, { cls, count: 1, agentId: run.agentId });
+      }
     }
-    for (const [cls, count] of countByClass.entries()) {
+    for (const { cls, count, agentId } of countByKey.values()) {
       if (count >= STORM_CAP_MAX_FAILS) {
-        return { hit: true, errorClass: cls, count };
+        return { hit: true, errorClass: cls, count, hitAgentId: agentId };
       }
     }
     return { hit: false };
@@ -2342,11 +2351,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   async function checkAndApplyStormCap(input: {
     issue: typeof issues.$inferSelect;
     recoveryIssue: typeof issues.$inferSelect;
-    assigneeAgentId: string;
+    assigneeAgentId: string | null;
     runId: string | null | undefined;
   }): Promise<{ kind: "not_hit" } | { kind: "already_parked" } | { kind: "parked"; errorClass: AdapterErrorClass }> {
-    // Guard: command_line_too_long bulk adapter swap path is disabled.
-    // For ALL classes: if ≥2 failures in last 1h with same error class → park.
+    // For ALL error classes: if ≥2 failures in last 1h with same (agentId, errorClass) → park.
+    // When assigneeAgentId is null (unassigned blocker), check all agents' runs for the issue.
     const recentRuns = await loadRecentFailedRunsForIssue(
       input.issue.companyId,
       input.assigneeAgentId,
@@ -2355,16 +2364,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const cap = detectStormCapHit(recentRuns);
     if (!cap.hit) return { kind: "not_hit" };
 
-    // Idempotency: if agent is already parked by a previous storm cap, skip comment.
+    const effectiveAgentId = cap.hitAgentId;
+
+    // Idempotency: if the offending agent is already parked by a previous storm cap, skip comment.
     const agent = await db
       .select({ status: agents.status, pauseReason: agents.pauseReason })
       .from(agents)
-      .where(eq(agents.id, input.assigneeAgentId))
+      .where(eq(agents.id, effectiveAgentId))
       .then((rows) => rows[0] ?? null);
 
     if (agent?.pauseReason === "recovery_park") {
       logger.info(
-        { agentId: input.assigneeAgentId, issueId: input.recoveryIssue.id, errorClass: cap.errorClass },
+        { agentId: effectiveAgentId, issueId: input.recoveryIssue.id, errorClass: cap.errorClass },
         "storm cap: agent already parked, skipping duplicate comment",
       );
       return { kind: "already_parked" };
@@ -2372,7 +2383,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
     const prefix = await getCompanyIssuePrefix(input.issue.companyId);
     const parkedComment = buildStormCapParkedComment({
-      agentId: input.assigneeAgentId,
+      agentId: effectiveAgentId,
       recoveryIssue: input.recoveryIssue,
       errorClass: cap.errorClass,
       failCount: cap.count,
@@ -2388,11 +2399,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     await db
       .update(agents)
       .set({ status: "paused", pauseReason: "recovery_park", pausedAt: new Date(), updatedAt: new Date() })
-      .where(eq(agents.id, input.assigneeAgentId));
+      .where(eq(agents.id, effectiveAgentId));
 
     logger.warn(
       {
-        agentId: input.assigneeAgentId,
+        agentId: effectiveAgentId,
         issueId: input.recoveryIssue.id,
         sourceIssueId: input.issue.id,
         errorClass: cap.errorClass,


### PR DESCRIPTION
## Summary

Implements GOV-4: prevents recovery storms by capping escalation ticket creation when the same adapter error class recurs within a 1-hour window.

**Changes in `server/src/services/recovery/`:**

- `issue-graph-liveness.ts`: `AdapterErrorClass` type (6 classes: `adapter_failed`, `command_line_too_long`, `auth_quota`, `timeout`, `test_failure`, `deploy_mismatch`), `classifyAdapterErrorClass()`, `STORM_CAP_WINDOW_MS` (1h), `STORM_CAP_MAX_FAILS` (2), `ADAPTER_ERROR_CLASS_RECOMMENDED_ACTIONS`
- `service.ts`: `checkAndApplyStormCap()` — before spawning a new escalation ticket, checks recent failed runs for the recovery issue's assignee (or any agent if unassigned); if the same `(agentId, errorClass)` appears ≥2 times in 1h → PARKED comment on issue + `agent.pauseReason='recovery_park'`; idempotent (skip if already parked)
- `index.ts`: exports the new GOV-4 types/constants

**Bulk adapter swap guard:** `command_line_too_long` class explicitly disabled in PARKED comment.

**`reconcileIssueGraphLiveness()` result** now includes `stormCapped` counter.

## Test plan

- [x] `npx vitest run server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts` — 10/10 pass
- [x] `npx tsc --noEmit` from `server/` — clean
- [x] Scenario (c): 3 cmd-too-long runs → `stormCapped=1`, `escalationsCreated=0`, 1 PARKED comment, `agent.pauseReason=recovery_park`
- [x] Second reconciliation → comment count unchanged (idempotency)
- [x] Normal finding with no recent failures → escalation still created (no regression)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)