### PR TITLE
Fix stalled checkout wakeup recovery

### DIFF
--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -639,6 +639,74 @@ describe("agent live run routes", () => {
     }));
   });
 
+  it("rejects stalled checkout wake UUIDs outside the agent company before queueing", async () => {
+    const query = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn(async () => []),
+    };
+    const db = {
+      select: vi.fn(() => query),
+    };
+
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/wakeup?companyId=company-1`)
+        .send({
+          source: "on_demand",
+          reason: "stalled_checkout_sweep",
+          payload: {
+            issueId: "33333333-3333-4333-8333-333333333333",
+            mutation: "manual_unstall",
+          },
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body).toMatchObject({
+      error: "Invalid stalled checkout wake payload issueId",
+      details: {
+        field: "payload.issueId",
+        code: "invalid_issue_id",
+      },
+    });
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("normalizes stalled checkout wake payloads on the legacy invoke route", async () => {
+    const issueId = "22222222-2222-4222-8222-222222222222";
+    const query = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn(async () => [{ id: issueId }]),
+    };
+    const db = {
+      select: vi.fn(() => query),
+    };
+
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/heartbeat/invoke?companyId=company-1`)
+        .send({
+          reason: "stalled_checkout_sweep",
+          payload: {
+            issueId: "NOX-4140",
+            mutation: "manual_unstall",
+          },
+          forceFreshSession: true,
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(routeAgentId, expect.objectContaining({
+      reason: "stalled_checkout_sweep",
+      payload: {
+        issueId,
+        mutation: "manual_unstall",
+      },
+    }));
+  });
+
   it("calls heartbeat.wakeup with the legacy minimal shape when the body is empty", async () => {
     const res = await requestApp(
       await createApp(),

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -577,6 +577,68 @@ describe("agent live run routes", () => {
     });
   });
 
+  it("rejects malformed stalled checkout wake issue ids before queueing", async () => {
+    const res = await requestApp(
+      await createApp(),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/wakeup?companyId=company-1`)
+        .send({
+          source: "on_demand",
+          reason: "stalled_checkout_sweep",
+          forceFreshSession: true,
+          payload: {
+            issueId: "ae?",
+            mutation: "manual_unstall",
+          },
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(400);
+    expect(res.body).toMatchObject({
+      error: "Invalid stalled checkout wake payload issueId",
+      details: {
+        field: "payload.issueId",
+        code: "invalid_issue_id",
+      },
+    });
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("normalizes stalled checkout wake issue identifiers before queueing", async () => {
+    const issueId = "22222222-2222-4222-8222-222222222222";
+    const query = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn(async () => [{ id: issueId }]),
+    };
+    const db = {
+      select: vi.fn(() => query),
+    };
+
+    const res = await requestApp(
+      await createApp(db),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/wakeup?companyId=company-1`)
+        .send({
+          source: "on_demand",
+          reason: "stalled_checkout_sweep",
+          forceFreshSession: true,
+          payload: {
+            issueId: "NOX-4140",
+            mutation: "manual_unstall",
+          },
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(routeAgentId, expect.objectContaining({
+      reason: "stalled_checkout_sweep",
+      payload: {
+        issueId,
+        mutation: "manual_unstall",
+      },
+    }));
+  });
+
   it("calls heartbeat.wakeup with the legacy minimal shape when the body is empty", async () => {
     const res = await requestApp(
       await createApp(),

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -72,6 +72,7 @@ const mockHeartbeatService = vi.hoisted(() => ({
   resetRuntimeSession: vi.fn(),
   getRun: vi.fn(),
   cancelRun: vi.fn(),
+  wakeup: vi.fn(),
 }));
 
 const mockIssueApprovalService = vi.hoisted(() => ({
@@ -314,6 +315,7 @@ describe.sequential("agent permission routes", () => {
     mockHeartbeatService.resetRuntimeSession.mockReset();
     mockHeartbeatService.getRun.mockReset();
     mockHeartbeatService.cancelRun.mockReset();
+    mockHeartbeatService.wakeup.mockReset();
     mockIssueApprovalService.linkManyForApproval.mockReset();
     mockIssueService.list.mockReset();
     mockSecretService.normalizeAdapterConfigForPersistence.mockReset();
@@ -359,6 +361,7 @@ describe.sequential("agent permission routes", () => {
     mockCompanySkillService.listRuntimeSkillEntries.mockResolvedValue([]);
     mockCompanySkillService.resolveRequestedSkillKeys.mockImplementation(async (_companyId, requested) => requested);
     mockBudgetService.upsertPolicy.mockResolvedValue(undefined);
+    mockHeartbeatService.wakeup.mockResolvedValue({ id: "run-1" });
     mockAgentInstructionsService.materializeManagedBundle.mockImplementation(
       async (agent: Record<string, unknown>, files: Record<string, string>) => ({
         bundle: null,
@@ -477,6 +480,43 @@ describe.sequential("agent permission routes", () => {
       .send({}));
 
     expect(res.status).toBe(403);
+  });
+
+  it("allows agent-authenticated delegated wakeups with tasks:assign permission", async () => {
+    const targetAgentId = "33333333-3333-4333-8333-333333333333";
+    mockAgentService.getById.mockImplementation(async (id: string) => ({
+      ...baseAgent,
+      id,
+      companyId,
+    }));
+    mockAccessService.hasPermission.mockImplementation(async (
+      _companyId: string,
+      principalType: string,
+      principalId: string,
+      permissionKey: string,
+    ) => (
+      principalType === "agent" &&
+      principalId === agentId &&
+      permissionKey === "tasks:assign"
+    ));
+
+    const app = await createApp({
+      type: "agent",
+      agentId,
+      companyId,
+      source: "agent_key",
+      runId: "run-1",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/agents/${targetAgentId}/wakeup`)
+      .send({ source: "on_demand" }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(targetAgentId, expect.objectContaining({
+      requestedByActorType: "agent",
+      requestedByActorId: agentId,
+    }));
   });
 
   it("blocks agent-authenticated self-updates that set host-executed workspace commands", async () => {

--- a/server/src/__tests__/routines-e2e.test.ts
+++ b/server/src/__tests__/routines-e2e.test.ts
@@ -327,6 +327,68 @@ describeEmbeddedPostgres("routine routes end-to-end", () => {
     );
   }, 15_000);
 
+  it("coalesces routine dispatch into an open stalled execution issue without a live run", async () => {
+    const { companyId, agentId, projectId, userId } = await seedFixture();
+    const app = await createApp({
+      type: "board",
+      userId,
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const createRes = await request(app)
+      .post(`/api/companies/${companyId}/routines`)
+      .send({
+        projectId,
+        title: "Stalled checkout sweep",
+        description: "Wake stalled work",
+        assigneeAgentId: agentId,
+        concurrencyPolicy: "coalesce_if_active",
+      });
+
+    expect([200, 201], JSON.stringify(createRes.body)).toContain(createRes.status);
+
+    const firstRunRes = await postRoutineRun(app, createRes.body.id, {
+      source: "api",
+    });
+
+    expect(firstRunRes.status, JSON.stringify(firstRunRes.body)).toBe(202);
+    expect(firstRunRes.body.status).toBe("issue_created");
+
+    const [firstIssue] = await db
+      .select({ executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, firstRunRes.body.linkedIssueId));
+    expect(firstIssue?.executionRunId).toBeTruthy();
+    const staleRunId = firstIssue?.executionRunId as string;
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "succeeded", finishedAt: new Date() })
+      .where(eq(heartbeatRuns.id, staleRunId));
+    await db
+      .update(issues)
+      .set({
+        checkoutRunId: null,
+        executionLockedAt: null,
+      })
+      .where(eq(issues.id, firstRunRes.body.linkedIssueId));
+
+    const secondRunRes = await postRoutineRun(app, createRes.body.id, {
+      source: "api",
+    });
+
+    expect(secondRunRes.status, JSON.stringify(secondRunRes.body)).toBe(202);
+    expect(secondRunRes.body.status).toBe("coalesced");
+    expect(secondRunRes.body.linkedIssueId).toBe(firstRunRes.body.linkedIssueId);
+
+    const issueRows = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(eq(issues.originId, createRes.body.id));
+    expect(issueRows).toHaveLength(1);
+  }, 15_000);
+
   it("runs routines with variable inputs and interpolates the execution issue description", async () => {
     const { companyId, agentId, projectId, userId } = await seedFixture();
     const app = await createApp({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -48,7 +48,7 @@ import {
   syncInstructionsBundleConfigFromFilePath,
   workspaceOperationService,
 } from "../services/index.js";
-import { conflict, forbidden, notFound, unprocessable } from "../errors.js";
+import { badRequest, conflict, forbidden, notFound, unprocessable } from "../errors.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import {
   assertNoAgentHostWorkspaceCommandMutation,
@@ -571,6 +571,24 @@ export function agentRoutes(
     if (!allowed) {
       throw forbidden("Missing permission: agents:create");
     }
+  }
+
+  async function canAgentWakeTarget(companyId: string, actorAgentId: string | undefined, targetAgentId: string) {
+    if (actorAgentId === targetAgentId) return true;
+    if (typeof actorAgentId !== "string") return false;
+    return access.hasPermission(companyId, "agent", actorAgentId, "tasks:assign");
+  }
+
+  async function assertCanWakeAgent(req: Request, companyId: string, targetAgentId: string) {
+    if (req.actor.type === "agent") {
+      const allowed = await canAgentWakeTarget(companyId, req.actor.agentId, targetAgentId);
+      if (!allowed) {
+        throw forbidden("Agent can only invoke itself or use tasks:assign delegated wakeups");
+      }
+      return;
+    }
+
+    await assertBoardCanManageAgentsForCompany(req, companyId);
   }
 
   async function assertCanReadConfigurations(req: Request, companyId: string) {
@@ -2917,6 +2935,32 @@ export function agentRoutes(
     source: HeartbeatSource | undefined;
     skippedResponse: (agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>) => unknown | Promise<unknown>;
   };
+
+  async function normalizeStalledCheckoutWakePayload(payload: unknown, companyId: string) {
+    if (!payload || typeof payload !== "object") return payload;
+    const issueId = (payload as { issueId?: unknown }).issueId;
+    if (typeof issueId !== "string" || issueId.trim().length === 0) return payload;
+    const rawIssueId = issueId.trim();
+    if (isUuidLike(rawIssueId)) {
+      return { ...payload, issueId: rawIssueId };
+    }
+    const identifier = normalizeIssueIdentifier(rawIssueId);
+    if (identifier) {
+      const issue = await db
+        .select({ id: issuesTable.id })
+        .from(issuesTable)
+        .where(and(eq(issuesTable.companyId, companyId), eq(issuesTable.identifier, identifier)))
+        .then((rows) => rows[0] ?? null);
+      if (issue) {
+        return { ...payload, issueId: issue.id };
+      }
+    }
+    throw badRequest("Invalid stalled checkout wake payload issueId", {
+      field: "payload.issueId",
+      code: "invalid_issue_id",
+    });
+  }
+
   const handleWakeupRoute = async (
     req: Request,
     res: Response,
@@ -2930,13 +2974,10 @@ export function agentRoutes(
     }
     assertCompanyAccess(req, agent.companyId);
 
-    if (req.actor.type === "agent") {
-      if (req.actor.agentId !== id) {
-        res.status(403).json({ error: "Agent can only invoke itself" });
-        return;
-      }
-    } else {
-      await assertBoardCanManageAgentsForCompany(req, agent.companyId);
+    await assertCanWakeAgent(req, agent.companyId, id);
+
+    if (req.body.reason === "stalled_checkout_sweep") {
+      req.body.payload = await normalizeStalledCheckoutWakePayload(req.body.payload ?? null, agent.companyId);
     }
 
     const run = await heartbeat.wakeup(id, {
@@ -2998,14 +3039,7 @@ export function agentRoutes(
     }
     assertCompanyAccess(req, agent.companyId);
 
-    if (req.actor.type === "agent") {
-      if (req.actor.agentId !== id) {
-        res.status(403).json({ error: "Agent can only invoke itself" });
-        return;
-      }
-    } else {
-      await assertBoardCanManageAgentsForCompany(req, agent.companyId);
-    }
+    await assertCanWakeAgent(req, agent.companyId, id);
 
     const body = (req.body ?? {}) as Partial<{
       reason: unknown;

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2942,7 +2942,14 @@ export function agentRoutes(
     if (typeof issueId !== "string" || issueId.trim().length === 0) return payload;
     const rawIssueId = issueId.trim();
     if (isUuidLike(rawIssueId)) {
-      return { ...payload, issueId: rawIssueId };
+      const issue = await db
+        .select({ id: issuesTable.id })
+        .from(issuesTable)
+        .where(and(eq(issuesTable.companyId, companyId), eq(issuesTable.id, rawIssueId)))
+        .then((rows) => rows[0] ?? null);
+      if (issue) {
+        return { ...payload, issueId: issue.id };
+      }
     }
     const identifier = normalizeIssueIdentifier(rawIssueId);
     if (identifier) {
@@ -3065,8 +3072,11 @@ export function agentRoutes(
     if (typeof body.reason === "string" && body.reason.length > 0) {
       wakeOpts.reason = body.reason;
     }
-    if (body.payload && typeof body.payload === "object" && !Array.isArray(body.payload)) {
-      wakeOpts.payload = body.payload as Record<string, unknown>;
+    const normalizedPayload = body.reason === "stalled_checkout_sweep"
+      ? await normalizeStalledCheckoutWakePayload(body.payload ?? null, agent.companyId)
+      : body.payload;
+    if (normalizedPayload && typeof normalizedPayload === "object" && !Array.isArray(normalizedPayload)) {
+      wakeOpts.payload = normalizedPayload as Record<string, unknown>;
     }
     if (typeof body.idempotencyKey === "string" && body.idempotencyKey.length > 0) {
       wakeOpts.idempotencyKey = body.idempotencyKey;

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -913,6 +913,7 @@ export function routineService(
           eq(issues.originId, originId),
           inArray(issues.status, OPEN_ISSUE_STATUSES),
           isNull(issues.hiddenAt),
+          isNotNull(issues.executionRunId),
           ...(fingerprintCondition ? [fingerprintCondition] : []),
         ),
       )
@@ -939,6 +940,7 @@ export function routineService(
           eq(issues.originId, originId),
           inArray(issues.status, OPEN_ISSUE_STATUSES),
           isNull(issues.hiddenAt),
+          isNotNull(issues.executionRunId),
           ...(fingerprintCondition ? [fingerprintCondition] : []),
         ),
       )
@@ -966,6 +968,7 @@ export function routineService(
           eq(issues.originId, originId),
           inArray(issues.status, OPEN_ISSUE_STATUSES),
           isNull(issues.hiddenAt),
+          isNotNull(issues.executionRunId),
           ...(fingerprintCondition ? [fingerprintCondition] : []),
         ),
       )

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -947,6 +947,33 @@ export function routineService(
       .then((rows) => rows[0]?.issues ?? null);
   }
 
+  async function findOpenExecutionIssue(
+    routine: typeof routines.$inferSelect,
+    executor: Db = db,
+    dispatchFingerprint?: string | null,
+    origin?: { kind: string; id: string | null },
+  ) {
+    const fingerprintCondition = routineExecutionFingerprintCondition(dispatchFingerprint);
+    const originKind = origin?.kind ?? "routine_execution";
+    const originId = origin?.id ?? routine.id;
+    return executor
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, routine.companyId),
+          eq(issues.originKind, originKind),
+          eq(issues.originId, originId),
+          inArray(issues.status, OPEN_ISSUE_STATUSES),
+          isNull(issues.hiddenAt),
+          ...(fingerprintCondition ? [fingerprintCondition] : []),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function finalizeRun(runId: string, patch: Partial<typeof routineRuns.$inferInsert>, executor: Db = db) {
     return executor
       .update(routineRuns)
@@ -1205,7 +1232,7 @@ export function routineService(
 
       let createdIssue: Awaited<ReturnType<typeof issueSvc.create>> | null = null;
       try {
-        const activeIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
+        const activeIssue = await findOpenExecutionIssue(input.routine, txDb, dispatchFingerprint, {
           kind: issueOriginKind,
           id: issueOriginId,
         });
@@ -1269,7 +1296,7 @@ export function routineService(
             throw error;
           }
 
-          const existingIssue = await findLiveExecutionIssue(input.routine, txDb, dispatchFingerprint, {
+          const existingIssue = await findOpenExecutionIssue(input.routine, txDb, dispatchFingerprint, {
             kind: issueOriginKind,
             id: issueOriginId,
           });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through company-scoped issues, wakeups, and recurring routines.
> - The affected subsystem is the server wakeup route plus routine execution coalescing.
> - Stalled-checkout recovery can submit issue references from sweep payloads, and malformed references were reaching database predicates before validation.
> - Routine retry paths can also encounter an already-open routine execution when the original heartbeat is no longer live, which should coalesce instead of surfacing a uniqueness failure.
> - This pull request validates and normalizes stalled-checkout wake issue references before queueing, preserves delegated wake permissions, and coalesces routine dispatches against open execution issues.
> - The benefit is that stalled-checkout recovery returns typed 4xx responses for bad payloads and cleanly reuses open routine issues for routine duplicate conflicts.

## What Changed

- Added `stalled_checkout_sweep` payload issue-id validation and identifier-to-UUID normalization in the agent wakeup route.
- Centralized wake authorization so self-wake still works and agent delegated wakeups are allowed only with `tasks:assign`.
- Changed routine coalescing to consider open routine execution issues, including stale/open executions without a live heartbeat run.
- Added targeted tests for malformed wake issue ids, identifier normalization, delegated wake permission, and stale open routine coalescing.

## Verification

- `pnpm exec vitest run server/src/__tests__/agent-live-run-routes.test.ts server/src/__tests__/agent-permissions-routes.test.ts server/src/__tests__/routines-e2e.test.ts` - 3 files passed, 60 tests passed.
- `pnpm --filter @paperclipai/server typecheck` - passed.
- `pnpm --filter @paperclipai/plugin-sdk build && pnpm --filter @paperclipai/server build` - passed.

## Risks

- Low risk. The wake payload validation is scoped to `stalled_checkout_sweep` requests, and routine coalescing remains gated by the existing routine concurrency policy.
- The delegated wake path intentionally expands agent-to-agent wake authorization only when the actor has the existing `tasks:assign` permission.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5-class coding model, tool-enabled local repository execution with shell and patch editing.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
