### PR TITLE
[codex] Fix CPP sweep escalation constraints

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -379,6 +379,26 @@ type PaperclipWakeTreeHoldSummary = {
   reason: string | null;
 };
 
+type PaperclipWakeCppBoardEscalationContext = {
+  bindingContexts: Array<{
+    source: string | null;
+    constraints: string | null;
+    reviewGate: string | null;
+  }>;
+  latestOverride: {
+    commentId: string | null;
+    issueId: string | null;
+    author: string | null;
+    optionId: string | null;
+    bodyExcerpt: string | null;
+    createdAt: string | null;
+  } | null;
+  bannedOptions: Array<{
+    optionId: string | null;
+    reason: string | null;
+  }>;
+};
+
 type PaperclipWakePayload = {
   reason: string | null;
   issue: PaperclipWakeIssue | null;
@@ -391,6 +411,7 @@ type PaperclipWakePayload = {
   executionStage: PaperclipWakeExecutionStage | null;
   continuationSummary: PaperclipWakeContinuationSummary | null;
   livenessContinuation: PaperclipWakeLivenessContinuation | null;
+  cppBoardEscalationContext: PaperclipWakeCppBoardEscalationContext | null;
   interactionKind: string | null;
   interactionStatus: string | null;
   childIssueSummaries: PaperclipWakeChildIssueSummary[];
@@ -505,6 +526,47 @@ function normalizePaperclipWakeTreeHoldSummary(value: unknown): PaperclipWakeTre
   return { holdId, rootIssueId, mode, reason };
 }
 
+function normalizePaperclipWakeCppBoardEscalationContext(value: unknown): PaperclipWakeCppBoardEscalationContext | null {
+  const context = parseObject(value);
+  const bindingContexts = Array.isArray(context.bindingContexts)
+    ? context.bindingContexts
+        .map((entry) => {
+          const binding = parseObject(entry);
+          const source = asString(binding.source, "").trim() || null;
+          const constraints = asString(binding.constraints, "").trim() || null;
+          const reviewGate = asString(binding.reviewGate, "").trim() || null;
+          if (!source && !constraints && !reviewGate) return null;
+          return { source, constraints, reviewGate };
+        })
+        .filter((entry): entry is { source: string | null; constraints: string | null; reviewGate: string | null } => Boolean(entry))
+    : [];
+  const overrideRaw = parseObject(context.latestOverride);
+  const bodyExcerpt = asString(overrideRaw.bodyExcerpt, "").trim() || null;
+  const latestOverride = bodyExcerpt
+    ? {
+        commentId: asString(overrideRaw.commentId, "").trim() || null,
+        issueId: asString(overrideRaw.issueId, "").trim() || null,
+        author: asString(overrideRaw.author, "").trim() || null,
+        optionId: asString(overrideRaw.optionId, "").trim() || null,
+        bodyExcerpt,
+        createdAt: asString(overrideRaw.createdAt, "").trim() || null,
+      }
+    : null;
+  const bannedOptions = Array.isArray(context.bannedOptions)
+    ? context.bannedOptions
+        .map((entry) => {
+          const option = parseObject(entry);
+          const optionId = asString(option.optionId, "").trim() || null;
+          const reason = asString(option.reason, "").trim() || null;
+          if (!optionId && !reason) return null;
+          return { optionId, reason };
+        })
+        .filter((entry): entry is { optionId: string | null; reason: string | null } => Boolean(entry))
+    : [];
+  if (bindingContexts.length === 0 && !latestOverride && bannedOptions.length === 0) return null;
+  return { bindingContexts, latestOverride, bannedOptions };
+}
+
 function normalizePaperclipWakeExecutionPrincipal(value: unknown): PaperclipWakeExecutionPrincipal | null {
   const principal = parseObject(value);
   const typeRaw = asString(principal.type, "").trim().toLowerCase();
@@ -569,6 +631,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
   const executionStage = normalizePaperclipWakeExecutionStage(payload.executionStage);
   const continuationSummary = normalizePaperclipWakeContinuationSummary(payload.continuationSummary);
   const livenessContinuation = normalizePaperclipWakeLivenessContinuation(payload.livenessContinuation);
+  const cppBoardEscalationContext = normalizePaperclipWakeCppBoardEscalationContext(payload.cppBoardEscalationContext);
   const childIssueSummaries = Array.isArray(payload.childIssueSummaries)
     ? payload.childIssueSummaries
         .map((entry) => normalizePaperclipWakeChildIssueSummary(entry))
@@ -586,7 +649,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     : [];
 
   const activeTreeHold = normalizePaperclipWakeTreeHoldSummary(payload.activeTreeHold);
-  if (comments.length === 0 && commentIds.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !livenessContinuation && !normalizePaperclipWakeIssue(payload.issue)) {
+  if (comments.length === 0 && commentIds.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !livenessContinuation && !cppBoardEscalationContext && !normalizePaperclipWakeIssue(payload.issue)) {
     return null;
   }
 
@@ -602,6 +665,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     executionStage,
     continuationSummary,
     livenessContinuation,
+    cppBoardEscalationContext,
     interactionKind: asString(payload.interactionKind, "").trim() || null,
     interactionStatus: asString(payload.interactionStatus, "").trim() || null,
     childIssueSummaries,
@@ -730,6 +794,38 @@ export function renderPaperclipWakePrompt(
     if (normalized.activeTreeHold) {
       const hold = normalized.activeTreeHold;
       lines.push(`- active tree hold: ${hold.holdId ?? "unknown"}${hold.rootIssueId ? ` rooted at ${hold.rootIssueId}` : ""}${hold.mode ? ` (${hold.mode})` : ""}`);
+    }
+  }
+  if (normalized.cppBoardEscalationContext) {
+    const context = normalized.cppBoardEscalationContext;
+    lines.push(
+      "",
+      "CPP board-answer sweep context:",
+      "- Treat binding parent/blocker Constraints / Risks and Review Gate text as current input before recommending an answer.",
+      "- Latest Nox/Cameron/local-board override comments supersede autonomous sweep recommendations unless a newer explicit board/user decision changes the state.",
+      "- If the same `403 Board access required` recommendation was already posted for the same interaction and option, do not post another escalation comment.",
+    );
+    if (context.bindingContexts.length > 0) {
+      lines.push("Binding issue text:");
+      for (const binding of context.bindingContexts) {
+        lines.push(`- ${binding.source ?? "unknown issue"}`);
+        if (binding.constraints) lines.push(`  Constraints / Risks: ${binding.constraints}`);
+        if (binding.reviewGate) lines.push(`  Review Gate: ${binding.reviewGate}`);
+      }
+    }
+    if (context.latestOverride) {
+      const override = context.latestOverride;
+      lines.push(
+        "Latest override comment:",
+        `- ${override.createdAt ?? "unknown time"} ${override.author ?? "unknown author"}${override.optionId ? ` option \`${override.optionId}\`` : ""}${override.commentId ? ` comment ${override.commentId}` : ""}`,
+        `  ${override.bodyExcerpt ?? ""}`,
+      );
+    }
+    if (context.bannedOptions.length > 0) {
+      lines.push("Banned/deprioritized options from binding context:");
+      for (const option of context.bannedOptions) {
+        lines.push(`- ${option.optionId ?? "unknown option"}: ${option.reason ?? "blocked by binding context"}`);
+      }
     }
   }
   if (normalized.missingCount > 0) {

--- a/releases/v2026.515.0.md
+++ b/releases/v2026.515.0.md
@@ -1,0 +1,11 @@
+# v2026.515.0
+
+> Released: 2026-05-15
+
+## Fixes
+
+- **Local agent Paperclip API callbacks** — `codex_local` and other loopback-bound local agent runs now prefer the loopback Paperclip API URL over configured private-network hostnames when injecting runtime callback URLs. Private-network and Tailscale routes remain available for remote-capable binds, avoiding local heartbeat failures where agents received a Tailscale URL that refused connections from the local runtime.
+
+## Upgrade Guide
+
+No database migrations or configuration changes are required.

--- a/server/src/__tests__/cpp-board-escalation.test.ts
+++ b/server/src/__tests__/cpp-board-escalation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCppBoardEscalationContext,
+  extractBoardAccessRecommendationFingerprint,
+  findLatestOverrideComment,
+  optionViolatesBindingConstraints,
+  shouldSuppressDuplicateBoardAccessRecommendation,
+} from "../services/cpp-board-escalation.js";
+
+describe("CPP board escalation sweep context", () => {
+  it("detects latest non-sweep Nox/Cameron override comments before autonomous recommendations", () => {
+    const override = findLatestOverrideComment([
+      {
+        id: "sweep-comment",
+        issueId: "nox-785",
+        authorAgentId: "nox-clone",
+        createdAt: "2026-05-21T08:27:02.418Z",
+        body: "Autonomous interaction decision for NOX-785: choose `clerk_replacement`. API returned `403 Board access required`.",
+      },
+      {
+        id: "nox-override",
+        issueId: "nox-785",
+        authorAgentId: "nox",
+        createdAt: "2026-05-21T08:12:27.268Z",
+        body: "**Override - Nox board recommendation stands at `accept_attempted_e2e`.** The hourly sweep flipped to `clerk_replacement`, but do not dispatch Clerk replacement.",
+      },
+    ]);
+
+    expect(override?.commentId).toBe("nox-override");
+    expect(override?.optionId).toBe("accept_attempted_e2e");
+    expect(override?.bodyExcerpt).toContain("Nox board recommendation stands");
+  });
+
+  it("treats parent Constraints / Risks and Review Gate as binding and rejects new Clerk e2e scope", () => {
+    const context = buildCppBoardEscalationContext({
+      issues: [
+        {
+          id: "nox-3992",
+          identifier: "NOX-3992",
+          title: "ESCALATION: board-answer NOX-785 e2e proof path",
+          description: [
+            "**Constraints / Risks:**",
+            "No Cameron DM dispatch. Do not dispatch a new Clerk e2e feature from this escalation unless Cameron explicitly accepts that scope.",
+            "",
+            "**Review Gate:**",
+            "Nox must review any board-answer change before closure.",
+          ].join("\n"),
+        },
+      ],
+      comments: [],
+    });
+
+    expect(context?.bindingContexts[0]?.source).toBe("NOX-3992");
+    expect(context?.bindingContexts[0]?.constraints).toContain("Do not dispatch a new Clerk e2e feature");
+    expect(context?.bannedOptions).toEqual([
+      {
+        optionId: "clerk_replacement",
+        reason: "clerk_replacement maps onto banned new Clerk e2e/replacement scope in NOX-3992",
+      },
+    ]);
+
+    expect(optionViolatesBindingConstraints({
+      optionId: "accept_attempted_e2e",
+      optionDescription: "Accept the attempted historical e2e proof and close the board gate",
+      bindingContexts: context?.bindingContexts ?? [],
+    }).rejected).toBe(false);
+  });
+
+  it("fingerprints and suppresses unchanged duplicate Board access escalation recommendations", () => {
+    const body = [
+      "ESCALATION: NOX-785 board-answer blocker.",
+      "The API returned `403 Board access required`.",
+      "Decision required: resolve interaction f20b5a0f-7edc-402b-ba69-ff007928e01e with option `accept_attempted_e2e`.",
+    ].join("\n");
+
+    expect(extractBoardAccessRecommendationFingerprint(body)).toEqual({
+      interactionId: "f20b5a0f-7edc-402b-ba69-ff007928e01e",
+      optionId: "accept_attempted_e2e",
+    });
+
+    expect(shouldSuppressDuplicateBoardAccessRecommendation(body, [
+      {
+        id: "previous-same-state",
+        issueId: "nox-3992",
+        createdAt: "2026-05-21T08:42:59.538Z",
+        body,
+      },
+    ])).toBe(true);
+
+    expect(shouldSuppressDuplicateBoardAccessRecommendation(body, [
+      {
+        id: "previous-different-state",
+        issueId: "nox-3992",
+        createdAt: "2026-05-21T08:42:59.538Z",
+        body: body.replace("accept_attempted_e2e", "clerk_replacement"),
+      },
+    ])).toBe(false);
+  });
+});

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -22,6 +22,7 @@ import {
   issueDocuments,
   issueRecoveryActions,
   issueRelations,
+  issueThreadInteractions,
   issueTreeHoldMembers,
   issueTreeHolds,
   issueWorkProducts,
@@ -79,6 +80,7 @@ import {
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
+  recoveryService,
 } from "../services/recovery/index.ts";
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -328,6 +330,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(issueDocuments);
     await db.delete(documentRevisions);
     await db.delete(documents);
+    await db.delete(issueThreadInteractions);
     await db.delete(issueRelations);
     await db.delete(issueRecoveryActions);
     await db.delete(issueTreeHoldMembers);
@@ -523,6 +526,187 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     return { environmentId, leaseId };
   }
+
+  it("routes stale operator-owned issue interactions to the board surface without agent wakeups", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const interactionId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "DevOps",
+      role: "devops",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs operator answer",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: "PC-1",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "ask_user_questions",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      createdByAgentId: agentId,
+      payload: { version: 1, questions: [] },
+      updatedAt: new Date("2026-05-15T20:00:00.000Z"),
+    });
+
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    const result = await recovery.reconcileStalledIssueThreadInteractions({
+      now: new Date("2026-05-15T20:11:00.000Z"),
+      thresholdMs: 10 * 60 * 1000,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      operatorRouted: 1,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    await expect(db.select().from(agentWakeupRequests)).resolves.toHaveLength(0);
+    const events = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
+    expect(events).toEqual([
+      expect.objectContaining({
+        actorType: "system",
+        action: "issue.thread_interaction_operator_waiting",
+        details: expect.objectContaining({
+          interactionId,
+          resolver: "operator_board",
+        }),
+      }),
+    ]);
+  });
+
+  it("wakes stale agent-owned issue interactions through the system recovery actor", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const interactionId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs agent follow-up",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: "PC-1",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "suggest_tasks",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      createdByAgentId: agentId,
+      payload: { version: 1, tasks: [] },
+      updatedAt: new Date("2026-05-15T20:00:00.000Z"),
+    });
+
+    const wakeupId = randomUUID();
+    const enqueueWakeup = vi.fn(async (targetAgentId: string, opts: any) => {
+      await db.insert(agentWakeupRequests).values({
+        id: wakeupId,
+        companyId,
+        agentId: targetAgentId,
+        source: opts.source,
+        triggerDetail: opts.triggerDetail,
+        reason: opts.reason,
+        payload: opts.payload,
+        status: "queued",
+        requestedByActorType: opts.requestedByActorType,
+        requestedByActorId: opts.requestedByActorId,
+        contextSnapshot: opts.contextSnapshot,
+      });
+      return {
+        id: randomUUID(),
+        companyId,
+        agentId: targetAgentId,
+        invocationSource: opts.source,
+        triggerDetail: opts.triggerDetail,
+        status: "queued",
+        contextSnapshot: opts.contextSnapshot,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any;
+    });
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const result = await recovery.reconcileStalledIssueThreadInteractions({
+      now: new Date("2026-05-15T20:11:00.000Z"),
+      thresholdMs: 10 * 60 * 1000,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 1,
+      skipped: 0,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        reason: "issue_interaction_stalled",
+      }),
+    );
+    const wakeups = await db.select().from(agentWakeupRequests);
+    expect(wakeups).toEqual([
+      expect.objectContaining({
+        agentId,
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        reason: "issue_interaction_stalled",
+        payload: expect.objectContaining({
+          issueId,
+          interactionId,
+          mutation: "stalled_interaction_recovery",
+        }),
+      }),
+    ]);
+  });
 
   async function seedStrandedIssueFixture(input: {
     status: "todo" | "in_progress";

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -599,6 +599,79 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     ]);
   });
 
+  it("skips self-created pending interactions when recent external unblock evidence is in flight", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const interactionId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs external source",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: "PC-1",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "ask_user_questions",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      createdByAgentId: agentId,
+      payload: { version: 1, questions: [] },
+      updatedAt: new Date("2026-05-15T20:00:00.000Z"),
+    });
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      authorType: "agent",
+      body: "External source unblock is in flight: pinged source owner via Telegram for the ESX file.",
+      createdAt: new Date("2026-05-15T20:05:00.000Z"),
+      updatedAt: new Date("2026-05-15T20:05:00.000Z"),
+    });
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const result = await recovery.reconcileStalledIssueThreadInteractions({
+      now: new Date("2026-05-15T20:11:00.000Z"),
+      thresholdMs: 10 * 60 * 1000,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+    await expect(db.select().from(agentWakeupRequests)).resolves.toHaveLength(0);
+    await expect(db.select().from(activityLog).where(eq(activityLog.entityId, issueId))).resolves.toHaveLength(0);
+  });
+
   it("wakes stale agent-owned issue interactions through the system recovery actor", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -180,4 +180,32 @@ describe("buildInviteOnboardingTextDocument", () => {
       networkSpy.mockRestore();
     }
   });
+
+  it("excludes allowed hostnames from onboarding candidates when the server is loopback-bound", () => {
+    const req = buildReq("127.0.0.1:3100");
+    const invite = {
+      id: "invite-5",
+      companyId: "company-1",
+      inviteType: "company_join",
+      allowedJoinTypes: "agent",
+      tokenHash: "hash",
+      defaultsPayload: null,
+      expiresAt: new Date("2026-03-05T00:00:00.000Z"),
+      invitedByUserId: null,
+      revokedAt: null,
+      acceptedAt: null,
+      createdAt: new Date("2026-03-04T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-04T00:00:00.000Z"),
+    } as const;
+
+    const text = buildInviteOnboardingTextDocument(req, "token-loopback", invite as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+    });
+
+    expect(text).toContain("http://127.0.0.1:3100");
+    expect(text).not.toContain("http://cb-threadripper.tail3a8e2d.ts.net:3100");
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1160,6 +1160,49 @@ describeEmbeddedPostgres("issueService.list participantAgentId", () => {
     expect(comments.map((comment) => comment.id)).toEqual([firstCommentId]);
   });
 
+  it("reuses unchanged agent Board access recommendations instead of inserting duplicates", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const body = [
+      "ESCALATION: NOX-785 board-answer blocker.",
+      "The API returned `403 Board access required`.",
+      "Decision required: resolve interaction f20b5a0f-7edc-402b-ba69-ff007928e01e with option `accept_attempted_e2e`.",
+    ].join("\n");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "NOX-CLONE",
+      role: "manager",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Board access issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    const first = await svc.addComment(issueId, body, { agentId });
+    const second = await svc.addComment(issueId, body, { agentId });
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+
+    expect(second.id).toBe(first.id);
+    expect(comments).toHaveLength(1);
+  });
+
   it("lists user comments when derived run attribution scans a timestamp window", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -80,6 +80,52 @@ describe("runtime API discovery", () => {
     ]);
   });
 
+  it("uses the loopback bind host before allowed hostnames for local runtime URLs", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+      }),
+    ).toBe("http://127.0.0.1:3100");
+  });
+
+  it("keeps allowed hostnames ahead of non-loopback bind hosts for primary runtime URLs", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["paperclip.example.test"],
+        bindHost: "192.168.6.178",
+        port: 3100,
+      }),
+    ).toBe("http://paperclip.example.test:3100");
+  });
+
+  it("skips allowed hostnames when building candidates for loopback-bound runtimes", () => {
+    expect(
+      buildRuntimeApiCandidateUrls({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+        networkInterfacesMap: {},
+      }),
+    ).toEqual(["http://127.0.0.1:3100"]);
+  });
+
+  it("keeps allowed hostnames for wildcard-bound remote-capable runtimes", () => {
+    expect(
+      buildRuntimeApiCandidateUrls({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+        bindHost: "0.0.0.0",
+        port: 3100,
+        networkInterfacesMap: {},
+      }),
+    ).toEqual(["http://cb-threadripper.tail3a8e2d.ts.net:3100"]);
+  });
+
   it("adds host.docker.internal when the explicit base URL is loopback", () => {
     expect(
       buildRuntimeApiCandidateUrls({

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -151,6 +151,14 @@ vi.mock("../services/index.js", () => ({
       skipped: 0,
       issueIds: [],
     })),
+    reconcileStalledIssueThreadInteractions: vi.fn(async () => ({
+      scanned: 0,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [],
+      issueIds: [],
+    })),
     tickTimers: vi.fn(async () => ({ enqueued: 0 })),
   })),
   instanceSettingsService: vi.fn(() => ({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -696,6 +696,12 @@ export async function startServer(): Promise<StartedServer> {
         }
       })
       .then(async () => {
+        const reconciled = await heartbeat.reconcileStalledIssueThreadInteractions();
+        if (reconciled.operatorRouted > 0 || reconciled.agentWoken > 0) {
+          logger.warn({ ...reconciled }, "startup stalled interaction reconciliation routed pending interactions");
+        }
+      })
+      .then(async () => {
         const reconciled = await heartbeat.reconcileIssueGraphLiveness();
         if (reconciled.escalationsCreated > 0) {
           logger.warn({ ...reconciled }, "startup issue-graph liveness reconciliation created escalations");
@@ -759,6 +765,12 @@ export async function startServer(): Promise<StartedServer> {
               { promotedScheduledRetries: promotion.promoted, promotedScheduledRetryRunIds: promotion.runIds, ...reconciled },
               "periodic heartbeat recovery changed assigned issue state",
             );
+          }
+        })
+        .then(async () => {
+          const reconciled = await heartbeat.reconcileStalledIssueThreadInteractions();
+          if (reconciled.operatorRouted > 0 || reconciled.agentWoken > 0) {
+            logger.warn({ ...reconciled }, "periodic stalled interaction reconciliation routed pending interactions");
           }
         })
         .then(async () => {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1491,10 +1491,13 @@ function buildOnboardingConnectionCandidates(input: {
     candidates.add(`${protocol}//${bindHost}${port}`);
   }
 
-  for (const rawHost of input.allowedHostnames) {
-    const host = normalizeHostname(rawHost);
-    if (!host) continue;
-    candidates.add(`${protocol}//${host}${port}`);
+  const includeAllowedHostnames = !bindHost || !isLoopbackHost(bindHost);
+  if (includeAllowedHostnames) {
+    for (const rawHost of input.allowedHostnames) {
+      const host = normalizeHostname(rawHost);
+      if (!host) continue;
+      candidates.add(`${protocol}//${host}${port}`);
+    }
   }
 
   if (base && isLoopbackHost(base.hostname)) {

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -61,6 +61,11 @@ export function choosePrimaryRuntimeApiUrl(input: {
     }
   }
 
+  const bindHost = normalizeHost(input.bindHost);
+  if (bindHost && isLoopbackHost(bindHost)) {
+    return formatOrigin("http:", bindHost, input.port);
+  }
+
   const allowedHostname = input.allowedHostnames
     .map((value) => value.trim())
     .find(Boolean);
@@ -68,7 +73,6 @@ export function choosePrimaryRuntimeApiUrl(input: {
     return formatOrigin("http:", allowedHostname, input.port);
   }
 
-  const bindHost = normalizeHost(input.bindHost);
   if (bindHost && !isWildcardHost(bindHost)) {
     return formatOrigin("http:", bindHost, input.port);
   }
@@ -128,13 +132,16 @@ export function buildRuntimeApiCandidateUrls(input: {
   pushCandidate(candidates, seen, input.preferredApiUrl);
   pushCandidate(candidates, seen, explicitOrigin);
 
-  for (const rawHost of input.allowedHostnames) {
-    const host = normalizeHost(rawHost);
-    if (!host) continue;
-    pushCandidate(candidates, seen, formatOrigin(protocol, host, input.port));
+  const bindHost = normalizeHost(input.bindHost);
+  const includeAllowedHostnames = !bindHost || !isLoopbackHost(bindHost);
+  if (includeAllowedHostnames) {
+    for (const rawHost of input.allowedHostnames) {
+      const host = normalizeHost(rawHost);
+      if (!host) continue;
+      pushCandidate(candidates, seen, formatOrigin(protocol, host, input.port));
+    }
   }
 
-  const bindHost = normalizeHost(input.bindHost);
   if (bindHost && !isWildcardHost(bindHost)) {
     pushCandidate(candidates, seen, formatOrigin(protocol, bindHost, input.port));
   }

--- a/server/src/services/cpp-board-escalation.ts
+++ b/server/src/services/cpp-board-escalation.ts
@@ -1,0 +1,221 @@
+export interface CppEscalationIssueContext {
+  id?: string | null;
+  identifier?: string | null;
+  title?: string | null;
+  description?: string | null;
+}
+
+export interface CppEscalationCommentContext {
+  id?: string | null;
+  issueId?: string | null;
+  body: string;
+  authorAgentId?: string | null;
+  authorUserId?: string | null;
+  authorType?: string | null;
+  createdAt?: Date | string | null;
+}
+
+export interface CppBindingContext {
+  source: string;
+  constraints: string | null;
+  reviewGate: string | null;
+}
+
+export interface CppOverrideContext {
+  commentId: string | null;
+  issueId: string | null;
+  author: string | null;
+  optionId: string | null;
+  bodyExcerpt: string;
+  createdAt: string | null;
+}
+
+export interface CppRecommendationFingerprint {
+  interactionId: string | null;
+  optionId: string | null;
+}
+
+const OPTION_ID_RE = /^[a-z][a-z0-9_:-]{2,}$/i;
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+const SWEEP_COMMENT_RE =
+  /^\s*(?:ESCALATION:|Autonomous (?:CPP |interaction )?decision|NOX-\d+\s+sweep attempted|Sweep echo\b|What I tried\/delegated:)/i;
+const OVERRIDE_COMMENT_RE =
+  /\b(override|standing recommendation|operative decision|recommendation stands|binding|cameron|local-board|nox)\b/i;
+const BOARD_ACCESS_RE = /\b(?:403\s+)?board access required\b/i;
+const NEW_CLERK_E2E_SCOPE_RE =
+  /\b(clerk(?:\s+\w+){0,4}\s+e2e|e2e(?:\s+\w+){0,4}\s+clerk|clerk_replacement|replacement(?:\s+\w+){0,5}\s+clerk|new(?:\s+\w+){0,5}\s+e2e)\b/i;
+const NEW_FEATURE_BAN_RE =
+  /\b(no|not|without|unless|must not|do not|bar|bans?|forbid|reject)\b[\s\S]{0,180}\b(new|dispatch|feature|clerk|e2e|replacement|scope)\b/i;
+
+function compactWhitespace(value: string) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function truncate(value: string, max = 700) {
+  const compacted = compactWhitespace(value);
+  return compacted.length > max ? `${compacted.slice(0, max - 1)}...` : compacted;
+}
+
+export function extractMarkdownSection(body: string | null | undefined, heading: string): string | null {
+  if (!body) return null;
+  const escapedHeading = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    String.raw`(?:^|\n)\s*(?:#{1,6}\s*)?\*\*${escapedHeading}:\*\*\s*\n?([\s\S]*?)(?=\n\s*(?:#{1,6}\s*)?\*\*[^*\n]+:\*\*|\n\s*#{1,6}\s+|$)`,
+    "i",
+  );
+  const match = body.match(pattern);
+  const value = match?.[1]?.trim();
+  return value ? value : null;
+}
+
+function contextLabel(issue: CppEscalationIssueContext) {
+  return issue.identifier ?? issue.title ?? issue.id ?? "unknown issue";
+}
+
+export function extractBindingContexts(issues: CppEscalationIssueContext[]): CppBindingContext[] {
+  const contexts: CppBindingContext[] = [];
+  for (const issue of issues) {
+    const constraints = extractMarkdownSection(issue.description, "Constraints / Risks");
+    const reviewGate = extractMarkdownSection(issue.description, "Review Gate");
+    if (!constraints && !reviewGate) continue;
+    contexts.push({
+      source: contextLabel(issue),
+      constraints: constraints ? truncate(constraints, 900) : null,
+      reviewGate: reviewGate ? truncate(reviewGate, 500) : null,
+    });
+  }
+  return contexts;
+}
+
+function extractBacktickOptionIds(body: string) {
+  const ids: string[] = [];
+  for (const match of body.matchAll(/`([^`]+)`/g)) {
+    const value = match[1]?.trim();
+    if (!value || UUID_RE.test(value) || !OPTION_ID_RE.test(value)) continue;
+    ids.push(value);
+  }
+  return ids;
+}
+
+export function extractPreferredOptionId(body: string): string | null {
+  const backtickIds = extractBacktickOptionIds(body);
+  const ranked = backtickIds.find((id) => /^(accept_|clerk_|reset_|owner_|create_|reject_|defer_)/i.test(id));
+  if (ranked) return ranked;
+  return backtickIds[0] ?? null;
+}
+
+function isSweepGeneratedComment(comment: CppEscalationCommentContext) {
+  return SWEEP_COMMENT_RE.test(comment.body);
+}
+
+function isOverrideComment(comment: CppEscalationCommentContext) {
+  const author = `${comment.authorType ?? ""} ${comment.authorUserId ?? ""}`.toLowerCase();
+  if (author.includes("local-board")) return true;
+  return OVERRIDE_COMMENT_RE.test(comment.body) && !isSweepGeneratedComment(comment);
+}
+
+export function findLatestOverrideComment(comments: CppEscalationCommentContext[]): CppOverrideContext | null {
+  const sorted = [...comments].sort((left, right) => {
+    const leftTime = left.createdAt ? new Date(left.createdAt).getTime() : 0;
+    const rightTime = right.createdAt ? new Date(right.createdAt).getTime() : 0;
+    return rightTime - leftTime;
+  });
+
+  for (const comment of sorted) {
+    if (!isOverrideComment(comment)) continue;
+    return {
+      commentId: comment.id ?? null,
+      issueId: comment.issueId ?? null,
+      author: comment.authorUserId ?? comment.authorAgentId ?? comment.authorType ?? null,
+      optionId: extractPreferredOptionId(comment.body),
+      bodyExcerpt: truncate(comment.body, 700),
+      createdAt: comment.createdAt ? new Date(comment.createdAt).toISOString() : null,
+    };
+  }
+  return null;
+}
+
+export function optionViolatesBindingConstraints(input: {
+  optionId?: string | null;
+  optionDescription?: string | null;
+  bindingContexts: CppBindingContext[];
+}): { rejected: boolean; reason: string | null } {
+  const optionText = `${input.optionId ?? ""} ${input.optionDescription ?? ""}`;
+  if (!NEW_CLERK_E2E_SCOPE_RE.test(optionText)) return { rejected: false, reason: null };
+
+  for (const context of input.bindingContexts) {
+    const bindingText = `${context.constraints ?? ""}\n${context.reviewGate ?? ""}`;
+    if (!NEW_FEATURE_BAN_RE.test(bindingText) && !NEW_CLERK_E2E_SCOPE_RE.test(bindingText)) continue;
+    return {
+      rejected: true,
+      reason: `${input.optionId ?? "option"} maps onto banned new Clerk e2e/replacement scope in ${context.source}`,
+    };
+  }
+
+  return { rejected: false, reason: null };
+}
+
+export function extractBoardAccessRecommendationFingerprint(body: string): CppRecommendationFingerprint | null {
+  if (!BOARD_ACCESS_RE.test(body)) return null;
+  const interactionId = body.match(UUID_RE)?.[0] ?? null;
+  const optionId = extractPreferredOptionId(body);
+  if (!interactionId && !optionId) return null;
+  return { interactionId, optionId };
+}
+
+function sameFingerprint(left: CppRecommendationFingerprint, right: CppRecommendationFingerprint) {
+  return (left.interactionId ?? null) === (right.interactionId ?? null) &&
+    (left.optionId ?? null) === (right.optionId ?? null);
+}
+
+export function shouldSuppressDuplicateBoardAccessRecommendation(
+  nextBody: string,
+  recentComments: CppEscalationCommentContext[],
+) {
+  return Boolean(findUnchangedBoardAccessRecommendation(nextBody, recentComments));
+}
+
+export function findUnchangedBoardAccessRecommendation(
+  nextBody: string,
+  recentComments: CppEscalationCommentContext[],
+): CppEscalationCommentContext | null {
+  const next = extractBoardAccessRecommendationFingerprint(nextBody);
+  if (!next) return null;
+
+  const sorted = [...recentComments].sort((left, right) => {
+    const leftTime = left.createdAt ? new Date(left.createdAt).getTime() : 0;
+    const rightTime = right.createdAt ? new Date(right.createdAt).getTime() : 0;
+    return rightTime - leftTime;
+  });
+
+  for (const comment of sorted) {
+    const previous = extractBoardAccessRecommendationFingerprint(comment.body);
+    if (!previous) continue;
+    return sameFingerprint(next, previous) ? comment : null;
+  }
+
+  return null;
+}
+
+export function buildCppBoardEscalationContext(input: {
+  issues: CppEscalationIssueContext[];
+  comments: CppEscalationCommentContext[];
+}) {
+  const bindingContexts = extractBindingContexts(input.issues);
+  const latestOverride = findLatestOverrideComment(input.comments);
+  const clerkReplacementCheck = optionViolatesBindingConstraints({
+    optionId: "clerk_replacement",
+    optionDescription: "Create Clerk e2e replacement / new Clerk Playwright proof path",
+    bindingContexts,
+  });
+
+  if (bindingContexts.length === 0 && !latestOverride && !clerkReplacementCheck.rejected) return null;
+
+  return {
+    bindingContexts,
+    latestOverride,
+    bannedOptions: clerkReplacementCheck.rejected
+      ? [{ optionId: "clerk_replacement", reason: clerkReplacementCheck.reason }]
+      : [],
+  };
+}

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6593,6 +6593,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.reconcileStrandedAssignedIssues();
   }
 
+  async function reconcileStalledIssueThreadInteractions(opts?: {
+    now?: Date;
+    thresholdMs?: number;
+    runId?: string | null;
+  }) {
+    return recovery.reconcileStalledIssueThreadInteractions(opts);
+  }
+
   function issueIdFromRunContext(contextSnapshot: unknown) {
     const context = parseObject(contextSnapshot);
     return readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
@@ -9744,6 +9752,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     reconcileStrandedAssignedIssues,
+
+    reconcileStalledIssueThreadInteractions,
 
     buildIssueGraphLivenessAutoRecoveryPreview,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -108,6 +108,7 @@ import {
   getIssueContinuationSummaryDocument,
   refreshIssueContinuationSummary,
 } from "./issue-continuation-summary.js";
+import { buildCppBoardEscalationContext } from "./cpp-board-escalation.js";
 import { executionWorkspaceService, mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { workspaceOperationService } from "./workspace-operations.js";
 import { isProcessGroupAlive, terminateLocalService } from "./local-service-supervisor.js";
@@ -1924,6 +1925,12 @@ async function buildPaperclipWakePayload(input: {
           .where(and(eq(issues.id, issueId), eq(issues.companyId, input.companyId)))
           .then((rows) => rows[0] ?? null)
       : null);
+  const cppBoardEscalationContext = await collectCppBoardEscalationWakeContext({
+    db: input.db,
+    companyId: input.companyId,
+    issueId,
+    contextSnapshot: input.contextSnapshot,
+  });
   if (commentIds.length === 0 && Object.keys(executionStage).length === 0 && !issueSummary) return null;
 
   const commentRows =
@@ -2050,6 +2057,7 @@ async function buildPaperclipWakePayload(input: {
           updatedAt: continuationSummary.updatedAt.toISOString(),
         }
       : null,
+    cppBoardEscalationContext,
     commentIds,
     latestCommentId: commentIds[commentIds.length - 1] ?? null,
     comments,
@@ -2065,6 +2073,97 @@ async function buildPaperclipWakePayload(input: {
 
 function runTaskKey(run: typeof heartbeatRuns.$inferSelect) {
   return deriveTaskKey(run.contextSnapshot as Record<string, unknown> | null, null);
+}
+
+function isCppBoardEscalationWake(contextSnapshot: Record<string, unknown>) {
+  const reason = readNonEmptyString(contextSnapshot.wakeReason);
+  const interactionKind = readNonEmptyString(contextSnapshot.interactionKind);
+  if (reason === "issue_interaction_stalled") return true;
+  return Boolean(interactionKind && (interactionKind === "ask_user_questions" || interactionKind === "request_confirmation"));
+}
+
+async function collectCppBoardEscalationWakeContext(input: {
+  db: Db;
+  companyId: string;
+  issueId: string | null;
+  contextSnapshot: Record<string, unknown>;
+}) {
+  if (!input.issueId || !isCppBoardEscalationWake(input.contextSnapshot)) return null;
+
+  const relatedIssueIds = new Set<string>([input.issueId]);
+  const unresolvedBlockerIssueIds = Array.isArray(input.contextSnapshot.unresolvedBlockerIssueIds)
+    ? input.contextSnapshot.unresolvedBlockerIssueIds.filter((value): value is string => typeof value === "string" && value.length > 0)
+    : [];
+  for (const blockerId of unresolvedBlockerIssueIds) relatedIssueIds.add(blockerId);
+
+  const blockerRows = await input.db
+    .select({ issueId: issueRelations.issueId })
+    .from(issueRelations)
+    .where(and(
+      eq(issueRelations.companyId, input.companyId),
+      eq(issueRelations.relatedIssueId, input.issueId),
+      eq(issueRelations.type, "blocks"),
+    ));
+  for (const blocker of blockerRows) relatedIssueIds.add(blocker.issueId);
+
+  const sourceIssueRows = await input.db
+    .select({
+      id: issues.id,
+      parentId: issues.parentId,
+      identifier: issues.identifier,
+      title: issues.title,
+      description: issues.description,
+    })
+    .from(issues)
+    .where(and(eq(issues.companyId, input.companyId), inArray(issues.id, Array.from(relatedIssueIds))));
+
+  const queue = sourceIssueRows.map((issue) => issue.parentId).filter((id): id is string => Boolean(id));
+  const seenParents = new Set<string>();
+  while (queue.length > 0 && seenParents.size < 6) {
+    const parentId = queue.shift();
+    if (!parentId || seenParents.has(parentId) || relatedIssueIds.has(parentId)) continue;
+    seenParents.add(parentId);
+    relatedIssueIds.add(parentId);
+    const parent = await input.db
+      .select({
+        id: issues.id,
+        parentId: issues.parentId,
+        identifier: issues.identifier,
+        title: issues.title,
+        description: issues.description,
+      })
+      .from(issues)
+      .where(and(eq(issues.companyId, input.companyId), eq(issues.id, parentId)))
+      .then((rows) => rows[0] ?? null);
+    if (parent?.parentId) queue.push(parent.parentId);
+  }
+
+  const issueRows = await input.db
+    .select({
+      id: issues.id,
+      identifier: issues.identifier,
+      title: issues.title,
+      description: issues.description,
+    })
+    .from(issues)
+    .where(and(eq(issues.companyId, input.companyId), inArray(issues.id, Array.from(relatedIssueIds))));
+
+  const comments = await input.db
+    .select({
+      id: issueComments.id,
+      issueId: issueComments.issueId,
+      body: issueComments.body,
+      authorAgentId: issueComments.authorAgentId,
+      authorUserId: issueComments.authorUserId,
+      authorType: issueComments.authorType,
+      createdAt: issueComments.createdAt,
+    })
+    .from(issueComments)
+    .where(and(eq(issueComments.companyId, input.companyId), inArray(issueComments.issueId, Array.from(relatedIssueIds))))
+    .orderBy(desc(issueComments.createdAt))
+    .limit(40);
+
+  return buildCppBoardEscalationContext({ issues: issueRows, comments });
 }
 
 function isSameTaskScope(left: string | null, right: string | null) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -75,6 +75,7 @@ import {
 } from "./issue-tree-control.js";
 import { parseIssueGraphLivenessIncidentKey } from "./recovery/origins.js";
 import { classifyIssueGraphLiveness, type IssueLivenessFinding } from "./recovery/issue-graph-liveness.js";
+import { findUnchangedBoardAccessRecommendation } from "./cpp-board-escalation.js";
 
 const ALL_ISSUE_STATUSES = ["backlog", "todo", "in_progress", "in_review", "blocked", "done", "cancelled"];
 const MAX_ISSUE_COMMENT_PAGE_LIMIT = 500;
@@ -5085,6 +5086,34 @@ export function issueService(db: Db) {
       const presentation = issueCommentPresentationSchema.nullable().parse(options?.presentation ?? null);
       const metadata = issueCommentMetadataSchema.nullable().parse(options?.metadata ?? null);
       const createdAt = options?.createdAt ? new Date(options.createdAt) : null;
+      if (actor.agentId) {
+        const recentComments = await db
+          .select({
+            id: issueComments.id,
+            issueId: issueComments.issueId,
+            body: issueComments.body,
+            authorAgentId: issueComments.authorAgentId,
+            authorUserId: issueComments.authorUserId,
+            authorType: issueComments.authorType,
+            createdAt: issueComments.createdAt,
+          })
+          .from(issueComments)
+          .where(and(eq(issueComments.companyId, issue.companyId), eq(issueComments.issueId, issueId)))
+          .orderBy(desc(issueComments.createdAt))
+          .limit(25);
+        const unchangedRecommendation = findUnchangedBoardAccessRecommendation(redactedBody, recentComments);
+        if (unchangedRecommendation) {
+          const existingId = unchangedRecommendation.id;
+          const existing = existingId
+            ? await db
+              .select()
+              .from(issueComments)
+              .where(eq(issueComments.id, existingId))
+              .then((rows) => rows[0] ?? null)
+            : null;
+          if (existing) return redactIssueComment(existing, currentUserRedactionOptions.enabled);
+        }
+      }
       const [comment] = await db
         .insert(issueComments)
         .values({

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, lt, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -269,6 +269,10 @@ function isAgentInvokable(agent: typeof agents.$inferSelect | null | undefined) 
   return Boolean(agent && !["paused", "terminated", "pending_approval"].includes(agent.status));
 }
 
+function isOperatorResolvedInteractionKind(kind: string) {
+  return kind === "ask_user_questions" || kind === "request_confirmation";
+}
+
 function isStrandedIssueRecoveryIssue(issue: Pick<typeof issues.$inferSelect, "originKind">) {
   return isStrandedIssueRecoveryOriginKind(issue.originKind);
 }
@@ -473,6 +477,161 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  async function hasQueuedInteractionWake(companyId: string, issueId: string, interactionId: string) {
+    return db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+          sql`${agentWakeupRequests.payload} ->> 'interactionId' = ${interactionId}`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  async function reconcileStalledIssueThreadInteractions(opts?: {
+    now?: Date;
+    thresholdMs?: number;
+    runId?: string | null;
+  }) {
+    const now = opts?.now ?? new Date();
+    const thresholdMs = Math.max(60_000, Math.floor(opts?.thresholdMs ?? 10 * 60 * 1000));
+    const cutoff = new Date(now.getTime() - thresholdMs);
+    const candidates = await db
+      .select({
+        id: issueThreadInteractions.id,
+        companyId: issueThreadInteractions.companyId,
+        issueId: issueThreadInteractions.issueId,
+        kind: issueThreadInteractions.kind,
+        status: issueThreadInteractions.status,
+        continuationPolicy: issueThreadInteractions.continuationPolicy,
+        createdByAgentId: issueThreadInteractions.createdByAgentId,
+        createdByUserId: issueThreadInteractions.createdByUserId,
+        sourceCommentId: issueThreadInteractions.sourceCommentId,
+        sourceRunId: issueThreadInteractions.sourceRunId,
+        updatedAt: issueThreadInteractions.updatedAt,
+        issueIdentifier: issues.identifier,
+        issueStatus: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+        projectId: issues.projectId,
+      })
+      .from(issueThreadInteractions)
+      .innerJoin(issues, eq(issueThreadInteractions.issueId, issues.id))
+      .where(
+        and(
+          eq(issueThreadInteractions.status, "pending"),
+          lt(issueThreadInteractions.updatedAt, cutoff),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(asc(issueThreadInteractions.updatedAt))
+      .limit(100);
+
+    const result = {
+      scanned: candidates.length,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [] as string[],
+      issueIds: [] as string[],
+    };
+    const seenIssues = new Set<string>();
+
+    for (const interaction of candidates) {
+      result.interactionIds.push(interaction.id);
+      if (!seenIssues.has(interaction.issueId)) {
+        seenIssues.add(interaction.issueId);
+        result.issueIds.push(interaction.issueId);
+      }
+
+      if (isOperatorResolvedInteractionKind(interaction.kind)) {
+        result.operatorRouted += 1;
+        await logActivity(db, {
+          companyId: interaction.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: null,
+          runId: opts?.runId ?? null,
+          action: "issue.thread_interaction_operator_waiting",
+          entityType: "issue",
+          entityId: interaction.issueId,
+          details: {
+            source: "recovery.reconcile_stalled_issue_thread_interactions",
+            interactionId: interaction.id,
+            interactionKind: interaction.kind,
+            interactionStatus: interaction.status,
+            issueIdentifier: interaction.issueIdentifier,
+            ageMs: Math.max(0, now.getTime() - interaction.updatedAt.getTime()),
+            resolver: "operator_board",
+          },
+        });
+        continue;
+      }
+
+      const agentId = interaction.assigneeAgentId ?? interaction.createdByAgentId;
+      if (!agentId) {
+        result.skipped += 1;
+        continue;
+      }
+      const agent = await getAgent(agentId);
+      if (!agent || agent.companyId !== interaction.companyId || !isAgentInvokable(agent)) {
+        result.skipped += 1;
+        continue;
+      }
+      if (await hasQueuedInteractionWake(interaction.companyId, interaction.issueId, interaction.id)) {
+        result.skipped += 1;
+        continue;
+      }
+      if (
+        await isInvocationBudgetBlocked(
+          { id: interaction.issueId, companyId: interaction.companyId, projectId: interaction.projectId },
+          agentId,
+        )
+      ) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const queued = await deps.enqueueWakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_interaction_stalled",
+        payload: {
+          issueId: interaction.issueId,
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          mutation: "stalled_interaction_recovery",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        contextSnapshot: {
+          issueId: interaction.issueId,
+          taskId: interaction.issueId,
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          interactionStatus: interaction.status,
+          sourceCommentId: interaction.sourceCommentId ?? null,
+          sourceRunId: interaction.sourceRunId ?? null,
+          wakeReason: "issue_interaction_stalled",
+          source: "recovery.reconcile_stalled_issue_thread_interactions",
+        },
+      });
+      if (queued) {
+        result.agentWoken += 1;
+      } else {
+        result.skipped += 1;
+      }
+    }
+
+    return result;
+  }
+
   async function enqueueStrandedIssueRecovery(input: {
     issueId: string;
     agentId: string;
@@ -536,7 +695,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     });
   }
 
-  async function isInvocationBudgetBlocked(issue: typeof issues.$inferSelect, agentId: string) {
+  async function isInvocationBudgetBlocked(
+    issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "projectId">,
+    agentId: string,
+  ) {
     const budgetBlock = await budgets.getInvocationBlock(issue.companyId, agentId, {
       issueId: issue.id,
       projectId: issue.projectId,
@@ -3046,6 +3208,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recordWatchdogDecision,
     scanSilentActiveRuns,
     reconcileStrandedAssignedIssues,
+    reconcileStalledIssueThreadInteractions,
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileIssueGraphLiveness,
     readRecoveryTimerIntervalMs,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNull, lt, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNull, lt, lte, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -273,6 +273,9 @@ function isOperatorResolvedInteractionKind(kind: string) {
   return kind === "ask_user_questions" || kind === "request_confirmation";
 }
 
+const EXTERNAL_UNBLOCK_COMMENT_PATTERN =
+  "(telegram|\\bdm\\b|direct message|external channel|external owner|source owner|outreach|pinged|messaged|slack|teams)";
+
 function isStrandedIssueRecoveryIssue(issue: Pick<typeof issues.$inferSelect, "originKind">) {
   return isStrandedIssueRecoveryOriginKind(issue.originKind);
 }
@@ -493,6 +496,52 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  async function hasRecentExternalUnblockEvidence(input: {
+    companyId: string;
+    issueId: string;
+    windowStart: Date;
+    now: Date;
+  }) {
+    return db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, input.companyId),
+          eq(issueComments.issueId, input.issueId),
+          gte(issueComments.createdAt, input.windowStart),
+          lte(issueComments.createdAt, input.now),
+          sql`(
+            ${issueComments.authorUserId} is not null
+            or lower(${issueComments.body}) ~ ${EXTERNAL_UNBLOCK_COMMENT_PATTERN}
+          )`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  async function isSelfCreatedInteractionWithExternalUnblockInFlight(input: {
+    interaction: {
+      companyId: string;
+      issueId: string;
+      createdByAgentId: string | null;
+      assigneeAgentId: string | null;
+    };
+    windowStart: Date;
+    now: Date;
+  }) {
+    if (!input.interaction.createdByAgentId) return false;
+    if (input.interaction.createdByAgentId !== input.interaction.assigneeAgentId) return false;
+
+    return hasRecentExternalUnblockEvidence({
+      companyId: input.interaction.companyId,
+      issueId: input.interaction.issueId,
+      windowStart: input.windowStart,
+      now: input.now,
+    });
+  }
+
   async function reconcileStalledIssueThreadInteractions(opts?: {
     now?: Date;
     thresholdMs?: number;
@@ -548,6 +597,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (!seenIssues.has(interaction.issueId)) {
         seenIssues.add(interaction.issueId);
         result.issueIds.push(interaction.issueId);
+      }
+
+      if (
+        await isSelfCreatedInteractionWithExternalUnblockInFlight({
+          interaction,
+          windowStart: cutoff,
+          now,
+        })
+      ) {
+        result.skipped += 1;
+        continue;
       }
 
       if (isOperatorResolvedInteractionKind(interaction.kind)) {


### PR DESCRIPTION
## Summary

Fixes the CPP board-answer sweep path so autonomous recommendations receive binding issue context before choosing an escalation path.

## What Changed

- Adds a CPP board escalation context helper that extracts parent/blocker constraints, review gates, latest Nox/Cameron/local-board overrides, and banned/deprioritized options.
- Injects that context into Paperclip wake payloads for stalled/request-confirmation/ask-user interactions and renders it in adapter wake prompts.
- Suppresses unchanged duplicate agent comments for the same `403 Board access required` interaction/option recommendation.
- Adds focused tests for override detection, constraint filtering, and duplicate suppression.

## Root Cause

The sweep prompt did not carry enough binding parent/blocker context into follow-up wakes, so stale autonomous recommendations could override explicit board decisions or parent constraints. Repeated board-access failures also produced duplicate escalation comments for unchanged state.

## Validation

- `pnpm exec vitest run server/src/__tests__/cpp-board-escalation.test.ts server/src/__tests__/issues-service.test.ts --testNamePattern "CPP board escalation|Board access recommendations"`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/server build`
- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm --filter @paperclipai/adapter-utils build`
- Manual NOX-3992 proof: live Paperclip data resolves to `accept_attempted_e2e`, rejects `clerk_replacement`, and leaves `accept_attempted_e2e` allowed.
