### PR TITLE
feat: environment-blocker detection with auto-provisioning child issue

### DIFF
--- a/server/src/features/environment-blocker/create-provisioning-issue.ts
+++ b/server/src/features/environment-blocker/create-provisioning-issue.ts
@@ -1,0 +1,48 @@
+import type { Db } from "@paperclipai/db";
+import { agentService, issueService } from "../../services/index.js";
+import type { EnvironmentBlockerResult } from "./detector.js";
+
+export async function createProvisioningChildIssue(
+  db: Db,
+  companyId: string,
+  sourceIssueId: string,
+  sourceIssueIdentifier: string,
+  blocker: EnvironmentBlockerResult,
+  createdByAgentId: string | null,
+): Promise<{ id: string; identifier: string }> {
+  const agentsSvc = agentService(db);
+  const svc = issueService(db);
+
+  const agents = await agentsSvc.list(companyId);
+
+  let assigneeAgentId: string | null = null;
+  if (blocker.ownerType === "CTO") {
+    const cto = agents.find(
+      (a) =>
+        a.name?.toUpperCase() === "CTO" ||
+        (a.title ?? "").toUpperCase().includes("CTO") ||
+        (a.title ?? "").toUpperCase().includes("CHIEF TECHNOLOGY"),
+    );
+    assigneeAgentId = cto?.id ?? null;
+  } else {
+    const ceo = agents.find(
+      (a) =>
+        a.name?.toUpperCase() === "CEO" ||
+        (a.title ?? "").toUpperCase().includes("CEO") ||
+        (a.title ?? "").toUpperCase().includes("CHIEF EXECUTIVE"),
+    );
+    assigneeAgentId = ceo?.id ?? null;
+  }
+
+  const issue = await svc.create(companyId, {
+    parentId: sourceIssueId,
+    title: `Provision ${blocker.resource} for ${sourceIssueIdentifier}`,
+    description: `Provisioning blocker auto-detected from [${sourceIssueIdentifier}](/PAI/issues/${sourceIssueIdentifier}).\n\nEnvironment needed: **${blocker.resource}**\n\nOnce provisioned, mark this issue done to unblock the parent.`,
+    status: "todo",
+    priority: "high",
+    assigneeAgentId,
+    createdByAgentId,
+  });
+
+  return { id: issue.id, identifier: issue.identifier ?? issue.id };
+}

--- a/server/src/features/environment-blocker/detector.test.ts
+++ b/server/src/features/environment-blocker/detector.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { detectEnvironmentBlocker } from "./detector.js";
+
+describe("detectEnvironmentBlocker", () => {
+  it("returns found=false when no blocker pattern present", () => {
+    const result = detectEnvironmentBlocker("This issue tracks onboarding work.");
+    expect(result.found).toBe(false);
+  });
+
+  it("detects basic blocker pattern", () => {
+    const result = detectEnvironmentBlocker(
+      "Work cannot start. Blocked until: MT5 terminal is available.",
+    );
+    expect(result.found).toBe(true);
+    expect(result.resource).toContain("MT5 terminal");
+  });
+
+  it("assigns CTO ownership for VPS resource", () => {
+    const result = detectEnvironmentBlocker(
+      "Blocked until: VPS is provisioned.",
+    );
+    expect(result.found).toBe(true);
+    expect(result.ownerType).toBe("CTO");
+  });
+
+  it("assigns CTO ownership for MT5 resource", () => {
+    const result = detectEnvironmentBlocker(
+      "Blocked until: MT5 terminal is available.",
+    );
+    expect(result.ownerType).toBe("CTO");
+  });
+
+  it("assigns CTO ownership for infra/cloud resources", () => {
+    for (const word of ["cloud", "terraform", "infra", "docker", "k8s", "database"]) {
+      const result = detectEnvironmentBlocker(
+        `Blocked until: ${word} is available.`,
+      );
+      expect(result.ownerType).toBe("CTO");
+    }
+  });
+
+  it("assigns CEO ownership for non-infra resources", () => {
+    const result = detectEnvironmentBlocker(
+      "Blocked until: broker account is available.",
+    );
+    expect(result.found).toBe(true);
+    expect(result.ownerType).toBe("CEO");
+  });
+
+  it("is case-insensitive for pattern matching", () => {
+    const result = detectEnvironmentBlocker(
+      "BLOCKED UNTIL: VPS IS PROVISIONED.",
+    );
+    expect(result.found).toBe(true);
+    expect(result.ownerType).toBe("CTO");
+  });
+
+  it("matches 'access available' variant", () => {
+    const result = detectEnvironmentBlocker(
+      "Blocked until: broker API access available.",
+    );
+    expect(result.found).toBe(true);
+  });
+});

--- a/server/src/features/environment-blocker/detector.ts
+++ b/server/src/features/environment-blocker/detector.ts
@@ -1,0 +1,22 @@
+export interface EnvironmentBlockerResult {
+  found: boolean;
+  resource: string;
+  ownerType: "CTO" | "CEO";
+}
+
+const BLOCKER_PATTERN =
+  /blocked\s+until:\s*([a-z0-9\s\/\-,]+?)\s+(?:is\s+)?(?:access\s+)?(?:available|provisioned)/i;
+
+const CTO_RESOURCE_PATTERN =
+  /\b(mt5|mt4|vps|cloud|terraform|infra|infrastructure|network|docker|k8s|kubernetes|database|db|server|broker\s+api|api\s+key|rdp|ssh)\b/i;
+
+export function detectEnvironmentBlocker(description: string): EnvironmentBlockerResult {
+  const match = BLOCKER_PATTERN.exec(description);
+  if (!match) {
+    return { found: false, resource: "", ownerType: "CEO" };
+  }
+
+  const resource = match[1].trim();
+  const ownerType = CTO_RESOURCE_PATTERN.test(resource) ? "CTO" : "CEO";
+  return { found: true, resource, ownerType };
+}

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { detectEnvironmentBlocker } from "../features/environment-blocker/detector.js";
+import { createProvisioningChildIssue } from "../features/environment-blocker/create-provisioning-issue.js";
 import { Router, type Request, type Response } from "express";
 import multer from "multer";
 import { z } from "zod";
@@ -3156,12 +3158,50 @@ export function issueRoutes(
       actor.actorType,
     );
     assertCanManageIssueMonitor(req, req.body.assigneeAgentId ?? null, Boolean(executionPolicy?.monitor));
+
+    // Detect environment blockers and inject auto-provisioning child issue if needed.
+    // Guarded by PAPERCLIP_ENV_BLOCKER_DETECTION=true (disabled by default for safe rollout).
+    const envBlockerDetectionEnabled = process.env.PAPERCLIP_ENV_BLOCKER_DETECTION === "true";
+    let injectedBlockerIssueId: string | null = null;
+    if (
+      envBlockerDetectionEnabled &&
+      req.body.description &&
+      (!Array.isArray(req.body.blockedByIssueIds) || req.body.blockedByIssueIds.length === 0)
+    ) {
+      const envBlocker = detectEnvironmentBlocker(req.body.description);
+      if (envBlocker.found) {
+        // We need the issue to exist first so we can set parentId on the child.
+        // Create issue without blockers, then create child, then update blockers.
+        injectedBlockerIssueId = "__pending__";
+      }
+    }
+
     const issue = await svc.create(companyId, {
       ...req.body,
       executionPolicy,
       createdByAgentId: actor.agentId,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
     });
+
+    if (injectedBlockerIssueId === "__pending__" && req.body.description) {
+      const envBlocker = detectEnvironmentBlocker(req.body.description);
+      if (envBlocker.found) {
+        try {
+          const childIssue = await createProvisioningChildIssue(
+            db,
+            companyId,
+            issue.id,
+            issue.identifier ?? issue.id,
+            envBlocker,
+            actor.agentId ?? null,
+          );
+          await svc.update(issue.id, { blockedByIssueIds: [childIssue.id], status: "blocked" });
+        } catch (err) {
+          // Log but don't fail the issue creation if auto-provisioning fails
+          logger.warn({ err, issueId: issue.id }, "env-blocker: failed to create provisioning child issue");
+        }
+      }
+    }
     await issueReferencesSvc.syncIssue(issue.id);
     const referenceSummary = await issueReferencesSvc.listIssueReferenceSummary(issue.id);
     const referenceDiff = issueReferencesSvc.diffIssueReferenceSummary(
@@ -3632,6 +3672,37 @@ export function issueRoutes(
     if (assigneeWillChange && !transition.workflowControlledAssignment) {
       if (!isAgentReturningIssueToCreator) {
         await assertCanAssignTasks(req, existing.companyId);
+      }
+    }
+
+    // Detect environment blockers on description update and auto-create provisioning child issue.
+    // Guarded by PAPERCLIP_ENV_BLOCKER_DETECTION=true (disabled by default for safe rollout).
+    if (
+      process.env.PAPERCLIP_ENV_BLOCKER_DETECTION === "true" &&
+      updateFields.description !== undefined &&
+      !Array.isArray(req.body.blockedByIssueIds)
+    ) {
+      const existingBlockers = await svc.getRelationSummaries(existing.id);
+      if (existingBlockers.blockedBy.length === 0) {
+        const envBlocker = detectEnvironmentBlocker(updateFields.description as string);
+        if (envBlocker.found) {
+          try {
+            const childIssue = await createProvisioningChildIssue(
+              db,
+              existing.companyId,
+              existing.id,
+              existing.identifier ?? existing.id,
+              envBlocker,
+              actor.agentId ?? null,
+            );
+            updateFields.blockedByIssueIds = [childIssue.id];
+            if (updateFields.status === undefined) {
+              updateFields.status = "blocked";
+            }
+          } catch (err) {
+            logger.warn({ err, issueId: existing.id }, "env-blocker: failed to create provisioning child issue on update");
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies; when issues block on external environments (MT5, VPS, broker APIs), they frequently stall with no clear owner or auto-recovery path
> - The issues subsystem handles creation and updates but has no pattern-matching for environment dependencies embedded in descriptions
> - When an issue description says "Blocked until: <resource> is available/provisioned", the system should automatically create a child provisioning issue and link it as a first-class blocker so the parent auto-resumes when the child is marked done
> - Ownership needs to be correct: infra/VPS/MT5/cloud/database resources belong to CTO; others to CEO
> - Idempotency is critical: if an issue already has blockedByIssueIds, we must not create duplicates
> - This pull request adds a detector module, a provisioning child issue helper, and hooks into both POST /companies/:companyId/issues and PATCH /issues/:id
> - The benefit is automatic structured escalation for environment-gated issues, removing the need for human or agent workarounds

## What Changed

- `server/src/features/environment-blocker/detector.ts`: regex pattern matcher and ownership logic (CTO for infra/VPS/MT5/cloud/database, CEO otherwise)
- `server/src/features/environment-blocker/create-provisioning-issue.ts`: creates child issue assigned to appropriate CTO/CEO agent found by name/title lookup
- `server/src/routes/issues.ts`: detection hook in POST handler (fires after issue is created, before returning response) and PATCH handler (fires when description changes, checks existing blockers first)
- `server/src/features/environment-blocker/detector.test.ts`: 8 unit tests covering all spec scenarios

## Verification

```bash
cd server
npx vitest run --reporter=verbose src/features/environment-blocker/detector.test.ts
# 8/8 tests pass

npx tsc --noEmit --project tsconfig.json
# no errors
```

For live testing (requires PAPERCLIP_ENV_BLOCKER_DETECTION=true):
1. POST a new issue with description containing "Blocked until: MT5 terminal is available."
2. Verify a child issue is created titled "Provision MT5 terminal for <identifier>"
3. Verify parent is in `blocked` state with `blockedByIssueIds` pointing to child
4. Verify child is assigned to CTO agent

## Risks

- Feature is gated behind `PAPERCLIP_ENV_BLOCKER_DETECTION=true` env var (off by default) — zero risk when disabled
- When enabled, `createProvisioningChildIssue` failure is caught and logged without failing the main issue operation — safe degradation
- Ownership lookup is name/title-based; companies without a CTO/CEO agent get `assigneeAgentId: null` on the child (still functional, just unassigned)
- Detection fires on all description updates, but idempotency check (existing blockers) prevents duplicate children

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Capabilities: tool use, code execution, multi-file editing, TypeScript analysis

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — API-only change)
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge