### PR TITLE
feat(server): add POST /api/recovery-actions/:id/resolve endpoint

### DIFF
--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5655,5 +5655,98 @@ export function issueRoutes(
     res.json({ ok: true });
   });
 
+  // Escape-hatch: agent marks a recovery action resolved by its own ID (no source issue required in URL).
+  // Auth: issue assignee, recovery action owner, or agent with checkout-management override for either.
+  const resolveRecoveryActionByIdSchema = z.object({ reason: z.string().max(2000) }).strict();
+  const TERMINAL_RECOVERY_STATUSES = ["resolved", "cancelled"] as const;
+
+  router.post("/recovery-actions/:id/resolve", validate(resolveRecoveryActionByIdSchema), async (req, res) => {
+    const id = req.params.id as string;
+    const recoveryAction = await recoveryActionsSvc.getById(id);
+    if (!recoveryAction) {
+      res.status(404).json({ error: "Recovery action not found" });
+      return;
+    }
+    assertCompanyAccess(req, recoveryAction.companyId);
+
+    if ((TERMINAL_RECOVERY_STATUSES as readonly string[]).includes(recoveryAction.status)) {
+      res.json({ recoveryAction });
+      return;
+    }
+
+    const sourceIssue = await svc.getById(recoveryAction.sourceIssueId);
+    if (!sourceIssue) {
+      res.status(404).json({ error: "Source issue not found" });
+      return;
+    }
+
+    if (req.actor.type === "agent") {
+      const actorAgentId = req.actor.agentId;
+      if (!actorAgentId) {
+        res.status(403).json({ error: "Agent authentication required" });
+        return;
+      }
+      const isAssignee = sourceIssue.assigneeAgentId === actorAgentId;
+      const isOwner = recoveryAction.ownerAgentId === actorAgentId;
+      const hasAssigneeOverride =
+        sourceIssue.assigneeAgentId != null &&
+        (await hasActiveCheckoutManagementOverride(actorAgentId, recoveryAction.companyId, sourceIssue.assigneeAgentId));
+      const hasOwnerOverride =
+        recoveryAction.ownerAgentId != null &&
+        (await hasActiveCheckoutManagementOverride(actorAgentId, recoveryAction.companyId, recoveryAction.ownerAgentId));
+      if (!isAssignee && !isOwner && !hasAssigneeOverride && !hasOwnerOverride) {
+        res.status(403).json({
+          error: "Only the issue assignee or recovery action owner may resolve this recovery action",
+          details: {
+            recoveryActionId: id,
+            issueId: sourceIssue.id,
+            actorAgentId,
+            assigneeAgentId: sourceIssue.assigneeAgentId,
+            ownerAgentId: recoveryAction.ownerAgentId,
+          },
+        });
+        return;
+      }
+    }
+
+    const { reason } = req.body as { reason: string };
+    const actor = getActorInfo(req);
+    const resolved = await recoveryActionsSvc.resolveActiveForIssue({
+      companyId: recoveryAction.companyId,
+      sourceIssueId: recoveryAction.sourceIssueId,
+      actionId: id,
+      status: "resolved",
+      outcome: "restored",
+      resolutionNote: reason,
+    });
+
+    if (!resolved) {
+      const current = await recoveryActionsSvc.getById(id);
+      res.json({ recoveryAction: current ?? recoveryAction });
+      return;
+    }
+
+    await logActivity(db, {
+      companyId: resolved.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "issue.recovery_action_resolved",
+      entityType: "issue",
+      entityId: resolved.sourceIssueId,
+      details: {
+        identifier: sourceIssue.identifier,
+        recoveryActionId: resolved.id,
+        recoveryActionStatus: resolved.status,
+        outcome: resolved.outcome,
+        resolutionNote: resolved.resolutionNote,
+        source: "agent_manual_resolve",
+      },
+    });
+
+    res.json({ recoveryAction: resolved });
+  });
+
   return router;
 }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5657,7 +5657,7 @@ export function issueRoutes(
 
   // Escape-hatch: agent marks a recovery action resolved by its own ID (no source issue required in URL).
   // Auth: issue assignee, recovery action owner, or agent with checkout-management override for either.
-  const resolveRecoveryActionByIdSchema = z.object({ reason: z.string().max(2000) }).strict();
+  const resolveRecoveryActionByIdSchema = z.object({ reason: z.string().min(1).max(2000) }).strict();
   const TERMINAL_RECOVERY_STATUSES = ["resolved", "cancelled"] as const;
 
   router.post("/recovery-actions/:id/resolve", validate(resolveRecoveryActionByIdSchema), async (req, res) => {

--- a/server/src/services/issue-recovery-actions.ts
+++ b/server/src/services/issue-recovery-actions.ts
@@ -120,6 +120,16 @@ export function issueRecoveryActionService(db: Db) {
     }
   }
 
+  async function getById(id: string): Promise<IssueRecoveryAction | null> {
+    const row = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, id))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    return row ? toReadModel(row) : null;
+  }
+
   async function getActiveForIssue(companyId: string, sourceIssueId: string): Promise<IssueRecoveryAction | null> {
     const row = await db
       .select()
@@ -287,6 +297,7 @@ export function issueRecoveryActionService(db: Db) {
   }
 
   return {
+    getById,
     getActiveForIssue,
     listActiveForIssues,
     resolveActiveForIssue,

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -740,6 +740,38 @@ Terminal states: `done`, `cancelled`
 
 ---
 
+## Recovery Actions
+
+Recovery actions are created automatically by Paperclip when an agent's run fails or a disposition is missing. They signal that an issue is stranded and needs intervention.
+
+### Reading recovery action state
+
+`GET /api/issues/:id/recovery-actions` — returns `{ active, actions[] }` for a specific issue.
+
+The `activeRecoveryAction` field is also included in the standard `GET /api/issues/:id` response.
+
+### Resolving a recovery action by ID (escape-hatch)
+
+Use this when you are the assignee or the recovery owner and want to dismiss a stale or false-positive recovery action without knowing the source issue URL.
+
+```
+POST /api/recovery-actions/:id/resolve
+{ "reason": "Explanation of how the situation was resolved" }
+```
+
+**Auth:** issue assignee, recovery action owner, or agent with checkout-management override for either. Board/user tokens are accepted without agent-specific checks.
+
+**Idempotent:** if the recovery action is already `resolved` or `cancelled`, returns 200 with the existing record unchanged.
+
+**Response:**
+```json
+{ "recoveryAction": { "id": "...", "status": "resolved", "outcome": "restored", "resolutionNote": "...", "resolvedAt": "..." } }
+```
+
+**When to use:** a recovery action was created for a run that you have already handled — the issue is now properly disposed and the system-generated recovery is stale. Calling this endpoint clears the `activeRecoveryAction` on the source issue and logs an `issue.recovery_action_resolved` activity event.
+
+---
+
 ## Error Handling
 
 | Code | Meaning            | What to Do                                                           |


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents can get stranded: a run fails mid-way, or a successful run leaves an issue without a valid disposition
> - The recovery system auto-creates a `IssueRecoveryAction` record and wakes the responsible agent to fix it
> - But agents sometimes handle the situation themselves (fix and close the issue) without going through the recovery flow
> - Those recovery actions then persist as stale noise, re-waking the agent repeatedly with no-op heartbeats
> - There was no escape-hatch: `POST /issues/:id/recovery-actions/resolve` requires knowing the source issue ID and takes many optional fields — too heavyweight for a simple "I already handled this" signal
> - This PR adds `POST /api/recovery-actions/:id/resolve` — resolve by recovery action ID, with just a `reason` string
> - The benefit is a minimal, idempotent escape-hatch agents can call once they know a recovery action is stale, stopping the re-wake loop

## What Changed

- **`server/src/services/issue-recovery-actions.ts`**: Adds `getById(id)` method that looks up a recovery action by ID regardless of its current status. Exported in the service return object.
- **`server/src/routes/issues.ts`**: Adds `POST /recovery-actions/:id/resolve` route with:
  - Zod schema validation (`{ reason: string, max 2000 chars }`, strict — no extra fields)
  - Company-scoped access check via `assertCompanyAccess`
  - Idempotency: already-terminal (`resolved`/`cancelled`) records return 200 unchanged
  - Agent auth: only issue assignee, recovery action owner, or agent with checkout-management override for either may resolve; board/user tokens bypass the agent check
  - Calls `resolveActiveForIssue` with `status: "resolved", outcome: "restored"`, persisting the reason as `resolutionNote`
  - Logs `issue.recovery_action_resolved` activity event
- **`skills/paperclip/references/api-reference.md`**: Adds "Recovery Actions" section documenting the read path and the new resolve endpoint with auth rules, idempotency behaviour, and when to use it.

## Verification

```bash
# 404 for unknown ID
curl -s -X POST http://127.0.0.1:3101/api/recovery-actions/00000000-0000-0000-0000-000000000000/resolve \
  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"reason":"test"}'
# → {"error":"Recovery action not found"}

# Validation: missing reason → 400
curl -s -X POST http://127.0.0.1:3101/api/recovery-actions/00000000-.../resolve \
  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{}'
# → {"error":"Validation error","details":[{"path":["reason"],"message":"Required"}]}

# Resolve a real active action (tested against local instance recovery action d8ee293f):
curl -s -X POST http://127.0.0.1:3101/api/recovery-actions/d8ee293f-2889-439a-928a-4354e74295db/resolve \
  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"reason":"Endpoint validation test"}'
# → {"recoveryAction":{"status":"resolved","outcome":"restored","resolutionNote":"..."}}

# Idempotent: second call returns same resolved record
# (tested and confirmed)
```

All four acceptance criteria verified live against running local Paperclip instance (port 3101).

## Risks

- **Low risk.** New endpoint is additive; existing `/issues/:id/recovery-actions/resolve` route is unchanged.
- Auth logic mirrors the existing checkout-management override pattern already used in the checkout flow. The only new surface is the `getById` query which is a simple PK lookup.
- The `outcome: "restored"` choice is intentional and opinionated — this endpoint is for "I've handled it" dismissals, not for tracking escalation or cancellation paths (those can still use the full `/issues/:id/recovery-actions/resolve`).

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6
- Context: 200k, extended multi-turn session with tool use (Bash, Read, Edit, Grep)
- Mode: Agentic (running as Paperclip CTO agent in heartbeat execution)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (manual live testing documented above; unit tests not added — the route follows the exact same auth/resolve pattern as the existing endpoint)
- [x] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [x] I have updated relevant documentation to reflect my changes (skill docs updated)
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge