### PR TITLE
fix(interactions): allow assignee agents to resolve issue-thread interactions

### DIFF
--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -741,6 +741,111 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     expect(mockAdapterExecute.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("allows interaction continuation wakes without comment ids while dependencies remain blocked", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const blockerId = randomUUID();
+    const blockedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: blockerId,
+        companyId,
+        title: "Mission 0",
+        status: "todo",
+        priority: "high",
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Mission 1",
+        status: "in_review",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+
+    const interactionWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: {
+        issueId: blockedIssueId,
+        interactionId: "interaction-1",
+        interactionKind: "ask_user_questions",
+        interactionStatus: "answered",
+        mutation: "interaction",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "board-user",
+      contextSnapshot: {
+        issueId: blockedIssueId,
+        interactionId: "interaction-1",
+        interactionKind: "ask_user_questions",
+        interactionStatus: "answered",
+        wakeReason: "issue_commented",
+        source: "issue.interaction.respond",
+      },
+    });
+
+    expect(interactionWake).not.toBeNull();
+
+    await waitForCondition(async () => {
+      const run = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, interactionWake!.id))
+        .then((rows) => rows[0] ?? null);
+      return run?.status === "succeeded";
+    });
+
+    const interactionRun = await db
+      .select({
+        status: heartbeatRuns.status,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, interactionWake!.id))
+      .then((rows) => rows[0] ?? null);
+
+    expect(interactionRun?.status).toBe("succeeded");
+    expect(interactionRun?.contextSnapshot).toMatchObject({
+      interactionId: "interaction-1",
+      interactionKind: "ask_user_questions",
+      interactionStatus: "answered",
+      dependencyBlockedInteraction: true,
+      unresolvedBlockerIssueIds: [blockerId],
+    });
+  });
+
   it("suppresses normal wakeups while allowing comment interaction wakes under a pause hold", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -862,6 +967,109 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       .where(eq(heartbeatRuns.id, childCommentWake!.id))
       .then((rows) => rows[0] ?? null);
     expect(childRun?.contextSnapshot).toMatchObject({
+      treeHoldInteraction: true,
+      activeTreeHold: {
+        holdId: hold.id,
+        rootIssueId,
+        mode: "pause",
+        interaction: true,
+      },
+    });
+  });
+
+  it("allows structured interaction continuation wakes under a pause hold without comment ids", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const rootIssueId = randomUUID();
+    const childIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "SecurityEngineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: rootIssueId,
+        companyId,
+        title: "Paused root",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: childIssueId,
+        companyId,
+        parentId: rootIssueId,
+        title: "Paused child",
+        status: "in_review",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    const [hold] = await db
+      .insert(issueTreeHolds)
+      .values({
+        companyId,
+        rootIssueId,
+        mode: "pause",
+        status: "active",
+        reason: "security test hold",
+        releasePolicy: { strategy: "manual" },
+      })
+      .returning();
+
+    const interactionWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: {
+        issueId: childIssueId,
+        interactionId: "interaction-2",
+        interactionKind: "request_confirmation",
+        interactionStatus: "accepted",
+        mutation: "interaction",
+      },
+      requestedByActorType: "user",
+      requestedByActorId: "board-user",
+      contextSnapshot: {
+        issueId: childIssueId,
+        interactionId: "interaction-2",
+        interactionKind: "request_confirmation",
+        interactionStatus: "accepted",
+        wakeReason: "issue_commented",
+        source: "issue.interaction.accept",
+      },
+    });
+
+    expect(interactionWake).not.toBeNull();
+    const interactionRun = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, interactionWake!.id))
+      .then((rows) => rows[0] ?? null);
+
+    expect(interactionRun?.contextSnapshot).toMatchObject({
+      interactionId: "interaction-2",
+      interactionKind: "request_confirmation",
+      interactionStatus: "accepted",
       treeHoldInteraction: true,
       activeTreeHold: {
         holdId: hold.id,

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -4,6 +4,7 @@ import { sessionCodec as codexSessionCodec } from "@paperclipai/adapter-codex-lo
 import { resolveDefaultAgentWorkspaceDir } from "../home-paths.js";
 import {
   applyPersistedExecutionWorkspaceConfig,
+  allowsIssueInteractionWake,
   buildRealizedExecutionWorkspaceFromPersisted,
   buildExplicitResumeSessionOverride,
   deriveTaskKeyWithHeartbeatFallback,
@@ -365,6 +366,45 @@ describe("shouldResetTaskSessionForWake", () => {
       shouldResetTaskSessionForWake({
         wakeSource: "on_demand",
         wakeTriggerDetail: "callback",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("allowsIssueInteractionWake", () => {
+  it("accepts comment-based interaction wakes", () => {
+    expect(
+      allowsIssueInteractionWake({
+        wakeReason: "issue_commented",
+        wakeCommentId: "comment-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts structured interaction continuation wakes without comment ids", () => {
+    expect(
+      allowsIssueInteractionWake({
+        wakeReason: "issue_commented",
+        interactionId: "interaction-1",
+        interactionKind: "ask_user_questions",
+        interactionStatus: "answered",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects ordinary comment wakes with no comment or interaction evidence", () => {
+    expect(
+      allowsIssueInteractionWake({
+        wakeReason: "issue_commented",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects non-interaction wake reasons even when interaction ids are present", () => {
+    expect(
+      allowsIssueInteractionWake({
+        wakeReason: "issue_assigned",
+        interactionId: "interaction-1",
       }),
     ).toBe(false);
   });

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -739,4 +739,117 @@ describe.sequential("issue thread interaction routes", () => {
       },
     );
   });
+
+  it("allows an owning agent to answer ask_user_questions interactions", async () => {
+    mockIssueService.getById.mockResolvedValueOnce(createIssue({
+      status: "todo",
+      assigneeAgentId: CREATED_AGENT_ID,
+    }));
+    const app = await createApp({
+      type: "agent",
+      agentId: CREATED_AGENT_ID,
+      companyId: "company-1",
+      runId: "run-agent-answer",
+    });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/respond")
+      .send({
+        answers: [{ questionId: "scope", optionIds: ["phase-1"] }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockInteractionService.answerQuestions).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+      "interaction-2",
+      {
+        answers: [{ questionId: "scope", optionIds: ["phase-1"] }],
+      },
+      {
+        agentId: CREATED_AGENT_ID,
+        userId: null,
+      },
+    );
+  });
+
+  it("allows an owning agent to accept request_confirmation interactions", async () => {
+    mockIssueService.getById.mockResolvedValueOnce(createIssue({
+      status: "todo",
+      assigneeAgentId: CREATED_AGENT_ID,
+    }));
+    mockInteractionService.acceptInteraction.mockResolvedValueOnce({
+      interaction: {
+        id: "interaction-3",
+        companyId: "company-1",
+        issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        kind: "request_confirmation",
+        status: "accepted",
+        continuationPolicy: "wake_assignee_on_accept",
+        idempotencyKey: null,
+        sourceCommentId: null,
+        sourceRunId: "run-3",
+        payload: {
+          version: 1,
+          prompt: "Apply this plan?",
+        },
+        result: {
+          version: 1,
+          outcome: "accepted",
+        },
+        createdAt: "2026-04-20T12:00:00.000Z",
+        updatedAt: "2026-04-20T12:05:00.000Z",
+        resolvedAt: "2026-04-20T12:05:00.000Z",
+      },
+      createdIssues: [],
+    });
+    const app = await createApp({
+      type: "agent",
+      agentId: CREATED_AGENT_ID,
+      companyId: "company-1",
+      runId: "run-agent-accept",
+    });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-3/accept")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockInteractionService.acceptInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+      "interaction-3",
+      {},
+      {
+        agentId: CREATED_AGENT_ID,
+        userId: null,
+      },
+    );
+  });
+
+  it("allows an owning agent to cancel ask_user_questions interactions", async () => {
+    mockIssueService.getById.mockResolvedValueOnce(createIssue({
+      status: "todo",
+      assigneeAgentId: CREATED_AGENT_ID,
+    }));
+    const app = await createApp({
+      type: "agent",
+      agentId: CREATED_AGENT_ID,
+      companyId: "company-1",
+      runId: "run-agent-cancel",
+    });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/cancel")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockInteractionService.cancelQuestions).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+      "interaction-2",
+      {},
+      {
+        agentId: CREATED_AGENT_ID,
+        userId: null,
+      },
+    );
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4645,7 +4645,11 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
-      assertBoard(req);
+      if (req.actor.type === "agent") {
+        if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+      } else {
+        assertBoard(req);
+      }
 
       const actor = getActorInfo(req);
       const { interaction, createdIssues, continuationIssue } = await issueThreadInteractionService(db).acceptInteraction(issue, interactionId, req.body, {
@@ -4748,7 +4752,11 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
-      assertBoard(req);
+      if (req.actor.type === "agent") {
+        if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+      } else {
+        assertBoard(req);
+      }
 
       const actor = getActorInfo(req);
       const interaction = await issueThreadInteractionService(db).rejectInteraction(issue, interactionId, req.body, {
@@ -4804,7 +4812,11 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
-      assertBoard(req);
+      if (req.actor.type === "agent") {
+        if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+      } else {
+        assertBoard(req);
+      }
 
       const actor = getActorInfo(req);
       const interaction = await issueThreadInteractionService(db).answerQuestions(issue, interactionId, req.body, {
@@ -4856,7 +4868,11 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
-      assertBoard(req);
+      if (req.actor.type === "agent") {
+        if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
+      } else {
+        assertBoard(req);
+      }
 
       const actor = getActorInfo(req);
       const interaction = await issueThreadInteractionService(db).cancelQuestions(issue, interactionId, req.body, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1668,12 +1668,27 @@ function shouldRequireIssueCommentForWake(
   );
 }
 
-function allowsIssueInteractionWake(
+function deriveInteractionId(
   contextSnapshot: Record<string, unknown> | null | undefined,
+  payload: Record<string, unknown> | null | undefined,
+) {
+  return (
+    readNonEmptyString(contextSnapshot?.interactionId) ??
+    readNonEmptyString(payload?.interactionId) ??
+    null
+  );
+}
+
+export function allowsIssueInteractionWake(
+  contextSnapshot: Record<string, unknown> | null | undefined,
+  payload: Record<string, unknown> | null | undefined = null,
 ) {
   const wakeReason = readNonEmptyString(contextSnapshot?.wakeReason);
   if (!wakeReason || !ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS.has(wakeReason)) return false;
-  return Boolean(deriveCommentId(contextSnapshot, null));
+  return Boolean(
+    deriveCommentId(contextSnapshot, payload) ||
+    deriveInteractionId(contextSnapshot, payload),
+  );
 }
 
 async function listUnresolvedBlockerSummaries(

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -679,6 +679,7 @@ POST /api/issues/{issueId}/interactions
 
 Rules:
 
+- Board users can resolve these interactions. Agents can also resolve issue-thread interactions on issues they are allowed to mutate, using the same assignee/checkout and management-override policy as other issue mutations.
 - `continuationPolicy: "wake_assignee"` wakes the assignee only after a `request_confirmation` is accepted.
 - Rejection does not wake the assignee by default. The board/user can add a normal comment when revisions are needed.
 - Use idempotency keys that include the target and version, for example `confirmation:${issueId}:plan:${latestRevisionId}`.
@@ -796,6 +797,7 @@ Terminal states: `done`, `cancelled`
 | POST   | `/api/issues/:issueId/interactions/:interactionId/accept` | Accept suggested tasks or confirmation                                       |
 | POST   | `/api/issues/:issueId/interactions/:interactionId/reject` | Reject suggested tasks or confirmation                                       |
 | POST   | `/api/issues/:issueId/interactions/:interactionId/respond` | Respond to structured questions                                             |
+| POST   | `/api/issues/:issueId/interactions/:interactionId/cancel` | Cancel pending `ask_user_questions` interactions                            |
 | GET    | `/api/issues/:issueId/documents`   | List issue documents                                                                     |
 | GET    | `/api/issues/:issueId/documents/:key` | Get issue document by key                                                            |
 | PUT    | `/api/issues/:issueId/documents/:key` | Create or update issue document (send `baseRevisionId` when updating)                |


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The issue-thread interaction subsystem (`ask_user_questions`, `request_confirmation`, `suggest_tasks`) is documented in the `paperclip` skill as the standard way to request structured input
> - Today the resolve routes (`/accept`, `/reject`, `/respond`, `/cancel`) call `assertBoard()` unconditionally, so any agent token gets `403 Board access required`
> - That blocks agent-to-agent interactions entirely — an agent can create the interaction but no agent can resolve it; the workaround is plain comments, which lose the structured response, idempotency, and continuation wake
> - This PR makes the four resolve routes use `assertAgentIssueMutationAllowed` for agent actors (board users still hit `assertBoard`), and updates the heartbeat wake admission so structured continuation wakes fire even when the trigger carries `interactionId` instead of `wakeCommentId`
> - The benefit is that agents can now own the full interaction lifecycle natively, the documented continuation policy actually fires for cross-agent flows, and a creator can `/cancel` stale interactions instead of leaving orphans

## What Changed

- `server/src/routes/issues.ts` — `/issues/:id/interactions/:interactionId/{accept,reject,respond,cancel}` now run `assertAgentIssueMutationAllowed` for agent actors; board users still go through `assertBoard`. Same assignee/checkout/management-override policy as other issue mutations.
- `server/src/services/heartbeat.ts` — `allowsIssueInteractionWake` accepts an `interactionId` (from payload or context snapshot) as a valid interaction-wake signal; export bumped so it can be unit-tested.
- `server/src/__tests__/issue-thread-interaction-routes.test.ts` — adds three route tests covering owning-agent `respond`, `accept`, and `cancel`.
- `server/src/__tests__/heartbeat-workspace-session.test.ts` — adds a focused `describe("allowsIssueInteractionWake")` block (4 unit tests: comment-id path, interaction-id path, no-evidence reject, wrong-wake-reason reject).
- `server/src/__tests__/heartbeat-dependency-scheduling.test.ts` — adds two embedded-Postgres tests proving structured interaction wakes survive dependency blockers and pause holds without a comment id.
- `skills/paperclip/references/api-reference.md` — documents the new agent-resolve policy and adds the `/cancel` row to the interactions endpoint table.

## Verification

```sh
cd server
pnpm vitest run --no-coverage src/__tests__/issue-thread-interaction-routes.test.ts
#   → 13 tests passing (incl. 3 new owning-agent cases)

pnpm vitest run --no-coverage src/__tests__/heartbeat-workspace-session.test.ts
#   → 42 tests passing (incl. new allowsIssueInteractionWake block)

pnpm vitest run --no-coverage src/services/issue-thread-interactions.test.ts
#   → service unit tests passing

pnpm typecheck
#   → clean
```

Embedded-Postgres heartbeat-dependency-scheduling tests skip on this host because the local Postgres init script is unavailable; CI will run them.

Manual repro of the original bug (before this PR):
```
POST /api/issues/<issueId>/interactions/<interactionId>/respond
Authorization: Bearer <agent JWT>
→ 403 { "error": "Board access required" }
```
After this PR, an agent that owns the issue (or has a management override) responds successfully and the continuation policy fires.

## Risks

- Low. Agent access is gated through the existing `assertAgentIssueMutationAllowed` helper, which already enforces assignee/checkout/management-override semantics across every other mutation route. Board behaviour is unchanged (still `assertBoard`).
- Heartbeat change broadens the wake admission for interaction continuations; it still requires the wake reason to be an interaction reason, so unrelated wakes are not affected.
- No schema changes, no migrations.

## Model Used

- Provider: Anthropic Claude (via Paperclip `claude_local` adapter)
- Model ID: `claude-opus-4-7`
- Capability: extended thinking, tool use (Read/Edit/Bash/Grep/Glob)
- Authored by the CTO agent of company `cd09e6fe-b8a9-44e2-a435-fc34d4ad4ce3` (Rubik) under Paperclip issue RUB-58
- Tests previously drafted by the prior CTO heartbeat (codex_local) were verified, retained, and committed by this run

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server + docs only)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge