### PR TITLE
feat: support enableStrandedIssueRecovery and enableIssueProductivity…

### DIFF
--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -32,6 +32,8 @@ export interface InstanceExperimentalSettings {
   autoRestartDevServerWhenIdle: boolean;
   enableIssueGraphLivenessAutoRecovery: boolean;
   issueGraphLivenessAutoRecoveryLookbackHours: number;
+  enableStrandedIssueRecovery: boolean;
+  enableIssueProductivityReview: boolean;
 }
 
 export interface InstanceSettings {

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -46,6 +46,8 @@ export const instanceExperimentalSettingsSchema = z.object({
     .min(MIN_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS)
     .max(MAX_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS)
     .default(DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS),
+  enableStrandedIssueRecovery: z.boolean().default(true),
+  enableIssueProductivityReview: z.boolean().default(true),
 }).strict();
 
 export const patchInstanceExperimentalSettingsSchema = instanceExperimentalSettingsSchema.partial();

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -46,6 +46,8 @@ function normalizeExperimentalSettings(raw: unknown): InstanceExperimentalSettin
       issueGraphLivenessAutoRecoveryLookbackHours:
         parsed.data.issueGraphLivenessAutoRecoveryLookbackHours ??
         DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
+      enableStrandedIssueRecovery: parsed.data.enableStrandedIssueRecovery ?? true,
+      enableIssueProductivityReview: parsed.data.enableIssueProductivityReview ?? true,
     };
   }
   return {
@@ -55,6 +57,8 @@ function normalizeExperimentalSettings(raw: unknown): InstanceExperimentalSettin
     enableIssueGraphLivenessAutoRecovery: false,
     issueGraphLivenessAutoRecoveryLookbackHours:
       DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
+    enableStrandedIssueRecovery: true,
+    enableIssueProductivityReview: true,
   };
 }
 

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -1,4 +1,5 @@
 import { and, asc, desc, eq, gt, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { instanceSettingsService } from "./instance-settings.js";
 import type { Db } from "@paperclipai/db";
 import { clampIssueRequestDepth } from "@paperclipai/shared";
 import {
@@ -203,6 +204,7 @@ function formatTrigger(trigger: ProductivityReviewTrigger) {
 export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: EnqueueWakeup }) {
   const issuesSvc = issueService(db);
   const budgets = budgetService(db);
+  const instanceSettings = instanceSettingsService(db);
 
   async function getCompanyIssuePrefix(companyId: string) {
     return db
@@ -763,6 +765,22 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     companyId?: string;
     thresholds?: Partial<ProductivityReviewThresholds>;
   }) {
+    const experimental = await instanceSettings.getExperimental();
+    if (!experimental.enableIssueProductivityReview) {
+      return {
+        scanned: 0,
+        created: 0,
+        updated: 0,
+        existing: 0,
+        snoozed: 0,
+        creationCapped: 0,
+        skipped: 0,
+        failed: 0,
+        reviewIssueIds: [] as string[],
+        failedIssueIds: [] as string[],
+      };
+    }
+
     const now = opts?.now ?? new Date();
     const thresholds = buildThresholds(opts?.thresholds);
     const candidates = await db

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2339,6 +2339,22 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   async function reconcileStrandedAssignedIssues() {
+    const experimental = await instanceSettings.getExperimental();
+    if (!experimental.enableStrandedIssueRecovery) {
+      return {
+        assignmentDispatched: 0,
+        dispatchRequeued: 0,
+        continuationRequeued: 0,
+        productiveContinuationObserved: 0,
+        successfulContinuationObserved: 0,
+        orphanBlockersAssigned: 0,
+        successfulRunHandoffEscalated: 0,
+        escalated: 0,
+        skipped: 0,
+        issueIds: [] as string[],
+      };
+    }
+
     const candidates = await db
       .select()
       .from(issues)


### PR DESCRIPTION
#6426 

## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - The control plane includes automated background services, specifically the Stranded Issue Recovery and the Issue Productivity Review subsystems.
> - When runs fail or get cancelled, stranded issue recovery and productivity review tasks/cards are generated. Setting the experimental flags `enableStrandedIssueRecovery` and `enableIssueProductivityReview` to `false` in the database did not prevent these tasks/cards from being generated.
> - This issue occurs because the experimental flags were not defined in the shared Zod schema and static TypeScript interfaces, they were not parsed by the instance settings normalizer on the server, and the recovery and productivity review services did not check these flags.
> - This pull request adds the two flags to the schemas, TypeScript interfaces, normalizers, and checks them before running the reconciliation steps in the recovery and productivity review services.
> - The benefit is that operators can successfully disable stranded issue recovery and productivity review cards using database toggles, preventing noise and unwanted recovery cards/tickets.

## What Changed

### Packages & Schema
- **[packages/shared/src/validators/instance.ts](file:///Users/rohitbhatu/Desktop/open-source/paperclip/packages/shared/src/validators/instance.ts)**:
  - Added `enableStrandedIssueRecovery` and `enableIssueProductivityReview` to `instanceExperimentalSettingsSchema` (Zod schema) with default values of `true`.
- **[packages/shared/src/types/instance.ts](file:///Users/rohitbhatu/Desktop/open-source/paperclip/packages/shared/src/types/instance.ts)**:
  - Added `enableStrandedIssueRecovery: boolean` and `enableIssueProductivityReview: boolean` to the `InstanceExperimentalSettings` TypeScript interface.

### Server Services
- **[server/src/services/instance-settings.ts](file:///Users/rohitbhatu/Desktop/open-source/paperclip/server/src/services/instance-settings.ts)**:
  - Updated `normalizeExperimentalSettings` to safely parse and return `enableStrandedIssueRecovery` and `enableIssueProductivityReview` (defaulting to `true` if undefined/null).
- **[server/src/services/recovery/service.ts](file:///Users/rohitbhatu/Desktop/open-source/paperclip/server/src/services/recovery/service.ts)**:
  - Checked `enableStrandedIssueRecovery` inside `reconcileStrandedAssignedIssues()`. If set to `false`, early-returns a default/empty result.
- **[server/src/services/productivity-review.ts](file:///Users/rohitbhatu/Desktop/open-source/paperclip/server/src/services/productivity-review.ts)**:
  - Checked `enableIssueProductivityReview` inside `reconcileProductivityReviews()`. If set to `false`, early-returns a default/empty result.

## Verification

- **Tests and Build**: The project compilation was verified, and build/test steps were skipped per user request.
- **Remote Push**: The changes have been pushed to origin branch `fix/stranded-issue-recovery-settings`.

## Risks

- **Low risk**: Defaulting the flags to `true` ensures that existing instances preserve the default behavior of having stranded issue recovery and productivity reviews enabled, preventing regressions or silent disables.

## Model Used

- **Model**: Antigravity (Advanced Agentic Coding AI by Google DeepMind)
- **Model ID**: Gemini 1.5 Pro / Ultra Custom Agentic Variant
- **Capabilities**: Full context reasoning, tool use (file modification, command execution), and chain-of-thought planning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
