### PR TITLE
fix: unwrap DrizzleQueryError cause chain in isIssuePrefixConflict

### DIFF
--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -125,16 +125,24 @@ export function companyService(db: Db) {
   }
 
   function isIssuePrefixConflict(error: unknown) {
-    const constraint = typeof error === "object" && error !== null && "constraint" in error
-      ? (error as { constraint?: string }).constraint
-      : typeof error === "object" && error !== null && "constraint_name" in error
-        ? (error as { constraint_name?: string }).constraint_name
-        : undefined;
-    return typeof error === "object"
-      && error !== null
-      && "code" in error
-      && (error as { code?: string }).code === "23505"
-      && constraint === "companies_issue_prefix_idx";
+    // drizzle-orm@0.45+ wraps the underlying postgres-js error in a
+    // DrizzleQueryError whose `.cause` carries the SQLSTATE code and the
+    // constraint name. Walking the cause chain keeps the retry loop in
+    // createCompanyWithUniquePrefix working under both old and new shapes.
+    for (let current: unknown = error; current; ) {
+      if (typeof current !== "object" || current === null) break;
+      const candidate = current as {
+        code?: string;
+        constraint?: string;
+        constraint_name?: string;
+        cause?: unknown;
+      };
+      const constraint = candidate.constraint ?? candidate.constraint_name;
+      if (candidate.code === "23505" && constraint === "companies_issue_prefix_idx") return true;
+      if (candidate.cause === current) break;
+      current = candidate.cause;
+    }
+    return false;
   }
 
   async function createCompanyWithUniquePrefix(data: typeof companies.$inferInsert) {


### PR DESCRIPTION
Fixes #6462.

## Summary

- `isIssuePrefixConflict` in `server/src/services/companies.ts` only inspected the outer thrown error. Since `drizzle-orm@0.45` wraps query errors in a `DrizzleQueryError` whose `.cause` carries the real `PostgresError`, the check never matched a 23505 prefix collision and the retry loop in `createCompanyWithUniquePrefix` bailed on the first attempt — surfacing as a 500 on `POST /api/companies`.
- Walk the `cause` chain so the check works under both the old (raw `PostgresError`) and new (`DrizzleQueryError`-wrapped) shapes.

## Diff

One file, 28 lines:

```
server/src/services/companies.ts | 28 ++++++++++++++++++----------
1 file changed, 18 insertions(+), 10 deletions(-)
```

## Test plan

- [ ] Have two companies whose `issue_prefix` would collide (e.g. names "Test Corp" and "Test 2").
- [ ] `POST /api/companies` with the second name.
- [ ] Before: HTTP 500, `DrizzleQueryError … duplicate key value violates unique constraint "companies_issue_prefix_idx"` logged.
- [ ] After: HTTP 200, company created with prefix `TESA` (next suffix); subsequent collisions produce `TESAA`, `TESAAA`, etc.

The retry ceiling and prefix-derivation logic are untouched — this PR only restores the conditional that lets the existing retry loop see prefix conflicts again.