### PR TITLE
fix(authz): allow agents to respond to ask_user_questions interactions

### DIFF
--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -706,6 +706,44 @@ describe.sequential("issue thread interaction routes", () => {
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
+  it("allows an agent to respond to ask_user_questions without board access", async () => {
+    const app = await createApp({
+      type: "agent",
+      agentId: CREATED_AGENT_ID,
+      companyId: "company-1",
+      runId: "run-1",
+    });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/respond")
+      .send({
+        answers: [{ questionId: "scope", optionIds: ["phase-1"] }],
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockInteractionService.answerQuestions).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }),
+      "interaction-2",
+      expect.objectContaining({ answers: [{ questionId: "scope", optionIds: ["phase-1"] }] }),
+      expect.objectContaining({ agentId: CREATED_AGENT_ID, userId: null }),
+    );
+  });
+
+  it("blocks a non-board unauthenticated actor from responding", async () => {
+    const app = await createApp({
+      type: "none",
+    });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-2/respond")
+      .send({
+        answers: [{ questionId: "scope", optionIds: ["phase-1"] }],
+      });
+
+    expect(res.status).toBe(401);
+    expect(mockInteractionService.answerQuestions).not.toHaveBeenCalled();
+  });
+
   it("allows agent-authored interaction creation and stamps the active run id", async () => {
     const app = await createApp({
       type: "agent",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4804,7 +4804,9 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
-      assertBoard(req);
+      if (req.actor.type !== "agent") {
+        assertBoard(req);
+      }
 
       const actor = getActorInfo(req);
       const interaction = await issueThreadInteractionService(db).answerQuestions(issue, interactionId, req.body, {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents can create `ask_user_questions` interactions on issues to route structured Q&A to another agent or board user
> - When a target agent calls `POST /api/issues/:id/interactions/:interactionId/respond`, it gets `{"error":"Board access required"}` because the endpoint unconditionally required board access for all non-board actors
> - The deployed version attempted a partial fix (checking `isAssignee && isWakeAssigneePolicy`) but this still blocks agent-to-agent workflows where the responding agent is not the issue's current assignee
> - This PR replaces the overly-restrictive agent check with a simple gate: board access is only required for non-agent actors; any authenticated company agent (already gated by `assertCompanyAccess`) may respond
> - The benefit is that agent-to-agent `ask_user_questions` workflows work correctly end-to-end without requiring the responding agent to be the issue's current assignee

## What Changed

- `server/src/routes/issues.ts`: In the `POST /issues/:id/interactions/:interactionId/respond` handler, replaced `assertBoard(req)` with a conditional that only applies the board check when the actor is not an agent. Agents already pass `assertCompanyAccess` which verifies same-company membership.
- `server/src/__tests__/issue-thread-interaction-routes.test.ts`: Added two regression tests — one confirming an agent (non-assignee) can call respond successfully, one confirming an unauthenticated actor still gets 401.

## Verification

```bash
# Run the interaction routes test suite
pnpm test server/src/__tests__/issue-thread-interaction-routes.test.ts

# Specific new tests:
# - "allows an agent to respond to ask_user_questions without board access" → 200
# - "blocks a non-board unauthenticated actor from responding" → 401
```

Manual verification:
1. Create an `ask_user_questions` interaction on an issue assigned to Agent A
2. Call the `/respond` endpoint with Agent B's JWT (different agent, same company)
3. Expect HTTP 200 and the interaction marked as `answered`

## Risks

- Low risk. The change relaxes the authorization check only for agent actors. Board users are unaffected (still require board access). The response action itself has no side effects beyond marking the interaction answered and waking the continuation target — it does not modify issue ownership, status, or assignments.
- Any authenticated company agent could now answer any pending `ask_user_questions` interaction in their company. This is the intended behavior since the interaction was already scoped to a company issue and the response data is visible to all parties.

## Model Used

- Provider: Anthropic
- Model ID: `claude-sonnet-4-6`
- Context window: 200k tokens
- Capabilities: tool use, code execution, file editing

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge