### PR TITLE
fix(heartbeat): auto-terminate process_detached runs silent > 6h

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -198,6 +198,7 @@ const WAKE_COMMENT_IDS_KEY = "wakeCommentIds";
 const PAPERCLIP_WAKE_PAYLOAD_KEY = "paperclipWake";
 const PAPERCLIP_HARNESS_CHECKOUT_KEY = "paperclipHarnessCheckedOut";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+const DETACHED_RUN_SILENT_TERMINATE_THRESHOLD_MS = 6 * 60 * 60 * 1000; // 6 hours
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INLINE_WAKE_COMMENTS = 8;
@@ -6607,6 +6608,61 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
                 processPid: run.processPid,
               },
             });
+          }
+        } else {
+          // Run is already marked process_detached. If it has been silent beyond the
+          // threshold, kill the child process group and finalize the run as failed so
+          // it doesn't hang indefinitely awaiting board intervention.
+          const silenceRefTime = run.lastOutputAt ?? run.updatedAt ?? run.startedAt ?? run.createdAt;
+          const silenceAgeMs = silenceRefTime ? now.getTime() - new Date(silenceRefTime).getTime() : Infinity;
+          if (silenceAgeMs > DETACHED_RUN_SILENT_TERMINATE_THRESHOLD_MS) {
+            const silenceHours = Math.round(silenceAgeMs / 3600000);
+            const terminateMessage = `Detached child pid ${run.processPid} silent for ${silenceHours}h; force-terminating`;
+            await terminateHeartbeatRunProcess({
+              pid: run.processPid,
+              processGroupId: run.processGroupId,
+            });
+            let finalizedDetachedRun = await setRunStatus(run.id, "failed", {
+              error: terminateMessage,
+              errorCode: "process_detached_silent",
+              finishedAt: now,
+              resultJson: mergeRunStopMetadataForAgent(
+                { adapterType, adapterConfig },
+                "failed",
+                {
+                  resultJson: parseObject(run.resultJson),
+                  errorCode: "process_detached_silent",
+                  errorMessage: terminateMessage,
+                },
+              ),
+            });
+            await setWakeupStatus(run.wakeupRequestId, "failed", {
+              finishedAt: now,
+              error: terminateMessage,
+            });
+            if (!finalizedDetachedRun) finalizedDetachedRun = await getRun(run.id);
+            if (!finalizedDetachedRun) continue;
+            finalizedDetachedRun =
+              (await classifyAndPersistRunLiveness(finalizedDetachedRun, parseObject(finalizedDetachedRun.resultJson))) ??
+              finalizedDetachedRun;
+            await releaseEnvironmentLeasesForRun({
+              runId: finalizedDetachedRun.id,
+              companyId: finalizedDetachedRun.companyId,
+              agentId: finalizedDetachedRun.agentId,
+              status: finalizedDetachedRun.status,
+              failureReason: finalizedDetachedRun.error ?? undefined,
+            });
+            await releaseIssueExecutionAndPromote(finalizedDetachedRun);
+            await appendRunEvent(finalizedDetachedRun, await nextRunEventSeq(finalizedDetachedRun.id), {
+              eventType: "lifecycle",
+              stream: "system",
+              level: "error",
+              message: terminateMessage,
+              payload: { processPid: run.processPid, silenceAgeMs },
+            });
+            await finalizeAgentStatus(run.agentId, "failed");
+            reaped.push(run.id);
+            continue;
           }
         }
         continue;


### PR DESCRIPTION
## Problem

Closes #6406

When `reapOrphanedRuns()` finds a run already marked `process_detached`, it unconditionally `continue`s — it never schedules termination. The child process stays alive forever and recovery requires a board-only cancel endpoint that agents cannot reach. This caused a 15-day hang on 2026-05-05.

## Change

**`server/src/services/heartbeat.ts`**

Adds a silent-terminate branch inside the `processPidAlive` block for runs already in `process_detached` state:

- Computes silence age from `lastOutputAt` (falling back to `updatedAt / startedAt / createdAt`)
- If `silenceAgeMs > DETACHED_RUN_SILENT_TERMINATE_THRESHOLD_MS` (6h): calls `terminateHeartbeatRunProcess()`, finalizes the run as `failed` with `errorCode: "process_detached_silent"`, and runs the full cleanup sequence (release leases, release issue execution, finalize agent status) — identical to the `process_lost` path
- Runs within the 6h window are still left alive (they may still produce output)

```
const DETACHED_RUN_SILENT_TERMINATE_THRESHOLD_MS = 6 * 60 * 60 * 1000; // 6 hours
```

## Testing

Manual verification path:
1. Start a `claude --print` heartbeat run
2. Kill the server while the child is mid-run
3. Restart the server; confirm run enters `process_detached`
4. Manually set `lastOutputAt` to 7h ago in DB
5. Trigger reaper; confirm run finalizes as `failed` with `errorCode: process_detached_silent`

## Notes

- No retry is issued for `process_detached_silent` (unlike `process_lost`) — the run already survived the detach window, retrying is unlikely to help
- R2 (idle-read deadline in `adapter-claude-local`) is not included here but is the complementary upstream fix to prevent stalled SSE reads from triggering detachment in the first place