### PR TITLE
fix(openclaw-gateway): bump PROTOCOL_VERSION to 4 and strip agentParams.paperclip

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -86,7 +86,7 @@ type GatewayClientRequestOptions = {
   expectFinal?: boolean;
 };
 
-const PROTOCOL_VERSION = 3;
+const PROTOCOL_VERSION = 4;
 const DEFAULT_SCOPES = ["operator.admin"];
 const DEFAULT_CLIENT_ID = "gateway-client";
 const DEFAULT_CLIENT_MODE = "backend";
@@ -1139,7 +1139,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     idempotencyKey: ctx.runId,
   };
   delete agentParams.text;
-  agentParams.paperclip = paperclipPayload;
+  delete agentParams.paperclip;
 
   const configuredAgentId = nonEmpty(ctx.config.agentId);
   if (configuredAgentId && !nonEmpty(agentParams.agentId)) {


### PR DESCRIPTION
## Summary

- Bumps `PROTOCOL_VERSION` from `3` to `4` — required by openclaw `2026.5.19`
- Replaces `agentParams.paperclip = paperclipPayload` with `delete agentParams.paperclip` — the gateway rejects requests containing unknown properties per its JSON Schema

## Background

Both of these were applied as emergency hotfixes directly to the installed dist bundle at `/opt/homebrew/lib/node_modules/paperclipai/node_modules/@paperclipai/adapter-openclaw-gateway/dist/server/execute.js`. Without this source fix, any `npm update paperclipai` would silently overwrite the hotfixes and break all openclaw-gateway agents again.

## Test plan

- [ ] `pnpm build` passes in `packages/adapters/openclaw-gateway`
- [ ] Agent connected via openclaw_gateway adapter can execute a routine without `openclaw_gateway_request_failed` or protocol mismatch error
- [ ] No unknown-property schema rejection in openclaw gateway logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)