### PR TITLE
feat(adapter-claude-local): honor adapterConfig.mcpServers per-agent via --mcp-config

### DIFF
--- a/packages/adapters/claude-local/src/server/claude-config.test.ts
+++ b/packages/adapters/claude-local/src/server/claude-config.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { materializeAgentMcpConfig } from "./claude-config.js";
+
+describe("materializeAgentMcpConfig", () => {
+  it("returns null when mcpServers is empty", async () => {
+    const result = await materializeAgentMcpConfig({ agentId: "agent-1", mcpServers: {} });
+    expect(result).toBeNull();
+  });
+
+  it("writes mcp.json and returns its path when mcpServers has entries", async () => {
+    const agentId = `test-agent-${Date.now()}`;
+    const mcpServers = {
+      playwright: {
+        command: "npx",
+        args: ["@playwright/mcp@latest"],
+        type: "stdio",
+      },
+    };
+
+    const filePath = await materializeAgentMcpConfig({ agentId, mcpServers });
+
+    expect(filePath).not.toBeNull();
+    expect(filePath).toContain(agentId);
+    expect(path.isAbsolute(filePath!)).toBe(true);
+
+    const written = JSON.parse(await fs.readFile(filePath!, "utf-8"));
+    expect(written).toEqual({ mcpServers });
+  });
+
+  it("overwrites an existing mcp.json on subsequent calls", async () => {
+    const agentId = `test-agent-overwrite-${Date.now()}`;
+
+    await materializeAgentMcpConfig({
+      agentId,
+      mcpServers: { old: { command: "old-server", args: [], type: "stdio" } },
+    });
+
+    const updated = { new: { command: "new-server", args: [], type: "stdio" } };
+    const filePath = await materializeAgentMcpConfig({ agentId, mcpServers: updated });
+
+    const written = JSON.parse(await fs.readFile(filePath!, "utf-8"));
+    expect(written).toEqual({ mcpServers: updated });
+  });
+
+  it("places the file under os.tmpdir()", async () => {
+    const agentId = `test-agent-tmpdir-${Date.now()}`;
+    const filePath = await materializeAgentMcpConfig({
+      agentId,
+      mcpServers: { srv: { command: "x", args: [], type: "stdio" } },
+    });
+    expect(filePath!.startsWith(os.tmpdir())).toBe(true);
+  });
+});

--- a/packages/adapters/claude-local/src/server/claude-config.ts
+++ b/packages/adapters/claude-local/src/server/claude-config.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Writes a per-agent mcp.json to a stable temp dir and returns its path.
+ * Returns null when mcpServers is empty so callers can skip the --mcp-config flag.
+ */
+export async function materializeAgentMcpConfig(opts: {
+  agentId: string;
+  mcpServers: Record<string, unknown>;
+}): Promise<string | null> {
+  if (Object.keys(opts.mcpServers).length === 0) return null;
+  const dir = path.join(os.tmpdir(), "paperclip-mcp", opts.agentId);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, "mcp.json");
+  await fs.writeFile(filePath, JSON.stringify({ mcpServers: opts.mcpServers }, null, 2), "utf-8");
+  return filePath;
+}

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -34,6 +34,7 @@ import {
 import { resolveClaudeDesiredSkillNames } from "./skills.js";
 import { isBedrockModelId } from "./models.js";
 import { prepareClaudePromptBundle } from "./prompt-cache.js";
+import { materializeAgentMcpConfig } from "./claude-config.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -371,6 +372,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
   const effectiveInstructionsFilePath = promptBundle.instructionsFilePath ?? undefined;
 
+  const mcpServers = parseObject(config.mcpServers);
+  const mcpConfigPath = await materializeAgentMcpConfig({ agentId: agent.id, mcpServers });
+
   const runtimeSessionParams = parseObject(runtime.sessionParams);
   const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
   const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
@@ -433,6 +437,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const buildClaudeArgs = (
     resumeSessionId: string | null,
     attemptInstructionsFilePath: string | undefined,
+    mcpConfigPath: string | null,
   ) => {
     const args = ["--print", "-", "--output-format", "stream-json", "--verbose"];
     if (resumeSessionId) args.push("--resume", resumeSessionId);
@@ -452,6 +457,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     if (attemptInstructionsFilePath && !resumeSessionId) {
       args.push("--append-system-prompt-file", attemptInstructionsFilePath);
     }
+    if (mcpConfigPath) args.push("--mcp-config", mcpConfigPath);
     args.push("--add-dir", promptBundle.addDir);
     if (extraArgs.length > 0) args.push(...extraArgs);
     return args;
@@ -475,7 +481,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
 
   const runAttempt = async (resumeSessionId: string | null) => {
     const attemptInstructionsFilePath = resumeSessionId ? undefined : effectiveInstructionsFilePath;
-    const args = buildClaudeArgs(resumeSessionId, attemptInstructionsFilePath);
+    const args = buildClaudeArgs(resumeSessionId, attemptInstructionsFilePath, mcpConfigPath);
     const commandNotes: string[] = [];
     if (!resumeSessionId) {
       commandNotes.push(`Using stable Claude prompt bundle ${promptBundle.bundleKey}.`);

--- a/packages/adapters/claude-local/vitest.config.ts
+++ b/packages/adapters/claude-local/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     projects: [
       "packages/db",
       "packages/adapter-utils",
+      "packages/adapters/claude-local",
       "packages/adapters/codex-local",
       "packages/adapters/opencode-local",
       "server",


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents; each agent's runtime behavior is configured via `adapterConfig` fields stored in the DB
> - The `claude_local` adapter drives the Claude Code CLI — it is responsible for translating `adapterConfig` into CLI flags and environment variables on each heartbeat invocation
> - `adapterConfig.mcpServers` is an established schema field (PATCHable via the API) for declaring per-agent MCP tool servers
> - Grep across the published `@paperclipai/adapter-claude-local@2026.517.0` `dist/` returns zero matches for `mcp`, `mcpServers`, or `--mcp-config` — the field is accepted but silently ignored at runtime
> - The consequence is that any per-agent MCP configuration (e.g. playwright for a BA agent) has no effect; operators must fall back to user-scope `~/.claude.json` mcpServers, which applies to every agent on the host without isolation
> - This PR wires `adapterConfig.mcpServers` through: on each invocation, the adapter materializes a per-agent `mcp.json` under `$TMPDIR/paperclip-mcp/<agentId>/` and passes `--mcp-config <path>` to the claude CLI
> - The benefit is that per-agent MCP isolation becomes real — BA gets playwright, Coder doesn't; future privileged-stdio servers can be scoped safely

## What Changed

- **`packages/adapters/claude-local/src/server/claude-config.ts`** (new) — exports `materializeAgentMcpConfig({ agentId, mcpServers })`: writes `{ mcpServers }` as JSON to `$TMPDIR/paperclip-mcp/<agentId>/mcp.json`, returns the path or `null` when `mcpServers` is empty
- **`packages/adapters/claude-local/src/server/execute.ts`** — imports the helper; calls it in `execute()` after the prompt bundle is prepared; passes the resulting path as `--mcp-config <path>` inside `buildClaudeArgs`; no flag emitted when path is null (empty mcpServers — zero behavior change for agents without the field set)
- **`packages/adapters/claude-local/src/server/claude-config.test.ts`** (new) — 4 unit tests: returns null for empty mcpServers, writes correct JSON content, overwrites on subsequent calls, places file under `os.tmpdir()`
- **`packages/adapters/claude-local/vitest.config.ts`** (new) — vitest config for the package (`environment: "node"`)
- **`vitest.config.ts`** (root) — adds `packages/adapters/claude-local` to the test projects list so CI picks up the new tests

## Verification

- `pnpm typecheck` in `packages/adapters/claude-local` — exits 0
- `pnpm exec vitest run packages/adapters/claude-local` from repo root — 4/4 tests pass in 216ms
- Runtime: set `adapterConfig.mcpServers.playwright` on a `claude_local` agent and trigger a heartbeat; confirm `--mcp-config /tmp/paperclip-mcp/<agentId>/mcp.json` appears in the logged command args and the MCP server is available inside the Claude session

## Risks

- Low risk for agents with no `mcpServers` set — the code path is gated behind `Object.keys(mcpServers).length === 0` returning null, so `buildClaudeArgs` is unchanged for the common case
- The `mcp.json` file persists between runs (stable path per agentId); a subsequent run with an updated `mcpServers` PATCH overwrites it atomically via `writeFile`
- If `$TMPDIR` is not writable the adapter will throw at run-start — this is an intentional hard fail rather than silently ignoring the config

## Model Used

- Provider: Anthropic
- Model ID: claude-sonnet-4-6
- Context: standard context window, tool use enabled, no extended thinking
- Executed via Paperclip `claude_local` adapter heartbeat

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge