### PR TITLE
feat: PRO issue reopen protection + adapter modelProfile + heartbeat polish

### DIFF
--- a/.gstack/browse-console.log
+++ b/.gstack/browse-console.log
@@ -1,0 +1,871 @@
+[2026-04-21T14:56:00.946Z] [debug] [vite] connecting...
+[2026-04-21T14:56:00.981Z] [debug] [vite] connected.
+[2026-04-21T14:56:01.293Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:56:42.185Z] [debug] [vite] connecting...
+[2026-04-21T14:56:42.210Z] [debug] [vite] connected.
+[2026-04-21T14:56:42.486Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:56:54.657Z] [debug] [vite] connecting...
+[2026-04-21T14:56:54.689Z] [debug] [vite] connected.
+[2026-04-21T14:56:55.064Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:57:06.720Z] [debug] [vite] connecting...
+[2026-04-21T14:57:06.744Z] [debug] [vite] connected.
+[2026-04-21T14:57:07.046Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:57:20.775Z] [debug] [vite] connecting...
+[2026-04-21T14:57:20.817Z] [debug] [vite] connected.
+[2026-04-21T14:57:21.442Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:57:34.834Z] [debug] [vite] connecting...
+[2026-04-21T14:57:34.888Z] [debug] [vite] connected.
+[2026-04-21T14:57:35.413Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:57:48.250Z] [debug] [vite] connecting...
+[2026-04-21T14:57:48.291Z] [debug] [vite] connected.
+[2026-04-21T14:57:48.514Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:58:01.296Z] [debug] [vite] connecting...
+[2026-04-21T14:58:01.307Z] [debug] [vite] connected.
+[2026-04-21T14:58:01.690Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:58:14.691Z] [debug] [vite] connecting...
+[2026-04-21T14:58:14.716Z] [debug] [vite] connected.
+[2026-04-21T14:58:14.925Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:58:28.113Z] [debug] [vite] connecting...
+[2026-04-21T14:58:28.133Z] [debug] [vite] connected.
+[2026-04-21T14:58:28.357Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:58:29.864Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:58:30.884Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:58:32.890Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:58:36.898Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:58:41.346Z] [debug] [vite] connecting...
+[2026-04-21T14:58:41.385Z] [debug] [vite] connected.
+[2026-04-21T14:58:41.616Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:58:54.548Z] [debug] [vite] connecting...
+[2026-04-21T14:58:54.558Z] [debug] [vite] connected.
+[2026-04-21T14:58:54.984Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:59:09.797Z] [debug] [vite] connecting...
+[2026-04-21T14:59:09.827Z] [debug] [vite] connected.
+[2026-04-21T14:59:10.026Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:59:11.351Z] [error] In HTML, %s cannot be a descendant of <%s>.
+This will cause a hydration error.%s <a> a 
+
+  ...
+    <div className="flex min-w...">
+      <div>
+      <div className="flex flex-...">
+        <main id="main-content" ref={{...}} tabIndex={-1} className="flex-1 p-4...">
+          <Outlet>
+            <RenderedRoute match={{params:{...}, ...}} routeContext={{outlet:null, ...}}>
+              <AgentDetail>
+                <div className="space-y-6">
+                  <div>
+                  <Tabs>
+                  <div>
+                  <AgentOverview agent={{id:"d7f41c...", ...}} runs={[...]} assignedIssues={[...]} ...>
+                    <div className="space-y-8">
+                      <LatestRunCard runs={[...]} agentId="evidence-c...">
+                        <div className="space-y-3">
+                          <div>
+                          <CompanyLink to="/agents/ev..." className="block bord...">
+                            <LinkWithRef ref={null} to="/SUP/agent..." className="block bord...">
+>                             <a
+>                               className="block border rounded-lg p-4 space-y-2 w-full no-underline transition-colors..."
+>                               href="/SUP/agents/evidence-critic/runs/e5600538-1f91-418e-babe-01cfac36ceda"
+>                               onClick={function handleClick}
+>                               ref={function}
+>                               target={undefined}
+>                               data-discover="true"
+>                             >
+                                <div>
+                                ...
+                                  <Primitive.button.Slot type="button" aria-haspopup="dialog" aria-expanded={false} ...>
+                                    <Primitive.button.SlotClone type="button" aria-haspopup="dialog" ...>
+                                      <LinkWithRef ref={function} to="/SUP/issue..." state={undefined} ...>
+>                                       <a
+>                                         className="inline-flex items-center gap-1.5 align-baseline"
+>                                         onMouseEnter={function}
+>                                         onFocus={function onFocus}
+>                                         onTouchStart={function onTouchStart}
+>                                         onClickCapture={function onClickCapture}
+>                                         type="button"
+>                                         aria-haspopup="dialog"
+>                                         aria-expanded={false}
+>                                         aria-controls="radix-_r_1a_"
+>                                         data-state="closed"
+>                                         data-slot="popover-trigger"
+>                                         onMouseLeave={function onMouseLeave}
+>                                         href="/SUP/issues/SUP-1251"
+>                                         onClick={function handleClick}
+>                                         ref={function}
+>                                         target={undefined}
+>                                         data-discover="true"
+>                                       >
+                      ...
+        ...
+
+[2026-04-21T14:59:11.351Z] [error] <%s> cannot contain a nested %s.
+See this log for the ancestor stack trace. a <a>
+[2026-04-21T14:59:11.400Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:59:12.406Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:59:14.412Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:59:18.419Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:59:22.944Z] [debug] [vite] connecting...
+[2026-04-21T14:59:22.970Z] [debug] [vite] connected.
+[2026-04-21T14:59:23.209Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:59:23.595Z] [error] In HTML, %s cannot be a descendant of <%s>.
+This will cause a hydration error.%s <a> a 
+
+  ...
+    <div className="flex min-w...">
+      <div>
+      <div className="flex flex-...">
+        <main id="main-content" ref={{...}} tabIndex={-1} className="flex-1 p-4...">
+          <Outlet>
+            <RenderedRoute match={{params:{...}, ...}} routeContext={{outlet:null, ...}}>
+              <AgentDetail>
+                <div className="space-y-6">
+                  <div>
+                  <Tabs>
+                  <div>
+                  <AgentOverview agent={{id:"613ecd...", ...}} runs={[...]} assignedIssues={[...]} ...>
+                    <div className="space-y-8">
+                      <LatestRunCard runs={[...]} agentId="evidence-u...">
+                        <div className="space-y-3">
+                          <div>
+                          <CompanyLink to="/agents/ev..." className="block bord...">
+                            <LinkWithRef ref={null} to="/SUP/agent..." className="block bord...">
+>                             <a
+>                               className="block border rounded-lg p-4 space-y-2 w-full no-underline transition-colors..."
+>                               href="/SUP/agents/evidence-upserter/runs/6f8c45b7-93e0-45c0-9f29-000b4ca7e98f"
+>                               onClick={function handleClick}
+>                               ref={function}
+>                               target={undefined}
+>                               data-discover="true"
+>                             >
+                                <div>
+                                ...
+                                  <Primitive.button.Slot type="button" aria-haspopup="dialog" aria-expanded={false} ...>
+                                    <Primitive.button.SlotClone type="button" aria-haspopup="dialog" ...>
+                                      <LinkWithRef ref={function} to="/SUP/issue..." state={undefined} ...>
+>                                       <a
+>                                         className="inline-flex items-center gap-1.5 align-baseline"
+>                                         onMouseEnter={function}
+>                                         onFocus={function onFocus}
+>                                         onTouchStart={function onTouchStart}
+>                                         onClickCapture={function onClickCapture}
+>                                         type="button"
+>                                         aria-haspopup="dialog"
+>                                         aria-expanded={false}
+>                                         aria-controls="radix-_r_10_"
+>                                         data-state="closed"
+>                                         data-slot="popover-trigger"
+>                                         onMouseLeave={function onMouseLeave}
+>                                         href="/SUP/issues/RESCORE-2026"
+>                                         onClick={function handleClick}
+>                                         ref={function}
+>                                         target={undefined}
+>                                         data-discover="true"
+>                                       >
+                      ...
+        ...
+
+[2026-04-21T14:59:23.595Z] [error] <%s> cannot contain a nested %s.
+See this log for the ancestor stack trace. a <a>
+[2026-04-21T14:59:23.673Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:59:24.680Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:59:26.686Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:59:30.691Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T14:59:37.478Z] [debug] [vite] connecting...
+[2026-04-21T14:59:37.494Z] [debug] [vite] connected.
+[2026-04-21T14:59:37.821Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T14:59:51.363Z] [debug] [vite] connecting...
+[2026-04-21T14:59:51.390Z] [debug] [vite] connected.
+[2026-04-21T14:59:51.585Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:00:05.085Z] [debug] [vite] connecting...
+[2026-04-21T15:00:05.104Z] [debug] [vite] connected.
+[2026-04-21T15:00:05.381Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:00:22.725Z] [debug] [vite] connecting...
+[2026-04-21T15:00:22.747Z] [debug] [vite] connected.
+[2026-04-21T15:00:22.975Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:00:35.815Z] [debug] [vite] connecting...
+[2026-04-21T15:00:35.821Z] [debug] [vite] connected.
+[2026-04-21T15:00:36.075Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:00:56.351Z] [debug] [vite] connecting...
+[2026-04-21T15:00:56.406Z] [debug] [vite] connected.
+[2026-04-21T15:00:56.580Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:00:56.941Z] [error] In HTML, %s cannot be a descendant of <%s>.
+This will cause a hydration error.%s <a> a 
+
+  ...
+    <div className="flex min-w...">
+      <div>
+      <div className="flex flex-...">
+        <main id="main-content" ref={{...}} tabIndex={-1} className="flex-1 p-4...">
+          <Outlet>
+            <RenderedRoute match={{params:{...}, ...}} routeContext={{outlet:null, ...}}>
+              <AgentDetail>
+                <div className="space-y-6">
+                  <div>
+                  <Tabs>
+                  <div>
+                  <AgentOverview agent={{id:"4b4583...", ...}} runs={[...]} assignedIssues={[...]} ...>
+                    <div className="space-y-8">
+                      <LatestRunCard runs={[...]} agentId="seo-geo-op...">
+                        <div className="space-y-3">
+                          <div>
+                          <CompanyLink to="/agents/se..." className="block bord...">
+                            <LinkWithRef ref={null} to="/SUP/agent..." className="block bord...">
+>                             <a
+>                               className="block border rounded-lg p-4 space-y-2 w-full no-underline transition-colors..."
+>                               href="/SUP/agents/seo-geo-optimizer/runs/b8574727-2d54-4c87-a819-3cc5cdabbf98"
+>                               onClick={function handleClick}
+>                               ref={function}
+>                               target={undefined}
+>                               data-discover="true"
+>                             >
+                                <div>
+                                ...
+                                  <Primitive.button.Slot type="button" aria-haspopup="dialog" aria-expanded={false} ...>
+                                    <Primitive.button.SlotClone type="button" aria-haspopup="dialog" ...>
+                                      <LinkWithRef ref={function} to="/SUP/issue..." state={undefined} ...>
+>                                       <a
+>                                         className="inline-flex items-center gap-1.5 align-baseline"
+>                                         onMouseEnter={function}
+>                                         onFocus={function onFocus}
+>                                         onTouchStart={function onTouchStart}
+>                                         onClickCapture={function onClickCapture}
+>                                         type="button"
+>                                         aria-haspopup="dialog"
+>                                         aria-expanded={false}
+>                                         aria-controls="radix-_r_10_"
+>                                         data-state="closed"
+>                                         data-slot="popover-trigger"
+>                                         onMouseLeave={function onMouseLeave}
+>                                         href="/SUP/issues/SUP-1239"
+>                                         onClick={function handleClick}
+>                                         ref={function}
+>                                         target={undefined}
+>                                         data-discover="true"
+>                                       >
+                      ...
+        ...
+
+[2026-04-21T15:00:56.941Z] [error] <%s> cannot contain a nested %s.
+See this log for the ancestor stack trace. a <a>
+[2026-04-21T15:01:11.860Z] [debug] [vite] connecting...
+[2026-04-21T15:01:11.901Z] [debug] [vite] connected.
+[2026-04-21T15:01:12.203Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:01:51.047Z] [debug] [vite] connecting...
+[2026-04-21T15:01:51.089Z] [debug] [vite] connected.
+[2026-04-21T15:01:51.325Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:02:07.294Z] [debug] [vite] connecting...
+[2026-04-21T15:02:07.310Z] [debug] [vite] connected.
+[2026-04-21T15:02:07.621Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:02:22.230Z] [debug] [vite] connecting...
+[2026-04-21T15:02:22.256Z] [debug] [vite] connected.
+[2026-04-21T15:02:22.485Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:02:36.857Z] [debug] [vite] connecting...
+[2026-04-21T15:02:36.877Z] [debug] [vite] connected.
+[2026-04-21T15:02:37.283Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:02:56.657Z] [debug] [vite] connecting...
+[2026-04-21T15:02:56.699Z] [debug] [vite] connected.
+[2026-04-21T15:02:56.961Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:02:57.333Z] [error] In HTML, %s cannot be a descendant of <%s>.
+This will cause a hydration error.%s <a> a 
+
+  ...
+    <div className="flex min-w...">
+      <div>
+      <div className="flex flex-...">
+        <main id="main-content" ref={{...}} tabIndex={-1} className="flex-1 p-4...">
+          <Outlet>
+            <RenderedRoute match={{params:{...}, ...}} routeContext={{outlet:null, ...}}>
+              <AgentDetail>
+                <div className="space-y-6">
+                  <div>
+                  <Tabs>
+                  <div>
+                  <AgentOverview agent={{id:"bf5f74...", ...}} runs={[...]} assignedIssues={[...]} ...>
+                    <div className="space-y-8">
+                      <LatestRunCard runs={[...]} agentId="verificati...">
+                        <div className="space-y-3">
+                          <div>
+                          <CompanyLink to="/agents/ve..." className="block bord...">
+                            <LinkWithRef ref={null} to="/SUP/agent..." className="block bord...">
+>                             <a
+>                               className="block border rounded-lg p-4 space-y-2 w-full no-underline transition-colors..."
+>                               href="/SUP/agents/verification-runner/runs/5d907727-0613-43cc-8a8e-454eb642892d"
+>                               onClick={function handleClick}
+>                               ref={function}
+>                               target={undefined}
+>                               data-discover="true"
+>                             >
+                                <div>
+                                ...
+                                  <Primitive.button.Slot type="button" aria-haspopup="dialog" aria-expanded={false} ...>
+                                    <Primitive.button.SlotClone type="button" aria-haspopup="dialog" ...>
+                                      <LinkWithRef ref={function} to="/SUP/issue..." state={undefined} ...>
+>                                       <a
+>                                         className="inline-flex items-center gap-1.5 align-baseline"
+>                                         onMouseEnter={function}
+>                                         onFocus={function onFocus}
+>                                         onTouchStart={function onTouchStart}
+>                                         onClickCapture={function onClickCapture}
+>                                         type="button"
+>                                         aria-haspopup="dialog"
+>                                         aria-expanded={false}
+>                                         aria-controls="radix-_r_10_"
+>                                         data-state="closed"
+>                                         data-slot="popover-trigger"
+>                                         onMouseLeave={function onMouseLeave}
+>                                         href="/SUP/issues/SUP-1231"
+>                                         onClick={function handleClick}
+>                                         ref={function}
+>                                         target={undefined}
+>                                         data-discover="true"
+>                                       >
+                      ...
+        ...
+
+[2026-04-21T15:02:57.333Z] [error] <%s> cannot contain a nested %s.
+See this log for the ancestor stack trace. a <a>
+[2026-04-21T15:03:11.865Z] [debug] [vite] connecting...
+[2026-04-21T15:03:11.904Z] [debug] [vite] connected.
+[2026-04-21T15:03:12.116Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:03:24.971Z] [debug] [vite] connecting...
+[2026-04-21T15:03:25.002Z] [debug] [vite] connected.
+[2026-04-21T15:03:25.247Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:03:39.148Z] [debug] [vite] connecting...
+[2026-04-21T15:03:39.168Z] [debug] [vite] connected.
+[2026-04-21T15:03:39.547Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:04:10.624Z] [debug] [vite] connecting...
+[2026-04-21T15:04:10.667Z] [debug] [vite] connected.
+[2026-04-21T15:04:10.871Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:04:29.088Z] [debug] [vite] connecting...
+[2026-04-21T15:04:29.150Z] [debug] [vite] connected.
+[2026-04-21T15:04:29.401Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:05:50.008Z] [debug] [vite] connecting...
+[2026-04-21T15:05:50.051Z] [debug] [vite] connected.
+[2026-04-21T15:05:50.270Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:05:50.597Z] [error] In HTML, %s cannot be a descendant of <%s>.
+This will cause a hydration error.%s <a> a 
+
+  ...
+    <div className="flex min-w...">
+      <div>
+      <div className="flex flex-...">
+        <main id="main-content" ref={{...}} tabIndex={-1} className="flex-1 p-4...">
+          <Outlet>
+            <RenderedRoute match={{params:{...}, ...}} routeContext={{outlet:null, ...}}>
+              <AgentDetail>
+                <div className="space-y-6">
+                  <div>
+                  <Tabs>
+                  <div>
+                  <AgentOverview agent={{id:"cdb82a...", ...}} runs={[...]} assignedIssues={[...]} ...>
+                    <div className="space-y-8">
+                      <LatestRunCard runs={[...]} agentId="editorial-...">
+                        <div className="space-y-3">
+                          <div>
+                          <CompanyLink to="/agents/ed..." className="block bord...">
+                            <LinkWithRef ref={null} to="/SUP/agent..." className="block bord...">
+>                             <a
+>                               className="block border rounded-lg p-4 space-y-2 w-full no-underline transition-colors..."
+>                               href="/SUP/agents/editorial-advisor/runs/3c3c5d54-1eb3-4a4d-914d-5009e87aa96c"
+>                               onClick={function handleClick}
+>                               ref={function}
+>                               target={undefined}
+>                               data-discover="true"
+>                             >
+                                <div>
+                                ...
+                                  <Primitive.button.Slot type="button" aria-haspopup="dialog" aria-expanded={false} ...>
+                                    <Primitive.button.SlotClone type="button" aria-haspopup="dialog" ...>
+                                      <LinkWithRef ref={function} to="/SUP/issue..." state={undefined} ...>
+>                                       <a
+>                                         className="inline-flex items-center gap-1.5 align-baseline"
+>                                         onMouseEnter={function}
+>                                         onFocus={function onFocus}
+>                                         onTouchStart={function onTouchStart}
+>                                         onClickCapture={function onClickCapture}
+>                                         type="button"
+>                                         aria-haspopup="dialog"
+>                                         aria-expanded={false}
+>                                         aria-controls="radix-_r_10_"
+>                                         data-state="closed"
+>                                         data-slot="popover-trigger"
+>                                         onMouseLeave={function onMouseLeave}
+>                                         href="/SUP/issues/SUP-779"
+>                                         onClick={function handleClick}
+>                                         ref={function}
+>                                         target={undefined}
+>                                         data-discover="true"
+>                                       >
+                      ...
+        ...
+
+[2026-04-21T15:05:50.597Z] [error] <%s> cannot contain a nested %s.
+See this log for the ancestor stack trace. a <a>
+[2026-04-21T15:06:04.618Z] [debug] [vite] connecting...
+[2026-04-21T15:06:04.669Z] [debug] [vite] connected.
+[2026-04-21T15:06:04.871Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:06:19.330Z] [debug] [vite] connecting...
+[2026-04-21T15:06:19.369Z] [debug] [vite] connected.
+[2026-04-21T15:06:19.807Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:06:32.949Z] [debug] [vite] connecting...
+[2026-04-21T15:06:32.978Z] [debug] [vite] connected.
+[2026-04-21T15:06:33.219Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:06:46.827Z] [debug] [vite] connecting...
+[2026-04-21T15:06:46.863Z] [debug] [vite] connected.
+[2026-04-21T15:06:47.105Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:06:59.848Z] [debug] [vite] connecting...
+[2026-04-21T15:06:59.860Z] [debug] [vite] connected.
+[2026-04-21T15:07:00.344Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:07:12.170Z] [debug] [vite] connecting...
+[2026-04-21T15:07:12.194Z] [debug] [vite] connected.
+[2026-04-21T15:07:12.505Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:07:25.241Z] [debug] [vite] connecting...
+[2026-04-21T15:07:25.301Z] [debug] [vite] connected.
+[2026-04-21T15:07:25.543Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:07:44.991Z] [debug] [vite] connecting...
+[2026-04-21T15:07:45.025Z] [debug] [vite] connected.
+[2026-04-21T15:07:45.338Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:07:46.092Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:46.167Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:46.285Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:47.101Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:47.169Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:47.288Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:49.105Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:49.174Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:49.294Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:53.116Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:53.181Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:07:53.301Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:08:00.226Z] [debug] [vite] connecting...
+[2026-04-21T15:08:00.314Z] [debug] [vite] connected.
+[2026-04-21T15:08:00.488Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:08:01.426Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:08:02.526Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:08:04.532Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:08:08.538Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:08:14.170Z] [debug] [vite] connecting...
+[2026-04-21T15:08:14.195Z] [debug] [vite] connected.
+[2026-04-21T15:08:14.451Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:08:15.474Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:08:16.556Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:08:18.562Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:08:22.566Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:08:30.344Z] [debug] [vite] connecting...
+[2026-04-21T15:08:30.391Z] [debug] [vite] connected.
+[2026-04-21T15:08:30.608Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:08:45.171Z] [debug] [vite] connecting...
+[2026-04-21T15:08:45.195Z] [debug] [vite] connected.
+[2026-04-21T15:08:45.595Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:09:01.184Z] [debug] [vite] connecting...
+[2026-04-21T15:09:01.224Z] [debug] [vite] connected.
+[2026-04-21T15:09:01.442Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:09:18.146Z] [debug] [vite] connecting...
+[2026-04-21T15:09:18.197Z] [debug] [vite] connected.
+[2026-04-21T15:09:18.387Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:09:18.794Z] [warning] WebSocket connection to 'ws://127.0.0.1:3100/api/companies/7cec5ab7-bf5b-43d4-9ec9-6f16b8759c37/events/ws' failed: WebSocket is closed before the connection is established.
+[2026-04-21T15:09:37.815Z] [debug] [vite] connecting...
+[2026-04-21T15:09:37.847Z] [debug] [vite] connected.
+[2026-04-21T15:09:38.299Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:09:39.099Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:39.099Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:39.099Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:39.100Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:40.089Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:40.090Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:40.097Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:40.109Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:42.096Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:42.096Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:42.101Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:42.110Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:46.106Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:46.110Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:46.111Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:46.118Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:51.019Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:51.019Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:51.019Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:51.019Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:52.139Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:52.139Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:52.139Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:52.139Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:54.145Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:54.145Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:54.145Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:54.145Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:58.155Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:58.160Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:58.160Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:09:58.160Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:14.993Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:14.993Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:14.993Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:14.993Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:15.996Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:15.997Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:15.997Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:15.997Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:18.004Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:18.004Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:18.005Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:18.005Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:22.015Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:22.018Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:22.019Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:22.019Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:45.161Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:45.161Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:45.161Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:45.163Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:46.193Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:46.193Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:46.193Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:46.194Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:48.200Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:48.201Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:48.202Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:48.202Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:52.212Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:52.212Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:52.212Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:10:52.212Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:03.495Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:03.496Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:03.496Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:03.496Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:04.500Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:04.501Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:04.501Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:04.501Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:06.507Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:06.507Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:06.507Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:06.508Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:10.737Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:10.737Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:10.738Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:10.738Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:13.724Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:13.724Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:13.724Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:13.724Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:14.731Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:14.733Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:14.733Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:14.733Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:16.740Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:16.741Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:16.741Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:16.741Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:20.752Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:20.753Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:20.762Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:20.762Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:43.734Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:43.734Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:43.735Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:43.735Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:44.742Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:44.742Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:44.743Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:44.743Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:46.752Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:46.752Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:46.753Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:46.753Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:50.815Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:50.815Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:50.817Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:11:50.817Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:21.442Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:21.453Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:21.453Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:21.453Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:22.448Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:22.460Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:22.460Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:22.461Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:24.453Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:24.467Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:24.467Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:24.468Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:28.463Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:28.479Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:28.481Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:28.490Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:29.146Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:29.146Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:29.146Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:29.147Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:30.157Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:30.158Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:30.159Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:30.159Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:32.175Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:32.175Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:32.176Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:32.176Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:36.183Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:36.192Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:36.192Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:36.192Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:37.517Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:37.517Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:37.517Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:37.517Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:38.572Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:38.572Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:38.573Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:38.573Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:40.577Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:40.577Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:40.578Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:40.578Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:44.592Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:44.592Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:44.602Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:12:44.602Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:48.772Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:48.772Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:48.772Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:48.772Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:50.363Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:50.363Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:50.363Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:50.364Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:52.452Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:52.452Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:52.453Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:52.453Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:56.459Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:56.460Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:56.460Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:14:56.460Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:15:57.249Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:15:57.249Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:15:57.249Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:15:57.249Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:15:58.389Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:15:58.401Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:15:58.401Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:15:58.401Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:00.468Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:00.468Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:00.468Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:00.469Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:04.476Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:04.485Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:04.485Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:04.485Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:15.508Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:15.508Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:15.508Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:15.508Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:16.512Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:16.512Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:16.513Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:16.513Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:18.524Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:18.524Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:18.525Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:18.526Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:22.535Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:22.535Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:22.545Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:16:22.548Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:13.998Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:14.007Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:14.007Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:14.007Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:15.037Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:15.037Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:15.037Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:15.037Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:17.042Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:17.042Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:17.042Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:17.043Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:21.047Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:21.048Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:21.048Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:17:21.048Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:18:33.645Z] [debug] [vite] connecting...
+[2026-04-21T15:18:33.694Z] [debug] [vite] connected.
+[2026-04-21T15:18:33.944Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:18:34.362Z] [warning] WebSocket connection to 'ws://127.0.0.1:3100/api/companies/7cec5ab7-bf5b-43d4-9ec9-6f16b8759c37/events/ws' failed: WebSocket is closed before the connection is established.
+[2026-04-21T15:18:34.420Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:18:34.489Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:18:52.685Z] [debug] [vite] connecting...
+[2026-04-21T15:18:52.722Z] [debug] [vite] connected.
+[2026-04-21T15:18:52.972Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:19:13.050Z] [debug] [vite] connecting...
+[2026-04-21T15:19:13.100Z] [debug] [vite] connected.
+[2026-04-21T15:19:13.340Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:19:32.287Z] [debug] [vite] connecting...
+[2026-04-21T15:19:32.312Z] [debug] [vite] connected.
+[2026-04-21T15:19:32.557Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:19:51.609Z] [debug] [vite] connecting...
+[2026-04-21T15:19:51.639Z] [debug] [vite] connected.
+[2026-04-21T15:19:52.105Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:20:06.135Z] [debug] [vite] connecting...
+[2026-04-21T15:20:06.209Z] [debug] [vite] connected.
+[2026-04-21T15:20:06.412Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:20:22.925Z] [debug] [vite] connecting...
+[2026-04-21T15:20:22.943Z] [debug] [vite] connected.
+[2026-04-21T15:20:23.272Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:20:43.894Z] [debug] [vite] connecting...
+[2026-04-21T15:20:43.929Z] [debug] [vite] connected.
+[2026-04-21T15:20:44.428Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:21:06.280Z] [debug] [vite] connecting...
+[2026-04-21T15:21:06.309Z] [debug] [vite] connected.
+[2026-04-21T15:21:06.606Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:21:26.897Z] [debug] [vite] connecting...
+[2026-04-21T15:21:26.900Z] [debug] [vite] connected.
+[2026-04-21T15:21:27.225Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:22:20.032Z] [debug] [vite] connecting...
+[2026-04-21T15:22:20.057Z] [debug] [vite] connected.
+[2026-04-21T15:22:20.396Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:22:38.377Z] [debug] [vite] connecting...
+[2026-04-21T15:22:38.405Z] [debug] [vite] connected.
+[2026-04-21T15:22:39.004Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:22:42.126Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:22:43.211Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:22:45.215Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:22:49.225Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:22:56.349Z] [debug] [vite] connecting...
+[2026-04-21T15:22:56.374Z] [debug] [vite] connected.
+[2026-04-21T15:22:56.650Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:23:12.766Z] [debug] [vite] connecting...
+[2026-04-21T15:23:12.791Z] [debug] [vite] connected.
+[2026-04-21T15:23:13.082Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:23:13.610Z] [warning] WebSocket connection to 'ws://127.0.0.1:3100/api/companies/7cec5ab7-bf5b-43d4-9ec9-6f16b8759c37/events/ws' failed: WebSocket is closed before the connection is established.
+[2026-04-21T15:23:33.945Z] [debug] [vite] connecting...
+[2026-04-21T15:23:33.988Z] [debug] [vite] connected.
+[2026-04-21T15:23:34.211Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:23:35.384Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:23:35.384Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:23:36.395Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:23:36.399Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:23:38.398Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:23:38.403Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:23:42.401Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:23:42.408Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:23:54.143Z] [debug] [vite] connecting...
+[2026-04-21T15:23:54.171Z] [debug] [vite] connected.
+[2026-04-21T15:23:54.615Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:24:17.962Z] [debug] [vite] connecting...
+[2026-04-21T15:24:18.018Z] [debug] [vite] connected.
+[2026-04-21T15:24:18.443Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:24:36.097Z] [debug] [vite] connecting...
+[2026-04-21T15:24:36.129Z] [debug] [vite] connected.
+[2026-04-21T15:24:36.519Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:24:37.609Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:24:38.626Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:24:40.632Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:24:44.638Z] [error] Failed to load resource: the server responded with a status of 404 (Not Found)
+[2026-04-21T15:25:00.530Z] [debug] [vite] connecting...
+[2026-04-21T15:25:00.583Z] [debug] [vite] connected.
+[2026-04-21T15:25:00.819Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:25:17.707Z] [debug] [vite] connecting...
+[2026-04-21T15:25:17.735Z] [debug] [vite] connected.
+[2026-04-21T15:25:18.131Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:26:08.080Z] [debug] [vite] connecting...
+[2026-04-21T15:26:08.134Z] [debug] [vite] connected.
+[2026-04-21T15:26:08.360Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:26:29.817Z] [debug] [vite] connecting...
+[2026-04-21T15:26:29.843Z] [debug] [vite] connected.
+[2026-04-21T15:26:30.244Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:26:47.294Z] [debug] [vite] connecting...
+[2026-04-21T15:26:47.332Z] [debug] [vite] connected.
+[2026-04-21T15:26:47.585Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:26:47.921Z] [error] In HTML, %s cannot be a descendant of <%s>.
+This will cause a hydration error.%s <a> a 
+
+  ...
+    <div className="flex min-w...">
+      <div>
+      <div className="flex flex-...">
+        <main id="main-content" ref={{...}} tabIndex={-1} className="flex-1 p-4...">
+          <Outlet>
+            <RenderedRoute match={{params:{...}, ...}} routeContext={{outlet:null, ...}}>
+              <AgentDetail>
+                <div className="space-y-6">
+                  <div>
+                  <Tabs>
+                  <div>
+                  <AgentOverview agent={{id:"4b4583...", ...}} runs={[...]} assignedIssues={[...]} ...>
+                    <div className="space-y-8">
+                      <LatestRunCard runs={[...]} agentId="seo-geo-op...">
+                        <div className="space-y-3">
+                          <div>
+                          <CompanyLink to="/agents/se..." className="block bord...">
+                            <LinkWithRef ref={null} to="/SUP/agent..." className="block bord...">
+>                             <a
+>                               className="block border rounded-lg p-4 space-y-2 w-full no-underline transition-colors..."
+>                               href="/SUP/agents/seo-geo-optimizer/runs/b8574727-2d54-4c87-a819-3cc5cdabbf98"
+>                               onClick={function handleClick}
+>                               ref={function}
+>                               target={undefined}
+>                               data-discover="true"
+>                             >
+                                <div>
+                                ...
+                                  <Primitive.button.Slot type="button" aria-haspopup="dialog" aria-expanded={false} ...>
+                                    <Primitive.button.SlotClone type="button" aria-haspopup="dialog" ...>
+                                      <LinkWithRef ref={function} to="/SUP/issue..." state={undefined} ...>
+>                                       <a
+>                                         className="inline-flex items-center gap-1.5 align-baseline"
+>                                         onMouseEnter={function}
+>                                         onFocus={function onFocus}
+>                                         onTouchStart={function onTouchStart}
+>                                         onClickCapture={function onClickCapture}
+>                                         type="button"
+>                                         aria-haspopup="dialog"
+>                                         aria-expanded={false}
+>                                         aria-controls="radix-_r_10_"
+>                                         data-state="closed"
+>                                         data-slot="popover-trigger"
+>                                         onMouseLeave={function onMouseLeave}
+>                                         href="/SUP/issues/SUP-1239"
+>                                         onClick={function handleClick}
+>                                         ref={function}
+>                                         target={undefined}
+>                                         data-discover="true"
+>                                       >
+                      ...
+        ...
+
+[2026-04-21T15:26:47.921Z] [error] <%s> cannot contain a nested %s.
+See this log for the ancestor stack trace. a <a>
+[2026-04-21T15:27:04.321Z] [debug] [vite] connecting...
+[2026-04-21T15:27:04.361Z] [debug] [vite] connected.
+[2026-04-21T15:27:04.627Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:27:21.915Z] [debug] [vite] connecting...
+[2026-04-21T15:27:21.935Z] [debug] [vite] connected.
+[2026-04-21T15:27:22.292Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:27:40.407Z] [debug] [vite] connecting...
+[2026-04-21T15:27:40.449Z] [debug] [vite] connected.
+[2026-04-21T15:27:40.685Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:27:56.925Z] [debug] [vite] connecting...
+[2026-04-21T15:27:56.984Z] [debug] [vite] connected.
+[2026-04-21T15:27:57.202Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:28:20.291Z] [debug] [vite] connecting...
+[2026-04-21T15:28:20.383Z] [debug] [vite] connected.
+[2026-04-21T15:28:20.571Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:28:39.138Z] [debug] [vite] connecting...
+[2026-04-21T15:28:39.161Z] [debug] [vite] connected.
+[2026-04-21T15:28:39.411Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:28:55.016Z] [debug] [vite] connecting...
+[2026-04-21T15:28:55.073Z] [debug] [vite] connected.
+[2026-04-21T15:28:55.302Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:29:13.293Z] [debug] [vite] connecting...
+[2026-04-21T15:29:13.363Z] [debug] [vite] connected.
+[2026-04-21T15:29:14.357Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:29:41.865Z] [debug] [vite] connecting...
+[2026-04-21T15:29:41.904Z] [debug] [vite] connected.
+[2026-04-21T15:29:42.158Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold
+[2026-04-21T15:30:29.737Z] [debug] [vite] connecting...
+[2026-04-21T15:30:29.764Z] [debug] [vite] connected.
+[2026-04-21T15:30:30.004Z] [info] %cDownload the React DevTools for a better development experience: https://react.dev/link/react-devtools font-weight:bold

--- a/.gstack/browse-dialog.log
+++ b/.gstack/browse-dialog.log
@@ -1,0 +1,4 @@
+[2026-04-21T14:56:41.916Z] [beforeunload] "" → accepted
+[2026-04-21T15:20:43.813Z] [beforeunload] "" → accepted
+[2026-04-21T15:28:39.045Z] [beforeunload] "" → accepted
+[2026-04-21T15:29:41.757Z] [beforeunload] "" → accepted

--- a/packages/adapters/claude-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/claude-local/src/server/execute.remote.test.ts
@@ -214,9 +214,9 @@ describe("claude remote execution", () => {
         adapterConfig: {},
       },
       runtime: {
-        sessionId: "session-123",
+        sessionId: "550e8400-e29b-41d4-a716-446655440000",
         sessionParams: {
-          sessionId: "session-123",
+          sessionId: "550e8400-e29b-41d4-a716-446655440000",
           cwd: "/remote/workspace",
           remoteExecution: {
             transport: "ssh",
@@ -226,7 +226,7 @@ describe("claude remote execution", () => {
             remoteCwd: "/remote/workspace",
           },
         },
-        sessionDisplayId: "session-123",
+        sessionDisplayId: "550e8400-e29b-41d4-a716-446655440000",
         taskKey: null,
       },
       config: {
@@ -256,7 +256,7 @@ describe("claude remote execution", () => {
     expect(runChildProcess).toHaveBeenCalledTimes(1);
     const call = runChildProcess.mock.calls[0] as unknown as [string, string, string[]] | undefined;
     expect(call?.[2]).toContain("--resume");
-    expect(call?.[2]).toContain("session-123");
+    expect(call?.[2]).toContain("550e8400-e29b-41d4-a716-446655440000");
   });
 
 });

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -432,9 +432,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const runtimePromptBundleKey = asString(runtimeSessionParams.promptBundleKey, "");
   const hasMatchingPromptBundle =
     runtimePromptBundleKey.length === 0 || runtimePromptBundleKey === promptBundle.bundleKey;
+  const isValidUuidSession = (sessionId: string) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId);
   const canResumeSession =
     runtimeSessionId.length > 0 &&
     hasMatchingPromptBundle &&
+    isValidUuidSession(runtimeSessionId) &&
     (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(effectiveExecutionCwd)) &&
     adapterExecutionTargetSessionMatches(runtimeRemoteExecution, executionTarget);
   const sessionId = canResumeSession ? runtimeSessionId : null;
@@ -455,6 +458,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     await onLog(
       "stdout",
       `[paperclip] Claude session "${runtimeSessionId}" does not match the current remote execution identity and will not be resumed in "${effectiveExecutionCwd}". Starting a fresh remote session.\n`,
+    );
+  } else if (runtimeSessionId && !isValidUuidSession(runtimeSessionId)) {
+    await onLog(
+      "stdout",
+      `[paperclip] Claude session "${runtimeSessionId}" is not a valid UUID and will not be resumed. Starting a fresh session.\n`,
     );
   } else if (runtimeSessionId && !canResumeSession) {
     await onLog(

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -174,6 +174,6 @@ export function isClaudeUnknownSessionError(parsed: Record<string, unknown>): bo
     .filter(Boolean);
 
   return allMessages.some((msg) =>
-    /no conversation found with session id|unknown session|session .* not found/i.test(msg),
+    /no conversation found with session id|unknown session|session .* not found|not a valid uuid/i.test(msg),
   );
 }

--- a/packages/adapters/opencode-local/src/index.ts
+++ b/packages/adapters/opencode-local/src/index.ts
@@ -4,11 +4,11 @@ export const label = "OpenCode (local)";
 export const DEFAULT_OPENCODE_LOCAL_MODEL = "openai/gpt-5.2-codex";
 
 export const models: Array<{ id: string; label: string }> = [
+  { id: "minimax/MiniMax-M2.7", label: "minimax/MiniMax-M2.7" },
+  { id: "minimax/MiniMax-M2.7-highspeed", label: "minimax/MiniMax-M2.7-highspeed" },
   { id: DEFAULT_OPENCODE_LOCAL_MODEL, label: DEFAULT_OPENCODE_LOCAL_MODEL },
   { id: "openai/gpt-5.4", label: "openai/gpt-5.4" },
   { id: "openai/gpt-5.2", label: "openai/gpt-5.2" },
-  { id: "openai/gpt-5.1-codex-max", label: "openai/gpt-5.1-codex-max" },
-  { id: "openai/gpt-5.1-codex-mini", label: "openai/gpt-5.1-codex-mini" },
 ];
 
 export const agentConfigurationDoc = `# opencode_local agent configuration

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -61,6 +61,7 @@ export interface IssueLabel {
 export interface IssueAssigneeAdapterOverrides {
   adapterConfig?: Record<string, unknown>;
   useProjectWorkspace?: boolean;
+  modelProfile?: string | null;
 }
 
 export type DocumentFormat = "markdown";

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -44,6 +44,7 @@ export const issueAssigneeAdapterOverridesSchema = z
   .object({
     adapterConfig: z.record(z.unknown()).optional(),
     useProjectWorkspace: z.boolean().optional(),
+    modelProfile: z.string().trim().min(1).max(64).optional().nullable(),
   })
   .strict();
 

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -16,6 +16,7 @@ import {
   ensurePostgresDatabase,
   heartbeatRuns,
   issueComments,
+  issueRelations,
   issues,
 } from "@paperclipai/db";
 import { heartbeatService } from "../services/heartbeat.ts";
@@ -1198,6 +1199,212 @@ describe("heartbeat comment wake batching", () => {
       await gateway.close();
     }
   }, 120_000);
+
+  it("does not reopen done harness-liveness issues after blocked_by_unassigned_issue is resolved", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const blockedIssueId = randomUUID();
+    const escalationIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values([
+        {
+          id: blockerIssueId,
+          companyId,
+          issueNumber: 1,
+          identifier: `${issuePrefix}-37`,
+          title: "Unassigned blocker",
+          status: "todo",
+          priority: "medium",
+        },
+        {
+          id: blockedIssueId,
+          companyId,
+          issueNumber: 2,
+          identifier: `${issuePrefix}-44`,
+          title: "Blocked parent issue",
+          status: "blocked",
+          priority: "high",
+          blockedByIssueIds: [blockerIssueId],
+        },
+        {
+          id: escalationIssueId,
+          companyId,
+          issueNumber: 3,
+          identifier: `${issuePrefix}-106`,
+          title: "Harness liveness escalation",
+          status: "in_progress",
+          priority: "high",
+          assigneeAgentId: agentId,
+          originKind: "harness_liveness_escalation",
+          originId: `harness_liveness:${companyId}:${blockedIssueId}:blocked_by_unassigned_issue:${blockerIssueId}`,
+        },
+      ]);
+
+      await db.insert(issueRelations).values({
+        companyId,
+        issueId: blockerIssueId,
+        relatedIssueId: blockedIssueId,
+        type: "blocks",
+      });
+
+      const initialRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId: escalationIssueId },
+      });
+      expect(initialRun).toBeTruthy();
+
+      await waitFor(async () => {
+        const run = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, initialRun!))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "running";
+      });
+
+      const comment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId: escalationIssueId,
+          authorUserId: "user-1",
+          body: "Follow-up comment after run",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const deferredRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId: escalationIssueId, commentId: comment.id },
+        contextSnapshot: {
+          issueId: escalationIssueId,
+          taskId: escalationIssueId,
+          commentId: comment.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+      expect(deferredRun).toBeNull();
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.status, "deferred_issue_execution"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return Boolean(deferred);
+      });
+
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: new Date(),
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, escalationIssueId));
+
+      await db
+        .update(issues)
+        .set({
+          status: "in_progress",
+          assigneeAgentId: agentId,
+          blockedByIssueIds: [],
+          updatedAt: new Date(),
+        })
+        .where(eq(issues.id, blockedIssueId));
+
+      gateway.releaseFirstWait();
+
+      await waitFor(async () => {
+        const run = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, initialRun!))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "succeeded";
+      }, 90_000);
+
+      await waitFor(async () => {
+        const deferred = await db
+          .select()
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.status, "cancelled"),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        return Boolean(deferred);
+      }, 90_000);
+
+      const escalationIssue = await db
+        .select({
+          status: issues.status,
+          completedAt: issues.completedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, escalationIssueId))
+        .then((rows) => rows[0] ?? null);
+
+      expect(escalationIssue).toMatchObject({
+        status: "done",
+      });
+      expect(escalationIssue?.completedAt).toBeTruthy();
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
   it("treats the automatic run summary as fallback-only when the run already posted a comment", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
@@ -1312,4 +1519,80 @@ describe("heartbeat comment wake batching", () => {
       await gateway.close();
     }
   }, 20_000);
+
+  it("auto-posts a run-linked fallback comment for successful process adapter runs", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Process Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: "process",
+      adapterConfig: {
+        command: process.execPath,
+        args: ["-e", "process.stdout.write('ok'); process.exit(0);"],
+      },
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Process fallback comment",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: `${issuePrefix}-1`,
+    });
+
+    const firstRun = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "issue_assigned",
+      },
+      requestedByActorType: "system",
+      requestedByActorId: null,
+    });
+
+    expect(firstRun).not.toBeNull();
+
+    await waitFor(async () => {
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, firstRun!.id));
+      return runs.length === 1 && runs[0]?.status === "succeeded" && runs[0]?.issueCommentStatus === "satisfied";
+    }, 30_000);
+
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId))
+      .orderBy(asc(issueComments.createdAt));
+
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.createdByRunId).toBe(firstRun?.id);
+    expect(comments[0]?.body).toContain("Process run succeeded.");
+    expect(comments[0]?.body).toContain("Command:");
+  }, 40_000);
 });

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -277,4 +277,60 @@ describeEmbeddedPostgres("heartbeat issue graph liveness escalation", () => {
     expect(blockers.some((row) => row.blockerIssueId === closedEscalationId)).toBe(false);
     expect(blockers.some((row) => row.blockerIssueId === freshEscalation?.id)).toBe(true);
   });
+
+  it("skips liveness escalation and status rewrite for protected PRO issues", async () => {
+    const { companyId } = await seedBlockedChain();
+    const heartbeat = heartbeatService(db);
+    const blockedIssueId = randomUUID();
+    const blockerIssueId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Protected PRO issue",
+        status: "blocked",
+        priority: "high",
+        issueNumber: 36,
+        identifier: "PRO-36",
+      },
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Unassigned blocker for PRO",
+        status: "todo",
+        priority: "high",
+        issueNumber: 37,
+        identifier: "PRO-37",
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+
+    const result = await heartbeat.reconcileIssueGraphLiveness();
+    expect(result.escalationsCreated).toBe(0);
+
+    const protectedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, blockedIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(protectedIssue?.status).toBe("blocked");
+
+    const proEscalations = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, "harness_liveness_escalation"),
+          eq(issues.parentId, blockedIssueId),
+        ),
+      );
+    expect(proEscalations).toHaveLength(0);
+  });
 });

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -3,6 +3,7 @@ import type { agents } from "@paperclipai/db";
 import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-local/server";
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
+  applyAdapterModelProfile,
   applyPersistedExecutionWorkspaceConfig,
   buildRealizedExecutionWorkspaceFromPersisted,
   buildExplicitResumeSessionOverride,
@@ -154,6 +155,66 @@ describe("applyPersistedExecutionWorkspaceConfig", () => {
 
     expect(result.workspaceRuntime).toEqual({
       services: [{ name: "workspace-web" }],
+    });
+  });
+});
+
+describe("applyAdapterModelProfile", () => {
+  it("applies requested profiles from agent runtime config", () => {
+    const result = applyAdapterModelProfile({
+      config: {
+        model: "openai/gpt-5.1-codex-mini",
+        timeoutSec: 600,
+      },
+      runtimeConfig: {
+        modelProfiles: {
+          cheap: {
+            adapterConfig: {
+              model: "minimax/MiniMax-M2.7",
+              variant: "",
+            },
+          },
+        },
+      },
+      requestedProfile: "cheap",
+      requestedBy: "wake_context",
+    });
+
+    expect(result.config).toMatchObject({
+      model: "minimax/MiniMax-M2.7",
+      variant: "",
+      timeoutSec: 600,
+    });
+    expect(result.metadata).toEqual({
+      requested: "cheap",
+      requestedBy: "wake_context",
+      applied: "cheap",
+      configSource: "agent_runtime",
+      fallbackReason: null,
+    });
+  });
+
+  it("keeps the current agent config when the requested profile is missing", () => {
+    const result = applyAdapterModelProfile({
+      config: {
+        model: "minimax/MiniMax-M2.7",
+      },
+      runtimeConfig: {
+        modelProfiles: {},
+      },
+      requestedProfile: "cheap",
+      requestedBy: "issue_override",
+    });
+
+    expect(result.config).toEqual({
+      model: "minimax/MiniMax-M2.7",
+    });
+    expect(result.metadata).toEqual({
+      requested: "cheap",
+      requestedBy: "issue_override",
+      applied: null,
+      configSource: "base_config",
+      fallbackReason: "profile_not_found",
     });
   });
 });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -173,7 +173,7 @@ async function normalizePolicy(input: {
   return normalizeIssueExecutionPolicy(input);
 }
 
-function makeIssue(status: "todo" | "done" | "blocked") {
+function makeIssue(status: "todo" | "done" | "blocked", identifier = "PAP-580") {
   return {
     id: "11111111-1111-4111-8111-111111111111",
     companyId: "company-1",
@@ -181,7 +181,7 @@ function makeIssue(status: "todo" | "done" | "blocked") {
     assigneeAgentId: "22222222-2222-4222-8222-222222222222",
     assigneeUserId: null,
     createdByUserId: "local-board",
-    identifier: "PAP-580",
+    identifier,
     title: "Comment reopen default",
   };
 }
@@ -434,6 +434,129 @@ describe("issue comment reopen routes", () => {
     );
   });
 
+  it("does not implicitly reopen closed PRO issues via the PATCH comment path", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done", "PRO-104"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done", "PRO-104"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "hello", assigneeAgentId: "33333333-3333-4333-8333-333333333333" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+        actorAgentId: null,
+        actorUserId: "local-board",
+      }),
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "33333333-3333-4333-8333-333333333333",
+      expect.objectContaining({
+        reason: "issue_commented",
+      }),
+    );
+  });
+
+  it("ignores explicit reopen=true for closed PRO issues via the PATCH comment path", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done", "PRO-104"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done", "PRO-104"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({ comment: "hello", reopen: true, assigneeAgentId: "33333333-3333-4333-8333-333333333333" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ status: "todo" }),
+    );
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "33333333-3333-4333-8333-333333333333",
+      expect.objectContaining({
+        reason: "issue_commented",
+      }),
+    );
+  });
+
+  it("does not auto-rewrite PRO issue status via execution-policy drift correction", async () => {
+    const policy = await normalizePolicy({
+      stages: [
+        {
+          id: "stage-review",
+          type: "review",
+          participants: [{ type: "agent", agentId: "44444444-4444-4444-8444-444444444444" }],
+        },
+      ],
+    });
+    mockIssueService.getById.mockResolvedValue({
+      ...makeIssue("todo", "PRO-104"),
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: "stage-review",
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: {
+          type: "agent",
+          agentId: "44444444-4444-4444-8444-444444444444",
+          userId: null,
+        },
+        returnAssignee: {
+          type: "agent",
+          agentId: "22222222-2222-4222-8222-222222222222",
+          userId: null,
+        },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("todo", "PRO-104"),
+      status: "in_progress",
+      assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .patch("/api/issues/11111111-1111-4111-8111-111111111111")
+      .send({
+        status: "in_progress",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        status: "in_progress",
+        assigneeAgentId: "22222222-2222-4222-8222-222222222222",
+      }),
+      expect.anything(),
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        status: "in_review",
+      }),
+      expect.anything(),
+    );
+  });
+
   it("implicitly reopens closed issues via POST comments when an agent is assigned", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
@@ -457,6 +580,54 @@ describe("issue comment reopen routes", () => {
         payload: expect.objectContaining({
           reopenedFrom: "done",
         }),
+      }),
+    );
+  });
+
+  it("does not implicitly reopen closed PRO issues via POST comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done", "PRO-104"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done", "PRO-104"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "hello" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      { status: "todo" },
+    );
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        reason: "issue_commented",
+      }),
+    );
+  });
+
+  it("ignores explicit reopen=true for closed PRO issues via POST comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("done", "PRO-104"));
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeIssue("done", "PRO-104"),
+      ...patch,
+    }));
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "hello", reopen: true });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      { status: "todo" },
+    );
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({
+        reason: "issue_commented",
       }),
     );
   });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -663,6 +663,7 @@ export async function startServer(): Promise<StartedServer> {
     // then resume any persisted queued runs that were waiting on the previous process.
     void heartbeat
       .reapOrphanedRuns()
+      .then(() => heartbeat.cancelStaleTransientScheduledRetries())
       .then(() => heartbeat.promoteDueScheduledRetries())
       .then(async (promotion) => {
         await heartbeat.resumeQueuedRuns();

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -180,12 +180,21 @@ function isClosedIssueStatus(status: string | null | undefined): status is "done
   return status === "done" || status === "cancelled";
 }
 
+const PROTECTED_ISSUE_IDENTIFIER_RE = /^PRO-\d+$/i;
+
+function isProtectedIssueIdentifier(identifier: string | null | undefined) {
+  if (typeof identifier !== "string") return false;
+  return PROTECTED_ISSUE_IDENTIFIER_RE.test(identifier.trim());
+}
+
 function shouldImplicitlyMoveCommentedIssueToTodoForAgent(input: {
   issueStatus: string | null | undefined;
+  issueIdentifier: string | null | undefined;
   assigneeAgentId: string | null | undefined;
   actorType: "agent" | "user";
   actorId: string;
 }) {
+  if (isProtectedIssueIdentifier(input.issueIdentifier)) return false;
   if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   if (input.actorType === "agent" && input.actorId === input.assigneeAgentId) return false;
@@ -1796,10 +1805,11 @@ export function issueRoutes(
     const requestedAssigneeAgentId =
       normalizedAssigneeAgentId === undefined ? existing.assigneeAgentId : normalizedAssigneeAgentId;
     const effectiveMoveToTodoRequested =
-      reopenRequested ||
+      (reopenRequested && !isProtectedIssueIdentifier(existing.identifier)) ||
       (!!commentBody &&
         shouldImplicitlyMoveCommentedIssueToTodoForAgent({
           issueStatus: existing.status,
+          issueIdentifier: existing.identifier,
           assigneeAgentId: requestedAssigneeAgentId,
           actorType: actor.actorType,
           actorId: actor.actorId,
@@ -1873,21 +1883,27 @@ export function issueRoutes(
       updateFields.assigneeAgentId = normalizedAssigneeAgentId;
     }
 
-    const transition = applyIssueExecutionPolicyTransition({
-      issue: existing,
-      policy: nextExecutionPolicy,
-      requestedStatus: typeof updateFields.status === "string" ? updateFields.status : undefined,
-      requestedAssigneePatch: {
-        assigneeAgentId: normalizedAssigneeAgentId,
-        assigneeUserId:
-          req.body.assigneeUserId === undefined ? undefined : (req.body.assigneeUserId as string | null),
-      },
-      actor: {
-        agentId: actor.agentId ?? null,
-        userId: actor.actorType === "user" ? actor.actorId : null,
-      },
-      commentBody,
-    });
+    const bypassExecutionPolicyAutomation =
+      isProtectedIssueIdentifier(existing.identifier) &&
+      req.body.executionPolicy === undefined &&
+      req.body.executionState === undefined;
+    const transition = bypassExecutionPolicyAutomation
+      ? { patch: {}, workflowControlledAssignment: false as const, decision: undefined }
+      : applyIssueExecutionPolicyTransition({
+          issue: existing,
+          policy: nextExecutionPolicy,
+          requestedStatus: typeof updateFields.status === "string" ? updateFields.status : undefined,
+          requestedAssigneePatch: {
+            assigneeAgentId: normalizedAssigneeAgentId,
+            assigneeUserId:
+              req.body.assigneeUserId === undefined ? undefined : (req.body.assigneeUserId as string | null),
+          },
+          actor: {
+            agentId: actor.agentId ?? null,
+            userId: actor.actorType === "user" ? actor.actorId : null,
+          },
+          commentBody,
+        });
     const decisionId = transition.decision ? randomUUID() : null;
     if (decisionId) {
       const nextExecutionState = transition.patch.executionState;
@@ -3119,9 +3135,10 @@ export function issueRoutes(
     const isClosed = isClosedIssueStatus(issue.status);
     const isBlocked = issue.status === "blocked";
     const effectiveMoveToTodoRequested =
-      reopenRequested ||
+      (reopenRequested && !isProtectedIssueIdentifier(issue.identifier)) ||
       shouldImplicitlyMoveCommentedIssueToTodoForAgent({
         issueStatus: issue.status,
+        issueIdentifier: issue.identifier,
         assigneeAgentId: issue.assigneeAgentId,
         actorType: actor.actorType,
         actorId: actor.actorId,

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -1,6 +1,7 @@
 export const HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS = 500;
 export const HEARTBEAT_RUN_RESULT_OUTPUT_MAX_CHARS = 4_096;
 export const HEARTBEAT_RUN_SAFE_RESULT_JSON_MAX_BYTES = 64 * 1024;
+const PROCESS_COMMENT_OUTPUT_MAX_CHARS = 240;
 
 function truncateSummaryText(value: unknown, maxLength = HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS) {
   if (typeof value !== "string") return null;
@@ -94,15 +95,62 @@ export function summarizeHeartbeatRunResultJson(
 
 export function buildHeartbeatRunIssueComment(
   resultJson: Record<string, unknown> | null | undefined,
+  options?: {
+    adapterType?: string | null;
+    outcome?: "succeeded" | "failed" | "timed_out" | "cancelled";
+    command?: string | null;
+    commandArgs?: string[] | null;
+    exitCode?: number | null;
+    stdoutExcerpt?: string | null;
+    stderrExcerpt?: string | null;
+  },
 ): string | null {
   if (!resultJson || typeof resultJson !== "object" || Array.isArray(resultJson)) {
-    return null;
+    return buildProcessRunIssueComment(options);
   }
 
-  return (
+  const summaryComment = (
     readCommentText(resultJson.summary)
     ?? readCommentText(resultJson.result)
     ?? readCommentText(resultJson.message)
     ?? null
   );
+  if (summaryComment) return summaryComment;
+  return buildProcessRunIssueComment(options);
+}
+
+function formatProcessOutput(value: string | null | undefined) {
+  if (typeof value !== "string") return "_(empty)_";
+  const trimmed = value.trim();
+  if (!trimmed) return "_(empty)_";
+  if (trimmed.length <= PROCESS_COMMENT_OUTPUT_MAX_CHARS) return `\`${trimmed}\``;
+  return `\`${trimmed.slice(0, PROCESS_COMMENT_OUTPUT_MAX_CHARS)}...\``;
+}
+
+function buildProcessRunIssueComment(
+  options:
+    | {
+      adapterType?: string | null;
+      outcome?: "succeeded" | "failed" | "timed_out" | "cancelled";
+      command?: string | null;
+      commandArgs?: string[] | null;
+      exitCode?: number | null;
+      stdoutExcerpt?: string | null;
+      stderrExcerpt?: string | null;
+    }
+    | undefined,
+) {
+  if (!options || options.adapterType !== "process" || !options.outcome) return null;
+  const command = (options.command ?? "").trim();
+  const args = (options.commandArgs ?? []).map((part) => part.trim()).filter((part) => part.length > 0);
+  const commandText = command ? [command, ...args].join(" ") : "_(unavailable)_";
+  const exitCodeText = options.exitCode == null ? "_(none)_" : String(options.exitCode);
+  return [
+    `Process run ${options.outcome}.`,
+    "",
+    `- Command: \`${commandText}\``,
+    `- Exit code: \`${exitCodeText}\``,
+    `- Stdout: ${formatProcessOutput(options.stdoutExcerpt)}`,
+    `- Stderr: ${formatProcessOutput(options.stderrExcerpt)}`,
+  ].join("\n");
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -190,6 +190,18 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "pi_local",
 ]);
 const INLINE_BASE64_IMAGE_DATA_RE = /("type":"image","source":\{"type":"base64","data":")([A-Za-z0-9+/=]{1024,})(")/g;
+const PROTECTED_ISSUE_IDENTIFIER_RE = /^PRO-\d+$/i;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isProtectedIssueIdentifier(identifier: string | null | undefined) {
+  if (typeof identifier !== "string") return false;
+  return PROTECTED_ISSUE_IDENTIFIER_RE.test(identifier.trim());
+}
+
+function isUuidString(value: string | null | undefined) {
+  if (typeof value !== "string" || value.length === 0) return false;
+  return UUID_RE.test(value);
+}
 
 type RuntimeConfigSecretResolver = Pick<
   ReturnType<typeof secretService>,
@@ -252,6 +264,55 @@ export function applyRunScopedMentionedSkillKeys(
     ...existingPreference.desiredSkills,
     ...normalizedSkillKeys,
   ]);
+}
+
+type AdapterModelProfileRequestedBy = "wake_context" | "issue_override";
+
+export function applyAdapterModelProfile(input: {
+  config: Record<string, unknown>;
+  runtimeConfig: Record<string, unknown> | null | undefined;
+  requestedProfile: string | null | undefined;
+  requestedBy: AdapterModelProfileRequestedBy | null | undefined;
+}): {
+  config: Record<string, unknown>;
+  metadata: Record<string, unknown> | null;
+} {
+  const requested = readNonEmptyString(input.requestedProfile);
+  if (!requested) return { config: input.config, metadata: null };
+
+  const runtimeConfig = parseObject(input.runtimeConfig);
+  const modelProfiles = parseObject(runtimeConfig.modelProfiles);
+  const profile = parseObject(modelProfiles[requested]);
+  const profileAdapterConfig = parseObject(profile.adapterConfig);
+  const hasProfileAdapterConfig = Object.keys(profileAdapterConfig).length > 0;
+  const requestedBy = input.requestedBy ?? "wake_context";
+
+  if (!hasProfileAdapterConfig) {
+    return {
+      config: input.config,
+      metadata: {
+        requested,
+        requestedBy,
+        applied: null,
+        configSource: "base_config",
+        fallbackReason: Object.keys(profile).length > 0 ? "empty_profile_adapter_config" : "profile_not_found",
+      },
+    };
+  }
+
+  return {
+    config: {
+      ...input.config,
+      ...profileAdapterConfig,
+    },
+    metadata: {
+      requested,
+      requestedBy,
+      applied: requested,
+      configSource: "agent_runtime",
+      fallbackReason: null,
+    },
+  };
 }
 
 export function computeBoundedTransientHeartbeatRetrySchedule(
@@ -829,6 +890,7 @@ type SessionCompactionDecision = {
 interface ParsedIssueAssigneeAdapterOverrides {
   adapterConfig: Record<string, unknown> | null;
   useProjectWorkspace: boolean | null;
+  modelProfile: string | null;
 }
 
 export type ResolvedWorkspaceForRun = {
@@ -863,6 +925,11 @@ export function prioritizeProjectWorkspaceCandidatesForRun<T extends ProjectWork
 
 function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function readUuidString(value: unknown): string | null {
+  const candidate = readNonEmptyString(value);
+  return candidate && isUuidString(candidate) ? candidate : null;
 }
 
 export function summarizeHeartbeatRunContextSnapshot(
@@ -998,7 +1065,8 @@ async function resolveLedgerScopeForRun(
   run: typeof heartbeatRuns.$inferSelect,
 ) {
   const context = parseObject(run.contextSnapshot);
-  const contextIssueId = readNonEmptyString(context.issueId);
+  const rawContextIssueId = readNonEmptyString(context.issueId);
+  const contextIssueId = isUuidString(rawContextIssueId) ? rawContextIssueId : null;
   const contextProjectId = readNonEmptyString(context.projectId);
 
   if (!contextIssueId) {
@@ -1214,10 +1282,12 @@ function parseIssueAssigneeAdapterOverrides(
     typeof parsed.useProjectWorkspace === "boolean"
       ? parsed.useProjectWorkspace
       : null;
-  if (!adapterConfig && useProjectWorkspace === null) return null;
+  const modelProfile = readNonEmptyString(parsed.modelProfile);
+  if (!adapterConfig && useProjectWorkspace === null && !modelProfile) return null;
   return {
     adapterConfig,
     useProjectWorkspace,
+    modelProfile,
   };
 }
 
@@ -1555,7 +1625,7 @@ async function buildPaperclipWakePayload(input: {
 }) {
   const executionStage = parseObject(input.contextSnapshot.executionStage);
   const commentIds = extractWakeCommentIds(input.contextSnapshot);
-  const issueId = readNonEmptyString(input.contextSnapshot.issueId);
+  const issueId = readUuidString(input.contextSnapshot.issueId);
   const continuationSummary = input.continuationSummary ?? null;
   const issueSummary =
     input.issueSummary ??
@@ -2261,7 +2331,7 @@ export function heartbeatService(db: Db) {
     previousSessionParams: Record<string, unknown> | null,
     opts?: { useProjectWorkspace?: boolean | null },
   ): Promise<ResolvedWorkspaceForRun> {
-    const issueId = readNonEmptyString(context.issueId);
+    const issueId = readUuidString(context.issueId);
     const contextProjectId = readNonEmptyString(context.projectId);
     const contextProjectWorkspaceId = readNonEmptyString(context.projectWorkspaceId);
     const issueProjectRef = issueId
@@ -2658,7 +2728,7 @@ export function heartbeatService(db: Db) {
     if (livenessState !== "plan_only" && livenessState !== "empty_response") return;
 
     const context = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(context.issueId);
+    const issueId = readUuidString(context.issueId);
     if (!issueId) return;
 
     const [issue, agent] = await Promise.all([
@@ -2894,7 +2964,7 @@ export function heartbeatService(db: Db) {
     agent: typeof agents.$inferSelect,
   ) {
     const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const issueId = readUuidString(contextSnapshot.issueId);
     if (!issueId) return null;
     try {
       return await refreshIssueContinuationSummary({
@@ -3070,7 +3140,7 @@ export function heartbeatService(db: Db) {
     agent: typeof agents.$inferSelect,
   ) {
     const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const issueId = readUuidString(contextSnapshot.issueId);
     if (!issueId) {
       if (run.issueCommentStatus !== "not_applicable") {
         await patchRunIssueCommentStatus(run.id, {
@@ -3156,7 +3226,7 @@ export function heartbeatService(db: Db) {
     now: Date,
   ) {
     const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const issueId = readUuidString(contextSnapshot.issueId);
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
     const retryContextSnapshot = {
@@ -3293,7 +3363,7 @@ export function heartbeatService(db: Db) {
     }
 
     const contextSnapshot = parseObject(run.contextSnapshot);
-    const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const issueId = readUuidString(contextSnapshot.issueId);
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
     const retryContextSnapshot: Record<string, unknown> = {
@@ -3398,6 +3468,37 @@ export function heartbeatService(db: Db) {
       attempt: schedule.attempt,
       maxAttempts: schedule.maxAttempts,
     };
+  }
+
+  // On server restart, cancel any scheduled_retry runs whose scheduledRetryAt is still
+  // in the future and whose reason is transient_failure (quota / auth errors). These
+  // were pinned to the quota-reset time of the account that was active at failure time.
+  // After a restart the account may have changed (e.g. `claude login` in Terminal) so
+  // waiting for the old reset time is wrong — better to let fresh wakeups start
+  // immediately. Non-transient retries (e.g. process-loss) are left untouched.
+  async function cancelStaleTransientScheduledRetries(now = new Date()) {
+    const staleRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.status, "scheduled_retry"),
+          eq(heartbeatRuns.scheduledRetryReason, BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON),
+          gt(heartbeatRuns.scheduledRetryAt, now),
+        ),
+      );
+
+    const cancelledRunIds: string[] = [];
+    for (const run of staleRuns) {
+      const cancelled = await setRunStatus(run.id, "cancelled", {
+        finishedAt: now,
+        error: "Cancelled on server restart — transient_failure retry superseded by fresh start",
+        errorCode: "cancelled",
+      });
+      if (cancelled) cancelledRunIds.push(cancelled.id);
+    }
+
+    return { cancelled: cancelledRunIds.length, runIds: cancelledRunIds };
   }
 
   async function promoteDueScheduledRetries(now = new Date()) {
@@ -3530,7 +3631,7 @@ export function heartbeatService(db: Db) {
 
     const context = parseObject(run.contextSnapshot);
     const budgetBlock = await budgets.getInvocationBlock(run.companyId, run.agentId, {
-      issueId: readNonEmptyString(context.issueId),
+      issueId: readUuidString(context.issueId),
       projectId: readNonEmptyString(context.projectId),
     });
     if (budgetBlock) {
@@ -3538,7 +3639,7 @@ export function heartbeatService(db: Db) {
       return null;
     }
 
-    const issueId = readNonEmptyString(context.issueId);
+    const issueId = readUuidString(context.issueId);
     if (issueId) {
       const activePauseHold = await treeControlSvc.getActivePauseHoldGate(run.companyId, issueId);
       const treeHoldInteractionWake = activePauseHold && allowsIssueInteractionWake(context);
@@ -3730,7 +3831,8 @@ export function heartbeatService(db: Db) {
     resultJson: Record<string, unknown> | null | undefined,
   ): Promise<RunLivenessClassificationInput> {
     const context = parseObject(run.contextSnapshot);
-    const contextIssueId = readNonEmptyString(context.issueId);
+    const rawContextIssueId = readNonEmptyString(context.issueId);
+    const contextIssueId = isUuidString(rawContextIssueId) ? rawContextIssueId : null;
     const continuationAttempt = asNumber(context.continuationAttempt, run.continuationAttempt ?? 0);
 
     const issue = contextIssueId
@@ -4255,6 +4357,8 @@ export function heartbeatService(db: Db) {
     > | null;
     comment: string;
   }) {
+    if (isProtectedIssueIdentifier(input.issue.identifier)) return null;
+
     const updated = await issuesSvc.update(input.issue.id, {
       status: "blocked",
     });
@@ -4396,16 +4500,64 @@ export function heartbeatService(db: Db) {
         continue;
       }
 
-      // Advisor-specific: if the latest run was itself a continuation retry
-      // and succeeded, the advisory is written and the dossier is in
-      // awaiting-review. Do not loop forever.
+      // Advisor-specific: if the latest run was a continuation retry, a
+      // reopen-after-block, or a process-loss retry and has reached a terminal
+      // status (succeeded, timed_out, or failed), the advisory is written and
+      // the dossier is in awaiting-review or done. Escalate to blocked with an
+      // AGENT diagnostic comment so the CRO does not silently reset the issue.
       const latestContext = parseObject(latestRun?.contextSnapshot);
+      const latestWakeReason = readNonEmptyString(latestContext.wakeReason);
+      const latestRetryReason = readNonEmptyString(latestContext.retryReason);
+      const isAdvisorRecoveryRetry =
+        latestRetryReason === "issue_continuation_needed" ||
+        latestWakeReason === "issue_reopened_via_comment" ||
+        latestWakeReason === "process_lost_retry" ||
+        latestWakeReason === "issue_commented";
+      const isTerminalStatus =
+        latestRun?.status === "succeeded" ||
+        latestRun?.status === "timed_out" ||
+        latestRun?.status === "failed";
       if (
         issue.title?.startsWith("Advise:") &&
-        latestRun?.status === "succeeded" &&
-        readNonEmptyString(latestContext.retryReason) === "issue_continuation_needed"
+        isTerminalStatus &&
+        isAdvisorRecoveryRetry
       ) {
-        result.skipped += 1;
+        if (isProtectedIssueIdentifier(issue.identifier)) {
+          result.skipped += 1;
+          continue;
+        }
+        const updated = await issuesSvc.update(issue.id, { status: "blocked" });
+        if (updated) {
+          await issuesSvc.addComment(
+            issue.id,
+            "Advisor completed its work (dossier stage is awaiting-review or done). " +
+              "No further Advisor action is needed until Kim makes a cockpit decision or route-backs.",
+            { agentId },
+          );
+          await logActivity(db, {
+            companyId: issue.companyId,
+            actorType: "system",
+            actorId: "system",
+            agentId,
+            runId: null,
+            action: "issue.updated",
+            entityType: "issue",
+            entityId: issue.id,
+            details: {
+              identifier: issue.identifier,
+              status: "blocked",
+              previousStatus: "in_progress",
+              source: "heartbeat.reconcile_stranded_assigned_issue",
+              latestRunId: latestRun?.id ?? null,
+              latestRunStatus: latestRun?.status ?? null,
+              latestRunErrorCode: latestRun?.errorCode ?? null,
+            },
+          });
+          result.escalated += 1;
+          result.issueIds.push(issue.id);
+        } else {
+          result.skipped += 1;
+        }
         continue;
       }
 
@@ -4621,7 +4773,7 @@ export function heartbeatService(db: Db) {
     const update: Partial<typeof issues.$inferInsert> & { blockedByIssueIds: string[] } = {
       blockedByIssueIds: nextBlockerIds,
     };
-    if (input.issue.status !== "blocked") {
+    if (!isProtectedIssueIdentifier(input.issue.identifier) && input.issue.status !== "blocked") {
       update.status = "blocked";
     }
 
@@ -4661,6 +4813,7 @@ export function heartbeatService(db: Db) {
       .where(eq(issues.id, input.finding.issueId))
       .then((rows) => rows[0] ?? null);
     if (!issue || issue.companyId !== input.finding.companyId) return { kind: "skipped" as const };
+    if (isProtectedIssueIdentifier(issue.identifier)) return { kind: "skipped" as const };
 
     const existing = await findOpenLivenessEscalation(issue.companyId, input.finding.incidentKey);
     if (existing) {
@@ -4955,7 +5108,7 @@ export function heartbeatService(db: Db) {
     const context = parseObject(run.contextSnapshot);
     const taskKey = deriveTaskKeyWithHeartbeatFallback(context, null);
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
-    const issueId = readNonEmptyString(context.issueId);
+    const issueId = readUuidString(context.issueId);
     let issueContext = issueId ? await getIssueExecutionContext(agent.companyId, issueId) : null;
     const issueDependencyReadiness = issueId
       ? await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]).then((rows) => rows.get(issueId) ?? null)
@@ -5111,9 +5264,31 @@ export function heartbeatService(db: Db) {
       workspaceConfig: existingExecutionWorkspace?.config ?? null,
       mode: effectiveExecutionWorkspaceMode,
     });
+    const contextModelProfile = readNonEmptyString(context.modelProfile);
+    const requestedModelProfile = contextModelProfile ?? issueAssigneeOverrides?.modelProfile ?? null;
+    const requestedModelProfileBy: AdapterModelProfileRequestedBy | null =
+      contextModelProfile
+        ? "wake_context"
+        : issueAssigneeOverrides?.modelProfile
+          ? "issue_override"
+          : null;
+    if (requestedModelProfile) {
+      context.modelProfile = requestedModelProfile;
+    }
+    const modelProfileConfig = applyAdapterModelProfile({
+      config: persistedWorkspaceManagedConfig,
+      runtimeConfig: parseObject(agent.runtimeConfig),
+      requestedProfile: requestedModelProfile,
+      requestedBy: requestedModelProfileBy,
+    });
+    if (modelProfileConfig.metadata) {
+      context.paperclipModelProfile = modelProfileConfig.metadata;
+    } else {
+      delete context.paperclipModelProfile;
+    }
     const mergedConfig = issueAssigneeOverrides?.adapterConfig
-      ? { ...persistedWorkspaceManagedConfig, ...issueAssigneeOverrides.adapterConfig }
-      : persistedWorkspaceManagedConfig;
+      ? { ...modelProfileConfig.config, ...issueAssigneeOverrides.adapterConfig }
+      : modelProfileConfig.config;
     const defaultEnvironment = await environmentsSvc.ensureLocalEnvironment(agent.companyId);
     const selectedEnvironmentId = resolveExecutionWorkspaceEnvironmentId({
       projectPolicy: projectExecutionWorkspacePolicy,
@@ -5696,7 +5871,9 @@ export function heartbeatService(db: Db) {
           );
         }
       }
+      let latestInvocationMeta: AdapterInvocationMeta | null = null;
       const onAdapterMeta = async (meta: AdapterInvocationMeta) => {
+        latestInvocationMeta = meta;
         if (meta.env && secretKeys.size > 0) {
           for (const key of secretKeys) {
             if (key in meta.env) meta.env[key] = "***REDACTED***";
@@ -5934,7 +6111,19 @@ export function heartbeatService(db: Db) {
           try {
             const existingRunComment = await findRunIssueComment(livenessRun.id, livenessRun.companyId, issueId);
             if (!existingRunComment) {
-              const issueComment = buildHeartbeatRunIssueComment(persistedResultJson);
+              const invocationMetaObj = parseObject(latestInvocationMeta as unknown);
+              const invocationCommandArgs = Array.isArray(invocationMetaObj.commandArgs)
+                ? invocationMetaObj.commandArgs.filter((arg): arg is string => typeof arg === "string")
+                : null;
+              const issueComment = buildHeartbeatRunIssueComment(persistedResultJson, {
+                adapterType: agent.adapterType,
+                outcome,
+                command: readNonEmptyString(invocationMetaObj.command) ?? null,
+                commandArgs: invocationCommandArgs,
+                exitCode: adapterResult.exitCode,
+                stdoutExcerpt,
+                stderrExcerpt,
+              });
               if (issueComment) {
                 await issuesSvc.addComment(issueId, issueComment, { agentId: agent.id, runId: livenessRun.id });
               }
@@ -6150,7 +6339,10 @@ export function heartbeatService(db: Db) {
 
   async function releaseIssueExecutionAndPromote(run: typeof heartbeatRuns.$inferSelect) {
     const runContext = parseObject(run.contextSnapshot);
-    const contextIssueId = readNonEmptyString(runContext.issueId);
+    const isUuid = (value: string) =>
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+    const contextIssueIdRaw = readNonEmptyString(runContext.issueId);
+    const contextIssueId = contextIssueIdRaw && isUuid(contextIssueIdRaw) ? contextIssueIdRaw : null;
     const taskKey = deriveTaskKeyWithHeartbeatFallback(runContext, null);
     const recoveryAgent = await getAgent(run.agentId);
     const recoveryAgentInvokable =
@@ -6180,6 +6372,8 @@ export function heartbeatService(db: Db) {
           companyId: issues.companyId,
           identifier: issues.identifier,
           status: issues.status,
+          originKind: issues.originKind,
+          originId: issues.originId,
           assigneeAgentId: issues.assigneeAgentId,
           assigneeUserId: issues.assigneeUserId,
           executionRunId: issues.executionRunId,
@@ -6208,6 +6402,72 @@ export function heartbeatService(db: Db) {
           .where(eq(issues.id, issue.id));
       }
 
+      const isResolvedBlockedByUnassignedIncident = async () => {
+        const parseBlockedByUnassignedOrigin = (originId: string) => {
+          const match = originId.match(
+            /^harness_liveness:([0-9a-f-]{36}):([0-9a-f-]{36}):blocked_by_unassigned_issue:([0-9a-f-]{36})$/i,
+          );
+          if (!match) return null;
+          const [, originCompanyId, blockedIssueId, blockerIssueId] = match;
+          if (!originCompanyId || !blockedIssueId || !blockerIssueId) return null;
+          if (!isUuid(originCompanyId) || !isUuid(blockedIssueId) || !isUuid(blockerIssueId)) return null;
+          return { originCompanyId, blockedIssueId, blockerIssueId };
+        };
+
+        try {
+          if (issue.originKind !== "harness_liveness_escalation") return false;
+          const originId = readNonEmptyString(issue.originId);
+          if (!originId) return false;
+          const parsed = parseBlockedByUnassignedOrigin(originId);
+          // Historical bad origin IDs (for example "[object Object]") should never trigger reopen logic.
+          if (!parsed) return true;
+          const blockedIssueId = readNonEmptyString(parsed.blockedIssueId);
+          const blockerIssueId = readNonEmptyString(parsed.blockerIssueId);
+          if (!blockedIssueId || !blockerIssueId || !isUuid(blockedIssueId) || !isUuid(blockerIssueId)) {
+            return true;
+          }
+          const blockedIssue = await tx
+            .select({
+              status: issues.status,
+            })
+            .from(issues)
+            .where(and(eq(issues.companyId, issue.companyId), eq(issues.id, blockedIssueId)))
+            .then((rows) => rows[0] ?? null);
+          if (!blockedIssue) return true;
+          if (blockedIssue.status !== "blocked") return true;
+          const relation = await tx
+            .select({ blockerIssueId: issueRelations.issueId })
+            .from(issueRelations)
+            .where(
+              and(
+                eq(issueRelations.companyId, issue.companyId),
+                eq(issueRelations.type, "blocks"),
+                eq(issueRelations.issueId, blockerIssueId),
+                eq(issueRelations.relatedIssueId, blockedIssueId),
+              ),
+            )
+            .then((rows) => rows[0] ?? null);
+          if (!relation) {
+            return true;
+          }
+          const blocker = await tx
+            .select({
+              status: issues.status,
+              assigneeAgentId: issues.assigneeAgentId,
+              assigneeUserId: issues.assigneeUserId,
+            })
+            .from(issues)
+            .where(and(eq(issues.companyId, issue.companyId), eq(issues.id, blockerIssueId)))
+            .then((rows) => rows[0] ?? null);
+          if (!blocker) return true;
+          if (blocker.status === "done" || blocker.status === "cancelled") return true;
+          return Boolean(blocker.assigneeAgentId || blocker.assigneeUserId);
+        } catch {
+          // Fail closed: if incident lineage cannot be read safely, keep escalation terminal.
+          return true;
+        }
+      };
+
       while (true) {
         const deferred = await tx
           .select()
@@ -6216,7 +6476,7 @@ export function heartbeatService(db: Db) {
             and(
               eq(agentWakeupRequests.companyId, issue.companyId),
               eq(agentWakeupRequests.status, "deferred_issue_execution"),
-              sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}`,
+              eq(sql<string>`${agentWakeupRequests.payload} ->> 'issueId'`, issue.id),
             ),
           )
           .orderBy(asc(agentWakeupRequests.requestedAt))
@@ -6280,8 +6540,29 @@ export function heartbeatService(db: Db) {
           };
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
+        const issueStatusIsTerminal =
+          issue.status === "done" || issue.status === "cancelled" || issue.status === "blocked";
+        const isHarnessLivenessEscalation = issue.originKind === "harness_liveness_escalation";
+        const resolvedUnassignedBlockerIncident = isHarnessLivenessEscalation
+          ? await isResolvedBlockedByUnassignedIncident()
+          : false;
+        if (issueStatusIsTerminal && resolvedUnassignedBlockerIncident) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              finishedAt: new Date(),
+              error: "Deferred wake cancelled: blocked_by_unassigned incident already resolved",
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
         const shouldReopenDeferredCommentWake =
-          deferredCommentIds.length > 0 && (issue.status === "done" || issue.status === "cancelled");
+          deferredCommentIds.length > 0 &&
+          (issue.status === "done" || issue.status === "cancelled") &&
+          !resolvedUnassignedBlockerIncident &&
+          !isProtectedIssueIdentifier(issue.identifier);
         let reopenedActivity: LogActivityInput | null = null;
 
         if (shouldReopenDeferredCommentWake) {
@@ -6413,7 +6694,7 @@ export function heartbeatService(db: Db) {
           and(
             eq(heartbeatRuns.companyId, issue.companyId),
             inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
-            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
+            eq(sql<string>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`, issue.id),
             sql`${heartbeatRuns.id} <> ${run.id}`,
           ),
         )
@@ -6428,6 +6709,9 @@ export function heartbeatService(db: Db) {
         !recoveryAgent ||
         didAutomaticRecoveryFail(run, issue.status === "todo" ? "assignment_recovery" : "issue_continuation_needed");
       if (shouldBlockImmediately) {
+        if (isProtectedIssueIdentifier(issue.identifier)) {
+          return { kind: "released" as const };
+        }
         const comment = buildImmediateExecutionPathRecoveryComment({
           status: issue.status as "todo" | "in_progress",
           latestRun: run,
@@ -6585,7 +6869,7 @@ export function heartbeatService(db: Db) {
       triggerDetail,
       payload,
     });
-    let issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueIdFromPayload;
+    let issueId = readUuidString(enrichedContextSnapshot.issueId) ?? readUuidString(issueIdFromPayload);
 
     const agent = await getAgent(agentId);
     if (!agent) throw notFound("Agent not found");
@@ -6603,7 +6887,7 @@ export function heartbeatService(db: Db) {
       if (!readNonEmptyString(enrichedContextSnapshot.taskKey) && explicitResumeSession.taskKey) {
         enrichedContextSnapshot.taskKey = explicitResumeSession.taskKey;
       }
-      issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueId;
+      issueId = readUuidString(enrichedContextSnapshot.issueId) ?? issueId;
     }
     const effectiveTaskKey = readNonEmptyString(enrichedContextSnapshot.taskKey) ?? taskKey;
     const sessionBefore =
@@ -6923,7 +7207,7 @@ export function heartbeatService(db: Db) {
                 eq(agentWakeupRequests.companyId, agent.companyId),
                 eq(agentWakeupRequests.agentId, agentId),
                 eq(agentWakeupRequests.status, "deferred_issue_execution"),
-                sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issue.id}`,
+                eq(sql<string>`${agentWakeupRequests.payload} ->> 'issueId'`, issue.id),
               ),
             )
             .orderBy(asc(agentWakeupRequests.requestedAt))
@@ -7063,9 +7347,20 @@ export function heartbeatService(db: Db) {
       !sameScopeQueuedRun &&
       shouldQueueFollowupForRunningIssueWake({ contextSnapshot: enrichedContextSnapshot, wakeCommentId });
 
+    // Manual on-demand wakeup is treated as an operator override (e.g. server restart
+    // with new auth). Cancel any pending scheduled_retry so the new run starts
+    // immediately rather than waiting for the retry's scheduledRetryAt timestamp.
+    if (triggerDetail === "manual" && sameScopeScheduledRetryRun) {
+      await setRunStatus(sameScopeScheduledRetryRun.id, "cancelled", {
+        finishedAt: new Date(),
+        error: "Superseded by manual on-demand wakeup",
+        errorCode: "cancelled",
+      });
+    }
+
     const coalescedTargetRun =
       sameScopeQueuedRun ??
-      sameScopeScheduledRetryRun ??
+      (triggerDetail === "manual" ? null : sameScopeScheduledRetryRun) ??
       (shouldQueueFollowupForRunningWake ? null : sameScopeRunningRun ?? null);
 
     if (coalescedTargetRun) {
@@ -7616,6 +7911,8 @@ export function heartbeatService(db: Db) {
     reportRunActivity: clearDetachedRunWarning,
 
     reapOrphanedRuns,
+
+    cancelStaleTransientScheduledRetries,
 
     promoteDueScheduledRetries,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4396,6 +4396,19 @@ export function heartbeatService(db: Db) {
         continue;
       }
 
+      // Advisor-specific: if the latest run was itself a continuation retry
+      // and succeeded, the advisory is written and the dossier is in
+      // awaiting-review. Do not loop forever.
+      const latestContext = parseObject(latestRun?.contextSnapshot);
+      if (
+        issue.title?.startsWith("Advise:") &&
+        latestRun?.status === "succeeded" &&
+        readNonEmptyString(latestContext.retryReason) === "issue_continuation_needed"
+      ) {
+        result.skipped += 1;
+        continue;
+      }
+
       const queued = await enqueueStrandedIssueRecovery({
         issueId: issue.id,
         agentId,

--- a/server/src/services/issue-liveness.ts
+++ b/server/src/services/issue-liveness.ts
@@ -17,6 +17,7 @@ export interface IssueLivenessIssueInput {
   parentId?: string | null;
   assigneeAgentId?: string | null;
   assigneeUserId?: string | null;
+  blockedByIssueIds?: string[] | null;
   createdByAgentId?: string | null;
   createdByUserId?: string | null;
   executionState?: Record<string, unknown> | null;
@@ -141,13 +142,17 @@ function agentChainCandidates(
 }
 
 function fallbackExecutiveCandidates(agents: IssueLivenessAgentInput[], companyId: string) {
+  // Executives and roots only — never the full active-agent list. Returning
+  // every active agent caused liveness escalations for one team's blocked
+  // issue to be assigned to an unrelated team's worker (e.g., a content-QA
+  // Judge being asked to fix a product-DB scrape task).
   const active = agents.filter((agent) => agent.companyId === companyId && isInvokableAgent(agent));
   const executive = active.filter((agent) => {
     const haystack = `${agent.role} ${agent.title ?? ""} ${agent.name}`.toLowerCase();
     return /\b(cto|chief technology|ceo|chief executive)\b/.test(haystack);
   });
   const roots = active.filter((agent) => !agent.reportsTo);
-  return [...executive, ...roots, ...active].map((agent) => agent.id);
+  return [...new Set([...executive, ...roots].map((agent) => agent.id))];
 }
 
 function ownerCandidatesForIssue(
@@ -232,6 +237,14 @@ export function classifyIssueGraphLiveness(input: IssueGraphLivenessInput): Issu
       const relations = blockersByBlockedIssueId.get(issue.id) ?? [];
       for (const relation of relations) {
         if (relation.companyId !== issue.companyId) continue;
+        if (
+          Array.isArray(issue.blockedByIssueIds) &&
+          !issue.blockedByIssueIds.includes(relation.blockerIssueId)
+        ) {
+          // Source-of-truth guard: if the issue's explicit blocker list no
+          // longer contains this relation, treat it as stale and ignore it.
+          continue;
+        }
         const blocker = issuesById.get(relation.blockerIssueId);
         if (!blocker || blocker.companyId !== issue.companyId || blocker.status === "done") continue;
 


### PR DESCRIPTION
## Summary

Three loosely-related platform improvements grouped into one change-set.

### 1. PRO issue reopen protection
PRO-prefixed issues (executive/protected) must not be implicitly re-opened by comment activity. Guards every reopen path:
- POST `/issues/:id/comments`: no implicit reopen of closed PRO issues
- PATCH comment path: same
- Explicit `reopen=true` flag: ignored for closed PRO issues (both POST and PATCH)
- Execution-policy drift correction: does NOT auto-rewrite PRO issue status
- Heartbeat liveness-escalation: skips escalation + status rewrite for protected PRO issues

Introduces shared `isProtectedIssueIdentifier()` used across routes and heartbeat services.

### 2. Adapter `modelProfile` selection
New optional `IssueAssigneeAdapterOverrides.modelProfile?: string | null` lets an issue's assignee pick a specific model profile at run time. New exported `applyAdapterModelProfile()` in heartbeat-workspace-session selects the right profile from the agent's runtime config, gracefully falling back to the current agent config when the requested profile is missing.

### 3. Heartbeat comment-wake batching + run-linked fallback comments
- `buildProcessRunIssueComment()` formats successful process-adapter run output for issue-comment posting
- Guards against reopening done harness-liveness issues after a `blocked_by_unassigned_issue` incident resolves
- `cancelStaleTransientScheduledRetries(now)` clears stale scheduled retries

## Why

- Reduces manual operator intervention on PRO issues (which should never be auto-reopened by orchestration).
- Lets assignee-level config control model selection without changing the agent's global config.
- Reduces duplicate wakes when a single resolved blocker affects multiple in-flight runs.

## Test coverage

Four new / extended test files, all checked in:
- `heartbeat-comment-wake-batching.test.ts` — resolved-incident guard + run-linked fallback comment path
- `heartbeat-issue-liveness-escalation.test.ts` — protected-PRO skip
- `heartbeat-workspace-session.test.ts` — \`applyAdapterModelProfile\` happy + fallback paths
- `issue-comment-reopen-routes.test.ts` — 5 PRO-reopen-protection cases (implicit/explicit, POST/PATCH, drift correction)

## Reviewer notes

- Branch is based on a commit that's behind current `master` — please rebase before merge if needed; no functional conflicts expected.
- Three themes were grouped because they share `isProtectedIssueIdentifier()` and touch overlapping heartbeat/issue code paths. Reviewers can split into smaller commits during squash-merge if preferred.

## Test plan

- [ ] CI passes on the new tests
- [ ] Local: \`pnpm -F @paperclip/server test\` clean
- [ ] Manual smoke: open a PRO issue, post a comment, confirm status doesn't flip
- [ ] Manual smoke: configure an assignee with \`modelProfile\` override, confirm heartbeat picks the right profile