### PR TITLE
fix(server): unwrap company prefix conflict errors

### DIFF
--- a/server/src/__tests__/companies-service.test.ts
+++ b/server/src/__tests__/companies-service.test.ts
@@ -1,0 +1,51 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { companies, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { companyService } from "../services/companies.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres company service tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("companyService", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-companies-service-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("allocates the next derived issue prefix when the first candidate conflicts", async () => {
+    await db.insert(companies).values({
+      id: randomUUID(),
+      name: "Tectara Systems",
+      issuePrefix: "TEC",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const created = await companyService(db).create({
+      name: "Tecton Forge Lab",
+      budgetMonthlyCents: 0,
+    });
+
+    expect(created).toMatchObject({
+      name: "Tecton Forge Lab",
+      issuePrefix: "TECA",
+      budgetMonthlyCents: 0,
+    });
+  });
+});

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -124,17 +124,21 @@ export function companyService(db: Db) {
     return "A".repeat(attempt - 1);
   }
 
-  function isIssuePrefixConflict(error: unknown) {
-    const constraint = typeof error === "object" && error !== null && "constraint" in error
-      ? (error as { constraint?: string }).constraint
-      : typeof error === "object" && error !== null && "constraint_name" in error
-        ? (error as { constraint_name?: string }).constraint_name
-        : undefined;
-    return typeof error === "object"
-      && error !== null
-      && "code" in error
-      && (error as { code?: string }).code === "23505"
-      && constraint === "companies_issue_prefix_idx";
+  function isIssuePrefixConflict(error: unknown): boolean {
+    if (typeof error !== "object" || error === null) return false;
+
+    const candidate = error as {
+      code?: string;
+      constraint?: string;
+      constraint_name?: string;
+      cause?: unknown;
+    };
+    const constraint = candidate.constraint ?? candidate.constraint_name;
+    if (candidate.code === "23505" && constraint === "companies_issue_prefix_idx") {
+      return true;
+    }
+
+    return isIssuePrefixConflict(candidate.cause);
   }
 
   async function createCompanyWithUniquePrefix(data: typeof companies.$inferInsert) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies and each company owns its own issue namespace.
> - Company creation derives an issue prefix from the company name so routes and issue identifiers stay human-readable.
> - The service already attempted to retry with suffixed prefixes when a derived prefix conflicts, e.g. `TEC` then `TECA`.
> - In production the unique-constraint error is wrapped by Drizzle, so the conflict detector only saw `DrizzleQueryError`, not the nested Postgres `23505` cause.
> - That made `/api/companies` return a 500 for new company names whose first three letters matched an existing company prefix.
> - This pull request unwraps nested causes when detecting company issue-prefix conflicts and adds an embedded-Postgres regression test.
> - The benefit is reliable multi-company creation without exposing a raw internal server error for normal prefix collisions.

## What Changed

- Updated `companyService` prefix-conflict detection to recursively inspect nested `cause` errors for Postgres `23505` on `companies_issue_prefix_idx`.
- Added a regression test that seeds an existing `TEC` company and verifies creating `Tecton Forge Lab` succeeds with `TECA`.

## Verification

- `pnpm vitest run server/src/__tests__/companies-service.test.ts`
- Manual local verification against a running Paperclip instance: `POST /api/companies` with `{"name":"Tecton Forge Lab"}` returned `201` and `issuePrefix: "TECA"` after hot-patching the running package.

## Risks

- Low risk. The change only broadens detection for the existing retry path to include wrapped Drizzle/Postgres errors.
- If a non-Postgres error has a misleading nested cause with the same code/constraint, it would be treated as retryable, but the retry loop is bounded and specific to company prefix allocation.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex / GPT-5.5 via Hermes Agent CLI with tool use and code execution; systematic debugging workflow.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
