### PR TITLE
fix(shared): add originFingerprint to createIssueBaseSchema

### DIFF
--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -390,6 +390,7 @@ const createIssueBaseSchema = z.object({
   executionWorkspacePreference: z.enum(ISSUE_EXECUTION_WORKSPACE_PREFERENCES).optional().nullable(),
   executionWorkspaceSettings: issueExecutionWorkspaceSettingsSchema.optional().nullable(),
   labelIds: z.array(z.string().uuid()).optional(),
+  originFingerprint: z.string().min(1).optional(),
 });
 
 export const createIssueInputSchema = createIssueBaseSchema.extend({


### PR DESCRIPTION
## Problem

`originFingerprint` is a field that is stored on issues at creation time, but it was missing from `createIssueBaseSchema` in `packages/shared/src/validators/issue.ts`. This caused validation errors when `originFingerprint` was passed in create-issue requests (e.g. from internal tooling that sets dedup fingerprints on programmatically-created issues).

## Change

Add `originFingerprint: z.string().min(1).optional()` to `createIssueBaseSchema`.

This mirrors the field already present on the issue model and makes it passable through the create-issue validation layer without being stripped or rejected.

## Testing

- The field is `optional()` so existing callers are unaffected.
- Callers that pass `originFingerprint` in a create-issue payload will no longer receive a validation error for an unknown field.