### PR TITLE
fix(heartbeat): finalize 'satisfied' when contextSnapshot.issueId is absent

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1599,4 +1599,121 @@ describe("heartbeat comment wake batching", () => {
       await gateway.close();
     }
   }, 20_000);
+
+  it("finalizes 'satisfied' when contextSnapshot.issueId is absent but a run-linked comment exists (Wake-9 regression)", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "QA Harness Agent",
+        role: "tester",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Wake-9 regression: issueId absent from contextSnapshot",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      // Reproduces the Wake-9 production trigger: contextSnapshot omits issueId.
+      // The auto-post path resolves the issue from agent assignment
+      // (effectiveIssueIdForAutoPost), but contextSnapshot is never updated.
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "on_demand",
+        triggerDetail: "manual",
+        reason: "manual_wake",
+        payload: {},
+        contextSnapshot: {
+          actorId: "test-user",
+          wakeSource: "on_demand",
+          wakeTriggerDetail: "manual",
+          triggeredBy: "board",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "test-user",
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      // Insert the run-linked comment directly (matches what the auto-post path
+      // does via issuesSvc.addComment on the effectiveIssueIdForAutoPost branch).
+      const insertedComment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorAgentId: agentId,
+          authorUserId: null,
+          createdByRunId: firstRun!.id,
+          body: "Identity report body for Wake-9 regression test.",
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      gateway.releaseFirstWait();
+
+      await waitFor(async () => {
+        const runs = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.agentId, agentId));
+        return runs.length === 1
+          && runs[0]?.status === "succeeded"
+          && runs[0]?.issueCommentStatus === "satisfied";
+      });
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId));
+
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.issueCommentStatus).toBe("satisfied");
+      expect(runs[0]?.issueCommentSatisfiedByCommentId).toBe(insertedComment!.id);
+
+      // Issue status must remain unchanged (Wake-9 invariant).
+      const issuesRows = await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId));
+      expect(issuesRows[0]?.status).toBe("blocked");
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 20_000);
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3027,6 +3027,23 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
+  async function findRunIssueCommentByRunIdOnly(runId: string, companyId: string) {
+    return db
+      .select({
+        id: issueComments.id,
+      })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, companyId),
+          eq(issueComments.createdByRunId, runId),
+        ),
+      )
+      .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function refreshContinuationSummaryForRun(
     run: typeof heartbeatRuns.$inferSelect,
     agent: typeof agents.$inferSelect,
@@ -3210,6 +3227,24 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
     if (!issueId) {
+      // Wake-9 case: contextSnapshot.issueId can be absent even when the run
+      // produced an auto-posted comment via the effectiveIssueIdForAutoPost
+      // fallback path. The comment-side FK (issue_comments.created_by_run_id)
+      // is authoritative; consult it before falling back to 'not_applicable'.
+      const fallbackComment = await findRunIssueCommentByRunIdOnly(run.id, run.companyId);
+      if (fallbackComment) {
+        if (
+          run.issueCommentStatus !== "satisfied"
+          || run.issueCommentSatisfiedByCommentId !== fallbackComment.id
+        ) {
+          await patchRunIssueCommentStatus(run.id, {
+            issueCommentStatus: "satisfied",
+            issueCommentSatisfiedByCommentId: fallbackComment.id,
+            issueCommentRetryQueuedAt: null,
+          });
+        }
+        return { outcome: "satisfied" as const, queuedRun: null };
+      }
       if (run.issueCommentStatus !== "not_applicable") {
         await patchRunIssueCommentStatus(run.id, {
           issueCommentStatus: "not_applicable",


### PR DESCRIPTION
## Summary

`finalizeIssueCommentPolicy` (in `server/src/services/heartbeat.ts`) exits at its `!issueId` guard before consulting the comment-side foreign key. When a heartbeat run finishes WITHOUT `contextSnapshot.issueId` set but an `issue_comments` row exists with `created_by_run_id = run.id`, the run row's reverse-pointer columns are never populated:

| Column | Observed | Expected (when a run-linked comment exists) |
|---|---|---|
| `heartbeat_runs.issue_comment_status` | `'not_applicable'` (the default) | `'satisfied'` |
| `heartbeat_runs.issue_comment_satisfied_by_comment_id` | `NULL` | `<the comment's id>` |

The forward FK (`issue_comments.created_by_run_id`) is correct — the data itself is not lost — but any UI or query that relies on the run-side reverse pointer sees incomplete metadata for these runs.

## Root cause

In `finalizeIssueCommentPolicy`, the current early-return branch is:

```ts
const issueId = readNonEmptyString(contextSnapshot.issueId);
if (!issueId) {
  if (run.issueCommentStatus !== "not_applicable") {
    await patchRunIssueCommentStatus(run.id, {
      issueCommentStatus: "not_applicable",
      issueCommentSatisfiedByCommentId: null,
      issueCommentRetryQueuedAt: null,
    });
  }
  return { outcome: "not_applicable" as const, queuedRun: null };
}

const postedComment = await findRunIssueComment(run.id, run.companyId, issueId);
if (postedComment) {
  await patchRunIssueCommentStatus(run.id, {
    issueCommentStatus: "satisfied",
    issueCommentSatisfiedByCommentId: postedComment.id,
    issueCommentRetryQueuedAt: null,
  });
  return { outcome: "satisfied" as const, queuedRun: null };
}
```

The `findRunIssueComment` lookup is gated behind a non-null `issueId`, but comments can be inserted with `created_by_run_id` via paths that don't require `contextSnapshot.issueId` to be set (the `issue_comments.created_by_run_id` FK to `heartbeat_runs.id` is the authoritative linkage and lives independently of any contextSnapshot copy). So the early-return drops a real comment on the floor from the run row's perspective.

## Change

Two-hunk additive patch in `server/src/services/heartbeat.ts`:

1. **New helper `findRunIssueCommentByRunIdOnly(runId, companyId)`** placed immediately after the existing `findRunIssueComment` helper. Same shape (selects only `id`, `ORDER BY created_at DESC, id DESC LIMIT 1`, cross-tenant safe via `company_id` filter) — minus the `issueId` predicate. Returns the most recent run-linked comment id (mirrors `findRunIssueComment`'s multi-comment ordering policy).
2. **Consult the helper inside the `!issueId` branch** of `finalizeIssueCommentPolicy` before falling back to `'not_applicable'`. If a fallback comment exists, transition to:
   - `issue_comment_status = 'satisfied'`
   - `issue_comment_satisfied_by_comment_id = <comment.id>`
   - `issue_comment_retry_queued_at = NULL`
   
   Guarded for idempotency: a re-run of `finalizeIssueCommentPolicy` on an already-satisfied row pointing at the same comment is a no-op (no UPDATE issued). Matches the existing guard pattern on the `!= 'not_applicable'` side of the branch.

No schema change. The `heartbeat_runs.issue_comment_*` columns already exist; this PR only changes when they are written.

No public-API change. `finalizeIssueCommentPolicy` is an internal closure inside `heartbeatService`; its three existing call sites (`heartbeat.ts:5758`, `5839`, `5902`) await the result but do not branch on the `outcome` value, so the new `'satisfied'` return value from the fallback path is observed only by the DB state it writes.

## Tests

Adds one regression test to the existing canonical state-machine file `server/src/__tests__/heartbeat-comment-wake-batching.test.ts` (matches the file's existing convention of 10 `it()` blocks in one `describe`; not split into a new file).

Test name (currently):

> `finalizes 'satisfied' when contextSnapshot.issueId is absent but a run-linked comment exists (Wake-9 regression)`

The new test:

- Inserts company / agent (`adapterType: "openclaw_gateway"`) / issue rows.
- Calls `heartbeat.wakeup(...)` with a `contextSnapshot` that contains `actorId`, `wakeSource`, `wakeTriggerDetail`, `triggeredBy` but **no `issueId` key** (and no `issueId` in the payload either).
- Inserts an `issue_comments` row directly with `createdByRunId = run.id`.
- Releases the controlled-gateway wait and awaits run completion.
- Asserts `runs[0].issueCommentStatus === 'satisfied'` AND `runs[0].issueCommentSatisfiedByCommentId === insertedComment.id`.
- Asserts the issue's `status` is unchanged.

Without the patch this test fails with `issueCommentStatus === 'not_applicable'` and `issueCommentSatisfiedByCommentId === null` (the pre-patch behavior). With the patch it passes.

Full file result on a clean checkout (this branch is rooted at `v2026.428.0-canary.5`): **10/10 passing**, including all 9 pre-existing `it()` blocks in the same describe.

## Backwards compatibility

- **No schema migration.** Columns `issue_comment_status`, `issue_comment_satisfied_by_comment_id`, `issue_comment_retry_queued_at` already exist in `heartbeat_runs`.
- **No data backfill.** Existing rows that previously stayed at `'not_applicable' / NULL` despite having an `issue_comments.created_by_run_id` link will continue to do so until they are touched again by `finalizeIssueCommentPolicy`. The forward FK on the comment side is the authoritative linkage and is unaffected.
- **No public API change.** The three existing call sites of `finalizeIssueCommentPolicy` do not branch on the returned `outcome` value, so callers see the same shape; only the DB state written by the function changes for runs in the previously-affected state.
- **No new dependencies.**
- **Idempotency:** the guard `run.issueCommentStatus !== "satisfied" || run.issueCommentSatisfiedByCommentId !== fallbackComment.id` ensures a re-run of `finalizeIssueCommentPolicy` on an already-satisfied row issues zero writes.

## Performance / locking

The new helper does a single-row indexed lookup:

```sql
SELECT id
  FROM issue_comments
 WHERE company_id        = $1
   AND created_by_run_id = $2
 ORDER BY created_at DESC, id DESC
 LIMIT 1;
```

There is no covering index on `(company_id, created_by_run_id)` today; the query plan uses the existing `issue_comments_company_idx` plus a filter on `created_by_run_id`. At typical row counts this is sub-millisecond; happy to add a partial index in a follow-up if benchmarks suggest it's worth it:

```sql
CREATE INDEX ix_issue_comments_company_run
  ON issue_comments(company_id, created_by_run_id)
  WHERE created_by_run_id IS NOT NULL;
```

Not blocking for this PR.

## Notes for maintainers

1. **Test name**: the current test name carries a parenthetical `(Wake-9 regression)` that refers to the originating context where the bug was first observed in our deployment. If you'd prefer a more upstream-flavoured name, happy to amend to e.g. `finalizes 'satisfied' when contextSnapshot.issueId is absent but a run-linked comment exists` (drop the parenthetical) — your call.
2. **Multi-comment policy**: deliberately mirrors `findRunIssueComment`'s `ORDER BY desc(createdAt), desc(id) LIMIT 1` — if you have a stricter "exactly one comment" invariant in mind, I can tighten the helper to assert that instead.
3. **Trigger-based alternative**: a `BEFORE/AFTER INSERT` trigger on `issue_comments` could collapse this into an in-database invariant, but the rest of the `issueCommentStatus` state machine lives in application code (`heartbeat.ts:patchRunIssueCommentStatus`), and doing one transition in-DB and the rest in app code felt inconsistent. Happy to switch if you'd prefer the trigger approach.
4. **Discovered during** a production-deployment audit of the run-row metadata; the forward FK was always correct, only the run-row reverse pointer was missing. No data corruption, just incomplete denormalised metadata.

## Checklist

- [x] No public API change
- [x] No schema migration
- [x] New helper is symmetric in style with existing `findRunIssueComment`
- [x] Idempotency guard added (`status === 'satisfied' && satisfied_by === comment.id` short-circuits)
- [x] Regression test added inside the canonical state-machine file (no new file)
- [x] All 10 tests in `heartbeat-comment-wake-batching.test.ts` pass on a clean checkout from `v2026.428.0-canary.5`
- [x] `pnpm typecheck` clean (no new types added; helper uses existing inference)
- [ ] `pnpm run check:tokens` — please run in CI (forbidden-token guard); no token-shape strings were introduced
- [ ] Maintainer review of the test name (drop `(Wake-9 regression)` parenthetical?)

## Thinking Path

Started from the observed symptom: `heartbeat_runs.issue_comment_satisfied_by_comment_id` was `NULL` on a real run whose `issue_comments` row correctly carried `created_by_run_id` pointing back at that run. The forward FK was right; only the run-side reverse pointer was missing.

Traced the inconsistency to `finalizeIssueCommentPolicy`'s `!issueId` early-return, which exits before `findRunIssueComment` is consulted. Because `findRunIssueComment` is gated on a non-null `issueId`, any comment-creation path that lands an `issue_comments` row with `created_by_run_id` set but without `contextSnapshot.issueId` populated on the run causes the run row's tracking columns to stay at their defaults.

Considered three approaches:

1. A `BEFORE/AFTER INSERT` Postgres trigger on `issue_comments` that updates `heartbeat_runs` when `NEW.created_by_run_id IS NOT NULL`. Rejected because the rest of the `issueCommentStatus` state machine lives in application code (`patchRunIssueCommentStatus`), and mixing in-DB and in-app state transitions makes the policy harder to reason about and harder to feature-flag.
2. Tightening the new helper to assert exactly one comment per `created_by_run_id`. Rejected for v1 to avoid widening the diff with a policy decision the maintainers haven't asked for; the existing `findRunIssueComment` already accepts multiple and takes the most recent via `ORDER BY DESC LIMIT 1`, and the new helper deliberately mirrors that.
3. A minimal symmetric helper (`findRunIssueCommentByRunIdOnly`) that's exactly `findRunIssueComment` minus the `issueId` predicate, consulted only inside the `!issueId` branch before falling back to `'not_applicable'`. Chosen because it keeps the diff small (one new helper + 18 lines in the branch), the helper sits next to its sibling so future readers see them as a pair, and the change is invisible to callers that already had a populated `issueId`.

Added an idempotency guard (`status !== 'satisfied' || satisfied_by !== fallbackComment.id`) so a re-invocation on an already-satisfied row writes zero rows — mirrors the existing `!= 'not_applicable'` guard on the same function's other branches. After review feedback, narrowed the helper's `SELECT` from `(id, issueId)` to `(id)` only, since the caller in `finalizeIssueCommentPolicy` uses only `.id`.

## Model Used

This patch was prepared with the assistance of Anthropic's Claude (specifically Claude Opus 4.7, via the Claude Code CLI). The workflow used read-only DB introspection of a deployment where the bug was first observed, followed by code inspection of the upstream `paperclipai/paperclip` checkout pinned at `v2026.428.0-canary.5`, plus targeted `vitest` runs on the new regression test and the pre-existing 9 tests in `heartbeat-comment-wake-batching.test.ts`. Each push and each amend was a deliberate authorized step; no commit was made or pushed without explicit human authorization.

Author and committer on the commit are Karan Sekar &lt;aynkharan@gmail.com&gt;. No `Co-Authored-By: Claude` trailer is attached, per Anthropic's standing policy on AI authorship attribution.
