### PR TITLE
FF-442: Enforce issue branch matches workspace on wake/checkout

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -923,6 +923,7 @@ export function applyPaperclipWorkspaceEnv(
     workspaceRepoUrl?: string | null;
     workspaceRepoRef?: string | null;
     workspaceBranch?: string | null;
+    workspaceExpectedBranch?: string | null;
     workspaceWorktreePath?: string | null;
     agentHome?: string | null;
   },
@@ -935,6 +936,7 @@ export function applyPaperclipWorkspaceEnv(
     ["PAPERCLIP_WORKSPACE_REPO_URL", input.workspaceRepoUrl],
     ["PAPERCLIP_WORKSPACE_REPO_REF", input.workspaceRepoRef],
     ["PAPERCLIP_WORKSPACE_BRANCH", input.workspaceBranch],
+    ["PAPERCLIP_EXPECTED_BRANCH", input.workspaceExpectedBranch],
     ["PAPERCLIP_WORKSPACE_WORKTREE_PATH", input.workspaceWorktreePath],
     ["AGENT_HOME", input.agentHome],
   ] as const;
@@ -1068,6 +1070,7 @@ export function refreshPaperclipWorkspaceEnvForExecution(input: {
   workspaceRepoUrl?: string | null;
   workspaceRepoRef?: string | null;
   workspaceBranch?: string | null;
+  workspaceExpectedBranch?: string | null;
   workspaceWorktreePath?: string | null;
   workspaceHints?: Array<Record<string, unknown>>;
   agentHome?: string | null;
@@ -1098,6 +1101,7 @@ export function refreshPaperclipWorkspaceEnvForExecution(input: {
     workspaceRepoUrl: input.workspaceRepoUrl,
     workspaceRepoRef: input.workspaceRepoRef,
     workspaceBranch: input.workspaceBranch,
+    workspaceExpectedBranch: input.workspaceExpectedBranch,
     workspaceWorktreePath: shapedWorkspaceEnv.workspaceWorktreePath,
     agentHome: input.agentHome,
   });

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -215,6 +215,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const workspaceId = asString(workspaceContext.workspaceId, "");
   const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
   const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const workspaceBranch = asString(workspaceContext.branchName, "");
+  const workspaceExpectedBranch =
+    asString(context.paperclipExpectedBranch, "") ||
+    asString(workspaceContext.expectedBranch, "") ||
+    workspaceBranch;
   const agentHome = asString(workspaceContext.agentHome, "");
   const workspaceHints = Array.isArray(context.paperclipWorkspaces)
     ? context.paperclipWorkspaces.filter(
@@ -297,6 +302,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     workspaceId,
     workspaceRepoUrl,
     workspaceRepoRef,
+    workspaceBranch,
+    workspaceExpectedBranch,
     workspaceHints,
     agentHome,
     executionTargetIsRemote,

--- a/server/src/__tests__/workspace-branch-preflight.test.ts
+++ b/server/src/__tests__/workspace-branch-preflight.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  branchMatchesSpec,
+  deriveExpectedBranchSpec,
+  extractBranchNamesFromText,
+} from "../services/workspace-branch-preflight.js";
+
+describe("workspace-branch-preflight", () => {
+  it("extracts a github tree branch from issue description", () => {
+    const branches = extractBranchNamesFromText(
+      "Merge https://github.com/freddiesflowers/ff_redshift_dw/tree/DE-455_braintree_load into develop",
+    );
+    expect(branches).toEqual(["DE-455_braintree_load"]);
+  });
+
+  it("derives ff issue prefix when no explicit branch is configured", () => {
+    const spec = deriveExpectedBranchSpec({
+      issue: { id: "issue-1", identifier: "FF-442", title: "Branch enforcement", workMode: null },
+      issueNumber: 442,
+      issueDescription: null,
+      persistedBranchName: null,
+      projectPolicy: null,
+      issueWorkspaceSettings: null,
+      projectId: "project-1",
+      repoRef: null,
+    });
+    expect(spec).toEqual({
+      exact: null,
+      prefix: "ff-442-",
+      label: "ff-442-*",
+    });
+  });
+
+  it("prefers persisted execution workspace branch over prefix heuristic", () => {
+    const spec = deriveExpectedBranchSpec({
+      issue: { id: "issue-1", identifier: "FF-442", title: "Branch enforcement", workMode: null },
+      issueNumber: 442,
+      issueDescription: null,
+      persistedBranchName: "ff-425-de-455-braintree",
+      projectPolicy: null,
+      issueWorkspaceSettings: null,
+      projectId: "project-1",
+      repoRef: null,
+    });
+    expect(spec).toEqual({
+      exact: "ff-425-de-455-braintree",
+      prefix: null,
+      label: "ff-425-de-455-braintree",
+    });
+  });
+
+  it("matches prefix and exact branch specs", () => {
+    expect(
+      branchMatchesSpec("ff-442-enforce-issue-branch", {
+        exact: null,
+        prefix: "ff-442-",
+        label: "ff-442-*",
+      }),
+    ).toBe(true);
+    expect(
+      branchMatchesSpec("ff-425-de-455-braintree", {
+        exact: "ff-425-de-455-braintree",
+        prefix: null,
+        label: "ff-425-de-455-braintree",
+      }),
+    ).toBe(true);
+    expect(
+      branchMatchesSpec("ff-438-de-480-deferred-income-balance", {
+        exact: null,
+        prefix: "ff-425-",
+        label: "ff-425-*",
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -95,6 +95,11 @@ import {
   type RealizedExecutionWorkspace,
   sanitizeRuntimeServiceBaseEnv,
 } from "./workspace-runtime.js";
+import {
+  enforceWorkspaceBranchPreflight,
+  expectedBranchForPersistence,
+  WorkspaceBranchPreflightError,
+} from "./workspace-branch-preflight.js";
 import { issueService } from "./issues.js";
 import {
   buildIssueMonitorClearedPatch,
@@ -7472,6 +7477,49 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           ]
         : []),
     ];
+    const branchPreflight = issueId
+      ? await enforceWorkspaceBranchPreflight(db, {
+      companyId: agent.companyId,
+      issueId,
+      issueIdentifier: issueRef?.identifier ?? null,
+      issueNumber: null,
+      issueTitle: issueRef?.title ?? null,
+      issueDescription: issueContext?.description ?? null,
+      workspaceCwd: executionWorkspace.cwd,
+      workspaceSource: executionWorkspace.source,
+      persistedBranchName: executionWorkspace.branchName ?? persistedExecutionWorkspace?.branchName ?? null,
+      projectPolicy: projectExecutionWorkspacePolicy,
+      issueWorkspaceSettings: (issueExecutionWorkspaceSettings ?? null) as Record<string, unknown> | null,
+      projectId: resolvedProjectId,
+      repoRef: executionWorkspace.repoRef,
+      issue: issueRef
+        ? {
+            id: issueRef.id,
+            identifier: issueRef.identifier,
+            title: issueRef.title,
+            workMode: issueRef.workMode,
+          }
+        : null,
+    })
+      : {
+          expectedBranch: executionWorkspace.branchName,
+          expectedSpec: null,
+          currentBranch: null,
+          autoCheckedOut: false,
+          warnings: [],
+        };
+    if (branchPreflight.warnings.length > 0) {
+      runtimeWorkspaceWarnings.push(...branchPreflight.warnings);
+    }
+    const resolvedBranchName =
+      branchPreflight.expectedSpec
+        ? expectedBranchForPersistence(branchPreflight.expectedSpec) ?? branchPreflight.currentBranch
+        : executionWorkspace.branchName ?? branchPreflight.currentBranch;
+    if (resolvedBranchName && executionWorkspace.branchName !== resolvedBranchName) {
+      executionWorkspace.branchName = resolvedBranchName;
+    }
+    const expectedBranchLabel =
+      branchPreflight.expectedSpec?.label ?? branchPreflight.expectedBranch ?? resolvedBranchName ?? null;
     context.paperclipWorkspace = {
       cwd: executionWorkspace.cwd,
       source: executionWorkspace.source,
@@ -7482,6 +7530,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       repoUrl: executionWorkspace.repoUrl,
       repoRef: executionWorkspace.repoRef,
       branchName: executionWorkspace.branchName,
+      expectedBranch: expectedBranchLabel,
       worktreePath: executionWorkspace.worktreePath,
       realization: workspaceRealization,
       agentHome: await (async () => {
@@ -7490,6 +7539,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         return home;
       })(),
     };
+    if (expectedBranchLabel) {
+      context.paperclipExpectedBranch = expectedBranchLabel;
+    } else {
+      delete context.paperclipExpectedBranch;
+    }
     context.paperclipWorkspaces = resolvedWorkspace.workspaceHints;
     const runtimeServiceIntents = (() => {
       const runtimeConfig = parseObject(resolvedConfig.workspaceRuntime);
@@ -8161,11 +8215,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
           // The inner catch did not fire, so we must record the failure here.
           const message = outerErr instanceof Error ? outerErr.message : "Unknown setup failure";
+          const setupErrorCode =
+            outerErr instanceof WorkspaceBranchPreflightError
+              ? outerErr.code
+              : "adapter_failed";
           logger.error({ err: outerErr, runId }, "heartbeat execution setup failed");
           const setupFailureAgent = await getAgent(run.agentId).catch(() => null);
           await setRunStatus(runId, "failed", {
             error: message,
-            errorCode: "adapter_failed",
+            errorCode: setupErrorCode,
             finishedAt: new Date(),
             ...(setupFailureAgent ? {
               resultJson: mergeRunStopMetadataForAgent(setupFailureAgent, "failed", {

--- a/server/src/services/workspace-branch-preflight.ts
+++ b/server/src/services/workspace-branch-preflight.ts
@@ -1,0 +1,471 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+import type { Db } from "@paperclipai/db";
+import { executionWorkspaces, issues, projectWorkspaces } from "@paperclipai/db";
+import { and, eq, inArray, isNotNull, ne } from "drizzle-orm";
+import { asString, parseObject, renderTemplate } from "../adapters/utils.js";
+import type { ExecutionWorkspaceIssueRef } from "./workspace-runtime.js";
+import type { ProjectExecutionWorkspacePolicy } from "@paperclipai/shared";
+
+const execFile = promisify(execFileCallback);
+
+export class WorkspaceBranchPreflightError extends Error {
+  readonly code = "workspace_branch_preflight";
+  readonly details: Record<string, unknown>;
+
+  constructor(message: string, details: Record<string, unknown> = {}) {
+    super(message);
+    this.name = "WorkspaceBranchPreflightError";
+    this.details = details;
+  }
+}
+
+export type ExpectedBranchSpec = {
+  /** Exact branch name required (git worktree / explicit override). */
+  exact: string | null;
+  /** When set, current branch must start with this prefix (e.g. `ff-442-`). */
+  prefix: string | null;
+  /** Human-readable summary for error messages. */
+  label: string;
+};
+
+export type WorkspaceBranchPreflightInput = {
+  companyId: string;
+  issueId: string;
+  issueIdentifier: string | null;
+  issueNumber: number | null;
+  issueTitle: string | null;
+  issueDescription: string | null;
+  workspaceCwd: string;
+  workspaceSource: "project_primary" | "task_session" | "agent_home";
+  persistedBranchName: string | null;
+  projectPolicy: ProjectExecutionWorkspacePolicy | null;
+  issueWorkspaceSettings: Record<string, unknown> | null;
+  skipPreflight?: boolean;
+};
+
+export type WorkspaceBranchPreflightResult = {
+  expectedBranch: string | null;
+  expectedSpec: ExpectedBranchSpec | null;
+  currentBranch: string | null;
+  autoCheckedOut: boolean;
+  warnings: string[];
+};
+
+const GITHUB_TREE_BRANCH_RE =
+  /github\.com\/[^/\s]+\/[^/\s]+\/tree\/([^/?#\s]+)/gi;
+
+function readIssueNumber(identifier: string | null, issueNumber: number | null): number | null {
+  if (typeof issueNumber === "number" && Number.isFinite(issueNumber)) return issueNumber;
+  if (!identifier) return null;
+  const match = identifier.match(/-(\d+)$/i);
+  return match ? Number.parseInt(match[1] ?? "", 10) : null;
+}
+
+function sanitizeBranchName(value: string): string {
+  return (
+    value
+      .trim()
+      .replace(/[^A-Za-z0-9._/-]+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^[-/.]+|[-/.]+$/g, "")
+      .slice(0, 120) || "paperclip-work"
+  );
+}
+
+function sanitizeSlugPart(value: string | null | undefined, fallback: string): string {
+  const raw = (value ?? "").trim().toLowerCase();
+  const normalized = raw
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "");
+  return normalized.length > 0 ? normalized : fallback;
+}
+
+function renderBranchTemplate(
+  template: string,
+  input: {
+    issue: ExecutionWorkspaceIssueRef | null;
+    projectId: string | null;
+    repoRef: string | null;
+  },
+): string {
+  const issueIdentifier = input.issue?.identifier ?? input.issue?.id ?? "issue";
+  const slug = sanitizeSlugPart(input.issue?.title, sanitizeSlugPart(issueIdentifier, "issue"));
+  return renderTemplate(template, {
+    issue: {
+      id: input.issue?.id ?? "",
+      identifier: input.issue?.identifier ?? "",
+      title: input.issue?.title ?? "",
+      issueNumber: readIssueNumber(input.issue?.identifier ?? null, null)?.toString() ?? "",
+    },
+    project: { id: input.projectId ?? "" },
+    workspace: { repoRef: input.repoRef ?? "" },
+    slug,
+  });
+}
+
+function parseBranchPolicy(raw: unknown): Record<string, unknown> {
+  return parseObject(raw);
+}
+
+function branchPolicyEnforcement(policy: ProjectExecutionWorkspacePolicy | null): "strict" | "off" {
+  const branchPolicy = parseBranchPolicy(policy?.branchPolicy);
+  const enforcement = asString(branchPolicy.enforcement, "strict");
+  return enforcement === "off" ? "off" : "strict";
+}
+
+function branchPolicyAutoCheckout(policy: ProjectExecutionWorkspacePolicy | null): boolean {
+  const branchPolicy = parseBranchPolicy(policy?.branchPolicy);
+  if (typeof branchPolicy.autoCheckout === "boolean") return branchPolicy.autoCheckout;
+  return true;
+}
+
+export function extractBranchNamesFromText(text: string | null | undefined): string[] {
+  if (!text) return [];
+  const found = new Set<string>();
+  for (const match of text.matchAll(GITHUB_TREE_BRANCH_RE)) {
+    const branch = match[1]?.trim();
+    if (branch) found.add(sanitizeBranchName(decodeURIComponent(branch)));
+  }
+  return [...found];
+}
+
+export function deriveExpectedBranchSpec(input: {
+  issue: ExecutionWorkspaceIssueRef | null;
+  issueNumber: number | null;
+  issueDescription: string | null;
+  persistedBranchName: string | null;
+  projectPolicy: ProjectExecutionWorkspacePolicy | null;
+  issueWorkspaceSettings: Record<string, unknown> | null;
+  projectId: string | null;
+  repoRef: string | null;
+}): ExpectedBranchSpec | null {
+  const issueRef = input.issue;
+  const settings = parseObject(input.issueWorkspaceSettings);
+  const branchOverride = asString(settings.branchOverride, "").trim();
+  if (branchOverride) {
+    const exact = sanitizeBranchName(branchOverride);
+    return { exact, prefix: null, label: exact };
+  }
+
+  if (input.persistedBranchName?.trim()) {
+    const exact = sanitizeBranchName(input.persistedBranchName);
+    return { exact, prefix: null, label: exact };
+  }
+
+  const branchPolicy = parseBranchPolicy(input.projectPolicy?.branchPolicy);
+  const issueStrategy = parseObject(settings.workspaceStrategy);
+  const projectStrategy = parseObject(input.projectPolicy?.workspaceStrategy);
+  const strategy = Object.keys(issueStrategy).length > 0 ? issueStrategy : projectStrategy;
+  const strategyType = asString(strategy.type, "");
+  const branchTemplate =
+    asString(branchPolicy.branchTemplate, "").trim() ||
+    asString(strategy.branchTemplate, "").trim() ||
+    (strategyType === "git_worktree" ? "{{issue.identifier}}-{{slug}}" : "");
+
+  if (branchTemplate) {
+    const exact = sanitizeBranchName(
+      renderBranchTemplate(branchTemplate, {
+        issue: issueRef,
+        projectId: input.projectId,
+        repoRef: input.repoRef,
+      }),
+    );
+    return { exact, prefix: null, label: exact };
+  }
+
+  const descriptionBranches = extractBranchNamesFromText(input.issueDescription);
+  if (descriptionBranches.length === 1) {
+    const exact = descriptionBranches[0]!;
+    return { exact, prefix: null, label: exact };
+  }
+
+  const prefixTemplate = asString(branchPolicy.identifierPrefixTemplate, "").trim();
+  const issueNum = readIssueNumber(issueRef?.identifier ?? null, input.issueNumber);
+  if (prefixTemplate && issueNum != null) {
+    const prefix = sanitizeBranchName(
+      renderBranchTemplate(prefixTemplate, {
+        issue: issueRef,
+        projectId: input.projectId,
+        repoRef: input.repoRef,
+      }),
+    );
+    return { exact: null, prefix: prefix.endsWith("-") ? prefix : `${prefix}-`, label: `${prefix}*` };
+  }
+
+  if (issueNum != null) {
+    const identifier = issueRef?.identifier ?? "";
+    const lowered = identifier.toLowerCase();
+    if (/^[a-z]+-\d+$/i.test(identifier)) {
+      const prefix = `${lowered.split("-")[0]}-${issueNum}-`;
+      return { exact: null, prefix, label: `${prefix}*` };
+    }
+  }
+
+  return null;
+}
+
+export function branchMatchesSpec(currentBranch: string, spec: ExpectedBranchSpec): boolean {
+  if (spec.exact) return currentBranch === spec.exact;
+  if (spec.prefix) return currentBranch.startsWith(spec.prefix);
+  return true;
+}
+
+export async function isGitRepository(cwd: string): Promise<boolean> {
+  try {
+    await execFile("git", ["rev-parse", "--git-dir"], { cwd });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readGitCurrentBranch(cwd: string): Promise<string | null> {
+  try {
+    const branch = await execFile(
+      "git",
+      ["symbolic-ref", "--quiet", "--short", "HEAD"],
+      { cwd },
+    );
+    return branch.stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function localBranchExists(cwd: string, branchName: string): Promise<boolean> {
+  try {
+    await execFile("git", ["show-ref", "--verify", `refs/heads/${branchName}`], { cwd });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function checkoutGitBranch(cwd: string, branchName: string): Promise<void> {
+  await execFile("git", ["checkout", branchName], { cwd });
+}
+
+export async function listSharedCwdInProgressConflicts(
+  db: Db,
+  input: {
+    companyId: string;
+    projectId: string | null;
+    workspaceCwd: string;
+    excludeIssueId: string;
+  },
+): Promise<Array<{ id: string; identifier: string | null }>> {
+  if (!input.projectId) return [];
+
+  const rows = await db
+    .select({
+      id: issues.id,
+      identifier: issues.identifier,
+      executionWorkspaceId: issues.executionWorkspaceId,
+      projectWorkspaceId: issues.projectWorkspaceId,
+    })
+    .from(issues)
+    .where(
+      and(
+        eq(issues.companyId, input.companyId),
+        eq(issues.projectId, input.projectId),
+        eq(issues.status, "in_progress"),
+        ne(issues.id, input.excludeIssueId),
+      ),
+    );
+
+  const executionWorkspaceIds = [
+    ...new Set(
+      rows
+        .map((row) => row.executionWorkspaceId)
+        .filter((value): value is string => typeof value === "string" && value.length > 0),
+    ),
+  ];
+
+  const cwdByExecutionWorkspaceId = new Map<string, string>();
+  if (executionWorkspaceIds.length > 0) {
+    const workspaceRows = await db
+      .select({ id: executionWorkspaces.id, cwd: executionWorkspaces.cwd })
+      .from(executionWorkspaces)
+      .where(
+        and(
+          eq(executionWorkspaces.companyId, input.companyId),
+          inArray(executionWorkspaces.id, executionWorkspaceIds),
+          isNotNull(executionWorkspaces.cwd),
+        ),
+      );
+    for (const row of workspaceRows) {
+      if (row.cwd) cwdByExecutionWorkspaceId.set(row.id, row.cwd);
+    }
+  }
+
+  const projectWorkspaceIds = [
+    ...new Set(
+      rows
+        .map((row) => row.projectWorkspaceId)
+        .filter((value): value is string => typeof value === "string" && value.length > 0),
+    ),
+  ];
+  const primaryCwdByProjectWorkspaceId = new Map<string, string>();
+  if (projectWorkspaceIds.length > 0) {
+    const projectWorkspaceRows = await db
+      .select({ id: projectWorkspaces.id, cwd: projectWorkspaces.cwd })
+      .from(projectWorkspaces)
+      .where(
+        and(
+          eq(projectWorkspaces.companyId, input.companyId),
+          inArray(projectWorkspaces.id, projectWorkspaceIds),
+        ),
+      );
+    for (const row of projectWorkspaceRows) {
+      if (row.cwd) primaryCwdByProjectWorkspaceId.set(row.id, row.cwd);
+    }
+  }
+
+  const normalizedTarget = input.workspaceCwd;
+  const conflicts: Array<{ id: string; identifier: string | null }> = [];
+  for (const row of rows) {
+    const executionCwd = row.executionWorkspaceId
+      ? cwdByExecutionWorkspaceId.get(row.executionWorkspaceId) ?? null
+      : null;
+    const primaryCwd = row.projectWorkspaceId
+      ? primaryCwdByProjectWorkspaceId.get(row.projectWorkspaceId) ?? null
+      : null;
+    const comparableCwd = executionCwd ?? primaryCwd;
+    if (comparableCwd && comparableCwd === normalizedTarget) {
+      conflicts.push({ id: row.id, identifier: row.identifier });
+    }
+  }
+  return conflicts;
+}
+
+export async function enforceWorkspaceBranchPreflight(
+  db: Db,
+  input: WorkspaceBranchPreflightInput & {
+    projectId: string | null;
+    repoRef: string | null;
+    issue: ExecutionWorkspaceIssueRef | null;
+  },
+): Promise<WorkspaceBranchPreflightResult> {
+  const warnings: string[] = [];
+  if (input.skipPreflight || process.env.PAPERCLIP_SKIP_BRANCH_PREFLIGHT === "true") {
+    return {
+      expectedBranch: input.persistedBranchName,
+      expectedSpec: null,
+      currentBranch: null,
+      autoCheckedOut: false,
+      warnings,
+    };
+  }
+
+  if (branchPolicyEnforcement(input.projectPolicy) === "off") {
+    return {
+      expectedBranch: input.persistedBranchName,
+      expectedSpec: null,
+      currentBranch: null,
+      autoCheckedOut: false,
+      warnings,
+    };
+  }
+
+  if (!(await isGitRepository(input.workspaceCwd))) {
+    return {
+      expectedBranch: input.persistedBranchName,
+      expectedSpec: null,
+      currentBranch: null,
+      autoCheckedOut: false,
+      warnings,
+    };
+  }
+
+  const conflicts = await listSharedCwdInProgressConflicts(db, {
+    companyId: input.companyId,
+    projectId: input.projectId,
+    workspaceCwd: input.workspaceCwd,
+    excludeIssueId: input.issueId,
+  });
+  if (conflicts.length > 0 && input.workspaceSource === "project_primary") {
+    const conflictLabels = conflicts
+      .map((row) => row.identifier ?? row.id)
+      .join(", ");
+    throw new WorkspaceBranchPreflightError(
+      `Workspace preflight refused: project primary path "${input.workspaceCwd}" is already checked out for in-progress issue(s) ${conflictLabels}. Use an isolated git worktree or finish/conflict-resolve the other issue first.`,
+      {
+        workspaceCwd: input.workspaceCwd,
+        conflictingIssues: conflicts,
+      },
+    );
+  }
+
+  const expectedSpec = deriveExpectedBranchSpec({
+    issue: input.issue,
+    issueNumber: input.issueNumber,
+    issueDescription: input.issueDescription,
+    persistedBranchName: input.persistedBranchName,
+    projectPolicy: input.projectPolicy,
+    issueWorkspaceSettings: input.issueWorkspaceSettings,
+    projectId: input.projectId,
+    repoRef: input.repoRef,
+  });
+
+  if (!expectedSpec) {
+    const currentBranch = await readGitCurrentBranch(input.workspaceCwd);
+    return {
+      expectedBranch: null,
+      expectedSpec: null,
+      currentBranch,
+      autoCheckedOut: false,
+      warnings,
+    };
+  }
+
+  let currentBranch = await readGitCurrentBranch(input.workspaceCwd);
+  let autoCheckedOut = false;
+
+  if (currentBranch && !branchMatchesSpec(currentBranch, expectedSpec)) {
+    if (expectedSpec.exact && branchPolicyAutoCheckout(input.projectPolicy)) {
+      if (await localBranchExists(input.workspaceCwd, expectedSpec.exact)) {
+        await checkoutGitBranch(input.workspaceCwd, expectedSpec.exact);
+        currentBranch = await readGitCurrentBranch(input.workspaceCwd);
+        autoCheckedOut = currentBranch === expectedSpec.exact;
+        if (autoCheckedOut) {
+          warnings.push(`Checked out branch "${expectedSpec.exact}" for ${input.issueIdentifier ?? input.issueId}.`);
+        }
+      }
+    }
+  }
+
+  if (!currentBranch) {
+    throw new WorkspaceBranchPreflightError(
+      `Workspace preflight failed: "${input.workspaceCwd}" is not on a named git branch (detached HEAD). Expected ${expectedSpec.label} for ${input.issueIdentifier ?? input.issueId}.`,
+      { expected: expectedSpec, workspaceCwd: input.workspaceCwd },
+    );
+  }
+
+  if (!branchMatchesSpec(currentBranch, expectedSpec)) {
+    throw new WorkspaceBranchPreflightError(
+      `Workspace preflight failed: git branch "${currentBranch}" does not match expected ${expectedSpec.label} for ${input.issueIdentifier ?? input.issueId} in "${input.workspaceCwd}". Checkout the issue branch before running the agent.`,
+      {
+        expected: expectedSpec,
+        actual: currentBranch,
+        workspaceCwd: input.workspaceCwd,
+        issueIdentifier: input.issueIdentifier,
+      },
+    );
+  }
+
+  const expectedBranch = expectedSpec.exact ?? expectedSpec.prefix ?? null;
+  return {
+    expectedBranch,
+    expectedSpec,
+    currentBranch,
+    autoCheckedOut,
+    warnings,
+  };
+}
+
+export function expectedBranchForPersistence(spec: ExpectedBranchSpec | null): string | null {
+  if (!spec) return null;
+  return spec.exact ?? null;
+}

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -690,6 +690,7 @@ function buildWorkspaceCommandEnv(input: {
   repoRoot: string;
   worktreePath: string;
   branchName: string;
+  expectedBranchName?: string | null;
   issue: ExecutionWorkspaceIssueRef | null;
   agent: ExecutionWorkspaceAgentRef;
   created: boolean;
@@ -714,6 +715,9 @@ function buildWorkspaceCommandEnv(input: {
   env.PAPERCLIP_ISSUE_IDENTIFIER = input.issue?.identifier ?? "";
   env.PAPERCLIP_ISSUE_TITLE = input.issue?.title ?? "";
   env.PAPERCLIP_ISSUE_WORK_MODE = input.issue?.workMode ?? "";
+  if (input.expectedBranchName) {
+    env.PAPERCLIP_EXPECTED_BRANCH = input.expectedBranchName;
+  }
   return env;
 }
 

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -63,6 +63,8 @@ Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLI
 
 If already checked out by you, returns normally. If owned by another agent: `409 Conflict` — stop, pick a different task. **Never retry a 409.**
 
+**Step 5.5 — Branch preflight (code issues on shared project workspaces).** Before editing or running repo tools, the harness enforces that `git branch --show-current` in `PAPERCLIP_WORKSPACE_CWD` matches the checked-out issue. The server injects `PAPERCLIP_EXPECTED_BRANCH` (and persists `currentExecutionWorkspace.branchName` when possible). A mismatch fails the heartbeat **before** the adapter runs, with `workspace_branch_preflight` in the run log. For `project_primary` paths, a second in-progress issue on the same cwd is refused. Override only when intentional: project `branchPolicy.enforcement: "off"`, or server env `PAPERCLIP_SKIP_BRANCH_PREFLIGHT=true`. Comment re-opens that inherit another issue's workspace via `inheritExecutionWorkspaceFromIssueId` should reuse that issue's branch metadata.
+
 **Step 6 — Understand context.** Prefer `GET /api/issues/{issueId}/heartbeat-context` first. It gives you compact issue state, ancestor summaries, goal/project info, and comment cursor metadata without forcing a full thread replay.
 
 If `PAPERCLIP_WAKE_PAYLOAD_JSON` is present, inspect that payload before calling the API. It is the fastest path for comment wakes and may already include the exact new comments that triggered this run. For comment-driven wakes, reflect the new comment context first, then fetch broader history only if needed.

--- a/skills/paperclip/references/issue-workspaces.md
+++ b/skills/paperclip/references/issue-workspaces.md
@@ -20,6 +20,12 @@ Read `currentExecutionWorkspace`:
 
 If `currentExecutionWorkspace` is `null`, the issue does not currently have a realized execution workspace. For child/follow-up work, create the child with `parentId` or use `inheritExecutionWorkspaceFromIssueId` so Paperclip preserves workspace continuity.
 
+## Branch preflight
+
+On checkout/wake for git-backed project workspaces, Paperclip derives an expected branch (execution workspace `branchName`, project/issue `branchTemplate`, PR links in the description, or `ff-<issueNumber>-*` style prefixes) and injects `PAPERCLIP_EXPECTED_BRANCH` into the adapter environment. Before the agent starts, the server compares `git branch --show-current` under `PAPERCLIP_WORKSPACE_CWD` and **fails the run** with `workspace_branch_preflight` when they disagree. Shared `project_primary` paths also refuse a second concurrent `in_progress` issue on the same cwd.
+
+Repo scripts such as `scripts/paperclip_verify_branch.sh` (FF DW) are a second line of defense inside the workspace; they read the same `PAPERCLIP_EXPECTED_BRANCH` variable when set.
+
 ## Control Services
 
 Prefer Paperclip-managed runtime service controls over manual `pnpm dev &` or ad-hoc background processes. These endpoints keep service state, URLs, logs, and ownership visible to other agents and the board.


### PR DESCRIPTION
## Summary

Prevents coding agents from running on the wrong git branch when using shared `project_primary` workspaces (incident: FF-425 woke on FF-438's branch).

- Adds `workspace-branch-preflight` service: derive expected branch from persisted workspace, template, description links, or `ff-<issueNumber>-*` prefix; detect shared-cwd conflicts; optional auto-checkout; fail heartbeat before adapter with `workspace_branch_preflight`.
- Integrates preflight in heartbeat + sets `PAPERCLIP_EXPECTED_BRANCH` for adapters.
- Unit tests (4) + skill/docs updates.

## Test plan

- [x] `vitest run server/src/__tests__/workspace-branch-preflight.test.ts`
- [x] `pnpm --filter @paperclipai/server typecheck`
- [ ] Deploy/restart instance from this build
- [ ] Smoke: wake issue on mismatched branch → run fails with `workspace_branch_preflight`

## FF tracking

[FF-442](https://paperclip instance issue) — Paperclip platform work for Freddie's Flowers.


Made with [Cursor](https://cursor.com)