### PR TITLE
feat(mcp-server): make PAPERCLIP_API_KEY check lazy (defer to first request)

### DIFF
--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -1,4 +1,4 @@
-import type { PaperclipMcpConfig } from "./config.js";
+import { resolveApiKey, type PaperclipMcpConfig } from "./config.js";
 
 export class PaperclipApiError extends Error {
   readonly status: number;
@@ -82,7 +82,7 @@ export class PaperclipApiClient {
 
     const url = new URL(path.slice(1), `${this.config.apiUrl}/`);
     const headers: Record<string, string> = {
-      Authorization: `Bearer ${this.config.apiKey}`,
+      Authorization: `Bearer ${resolveApiKey(this.config)}`,
       Accept: "application/json",
     };
     if (options.body !== undefined) {

--- a/packages/mcp-server/src/config.test.ts
+++ b/packages/mcp-server/src/config.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  normalizeApiUrl,
+  readConfigFromEnv,
+  resolveApiKey,
+  type PaperclipMcpConfig,
+} from "./config.js";
+
+const ORIGINAL_API_KEY = process.env.PAPERCLIP_API_KEY;
+
+afterEach(() => {
+  if (ORIGINAL_API_KEY === undefined) {
+    delete process.env.PAPERCLIP_API_KEY;
+  } else {
+    process.env.PAPERCLIP_API_KEY = ORIGINAL_API_KEY;
+  }
+});
+
+describe("normalizeApiUrl", () => {
+  it("appends /api when missing", () => {
+    expect(normalizeApiUrl("http://localhost:3100")).toBe("http://localhost:3100/api");
+  });
+
+  it("strips trailing slashes before appending", () => {
+    expect(normalizeApiUrl("http://localhost:3100///")).toBe("http://localhost:3100/api");
+  });
+
+  it("leaves a URL that already ends in /api unchanged", () => {
+    expect(normalizeApiUrl("http://localhost:3100/api")).toBe("http://localhost:3100/api");
+  });
+});
+
+describe("readConfigFromEnv", () => {
+  it("throws when PAPERCLIP_API_URL is missing", () => {
+    expect(() => readConfigFromEnv({})).toThrow(/PAPERCLIP_API_URL/);
+  });
+
+  it("returns config with empty apiKey when PAPERCLIP_API_KEY is missing", () => {
+    const config = readConfigFromEnv({ PAPERCLIP_API_URL: "http://localhost:3100" });
+    expect(config.apiUrl).toBe("http://localhost:3100/api");
+    expect(config.apiKey).toBe("");
+    expect(config.companyId).toBeNull();
+    expect(config.agentId).toBeNull();
+    expect(config.runId).toBeNull();
+  });
+
+  it("returns config with apiKey when provided", () => {
+    const config = readConfigFromEnv({
+      PAPERCLIP_API_URL: "http://localhost:3100",
+      PAPERCLIP_API_KEY: "token-from-env",
+      PAPERCLIP_COMPANY_ID: "company-1",
+      PAPERCLIP_AGENT_ID: "agent-1",
+      PAPERCLIP_RUN_ID: "run-1",
+    });
+    expect(config.apiKey).toBe("token-from-env");
+    expect(config.companyId).toBe("company-1");
+    expect(config.agentId).toBe("agent-1");
+    expect(config.runId).toBe("run-1");
+  });
+
+  it("treats whitespace-only PAPERCLIP_API_KEY as missing", () => {
+    const config = readConfigFromEnv({
+      PAPERCLIP_API_URL: "http://localhost:3100",
+      PAPERCLIP_API_KEY: "   ",
+    });
+    expect(config.apiKey).toBe("");
+  });
+});
+
+describe("resolveApiKey", () => {
+  const baseConfig: PaperclipMcpConfig = {
+    apiUrl: "http://localhost:3100/api",
+    apiKey: "",
+    companyId: null,
+    agentId: null,
+    runId: null,
+  };
+
+  beforeEach(() => {
+    delete process.env.PAPERCLIP_API_KEY;
+  });
+
+  it("returns the config apiKey when set", () => {
+    expect(resolveApiKey({ ...baseConfig, apiKey: "from-config" })).toBe("from-config");
+  });
+
+  it("falls back to current process.env.PAPERCLIP_API_KEY when config apiKey is empty", () => {
+    process.env.PAPERCLIP_API_KEY = "from-env";
+    expect(resolveApiKey(baseConfig)).toBe("from-env");
+  });
+
+  it("re-reads env each call so later updates are visible", () => {
+    expect(() => resolveApiKey(baseConfig)).toThrow(/Missing PAPERCLIP_API_KEY/);
+    process.env.PAPERCLIP_API_KEY = "set-after-startup";
+    expect(resolveApiKey(baseConfig)).toBe("set-after-startup");
+  });
+
+  it("accepts an explicit env override for testing", () => {
+    expect(resolveApiKey(baseConfig, { PAPERCLIP_API_KEY: "explicit" })).toBe("explicit");
+  });
+
+  it("throws a clear error when neither config nor env has a key", () => {
+    expect(() => resolveApiKey(baseConfig, {})).toThrow(/Missing PAPERCLIP_API_KEY/);
+  });
+});

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -1,5 +1,10 @@
 export interface PaperclipMcpConfig {
   apiUrl: string;
+  // apiKey may be empty at construction. The MCP server allows startup
+  // without PAPERCLIP_API_KEY so that a Hermes gateway can spawn it at boot
+  // for tool-list discovery (`mcp/list`) before any run-scoped credentials
+  // exist. Tool calls that actually need the key surface a clear error at
+  // invocation time via `resolveApiKey`.
   apiKey: string;
   companyId: string | null;
   agentId: string | null;
@@ -24,10 +29,10 @@ export function readConfigFromEnv(env: NodeJS.ProcessEnv = process.env): Papercl
   if (!apiUrl) {
     throw new Error("Missing PAPERCLIP_API_URL");
   }
-  const apiKey = nonEmpty(env.PAPERCLIP_API_KEY);
-  if (!apiKey) {
-    throw new Error("Missing PAPERCLIP_API_KEY");
-  }
+  // PAPERCLIP_API_KEY is intentionally NOT required at startup.
+  // `resolveApiKey` re-checks `process.env.PAPERCLIP_API_KEY` on every request
+  // and throws a clear error if it is still missing when a tool is invoked.
+  const apiKey = nonEmpty(env.PAPERCLIP_API_KEY) ?? "";
 
   return {
     apiUrl: normalizeApiUrl(apiUrl),
@@ -36,4 +41,17 @@ export function readConfigFromEnv(env: NodeJS.ProcessEnv = process.env): Papercl
     agentId: nonEmpty(env.PAPERCLIP_AGENT_ID),
     runId: nonEmpty(env.PAPERCLIP_RUN_ID),
   };
+}
+
+export function resolveApiKey(
+  config: PaperclipMcpConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (config.apiKey) return config.apiKey;
+  const fresh = nonEmpty(env.PAPERCLIP_API_KEY);
+  if (fresh) return fresh;
+  throw new Error(
+    "Missing PAPERCLIP_API_KEY: not set at server startup and not present in process.env at request time. " +
+      "Provide it via the MCP server's startup env, or inject it before the first tool call.",
+  );
 }


### PR DESCRIPTION
## Summary

Defer the `PAPERCLIP_API_KEY` requirement in [`@paperclipai/mcp-server`](packages/mcp-server/) from server startup to first authenticated request, so the server can be spawned for tool-list discovery without a key.

## Motivation

Today [`readConfigFromEnv`](packages/mcp-server/src/config.ts#L22-L39) throws on startup when `PAPERCLIP_API_KEY` is missing:

```
Failed to start Paperclip MCP server: Error: Missing PAPERCLIP_API_KEY
```

That blocks Hermes gateway-mode integration without a static long-lived key. Hermes spawns the MCP server at gateway boot to discover the tool list (`mcp/list`) — which happens **before** any run-scoped credentials exist. The startup-time check trips and the spawn fails, even though the tool-discovery call itself does not need a key. Sibling PR [#6473](https://github.com/paperclipai/paperclip/pull/6473) ships a `registry.ts` change that has Paperclip recommend the MCP tools to Hermes-local agents; that path is currently gated on operators planting a long-lived bearer token in `~/.hermes/.env` to work around this startup check.

## What this PR does

Two small code changes + one new test file:

1. [`packages/mcp-server/src/config.ts`](packages/mcp-server/src/config.ts) — `readConfigFromEnv` no longer throws on missing key; stores `\"\"` instead. Adds a new exported `resolveApiKey(config, env?)` helper that:
   - Returns the config-time key if one was set
   - Otherwise re-reads `process.env.PAPERCLIP_API_KEY` at request time
   - Otherwise throws a clear `Missing PAPERCLIP_API_KEY` error explaining both injection paths
2. [`packages/mcp-server/src/client.ts`](packages/mcp-server/src/client.ts) — `PaperclipApiClient.requestJson` calls `resolveApiKey(this.config)` instead of reading `this.config.apiKey` directly. One-line change.
3. [`packages/mcp-server/src/config.test.ts`](packages/mcp-server/src/config.test.ts) — 12 new test cases covering `normalizeApiUrl`, `readConfigFromEnv` with/without keys, `resolveApiKey` precedence (config → env → throw), env override for testing, and re-read semantics across calls.

The re-read-env-on-each-request semantics also enables architectures where the key is injected per-run (e.g. via per-tool-call env updates from the spawning gateway) without restarting the MCP server.

## Backward compatibility

Strictly additive. Operators who set `PAPERCLIP_API_KEY` at startup see **no behavior change** — `resolveApiKey` returns the config-time value without touching `process.env`. The same `Authorization: Bearer …` header is emitted with the same value.

The one observable change is for operators who were relying on the startup-failure as a \"fail fast on missing config\" guard — that signal moves from startup to the first tool invocation, with the same error message. Tool-list discovery (`mcp/list`) no longer trips on this.

## Test plan

- [x] `pnpm --filter @paperclipai/mcp-server typecheck` clean
- [x] `pnpm --filter @paperclipai/mcp-server test` — 24 passed (12 new + 12 pre-existing)
- [ ] Manual: start the MCP server with `PAPERCLIP_API_URL` set but no `PAPERCLIP_API_KEY`; confirm `mcp/list` works and a tool call returns the structured Missing-API-KEY error
- [ ] Manual: register in `~/.hermes/config.yaml` `mcp_servers:` with no env-passed key; confirm Hermes gateway boots tool list cleanly without a static key in the env

## Notes

This was discovered today during multi-agent integration work between the Paperclip and Hermes Claude Code agents on SparkEros's setup. Hermes' `tools/mcp_tool.py` filters parent env to an 8-key allowlist (`PATH, HOME, USER, LANG, LC_ALL, TERM, SHELL, TMPDIR`) before spawning stdio MCP subprocesses — so the operator workaround is to plant `PAPERCLIP_API_KEY` in `~/.hermes/.env` and reference it as `\${PAPERCLIP_API_KEY}` in the `mcp_servers.paperclip.env` block. That works, but requires a long-lived bearer token sitting on disk in plaintext. This PR removes the requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)