### PR TITLE
fix(plugins): wire PluginStreamBus so SSE bridge stops 501-ing

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -44,6 +44,7 @@ import { pluginUiStaticRoutes } from "./routes/plugin-ui-static.js";
 import { applyUiBranding } from "./ui-branding.js";
 import { logger } from "./middleware/logger.js";
 import { DEFAULT_LOCAL_PLUGIN_DIR, pluginLoader } from "./services/plugin-loader.js";
+import { createPluginStreamBus } from "./services/plugin-stream-bus.js";
 import { createPluginWorkerManager, type PluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createPluginJobScheduler } from "./services/plugin-job-scheduler.js";
 import { pluginJobStore } from "./services/plugin-job-store.js";
@@ -249,6 +250,7 @@ export async function createApp(
   });
   const hostServiceCleanup = createPluginHostServiceCleanup(lifecycle, hostServicesDisposers);
   let viteHtmlRenderer: ReturnType<typeof createCachedViteHtmlRenderer> | null = null;
+  const streamBus = createPluginStreamBus();
   const loader = pluginLoader(
     db,
     {
@@ -262,6 +264,7 @@ export async function createApp(
       jobStore,
       toolDispatcher,
       lifecycleManager: lifecycle,
+      streamBus,
       instanceInfo: {
         instanceId: opts.instanceId ?? "default",
         hostVersion: opts.hostVersion ?? "0.0.0",
@@ -293,7 +296,7 @@ export async function createApp(
       { scheduler, jobStore },
       { workerManager },
       { toolDispatcher },
-      { workerManager },
+      { workerManager, streamBus },
     ),
   );
   api.use(adapterRoutes());

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -43,6 +43,7 @@ import { pluginManifestValidator } from "./plugin-manifest-validator.js";
 import { pluginCapabilityValidator } from "./plugin-capability-validator.js";
 import { pluginRegistryService } from "./plugin-registry.js";
 import type { PluginWorkerManager, WorkerStartOptions, WorkerToHostHandlers } from "./plugin-worker-manager.js";
+import type { PluginStreamBus, StreamEventType } from "./plugin-stream-bus.js";
 import type { PluginEventBus } from "./plugin-event-bus.js";
 import type { PluginJobScheduler } from "./plugin-job-scheduler.js";
 import type { PluginJobStore } from "./plugin-job-store.js";
@@ -264,6 +265,20 @@ export interface PluginRuntimeServices {
   toolDispatcher: PluginToolDispatcher;
   /** Lifecycle manager for state transitions and worker lifecycle events. */
   lifecycleManager: PluginLifecycleManager;
+  /**
+   * Optional in-memory pub/sub bus for SSE push from worker to UI.
+   *
+   * When provided, the loader wires `onStreamNotification` on each spawned
+   * worker so that `streams.{open,emit,close}` JSON-RPC notifications from
+   * the worker are forwarded to the bus and fanned out to connected SSE
+   * clients matching `(pluginId, channel, companyId)`.
+   *
+   * When omitted, plugin SSE bridge requests return 501; useful for tests
+   * that don't exercise the bridge.
+   *
+   * @see PLUGIN_SPEC.md §19.8 — Real-Time Streaming
+   */
+  streamBus?: PluginStreamBus;
   /**
    * Factory that creates worker-to-host RPC handlers for a given plugin.
    *
@@ -1853,6 +1868,29 @@ export function pluginLoader(
         autoRestart: true,
         env: buildPluginWorkerEnv({ manifest, instanceInfo }),
       };
+
+      // Wire worker→host stream notifications to the runtime stream bus, if
+      // provided. The worker emits `streams.{open,emit,close}` JSON-RPC
+      // notifications; we translate each into a `streamBus.publish` so SSE
+      // clients receive the event. Without this wiring, plugin SSE bridge
+      // endpoints reject subscribers with 501 and stream events are
+      // silently dropped by the worker manager.
+      const streamBus = runtimeServices?.streamBus;
+      if (streamBus) {
+        workerOptions.onStreamNotification = (method, params) => {
+          const channel = typeof params.channel === "string" ? params.channel : null;
+          const companyId = typeof params.companyId === "string" ? params.companyId : null;
+          if (!channel || !companyId) return;
+          let eventType: StreamEventType = "message";
+          if (method === "streams.open") eventType = "open";
+          else if (method === "streams.close") eventType = "close";
+          const payload =
+            method === "streams.emit"
+              ? params.event ?? null
+              : { type: eventType, channel, companyId };
+          streamBus.publish(pluginId, channel, companyId, payload, eventType);
+        };
+      }
 
       // Repo-local plugin installs can resolve workspace TS sources at runtime
       // (for example @paperclipai/shared exports). Run those workers through


### PR DESCRIPTION
## Thinking Path

> - Paperclip's plugin host exposes an SSE bridge so worker processes can push live events to subscribed UI clients (chat tokens, progress updates, etc.).
> - The bus implementation `createPluginStreamBus()` exists in `server/src/services/plugin-stream-bus.ts`, and `pluginRoutes` already declares an optional `streamBus` field on `PluginRouteBridgeDeps`, but nothing in `app.ts` actually creates the bus or passes it through.
> - Without that wiring, every plugin SSE bridge GET (`/plugins/:id/bridge/stream/:channel`) returns 501 Not Implemented, and the worker→host `streams.{open,emit,close}` JSON-RPC notifications are silently dropped by `plugin-worker-manager` because no `onStreamNotification` callback is installed.
> - The concrete user-facing failure: the published `@lucitra/paperclip-plugin-chat` worker emits chat tokens on a per-thread channel; the UI subscribes via SSE; the endpoint 501s and chat replies only appear after a full page refresh.
> - This pull request finishes the wiring that was already half-present in the codebase: one bus instance created in `app.ts`, threaded into the loader runtime services AND the bridge deps, and the loader installs `onStreamNotification` on each spawned worker so the worker's `streams.*` notifications get republished on the bus.
> - The benefit is that documented per-channel SSE pushes from any plugin start working out of the box, with no Redis/NATS dependency for single-process deployments.

## What Changed

- `server/src/app.ts`
  - `const streamBus = createPluginStreamBus();`
  - Thread `streamBus` into the `pluginLoader` runtime services.
  - Thread `streamBus` into `pluginRoutes` via the existing 6th-arg `PluginRouteBridgeDeps`.
- `server/src/services/plugin-loader.ts`
  - Add optional `streamBus` field to `PluginRuntimeServices`, documented inline.
  - When spawning each worker, install `onStreamNotification` that forwards `streams.{open,emit,close}` JSON-RPC notifications onto `streamBus.publish(pluginId, channel, companyId, event, eventType)`.
  - `streams.emit` publishes the user-supplied event payload; `open`/`close` publish a minimal lifecycle envelope so SSE subscribers see channel state changes.

No changes to:

- `plugin-stream-bus.ts` (already complete)
- `plugin-worker-manager.ts` (`onStreamNotification` hook already supported; we just install it now)
- Any wire-format / public API

## Verification

- `pnpm -r typecheck` clean.
- Locally with the chat plugin: before the change, `GET /plugins/<id>/bridge/stream/chat:<threadId>` returned 501; after the change, the same request returns 200 with `text/event-stream` and the UI sees streaming tokens in real-time.
- Plugins without an SSE bridge see no behavior change — they don't subscribe, so the bus never publishes for them.
- `PLUGIN_SPEC.md §19.8 — Real-Time Streaming` describes this exact pipeline; this PR closes the implementation gap relative to the spec.

## Risks

- Low. `streamBus` is in-process / in-memory; for future multi-process deployments a Redis/NATS implementation of the same `PluginStreamBus` interface can be swapped in without changes to the loader or routes.
- Optional everywhere — passing `undefined` keeps the previous "501 on bridge stream" behavior (useful for tests that don't exercise the bridge).
- No DB / migration impact. No new dependencies.

## Model Used

Claude (Anthropic). Model ID: `claude-opus-4-7`. Extended thinking enabled. Tool use: code editing, repo grep, live service test.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable (no test currently exercises the SSE bridge end-to-end; happy to add one on request if maintainers want a regression guard)
- [x] If this change affects the UI, I have included before/after screenshots (UI not changed; behavior change is server-side SSE delivery — manual repro described above)
- [x] I have updated relevant documentation to reflect my changes (no doc surface affected — `PLUGIN_SPEC.md §19.8` already describes the intended behavior; this PR makes the implementation match it)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
