### PR TITLE
agents: emit configRedacted instead of {} for restricted views

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -52,6 +52,47 @@ Returns the agent record for the currently authenticated agent.
 }
 ```
 
+## Restricted Views (`configRedacted`)
+
+When a caller does **not** hold the `agents:create` permission, the agent read routes return a restricted projection that omits sensitive configuration and surfaces a self-describing flag:
+
+- `adapterConfig` and `runtimeConfig` are **omitted** from the response (not set to `{}`).
+- A `configRedacted: true` field is added so callers can distinguish a redacted projection from a genuinely-empty configuration.
+
+The `isSelf` shortcut (`GET /api/agents/me`, and `GET /api/agents/{agentId}` when `agentId` matches the caller) is unaffected — callers always see their own full config.
+
+Routes that apply this behavior:
+
+- `GET /api/agents/{agentId}` — restricted-view shape when the caller lacks `agents:create` and is not the target agent.
+- `GET /api/companies/{companyId}/agents` — every row uses the restricted-view shape when the caller lacks `agents:create`, including the caller's own row. Use `GET /api/agents/me` to read own full config from the list context.
+
+The config-only redaction path used by configuration-listing routes (e.g. config revisions) carries `configRedacted: false` so consumers can use a single uniform flag across both response shapes.
+
+**Restricted-view response example** (caller lacks `agents:create`):
+
+```json
+{
+  "id": "agent-42",
+  "name": "BackendEngineer",
+  "role": "engineer",
+  "status": "running",
+  "configRedacted": true
+}
+```
+
+**Privileged response example** (caller holds `agents:create`):
+
+```json
+{
+  "id": "agent-42",
+  "name": "BackendEngineer",
+  "adapterConfig": { "...": "..." },
+  "runtimeConfig": { "...": "..." }
+}
+```
+
+Privileged responses do **not** carry the `configRedacted` flag.
+
 ## Create Agent
 
 ```

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -398,8 +398,9 @@ describe.sequential("agent permission routes", () => {
     const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
 
     expect(res.status).toBe(200);
-    expect(res.body.adapterConfig).toEqual({});
-    expect(res.body.runtimeConfig).toEqual({});
+    expect(res.body).not.toHaveProperty("adapterConfig");
+    expect(res.body).not.toHaveProperty("runtimeConfig");
+    expect(res.body.configRedacted).toBe(true);
   }, 20_000);
 
   it("redacts company agent list for authenticated company members without agent admin permission", async () => {
@@ -419,10 +420,11 @@ describe.sequential("agent permission routes", () => {
     expect(res.body).toEqual([
       expect.objectContaining({
         id: agentId,
-        adapterConfig: {},
-        runtimeConfig: {},
+        configRedacted: true,
       }),
     ]);
+    expect(res.body[0]).not.toHaveProperty("adapterConfig");
+    expect(res.body[0]).not.toHaveProperty("runtimeConfig");
   });
 
   it("blocks agent updates for authenticated company members without agent admin permission", async () => {
@@ -1340,6 +1342,9 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(200);
     expect(res.body.access.canAssignTasks).toBe(true);
     expect(res.body.access.taskAssignSource).toBe("explicit_grant");
+    expect(res.body).toHaveProperty("adapterConfig");
+    expect(res.body).toHaveProperty("runtimeConfig");
+    expect(res.body.configRedacted).toBeUndefined();
   }, 15_000);
 
   it("keeps task assignment enabled when agent creation privilege is enabled", async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1272,10 +1272,10 @@ export function agentRoutes(
 
   function redactForRestrictedAgentView(agent: Awaited<ReturnType<typeof svc.getById>>) {
     if (!agent) return null;
+    const { adapterConfig: _adapterConfig, runtimeConfig: _runtimeConfig, ...rest } = agent;
     return {
-      ...agent,
-      adapterConfig: {},
-      runtimeConfig: {},
+      ...rest,
+      configRedacted: true as const,
     };
   }
 
@@ -1294,6 +1294,7 @@ export function agentRoutes(
       runtimeConfig: redactEventPayload(agent.runtimeConfig),
       permissions: agent.permissions,
       updatedAt: agent.updatedAt,
+      configRedacted: false as const,
     };
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and those agents introspect each other through `GET /api/agents/:id` and `GET /api/companies/:co/agents`.
> - The agent read routes use `redactForRestrictedAgentView` to hide `adapterConfig` and `runtimeConfig` from callers without the `agents:create` permission.
> - Today that helper substitutes `adapterConfig: {}` / `runtimeConfig: {}` into the response. Two failure modes follow:
>   - Consumers cannot tell "redacted-for-authz" apart from "actually empty", because the wire shape is identical.
>   - In production we've burned multiple full debug cycles (CTO → CEO → re-diagnosis) chasing a phantom "the database wiped my config" bug that was actually a redacted projection.
> - The persistence layer and permission gate (`actorCanReadConfigurationsForCompany`) are healthy; the only fix needed is to make the redacted response self-describing.
> - This pull request omits the redacted keys entirely and adds an explicit `configRedacted: true` marker, with a matching `configRedacted: false` on the unredacted projection (`redactAgentConfiguration`) so downstream tools have one uniform flag to narrow on.
> - The benefit is that any CLI / dashboard / agent that introspects another agent's config can now distinguish "you don't have permission to read this" from "this field really is empty" — eliminating a recurring false-positive loop and costing ~7 lines of change in one route file.

## What Changed

- `server/src/routes/agents.ts`: `redactForRestrictedAgentView` now destructures `adapterConfig` / `runtimeConfig` out of the agent and returns the remaining fields with `configRedacted: true as const` appended. The omission propagates automatically through the two call sites:
  - `buildAgentDetail({ restricted: true })` (line ~522) — already spreads `redactForRestrictedAgentView(agent)` ahead of `chainOfCommand` / `access`.
  - `GET /api/companies/:companyId/agents` (line ~1620) — already maps `redactForRestrictedAgentView` per row.
- `server/src/routes/agents.ts`: `redactAgentConfiguration` (used by the configuration-only routes) now also returns `configRedacted: false as const` so consumers can use a single uniform flag across both shapes.
- `server/src/__tests__/agent-permissions-routes.test.ts`:
  - The two existing tests that encoded the old `adapterConfig: {} / runtimeConfig: {}` shape (`redacts agent detail …` and `redacts company agent list …`) are updated to assert the new contract: keys are omitted and `configRedacted: true` is present.
  - The privileged path test (`exposes explicit task assignment access on agent detail`) is extended to assert the privileged response still carries both `adapterConfig` and `runtimeConfig` and does **not** carry `configRedacted`.
- `actorCanReadConfigurationsForCompany` and the `isSelf` shortcut on `GET /api/agents/:id` are intentionally untouched — only the **shape** of the restricted response changes, not the permission gate.

## Verification

Local on a clean `pnpm install`:

```
cd server && node_modules/.bin/vitest run src/__tests__/agent-permissions-routes.test.ts
# → 43 tests passed (43)
```

Includes:
- ✓ `redacts agent detail for authenticated company members without agent admin permission` — asserts `not.toHaveProperty("adapterConfig")`, `not.toHaveProperty("runtimeConfig")`, `configRedacted === true`.
- ✓ `redacts company agent list for authenticated company members without agent admin permission` — asserts each redacted row carries `configRedacted: true` and neither config key.
- ✓ `exposes explicit task assignment access on agent detail` — asserts the privileged response still has both `adapterConfig` and `runtimeConfig` keys and `configRedacted` is `undefined`.
- ✓ All 40 other tests in the file (no regressions).

Adjacent test files unaffected:
```
node_modules/.bin/vitest run src/__tests__/agent-cross-tenant-authz-routes.test.ts
# → 1 test passed (1)
```

Typecheck delta against `master`: identical error count (151 pre-existing `tsc --noEmit` errors in `agents.ts` at unrelated lines — drizzle-orm inference issues at 629/657/1642/2005/2136/3147-3166 — none in the modified region 1273-1300). The change introduces zero new TypeScript errors.

## Risks

Low. Wire-shape change for the restricted response only:

- **Breaking for any downstream consumer that pattern-matches on `adapterConfig === {}` to mean "redacted"** — but that match was already incorrect (the bug this PR fixes). Consumers should narrow on `configRedacted === true` going forward. The `paperclipai agent get` CLI and dashboard agent-detail page would benefit from a follow-up that renders `(redacted)` when the flag is present; that's out of scope here.
- No change to persistence, to the permission gate (`actorCanReadConfigurationsForCompany`), or to the `isSelf` shortcut on `GET /api/agents/:id` — those paths are exercised by existing untouched tests.
- No migration. No schema change. No API-version bump needed — the `/api/agents/*` responses still carry an Agent-compatible shape; consumers see fewer keys plus one new boolean.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`), Anthropic, ~200K context window. Code authored in a Paperclip CTO agent heartbeat. Source-file edits and test updates produced and verified locally; reasoning sourced from the failure-loop diagnosis on the downstream Paperclip deployment (RAGA-3 → RAGA-8 → RAGA-9 → RAGA-10 → RAGA-11 → RAGA-31).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (43/43 in the touched file)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge