### PR TITLE
feat(heartbeat): skip idle timer wakes before adapter invocation

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -687,17 +687,19 @@ Failed source-work retries, process-loss retries, transient/scheduled retries, m
 
 ## 11.6 Scheduler Rules
 
-Per-agent schedule fields in `adapter_config`:
+Per-agent schedule fields in `runtimeConfig.heartbeat`:
 
 - `enabled` boolean
 - `intervalSec` integer (minimum 30)
 - `maxConcurrentRuns` integer; new agents default to `20`; scheduler clamps configured values to `1..50`
+- `idleSkip.enabled` boolean; when true, unscoped timer wakes with no active assigned issue are recorded as skipped before adapter invocation
 
 Scheduler must skip invocation when:
 
 - agent is paused/terminated
 - an existing run is active
 - hard budget limit has been hit
+- `idleSkip.enabled` is true and the timer wake has no explicit issue plus no assigned `todo`, `in_progress`, `in_review`, or `blocked` issue
 
 ## 12. Governance and Approval Flows
 

--- a/server/src/__tests__/heartbeat-idle-skip.test.ts
+++ b/server/src/__tests__/heartbeat-idle-skip.test.ts
@@ -1,0 +1,405 @@
+import { randomUUID } from "node:crypto";
+import { eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  companySkills,
+  createDb,
+  documentRevisions,
+  documents,
+  environmentLeases,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueDocuments,
+  issues,
+  workspaceRuntimeServices,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { runningProcesses } from "../adapters/index.ts";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const mockAdapterExecute = vi.hoisted(() =>
+  vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+    errorMessage: null,
+    summary: "Idle-skip test run.",
+    provider: "test",
+    model: "test-model",
+  })),
+);
+
+vi.mock("../adapters/index.ts", async () => {
+  const actual = await vi.importActual<typeof import("../adapters/index.ts")>("../adapters/index.ts");
+  return {
+    ...actual,
+    getServerAdapter: vi.fn(() => ({
+      supportsLocalAgentJwt: false,
+      execute: mockAdapterExecute,
+    })),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat idle-skip tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function waitForRunToFinish(db: ReturnType<typeof createDb>, runId: string, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const run = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    if (run && ["succeeded", "failed", "cancelled", "timed_out"].includes(run.status)) return run;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  return db
+    .select()
+    .from(heartbeatRuns)
+    .where(eq(heartbeatRuns.id, runId))
+    .then((rows) => rows[0] ?? null);
+}
+
+async function heartbeatSideEffectFingerprint(db: ReturnType<typeof createDb>) {
+  const [active, events, activity, leases, runtimeServices] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(heartbeatRuns)
+      .where(sql`${heartbeatRuns.status} in ('queued', 'running', 'scheduled_retry')`),
+    db.select({ count: sql<number>`count(*)` }).from(heartbeatRunEvents),
+    db.select({ count: sql<number>`count(*)` }).from(activityLog),
+    db.select({ count: sql<number>`count(*)` }).from(environmentLeases),
+    db.select({ count: sql<number>`count(*)` }).from(workspaceRuntimeServices),
+  ]);
+
+  return [
+    active[0]?.count ?? 0,
+    events[0]?.count ?? 0,
+    activity[0]?.count ?? 0,
+    leases[0]?.count ?? 0,
+    runtimeServices[0]?.count ?? 0,
+  ].join(":");
+}
+
+async function waitForHeartbeatSideEffectsSettled(
+  db: ReturnType<typeof createDb>,
+  timeoutMs = 5_000,
+  quietMs = 500,
+) {
+  const deadline = Date.now() + timeoutMs;
+  let previous = "";
+  let stableSince = Date.now();
+
+  while (Date.now() < deadline) {
+    const current = await heartbeatSideEffectFingerprint(db);
+    const activeCount = Number(current.split(":")[0] ?? 0);
+    if (current !== previous || activeCount > 0) {
+      previous = current;
+      stableSince = Date.now();
+    } else if (Date.now() - stableSince >= quietMs) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error("Timed out waiting for heartbeat side effects to settle");
+}
+
+describeEmbeddedPostgres("heartbeat idle skip", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-idle-skip-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    mockAdapterExecute.mockClear();
+    runningProcesses.clear();
+    await waitForHeartbeatSideEffectsSettled(db);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(activityLog);
+    await db.delete(issueComments);
+    await db.delete(documentRevisions);
+    await db.delete(issueDocuments);
+    await db.delete(documents);
+    await db.delete(environmentLeases);
+    await db.delete(workspaceRuntimeServices);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companySkills);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgent(input: {
+    idleSkipEnabled?: boolean;
+    heartbeatEnabled?: boolean;
+    intervalSec?: number;
+    lastHeartbeatAt?: Date | null;
+  } = {}) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const now = new Date("2026-04-12T10:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          enabled: input.heartbeatEnabled ?? true,
+          intervalSec: input.intervalSec ?? 60,
+          maxConcurrentRuns: 1,
+          wakeOnDemand: true,
+          idleSkip: {
+            enabled: input.idleSkipEnabled ?? false,
+          },
+        },
+      },
+      permissions: {},
+      lastHeartbeatAt: input.lastHeartbeatAt ?? new Date(now.getTime() - 120_000),
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    return { companyId, agentId };
+  }
+
+  async function seedAssignedIssue(input: {
+    companyId: string;
+    agentId: string;
+    status: string;
+    hiddenAt?: Date | null;
+  }) {
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId: input.companyId,
+      title: `Assigned ${input.status} issue`,
+      status: input.status,
+      priority: "medium",
+      assigneeAgentId: input.agentId,
+      issueNumber: 1,
+      identifier: `IDL-${issueId.slice(0, 8).toUpperCase()}`,
+      hiddenAt: input.hiddenAt ?? null,
+    });
+    return issueId;
+  }
+
+  it("skips timer wakeups before creating a run when idleSkip is enabled and the agent has no active assigned issues", async () => {
+    const { agentId } = await seedAgent({ idleSkipEnabled: true });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "system",
+      reason: "heartbeat_timer",
+      requestedByActorType: "system",
+      requestedByActorId: "heartbeat_scheduler",
+      contextSnapshot: { source: "scheduler" },
+    });
+
+    expect(result).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+    expect(await db.select().from(heartbeatRuns)).toHaveLength(0);
+
+    const [wakeup] = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeup).toMatchObject({
+      source: "timer",
+      status: "skipped",
+      reason: "heartbeat.idle_skip.no_work",
+      requestedByActorType: "system",
+      requestedByActorId: "heartbeat_scheduler",
+    });
+    expect(wakeup.finishedAt).toBeInstanceOf(Date);
+
+    const [agent] = await db.select().from(agents).where(eq(agents.id, agentId));
+    expect(agent.lastHeartbeatAt?.getTime()).toBeGreaterThan(new Date("2026-04-12T09:58:00.000Z").getTime());
+  });
+
+  it("coalesces timer wakeups instead of idle-skipping while an unscoped run is active", async () => {
+    const { companyId, agentId } = await seedAgent({ idleSkipEnabled: true });
+    const runningRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: runningRunId,
+      companyId,
+      agentId,
+      invocationSource: "timer",
+      triggerDetail: "system",
+      status: "running",
+      contextSnapshot: {
+        wakeReason: "heartbeat_timer",
+        wakeSource: "timer",
+      },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "system",
+      reason: "heartbeat_timer",
+      contextSnapshot: { source: "scheduler" },
+    });
+
+    expect(result?.id).toBe(runningRunId);
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups).toHaveLength(1);
+    expect(wakeups[0]).toMatchObject({
+      status: "coalesced",
+      reason: "heartbeat_timer",
+      runId: runningRunId,
+    });
+    expect(wakeups.some((wakeup) => wakeup.reason === "heartbeat.idle_skip.no_work")).toBe(false);
+
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "succeeded", finishedAt: new Date(), updatedAt: new Date() })
+      .where(eq(heartbeatRuns.id, runningRunId));
+  });
+
+  it("does not skip timer wakeups when idleSkip is disabled", async () => {
+    const { agentId } = await seedAgent({ idleSkipEnabled: false });
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "system",
+      reason: "heartbeat_timer",
+    });
+
+    expect(run).not.toBeNull();
+    const finished = await waitForRunToFinish(db, run!.id);
+    expect(finished?.status).toBe("succeeded");
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["todo", "in_progress", "in_review", "blocked"])(
+    "does not skip timer wakeups when the agent has an assigned %s issue",
+    async (status) => {
+      const { companyId, agentId } = await seedAgent({ idleSkipEnabled: true });
+      await seedAssignedIssue({ companyId, agentId, status });
+      const heartbeat = heartbeatService(db);
+
+      const run = await heartbeat.wakeup(agentId, {
+        source: "timer",
+        triggerDetail: "system",
+        reason: "heartbeat_timer",
+      });
+
+      expect(run).not.toBeNull();
+      await waitForRunToFinish(db, run!.id);
+      expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("ignores hidden assigned issues when deciding whether a timer wake has work", async () => {
+    const { companyId, agentId } = await seedAgent({ idleSkipEnabled: true });
+    await seedAssignedIssue({
+      companyId,
+      agentId,
+      status: "todo",
+      hiddenAt: new Date("2026-04-12T09:59:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "system",
+      reason: "heartbeat_timer",
+    });
+
+    expect(result).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+    const [wakeup] = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeup.reason).toBe("heartbeat.idle_skip.no_work");
+  });
+
+  it("does not apply idleSkip to on-demand wakeups", async () => {
+    const { agentId } = await seedAgent({ idleSkipEnabled: true });
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "manual_ping",
+    });
+
+    expect(run).not.toBeNull();
+    await waitForRunToFinish(db, run!.id);
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not apply idleSkip to targeted timer wakeups", async () => {
+    const { companyId, agentId } = await seedAgent({ idleSkipEnabled: true });
+    const issueId = await seedAssignedIssue({ companyId, agentId, status: "backlog" });
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "system",
+      reason: "issue_monitor_due",
+      contextSnapshot: { issueId },
+      payload: { issueId },
+    });
+
+    expect(run).not.toBeNull();
+    await waitForRunToFinish(db, run!.id);
+    expect(mockAdapterExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets tickTimers record an idle skip and advance the timer baseline", async () => {
+    const { agentId } = await seedAgent({
+      idleSkipEnabled: true,
+      intervalSec: 60,
+      lastHeartbeatAt: new Date("2026-04-12T09:58:00.000Z"),
+    });
+    const heartbeat = heartbeatService(db);
+    const tickAt = new Date("2026-04-12T10:00:00.000Z");
+
+    const result = await heartbeat.tickTimers(tickAt);
+
+    expect(result).toMatchObject({ checked: 1, enqueued: 0, skipped: 1 });
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+
+    const [agent] = await db.select().from(agents).where(eq(agents.id, agentId));
+    expect(agent.lastHeartbeatAt?.getTime()).toBeGreaterThanOrEqual(tickAt.getTime());
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -315,6 +315,7 @@ function mergeAdapterRecoveryMetadata(input: {
   };
 }
 const RUNNING_ISSUE_WAKE_REASONS_REQUIRING_FOLLOWUP = new Set(["approval_approved"]);
+const IDLE_SKIP_ACTIVE_ISSUE_STATUSES = ["todo", "in_progress", "in_review", "blocked"] as const;
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -5833,13 +5834,67 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
   function parseHeartbeatPolicy(agent: typeof agents.$inferSelect) {
     const runtimeConfig = parseObject(agent.runtimeConfig);
     const heartbeat = parseObject(runtimeConfig.heartbeat);
+    const idleSkip = parseObject(heartbeat.idleSkip);
 
     return {
       enabled: asBoolean(heartbeat.enabled, false),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
       wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
+      idleSkipEnabled: asBoolean(idleSkip.enabled, false),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
     };
+  }
+
+  async function recordTimerIdleSkipIfIdle(agent: typeof agents.$inferSelect, opts: {
+    source: "timer";
+    triggerDetail: string | null;
+    payload: Record<string, unknown> | null;
+    requestedByActorType?: string | null;
+    requestedByActorId?: string | null;
+    idempotencyKey?: string | null;
+    checkedAt: Date;
+  }) {
+    return await db.transaction(async (tx) => {
+      const assignedIssue = await tx
+        .select({ id: issues.id })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, agent.companyId),
+            eq(issues.assigneeAgentId, agent.id),
+            inArray(issues.status, [...IDLE_SKIP_ACTIVE_ISSUE_STATUSES]),
+            isNull(issues.hiddenAt),
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+
+      if (assignedIssue) return false;
+
+      await tx.insert(agentWakeupRequests).values({
+        companyId: agent.companyId,
+        agentId: agent.id,
+        source: opts.source,
+        triggerDetail: opts.triggerDetail,
+        reason: "heartbeat.idle_skip.no_work",
+        payload: opts.payload,
+        status: "skipped",
+        requestedByActorType: opts.requestedByActorType ?? null,
+        requestedByActorId: opts.requestedByActorId ?? null,
+        idempotencyKey: opts.idempotencyKey ?? null,
+        finishedAt: opts.checkedAt,
+      });
+
+      await tx
+        .update(agents)
+        .set({
+          lastHeartbeatAt: opts.checkedAt,
+          updatedAt: opts.checkedAt,
+        })
+        .where(eq(agents.id, agent.id));
+
+      return true;
+    });
   }
 
   function parseMaxTurnContinuationPolicy(agent: typeof agents.$inferSelect): MaxTurnContinuationPolicy {
@@ -9317,6 +9372,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         finishedAt: new Date(),
       });
       return mergedRun;
+    }
+
+    if (source === "timer" && policy.idleSkipEnabled && !issueId && activeRuns.length === 0) {
+      const checkedAt = new Date();
+      const skipped = await recordTimerIdleSkipIfIdle(agent, {
+        source,
+        triggerDetail,
+        payload,
+        requestedByActorType: opts.requestedByActorType,
+        requestedByActorId: opts.requestedByActorId,
+        idempotencyKey: opts.idempotencyKey,
+        checkedAt,
+      });
+      if (skipped) {
+        return null;
+      }
     }
 
     const wakeupRequest = await db


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through heartbeat runs, and those runs eventually invoke local/cloud adapters such as Codex.
> - Timer heartbeats are useful for scheduled autonomous work, but unscoped timer wakes can still invoke an adapter even when the agent has no active assigned issue.
> - For local sessioned adapters, resuming a previous session can reuse session state, but it still may spend input/cached-input tokens for an idle heartbeat.
> - The cheapest path is to avoid creating a heartbeat run at all when the scheduler can prove there is no active assigned work for that agent.
> - This pull request adds an opt-in idle-skip gate for unscoped timer wakes only.
> - The benefit is lower token/cost churn for idle scheduled agents while preserving assignment, on-demand, issue-targeted, monitor, and comment-driven wake paths.
> - This is a smaller successor to the broader discussion in #3093 and keeps the behavioral surface intentionally narrow.

## What Changed

- Added `runtimeConfig.heartbeat.idleSkip.enabled` as an opt-in policy flag.
- When enabled, unscoped `source: "timer"` wakeups check for active assigned issues in `todo`, `in_progress`, `in_review`, or `blocked`.
- If no active assigned issue exists, Paperclip records a skipped `agent_wakeup_requests` row with reason `heartbeat.idle_skip.no_work`, advances `agents.lastHeartbeatAt`, and returns before creating a `heartbeat_runs` row or invoking the adapter.
- Targeted wakes with an explicit issue, on-demand wakes, assignment wakes, automation wakes, and disabled `idleSkip` behavior continue through the existing path.
- Updated the implementation spec scheduler section and added embedded Postgres coverage for skip and non-skip cases.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-idle-skip.test.ts`
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-idle-skip.test.ts src/__tests__/heartbeat-workspace-session.test.ts src/__tests__/codex-local-execute.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `git diff --check`
- Local instance smoke test: restarted the LaunchAgent-backed local server and confirmed `GET http://localhost:3100/api/health` returned `status: "ok"`.

## Risks

- Low risk because the feature is opt-in and only affects unscoped timer wakes.
- The skip heuristic is intentionally conservative: any visible assigned issue in `todo`, `in_progress`, `in_review`, or `blocked` allows the existing adapter invocation path.
- Operators who enable `idleSkip` for agents that expect purely ambient scheduled work with no assigned issues would need to keep it disabled or create explicit issue-targeted work.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 class coding agent, tool-assisted local repository editing and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
