### PR TITLE
fix(claude-local): detect proxy base URL as metered billing

### DIFF
--- a/packages/adapters/claude-local/src/server/billing-type.test.ts
+++ b/packages/adapters/claude-local/src/server/billing-type.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { resolveClaudeBillingType } from "./execute.js";
+
+describe("resolveClaudeBillingType", () => {
+  it("returns metered_api for AWS Bedrock", () => {
+    expect(resolveClaudeBillingType({ CLAUDE_CODE_USE_BEDROCK: "1" })).toBe("metered_api");
+    expect(resolveClaudeBillingType({ CLAUDE_CODE_USE_BEDROCK: "true" })).toBe("metered_api");
+    expect(
+      resolveClaudeBillingType({ ANTHROPIC_BEDROCK_BASE_URL: "https://bedrock-runtime.us-east-1.amazonaws.com" }),
+    ).toBe("metered_api");
+  });
+
+  it("returns api when a direct Anthropic API key is present", () => {
+    expect(resolveClaudeBillingType({ ANTHROPIC_API_KEY: "sk-ant-xxx" })).toBe("api");
+  });
+
+  it("returns metered_api when ANTHROPIC_BASE_URL points at a proxy (LiteLLM, OpenRouter, etc.)", () => {
+    expect(
+      resolveClaudeBillingType({ ANTHROPIC_BASE_URL: "https://litellm.internal/anthropic" }),
+    ).toBe("metered_api");
+    expect(
+      resolveClaudeBillingType({
+        ANTHROPIC_BASE_URL: "https://litellm.internal/anthropic",
+        ANTHROPIC_AUTH_TOKEN: "proxy-token",
+      }),
+    ).toBe("metered_api");
+  });
+
+  it("prefers ANTHROPIC_API_KEY over ANTHROPIC_BASE_URL when both are set", () => {
+    expect(
+      resolveClaudeBillingType({
+        ANTHROPIC_API_KEY: "sk-ant-xxx",
+        ANTHROPIC_BASE_URL: "https://proxy.example.com",
+      }),
+    ).toBe("api");
+  });
+
+  it("treats empty-string env values as unset", () => {
+    expect(
+      resolveClaudeBillingType({ ANTHROPIC_API_KEY: "", ANTHROPIC_BASE_URL: "   " }),
+    ).toBe("subscription");
+  });
+
+  it("falls back to subscription when no auth/proxy signal is present", () => {
+    expect(resolveClaudeBillingType({})).toBe("subscription");
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -116,9 +116,16 @@ function isBedrockAuth(env: Record<string, string>): boolean {
   );
 }
 
-function resolveClaudeBillingType(env: Record<string, string>): "api" | "subscription" | "metered_api" {
+export function resolveClaudeBillingType(
+  env: Record<string, string>,
+): "api" | "subscription" | "metered_api" {
   if (isBedrockAuth(env)) return "metered_api";
-  return hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY") ? "api" : "subscription";
+  if (hasNonEmptyEnvValue(env, "ANTHROPIC_API_KEY")) return "api";
+  // A custom base URL (LiteLLM, OpenRouter, self-hosted gateway, etc.) means
+  // the request is not hitting the default Anthropic endpoint backing a
+  // Claude.ai subscription, so cost reported by the upstream is real money.
+  if (hasNonEmptyEnvValue(env, "ANTHROPIC_BASE_URL")) return "metered_api";
+  return "subscription";
 }
 
 async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<ClaudeRuntimeConfig> {


### PR DESCRIPTION
# Thinking Path

- Paperclip enforces per-agent budgets by aggregating `cost_events.cost_cents`.
- The `claude-local` adapter classifies each run as `api`, `subscription`, or `metered_api` so the heartbeat service knows whether to record the upstream `costUsd`.
- Today the resolver only inspects `ANTHROPIC_BEDROCK_BASE_URL` and `ANTHROPIC_API_KEY`; any other proxy (LiteLLM, OpenRouter, self-hosted gateway) falls through to `subscription`, which downstream hard-zeros `cost_cents`. The run card still shows the upstream cost, so the user sees money spent but the budget's observed amount stays at $0.
- This PR adds an `ANTHROPIC_BASE_URL` check that returns `metered_api`, mirroring how Bedrock is detected one line above.
- The benefit is proxy-routed Claude Code spend now reaches the budget's observed amount and enforcement actually fires.

## What Changed

- `packages/adapters/claude-local/src/server/execute.ts` — `resolveClaudeBillingType` returns `metered_api` when `ANTHROPIC_BASE_URL` is set. Exported for testing.
- `packages/adapters/claude-local/src/server/billing-type.test.ts` — 6 vitest cases covering all branches and precedence.

## Verification

- `pnpm --filter @paperclipai/adapter-claude-local typecheck` — passes.
- `pnpm exec vitest run packages/adapters/claude-local` — 20/20 tests pass.
- Stock Claude.ai subscription users (no `ANTHROPIC_BASE_URL`) are unchanged.

## Risks

A subscription-backed reverse proxy would now be classified as metered, surfacing nominally-free spend. Safer than today's silent zeroing. The robust long-term fix is an explicit `billingType` field in agent runtime config — out of scope here.

## Model Used

Claude Sonnet 4.6 (1M context) — \`claude-sonnet-4-6[1m]\`, via Claude Code.

## Checklist

- [x] Thinking path included
- [x] Model used specified
- [x] Checked ROADMAP — Better Budgeting is a tracked direction, but this is a bug fix supporting that goal, not a new feature
- [x] Tests pass locally
- [x] Tests added
- [ ] UI screenshots — N/A, no UI change
- [ ] Docs — N/A, internal heuristic
- [x] Risks documented
- [x] Will address Greptile + reviewer comments