### PR TITLE
Harden plugin secret handling

### DIFF
--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -40,6 +40,7 @@ async function createApp(
   routeOverrides: {
     db?: unknown;
     jobDeps?: unknown;
+    webhookDeps?: unknown;
     toolDeps?: unknown;
     bridgeDeps?: unknown;
   } = {},
@@ -64,7 +65,7 @@ async function createApp(
     (routeOverrides.db ?? {}) as never,
     loader as never,
     routeOverrides.jobDeps as never,
-    undefined,
+    routeOverrides.webhookDeps as never,
     routeOverrides.toolDeps as never,
     routeOverrides.bridgeDeps as never,
   ));
@@ -381,6 +382,75 @@ describe.sequential("scoped plugin API routes", () => {
       }),
     );
   }, 20_000);
+});
+
+describe.sequential("plugin webhook security", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redacts sensitive webhook headers before persisting deliveries while forwarding originals to the worker", async () => {
+    const values = vi.fn(() => ({
+      returning: vi.fn().mockResolvedValue([{ id: "delivery-1" }]),
+    }));
+    const db = {
+      insert: vi.fn(() => ({ values })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({
+          where: vi.fn().mockResolvedValue(undefined),
+        })),
+      })),
+    };
+    const workerManager = {
+      call: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockRegistry.getById.mockResolvedValue({
+      id: pluginId,
+      pluginKey: "paperclip.example",
+      version: "1.0.0",
+      status: "ready",
+      manifestJson: {
+        id: "paperclip.example",
+        capabilities: ["webhooks.receive"],
+        webhooks: [{ endpointKey: "telegram" }],
+      },
+    });
+
+    const { app } = await createApp(boardActor(), {}, {
+      db,
+      webhookDeps: { workerManager },
+    });
+
+    const res = await request(app)
+      .post(`/api/plugins/${pluginId}/webhooks/telegram`)
+      .set("Authorization", "Bearer provider-secret")
+      .set("X-Hub-Signature-256", "sha256=provider-signature")
+      .set("X-Custom-Token", "provider-token")
+      .set("X-Request-Id", "request-1")
+      .send({ ok: true });
+
+    expect(res.status).toBe(200);
+    expect(values).toHaveBeenCalledWith(expect.objectContaining({
+      headers: expect.objectContaining({
+        authorization: "[redacted]",
+        "x-hub-signature-256": "[redacted]",
+        "x-custom-token": "[redacted]",
+        "x-request-id": "request-1",
+      }),
+    }));
+    expect(workerManager.call).toHaveBeenCalledWith(
+      pluginId,
+      "handleWebhook",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer provider-secret",
+          "x-hub-signature-256": "sha256=provider-signature",
+          "x-custom-token": "provider-token",
+        }),
+      }),
+    );
+  });
 });
 
 describe.sequential("plugin local folder routes", () => {

--- a/server/src/__tests__/plugin-telemetry-bridge.test.ts
+++ b/server/src/__tests__/plugin-telemetry-bridge.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createHostClientHandlers } from "../../../packages/plugins/sdk/src/host-client-factory.js";
 import { PLUGIN_RPC_ERROR_CODES } from "../../../packages/plugins/sdk/src/protocol.js";
-import { buildHostServices } from "../services/plugin-host-services.js";
+import { buildHostServices, flushPluginLogBuffer } from "../services/plugin-host-services.js";
+import { REDACTED_EVENT_VALUE } from "../redaction.js";
 
 const mockGetTelemetryClient = vi.hoisted(() => vi.fn());
 
@@ -110,5 +111,49 @@ describe("plugin telemetry bridge", () => {
     });
 
     expect(mockGetTelemetryClient).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("plugin log security", () => {
+  it("redacts plugin log messages and metadata before persistence", async () => {
+    const insertedRows: Array<Record<string, unknown>> = [];
+    const values = vi.fn(async (rows: Array<Record<string, unknown>>) => {
+      insertedRows.push(...rows);
+    });
+    const db = {
+      insert: vi.fn(() => ({ values })),
+    };
+
+    const services = buildHostServices(
+      db as never,
+      "plugin-record-id",
+      "linear",
+      createEventBusStub(),
+    );
+
+    await services.logger.log({
+      level: "info",
+      message: "Authorization: Bearer sk-plugin-log-secret",
+      meta: {
+        apiKey: "sk-plugin-meta-secret",
+        nested: {
+          password: "meta-password",
+          requestId: "request-1",
+        },
+        level: "attempted-pino-override",
+      },
+    });
+    await flushPluginLogBuffer();
+
+    expect(insertedRows).toHaveLength(1);
+    expect(insertedRows[0]?.message).toBe(`Authorization: Bearer ${REDACTED_EVENT_VALUE}`);
+    expect(insertedRows[0]?.meta).toMatchObject({
+      apiKey: REDACTED_EVENT_VALUE,
+      nested: {
+        password: REDACTED_EVENT_VALUE,
+        requestId: "request-1",
+      },
+    });
+    expect(insertedRows[0]?.meta).not.toHaveProperty("level");
   });
 });

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -147,6 +147,14 @@ const PLUGIN_SCOPED_API_RESPONSE_HEADER_ALLOWLIST = new Set([
   "last-modified",
   "x-request-id",
 ]);
+const SENSITIVE_PERSISTED_HEADER_NAMES = new Set([
+  "authorization",
+  "cookie",
+  "proxy-authorization",
+  "set-cookie",
+]);
+const SENSITIVE_PERSISTED_HEADER_PATTERN = /(?:^|[-_])(auth|key|secret|signature|token)(?:$|[-_])/i;
+const REDACTED_HEADER_VALUE = "[redacted]";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../../..");
@@ -406,6 +414,23 @@ export function pluginRoutes(
       } else if (typeof value === "string") {
         headers[lower] = value;
       }
+    }
+    return headers;
+  }
+
+  function sanitizePersistedWebhookHeaders(req: Request): Record<string, string> {
+    const headers: Record<string, string> = {};
+    for (const [name, value] of Object.entries(req.headers)) {
+      const lower = name.toLowerCase();
+      const shouldRedact = SENSITIVE_PERSISTED_HEADER_NAMES.has(lower)
+        || SENSITIVE_PERSISTED_HEADER_PATTERN.test(lower);
+      const normalized = Array.isArray(value)
+        ? value.join(", ")
+        : typeof value === "string"
+          ? value
+          : undefined;
+      if (normalized === undefined) continue;
+      headers[lower] = shouldRedact ? REDACTED_HEADER_VALUE : normalized;
     }
     return headers;
   }
@@ -2301,14 +2326,7 @@ export function pluginRoutes(
 
     // Step 5: Extract request data
     const requestId = randomUUID();
-    const rawHeaders: Record<string, string> = {};
-    for (const [key, value] of Object.entries(req.headers)) {
-      if (typeof value === "string") {
-        rawHeaders[key] = value;
-      } else if (Array.isArray(value)) {
-        rawHeaders[key] = value.join(", ");
-      }
-    }
+    const persistedHeaders = sanitizePersistedWebhookHeaders(req);
 
     // Use the raw buffer stashed by the express.json() `verify` callback.
     // This preserves the exact bytes the provider signed, whereas
@@ -2327,7 +2345,7 @@ export function pluginRoutes(
         webhookKey: endpointKey,
         status: "pending",
         payload,
-        headers: rawHeaders,
+        headers: persistedHeaders,
         startedAt,
       })
       .returning({ id: pluginWebhookDeliveries.id });

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -69,6 +69,7 @@ import { request as httpsRequest } from "node:https";
 import { isIP } from "node:net";
 import { logger } from "../middleware/logger.js";
 import { getTelemetryClient } from "../telemetry.js";
+import { redactSensitiveText, sanitizeRecord } from "../redaction.js";
 
 // ---------------------------------------------------------------------------
 // SSRF protection for plugin HTTP fetch
@@ -372,7 +373,7 @@ function truncStr(s: string, max: number): string {
   return s.slice(0, max) + "...[truncated]";
 }
 
-/** Sanitise a plugin-supplied meta object: enforce size limit and strip reserved keys. */
+/** Sanitise a plugin-supplied meta object: redact secrets, enforce size limit, and strip reserved keys. */
 function sanitiseMeta(meta: Record<string, unknown> | null | undefined): Record<string, unknown> | null {
   if (meta == null) return null;
   // Strip pino reserved keys
@@ -382,17 +383,18 @@ function sanitiseMeta(meta: Record<string, unknown> | null | undefined): Record<
       cleaned[k] = v;
     }
   }
+  const redacted = sanitizeRecord(cleaned);
   // Enforce total serialised size
   let json: string;
   try {
-    json = JSON.stringify(cleaned);
+    json = JSON.stringify(redacted);
   } catch {
     return { _sanitised: true, _error: "meta was not JSON-serialisable" };
   }
   if (json.length > MAX_LOG_META_JSON_LENGTH) {
     return { _sanitised: true, _error: `meta exceeded ${MAX_LOG_META_JSON_LENGTH} chars` };
   }
-  return cleaned;
+  return redacted;
 }
 
 interface BufferedLogEntry {
@@ -1049,7 +1051,10 @@ export function buildHostServices(
     logger: {
       async log(params) {
         const { level, meta } = params;
-        const safeMessage = truncStr(String(params.message ?? ""), MAX_LOG_MESSAGE_LENGTH);
+        const safeMessage = truncStr(
+          redactSensitiveText(String(params.message ?? "")),
+          MAX_LOG_MESSAGE_LENGTH,
+        );
         const safeMeta = sanitiseMeta(meta);
         const pluginLogger = logger.child({ service: "plugin-worker", pluginId });
         const logFields = {


### PR DESCRIPTION
## Summary
- redact sensitive webhook headers before persisting deliveries while preserving original headers for worker-side signature verification
- redact plugin log messages and nested metadata before persistence/logging
- update vulnerable dependency floors and document the non-applicable cli audit false positive
- adapt Better Auth typing after dependency upgrade

## Verification
- corepack pnpm audit --audit-level low
- corepack pnpm --filter @paperclipai/server exec tsc --noEmit
- corepack pnpm exec vitest run server/src/__tests__/plugin-routes-authz.test.ts --testTimeout=60000
- corepack pnpm exec vitest run server/src/__tests__/plugin-telemetry-bridge.test.ts server/src/__tests__/better-auth.test.ts --testTimeout=60000
- git diff --check