### PR TITLE
feat: improve live agent activity monitor

### DIFF
--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -28,7 +28,11 @@ export interface ActiveRunForIssue {
   agentName: string;
   adapterType: string;
   logBytes?: number | null;
+  lastOutputAt?: string | Date | null;
+  lastOutputSeq?: number | null;
+  lastOutputStream?: "stdout" | "stderr" | null;
   lastOutputBytes?: number | null;
+  processStartedAt?: string | Date | null;
   issueId?: string | null;
   livenessState?: RunLivenessFields["livenessState"];
   livenessReason?: string | null;
@@ -52,7 +56,11 @@ export interface LiveRunForIssue {
   agentName: string;
   adapterType: string;
   logBytes?: number | null;
+  lastOutputAt?: string | null;
+  lastOutputSeq?: number | null;
+  lastOutputStream?: "stdout" | "stderr" | null;
   lastOutputBytes?: number | null;
+  processStartedAt?: string | null;
   issueId?: string | null;
   livenessState?: RunLivenessFields["livenessState"];
   livenessReason?: string | null;

--- a/ui/src/components/ActiveAgentsPanel.test.tsx
+++ b/ui/src/components/ActiveAgentsPanel.test.tsx
@@ -151,6 +151,9 @@ describe("ActiveAgentsPanel", () => {
       minCount: 4,
       limit: undefined,
     });
+    expect(container.textContent).toContain("running");
+    expect(container.textContent).toContain("Live now");
+    expect(container.textContent).toContain("Waiting for run activity.");
 
     const moreLink = [...container.querySelectorAll("a")].find((anchor) =>
       anchor.textContent?.includes("more active/recent"),
@@ -226,6 +229,45 @@ describe("ActiveAgentsPanel", () => {
       );
       expect(issueLink?.textContent).toBe("PAP-3562 - Phase 4B: Implement LLM Wiki distillation UI");
       expect(issueLink?.getAttribute("href")).toBe("/issues/PAP-3562");
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("surfaces blocked issue state and backend next action in run cards", async () => {
+    mockHeartbeatsApi.liveRunsForCompany.mockResolvedValue([{
+      ...createIssueRun(1, "65274215-0000-4000-8000-000000000000"),
+      nextAction: "Waiting for COO to confirm deployment window.",
+      lastUsefulActionAt: "2026-04-24T12:05:00.000Z",
+    }]);
+    mockIssuesApi.get.mockResolvedValue({
+      ...createIssue(
+        "65274215-0000-4000-8000-000000000000",
+        "PAP-3562",
+        "Phase 4B: Implement LLM Wiki distillation UI",
+      ),
+      status: "blocked",
+    });
+
+    const root = createRoot(container);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ActiveAgentsPanel companyId="company-1" />
+        </QueryClientProvider>,
+      );
+    });
+
+    await waitForMicrotaskAssertion(() => {
+      expect(container.textContent).toContain("blocked");
+      expect(container.textContent).toContain("Waiting for COO to confirm deployment window.");
+      expect(container.textContent).toContain("Progress");
     });
 
     await act(async () => {

--- a/ui/src/components/ActiveAgentsPanel.tsx
+++ b/ui/src/components/ActiveAgentsPanel.tsx
@@ -10,10 +10,12 @@ import { cn, relativeTime } from "../lib/utils";
 import { ExternalLink } from "lucide-react";
 import { Identity } from "./Identity";
 import { RunChatSurface } from "./RunChatSurface";
+import { StatusBadge } from "./StatusBadge";
 import { useLiveRunTranscripts } from "./transcript/useLiveRunTranscripts";
 
 const MIN_DASHBOARD_RUNS = 4;
 const DASHBOARD_RUN_CARD_LIMIT = 4;
+const DASHBOARD_RUN_REFRESH_INTERVAL_MS = 5_000;
 const DASHBOARD_LOG_POLL_INTERVAL_MS = 15_000;
 const DASHBOARD_LOG_READ_LIMIT_BYTES = 64_000;
 const DASHBOARD_MAX_CHUNKS_PER_RUN = 40;
@@ -21,6 +23,34 @@ const EMPTY_TRANSCRIPT: TranscriptEntry[] = [];
 
 function isRunActive(run: LiveRunForIssue): boolean {
   return run.status === "queued" || run.status === "running";
+}
+
+function runStatusLabel(run: LiveRunForIssue, issue?: Issue): string {
+  if (issue?.status === "blocked") return "blocked";
+  if (run.status === "succeeded") return "done";
+  if (run.status === "failed" || run.status === "timed_out") return "error";
+  return run.status;
+}
+
+function lastActivityAt(run: LiveRunForIssue): string | Date {
+  return run.lastOutputAt ?? run.lastUsefulActionAt ?? run.finishedAt ?? run.startedAt ?? run.createdAt;
+}
+
+function lastActivityLabel(run: LiveRunForIssue): string {
+  const activityAt = lastActivityAt(run);
+  if (run.lastOutputAt) return `Output ${relativeTime(activityAt)}`;
+  if (run.lastUsefulActionAt) return `Progress ${relativeTime(activityAt)}`;
+  if (run.finishedAt) return `Finished ${relativeTime(activityAt)}`;
+  if (run.startedAt) return `Started ${relativeTime(activityAt)}`;
+  return `Created ${relativeTime(activityAt)}`;
+}
+
+function recentActivityText(run: LiveRunForIssue): string {
+  if (run.nextAction) return run.nextAction;
+  if (run.livenessReason) return run.livenessReason;
+  if (run.lastOutputAt) return `Last output ${relativeTime(run.lastOutputAt)}`;
+  if (run.finishedAt) return `Run ${run.status.replace(/_/g, " ")} ${relativeTime(run.finishedAt)}`;
+  return "Waiting for run activity.";
 }
 
 interface ActiveAgentsPanelProps {
@@ -51,6 +81,8 @@ export function ActiveAgentsPanel({
   const { data: liveRuns } = useQuery({
     queryKey: [...queryKeys.liveRuns(companyId), queryScope, { minRunCount, fetchLimit }],
     queryFn: () => heartbeatsApi.liveRunsForCompany(companyId, { minCount: minRunCount, limit: fetchLimit }),
+    refetchInterval: DASHBOARD_RUN_REFRESH_INTERVAL_MS,
+    refetchIntervalInBackground: true,
   });
 
   const runs = liveRuns ?? [];
@@ -152,7 +184,7 @@ const AgentRunCard = memo(function AgentRunCard({
       <div className="border-b border-border/60 px-3 py-3">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 pr-1">
               {isActive ? (
                 <span className="relative flex h-2.5 w-2.5 shrink-0">
                   <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-cyan-400 opacity-70" />
@@ -163,8 +195,11 @@ const AgentRunCard = memo(function AgentRunCard({
               )}
               <Identity name={run.agentName} size="sm" className="[&>span:last-child]:!text-[11px]" />
             </div>
-            <div className="mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+            <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
+              <StatusBadge status={runStatusLabel(run, issue)} />
               <span>{isActive ? "Live now" : run.finishedAt ? `Finished ${relativeTime(run.finishedAt)}` : `Started ${relativeTime(run.createdAt)}`}</span>
+              <span className="text-muted-foreground/50">·</span>
+              <span>{lastActivityLabel(run)}</span>
             </div>
           </div>
 
@@ -191,6 +226,11 @@ const AgentRunCard = memo(function AgentRunCard({
             </Link>
           </div>
         )}
+        <div className="mt-2 rounded-lg border border-border/50 bg-background/45 px-2.5 py-2">
+          <p className="line-clamp-2 text-[11px] leading-4 text-muted-foreground" title={recentActivityText(run)}>
+            {recentActivityText(run)}
+          </p>
+        </div>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-3">

--- a/ui/storybook/stories/agent-management.stories.tsx
+++ b/ui/storybook/stories/agent-management.stories.tsx
@@ -425,7 +425,10 @@ function StorybookQueryFixtures({ children }: { children: ReactNode }) {
   queryClient.setQueryData(queryKeys.adapters.all, adapterFixtures);
   queryClient.setQueryData(queryKeys.issues.list(COMPANY_ID), storybookIssues);
   queryClient.setQueryData([...queryKeys.issues.list(COMPANY_ID), "with-routine-executions"], storybookIssues);
-  queryClient.setQueryData([...queryKeys.liveRuns(COMPANY_ID), "dashboard"], liveRuns);
+  queryClient.setQueryData([...queryKeys.liveRuns(COMPANY_ID), "dashboard", { minRunCount: 4, fetchLimit: undefined }], liveRuns);
+  for (const issue of storybookIssues) {
+    queryClient.setQueryData(queryKeys.issues.detail(issue.id), issue);
+  }
   queryClient.setQueryData(queryKeys.instance.generalSettings, { censorUsernameInLogs: false });
   queryClient.setQueryData(queryKeys.agents.adapterModels(COMPANY_ID, "codex_local"), [
     { id: "gpt-5.4", label: "GPT-5.4" },


### PR DESCRIPTION
## Summary

- Adds richer live run metadata to the heartbeat API client types.
- Updates the active agents dashboard cards with live refresh, per-run issue detail lookup, status badges, and recent activity text.
- Extends tests and Storybook coverage for the live agent activity monitor.

## Context

Paperclip issue: [MUR-283](/MUR/issues/MUR-283)
Recovery/unblock issue: [MUR-288](/MUR/issues/MUR-288)

This PR is opened from the Pat-owned fork because the available `marketingcad` GitHub token has write access to `marketingcad/paperclip` but only read access to upstream `paperclipai/paperclip`.

## Validation

- Existing local implementation commit: `cad44fad9f14926e1fec431ae6308aff81540839`.
- Fork branch pushed successfully to `marketingcad/paperclip:feat/mur-283-real-time-agent-activity-monitor`.
- Live `/app` fallback deploy was attempted separately but blocked by container filesystem permissions, so live Playwright verification is still pending deployment.
