### PR TITLE
Bind env secrets on agent hire

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -85,6 +85,7 @@ const mockIssueService = vi.hoisted(() => ({
 const mockSecretService = vi.hoisted(() => ({
   normalizeAdapterConfigForPersistence: vi.fn(),
   resolveAdapterConfigForRuntime: vi.fn(),
+  syncEnvBindingsForTarget: vi.fn(),
 }));
 
 const mockAgentInstructionsService = vi.hoisted(() => ({
@@ -318,6 +319,7 @@ describe.sequential("agent permission routes", () => {
     mockIssueService.list.mockReset();
     mockSecretService.normalizeAdapterConfigForPersistence.mockReset();
     mockSecretService.resolveAdapterConfigForRuntime.mockReset();
+    mockSecretService.syncEnvBindingsForTarget.mockReset();
     mockAgentInstructionsService.materializeManagedBundle.mockReset();
     mockCompanySkillService.listRuntimeSkillEntries.mockReset();
     mockCompanySkillService.resolveRequestedSkillKeys.mockReset();
@@ -378,6 +380,7 @@ describe.sequential("agent permission routes", () => {
     );
     mockSecretService.normalizeAdapterConfigForPersistence.mockImplementation(async (_companyId, config) => config);
     mockSecretService.resolveAdapterConfigForRuntime.mockImplementation(async (_companyId, config) => ({ config }));
+    mockSecretService.syncEnvBindingsForTarget.mockResolvedValue([]);
     mockInstanceSettingsService.getGeneral.mockResolvedValue({
       censorUsernameInLogs: false,
     });
@@ -1023,6 +1026,44 @@ describe.sequential("agent permission routes", () => {
           },
         },
       }),
+    );
+  });
+
+  it("syncs env secret bindings when a hire is created without approval", async () => {
+    const env = {
+      FOO: {
+        type: "secret_ref",
+        secretId: "33333333-3333-4333-8333-333333333333",
+        version: "latest",
+      },
+    };
+    mockAgentService.create.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: { env },
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .send({
+        name: "Builder",
+        role: "engineer",
+        adapterType: "process",
+        adapterConfig: { env },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockSecretService.syncEnvBindingsForTarget).toHaveBeenCalledWith(
+      companyId,
+      { targetType: "agent", targetId: agentId },
+      env,
     );
   });
 

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2017,6 +2017,14 @@ export function agentRoutes(
       lastHeartbeatAt: null,
     });
     const agent = await materializeDefaultInstructionsBundleForNewAgent(createdAgent, instructionsBundle);
+    const agentEnv = asRecord(agent.adapterConfig)?.env;
+    if (agentEnv) {
+      await secretsSvc.syncEnvBindingsForTarget?.(
+        companyId,
+        { targetType: "agent", targetId: agent.id },
+        agentEnv,
+      );
+    }
 
     let approval: Awaited<ReturnType<typeof approvalsSvc.getById>> | null = null;
     const actor = getActorInfo(req);


### PR DESCRIPTION
## Summary
- The agent-hire route (`POST /companies/:companyId/agent-hires`) created the agent and persisted its `adapterConfig.env` `secret_ref`s but never wrote the corresponding `company_secret_bindings` rows.
- The direct-create route (`POST /companies/:companyId/agents`) already calls `secretsSvc.syncEnvBindingsForTarget` right after creating the agent — the hire route was missing that step.
- Result: any agent **hired** with env secrets came up unable to resolve them and failed every run with `Secret is not bound to agent:<id> at env.<KEY>` (`errorCode: adapter_failed`), staying stuck in `status=error` until something PATCHed the agent (which re-syncs bindings).

## Fix
Mirror the create handler in the hire handler: after `materializeDefaultInstructionsBundleForNewAgent`, call `secretsSvc.syncEnvBindingsForTarget` with the new agent's `env`. This covers both the approval and non-approval hire paths (binding rows are harmless for a pending agent and are idempotently rebuilt on approval/update).

## Test plan
- [x] Added a failing test (`syncs env secret bindings when a hire is created without approval`) in `agent-permissions-routes.test.ts`; verified it failed (sync called 0 times) before the fix and passes after.
- [x] `vitest run agent-permissions-routes.test.ts` — 44 passed.
- [x] `vitest run agent-skills-routes.test.ts secrets-routes.test.ts` — 38 passed (no regressions).
- [x] `tsc --noEmit` — no new type errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)