### PR TITLE
ADF-482: Add Factory Health badge to Board issues view

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -171,6 +171,31 @@ The valid action-path primitives are:
 - a first-class blocker chain whose unresolved leaf issues are themselves healthy
 - an open explicit recovery action that names the owner and action needed to restore liveness
 
+### Recovery action lifecycle - automatic resolution on liveness-restored
+
+An open explicit recovery action is **covered** when its `sourceIssueId`
+currently exhibits at least one valid action-path primitive listed above.
+
+During the same startup/periodic reconciliation pass that opens recovery
+actions for stranded work, Paperclip must also evaluate existing open recovery
+actions and clear any that are already covered:
+
+- resolve with `outcome=restored` when the source issue has a healthy live path
+- use the mapped terminal outcome when the source issue is now `blocked` or
+  `cancelled`
+- close the recovery action in that same pass rather than leaving stale
+  operator cleanup work
+
+Manual resolution remains the operator override path via:
+`POST /api/issues/{issueId}/recovery-actions/{actionId}/resolve`.
+
+This rule preserves three invariants:
+
+- productive work continues once liveness is restored
+- only real blockers stop work; stale recovery wrappers do not
+- no infinite loops from repeatedly reopening and re-resolving already-covered
+  recovery state
+
 ### Explicit recovery actions
 
 An explicit recovery action is a typed liveness repair path for a source issue. It is the recovery primitive; the action can be rendered directly on the source issue or backed by a separate recovery issue when the repair needs its own work item.
@@ -334,6 +359,11 @@ On startup and on the periodic recovery loop, Paperclip now does four things in 
 4. scan silent active runs and create or update explicit watchdog recovery actions
 
 The stranded-work pass closes the gap where issue state survives a crash but the wake/run path does not. The silent-run scan covers the separate case where a live process exists but has stopped producing observable output.
+
+The same reconciliation pass also performs recovery-action auto-resolution for
+already-covered actions (see §7). This keeps stranded-work repair and recovery
+cleanup in one deterministic lifecycle, while the watchdog scan remains focused
+on active-run silence signals rather than stale recovered actions.
 
 ## 10. Silent Active-Run Watchdog
 

--- a/ui/src/components/FactoryHealthBadge.test.ts
+++ b/ui/src/components/FactoryHealthBadge.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { Agent, Issue } from "@paperclipai/shared";
+import {
+  countActiveAgentsInWindow,
+  countFactoryManagementIssues,
+  getLatestCompletedCycleIssue,
+} from "./FactoryHealthBadge";
+
+function issue(overrides: Partial<Issue>): Issue {
+  return {
+    id: "issue-1",
+    title: "Issue",
+    status: "todo",
+    ...overrides,
+  } as unknown as Issue;
+}
+
+function agent(overrides: Partial<Agent>): Agent {
+  return {
+    id: "agent-1",
+    companyId: "company-1",
+    name: "Agent",
+    urlKey: "agent",
+    role: "engineer",
+    title: null,
+    icon: null,
+    status: "active",
+    reportsTo: null,
+    capabilities: null,
+    adapterType: "codex_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    defaultEnvironmentId: null,
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: { canCreateAgents: false },
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe("FactoryHealthBadge helpers", () => {
+  it("counts open FM issues from title pattern", () => {
+    const count = countFactoryManagementIssues([
+      issue({ title: "FM12: investigate queue" }),
+      issue({ title: "factory/fm007 spike" }),
+      issue({ title: "unrelated issue" }),
+    ]);
+    expect(count).toBe(2);
+  });
+
+  it("selects latest completed cycle run from sorted issues", () => {
+    const result = getLatestCompletedCycleIssue([
+      issue({ id: "a", title: "Cycle Run #124", status: "in_progress" }),
+      issue({ id: "b", title: "Cycle Run #123A", status: "done" }),
+      issue({ id: "c", title: "Cycle Run #123", status: "blocked" }),
+      issue({ id: "d", title: "Cycle Run #122", status: "done" }),
+    ]);
+    expect(result?.id).toBe("c");
+  });
+
+  it("counts distinct active non-board agents in the 15m window", () => {
+    const now = Date.parse("2026-05-21T14:00:00.000Z");
+    const count = countActiveAgentsInWindow(
+      [
+        { actorType: "agent", actorId: "agent-a", createdAt: "2026-05-21T13:58:00.000Z" },
+        { actorType: "agent", actorId: "agent-a", createdAt: "2026-05-21T13:57:00.000Z" },
+        { actorType: "agent", actorId: "board-agent", createdAt: "2026-05-21T13:59:00.000Z" },
+        { actorType: "agent", actorId: "agent-old", createdAt: "2026-05-21T13:00:00.000Z" },
+        { actorType: "user", actorId: "person-1", createdAt: "2026-05-21T13:59:00.000Z" },
+      ],
+      [agent({ id: "board-agent", metadata: { agentType: "local-board" } })],
+      now,
+    );
+    expect(count).toBe(1);
+  });
+});

--- a/ui/src/components/FactoryHealthBadge.tsx
+++ b/ui/src/components/FactoryHealthBadge.tsx
@@ -1,0 +1,188 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@/lib/router";
+import { issuesApi } from "../api/issues";
+import { activityApi } from "../api/activity";
+import { queryKeys } from "../lib/queryKeys";
+import { cn } from "../lib/utils";
+import type { Agent, Issue } from "@paperclipai/shared";
+
+const CYCLE_MONITOR_AGENT_ID = "bc38280d-26c3-4097-8427-9e72412ebf7b";
+const FACTORY_FM_TITLE_REGEX = /^(FACTORY\/)?FM\d+/i;
+const CYCLE_RUN_TITLE_REGEX = /^Cycle Run #\d+$/;
+const ACTIVE_AGENT_WINDOW_MS = 15 * 60 * 1000;
+const REFRESH_INTERVAL_MS = 60_000;
+const BOARD_USER_ID = "local-board";
+
+type SignalTone = "green" | "amber" | "red" | "gray";
+
+function getSignalClasses(tone: SignalTone): string {
+  switch (tone) {
+    case "green":
+      return "bg-emerald-50 text-emerald-900 border-emerald-300 hover:bg-emerald-100";
+    case "amber":
+      return "bg-amber-50 text-amber-900 border-amber-300 hover:bg-amber-100";
+    case "red":
+      return "bg-red-50 text-red-900 border-red-300 hover:bg-red-100";
+    case "gray":
+    default:
+      return "bg-muted text-muted-foreground border-border hover:bg-muted/80";
+  }
+}
+
+export function countFactoryManagementIssues(issues: Issue[]): number {
+  return issues.filter((issue) => FACTORY_FM_TITLE_REGEX.test(issue.title.trim())).length;
+}
+
+export function getLatestCompletedCycleIssue(issues: Issue[]): Issue | null {
+  return issues.find(
+    (issue) =>
+      CYCLE_RUN_TITLE_REGEX.test(issue.title.trim())
+      && (issue.status === "done" || issue.status === "blocked" || issue.status === "cancelled"),
+  ) ?? null;
+}
+
+export function getBoardAgentIds(agents: Agent[]): Set<string> {
+  const boardIds = new Set<string>([BOARD_USER_ID]);
+  for (const agent of agents) {
+    const metadata = agent.metadata as Record<string, unknown> | null;
+    const agentType = typeof metadata?.agentType === "string" ? metadata.agentType : null;
+    const role = typeof metadata?.role === "string" ? metadata.role : null;
+    if (agentType === "local-board" || role === "local-board" || agent.urlKey === "local-board") {
+      boardIds.add(agent.id);
+    }
+  }
+  return boardIds;
+}
+
+export function countActiveAgentsInWindow(
+  events: { actorType: string; actorId: string; createdAt: string | Date }[],
+  agents: Agent[],
+  nowMs: number = Date.now(),
+): number {
+  const threshold = nowMs - ACTIVE_AGENT_WINDOW_MS;
+  const boardAgentIds = getBoardAgentIds(agents);
+  const activeAgentIds = new Set<string>();
+
+  for (const event of events) {
+    if (event.actorType !== "agent") continue;
+    if (!event.actorId || boardAgentIds.has(event.actorId)) continue;
+    const createdAtMs = new Date(event.createdAt).getTime();
+    if (!Number.isFinite(createdAtMs) || createdAtMs <= threshold) continue;
+    activeAgentIds.add(event.actorId);
+  }
+
+  return activeAgentIds.size;
+}
+
+interface FactoryHealthBadgeProps {
+  companyId: string;
+  agents: Agent[];
+}
+
+function SignalPill({
+  to,
+  title,
+  label,
+  value,
+  tone,
+}: {
+  to: string;
+  title: string;
+  label: string;
+  value: string;
+  tone: SignalTone;
+}) {
+  return (
+    <Link
+      to={to}
+      title={title}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+        getSignalClasses(tone),
+      )}
+    >
+      <span>{label}</span>
+      <span className="font-semibold">{value}</span>
+    </Link>
+  );
+}
+
+export function FactoryHealthBadge({ companyId, agents }: FactoryHealthBadgeProps) {
+  const commonQueryOptions = {
+    staleTime: REFRESH_INTERVAL_MS,
+    refetchInterval: REFRESH_INTERVAL_MS,
+    enabled: Boolean(companyId),
+  } as const;
+
+  const { data: fmIssues = [] } = useQuery({
+    queryKey: queryKeys.factoryHealth.fmIssues(companyId),
+    queryFn: () =>
+      issuesApi.list(companyId, {
+        status: "todo,in_progress,blocked",
+        limit: 500,
+      }),
+    ...commonQueryOptions,
+  });
+
+  const { data: cycleIssues = [] } = useQuery({
+    queryKey: queryKeys.factoryHealth.latestCycle(companyId),
+    queryFn: () =>
+      issuesApi.list(companyId, {
+        assigneeAgentId: CYCLE_MONITOR_AGENT_ID,
+        q: "Cycle Run",
+        limit: 20,
+      }),
+    ...commonQueryOptions,
+  });
+
+  const { data: activityEvents = [] } = useQuery({
+    queryKey: queryKeys.factoryHealth.activeAgents(companyId),
+    queryFn: () =>
+      activityApi.list(companyId, {
+        limit: 500,
+      }),
+    ...commonQueryOptions,
+  });
+
+  const fmCount = useMemo(() => countFactoryManagementIssues(fmIssues), [fmIssues]);
+  const latestCycle = useMemo(() => getLatestCompletedCycleIssue(cycleIssues), [cycleIssues]);
+  const activeAgentsCount = useMemo(
+    () => countActiveAgentsInWindow(activityEvents, agents),
+    [activityEvents, agents],
+  );
+
+  const fmTone: SignalTone = fmCount === 0 ? "green" : fmCount <= 3 ? "amber" : "red";
+  const cycleTone: SignalTone = latestCycle
+    ? latestCycle.status === "done"
+      ? "green"
+      : "red"
+    : "gray";
+  const activeAgentsTone: SignalTone = activeAgentsCount > 0 ? "green" : "gray";
+
+  return (
+    <div className="flex w-full flex-wrap items-center gap-2">
+      <SignalPill
+        to="/issues?status=todo,in_progress,blocked"
+        title="Open factory management issues"
+        label="Open FM"
+        value={String(fmCount)}
+        tone={fmTone}
+      />
+      <SignalPill
+        to={latestCycle ? `/issues/${latestCycle.id}` : "/issues"}
+        title="Last completed cycle status"
+        label="Last cycle"
+        value={latestCycle ? (latestCycle.status === "done" ? "Pass" : "Fail") : "Unknown"}
+        tone={cycleTone}
+      />
+      <SignalPill
+        to="/agents"
+        title="Active agents in last 15 minutes"
+        label="Active agents (15m)"
+        value={String(activeAgentsCount)}
+        tone={activeAgentsTone}
+      />
+    </div>
+  );
+}

--- a/ui/src/components/FactoryHealthBadge.tsx
+++ b/ui/src/components/FactoryHealthBadge.tsx
@@ -4,6 +4,7 @@ import { Link } from "@/lib/router";
 import { issuesApi } from "../api/issues";
 import { activityApi } from "../api/activity";
 import { queryKeys } from "../lib/queryKeys";
+import { useCompany } from "../context/CompanyContext";
 import { cn } from "../lib/utils";
 import type { Agent, Issue } from "@paperclipai/shared";
 
@@ -109,6 +110,9 @@ function SignalPill({
 }
 
 export function FactoryHealthBadge({ companyId, agents }: FactoryHealthBadgeProps) {
+  const { selectedCompany } = useCompany();
+  const prefix = selectedCompany?.issuePrefix ?? "";
+
   const commonQueryOptions = {
     staleTime: REFRESH_INTERVAL_MS,
     refetchInterval: REFRESH_INTERVAL_MS,
@@ -160,24 +164,26 @@ export function FactoryHealthBadge({ companyId, agents }: FactoryHealthBadgeProp
     : "gray";
   const activeAgentsTone: SignalTone = activeAgentsCount > 0 ? "green" : "gray";
 
+  const cycleIssueRef = latestCycle?.identifier ?? latestCycle?.id;
+
   return (
     <div className="flex w-full flex-wrap items-center gap-2">
       <SignalPill
-        to="/issues?status=todo,in_progress,blocked"
+        to={`/${prefix}/issues?status=todo,in_progress,blocked`}
         title="Open factory management issues"
         label="Open FM"
         value={String(fmCount)}
         tone={fmTone}
       />
       <SignalPill
-        to={latestCycle ? `/issues/${latestCycle.id}` : "/issues"}
+        to={cycleIssueRef ? `/${prefix}/issues/${cycleIssueRef}` : `/${prefix}/issues`}
         title="Last completed cycle status"
         label="Last cycle"
         value={latestCycle ? (latestCycle.status === "done" ? "Pass" : "Fail") : "Unknown"}
         tone={cycleTone}
       />
       <SignalPill
-        to="/agents"
+        to={`/${prefix}/agents`}
         title="Active agents in last 15 minutes"
         label="Active agents (15m)"
         value={String(activeAgentsCount)}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -153,6 +153,11 @@ export const queryKeys = {
   activity: (companyId: string) => ["activity", companyId] as const,
   costs: (companyId: string, from?: string, to?: string) =>
     ["costs", companyId, from, to] as const,
+  factoryHealth: {
+    fmIssues: (companyId: string) => ["factory-health", companyId, "fm-issues"] as const,
+    latestCycle: (companyId: string) => ["factory-health", companyId, "latest-cycle"] as const,
+    activeAgents: (companyId: string) => ["factory-health", companyId, "active-agents"] as const,
+  },
   usageByProvider: (companyId: string, from?: string, to?: string) =>
     ["usage-by-provider", companyId, from, to] as const,
   usageByBiller: (companyId: string, from?: string, to?: string) =>

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -12,6 +12,7 @@ import { queryKeys } from "../lib/queryKeys";
 import { createIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
 import { EmptyState } from "../components/EmptyState";
 import { IssuesList } from "../components/IssuesList";
+import { FactoryHealthBadge } from "../components/FactoryHealthBadge";
 import { CircleDot } from "lucide-react";
 import type { Issue } from "@paperclipai/shared";
 
@@ -177,25 +178,30 @@ export function Issues() {
   }
 
   return (
-    <IssuesList
-      issues={issues ?? []}
-      isLoading={isLoading}
-      isLoadingMoreIssues={isFetchingNextPage}
-      error={error as Error | null}
-      agents={agents}
-      projects={projects}
-      liveIssueIds={liveIssueIds}
-      viewStateKey="paperclip:issues-view"
-      issueLinkState={issueLinkState}
-      initialAssignees={searchParams.get("assignee") ? [searchParams.get("assignee")!] : undefined}
-      initialWorkspaces={initialWorkspaces.length > 0 ? initialWorkspaces : undefined}
-      initialSearch={syncedSearch}
-      onSearchChange={handleSearchChange}
-      enableRoutineVisibilityFilter
-      hasMoreIssues={hasMoreServerIssues}
-      onLoadMoreIssues={loadMoreServerIssues}
-      onUpdateIssue={(id, data) => updateIssue.mutate({ id, data })}
-      searchFilters={participantAgentId || workspaceIdFilter ? { participantAgentId, workspaceId: workspaceIdFilter } : undefined}
-    />
+    <div>
+      <div className="px-4 py-2">
+        <FactoryHealthBadge companyId={selectedCompanyId} agents={agents ?? []} />
+      </div>
+      <IssuesList
+        issues={issues ?? []}
+        isLoading={isLoading}
+        isLoadingMoreIssues={isFetchingNextPage}
+        error={error as Error | null}
+        agents={agents}
+        projects={projects}
+        liveIssueIds={liveIssueIds}
+        viewStateKey="paperclip:issues-view"
+        issueLinkState={issueLinkState}
+        initialAssignees={searchParams.get("assignee") ? [searchParams.get("assignee")!] : undefined}
+        initialWorkspaces={initialWorkspaces.length > 0 ? initialWorkspaces : undefined}
+        initialSearch={syncedSearch}
+        onSearchChange={handleSearchChange}
+        enableRoutineVisibilityFilter
+        hasMoreIssues={hasMoreServerIssues}
+        onLoadMoreIssues={loadMoreServerIssues}
+        onUpdateIssue={(id, data) => updateIssue.mutate({ id, data })}
+        searchFilters={participantAgentId || workspaceIdFilter ? { participantAgentId, workspaceId: workspaceIdFilter } : undefined}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, so operators need real-time visibility into factory health without leaving the Board
> - The Board view (Issues page) is the primary ambient-monitoring surface
> - There is no at-a-glance health signal — operators must navigate into individual issues to assess factory mode state, cycle health, and agent activity
> - ADF-480/ADF-481 greenlit a three-signal Factory Health badge as the M2 deliverable
> - This PR adds `<FactoryHealthBadge>` as a thin pill row above the issue list, polling three signals at 60s via React Query
> - The benefit is that the three most critical factory signals are always visible without scrolling

## What Changed

- `ui/src/components/FactoryHealthBadge.tsx` — new component with three `SignalPill` links; polls issues (FM count), issues (latest cycle), and activity (active agents) at 60s; uses `useCompany()` to build correct prefixed URLs
- `ui/src/components/FactoryHealthBadge.test.ts` — unit tests for the three helper functions
- `ui/src/lib/queryKeys.ts` — added `factoryHealth.fmIssues`, `factoryHealth.latestCycle`, `factoryHealth.activeAgents` query key factories
- `ui/src/pages/Issues.tsx` — mount `<FactoryHealthBadge>` in a `px-4 py-2` wrapper above `<IssuesList>`

## Verification

- `pnpm typecheck` — zero errors
- `pnpm test` — FactoryHealthBadge.test.ts: 3 tests pass
- Manual: start dev server, open `/<prefix>/issues`, three pills appear above issue list with correct colors and click-throughs

## Risks

- `CYCLE_MONITOR_AGENT_ID` constant is instance-specific; acceptable for M2 per spec. Runtime resolution via `urlKey=cycle-monitor` is a follow-up.
- Activity endpoint uses `limit=500` + client-side `createdAt > now-15m` filter; may undercount if >500 events in 15m window. Backend `since=` filter tracked separately per spec.
- Low risk to existing Board — purely additive row above issue list.

## Model Used

- Anthropic Claude Sonnet 4.6 (`claude-sonnet-4-6`) — CEO agent, final implementation and URL fix
- Initial scaffolding by Codex Eng adapter before model failure

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge