### PR TITLE
feat(recovery): force-kill hung local runs at critical silence threshold

### DIFF
--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -6,6 +6,7 @@ import {
   MIN_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
   type IssueGraphLivenessAutoRecoveryPreview,
   type IssueGraphLivenessAutoRecoveryPreviewItem,
+  type RequestConfirmationPayload,
 } from "@paperclipai/shared";
 import {
   agents,
@@ -694,6 +695,127 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     );
   }
 
+  async function tryForceKillSilentRun(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    runningAgent: typeof agents.$inferSelect;
+  }): Promise<{ kind: "killed" | "not_running" | "failed" | "skipped"; detail?: string }> {
+    if (!SESSIONED_LOCAL_ADAPTERS.has(input.runningAgent.adapterType)) {
+      return { kind: "skipped", detail: "non_local_adapter" };
+    }
+    const running = runningProcesses.get(input.run.id);
+    const pid = running?.child.pid ?? input.run.processPid ?? null;
+    const processGroupId = running?.processGroupId ?? input.run.processGroupId ?? null;
+    if (typeof pid !== "number" && typeof processGroupId !== "number") {
+      return { kind: "not_running", detail: "no_process_metadata" };
+    }
+    const isAlive =
+      (typeof pid === "number" && isPidAlive(pid)) ||
+      (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId));
+    if (!isAlive) {
+      runningProcesses.delete(input.run.id);
+      return { kind: "not_running", detail: "already_dead" };
+    }
+    try {
+      await terminateLocalService(
+        {
+          pid: typeof pid === "number" && Number.isInteger(pid) && pid > 0 ? pid : (processGroupId ?? 0),
+          processGroupId:
+            typeof processGroupId === "number" && Number.isInteger(processGroupId) && processGroupId > 0
+              ? processGroupId
+              : null,
+        },
+        running ? { forceAfterMs: Math.max(1, running.graceSec) * 1000 } : { forceAfterMs: 5_000 },
+      );
+      runningProcesses.delete(input.run.id);
+      logger.info({ runId: input.run.id, pid, processGroupId }, "force-killed silent run at critical threshold");
+      return { kind: "killed" };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      logger.warn({ runId: input.run.id, pid, processGroupId, err: error }, "failed to force-kill silent run");
+      return { kind: "failed", detail };
+    }
+  }
+
+  async function ensureForceKillConfirmationInteraction(input: {
+    evaluationIssue: { id: string; companyId: string; identifier: string | null };
+    run: typeof heartbeatRuns.$inferSelect;
+    killResult: { kind: string; detail?: string };
+    silenceAgeMs: number | null;
+  }): Promise<void> {
+    const idempotencyKey = `force_kill_confirm:${input.run.id}`;
+    const existing = await db
+      .select({ id: issueThreadInteractions.id })
+      .from(issueThreadInteractions)
+      .where(
+        and(
+          eq(issueThreadInteractions.companyId, input.evaluationIssue.companyId),
+          eq(issueThreadInteractions.issueId, input.evaluationIssue.id),
+          eq(issueThreadInteractions.idempotencyKey, idempotencyKey),
+        ),
+      )
+      .limit(1);
+    if (existing.length > 0) return;
+
+    const killLine =
+      input.killResult.kind === "killed"
+        ? "The process group was force-killed by the watchdog."
+        : input.killResult.kind === "not_running"
+          ? "The process was already dead when the kill was attempted."
+          : `Kill attempt made (outcome: \`${input.killResult.kind}\`${input.killResult.detail ? ` — ${input.killResult.detail}` : ""}).`;
+
+    const payload: RequestConfirmationPayload = {
+      version: 1,
+      prompt: `Silent run \`${input.run.id}\` exceeded the critical silence threshold (${formatDuration(input.silenceAgeMs)}) and was force-killed. Acknowledge to allow recovery to proceed.`,
+      acceptLabel: "Acknowledge force-kill",
+      detailsMarkdown: [
+        killLine,
+        "",
+        `- Run: \`${input.run.id}\``,
+        `- Pid: \`${input.run.processPid ?? "unknown"}\``,
+        `- Process group: \`${input.run.processGroupId ?? "unknown"}\``,
+        `- Silent for: ${formatDuration(input.silenceAgeMs)}`,
+      ].join("\n"),
+    };
+
+    await db.insert(issueThreadInteractions).values({
+      companyId: input.evaluationIssue.companyId,
+      issueId: input.evaluationIssue.id,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      idempotencyKey,
+      title: "Force-killed hung run — acknowledge to unblock",
+      summary: `Run \`${input.run.id}\` was silent for ${formatDuration(input.silenceAgeMs)} and its process group was force-killed.`,
+      createdByAgentId: null,
+      createdByUserId: null,
+      sourceRunId: input.run.id,
+      payload,
+    });
+
+    await db
+      .update(issues)
+      .set({ updatedAt: new Date() })
+      .where(eq(issues.id, input.evaluationIssue.id));
+
+    await logActivity(db, {
+      companyId: input.evaluationIssue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: input.run.id,
+      action: "heartbeat.force_kill_confirmation_created",
+      entityType: "issue",
+      entityId: input.evaluationIssue.id,
+      details: {
+        source: "recovery.scan_silent_active_runs",
+        runId: input.run.id,
+        killKind: input.killResult.kind,
+        silenceAgeMs: input.silenceAgeMs,
+        idempotencyKey,
+      },
+    });
+  }
+
   function silenceStartedAtForRun(run: Pick<typeof heartbeatRuns.$inferSelect, "lastOutputAt" | "processStartedAt" | "startedAt" | "createdAt">) {
     return run.lastOutputAt ?? run.processStartedAt ?? run.startedAt ?? run.createdAt ?? null;
   }
@@ -724,6 +846,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const [row] = await db
       .select({
         id: issues.id,
+        companyId: issues.companyId,
         identifier: issues.identifier,
         status: issues.status,
         priority: issues.priority,
@@ -1356,6 +1479,27 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
     if (sourceIssue && isRecoveryOriginIssue(sourceIssue)) {
+      const silenceAgeMs = silenceAgeMsForRun(input.run, input.now);
+      const isCritical = (silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS;
+
+      // At the critical threshold, force-kill the stuck recovery run instead of spawning
+      // another nested recovery issue, then attach a single confirmation to the existing
+      // evaluation issue so the board can acknowledge the kill.
+      let killResult: Awaited<ReturnType<typeof tryForceKillSilentRun>> | null = null;
+      if (isCritical) {
+        killResult = await tryForceKillSilentRun({ run: input.run, runningAgent });
+        const evaluationIssue =
+          sourceIssue.originKind === STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND ? sourceIssue : existing;
+        if (evaluationIssue) {
+          await ensureForceKillConfirmationInteraction({
+            evaluationIssue: { id: evaluationIssue.id, companyId: evaluationIssue.companyId, identifier: evaluationIssue.identifier },
+            run: input.run,
+            killResult,
+            silenceAgeMs,
+          });
+        }
+      }
+
       await logActivity(db, {
         companyId: input.run.companyId,
         actorType: "system",
@@ -1371,6 +1515,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           sourceIssueIdentifier: sourceIssue.identifier,
           sourceIssueOriginKind: sourceIssue.originKind,
           existingEvaluationIssueId: existing?.id ?? null,
+          forcedKillAtCritical: isCritical,
+          killKind: killResult?.kind ?? null,
         },
       });
       return { kind: "skipped" as const };
@@ -1421,6 +1567,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           evaluationIssue: existing,
           run: input.run,
         });
+        const killResult = await tryForceKillSilentRun({ run: input.run, runningAgent });
+        await ensureForceKillConfirmationInteraction({
+          evaluationIssue: { id: existing.id, companyId: existing.companyId, identifier: existing.identifier },
+          run: input.run,
+          killResult,
+          silenceAgeMs: evidence.silenceAgeMs,
+        });
         return { kind: "escalated" as const, evaluationIssueId: existing.id };
       }
       if (level === "critical") {
@@ -1428,6 +1581,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           sourceIssue,
           evaluationIssue: existing,
           run: input.run,
+        });
+        const killResult = await tryForceKillSilentRun({ run: input.run, runningAgent });
+        await ensureForceKillConfirmationInteraction({
+          evaluationIssue: { id: existing.id, companyId: existing.companyId, identifier: existing.identifier },
+          run: input.run,
+          killResult,
+          silenceAgeMs: evidence.silenceAgeMs,
         });
       }
       return { kind: "existing" as const, evaluationIssueId: existing.id };
@@ -1490,6 +1650,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         sourceIssue,
         evaluationIssue: evaluation,
         run: input.run,
+      });
+      const killResult = await tryForceKillSilentRun({ run: input.run, runningAgent });
+      await ensureForceKillConfirmationInteraction({
+        evaluationIssue: { id: evaluation.id, companyId: evaluation.companyId, identifier: evaluation.identifier },
+        run: input.run,
+        killResult,
+        silenceAgeMs: evidence.silenceAgeMs,
       });
     }
     if (ownerAgentId) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The silent-run watchdog monitors active heartbeat runs for output silence
> - When a run goes silent beyond the suspicion threshold (1h), a `stale_active_run_evaluation` issue is created and an agent is assigned to review it
> - The reviewing agent then starts its own run to handle the evaluation issue
> - If *that* reviewing run also goes silent and reaches the critical threshold, the watchdog was spawning *another* evaluation issue, creating a recursive chain (observed as SYM-72, SYM-73 in production)
> - Additionally, for non-recursive runs at the critical threshold, the process was left alive indefinitely with no automated resolution
> - This PR adds: (1) a `tryForceKillSilentRun` helper that force-kills the process group via `terminateLocalService` at the critical silence threshold, and (2) an `ensureForceKillConfirmationInteraction` helper that attaches a single idempotent `request_confirmation` interaction to the evaluation issue so the board can acknowledge the kill
> - The benefit is that a hung run now has exactly one evaluation issue which becomes a single board confirmation after the force-kill, with no recursive recovery chains possible

## What Changed

- `server/src/services/recovery/service.ts`:
  - Added `tryForceKillSilentRun`: tries SIGTERM → SIGKILL on the process group of a local-adapter run that has reached critical silence; skips gracefully for non-local adapters and already-dead processes
  - Added `ensureForceKillConfirmationInteraction`: idempotent (keyed on `force_kill_confirm:{runId}`) insert of a `request_confirmation` interaction on the evaluation issue after the kill
  - Updated `createOrUpdateStaleRunEvaluation`: in the **recovery-origin guard** path, at critical silence, force-kills the current run and attaches the confirmation to the source evaluation issue instead of only logging; for **non-recovery critical runs**, force-kill and confirmation are emitted at the escalation point (new eval, escalated eval, and already-critical-existing-eval branches all covered)
  - Added `companyId` to the `findOpenStaleRunEvaluation` select so it can be passed to the confirmation helper
  - Imports `type RequestConfirmationPayload` from `@paperclipai/shared`

## Verification

- Manually reviewed that all three critical-level branches in `createOrUpdateStaleRunEvaluation` now call `tryForceKillSilentRun` + `ensureForceKillConfirmationInteraction`
- The `ensureForceKillConfirmationInteraction` is idempotent: if called multiple times for the same run it inserts at most one interaction (idempotency key `force_kill_confirm:{runId}` + unique index)
- For non-local adapters (`tryForceKillSilentRun` returns `kind: "skipped"`) the confirmation is still emitted so the board knows the critical threshold was reached even without an in-process kill handle
- For the recovery-origin path: after the kill, execution returns `kind: "skipped"` so no additional evaluation issue is created — this is unchanged behavior; only the kill + confirmation are new
- Note: full `pnpm test` could not be run in this environment due to disk space constraints; CI should be relied upon for test coverage

## Risks

- **Kill during legitimate quiet work**: A run that is genuinely silent (e.g., waiting on a long file write) will be killed after 4h. This was already the intended behavior per the critical threshold semantics — the PR makes the kill automatic rather than waiting for human/agent review. Low additional risk.
- **Double-kill**: If `scanSilentActiveRuns` fires multiple times while a run is at critical, `tryForceKillSilentRun` may be called more than once. The second call will find the process already dead and return `kind: "not_running"`. The `ensureForceKillConfirmationInteraction` idempotency key prevents duplicate interactions.
- **Non-local adapters**: The force-kill is skipped for adapters not in `SESSIONED_LOCAL_ADAPTERS`. The `request_confirmation` is still emitted, correctly surfacing the critical silence to the board.
- **Migration**: No schema changes. The `issueThreadInteractions` table is used as-is.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (claude-sonnet-4-6)
- Context window: 200k tokens
- Capabilities: extended thinking, tool use, code editing

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass (skipped — disk space; CI required)
- [x] I have added or updated tests where applicable (no new tests; risk noted)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — no UI changes)
- [x] I have updated relevant documentation to reflect my changes (N/A — internal service logic)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Made with [Cursor](https://cursor.com)