### PR TITLE
fix: preserve codex_local cheap primary model

### DIFF
--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -51,9 +51,7 @@ export const modelProfiles: AdapterModelProfileDefinition[] = [
     label: "Cheap",
     description: "Use the lowest-cost known Codex local model lane without changing the primary model.",
     adapterConfig: {
-      model: "gpt-5.3-codex-spark",
-      // Spark is the cheap lane by model price; high effort keeps Codex coding behavior usable for delegated work.
-      modelReasoningEffort: "high",
+      modelReasoningEffort: "low",
     },
     source: "adapter_default",
   },

--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -20,12 +20,21 @@ const cheapProfile: AdapterModelProfileDefinition = {
 };
 
 describe("heartbeat model profile application", () => {
-  it("uses the Codex local adapter cheap default when the agent has no runtime override", async () => {
+  it("keeps the Codex local primary model when the agent has no runtime cheap override", async () => {
     const modelProfile = resolveModelProfileApplication({
       adapterModelProfiles: await listAdapterModelProfiles("codex_local"),
       agentRuntimeConfig: {},
       issueModelProfile: "cheap",
       contextSnapshot: {},
+    });
+
+    const merged = mergeModelProfileAdapterConfig({
+      baseConfig: {
+        model: "gpt-5.4",
+        modelReasoningEffort: "high",
+      },
+      modelProfile,
+      issueAdapterConfig: null,
     });
 
     expect(modelProfile).toMatchObject({
@@ -35,9 +44,13 @@ describe("heartbeat model profile application", () => {
       configSource: "adapter_default",
       fallbackReason: null,
       adapterConfig: {
-        model: "gpt-5.3-codex-spark",
-        modelReasoningEffort: "high",
+        modelReasoningEffort: "low",
       },
+    });
+    expect(modelProfile.adapterConfig).not.toHaveProperty("model");
+    expect(merged).toEqual({
+      model: "gpt-5.4",
+      modelReasoningEffort: "low",
     });
   });
 


### PR DESCRIPTION
## Summary
- remove the `gpt-5.3-codex-spark` adapter-default model override from the `codex_local` `cheap` profile
- keep `cheap` focused on lowering reasoning effort so the agent's primary model lane stays intact by default
- extend the heartbeat model-profile regression test to assert `cheap` no longer injects a model override during merge

## Why
New companies or agents without explicit runtime `modelProfiles.cheap` data could still resolve `modelProfile=cheap` to `gpt-5.3-codex-spark` via adapter defaults. That breaks ChatGPT-billed Codex accounts and contradicts the profile description that says `cheap` should not change the primary model.

## Verification
- `./node_modules/.bin/vitest run server/src/__tests__/heartbeat-model-profile.test.ts`
- `PATH="/tmp/paperclip-upstream/node_modules/.bin:$PATH" corepack pnpm --filter @paperclipai/adapter-codex-local typecheck`
