### PR TITLE
feat(adapters/hermes-local): recommend MCP tools in authGuardPrompt

### DIFF
--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -454,8 +454,8 @@ const hermesLocalAdapter: ServerAdapterModule = {
         : "";
     const authGuardPrompt = [
       "Paperclip API safety rule:",
-      "Use Authorization: Bearer $PAPERCLIP_API_KEY on every Paperclip API request.",
-      "Use X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID on every Paperclip API request that writes or mutates data, including comments and issue updates.",
+      "Prefer the Paperclip MCP tools when they are available in your tool list (names start with `paperclip`, e.g. `paperclipAddComment`, `paperclipUpdateIssue`, `paperclipListComments`, `paperclipGetIssue`, `paperclipInboxLite`). They call Paperclip natively without a shell, are guaranteed structured, and bypass shell-execution scanners.",
+      "Only fall back to direct HTTP calls when the Paperclip MCP tools are NOT in your tool list. In that fallback case: use Authorization: Bearer $PAPERCLIP_API_KEY on every Paperclip API request, and use X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID on every request that writes or mutates data, including comments and issue updates.",
       "Never use a board, browser, or local-board session for Paperclip API writes.",
     ].join("\n");
 


### PR DESCRIPTION
## Summary

Two-line change to [`server/src/adapters/registry.ts`](server/src/adapters/registry.ts#L455-L460): updates the `authGuardPrompt` injected into Hermes-local agents to prefer the existing `@paperclipai/mcp-server` tools (`paperclipAddComment`, `paperclipUpdateIssue`, etc.) when they're in the agent's tool list, falling back to the original \`Authorization: Bearer $PAPERCLIP_API_KEY\` HTTP form otherwise.

## Motivation

The current prompt instructs the agent to use \`curl -H \"Authorization: Bearer $PAPERCLIP_API_KEY\"\` for all Paperclip API calls. That shell-pipe pattern is blocked by Hermes' `tools/approval.py` scanner as HIGH-severity dangerous, forcing operators to run Hermes with `HERMES_YOLO_MODE=1` and `security.tirith_enabled: false` — clearly not a long-term posture.

`@paperclipai/mcp-server` (this repo's [`packages/mcp-server/`](packages/mcp-server/), published to npm as `2026.517.0` on 2026-05-17) already exposes 40+ Paperclip operations as native MCP tool calls — no shell. The plumbing in [registry.ts:466-467](server/src/adapters/registry.ts#L466-L467) already injects `PAPERCLIP_API_KEY` + `PAPERCLIP_RUN_ID` into the agent's env, which the MCP server reads. The only missing piece for end-to-end functionality is:

1. Operator-side: register the MCP server in `~/.hermes/config.yaml`:
   \`\`\`yaml
   mcp_servers:
     paperclip:
       command: \"npx\"
       args: [\"-y\", \"@paperclipai/mcp-server\"]
       env:
         PAPERCLIP_API_URL: \"http://127.0.0.1:3100\"
   \`\`\`
2. Paperclip-side (this PR): tell the agent to prefer those tools.

With both in place, the agent uses `paperclipAddComment(...)` instead of `bash -c \"curl ...\"`, and Hermes operators can lift the `HERMES_YOLO_MODE=1` + `tirith_enabled: false` workarounds.

## Backward compatibility

Strictly additive in prompt content. No registry.ts API changes, no new fields, no migration.

- **Operators who have NOT registered `mcp_servers: paperclip:` in their Hermes config:** the agent's tool list won't contain any `paperclip*` names, so the prompt's first sentence is a no-op. The fallback sentence keeps the original behavior verbatim. No regression.
- **Operators who HAVE registered it:** the agent sees `paperclipAddComment` etc. in its tool list and uses them per the prompt. Approval.py event log goes quiet.

## Test plan

- [ ] Existing hermes_local adapter tests still pass (no behavior change for unregistered case)
- [ ] Manual end-to-end on a real Hermes gateway with `mcp_servers: paperclip:` registered: dispatch a \"post a comment saying X\" task, verify the run's tool-call log shows `paperclipAddComment` (not `bash`)
- [ ] Same test with `HERMES_YOLO_MODE` unset and `security.tirith_enabled: true`: verify the run completes (proves the path bypasses approval.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)