### PR TITLE
chore(security): enforce pnpm supply-chain policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,18 @@ packages:
   - server
   - ui
   - cli
+
+# ARES supply-chain policy enforcement candidate.
+# Branch: ares-pnpm-policy
+# Guardrail: do not merge until build/test verification passes under the repo's
+# pinned package manager and lifecycle-script allowlist is reviewed.
+minimumReleaseAge: 43200
+trustPolicy: no-downgrade
+strictDepBuilds: true
+allowBuilds:
+  "@paperclipai/plugin-cloudflare-sandbox": true
+  "@paperclipai/plugin-daytona": true
+  "@paperclipai/plugin-e2b": true
+  "@paperclipai/plugin-exe-dev": true
+  "@paperclipai/plugin-modal": true
+  "@paperclipai/plugin-workspace-diff": true


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies and depends on a large pnpm workspace supply chain.
> - The package-manager boundary is part of the security posture because lifecycle scripts and very new releases can execute code during install.
> - ARES reviewed the current workspace after dependency remediation and identified pnpm policy controls that can reduce supply-chain blast radius without touching runtime code.
> - The change is intentionally limited to `pnpm-workspace.yaml` so reviewers can evaluate policy behavior independently from dependency upgrades or Docker hardening.
> - The allowlist reflects the currently observed Paperclip plugin packages that need lifecycle builds.
> - This pull request adds a gated enforcement candidate for install-time dependency safety.
> - The benefit is a clearer, reviewable baseline for strict dependency builds, minimum release age, and no-downgrade trust policy.

## What Changed

- Added `minimumReleaseAge: 43200` to delay adoption of very new package releases by 12 hours.
- Added `trustPolicy: no-downgrade` to prevent downgrade-based trust regressions.
- Added `strictDepBuilds: true` so dependency lifecycle builds require explicit allowlisting.
- Added `allowBuilds` entries for the reviewed Paperclip plugin packages that currently require lifecycle build behavior.
- Added comments documenting that this is an ARES supply-chain enforcement candidate and should not merge until verification is accepted.

## Verification

Local verification:

- `pnpm install --frozen-lockfile` — passed.
- `pnpm run preflight:workspace-links` — passed after installing this isolated worktree's `node_modules`.
- `pnpm -r typecheck` — passed.
- `pnpm build` — passed.
- `git diff --check` — passed.
- `pnpm test:run` — attempted locally, but failed on existing root/test-environment prerequisites:
  - embedded Postgres cannot run as root for several suites;
  - `environment-live-ssh.test.ts` timed out after 5000ms.

Remote PR checks:

- GitHub PR workflow passed all visible checks for this branch:
  - policy
  - Typecheck + Release Registry
  - General tests (server)
  - General tests (workspaces-a)
  - General tests (workspaces-b)
  - Verify serialized server suites (1/4 through 4/4)
  - Build
  - Canary Dry Run
  - e2e
  - verify
  - security/snyk

ARES evidence report:

- `/root/multiagentebot/docs/security/ares-gate-execution-report-2026-05-22.md`
- report SHA256: `1a1e62874e3c01da097e0fc2723f8e3b607f8794a476d30a5017b8ef44888109`

## Risks

- Install behavior may become stricter for packages that rely on lifecycle builds but are not in `allowBuilds`.
- `minimumReleaseAge` can delay urgent dependency updates unless explicitly overridden by maintainers.
- The allowlist should be reviewed by maintainers because it encodes which plugin packages are permitted to run build scripts.

## Model Used

- OpenAI Codex via Hermes Agent CLI, model `gpt-5.5`, with terminal, file editing, git, Docker, and local security-scanner tool use. Human-supervised, gated execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass, or documented local environment gaps and confirmed remote CI passes
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
