### PR TITLE
Block destructive workspace cleanup with unreviewed git state

### DIFF
--- a/server/src/__tests__/execution-workspaces-service.test.ts
+++ b/server/src/__tests__/execution-workspaces-service.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import { promisify } from "node:util";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { inArray } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import {
   companies,
   createDb,
@@ -416,10 +416,10 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
 
     expect(readiness).toMatchObject({
       workspaceId: executionWorkspaceId,
-      state: "ready_with_warnings",
+      state: "blocked",
       isSharedWorkspace: false,
       isProjectPrimaryWorkspace: false,
-      isDestructiveCloseAllowed: true,
+      isDestructiveCloseAllowed: false,
       git: {
         workspacePath: worktreePath,
         branchName: "paperclip-close-check",
@@ -436,6 +436,9 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       "The workspace has 1 untracked file.",
       "This workspace is 1 commit ahead of main and is not merged.",
     ]));
+    expect(readiness?.blockingReasons).toEqual(expect.arrayContaining([
+      "This workspace has unreviewed git state; archive/cleanup requires an explicit project cleanup policy approval before destructive actions.",
+    ]));
     expect(readiness?.plannedActions.map((action) => action.kind)).toEqual(expect.arrayContaining([
       "archive_record",
       "cleanup_command",
@@ -443,5 +446,37 @@ describeEmbeddedPostgres("executionWorkspaceService.getCloseReadiness", () => {
       "git_worktree_remove",
       "git_branch_delete",
     ]));
+
+    await db.update(projects)
+      .set({
+        executionWorkspacePolicy: {
+          enabled: true,
+          workspaceStrategy: {
+            type: "git_worktree",
+            teardownCommand: "bash ./scripts/project-teardown.sh",
+          },
+          cleanupPolicy: {
+            allowDestructiveCloseWithWarnings: true,
+          },
+        },
+      })
+      .where(eq(projects.id, projectId));
+
+    const policyApprovedReadiness = await svc.getCloseReadiness(executionWorkspaceId);
+
+    expect(policyApprovedReadiness).toMatchObject({
+      workspaceId: executionWorkspaceId,
+      state: "ready_with_warnings",
+      isSharedWorkspace: false,
+      isProjectPrimaryWorkspace: false,
+      isDestructiveCloseAllowed: true,
+    });
+    expect(policyApprovedReadiness?.warnings).toEqual(expect.arrayContaining([
+      "The workspace has 1 untracked file.",
+      "This workspace is 1 commit ahead of main and is not merged.",
+    ]));
+    expect(policyApprovedReadiness?.blockingReasons).not.toContain(
+      "This workspace has unreviewed git state; archive/cleanup requires an explicit project cleanup policy approval before destructive actions.",
+    );
   }, 20_000);
 });

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -55,6 +55,11 @@ function readServiceStates(value: unknown): ExecutionWorkspaceConfig["serviceSta
     : null;
 }
 
+function cleanupPolicyAllowsDestructiveCloseWithWarnings(policy: Record<string, unknown> | null | undefined) {
+  if (!policy) return false;
+  return policy.allowDestructiveCloseWithWarnings === true;
+}
+
 async function pathExists(value: string | null | undefined) {
   if (!value) return false;
   try {
@@ -604,6 +609,20 @@ export function executionWorkspaceService(db: Db) {
           git.aheadCount === 1
             ? `This workspace is 1 commit ahead of ${git.baseRef ?? "the base ref"} and is not merged.`
             : `This workspace is ${git.aheadCount} commits ahead of ${git.baseRef ?? "the base ref"} and is not merged.`,
+        );
+      }
+
+      const hasUnreviewedGitState = Boolean(
+        git?.hasDirtyTrackedFiles ||
+        git?.hasUntrackedFiles ||
+        (git?.aheadCount && git.aheadCount > 0 && git.isMergedIntoBase === false),
+      );
+      const destructiveCloseAllowedByPolicy = cleanupPolicyAllowsDestructiveCloseWithWarnings(
+        projectPolicy?.cleanupPolicy,
+      );
+      if (!isSharedWorkspace && hasUnreviewedGitState && !destructiveCloseAllowedByPolicy) {
+        blockingReasons.push(
+          "This workspace has unreviewed git state; archive/cleanup requires an explicit project cleanup policy approval before destructive actions.",
         );
       }
       if (git?.behindCount && git.behindCount > 0) {


### PR DESCRIPTION
## Thinking Path
- Paperclip execution workspaces can be runtime-created/isolated, so archive/close may also imply destructive filesystem cleanup.
- Existing close readiness already detects dirty tracked files, untracked files, and unmerged ahead commits, but treated them as warnings.
- For isolated workspaces, those warnings are potential data-loss signals when cleanup removes the worktree.
- Shared workspaces should keep their existing session archival behavior because closing a session is not equivalent to destroying the shared project workspace.
- The safe default is to block destructive close when unreviewed git state exists, unless a project explicitly opts into destructive close with warnings via cleanup policy.

## What Changed
- Added a cleanup-policy helper that recognizes `cleanupPolicy.allowDestructiveCloseWithWarnings === true`.
- Updated execution workspace close-readiness logic to block non-shared workspace archive/cleanup when unreviewed git state exists and no explicit cleanup-policy override is present.
- Preserved existing git warnings and shared workspace archive behavior.
- Updated the git worktree close-readiness test to expect blocked destructive cleanup by default.

## Verification
- In the original installed worktree before clean-branch cherry-pick:
  - `pnpm vitest run server/src/__tests__/execution-workspaces-service.test.ts --pool forks --poolOptions.forks.singleFork` — passed.
  - `pnpm vitest run server/src/__tests__/execution-workspace-policy.test.ts --pool forks --poolOptions.forks.singleFork` — passed.
  - `git diff --check -- server/src/services/execution-workspaces.ts server/src/__tests__/execution-workspaces-service.test.ts` — passed with no output.
- In the clean upstream-based worktree after installing dependencies:
  - `pnpm vitest run server/src/__tests__/execution-workspaces-service.test.ts server/src/__tests__/execution-workspace-policy.test.ts --pool forks --poolOptions.forks.singleFork` — passed, 17 tests.
  - `git diff --check` — passed with no output.
- GitHub PR checks passed on the amended revision, including policy, typecheck/release registry, build, general tests, serialized server suites, e2e, canary dry run, Snyk, and verify.

## Risks
- Behavior change: isolated workspace cleanup that previously proceeded with warnings will now block until git state is reviewed or an explicit project cleanup policy permits destructive close with warnings.
- Projects that intentionally discard isolated workspaces may need to set the explicit cleanup policy override.
- Shared workspace archival is intentionally unaffected.

## Model Used
- GPT-5.5 via Hermes/OpenAI Codex CLI agent.

## Checklist
- [x] I checked `ROADMAP.md` and this does not duplicate planned roadmap-level core feature work.
- [x] I kept the change company-scoped and preserved control-plane invariants/activity behavior.
- [x] I updated tests for the changed behavior.
- [x] I ran targeted verification where dependencies were installed.
- [x] I did not introduce schema or API contract changes.
