### PR TITLE
fix(server): delete company child rows in FK-safe order

### DIFF
--- a/server/src/__tests__/cleanup-removal-service.test.ts
+++ b/server/src/__tests__/cleanup-removal-service.test.ts
@@ -6,14 +6,17 @@ import {
   agents,
   companies,
   companySkills,
+  costEvents,
   createDb,
   documents,
   documentRevisions,
+  financeEvents,
   heartbeatRuns,
   issueComments,
   issueDocuments,
   issueExecutionDecisions,
   issueReadStates,
+  issueThreadInteractions,
   issues,
 } from "@paperclipai/db";
 import {
@@ -44,11 +47,14 @@ describeEmbeddedPostgres("cleanup removal services", () => {
   afterEach(async () => {
     await db.delete(activityLog);
     await db.delete(issueReadStates);
+    await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(issueExecutionDecisions);
     await db.delete(documentRevisions);
     await db.delete(documents);
     await db.delete(companySkills);
+    await db.delete(financeEvents);
+    await db.delete(costEvents);
     await db.delete(heartbeatRuns);
     await db.delete(issues);
     await db.delete(agents);
@@ -227,5 +233,69 @@ describeEmbeddedPostgres("cleanup removal services", () => {
     await expect(db.select().from(documentRevisions).where(eq(documentRevisions.id, revisionId))).resolves.toHaveLength(0);
     await expect(db.select().from(issueReadStates).where(eq(issueReadStates.companyId, companyId))).resolves.toHaveLength(0);
     await expect(db.select().from(activityLog).where(eq(activityLog.companyId, companyId))).resolves.toHaveLength(0);
+  });
+
+  it("removes finance and cost events linked to heartbeat runs before deleting the company", async () => {
+    const { agentId, companyId, issueId, runId } = await seedFixture();
+    const costEventId = randomUUID();
+    const occurredAt = new Date("2026-05-01T12:00:00.000Z");
+
+    await db.insert(costEvents).values({
+      id: costEventId,
+      companyId,
+      agentId,
+      issueId,
+      heartbeatRunId: runId,
+      provider: "openai",
+      biller: "openai",
+      billingType: "tokens",
+      model: "gpt-4",
+      costCents: 12,
+      occurredAt,
+    });
+
+    await db.insert(financeEvents).values({
+      companyId,
+      agentId,
+      issueId,
+      heartbeatRunId: runId,
+      costEventId,
+      biller: "openai",
+      eventKind: "usage",
+      amountCents: 12,
+      currency: "USD",
+      direction: "debit",
+      estimated: false,
+      occurredAt,
+    });
+
+    const removed = await companyService(db).remove(companyId);
+
+    expect(removed?.id).toBe(companyId);
+    await expect(db.select().from(companies).where(eq(companies.id, companyId))).resolves.toHaveLength(0);
+    await expect(db.select().from(costEvents).where(eq(costEvents.companyId, companyId))).resolves.toHaveLength(0);
+    await expect(db.select().from(financeEvents).where(eq(financeEvents.companyId, companyId))).resolves.toHaveLength(0);
+    await expect(db.select().from(heartbeatRuns).where(eq(heartbeatRuns.companyId, companyId))).resolves.toHaveLength(0);
+  });
+
+  it("removes issue thread interactions before deleting the company", async () => {
+    const { companyId, issueId } = await seedFixture();
+
+    await db.insert(issueThreadInteractions).values({
+      companyId,
+      issueId,
+      kind: "suggest_tasks",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      payload: { version: 1, tasks: [] },
+    });
+
+    const removed = await companyService(db).remove(companyId);
+
+    expect(removed?.id).toBe(companyId);
+    await expect(
+      db.select().from(issueThreadInteractions).where(eq(issueThreadInteractions.companyId, companyId)),
+    ).resolves.toHaveLength(0);
+    await expect(db.select().from(companies).where(eq(companies.id, companyId))).resolves.toHaveLength(0);
   });
 });

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -6,18 +6,38 @@ import {
   assets,
   agents,
   agentApiKeys,
+  agentConfigRevisions,
   agentRuntimeState,
   agentTaskSessions,
   agentWakeupRequests,
   issues,
+  issueAttachments,
+  issueApprovals,
   issueComments,
+  issueDocuments,
+  issueExecutionDecisions,
+  issueInboxArchives,
+  issueLabels,
+  issueReadStates,
+  issueRecoveryActions,
+  issueReferenceMentions,
+  issueRelations,
+  issueThreadInteractions,
+  issueTreeHoldMembers,
+  issueTreeHolds,
+  issueWorkProducts,
   projects,
   goals,
   heartbeatRuns,
   heartbeatRunEvents,
+  heartbeatRunWatchdogDecisions,
   costEvents,
   financeEvents,
-  issueReadStates,
+  feedbackExports,
+  feedbackVotes,
+  documentRevisions,
+  executionWorkspaces,
+  inboxDismissals,
   approvalComments,
   approvals,
   activityLog,
@@ -28,6 +48,8 @@ import {
   companyMemberships,
   companySkills,
   documents,
+  workspaceOperations,
+  workspaceRuntimeServices,
 } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 import { environmentService } from "./environments.js";
@@ -268,13 +290,31 @@ export function companyService(db: Db) {
         await tx.delete(heartbeatRunEvents).where(eq(heartbeatRunEvents.companyId, id));
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.companyId, id));
         await tx.delete(activityLog).where(eq(activityLog.companyId, id));
+        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
+        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
+        await tx.delete(heartbeatRunWatchdogDecisions).where(eq(heartbeatRunWatchdogDecisions.companyId, id));
+        await tx.delete(workspaceOperations).where(eq(workspaceOperations.companyId, id));
+        await tx.delete(workspaceRuntimeServices).where(eq(workspaceRuntimeServices.companyId, id));
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, id));
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.companyId, id));
         await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.companyId, id));
+        await tx.delete(issueThreadInteractions).where(eq(issueThreadInteractions.companyId, id));
+        await tx.delete(feedbackVotes).where(eq(feedbackVotes.companyId, id));
+        await tx.delete(feedbackExports).where(eq(feedbackExports.companyId, id));
+        await tx.delete(issueInboxArchives).where(eq(issueInboxArchives.companyId, id));
+        await tx.delete(inboxDismissals).where(eq(inboxDismissals.companyId, id));
+        await tx.delete(issueTreeHoldMembers).where(eq(issueTreeHoldMembers.companyId, id));
+        await tx.delete(issueTreeHolds).where(eq(issueTreeHolds.companyId, id));
+        await tx.delete(issueRecoveryActions).where(eq(issueRecoveryActions.companyId, id));
+        await tx.delete(issueReferenceMentions).where(eq(issueReferenceMentions.companyId, id));
+        await tx.delete(issueRelations).where(eq(issueRelations.companyId, id));
+        await tx.delete(issueWorkProducts).where(eq(issueWorkProducts.companyId, id));
+        await tx.delete(issueAttachments).where(eq(issueAttachments.companyId, id));
+        await tx.delete(issueApprovals).where(eq(issueApprovals.companyId, id));
+        await tx.delete(issueExecutionDecisions).where(eq(issueExecutionDecisions.companyId, id));
+        await tx.delete(issueLabels).where(eq(issueLabels.companyId, id));
         await tx.delete(issueComments).where(eq(issueComments.companyId, id));
-        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
-        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
         await tx.delete(approvals).where(eq(approvals.companyId, id));
         await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));
@@ -284,12 +324,16 @@ export function companyService(db: Db) {
         await tx.delete(companyMemberships).where(eq(companyMemberships.companyId, id));
         await tx.delete(companySkills).where(eq(companySkills.companyId, id));
         await tx.delete(issueReadStates).where(eq(issueReadStates.companyId, id));
+        await tx.delete(issueDocuments).where(eq(issueDocuments.companyId, id));
+        await tx.delete(documentRevisions).where(eq(documentRevisions.companyId, id));
         await tx.delete(documents).where(eq(documents.companyId, id));
         await tx.delete(issues).where(eq(issues.companyId, id));
         await tx.delete(companyLogos).where(eq(companyLogos.companyId, id));
         await tx.delete(assets).where(eq(assets.companyId, id));
         await tx.delete(goals).where(eq(goals.companyId, id));
+        await tx.delete(executionWorkspaces).where(eq(executionWorkspaces.companyId, id));
         await tx.delete(projects).where(eq(projects.companyId, id));
+        await tx.delete(agentConfigRevisions).where(eq(agentConfigRevisions.companyId, id));
         await tx.delete(agents).where(eq(agents.companyId, id));
         const rows = await tx
           .delete(companies)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is a control plane that orchestrates AI agents inside companies
> - Companies can be deleted from the board UI or CLI (`DELETE /api/companies/:id`)
> - Deletion uses a manual transaction cascade in `companyService.remove()`, not DB-level `ON DELETE CASCADE` on most tables
> - Newer tables (`cost_events`, `finance_events`, `issue_thread_interactions`) added FKs to `heartbeat_runs` and `issues` with `ON DELETE no action`
> - The cascade deleted parents before children, causing 500 errors (first on `heartbeat_runs`, then on `issues`)
> - This pull request reorders deletes and clears the issue subgraph before removing issues
> - The benefit is company delete works reliably for companies with billing and thread-interaction history

## What Changed

- Reordered `companyService.remove()` in `server/src/services/companies.ts`:
  - Delete `finance_events` and `cost_events` before `heartbeat_runs`
  - Delete watchdog decisions and workspace operation/runtime rows before `heartbeat_runs`
  - Delete issue subgraph tables (including `issue_thread_interactions`) before `issues`
  - Delete `issue_documents` and `document_revisions` before `documents`
  - Delete `execution_workspaces` and `agent_config_revisions` before `projects` / `agents`
- Extended `cleanup-removal-service.test.ts` with regression tests for cost/finance + heartbeat run linkage and issue thread interactions
- Updated test `afterEach` cleanup for new tables

## Verification

- [x] `pnpm exec vitest run server/src/__tests__/cleanup-removal-service.test.ts` (4 tests pass)
- Manual: restart dev server, delete a company that previously failed (board or `pnpm paperclipai company delete "<name>" --yes --confirm "<name>"`)
- No UI changes; screenshots N/A

## Risks

- Low–medium: manual cascade is still brittle if a future table adds `ON DELETE no action` FKs without updating `remove()`. Mitigation: regression tests for known blockers; consider a follow-up to document required delete order or use cascades in schema.
- No migration; behavior-only fix for delete path.

## Model Used

Cursor Composer (agent-assisted implementation and PR authoring). Provider: Cursor. Capabilities: codebase search, terminal execution, structured edits. Human directed the fix after reproducing FK errors in local dev.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A)
- [ ] I have updated relevant documentation to reflect my changes (not required for internal cascade fix)
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge