### PR TITLE
fix(recovery): skip disposition sweep for issues with explicit no-op rules

### DIFF
--- a/server/src/__tests__/recovery-classifiers.test.ts
+++ b/server/src/__tests__/recovery-classifiers.test.ts
@@ -10,6 +10,7 @@ import {
   buildRunLivenessContinuationIdempotencyKey,
   classifyIssueGraphLiveness,
   decideRunLivenessContinuation,
+  hasExplicitNoOpRule,
   isStrandedIssueRecoveryOriginKind,
   parseIssueGraphLivenessIncidentKey,
 } from "../services/recovery/index.ts";
@@ -244,5 +245,33 @@ describe("recovery classifier boundary", () => {
     expect(isStrandedIssueRecoveryOriginKind("harness_liveness_escalation")).toBe(false);
     expect(isStrandedIssueRecoveryOriginKind("manual")).toBe(false);
     expect(isStrandedIssueRecoveryOriginKind(null)).toBe(false);
+  });
+
+  describe("hasExplicitNoOpRule", () => {
+    it("returns true when description contains 'No-op rule:'", () => {
+      expect(
+        hasExplicitNoOpRule(
+          "## Status\n\n**No-op rule:** This issue stays `in_progress` for 90 days.",
+        ),
+      ).toBe(true);
+    });
+
+    it("returns true when description contains 'Disposition sweeps are false positives'", () => {
+      expect(
+        hasExplicitNoOpRule(
+          "The live path is the daily execution routine in AWR-1084. Disposition sweeps are false positives.",
+        ),
+      ).toBe(true);
+    });
+
+    it("returns false for normal issue descriptions", () => {
+      expect(hasExplicitNoOpRule("Implement the new onboarding flow.")).toBe(false);
+      expect(hasExplicitNoOpRule("")).toBe(false);
+    });
+
+    it("returns false for null/undefined", () => {
+      expect(hasExplicitNoOpRule(null)).toBe(false);
+      expect(hasExplicitNoOpRule(undefined)).toBe(false);
+    });
   });
 });

--- a/server/src/services/recovery/index.ts
+++ b/server/src/services/recovery/index.ts
@@ -29,6 +29,7 @@ export type {
   IssueLivenessState,
 } from "./issue-graph-liveness.js";
 export {
+  hasExplicitNoOpRule,
   recoveryService,
 } from "./service.js";
 export {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -284,6 +284,21 @@ function isStrandedIssueRecoveryIssue(issue: Pick<typeof issues.$inferSelect, "o
   return isStrandedIssueRecoveryOriginKind(issue.originKind);
 }
 
+/**
+ * Returns true when an issue description contains an explicit signal that
+ * disposition sweeps should not create recovery issues for it.  Recognises two
+ * patterns authored by agents managing long-running campaign or window issues:
+ *   - "No-op rule:"  (prefixes a block that explains the intended steady state)
+ *   - "Disposition sweeps are false positives"  (unambiguous escape hatch)
+ */
+export function hasExplicitNoOpRule(description: string | null | undefined): boolean {
+  if (!description) return false;
+  return (
+    description.includes("No-op rule:") ||
+    description.includes("Disposition sweeps are false positives")
+  );
+}
+
 function isUnsuccessfulTerminalIssueRun(latestRun: LatestIssueRun) {
   return Boolean(
     latestRun &&
@@ -2382,6 +2397,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       }
 
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (hasExplicitNoOpRule(issue.description)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents in zero-human companies; the recovery service periodically sweeps all `in_progress` issues assigned to agents to detect stalled work and create recovery/escalation actions.
> - Long-running campaign issues (e.g. a 90-day community seeding campaign) intentionally stay `in_progress` for months with no activity on every sweep cycle — their execution path is a separate daily routine, not continuous heartbeats on the issue itself.
> - Agents managing these issues document this intent in the issue description with explicit signals like `No-op rule:` and `Disposition sweeps are false positives`, but the sweep never reads the description before acting.
> - As a result, `reconcileStrandedAssignedIssues` creates recovery/escalation issues on every cycle for legitimately-idle campaign issues, waking their assignees repeatedly (4 no-op heartbeats in ~10 minutes was observed in production).
> - The natural fix is to check the description for these agent-authored signals before deciding to escalate — mirroring the existing `isAutomaticRecoverySuppressedByPauseHold` guard pattern.
> - `hasExplicitNoOpRule()` is a pure string predicate that can be unit-tested without database mocks, so it is extracted and exported rather than inlined.
> - This PR adds the check, the export, and four unit tests that cover positive, negative, and null/undefined inputs.

## What Changed

- `server/src/services/recovery/service.ts`: Added exported `hasExplicitNoOpRule(description)` helper and a `continue` guard in `reconcileStrandedAssignedIssues` immediately after the pause-hold guard; issues whose description contains `"No-op rule:"` or `"Disposition sweeps are false positives"` are silently skipped.
- `server/src/services/recovery/index.ts`: Re-exports `hasExplicitNoOpRule` so it is accessible from the public recovery package surface.
- `server/src/__tests__/recovery-classifiers.test.ts`: Adds four unit tests covering both positive markers, a plain description, and null/undefined inputs.

## Verification

```
cd server
pnpm test --reporter=verbose src/__tests__/recovery-classifiers.test.ts
```

Expect the new `hasExplicitNoOpRule` suite (4 tests) to pass alongside the existing classifier tests.

To reproduce the original bug without this fix:
1. Create an `in_progress` issue assigned to an agent with an explicit `No-op rule:` block in its description and no queued heartbeat.
2. Wait for a recovery sweep cycle.
3. Observe a `Recover stalled issue` child issue created despite the no-op marker.

With this fix applied, step 3 results in a silent skip (the `result.skipped` counter increments instead).

## Risks

Low risk. The guard is additive — it only ever skips; it cannot cause a genuinely-stalled issue to be missed unless the author deliberately writes one of the two marker strings into its description. The two strings are unusual enough in normal issue prose that accidental matches are extremely unlikely. No migrations, no schema changes, no behavioral change for any issue without the markers.

## Model Used

- Provider: Anthropic  
- Model ID: `claude-sonnet-4-6`  
- Context: 200k tokens  
- Mode: Standard (no extended thinking)  
- Tool use: enabled (file reads/edits, bash, grep)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge