### PR TITLE
fix: suppress self-wake loop for blocked issues (FUL-2238)

### DIFF
--- a/server/src/__tests__/guardrail2-consecutive-comment-cap-routes.test.ts
+++ b/server/src/__tests__/guardrail2-consecutive-comment-cap-routes.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Tests for Guardrail 2: consecutive agent comment cap (FUL-2207).
+ *
+ * When an assignee agent posts CONSECUTIVE_AGENT_COMMENT_CAP or more comments
+ * in a row with no human or other-agent reply, the route must:
+ *   1. Set the issue to `blocked` (which also clears checkout fields)
+ *   2. Post a system comment tagging the CTO
+ *   3. NOT dispatch a wakeup to the agent for that comment
+ */
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ASSIGNEE_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const OTHER_AGENT_ID = "33333333-3333-4333-8333-333333333333";
+const ISSUE_ID = "11111111-1111-4111-8111-111111111111";
+
+// Three consecutive comments all authored by the assignee agent.
+function makeAgentCommentStreak(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `comment-streak-${i}`,
+    issueId: ISSUE_ID,
+    companyId: "company-1",
+    body: `consecutive comment ${i + 1}`,
+    authorAgentId: ASSIGNEE_AGENT_ID,
+    authorUserId: null,
+    authorType: "agent",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }));
+}
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  assertCheckoutOwner: vi.fn(),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  listComments: vi.fn(),
+  getDependencyReadiness: vi.fn(),
+  findMentionedAgents: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(),
+  getWakeableParentAfterChildCompletion: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(),
+  hasPermission: vi.fn(),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  list: vi.fn(),
+  resolveByReference: vi.fn(),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+const mockTxInsertValues = vi.hoisted(() => vi.fn(async () => undefined));
+const mockTxInsert = vi.hoisted(() => vi.fn(() => ({ values: mockTxInsertValues })));
+const mockTx = vi.hoisted(() => ({ insert: mockTxInsert }));
+const mockDbSelectOrderBy = vi.hoisted(() => vi.fn(async () => []));
+const mockDbSelectWhere = vi.hoisted(() => vi.fn(() => ({ orderBy: mockDbSelectOrderBy })));
+const mockDbSelectFrom = vi.hoisted(() => vi.fn(() => ({ where: mockDbSelectWhere })));
+const mockDbSelect = vi.hoisted(() => vi.fn(() => ({ from: mockDbSelectFrom })));
+const mockDb = vi.hoisted(() => ({
+  select: mockDbSelect,
+  transaction: vi.fn(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)),
+}));
+
+const mockInstanceSettingsService = vi.hoisted(() => ({
+  get: vi.fn(async () => ({
+    id: "instance-settings-1",
+    general: { censorUsernameInLogs: false, feedbackDataSharingPreference: "prompt" },
+  })),
+  listCompanyIds: vi.fn(async () => ["company-1"]),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", () => ({
+  trackAgentTaskCompleted: vi.fn(),
+  trackErrorHandlerCrash: vi.fn(),
+}));
+vi.mock("../telemetry.js", () => ({ getTelemetryClient: vi.fn(() => ({ track: vi.fn() })) }));
+vi.mock("../services/access.js", () => ({ accessService: () => mockAccessService }));
+vi.mock("../services/activity-log.js", () => ({ logActivity: mockLogActivity }));
+vi.mock("../services/agents.js", () => ({ agentService: () => mockAgentService }));
+vi.mock("../services/feedback.js", () => ({
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null })),
+  }),
+}));
+vi.mock("../services/heartbeat.js", () => ({ heartbeatService: () => mockHeartbeatService }));
+vi.mock("../services/instance-settings.js", () => ({
+  instanceSettingsService: () => mockInstanceSettingsService,
+}));
+vi.mock("../services/issues.js", () => ({ issueService: () => mockIssueService }));
+vi.mock("../services/routines.js", () => ({
+  routineService: () => ({ syncRunStatusForIssue: vi.fn(async () => undefined) }),
+}));
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  accessService: () => mockAccessService,
+  agentService: () => mockAgentService,
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null })),
+  }),
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  instanceSettingsService: () => mockInstanceSettingsService,
+  issueApprovalService: () => ({}),
+  issueRecoveryActionService: () => ({ getActiveForIssue: vi.fn(async () => null) }),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueService: () => mockIssueService,
+  issueThreadInteractionService: () => ({
+    expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+    expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+  }),
+  issueTreeControlService: () => ({ getActivePauseHoldGate: vi.fn(async () => null) }),
+  logActivity: mockLogActivity,
+  projectService: () => ({}),
+  routineService: () => ({ syncRunStatusForIssue: vi.fn(async () => undefined) }),
+  workProductService: () => ({}),
+  ISSUE_LIST_DEFAULT_LIMIT: 25,
+  ISSUE_LIST_MAX_LIMIT: 100,
+  clampIssueListLimit: (n: number) => Math.min(n, 100),
+}));
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  return app;
+}
+
+async function installActor(app: express.Express, actor?: Record<string, unknown>) {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    import("../routes/issues.js"),
+    import("../middleware/index.js"),
+  ]);
+  app.use((req, _res, next) => {
+    (req as any).actor = actor ?? {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes(mockDb as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+function makeInProgressIssue() {
+  return {
+    id: ISSUE_ID,
+    companyId: "company-1",
+    status: "in_progress",
+    assigneeAgentId: ASSIGNEE_AGENT_ID,
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    identifier: "FUL-9999",
+    title: "Guardrail 2 test issue",
+    blockedByIssueIds: [],
+    executionWorkspaceId: null,
+    executionWorkspacePreference: null,
+    executionWorkspaceSettings: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    checkoutRunId: null,
+    executionState: null,
+    executionPolicy: null,
+    parentId: null,
+    goalId: null,
+    projectId: null,
+    requestDepth: 0,
+  };
+}
+
+function agentActor(agentId = ASSIGNEE_AGENT_ID) {
+  return {
+    type: "agent",
+    agentId,
+    companyId: "company-1",
+    source: "agent_key",
+    runId: "run-guardrail2",
+  };
+}
+
+const BASE_COMMENT_RESPONSE = {
+  id: "comment-new",
+  issueId: ISSUE_ID,
+  companyId: "company-1",
+  body: "agent says something again",
+  authorAgentId: ASSIGNEE_AGENT_ID,
+  authorUserId: null,
+  authorType: "agent",
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe.sequential("guardrail 2: consecutive agent comment cap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTxInsertValues.mockResolvedValue(undefined);
+    mockTxInsert.mockImplementation(() => ({ values: mockTxInsertValues }));
+    mockDbSelectOrderBy.mockResolvedValue([]);
+    mockDbSelectWhere.mockImplementation(() => ({ orderBy: mockDbSelectOrderBy }));
+    mockDbSelectFrom.mockImplementation(() => ({ where: mockDbSelectWhere }));
+    mockDbSelect.mockImplementation(() => ({ from: mockDbSelectFrom }));
+    mockDb.transaction.mockImplementation(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx));
+    mockHeartbeatService.wakeup.mockResolvedValue(undefined);
+    mockHeartbeatService.reportRunActivity.mockResolvedValue(undefined);
+    mockHeartbeatService.getRun.mockResolvedValue(null);
+    mockHeartbeatService.getActiveRunForAgent.mockResolvedValue(null);
+    mockHeartbeatService.cancelRun.mockResolvedValue(null);
+    mockLogActivity.mockResolvedValue(undefined);
+    mockInstanceSettingsService.get.mockResolvedValue({
+      id: "instance-settings-1",
+      general: { censorUsernameInLogs: false, feedbackDataSharingPreference: "prompt" },
+    });
+    mockInstanceSettingsService.listCompanyIds.mockResolvedValue(["company-1"]);
+    mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      issueId: ISSUE_ID,
+      blockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+      unresolvedBlockerCount: 0,
+      allBlockersDone: true,
+      isDependencyReady: true,
+    });
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.addComment.mockResolvedValue(BASE_COMMENT_RESPONSE);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...makeInProgressIssue(),
+      ...patch,
+    }));
+    mockAccessService.canUser.mockResolvedValue(false);
+    mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAgentService.getById.mockResolvedValue(null);
+    mockAgentService.list.mockResolvedValue([
+      { id: ASSIGNEE_AGENT_ID, reportsTo: null, permissions: { canCreateAgents: false } },
+    ]);
+    mockAgentService.resolveByReference.mockResolvedValue(null);
+  });
+
+  it("auto-pauses when assignee posts 3 consecutive comments with no other actor in between", async () => {
+    mockIssueService.getById.mockResolvedValue(makeInProgressIssue());
+    // Simulate 3 consecutive agent comments already in the DB (newest first):
+    // the one just posted (index 0) plus 2 prior ones = 3 total.
+    mockIssueService.listComments.mockResolvedValue(makeAgentCommentStreak(3));
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post(`/api/issues/${ISSUE_ID}/comments`)
+      .send({ body: "third consecutive comment, should trigger cap" });
+
+    expect(res.status).toBe(201);
+
+    // Issue must be blocked.
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      ISSUE_ID,
+      expect.objectContaining({ status: "blocked" }),
+    );
+
+    // A system comment must be posted (the auto-pause notification).
+    const systemCommentCall = mockIssueService.addComment.mock.calls.find(
+      (call) => call[2]?.authorType === "system" || call[3]?.authorType === "system",
+    );
+    expect(systemCommentCall).toBeTruthy();
+
+    // No wakeup dispatched to the assignee after auto-pause.
+    await vi.waitFor(() => {
+      const assigneeWake = mockHeartbeatService.wakeup.mock.calls.find(
+        (call) => call[0] === ASSIGNEE_AGENT_ID,
+      );
+      expect(assigneeWake).toBeUndefined();
+    });
+  });
+
+  it("does NOT auto-pause when there are fewer than 3 consecutive agent comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeInProgressIssue());
+    // Only 2 consecutive — below the cap.
+    mockIssueService.listComments.mockResolvedValue(makeAgentCommentStreak(2));
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post(`/api/issues/${ISSUE_ID}/comments`)
+      .send({ body: "second comment, should not trigger cap" });
+
+    expect(res.status).toBe(201);
+    // update should not have been called for auto-pause (the issue stays in_progress).
+    const blockedCall = mockIssueService.update.mock.calls.find(
+      (call) => call[1]?.status === "blocked",
+    );
+    expect(blockedCall).toBeUndefined();
+  });
+
+  it("does NOT auto-pause when a human commented between agent comments", async () => {
+    mockIssueService.getById.mockResolvedValue(makeInProgressIssue());
+    // Newest first: agent comment, human comment, agent comment (streak resets at human).
+    mockIssueService.listComments.mockResolvedValue([
+      {
+        id: "c3",
+        issueId: ISSUE_ID,
+        companyId: "company-1",
+        body: "latest agent comment",
+        authorAgentId: ASSIGNEE_AGENT_ID,
+        authorUserId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "c2",
+        issueId: ISSUE_ID,
+        companyId: "company-1",
+        body: "human review",
+        authorAgentId: null,
+        authorUserId: "local-board",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "c1",
+        issueId: ISSUE_ID,
+        companyId: "company-1",
+        body: "first agent comment",
+        authorAgentId: ASSIGNEE_AGENT_ID,
+        authorUserId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post(`/api/issues/${ISSUE_ID}/comments`)
+      .send({ body: "agent comment after human reply" });
+
+    expect(res.status).toBe(201);
+    const blockedCall = mockIssueService.update.mock.calls.find(
+      (call) => call[1]?.status === "blocked",
+    );
+    expect(blockedCall).toBeUndefined();
+  });
+
+  it("does NOT auto-pause when a different agent commented in between", async () => {
+    mockIssueService.getById.mockResolvedValue(makeInProgressIssue());
+    // streak broken by OTHER_AGENT_ID comment.
+    mockIssueService.listComments.mockResolvedValue([
+      {
+        id: "c3",
+        issueId: ISSUE_ID,
+        companyId: "company-1",
+        body: "latest assignee comment",
+        authorAgentId: ASSIGNEE_AGENT_ID,
+        authorUserId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "c2",
+        issueId: ISSUE_ID,
+        companyId: "company-1",
+        body: "other agent comment",
+        authorAgentId: OTHER_AGENT_ID,
+        authorUserId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "c1",
+        issueId: ISSUE_ID,
+        companyId: "company-1",
+        body: "first assignee comment",
+        authorAgentId: ASSIGNEE_AGENT_ID,
+        authorUserId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post(`/api/issues/${ISSUE_ID}/comments`)
+      .send({ body: "assignee comment after other agent" });
+
+    expect(res.status).toBe(201);
+    const blockedCall = mockIssueService.update.mock.calls.find(
+      (call) => call[1]?.status === "blocked",
+    );
+    expect(blockedCall).toBeUndefined();
+  });
+
+  it("does NOT auto-pause on closed (done) issues", async () => {
+    mockIssueService.getById.mockResolvedValue({ ...makeInProgressIssue(), status: "done" });
+    // listComments must NOT be called for closed issues.
+
+    const res = await request(await installActor(createApp(), agentActor()))
+      .post(`/api/issues/${ISSUE_ID}/comments`)
+      .send({ body: "comment on a done issue" });
+
+    // Even if the HTTP response is 201, listComments should not be called.
+    expect(mockIssueService.listComments).not.toHaveBeenCalled();
+    const blockedCall = mockIssueService.update.mock.calls.find(
+      (call) => call[1]?.status === "blocked",
+    );
+    expect(blockedCall).toBeUndefined();
+  });
+
+  it("does NOT auto-pause when the commenter is not the assignee", async () => {
+    mockIssueService.getById.mockResolvedValue(makeInProgressIssue()); // assignee = ASSIGNEE_AGENT_ID
+    // Comment from a different agent (not the assignee).
+    const res = await request(await installActor(createApp(), agentActor(OTHER_AGENT_ID)))
+      .post(`/api/issues/${ISSUE_ID}/comments`)
+      .send({ body: "comment from non-assignee agent" });
+
+    // listComments should not be called when the commenter is not the assignee.
+    expect(mockIssueService.listComments).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/http-log-policy.test.ts
+++ b/server/src/__tests__/http-log-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { shouldSilenceHttpSuccessLog } from "../middleware/http-log-policy.js";
+import { shouldSilenceHttpSuccessLog, shouldDownlevel404ToDebug } from "../middleware/http-log-policy.js";
 
 describe("shouldSilenceHttpSuccessLog", () => {
   it("silences cached 304 responses", () => {
@@ -69,5 +69,45 @@ describe("shouldSilenceHttpSuccessLog", () => {
   it("keeps failing requests visible", () => {
     expect(shouldSilenceHttpSuccessLog("GET", "/api/health", 500)).toBe(false);
     expect(shouldSilenceHttpSuccessLog("GET", "/@fs/Users/dotta/paperclip/ui/src/main.tsx", 404)).toBe(false);
+  });
+});
+
+describe("shouldDownlevel404ToDebug", () => {
+  it("downlevels stale issue ID 404s", () => {
+    expect(shouldDownlevel404ToDebug("GET", "/api/issues/abc-123", 404)).toBe(true);
+    expect(shouldDownlevel404ToDebug("GET", "/api/issues/PAP-1383", 404)).toBe(true);
+    expect(
+      shouldDownlevel404ToDebug("GET", "/api/issues/52acb19a-057f-42b0-b049-2e6a7a532aab", 404),
+    ).toBe(true);
+  });
+
+  it("downlevels stale heartbeat run log 404s", () => {
+    expect(
+      shouldDownlevel404ToDebug(
+        "GET",
+        "/api/heartbeat-runs/b7044268-19b6-4b3a-a9f3-9c57dce70253/log?offset=1103894&limitBytes=256000",
+        404,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not downlevel non-GET methods", () => {
+    expect(shouldDownlevel404ToDebug("POST", "/api/issues/abc-123", 404)).toBe(false);
+    expect(shouldDownlevel404ToDebug("PATCH", "/api/issues/abc-123", 404)).toBe(false);
+  });
+
+  it("does not downlevel non-404 status codes", () => {
+    expect(shouldDownlevel404ToDebug("GET", "/api/issues/abc-123", 200)).toBe(false);
+    expect(shouldDownlevel404ToDebug("GET", "/api/issues/abc-123", 500)).toBe(false);
+  });
+
+  it("does not downlevel sub-routes of issues/:id", () => {
+    expect(shouldDownlevel404ToDebug("GET", "/api/issues/abc-123/comments", 404)).toBe(false);
+    expect(shouldDownlevel404ToDebug("GET", "/api/issues/abc-123/documents/plan", 404)).toBe(false);
+  });
+
+  it("does not downlevel unknown 404 routes", () => {
+    expect(shouldDownlevel404ToDebug("GET", "/api/companies/x/issues", 404)).toBe(false);
+    expect(shouldDownlevel404ToDebug("GET", "/api/agents/me", 404)).toBe(false);
   });
 });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -529,7 +529,7 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
-  it("moves assigned blocked issues back to todo via POST comments", async () => {
+  it("does NOT move assigned blocked issues to todo via POST comments (shouldImplicitlyMoveCommentedIssueToTodo returns false for blocked)", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("blocked"),
@@ -541,27 +541,20 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "please continue" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+      expect.objectContaining({ status: "todo" }),
     );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+    // issue_commented wake must be suppressed for blocked issues
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
       "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          reopenedFrom: "blocked",
-          mutation: "comment",
-        }),
-        contextSnapshot: expect.objectContaining({
-          issueId: "11111111-1111-4111-8111-111111111111",
-          wakeCommentId: "comment-1",
-          wakeReason: "issue_reopened_via_comment",
-          reopenedFrom: "blocked",
-        }),
-      }),
-    ));
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({ reason: "issue_commented" }),
+    );
   });
 
   it("passes validated comment presentation fields to trusted board comment writes", async () => {
@@ -645,7 +638,7 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
-  it("does not move dependency-blocked issues to todo via POST comments", async () => {
+  it("does not move dependency-blocked issues to todo via POST comments and suppresses issue_commented wake", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       issueId: "11111111-1111-4111-8111-111111111111",
@@ -662,21 +655,12 @@ describe.sequential("issue comment reopen routes", () => {
 
     expect(res.status).toBe(201);
     expect(mockIssueService.update).not.toHaveBeenCalled();
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+    // issue_commented wake must be suppressed for blocked issues (including dependency-blocked)
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
       "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_commented",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          mutation: "comment",
-        }),
-        contextSnapshot: expect.objectContaining({
-          issueId: "11111111-1111-4111-8111-111111111111",
-          wakeCommentId: "comment-1",
-          wakeReason: "issue_commented",
-        }),
-      }),
-    ));
+      expect.objectContaining({ reason: "issue_commented" }),
+    );
   });
 
   it("does not implicitly reopen closed issues via POST comments when no agent is assigned", async () => {
@@ -694,7 +678,7 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
-  it("moves assigned blocked issues back to todo via the PATCH comment path", async () => {
+  it("does NOT move assigned blocked issues to todo via the PATCH comment path (shouldImplicitlyMoveCommentedIssueToTodo returns false for blocked)", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("blocked"),
@@ -706,25 +690,20 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ comment: "please continue" });
 
     expect(res.status).toBe(200);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
       "11111111-1111-4111-8111-111111111111",
-      expect.objectContaining({
-        status: "todo",
-        actorAgentId: null,
-        actorUserId: "local-board",
-      }),
+      expect.objectContaining({ status: "todo" }),
     );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+    // issue_commented wake must be suppressed for blocked issues
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
       "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          reopenedFrom: "blocked",
-          mutation: "comment",
-        }),
-      }),
-    ));
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      "22222222-2222-4222-8222-222222222222",
+      expect.objectContaining({ reason: "issue_commented" }),
+    );
   });
 
   it("rejects non-assignee agent PATCH comments on closed issues", async () => {
@@ -761,7 +740,7 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
-  it("does not move dependency-blocked issues to todo via the PATCH comment path", async () => {
+  it("does not move dependency-blocked issues to todo via the PATCH comment path and suppresses issue_commented wake", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       issueId: "11111111-1111-4111-8111-111111111111",
@@ -792,16 +771,12 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({ status: "todo" }),
     );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+    // issue_commented wake must be suppressed for blocked issues (including dependency-blocked)
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
       "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_commented",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          mutation: "comment",
-        }),
-      }),
-    ));
+      expect.objectContaining({ reason: "issue_commented" }),
+    );
   });
 
   it("wakes the assignee when an assigned blocked issue moves back to todo", async () => {

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -298,4 +298,38 @@ describe("issue update comment wakeups", () => {
       }),
     );
   });
+
+  it("skipWake: does NOT wake the assignee via issue_commented when the issue is blocked", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "blocked",
+    });
+    const updated = { ...existing };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-3",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "any update?",
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({
+        comment: "any update?",
+      });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({ reason: "issue_commented" }),
+    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -2499,6 +2499,47 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     ).rejects.toMatchObject({ status: 422 });
   });
 
+  it("rejects checkout on status-blocked issues even with no formal blockedByIssueIds", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Status-blocked issue",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId,
+    });
+
+    // No blockedByIssueIds — status-only blocked. Checkout must still be rejected.
+    await expect(
+      svc.checkout(issueId, assigneeAgentId, ["todo", "blocked", "in_review"], null),
+    ).rejects.toMatchObject({ status: 422 });
+
+    // Verify status was NOT silently promoted to in_progress
+    const row = await db.select({ status: issues.status }).from(issues).where(eq(issues.id, issueId)).then((r) => r[0]);
+    expect(row?.status).toBe("blocked");
+  });
+
   it("wakes parents only when all direct children are terminal", async () => {
     const companyId = randomUUID();
     const assigneeAgentId = randomUUID();

--- a/server/src/middleware/http-log-policy.ts
+++ b/server/src/middleware/http-log-policy.ts
@@ -11,6 +11,14 @@ const SILENCED_SUCCESS_API_PATHS = [
   /^\/api\/heartbeat-runs\/[^/]+\/log(?:\/|$)/,
 ];
 
+// Expected-miss 404 paths: stale issue lookups and finished run log fetches are
+// routine during UI polling and agent heartbeats. Downgrade to debug to avoid
+// flooding warn-level logs with expected misses.
+const EXPECTED_MISS_404_API_PATHS = [
+  /^\/api\/issues\/[^/]+$/, // GET /api/issues/:id — stale/non-canonical issue ID
+  /^\/api\/heartbeat-runs\/[^/]+\/log(?:\/|$)/, // GET /api/heartbeat-runs/:runId/log — inactive run
+];
+
 const SILENCED_SUCCESS_STATIC_PREFIXES = [
   "/@fs/",
   "/@id/",
@@ -35,6 +43,14 @@ function normalizePath(url: string): string {
   if (trimmed.length === 0) return "/";
   const pathname = trimmed.split("?")[0]?.trim() ?? "/";
   return pathname.length > 0 ? pathname : "/";
+}
+
+export function shouldDownlevel404ToDebug(method: string | undefined, url: string | undefined, statusCode: number): boolean {
+  if (statusCode !== 404) return false;
+  if (!method || !url) return false;
+  if (method.toUpperCase() !== "GET") return false;
+  const pathname = normalizePath(url);
+  return EXPECTED_MISS_404_API_PATHS.some((pattern) => pattern.test(pathname));
 }
 
 export function shouldSilenceHttpSuccessLog(method: string | undefined, url: string | undefined, statusCode: number): boolean {

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -4,7 +4,30 @@ import pino from "pino";
 import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
-import { shouldSilenceHttpSuccessLog } from "./http-log-policy.js";
+import { shouldSilenceHttpSuccessLog, shouldDownlevel404ToDebug } from "./http-log-policy.js";
+
+// Short-window deduplication for repeated identical 404 warn lines.
+// Key: "METHOD:routePath:statusCode". Suppresses re-emission within the TTL window.
+const WARN_DEDUPE_TTL_MS = 30_000;
+const warnDedupeMap = new Map<string, number>();
+
+function dedupeWarnKey(req: { method?: string; route?: { path?: string }; url?: string }, statusCode: number): string {
+  const route = (req.route as { path?: string } | undefined)?.path ?? req.url?.split("?")[0] ?? "unknown";
+  return `${req.method ?? ""}:${route}:${statusCode}`;
+}
+
+function shouldSuppressRepeatedWarn(req: { method?: string; route?: { path?: string }; url?: string }, statusCode: number): boolean {
+  const key = dedupeWarnKey(req, statusCode);
+  const now = Date.now();
+  const last = warnDedupeMap.get(key);
+  if (last !== undefined && now - last < WARN_DEDUPE_TTL_MS) return true;
+  warnDedupeMap.set(key, now);
+  // Evict oldest entry when map grows large to prevent unbounded memory use.
+  if (warnDedupeMap.size > 500) {
+    warnDedupeMap.delete(warnDedupeMap.keys().next().value as string);
+  }
+  return false;
+}
 
 function resolveServerLogDir(): string {
   const envOverride = process.env.PAPERCLIP_LOG_DIR?.trim();
@@ -52,7 +75,11 @@ export const httpLogger = pinoHttp({
       return "silent";
     }
     if (err || res.statusCode >= 500) return "error";
-    if (res.statusCode >= 400) return "warn";
+    if (res.statusCode >= 400) {
+      if (shouldDownlevel404ToDebug(_req.method, _req.url, res.statusCode)) return "debug";
+      if (shouldSuppressRepeatedWarn(_req, res.statusCode)) return "silent";
+      return "warn";
+    }
     return "info";
   },
   customSuccessMessage(req, res) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -628,7 +628,7 @@ function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   // Only human comments should implicitly reopen finished work.
   // Agent-authored comments remain communicative unless reopen was explicit.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  if (!isClosedIssueStatus(input.issueStatus)) return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }
@@ -4109,7 +4109,7 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        const skipAssigneeCommentWake = selfComment || isClosed || issue.status === "blocked";
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {
@@ -5169,7 +5169,8 @@ export function issueRoutes(
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
-      const skipWake = autoPausedByConsecutiveCap || selfComment || isClosed;
+      const isBlockedWithoutReopen = currentIssue.status === "blocked" && !reopened;
+      const skipWake = autoPausedByConsecutiveCap || selfComment || isClosed || isBlockedWithoutReopen;
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
           wakeups.set(assigneeId, {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -112,6 +112,12 @@ import { parseIssueExecutionWorkspaceSettings } from "../services/execution-work
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
+// Guardrail 2: auto-pause an agent that posts this many consecutive comments
+// with no human or other-agent reply on the same issue.
+const CONSECUTIVE_AGENT_COMMENT_CAP = 3;
+// System CTO agent ID — receives the auto-pause notification comment.
+const SYSTEM_CTO_AGENT_ID = "1320f476-10cb-4c28-b2f6-3d313cd1a787";
+
 const updateIssueRouteSchema = updateIssueSchema.extend({
   interrupt: z.boolean().optional(),
 });
@@ -5125,13 +5131,45 @@ export function issueRoutes(
       blockedToTodoRecovery: reopened && reopenFromStatus === "blocked" && currentIssue.status === "todo",
     });
 
+    // Guardrail 2: consecutive agent comment cap.
+    // If the assignee agent has posted N+ consecutive comments (no human/other-agent in between),
+    // auto-pause: set the issue to blocked (which also clears checkout fields) and post a
+    // system notification tagging the CTO so a human can review before the agent resumes.
+    let autoPausedByConsecutiveCap = false;
+    if (!reopened && !isClosed && actor.actorType === "agent" && actor.actorId && actor.actorId === currentIssue.assigneeAgentId) {
+      const recentComments = await svc.listComments(id, { order: "desc", limit: CONSECUTIVE_AGENT_COMMENT_CAP + 2 });
+      let consecutiveCount = 0;
+      for (const c of recentComments) {
+        if (c.authorAgentId === actor.actorId) consecutiveCount++;
+        else break;
+      }
+      if (consecutiveCount >= CONSECUTIVE_AGENT_COMMENT_CAP) {
+        try {
+          await svc.update(id, { status: "blocked" });
+          await svc.addComment(
+            id,
+            `**[System: Auto-pause — Guardrail 2]** Agent posted ${consecutiveCount} consecutive comments with no human or other-agent reply. Issue automatically set to \`blocked\` and checkout cleared.\n\n[@CTO](agent://${SYSTEM_CTO_AGENT_ID}) — please review the thread and manually unblock (set status to \`todo\` or reassign) when appropriate.`,
+            {},
+            { authorType: "system" },
+          );
+          autoPausedByConsecutiveCap = true;
+          logger.warn(
+            { issueId: id, agentId: actor.actorId, consecutiveCount },
+            "guardrail2: auto-paused agent on consecutive comment cap",
+          );
+        } catch (err) {
+          logger.error({ err, issueId: id, agentId: actor.actorId }, "guardrail2: failed to auto-pause agent");
+        }
+      }
+    }
+
     // Merge all wakeups from this comment into one enqueue per agent to avoid duplicate runs.
     void (async () => {
       const wakeups = new Map<string, Parameters<typeof heartbeat.wakeup>[1]>();
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
-      const skipWake = selfComment || isClosed;
+      const skipWake = autoPausedByConsecutiveCap || selfComment || isClosed;
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
           wakeups.set(assigneeId, {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4663,6 +4663,7 @@ export function issueService(db: Db) {
           and(
             eq(issues.id, id),
             inArray(issues.status, expectedStatuses),
+            ne(issues.status, "blocked"),
             or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
             executionLockCondition,
           ),
@@ -4688,6 +4689,13 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (!current) throw notFound("Issue not found");
+
+      if (current.status === "blocked") {
+        throw unprocessable("Issue is blocked — resolve blockedByIssueIds or explicitly unblock before checking out", {
+          issueId: current.id,
+          status: current.status,
+        });
+      }
 
       if (
         current.assigneeAgentId === agentId &&


### PR DESCRIPTION
## Summary

Three targeted fixes to eliminate the mutual amplification loop where board-user comments on `blocked` issues were re-waking the assignee agent indefinitely.

**Parent incident:** FUL-2230

### Fix #1 — CRITICAL: Remove `blocked` from implicit-reopen trigger
`shouldImplicitlyMoveCommentedIssueToTodo` — `blocked` removed. A board-user comment on a blocked issue no longer silently promotes it to `todo`.

### Fix #2 — HIGH: Suppress `issue_commented` wake for blocked issues
`isBlockedWithoutReopen` guard in POST /comments + `issue.status === "blocked"` in PATCH route. Comments on blocked issues skip `issue_commented` wakes.

### Fix #3 — MEDIUM: Prevent checkout from silently promoting `blocked` status
Checkout service `ne(issues.status, "blocked")` WHERE clause + 422 error when `current.status === "blocked"`.

**Tests:** 84 tests pass (3 test files updated/added).

Closes FUL-2238