### PR TITLE
feat(mcp-server): add per-call runId override on write tools

### DIFF
--- a/packages/mcp-server/src/client.ts
+++ b/packages/mcp-server/src/client.ts
@@ -25,6 +25,11 @@ export class PaperclipApiError extends Error {
 export interface JsonRequestOptions {
   body?: unknown;
   includeRunId?: boolean;
+  // Per-call override for X-Paperclip-Run-Id. When set, takes precedence over
+  // the config-level runId (which is fixed at server startup). Lets long-lived
+  // MCP servers attribute writes to the caller's current run id even though
+  // PAPERCLIP_RUN_ID env vars are not re-injected per request.
+  runIdOverride?: string | null;
 }
 
 function isWriteMethod(method: string): boolean {
@@ -88,8 +93,14 @@ export class PaperclipApiClient {
     if (options.body !== undefined) {
       headers["Content-Type"] = "application/json";
     }
-    if ((options.includeRunId ?? isWriteMethod(method)) && this.config.runId) {
-      headers["X-Paperclip-Run-Id"] = this.config.runId;
+    if (options.includeRunId ?? isWriteMethod(method)) {
+      const effectiveRunId =
+        (typeof options.runIdOverride === "string" && options.runIdOverride.trim().length > 0
+          ? options.runIdOverride.trim()
+          : null) ?? this.config.runId;
+      if (effectiveRunId) {
+        headers["X-Paperclip-Run-Id"] = effectiveRunId;
+      }
     }
 
     const response = await fetch(url, {

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -52,6 +52,39 @@ describe("paperclip MCP tools", () => {
     );
   });
 
+  it("prefers per-call runId override over config runId on mutating requests", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockJsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipAddComment");
+    await tool.execute({
+      issueId: "PAP-1135",
+      body: "hello from MCP",
+      runId: "44444444-4444-4444-4444-444444444444",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["X-Paperclip-Run-Id"]).toBe(
+      "44444444-4444-4444-4444-444444444444",
+    );
+  });
+
+  it("falls back to config runId when the per-call runId is omitted", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockJsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tool = getTool("paperclipAddComment");
+    await tool.execute({
+      issueId: "PAP-1135",
+      body: "hello from MCP",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["X-Paperclip-Run-Id"]).toBe(
+      "33333333-3333-3333-3333-333333333333",
+    );
+  });
+
   it("uses default company id for company-scoped list tools", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       mockJsonResponse([{ id: "issue-1" }]),

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -58,6 +58,18 @@ const goalIdSchema = z.string().uuid();
 const approvalIdSchema = z.string().uuid();
 const documentKeySchema = z.string().trim().min(1).max(64);
 
+// Per-call X-Paperclip-Run-Id override. Merged into every write tool schema
+// so callers (typically agent prompts) can attach the current dispatched
+// run id without relying on PAPERCLIP_RUN_ID at MCP-server startup. A
+// long-lived MCP server cannot pick up a per-run env var; this lets the
+// caller pass it explicitly per request. Optional — falls back to
+// PAPERCLIP_RUN_ID env when omitted.
+const writeRunIdOverrideShape = {
+  runId: z.string().uuid().nullable().optional()
+    .describe("Override X-Paperclip-Run-Id for this call. Set to the agent's current dispatched run id (e.g. $PAPERCLIP_RUN_ID)."),
+} as const;
+const writeRunIdOverrideSchema = z.object(writeRunIdOverrideShape);
+
 const listIssuesSchema = z.object({
   companyId: companyIdOptional,
   status: z.string().optional(),
@@ -91,25 +103,27 @@ const upsertDocumentToolSchema = z.object({
   body: z.string().max(524288),
   changeSummary: z.string().trim().max(500).nullable().optional(),
   baseRevisionId: z.string().uuid().nullable().optional(),
+  ...writeRunIdOverrideShape,
 });
 
 const createIssueToolSchema = z.object({
   companyId: companyIdOptional,
-}).merge(createIssueInputSchema);
+}).merge(createIssueInputSchema).merge(writeRunIdOverrideSchema);
 
 const updateIssueToolSchema = z.object({
   issueId: issueIdSchema,
-}).merge(updateIssueSchema);
+}).merge(updateIssueSchema).merge(writeRunIdOverrideSchema);
 
 const checkoutIssueToolSchema = z.object({
   issueId: issueIdSchema,
   agentId: agentIdOptional,
   expectedStatuses: checkoutIssueSchema.shape.expectedStatuses.optional(),
+  ...writeRunIdOverrideShape,
 });
 
 const addCommentToolSchema = z.object({
   issueId: issueIdSchema,
-}).merge(addIssueCommentSchema);
+}).merge(addIssueCommentSchema).merge(writeRunIdOverrideSchema);
 
 const createSuggestTasksToolSchema = z.object({
   issueId: issueIdSchema,
@@ -120,6 +134,7 @@ const createSuggestTasksToolSchema = z.object({
   summary: z.string().trim().max(1000).nullable().optional(),
   continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("wake_assignee"),
   payload: suggestTasksPayloadSchema,
+  ...writeRunIdOverrideShape,
 });
 
 const createAskUserQuestionsToolSchema = z.object({
@@ -131,6 +146,7 @@ const createAskUserQuestionsToolSchema = z.object({
   summary: z.string().trim().max(1000).nullable().optional(),
   continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("wake_assignee"),
   payload: askUserQuestionsPayloadSchema,
+  ...writeRunIdOverrideShape,
 });
 
 const createRequestConfirmationToolSchema = z.object({
@@ -142,6 +158,7 @@ const createRequestConfirmationToolSchema = z.object({
   summary: z.string().trim().max(1000).nullable().optional(),
   continuationPolicy: issueThreadInteractionContinuationPolicySchema.optional().default("none"),
   payload: requestConfirmationPayloadSchema,
+  ...writeRunIdOverrideShape,
 });
 
 const approvalDecisionSchema = z.object({
@@ -149,16 +166,18 @@ const approvalDecisionSchema = z.object({
   action: z.enum(["approve", "reject", "requestRevision", "resubmit"]),
   decisionNote: z.string().optional(),
   payloadJson: z.string().optional(),
+  ...writeRunIdOverrideShape,
 });
 
 const createApprovalToolSchema = z.object({
   companyId: companyIdOptional,
-}).merge(createApprovalSchema);
+}).merge(createApprovalSchema).merge(writeRunIdOverrideSchema);
 
 const apiRequestSchema = z.object({
   method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]),
   path: z.string().min(1),
   jsonBody: z.string().optional(),
+  ...writeRunIdOverrideShape,
 });
 
 const workspaceRuntimeControlTargetSchema = z.object({
@@ -170,7 +189,7 @@ const workspaceRuntimeControlTargetSchema = z.object({
 const issueWorkspaceRuntimeControlSchema = z.object({
   issueId: issueIdSchema,
   action: z.enum(["start", "stop", "restart"]),
-}).merge(workspaceRuntimeControlTargetSchema);
+}).merge(workspaceRuntimeControlTargetSchema).merge(writeRunIdOverrideSchema);
 
 const waitForIssueWorkspaceServiceSchema = z.object({
   issueId: issueIdSchema,
@@ -354,7 +373,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
       "paperclipControlIssueWorkspaceServices",
       "Start, stop, or restart the current issue execution workspace runtime services",
       issueWorkspaceRuntimeControlSchema,
-      async ({ issueId, action, ...target }) => {
+      async ({ issueId, action, runId, ...target }) => {
         const runtime = await getIssueWorkspaceRuntime(client, issueId);
         const workspaceId = typeof runtime.workspace?.id === "string" ? runtime.workspace.id : null;
         if (!workspaceId) {
@@ -363,7 +382,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
         return client.requestJson(
           "POST",
           `/execution-workspaces/${encodeURIComponent(workspaceId)}/runtime-services/${action}`,
-          { body: target },
+          { body: target, runIdOverride: runId },
         );
       },
     ),
@@ -418,9 +437,10 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
       "paperclipCreateApproval",
       "Create a board approval request, optionally linked to one or more issues",
       createApprovalToolSchema,
-      async ({ companyId, ...body }) =>
+      async ({ companyId, runId, ...body }) =>
         client.requestJson("POST", `/companies/${client.resolveCompanyId(companyId)}/approvals`, {
           body,
+          runIdOverride: runId,
         }),
     ),
     makeTool(
@@ -445,86 +465,103 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
       "paperclipCreateIssue",
       "Create a new issue",
       createIssueToolSchema,
-      async ({ companyId, ...body }) =>
-        client.requestJson("POST", `/companies/${client.resolveCompanyId(companyId)}/issues`, { body }),
+      async ({ companyId, runId, ...body }) =>
+        client.requestJson("POST", `/companies/${client.resolveCompanyId(companyId)}/issues`, {
+          body,
+          runIdOverride: runId,
+        }),
     ),
     makeTool(
       "paperclipUpdateIssue",
       "Patch an issue, optionally including a comment; include resume=true when intentionally requesting follow-up on resumable closed work",
       updateIssueToolSchema,
-      async ({ issueId, ...body }) =>
-        client.requestJson("PATCH", `/issues/${encodeURIComponent(issueId)}`, { body }),
+      async ({ issueId, runId, ...body }) =>
+        client.requestJson("PATCH", `/issues/${encodeURIComponent(issueId)}`, {
+          body,
+          runIdOverride: runId,
+        }),
     ),
     makeTool(
       "paperclipCheckoutIssue",
       "Checkout an issue for an agent",
       checkoutIssueToolSchema,
-      async ({ issueId, agentId, expectedStatuses }) =>
+      async ({ issueId, agentId, expectedStatuses, runId }) =>
         client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/checkout`, {
           body: {
             agentId: client.resolveAgentId(agentId),
             expectedStatuses: expectedStatuses ?? ["todo", "backlog", "blocked"],
           },
+          runIdOverride: runId,
         }),
     ),
     makeTool(
       "paperclipReleaseIssue",
       "Release an issue checkout",
-      z.object({ issueId: issueIdSchema }),
-      async ({ issueId }) => client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/release`, { body: {} }),
+      z.object({ issueId: issueIdSchema, ...writeRunIdOverrideShape }),
+      async ({ issueId, runId }) =>
+        client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/release`, {
+          body: {},
+          runIdOverride: runId,
+        }),
     ),
     makeTool(
       "paperclipAddComment",
       "Add a comment to an issue; include resume=true when intentionally requesting follow-up on resumable closed work",
       addCommentToolSchema,
-      async ({ issueId, ...body }) =>
-        client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/comments`, { body }),
+      async ({ issueId, runId, ...body }) =>
+        client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/comments`, {
+          body,
+          runIdOverride: runId,
+        }),
     ),
     makeTool(
       "paperclipSuggestTasks",
       "Create a suggest_tasks interaction on an issue",
       createSuggestTasksToolSchema,
-      async ({ issueId, ...body }) =>
+      async ({ issueId, runId, ...body }) =>
         client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/interactions`, {
           body: {
             kind: "suggest_tasks",
             ...body,
           },
+          runIdOverride: runId,
         }),
     ),
     makeTool(
       "paperclipAskUserQuestions",
       "Create an ask_user_questions interaction on an issue",
       createAskUserQuestionsToolSchema,
-      async ({ issueId, ...body }) =>
+      async ({ issueId, runId, ...body }) =>
         client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/interactions`, {
           body: {
             kind: "ask_user_questions",
             ...body,
           },
+          runIdOverride: runId,
         }),
     ),
     makeTool(
       "paperclipRequestConfirmation",
       "Create a request_confirmation interaction on an issue",
       createRequestConfirmationToolSchema,
-      async ({ issueId, ...body }) =>
+      async ({ issueId, runId, ...body }) =>
         client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/interactions`, {
           body: {
             kind: "request_confirmation",
             ...body,
           },
+          runIdOverride: runId,
         }),
     ),
     makeTool(
       "paperclipUpsertIssueDocument",
       "Create or update an issue document",
       upsertDocumentToolSchema,
-      async ({ issueId, key, ...body }) =>
+      async ({ issueId, key, runId, ...body }) =>
         client.requestJson(
           "PUT",
           `/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}`,
-          { body },
+          { body, runIdOverride: runId },
         ),
     ),
     makeTool(
@@ -534,38 +571,41 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
         issueId: issueIdSchema,
         key: documentKeySchema,
         revisionId: z.string().uuid(),
+        ...writeRunIdOverrideShape,
       }),
-      async ({ issueId, key, revisionId }) =>
+      async ({ issueId, key, revisionId, runId }) =>
         client.requestJson(
           "POST",
           `/issues/${encodeURIComponent(issueId)}/documents/${encodeURIComponent(key)}/revisions/${encodeURIComponent(revisionId)}/restore`,
-          { body: {} },
+          { body: {}, runIdOverride: runId },
         ),
     ),
     makeTool(
       "paperclipLinkIssueApproval",
       "Link an approval to an issue",
-      z.object({ issueId: issueIdSchema }).merge(linkIssueApprovalSchema),
-      async ({ issueId, approvalId }) =>
+      z.object({ issueId: issueIdSchema, ...writeRunIdOverrideShape }).merge(linkIssueApprovalSchema),
+      async ({ issueId, approvalId, runId }) =>
         client.requestJson("POST", `/issues/${encodeURIComponent(issueId)}/approvals`, {
           body: { approvalId },
+          runIdOverride: runId,
         }),
     ),
     makeTool(
       "paperclipUnlinkIssueApproval",
       "Unlink an approval from an issue",
-      z.object({ issueId: issueIdSchema, approvalId: approvalIdSchema }),
-      async ({ issueId, approvalId }) =>
+      z.object({ issueId: issueIdSchema, approvalId: approvalIdSchema, ...writeRunIdOverrideShape }),
+      async ({ issueId, approvalId, runId }) =>
         client.requestJson(
           "DELETE",
           `/issues/${encodeURIComponent(issueId)}/approvals/${encodeURIComponent(approvalId)}`,
+          { runIdOverride: runId, includeRunId: true },
         ),
     ),
     makeTool(
       "paperclipApprovalDecision",
       "Approve, reject, request revision, or resubmit an approval",
       approvalDecisionSchema,
-      async ({ approvalId, action, decisionNote, payloadJson }) => {
+      async ({ approvalId, action, decisionNote, payloadJson, runId }) => {
         const path =
           action === "approve"
             ? `/approvals/${encodeURIComponent(approvalId)}/approve`
@@ -580,28 +620,30 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
             ? { payload: parseOptionalJson(payloadJson) ?? {} }
             : { decisionNote };
 
-        return client.requestJson("POST", path, { body });
+        return client.requestJson("POST", path, { body, runIdOverride: runId });
       },
     ),
     makeTool(
       "paperclipAddApprovalComment",
       "Add a comment to an approval",
-      z.object({ approvalId: approvalIdSchema, body: z.string().min(1) }),
-      async ({ approvalId, body }) =>
+      z.object({ approvalId: approvalIdSchema, body: z.string().min(1), ...writeRunIdOverrideShape }),
+      async ({ approvalId, body, runId }) =>
         client.requestJson("POST", `/approvals/${encodeURIComponent(approvalId)}/comments`, {
           body: { body },
+          runIdOverride: runId,
         }),
     ),
     makeTool(
       "paperclipApiRequest",
       "Make a JSON request to an existing Paperclip /api endpoint for unsupported operations",
       apiRequestSchema,
-      async ({ method, path, jsonBody }) => {
+      async ({ method, path, jsonBody, runId }) => {
         if (!path.startsWith("/") || path.includes("..")) {
           throw new Error("path must start with / and be relative to /api, and must not contain '..'");
         }
         return client.requestJson(method, path, {
           body: parseOptionalJson(jsonBody),
+          runIdOverride: runId,
         });
       },
     ),


### PR DESCRIPTION
## Summary

Add an optional \`runId\` field to every [`@paperclipai/mcp-server`](packages/mcp-server/) write tool's input schema so the caller can attach the current dispatched run id per request, instead of relying on the startup-time \`PAPERCLIP_RUN_ID\` env var. Required for long-lived MCP servers that serve many runs (e.g. Hermes gateway-mode \`lazy_load: true\`), where the env-var path is structurally incompatible with per-run id rotation.

## Motivation

`PAPERCLIP_RUN_ID` changes per agent dispatch. A long-lived MCP server process freezes its env at spawn time and cannot pick up per-run env updates. That makes the existing [`config.runId`](packages/mcp-server/src/config.ts#L6) path (read once from `PAPERCLIP_RUN_ID` at startup) unusable in gateway-mode integrations.

Observed today during multi-agent integration on SparkEros: with the MCP server registered in `~/.hermes/config.yaml` via `lazy_load: true` and a static `PAPERCLIP_API_KEY` planted in `~/.hermes/.env`, write tools return `401 \"Agent run id required\"` because the X-Paperclip-Run-Id header is either absent (no startup runId) or stale (frozen to whichever run was active when the MCP server first spawned). Agents fall back to `curl -H \"X-Paperclip-Run-Id: \$PAPERCLIP_RUN_ID\"` — which works because each `hermes chat` invocation IS per-run — but that defeats the purpose of registering the MCP server, since the curl path still requires `terminal` toolset and triggers `tools/approval.py`.

Sibling PRs in this stack:
- [#6473](https://github.com/paperclipai/paperclip/pull/6473) — registry.ts authGuardPrompt recommends MCP tools over curl-bearer
- [#6474](https://github.com/paperclipai/paperclip/pull/6474) — lazy PAPERCLIP_API_KEY check (defer to first request)
- This PR — per-call runId override for write tools

Together they make the MCP path viable for security-hardened Hermes (`HERMES_YOLO_MODE` unset, `tirith_enabled: true`).

## What this PR does

**`packages/mcp-server/src/client.ts`** — extends [`JsonRequestOptions`](packages/mcp-server/src/client.ts#L25-L28) with `runIdOverride?: string | null`. When set, `requestJson` sends `X-Paperclip-Run-Id` with that value, taking precedence over `config.runId`. When unset, behavior is unchanged.

**`packages/mcp-server/src/tools.ts`** — adds a shared `writeRunIdOverrideShape` mixin and merges it into every write tool's schema:

| Tool | Method |
|---|---|
| paperclipCreateIssue, paperclipUpdateIssue, paperclipCheckoutIssue, paperclipReleaseIssue | POST/PATCH |
| paperclipAddComment, paperclipSuggestTasks, paperclipAskUserQuestions, paperclipRequestConfirmation | POST |
| paperclipUpsertIssueDocument, paperclipRestoreIssueDocumentRevision | PUT/POST |
| paperclipLinkIssueApproval, paperclipUnlinkIssueApproval | POST/DELETE |
| paperclipCreateApproval, paperclipApprovalDecision, paperclipAddApprovalComment | POST |
| paperclipControlIssueWorkspaceServices | POST |
| paperclipApiRequest | any |

Each tool's execute function destructures `runId` and passes it as `runIdOverride` to `requestJson`. Read tools are untouched.

The schema field is described as: \`\"Override X-Paperclip-Run-Id for this call. Set to the agent's current dispatched run id (e.g. \$PAPERCLIP_RUN_ID).\"\` — visible to agents in their tool-list, so they know to populate it.

## Backward compatibility

Strictly additive.

- Callers that omit `runId`: same behavior as before (uses `config.runId` from `PAPERCLIP_RUN_ID` env if set; no header if not)
- Callers that set `PAPERCLIP_RUN_ID` at startup: same behavior as before
- The per-call override only kicks in when explicitly passed

No schema breakage — `runId` is optional/nullable.

## Test plan

- [x] `pnpm --filter @paperclipai/mcp-server typecheck` clean
- [x] `pnpm --filter @paperclipai/mcp-server test` — 14 passed (12 existing + 2 new)
- [x] New test 1: \"prefers per-call runId override over config runId on mutating requests\"
- [x] New test 2: \"falls back to config runId when the per-call runId is omitted\"
- [ ] Manual end-to-end: dispatch a Hermes-local agent task with `mcp_servers: paperclip:` registered, no static `PAPERCLIP_RUN_ID` in MCP env block; verify the agent's `paperclipAddComment` call with `runId: \$PAPERCLIP_RUN_ID` succeeds (no 401) and the comment is attributed to the correct run

## Discovery context

Found during multi-agent integration session between Paperclip CC Agent and Hermes CC Agent on SparkEros today (2026-05-20). The previous attempt at security re-enable hit the 401 write-path failure described above; this PR is the third in the three-PR stack to make the MCP path the operative path. After all three land, `HERMES_YOLO_MODE=1` + `security.tirith_enabled: false` can be lifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)