### PR TITLE
Handle control characters in Paperclip write API bodies

### DIFF
--- a/server/src/__tests__/error-handler.test.ts
+++ b/server/src/__tests__/error-handler.test.ts
@@ -75,4 +75,21 @@ describe("errorHandler", () => {
     expect(res.err).toBe(err);
     expect(res.__errorContext?.error?.message).toBe("db exploded");
   });
+
+  it("returns 400 for JSON body parse errors instead of reporting them as 500 crashes", () => {
+    const req = makeReq();
+    const res = makeRes() as any;
+    const next = vi.fn() as unknown as NextFunction;
+    const err = Object.assign(new SyntaxError("Unexpected token"), {
+      status: 400,
+      type: "entity.parse.failed",
+    });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "Invalid JSON body" });
+    expect(res.err).toBeUndefined();
+    expect(res.__errorContext).toBeUndefined();
+  });
 });

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -520,6 +520,45 @@ describe("agent issue mutation checkout ownership", () => {
     );
   });
 
+  it("preserves control characters in issue comments, patch comments, and document bodies", async () => {
+    const app = await createApp(ownerActor());
+    const body = "line 1\nline 2\twith tab\rcr segment";
+
+    await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body })
+      .expect(201);
+    await request(app)
+      .patch(`/api/issues/${issueId}`)
+      .send({ comment: body })
+      .expect(200);
+    await request(app)
+      .put(`/api/issues/${issueId}/documents/plan`)
+      .send({ format: "markdown", body })
+      .expect(200);
+
+    expect(mockIssueService.addComment).toHaveBeenNthCalledWith(
+      1,
+      issueId,
+      body,
+      expect.objectContaining({ agentId: ownerAgentId, runId: ownerRunId }),
+      expect.any(Object),
+    );
+    expect(mockIssueService.addComment).toHaveBeenNthCalledWith(
+      2,
+      issueId,
+      body,
+      expect.objectContaining({ agentId: ownerAgentId, runId: ownerRunId }),
+    );
+    expect(mockDocumentService.upsertIssueDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issueId,
+        key: "plan",
+        body,
+      }),
+    );
+  });
+
   it.each([
     [
       "work product create",

--- a/server/src/__tests__/multilingual-issues-routes.test.ts
+++ b/server/src/__tests__/multilingual-issues-routes.test.ts
@@ -49,6 +49,9 @@ describeEmbeddedPostgres("multilingual issue routes", () => {
     "- 日本語: ドキュメント本文を保持します。",
     "- हिन्दी: दस्तावेज़ पाठ सुरक्षित रहता है।",
   ].join("\n");
+  const controlCharComment = ["control comment line 1", "line 2\twith tab"].join("\r\n");
+  const controlCharDocument = ["# Control notes", "", "- first\tcolumn", "- second line"].join("\r\n");
+  const controlCharCompletionNote = ["control patch line 1", "line 2\twith tab"].join("\r\n");
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-multilingual-issues-");
@@ -161,6 +164,41 @@ describeEmbeddedPostgres("multilingual issue routes", () => {
     expect(completeRes.status, JSON.stringify(completeRes.body)).toBe(200);
     expect(completeRes.body.status).toBe("done");
     expect(completeRes.body.comment.body).toBe(completionNote);
+  });
+
+  it("preserves comment, document, and patch-comment bodies with CRLF and tabs", async () => {
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/issues`)
+      .send({
+        title: "Control character body test",
+        description: "Verifies CRLF and tab preservation.",
+        status: "todo",
+        priority: "medium",
+      });
+    expect(createRes.status, JSON.stringify(createRes.body)).toBe(201);
+    const issueRef = createRes.body.identifier;
+
+    const commentRes = await request(app)
+      .post(`/api/issues/${issueRef}/comments`)
+      .send({ body: controlCharComment });
+    expect(commentRes.status, JSON.stringify(commentRes.body)).toBe(201);
+    expect(commentRes.body.body).toBe(controlCharComment);
+
+    const documentRes = await request(app)
+      .put(`/api/issues/${issueRef}/documents/control-notes`)
+      .send({
+        title: "Control character QA",
+        format: "markdown",
+        body: controlCharDocument,
+      });
+    expect(documentRes.status, JSON.stringify(documentRes.body)).toBe(201);
+    expect(documentRes.body.body).toBe(controlCharDocument);
+
+    const patchRes = await request(app)
+      .patch(`/api/issues/${issueRef}`)
+      .send({ status: "done", comment: controlCharCompletionNote });
+    expect(patchRes.status, JSON.stringify(patchRes.body)).toBe(200);
+    expect(patchRes.body.comment.body).toBe(controlCharCompletionNote);
   });
 
   it("lists multilingual comments in write order", async () => {

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -33,6 +33,12 @@ function attachErrorContext(
   }
 }
 
+function isJsonBodyParseError(err: unknown): err is Error & { status?: number; statusCode?: number; type?: string } {
+  if (!(err instanceof SyntaxError)) return false;
+  const candidate = err as Error & { status?: number; statusCode?: number; type?: string };
+  return candidate.type === "entity.parse.failed" || candidate.status === 400 || candidate.statusCode === 400;
+}
+
 export function errorHandler(
   err: unknown,
   req: Request,
@@ -59,6 +65,11 @@ export function errorHandler(
 
   if (err instanceof ZodError) {
     res.status(400).json({ error: "Validation error", details: err.errors });
+    return;
+  }
+
+  if (isJsonBodyParseError(err)) {
+    res.status(400).json({ error: "Invalid JSON body" });
     return;
   }
 


### PR DESCRIPTION
## Summary

- JSON body parse failures from raw LF/CR/tab control characters now return `400 Invalid JSON body` instead of surfacing as `500 Internal server error` crashes.
- Adds route-level regression coverage that properly JSON-encoded multiline comment, patch-comment, and document bodies keep LF/CR/tab contents through the write paths.
- Keeps LEA-681 scoped to control-character body handling only. The unrelated dispatch-promotion authz diff from the dirty source worktree is not included.

## Test plan

- `cd server && pnpm exec vitest run src/__tests__/error-handler.test.ts src/__tests__/issue-agent-mutation-ownership-routes.test.ts src/__tests__/multilingual-issues-routes.test.ts` -> 42 tests passed

Note: the isolated worktree initially lacked `node_modules`; `pnpm install --frozen-lockfile` populated dependencies but exited non-zero on an existing plugin-sdk symlink during postinstall. The targeted test command above ran successfully after dependency links were present.
