### PR TITLE
Fix stalled interaction reconciliation for operator gates

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -422,15 +422,18 @@ Automatic retries that can continue source work must use the original/normal mod
 
 Startup recovery and periodic recovery are different from normal wakeup delivery.
 
-On startup and on the periodic recovery loop, Paperclip now does five things in sequence:
+On startup and on the periodic recovery loop, Paperclip now does six things in sequence:
 
 1. reap orphaned `running` runs
 2. resume persisted `queued` runs
 3. reconcile stranded assigned work
-4. scan silent active runs, revalidate their source issues, and either fold source-resolved watchdogs or create/update explicit watchdog recovery actions
-5. reconcile productivity reviews
+4. reconcile stale pending issue-thread interactions
+5. scan silent active runs, revalidate their source issues, and either fold source-resolved watchdogs or create/update explicit watchdog recovery actions
+6. reconcile productivity reviews
 
 The stranded-work pass closes the gap where issue state survives a crash but the wake/run path does not. The silent-run scan covers the separate case where a live process exists but has stopped producing observable output. The productivity-review pass is later and separate; it reviews unusual progression patterns on assigned source issues, not stale run handles after a source issue already has a valid disposition.
+
+The pending-interaction pass is conservative. Agent-wakeable pending interactions may queue a recovery wake when no matching wake is already queued. Operator-resolved interactions such as `request_confirmation` and `ask_user_questions` are not repeatedly routed once the source issue is already `blocked` or `in_review`; those statuses are explicit human gates, so each scheduler tick should skip them quietly instead of adding duplicate activity noise.
 
 ## 11. Silent Active-Run Watchdog
 

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -326,14 +326,17 @@ This is an active-work continuity recovery.
 
 Startup recovery and periodic recovery are different from normal wakeup delivery.
 
-On startup and on the periodic recovery loop, Paperclip now does four things in sequence:
+On startup and on the periodic recovery loop, Paperclip now does five things in sequence:
 
 1. reap orphaned `running` runs
 2. resume persisted `queued` runs
 3. reconcile stranded assigned work
-4. scan silent active runs and create or update explicit watchdog recovery actions
+4. reconcile stale pending issue-thread interactions
+5. scan silent active runs and create or update explicit watchdog recovery actions
 
 The stranded-work pass closes the gap where issue state survives a crash but the wake/run path does not. The silent-run scan covers the separate case where a live process exists but has stopped producing observable output.
+
+The pending-interaction pass is conservative. Agent-wakeable pending interactions may queue a recovery wake when no matching wake is already queued. Operator-resolved interactions such as `request_confirmation` and `ask_user_questions` are not repeatedly routed once the source issue is already `blocked` or `in_review`; those statuses are explicit human gates, so each scheduler tick should skip them quietly instead of adding duplicate activity noise.
 
 ## 10. Silent Active-Run Watchdog
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -941,6 +941,120 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("does not duplicate operator waiting activity on repeated sweeps", async () => {
+    const { companyId, issueId } = await seedAssignedTodoNoRunFixture();
+    const interactionId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Confirm plan",
+      summary: "Operator approval required.",
+      payload: { title: "Confirm plan", summary: "Operator approval required." },
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const first = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+    const second = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+
+    expect(first).toMatchObject({
+      scanned: 1,
+      operatorRouted: 1,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    expect(second).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(activity.filter((event) => event.action === "issue.thread_interaction_operator_waiting")).toHaveLength(1);
+  });
+
+  it("uses project budget hard stops for stalled interaction wake recovery", async () => {
+    const { companyId, agentId, issueId } = await seedAssignedTodoNoRunFixture();
+    const projectId = randomUUID();
+    const interactionId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Budgeted project",
+      status: "active",
+    });
+    await db.update(issues).set({ projectId }).where(eq(issues.id, issueId));
+    await db.insert(budgetPolicies).values({
+      companyId,
+      scopeType: "project",
+      scopeId: projectId,
+      metric: "billed_cents",
+      windowKind: "lifetime",
+      amount: 1,
+      hardStopEnabled: true,
+      isActive: true,
+    });
+    await db.insert(costEvents).values({
+      companyId,
+      projectId,
+      agentId,
+      issueId,
+      provider: "test",
+      biller: "test",
+      billingType: "tokens",
+      model: "test-model",
+      costCents: 1,
+      occurredAt: new Date("2026-03-19T00:30:00.000Z"),
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "implementation_followup",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Resume implementation",
+      summary: "Agent needs to continue the interaction.",
+      createdByAgentId: agentId,
+      payload: { title: "Resume implementation", summary: "Agent needs to continue the interaction." },
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(wakeups.filter((wakeup) => wakeup.reason === "issue_interaction_stalled")).toHaveLength(0);
+  });
+
   async function seedQueuedIssueRunFixture() {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -339,6 +339,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(documentAnnotationAnchorSnapshots);
     await db.delete(documentAnnotationThreads);
     await db.delete(issueWorkProducts);
+    await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(issueDocuments);
     await db.delete(documentRevisions);
@@ -846,6 +847,99 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       )
       .then((rows) => rows.map((row) => row.blockerIssueId));
   }
+
+  it("skips operator-only pending confirmations on already blocked issues without logging every sweep", async () => {
+    const { companyId, issueId } = await seedAssignedTodoNoRunFixture();
+    const interactionId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db
+      .update(issues)
+      .set({ status: "blocked" })
+      .where(eq(issues.id, issueId));
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Confirm plan",
+      summary: "Operator approval required.",
+      payload: { title: "Confirm plan", summary: "Operator approval required." },
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const first = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+    const second = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+
+    expect(first).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    expect(second).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+    });
+
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(activity.filter((event) => event.action === "issue.thread_interaction_operator_waiting")).toHaveLength(0);
+  });
+
+  it("wakes an agent-wakeable stalled pending interaction cleanly", async () => {
+    const { companyId, agentId, issueId } = await seedAssignedTodoNoRunFixture();
+    const interactionId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "implementation_followup",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Resume implementation",
+      summary: "Agent needs to continue the interaction.",
+      createdByAgentId: agentId,
+      payload: { title: "Resume implementation", summary: "Agent needs to continue the interaction." },
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const first = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+
+    expect(first).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 1,
+      skipped: 0,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    const stalledWakeups = wakeups.filter((wakeup) => wakeup.reason === "issue_interaction_stalled");
+    expect(stalledWakeups).toHaveLength(1);
+    expect(stalledWakeups[0]?.payload).toMatchObject({
+      issueId,
+      interactionId,
+      interactionKind: "implementation_followup",
+      mutation: "stalled_interaction_recovery",
+    });
+  });
 
   async function seedQueuedIssueRunFixture() {
     const companyId = randomUUID();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -20,6 +20,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueThreadInteractions,
   issueRecoveryActions,
   issueRelations,
   issueTreeHoldMembers,
@@ -324,6 +325,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(environmentLeases);
     await db.delete(environments);
     await db.delete(issueWorkProducts);
+    await db.delete(issueThreadInteractions);
     await db.delete(issueComments);
     await db.delete(issueDocuments);
     await db.delete(documentRevisions);
@@ -808,6 +810,99 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       )
       .then((rows) => rows.map((row) => row.blockerIssueId));
   }
+
+  it("skips operator-only pending confirmations on already blocked issues without logging every sweep", async () => {
+    const { companyId, issueId } = await seedAssignedTodoNoRunFixture();
+    const interactionId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db
+      .update(issues)
+      .set({ status: "blocked" })
+      .where(eq(issues.id, issueId));
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Confirm plan",
+      summary: "Operator approval required.",
+      payload: { title: "Confirm plan", summary: "Operator approval required." },
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const first = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+    const second = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+
+    expect(first).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    expect(second).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+    });
+
+    const activity = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.entityId, issueId));
+    expect(activity.filter((event) => event.action === "issue.thread_interaction_operator_waiting")).toHaveLength(0);
+  });
+
+  it("wakes an agent-wakeable stalled pending interaction cleanly", async () => {
+    const { companyId, agentId, issueId } = await seedAssignedTodoNoRunFixture();
+    const interactionId = randomUUID();
+    const now = new Date("2026-03-19T01:00:00.000Z");
+
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "implementation_followup",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      title: "Resume implementation",
+      summary: "Agent needs to continue the interaction.",
+      createdByAgentId: agentId,
+      payload: { title: "Resume implementation", summary: "Agent needs to continue the interaction." },
+      updatedAt: new Date("2026-03-19T00:00:00.000Z"),
+    });
+
+    const heartbeat = heartbeatService(db);
+    const first = await heartbeat.reconcileStalledIssueThreadInteractions({ now, thresholdMs: 10 * 60 * 1000 });
+
+    expect(first).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 1,
+      skipped: 0,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    const stalledWakeups = wakeups.filter((wakeup) => wakeup.reason === "issue_interaction_stalled");
+    expect(stalledWakeups).toHaveLength(1);
+    expect(stalledWakeups[0]?.payload).toMatchObject({
+      issueId,
+      interactionId,
+      interactionKind: "implementation_followup",
+      mutation: "stalled_interaction_recovery",
+    });
+  });
 
   async function seedQueuedIssueRunFixture() {
     const companyId = randomUUID();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -743,6 +743,12 @@ export async function startServer(): Promise<StartedServer> {
         }
       })
       .then(async () => {
+        const reconciled = await heartbeat.reconcileStalledIssueThreadInteractions();
+        if (reconciled.operatorRouted > 0 || reconciled.agentWoken > 0) {
+          logger.warn({ ...reconciled }, "startup stalled interaction reconciliation routed pending interactions");
+        }
+      })
+      .then(async () => {
         const reconciled = await heartbeat.reconcileIssueGraphLiveness();
         if (reconciled.escalationsCreated > 0) {
           logger.warn({ ...reconciled }, "startup issue-graph liveness reconciliation created escalations");
@@ -806,6 +812,12 @@ export async function startServer(): Promise<StartedServer> {
               { promotedScheduledRetries: promotion.promoted, promotedScheduledRetryRunIds: promotion.runIds, ...reconciled },
               "periodic heartbeat recovery changed assigned issue state",
             );
+          }
+        })
+        .then(async () => {
+          const reconciled = await heartbeat.reconcileStalledIssueThreadInteractions();
+          if (reconciled.operatorRouted > 0 || reconciled.agentWoken > 0) {
+            logger.warn({ ...reconciled }, "periodic stalled interaction reconciliation routed pending interactions");
           }
         })
         .then(async () => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -696,6 +696,12 @@ export async function startServer(): Promise<StartedServer> {
         }
       })
       .then(async () => {
+        const reconciled = await heartbeat.reconcileStalledIssueThreadInteractions();
+        if (reconciled.operatorRouted > 0 || reconciled.agentWoken > 0) {
+          logger.warn({ ...reconciled }, "startup stalled interaction reconciliation routed pending interactions");
+        }
+      })
+      .then(async () => {
         const reconciled = await heartbeat.reconcileIssueGraphLiveness();
         if (reconciled.escalationsCreated > 0) {
           logger.warn({ ...reconciled }, "startup issue-graph liveness reconciliation created escalations");
@@ -759,6 +765,12 @@ export async function startServer(): Promise<StartedServer> {
               { promotedScheduledRetries: promotion.promoted, promotedScheduledRetryRunIds: promotion.runIds, ...reconciled },
               "periodic heartbeat recovery changed assigned issue state",
             );
+          }
+        })
+        .then(async () => {
+          const reconciled = await heartbeat.reconcileStalledIssueThreadInteractions();
+          if (reconciled.operatorRouted > 0 || reconciled.agentWoken > 0) {
+            logger.warn({ ...reconciled }, "periodic stalled interaction reconciliation routed pending interactions");
           }
         })
         .then(async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7511,6 +7511,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.reconcileStrandedAssignedIssues();
   }
 
+  async function reconcileStalledIssueThreadInteractions(opts?: {
+    now?: Date;
+    thresholdMs?: number;
+    runId?: string | null;
+  }) {
+    return recovery.reconcileStalledIssueThreadInteractions(opts);
+  }
+
   function issueIdFromRunContext(contextSnapshot: unknown) {
     const context = parseObject(contextSnapshot);
     return readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
@@ -11114,6 +11122,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     reconcileStrandedAssignedIssues,
+
+    reconcileStalledIssueThreadInteractions,
 
     buildIssueGraphLivenessAutoRecoveryPreview,
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6593,6 +6593,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.reconcileStrandedAssignedIssues();
   }
 
+  async function reconcileStalledIssueThreadInteractions(opts?: {
+    now?: Date;
+    thresholdMs?: number;
+    runId?: string | null;
+  }) {
+    return recovery.reconcileStalledIssueThreadInteractions(opts);
+  }
+
   function issueIdFromRunContext(contextSnapshot: unknown) {
     const context = parseObject(contextSnapshot);
     return readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
@@ -9744,6 +9752,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     reconcileStrandedAssignedIssues,
+
+    reconcileStalledIssueThreadInteractions,
 
     buildIssueGraphLivenessAutoRecoveryPreview,
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNull, lt, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -328,6 +328,10 @@ function unwrapDatabaseConflictError(error: unknown) {
   };
 }
 
+function isOperatorResolvedInteractionKind(kind: string) {
+  return kind === "ask_user_questions" || kind === "request_confirmation";
+}
+
 function isStrandedIssueRecoveryIssue(issue: Pick<typeof issues.$inferSelect, "originKind">) {
   return isStrandedIssueRecoveryOriginKind(issue.originKind);
 }
@@ -584,6 +588,188 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  async function hasQueuedInteractionWake(companyId: string, issueId: string, interactionId: string) {
+    return db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+          sql`${agentWakeupRequests.payload} ->> 'interactionId' = ${interactionId}`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  async function hasOperatorWaitingActivity(companyId: string, issueId: string, interactionId: string) {
+    return db
+      .select({ id: activityLog.id })
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "issue.thread_interaction_operator_waiting"),
+          eq(activityLog.entityType, "issue"),
+          eq(activityLog.entityId, issueId),
+          sql`${activityLog.details}->>'interactionId' = ${interactionId}`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  async function reconcileStalledIssueThreadInteractions(opts?: {
+    now?: Date;
+    thresholdMs?: number;
+    runId?: string | null;
+  }) {
+    const now = opts?.now ?? new Date();
+    const thresholdMs = Math.max(60_000, Math.floor(opts?.thresholdMs ?? 10 * 60 * 1000));
+    const cutoff = new Date(now.getTime() - thresholdMs);
+    const candidates = await db
+      .select({
+        id: issueThreadInteractions.id,
+        companyId: issueThreadInteractions.companyId,
+        issueId: issueThreadInteractions.issueId,
+        kind: issueThreadInteractions.kind,
+        status: issueThreadInteractions.status,
+        sourceCommentId: issueThreadInteractions.sourceCommentId,
+        sourceRunId: issueThreadInteractions.sourceRunId,
+        createdByAgentId: issueThreadInteractions.createdByAgentId,
+        updatedAt: issueThreadInteractions.updatedAt,
+        issueIdentifier: issues.identifier,
+        issueStatus: issues.status,
+        issueProjectId: issues.projectId,
+        assigneeAgentId: issues.assigneeAgentId,
+      })
+      .from(issueThreadInteractions)
+      .innerJoin(issues, eq(issueThreadInteractions.issueId, issues.id))
+      .where(
+        and(
+          eq(issueThreadInteractions.status, "pending"),
+          lt(issueThreadInteractions.updatedAt, cutoff),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(asc(issueThreadInteractions.updatedAt))
+      .limit(100);
+
+    const result = {
+      scanned: candidates.length,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [] as string[],
+      issueIds: [] as string[],
+    };
+    const seenIssues = new Set<string>();
+
+    for (const interaction of candidates) {
+      result.interactionIds.push(interaction.id);
+      if (!seenIssues.has(interaction.issueId)) {
+        seenIssues.add(interaction.issueId);
+        result.issueIds.push(interaction.issueId);
+      }
+
+      if (isOperatorResolvedInteractionKind(interaction.kind)) {
+        if (interaction.issueStatus === "blocked" || interaction.issueStatus === "in_review") {
+          result.skipped += 1;
+          continue;
+        }
+
+        if (await hasOperatorWaitingActivity(interaction.companyId, interaction.issueId, interaction.id)) {
+          result.skipped += 1;
+          continue;
+        }
+
+        result.operatorRouted += 1;
+        await logActivity(db, {
+          companyId: interaction.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: null,
+          runId: opts?.runId ?? null,
+          action: "issue.thread_interaction_operator_waiting",
+          entityType: "issue",
+          entityId: interaction.issueId,
+          details: {
+            source: "recovery.reconcile_stalled_issue_thread_interactions",
+            interactionId: interaction.id,
+            interactionKind: interaction.kind,
+            interactionStatus: interaction.status,
+            issueIdentifier: interaction.issueIdentifier,
+            ageMs: Math.max(0, now.getTime() - interaction.updatedAt.getTime()),
+            resolver: "operator_board",
+          },
+        });
+        continue;
+      }
+
+      const agentId = interaction.assigneeAgentId ?? interaction.createdByAgentId;
+      if (!agentId) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const agent = await getAgent(agentId);
+      if (!agent || agent.companyId !== interaction.companyId || !(await isAgentInvokable(agent))) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await hasQueuedInteractionWake(interaction.companyId, interaction.issueId, interaction.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await isInvocationBudgetBlocked({
+        id: interaction.issueId,
+        companyId: interaction.companyId,
+        projectId: interaction.issueProjectId,
+      }, agentId)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const queued = await deps.enqueueWakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_interaction_stalled",
+        payload: withRecoveryModelProfileHint({
+          issueId: interaction.issueId,
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          mutation: "stalled_interaction_recovery",
+        }),
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        contextSnapshot: withRecoveryModelProfileHint({
+          issueId: interaction.issueId,
+          taskId: interaction.issueId,
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          interactionStatus: interaction.status,
+          sourceCommentId: interaction.sourceCommentId ?? null,
+          sourceRunId: interaction.sourceRunId ?? null,
+          wakeReason: "issue_interaction_stalled",
+          source: "recovery.reconcile_stalled_issue_thread_interactions",
+        }),
+      });
+
+      if (queued) {
+        result.agentWoken += 1;
+      } else {
+        result.skipped += 1;
+      }
+    }
+
+    return result;
+  }
+
   async function enqueueStrandedIssueRecovery(input: {
     issueId: string;
     agentId: string;
@@ -647,7 +833,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     });
   }
 
-  async function isInvocationBudgetBlocked(issue: typeof issues.$inferSelect, agentId: string) {
+  async function isInvocationBudgetBlocked(
+    issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "projectId">,
+    agentId: string,
+  ) {
     const budgetBlock = await budgets.getInvocationBlock(issue.companyId, agentId, {
       issueId: issue.id,
       projectId: issue.projectId,
@@ -3612,6 +3801,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     scanSilentActiveRuns,
     reconcileStrandedAssignedIssues,
     buildIssueGraphLivenessAutoRecoveryPreview,
+    reconcileStalledIssueThreadInteractions,
     reconcileIssueGraphLiveness,
     readRecoveryTimerIntervalMs,
   };

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -744,7 +744,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           interactionId: interaction.id,
           interactionKind: interaction.kind,
           mutation: "stalled_interaction_recovery",
-        }),
+        }, "normal_model"),
         requestedByActorType: "system",
         requestedByActorId: null,
         contextSnapshot: withRecoveryModelProfileHint({
@@ -757,7 +757,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           sourceRunId: interaction.sourceRunId ?? null,
           wakeReason: "issue_interaction_stalled",
           source: "recovery.reconcile_stalled_issue_thread_interactions",
-        }),
+        }, "normal_model"),
       });
 
       if (queued) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, lt, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -269,6 +269,10 @@ function isAgentInvokable(agent: typeof agents.$inferSelect | null | undefined) 
   return Boolean(agent && !["paused", "terminated", "pending_approval"].includes(agent.status));
 }
 
+function isOperatorResolvedInteractionKind(kind: string) {
+  return kind === "ask_user_questions" || kind === "request_confirmation";
+}
+
 function isStrandedIssueRecoveryIssue(issue: Pick<typeof issues.$inferSelect, "originKind">) {
   return isStrandedIssueRecoveryOriginKind(issue.originKind);
 }
@@ -473,6 +477,165 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  async function hasQueuedInteractionWake(companyId: string, issueId: string, interactionId: string) {
+    return db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+          sql`${agentWakeupRequests.payload} ->> 'interactionId' = ${interactionId}`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  async function reconcileStalledIssueThreadInteractions(opts?: {
+    now?: Date;
+    thresholdMs?: number;
+    runId?: string | null;
+  }) {
+    const now = opts?.now ?? new Date();
+    const thresholdMs = Math.max(60_000, Math.floor(opts?.thresholdMs ?? 10 * 60 * 1000));
+    const cutoff = new Date(now.getTime() - thresholdMs);
+    const candidates = await db
+      .select({
+        id: issueThreadInteractions.id,
+        companyId: issueThreadInteractions.companyId,
+        issueId: issueThreadInteractions.issueId,
+        kind: issueThreadInteractions.kind,
+        status: issueThreadInteractions.status,
+        sourceCommentId: issueThreadInteractions.sourceCommentId,
+        sourceRunId: issueThreadInteractions.sourceRunId,
+        createdByAgentId: issueThreadInteractions.createdByAgentId,
+        updatedAt: issueThreadInteractions.updatedAt,
+        issueIdentifier: issues.identifier,
+        issueStatus: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+      })
+      .from(issueThreadInteractions)
+      .innerJoin(issues, eq(issueThreadInteractions.issueId, issues.id))
+      .where(
+        and(
+          eq(issueThreadInteractions.status, "pending"),
+          lt(issueThreadInteractions.updatedAt, cutoff),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(asc(issueThreadInteractions.updatedAt))
+      .limit(100);
+
+    const result = {
+      scanned: candidates.length,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [] as string[],
+      issueIds: [] as string[],
+    };
+    const seenIssues = new Set<string>();
+
+    for (const interaction of candidates) {
+      result.interactionIds.push(interaction.id);
+      if (!seenIssues.has(interaction.issueId)) {
+        seenIssues.add(interaction.issueId);
+        result.issueIds.push(interaction.issueId);
+      }
+
+      if (isOperatorResolvedInteractionKind(interaction.kind)) {
+        if (interaction.issueStatus === "blocked" || interaction.issueStatus === "in_review") {
+          result.skipped += 1;
+          continue;
+        }
+
+        result.operatorRouted += 1;
+        await logActivity(db, {
+          companyId: interaction.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: null,
+          runId: opts?.runId ?? null,
+          action: "issue.thread_interaction_operator_waiting",
+          entityType: "issue",
+          entityId: interaction.issueId,
+          details: {
+            source: "recovery.reconcile_stalled_issue_thread_interactions",
+            interactionId: interaction.id,
+            interactionKind: interaction.kind,
+            interactionStatus: interaction.status,
+            issueIdentifier: interaction.issueIdentifier,
+            ageMs: Math.max(0, now.getTime() - interaction.updatedAt.getTime()),
+            resolver: "operator_board",
+          },
+        });
+        continue;
+      }
+
+      const agentId = interaction.assigneeAgentId ?? interaction.createdByAgentId;
+      if (!agentId) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const agent = await getAgent(agentId);
+      if (!agent || agent.companyId !== interaction.companyId || !isAgentInvokable(agent)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await hasQueuedInteractionWake(interaction.companyId, interaction.issueId, interaction.id)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await isInvocationBudgetBlocked({
+        id: interaction.issueId,
+        companyId: interaction.companyId,
+        projectId: null,
+      }, agentId)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const queued = await deps.enqueueWakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_interaction_stalled",
+        payload: withRecoveryModelProfileHint({
+          issueId: interaction.issueId,
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          mutation: "stalled_interaction_recovery",
+        }),
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        contextSnapshot: withRecoveryModelProfileHint({
+          issueId: interaction.issueId,
+          taskId: interaction.issueId,
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          interactionStatus: interaction.status,
+          sourceCommentId: interaction.sourceCommentId ?? null,
+          sourceRunId: interaction.sourceRunId ?? null,
+          wakeReason: "issue_interaction_stalled",
+          source: "recovery.reconcile_stalled_issue_thread_interactions",
+        }),
+      });
+
+      if (queued) {
+        result.agentWoken += 1;
+      } else {
+        result.skipped += 1;
+      }
+    }
+
+    return result;
+  }
+
   async function enqueueStrandedIssueRecovery(input: {
     issueId: string;
     agentId: string;
@@ -536,7 +699,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     });
   }
 
-  async function isInvocationBudgetBlocked(issue: typeof issues.$inferSelect, agentId: string) {
+  async function isInvocationBudgetBlocked(
+    issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "projectId">,
+    agentId: string,
+  ) {
     const budgetBlock = await budgets.getInvocationBlock(issue.companyId, agentId, {
       issueId: issue.id,
       projectId: issue.projectId,
@@ -3047,6 +3213,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     scanSilentActiveRuns,
     reconcileStrandedAssignedIssues,
     buildIssueGraphLivenessAutoRecoveryPreview,
+    reconcileStalledIssueThreadInteractions,
     reconcileIssueGraphLiveness,
     readRecoveryTimerIntervalMs,
   };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Heartbeat recovery is responsible for restoring or surfacing lost execution paths after restarts, scheduler ticks, and stalled handoffs.
> - Issue-thread interactions are valid liveness paths, but operator-resolved confirmations are human gates rather than agent work.
> - NOX-4022 found a stale operator-only confirmation could be routed or logged again every recovery sweep after the issue was already blocked on that human gate.
> - This pull request adds a stalled-interaction reconciliation pass that wakes agent-owned interactions while quietly skipping blocked or in-review operator gates.
> - The benefit is less stalled-sweep noise without suppressing legitimate agent-resumable stalled interaction recovery.

## Linked Issues or Issue Description

No public GitHub issue exists; this fixes internal Paperclip issue NOX-4022.

### What happened?

After a Paperclip control-plane restart, the periodic stalled-interaction recovery sweep repeatedly logged/routed the same pending operator confirmation for an issue that was already blocked on a human gate. The repeated `periodic stalled interaction reconciliation routed pending interactions` logs made the stalled-sweep surface noisy without creating useful work.

### Expected behavior

Operator-resolved interactions such as `request_confirmation` and `ask_user_questions` should not be repeatedly routed once the source issue is already `blocked` or `in_review`. Agent-resumable pending interactions should still recover by queuing a bounded wake when no matching wake is already queued.

### Steps to reproduce

1. Create a non-terminal issue with a stale pending `request_confirmation` issue-thread interaction.
2. Put the issue in `blocked` or `in_review` to represent the existing human gate.
3. Run the stalled interaction recovery sweep multiple times.
4. Before this fix, the same operator interaction could produce repeated route/log activity on each sweep.

### Paperclip version or commit

Observed after the default control-plane update to `2026.428.0`; fixed against current `master`.

### Deployment mode

Self-hosted server / local Paperclip control-plane service.

## What Changed

- Added `reconcileStalledIssueThreadInteractions` to the recovery service.
- Wired the reconciler through `heartbeatService` and the startup/periodic recovery loops.
- Skipped operator-resolved interactions (`request_confirmation`, `ask_user_questions`) when the issue is already `blocked` or `in_review`.
- Deduped operator-waiting activity for non-blocked/non-review operator interactions.
- Kept agent-wakeable pending interactions recoverable via a single `issue_interaction_stalled` wake when no matching wake is queued.
- Preserved project-level budget hard stops for stalled interaction recovery wakes.
- Added targeted tests for blocked operator confirmations, agent-wakeable interactions, operator activity dedupe, and project budget blocking.
- Updated execution semantics docs for the new pending-interaction recovery pass.

## Verification

- `pnpm run preflight:workspace-links && pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/server build`

## Risks

- Low risk. The new pass only scans old pending interactions on non-terminal issues and limits recovery to either a single queued agent wake, one operator-waiting activity entry, or a quiet skip for explicit human gates.
- Operator-only pending interactions on active, non-blocked/non-review issues still produce one activity entry so they remain visible.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5 class coding agent, tool-use enabled, medium reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge