### PR TITLE
Inherit OpenClaw gateway auth for child agents

### DIFF
--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -916,6 +916,223 @@ describe.sequential("agent permission routes", () => {
     );
   });
 
+  it("inherits same-gateway OpenClaw credentials when an agent creates a child agent", async () => {
+    const parentGatewayConfig = {
+      url: "ws://127.0.0.1:18790",
+      headers: {
+        "x-openclaw-token": "parent-gateway-token-1234567890",
+        "x-extra-header": "do-not-inherit",
+      },
+      paperclipApiUrl: "http://127.0.0.1:3100",
+      timeoutSec: 7200,
+      waitTimeoutMs: 7_200_000,
+      role: "operator",
+      scopes: ["operator.admin"],
+      devicePrivateKeyPem: "PARENT_DEVICE_KEY",
+      payloadTemplate: { parent: true },
+      agentId: "parent-agent-id",
+      sessionKey: "parent-session-key",
+      sessionKeyStrategy: "fixed",
+    };
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterType: "openclaw_gateway",
+      adapterConfig: parentGatewayConfig,
+      permissions: { canCreateAgents: true },
+    });
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "CMO",
+        role: "cmo",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {},
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const createInput = mockAgentService.create.mock.calls[0]?.[1] as { adapterConfig?: Record<string, unknown> };
+    expect(createInput.adapterConfig).toMatchObject({
+      url: "ws://127.0.0.1:18790",
+      headers: { "x-openclaw-token": "parent-gateway-token-1234567890" },
+      paperclipApiUrl: "http://127.0.0.1:3100",
+      timeoutSec: 7200,
+      waitTimeoutMs: 7_200_000,
+      role: "operator",
+      scopes: ["operator.admin"],
+      sessionKeyStrategy: "issue",
+    });
+    expect(createInput.adapterConfig?.headers).not.toHaveProperty("x-extra-header");
+    expect(createInput.adapterConfig?.devicePrivateKeyPem).toEqual(expect.stringContaining("BEGIN PRIVATE KEY"));
+    expect(createInput.adapterConfig?.devicePrivateKeyPem).not.toBe("PARENT_DEVICE_KEY");
+    expect(createInput.adapterConfig).not.toHaveProperty("payloadTemplate");
+    expect(createInput.adapterConfig).not.toHaveProperty("agentId");
+    expect(createInput.adapterConfig).not.toHaveProperty("sessionKey");
+  });
+
+  it("preserves explicit OpenClaw child credentials over same-gateway inheritance", async () => {
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterType: "openclaw_gateway",
+      adapterConfig: {
+        url: "ws://parent-gateway.local",
+        headers: { "x-openclaw-token": "parent-gateway-token-1234567890" },
+        timeoutSec: 7200,
+        waitTimeoutMs: 7_200_000,
+        role: "parent-role",
+        scopes: ["operator.admin"],
+      },
+      permissions: { canCreateAgents: true },
+    });
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "CMO",
+        role: "cmo",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: "ws://child-gateway.local",
+          headers: { "x-openclaw-token": "explicit-child-token-1234567890" },
+          timeoutSec: 300,
+          role: "child-role",
+          scopes: ["operator.read"],
+          sessionKeyStrategy: "run",
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const createInput = mockAgentService.create.mock.calls[0]?.[1] as { adapterConfig?: Record<string, unknown> };
+    expect(createInput.adapterConfig).toMatchObject({
+      url: "ws://child-gateway.local",
+      headers: { "x-openclaw-token": "explicit-child-token-1234567890" },
+      timeoutSec: 300,
+      waitTimeoutMs: 7_200_000,
+      role: "child-role",
+      scopes: ["operator.read"],
+      sessionKeyStrategy: "run",
+    });
+  });
+
+  it("rejects agent-created OpenClaw children without explicit or inheritable gateway auth", async () => {
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterType: "openclaw_gateway",
+      adapterConfig: { url: "ws://127.0.0.1:18790" },
+      permissions: { canCreateAgents: true },
+    });
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "CMO",
+        role: "cmo",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {},
+      }));
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toContain("openclaw_gateway_auth_header_missing");
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
+  it("inherits same-gateway OpenClaw credentials before persisting an agent hire approval payload", async () => {
+    mockAccessService.hasPermission.mockResolvedValue(true);
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterType: "openclaw_gateway",
+      adapterConfig: {
+        url: "ws://127.0.0.1:18790",
+        headers: { "x-openclaw-token": "parent-gateway-token-1234567890" },
+        paperclipApiUrl: "http://127.0.0.1:3100",
+        timeoutSec: 7200,
+        waitTimeoutMs: 7_200_000,
+        role: "operator",
+        scopes: ["operator.admin"],
+        devicePrivateKeyPem: "PARENT_DEVICE_KEY",
+      },
+      permissions: { canCreateAgents: true },
+    });
+    mockApprovalService.create.mockResolvedValue({
+      id: "approval-1",
+      type: "hire_agent",
+      status: "pending",
+    });
+
+    const app = await createApp(
+      {
+        type: "agent",
+        agentId,
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      },
+      { requireBoardApprovalForNewAgents: true },
+    );
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agent-hires`)
+      .send({
+        name: "CMO",
+        role: "cmo",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {},
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    const createInput = mockAgentService.create.mock.calls[0]?.[1] as { adapterConfig?: Record<string, unknown> };
+    expect(createInput.adapterConfig).toMatchObject({
+      url: "ws://127.0.0.1:18790",
+      headers: { "x-openclaw-token": "parent-gateway-token-1234567890" },
+      paperclipApiUrl: "http://127.0.0.1:3100",
+      timeoutSec: 7200,
+      waitTimeoutMs: 7_200_000,
+      role: "operator",
+      scopes: ["operator.admin"],
+      sessionKeyStrategy: "issue",
+    });
+    expect(createInput.adapterConfig?.devicePrivateKeyPem).toEqual(expect.stringContaining("BEGIN PRIVATE KEY"));
+    expect(createInput.adapterConfig?.devicePrivateKeyPem).not.toBe("PARENT_DEVICE_KEY");
+    expect(mockApprovalService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          adapterType: "openclaw_gateway",
+          requestedConfigurationSnapshot: expect.objectContaining({
+            adapterType: "openclaw_gateway",
+          }),
+        }),
+      }),
+    );
+  });
+
   it("seeds opencode agent creation with the static default model without live discovery", async () => {
     mockEnsureOpenCodeModelConfiguredAndAvailable.mockRejectedValue(
       new Error("`opencode models` should not be called during creation"),

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -821,6 +821,126 @@ export function agentRoutes(
     return trimmed.length > 0 ? trimmed : null;
   }
 
+  const OPENCLAW_GATEWAY_AUTH_HEADER_KEYS = [
+    "x-openclaw-token",
+    "x-openclaw-auth",
+    "authorization",
+  ] as const;
+  const OPENCLAW_GATEWAY_TOP_LEVEL_AUTH_KEYS = [
+    "authToken",
+    "token",
+    "password",
+  ] as const;
+  const OPENCLAW_GATEWAY_INHERITED_CONFIG_KEYS = [
+    "url",
+    "paperclipApiUrl",
+    "timeoutSec",
+    "waitTimeoutMs",
+    "role",
+    "scopes",
+  ] as const;
+
+  function findHeaderValueIgnoreCase(
+    headers: Record<string, unknown> | null,
+    targetKey: string,
+  ): { key: string; value: string } | null {
+    if (!headers) return null;
+    const target = targetKey.toLowerCase();
+    for (const [key, value] of Object.entries(headers)) {
+      if (key.toLowerCase() !== target) continue;
+      const normalized = asNonEmptyString(value);
+      if (normalized) return { key, value: normalized };
+    }
+    return null;
+  }
+
+  function hasOpenClawGatewayHeaderAuth(headers: Record<string, unknown> | null): boolean {
+    return OPENCLAW_GATEWAY_AUTH_HEADER_KEYS.some((key) =>
+      Boolean(findHeaderValueIgnoreCase(headers, key)),
+    );
+  }
+
+  function hasOpenClawGatewayAuth(adapterConfig: Record<string, unknown>): boolean {
+    if (hasOpenClawGatewayHeaderAuth(asRecord(adapterConfig.headers))) return true;
+    return OPENCLAW_GATEWAY_TOP_LEVEL_AUTH_KEYS.some((key) =>
+      Boolean(asNonEmptyString(adapterConfig[key])),
+    );
+  }
+
+  function cloneInheritedAdapterConfigValue(value: unknown): unknown {
+    return Array.isArray(value) ? [...value] : value;
+  }
+
+  function mergeInheritedOpenClawGatewayAuthHeaders(
+    childHeaders: Record<string, unknown> | null,
+    parentHeaders: Record<string, unknown> | null,
+  ): Record<string, unknown> | null {
+    if (!parentHeaders) return childHeaders;
+    const inheritedEntries: Array<[string, string]> = [];
+    for (const key of OPENCLAW_GATEWAY_AUTH_HEADER_KEYS) {
+      const entry = findHeaderValueIgnoreCase(parentHeaders, key);
+      if (entry) inheritedEntries.push([key, entry.value]);
+    }
+    if (inheritedEntries.length === 0) return childHeaders;
+    const nextHeaders = { ...(childHeaders ?? {}) };
+    for (const [key, value] of inheritedEntries) {
+      if (!findHeaderValueIgnoreCase(nextHeaders, key)) {
+        nextHeaders[key] = value;
+      }
+    }
+    return nextHeaders;
+  }
+
+  function applySameGatewayOpenClawInheritance(input: {
+    adapterType: string;
+    adapterConfig: Record<string, unknown>;
+    actorAgent: NonNullable<Awaited<ReturnType<typeof svc.getById>>> | null;
+  }): Record<string, unknown> {
+    if (input.adapterType !== "openclaw_gateway" || !input.actorAgent) {
+      return input.adapterConfig;
+    }
+
+    const next = { ...input.adapterConfig };
+    const parentConfig =
+      input.actorAgent.adapterType === "openclaw_gateway"
+        ? (asRecord(input.actorAgent.adapterConfig) ?? {})
+        : {};
+
+    for (const key of OPENCLAW_GATEWAY_INHERITED_CONFIG_KEYS) {
+      if (next[key] === undefined && parentConfig[key] !== undefined) {
+        next[key] = cloneInheritedAdapterConfigValue(parentConfig[key]);
+      }
+    }
+
+    const childHadAuth = hasOpenClawGatewayAuth(next);
+    if (!childHadAuth) {
+      for (const key of OPENCLAW_GATEWAY_TOP_LEVEL_AUTH_KEYS) {
+        if (next[key] === undefined && parentConfig[key] !== undefined) {
+          next[key] = parentConfig[key];
+        }
+      }
+      const mergedHeaders = mergeInheritedOpenClawGatewayAuthHeaders(
+        asRecord(next.headers),
+        asRecord(parentConfig.headers),
+      );
+      if (mergedHeaders) {
+        next.headers = mergedHeaders;
+      }
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(next, "sessionKeyStrategy")) {
+      next.sessionKeyStrategy = "issue";
+    }
+
+    if (!hasOpenClawGatewayAuth(next)) {
+      throw unprocessable(
+        "openclaw_gateway_auth_header_missing: agent-created openclaw_gateway children require explicit gateway credentials or an inheritable creator adapterConfig.headers.x-openclaw-token",
+      );
+    }
+
+    return next;
+  }
+
   function preserveInstructionsBundleConfig(
     existingAdapterConfig: Record<string, unknown>,
     nextAdapterConfig: Record<string, unknown>,
@@ -1954,7 +2074,7 @@ export function agentRoutes(
 
   router.post("/companies/:companyId/agent-hires", validate(createAgentHireSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
-    await assertCanCreateAgentsForCompany(req, companyId);
+    const actorAgent = await assertCanCreateAgentsForCompany(req, companyId);
     const sourceIssueIds = parseSourceIssueIds(req.body);
     const {
       desiredSkills: requestedDesiredSkills,
@@ -1971,9 +2091,14 @@ export function agentRoutes(
     );
     assertNoAgentAdapterConfigMutation(req, rawHireAdapterConfig);
     assertNoAgentRuntimeConfigAdapterConfigMutation(req, hireInput.runtimeConfig);
+    const inheritedHireAdapterConfig = applySameGatewayOpenClawInheritance({
+      adapterType: hireInput.adapterType,
+      adapterConfig: rawHireAdapterConfig,
+      actorAgent,
+    });
     const requestedAdapterConfig = applyCreateDefaultsByAdapterType(
       hireInput.adapterType,
-      rawHireAdapterConfig,
+      inheritedHireAdapterConfig,
     );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
       companyId,
@@ -2127,7 +2252,7 @@ export function agentRoutes(
 
   router.post("/companies/:companyId/agents", validate(createAgentSchema), async (req, res) => {
     const companyId = req.params.companyId as string;
-    await assertCanCreateAgentsForCompany(req, companyId);
+    const actorAgent = await assertCanCreateAgentsForCompany(req, companyId);
 
     const company = await db
       .select()
@@ -2157,9 +2282,14 @@ export function agentRoutes(
     );
     assertNoAgentAdapterConfigMutation(req, rawCreateAdapterConfig);
     assertNoAgentRuntimeConfigAdapterConfigMutation(req, createInput.runtimeConfig);
+    const inheritedCreateAdapterConfig = applySameGatewayOpenClawInheritance({
+      adapterType: createInput.adapterType,
+      adapterConfig: rawCreateAdapterConfig,
+      actorAgent,
+    });
     const requestedAdapterConfig = applyCreateDefaultsByAdapterType(
       createInput.adapterType,
-      rawCreateAdapterConfig,
+      inheritedCreateAdapterConfig,
     );
     const desiredSkillAssignment = await resolveDesiredSkillAssignment(
       companyId,


### PR DESCRIPTION
## Why
Agent-created same-gateway `openclaw_gateway` children could persist an adapter config with URL/timeouts/device auth, but no gateway auth header. Those children then failed at wake time with `unauthorized: gateway token missing` even though the creator agent already had working same-gateway credentials.

## What changed
- Direct `POST /api/companies/:companyId/agents` now inherits same-gateway OpenClaw defaults from an authenticated `openclaw_gateway` creator when the child omits them.
- `POST /api/companies/:companyId/agent-hires` applies the same inheritance before persistence/approval payload creation.
- Explicit child config wins over inherited defaults.
- Child configs get `sessionKeyStrategy: "issue"` unless explicitly set.
- Sensitive creator-only fields are not inherited: `devicePrivateKeyPem`, `payloadTemplate`, `agentId`, and `sessionKey`. A fresh child device key is still generated by the existing OpenClaw gateway create defaults.
- Agent-created `openclaw_gateway` children without explicit or inheritable auth now fail fast with `422 openclaw_gateway_auth_header_missing...`.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts` then `npm run install` in the `sqlite3` package to build the local native binding for focused tests.
- `pnpm exec vitest run server/src/__tests__/agent-permissions-routes.test.ts --maxWorkers=1 --minWorkers=1`
- `pnpm --filter @paperclipai/server typecheck`

## Live canary context
Jackie CMO was repaired separately by adding only `adapterConfig.headers.x-openclaw-token`. A post-repair wake no longer fails with gateway-token-missing, confirming this is the credential inheritance/persistence path rather than the proxy stack.