### PR TITLE
[codex] Bind orphaned timer wakes to project workspaces

### DIFF
--- a/cli/src/__tests__/common.test.ts
+++ b/cli/src/__tests__/common.test.ts
@@ -18,6 +18,7 @@ describe("resolveCommandContext", () => {
     delete process.env.PAPERCLIP_API_URL;
     delete process.env.PAPERCLIP_API_KEY;
     delete process.env.PAPERCLIP_COMPANY_ID;
+    delete process.env.PAPERCLIP_RUN_ID;
   });
 
   afterEach(() => {
@@ -78,6 +79,27 @@ describe("resolveCommandContext", () => {
     expect(resolved.api.apiBase).toBe("http://override:3200");
     expect(resolved.companyId).toBe("company-override");
     expect(resolved.api.apiKey).toBe("direct-token");
+  });
+
+  it("passes the heartbeat run id from env to the API client", () => {
+    const contextPath = createTempPath("context.json");
+    writeContext(
+      {
+        version: 1,
+        currentProfile: "default",
+        profiles: {
+          default: {
+            apiBase: "http://profile:3100",
+          },
+        },
+      },
+      contextPath,
+    );
+    process.env.PAPERCLIP_RUN_ID = "run-from-env";
+
+    const resolved = resolveCommandContext({ context: contextPath });
+
+    expect(resolved.api.runId).toBe("run-from-env");
   });
 
   it("throws when company is required but unresolved", () => {

--- a/cli/src/commands/client/common.ts
+++ b/cli/src/commands/client/common.ts
@@ -66,6 +66,7 @@ export function resolveCommandContext(
     options.companyId?.trim() ||
     process.env.PAPERCLIP_COMPANY_ID?.trim() ||
     profile.companyId;
+  const runId = process.env.PAPERCLIP_RUN_ID?.trim() || undefined;
 
   if (opts?.requireCompany && !companyId) {
     throw new Error(
@@ -76,6 +77,7 @@ export function resolveCommandContext(
   const api = new PaperclipApiClient({
     apiBase,
     apiKey,
+    runId,
     recoverAuth: explicitApiKey || !canAttemptInteractiveBoardAuth()
       ? undefined
       : async ({ error }) => {

--- a/server/src/__tests__/heartbeat-timer-assignment.test.ts
+++ b/server/src/__tests__/heartbeat-timer-assignment.test.ts
@@ -1,0 +1,219 @@
+import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+  projects,
+  projectWorkspaces,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const execFileAsync = promisify(execFile);
+
+const adapterExecute = vi.hoisted(() => vi.fn(async () => ({
+  exitCode: 0,
+  signal: null,
+  timedOut: false,
+  sessionParams: { sessionId: "timer-session" },
+  sessionDisplayId: "timer-session",
+  summary: "Timer assignment test run.",
+  provider: "test",
+  model: "test-model",
+})));
+
+vi.mock("../adapters/index.js", () => ({
+  getServerAdapter: () => ({
+    type: "codex_local",
+    execute: adapterExecute,
+    supportsLocalAgentJwt: false,
+  }),
+  listAdapterModelProfiles: async () => [],
+  runningProcesses: new Map(),
+}));
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat timer assignment tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function createGitRepo() {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-timer-assignment-repo-"));
+  await execFileAsync("git", ["init"], { cwd: repoRoot });
+  await execFileAsync("git", ["config", "user.email", "paperclip-test@example.com"], { cwd: repoRoot });
+  await execFileAsync("git", ["config", "user.name", "Paperclip Test"], { cwd: repoRoot });
+  await writeFile(path.join(repoRoot, "README.md"), "timer assignment workspace\n");
+  await execFileAsync("git", ["add", "README.md"], { cwd: repoRoot });
+  await execFileAsync("git", ["commit", "-m", "initial"], { cwd: repoRoot });
+  return repoRoot;
+}
+
+describeEmbeddedPostgres("heartbeat timer assignment", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  const tempRoots: string[] = [];
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("heartbeat-timer-assignment-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    adapterExecute.mockClear();
+    let idlePolls = 0;
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const runs = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns);
+      const hasActiveRun = runs.some((run) => run.status === "queued" || run.status === "running");
+      if (!hasActiveRun) {
+        idlePolls += 1;
+        if (idlePolls >= 5) break;
+      } else {
+        idlePolls = 0;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    while (tempRoots.length > 0) {
+      const root = tempRoots.pop();
+      if (root) await rm(root, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  afterAll(async () => {
+    await db.$client.end();
+    await tempDb?.cleanup();
+  });
+
+  it("binds an unscoped timer wake to the next assigned project issue", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+    const issueId = randomUUID();
+    const agentId = randomUUID();
+    const repoRoot = await createGitRepo();
+    tempRoots.push(repoRoot);
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Acme",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Timer Assignment",
+      status: "active",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      cwd: repoRoot,
+      isPrimary: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          enabled: true,
+          intervalSec: 60,
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      title: "Continue project work",
+      status: "todo",
+      workMode: "standard",
+      priority: "high",
+      assigneeAgentId: agentId,
+      identifier: "PAP-9321",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    adapterExecute.mockImplementationOnce(async () => {
+      await db.update(issues).set({ status: "done", updatedAt: new Date() }).where(eq(issues.id, issueId));
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        sessionParams: { sessionId: "timer-session" },
+        sessionDisplayId: "timer-session",
+        summary: "Timer assignment test run.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+
+    const heartbeat = heartbeatService(db);
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "system",
+      reason: "heartbeat_timer",
+      contextSnapshot: {
+        scheduler: "interval",
+      },
+    });
+
+    expect(run).not.toBeNull();
+    await vi.waitFor(async () => {
+      const latest = await heartbeat.getRun(run!.id);
+      expect(latest?.status).toBe("succeeded");
+    }, { timeout: 10_000 });
+
+    expect(adapterExecute).toHaveBeenCalledTimes(1);
+    const adapterInput = adapterExecute.mock.calls[0]?.[0] as {
+      context: Record<string, unknown>;
+    };
+    expect(adapterInput.context.issueId).toBe(issueId);
+    expect(adapterInput.context.taskId).toBe(issueId);
+    expect(adapterInput.context.projectId).toBe(projectId);
+    expect(adapterInput.context.timerSelectedIssueId).toBe(issueId);
+    expect(adapterInput.context.paperclipWorkspace).toEqual(expect.objectContaining({
+      cwd: repoRoot,
+      source: "project_primary",
+      strategy: "project_primary",
+      projectId,
+      workspaceId: projectWorkspaceId,
+    }));
+  }, 20_000);
+});

--- a/server/src/__tests__/heartbeat-timer-assignment.test.ts
+++ b/server/src/__tests__/heartbeat-timer-assignment.test.ts
@@ -206,6 +206,7 @@ describeEmbeddedPostgres("heartbeat timer assignment", () => {
     };
     expect(adapterInput.context.issueId).toBe(issueId);
     expect(adapterInput.context.taskId).toBe(issueId);
+    expect(adapterInput.context.taskKey).toBe("PAP-9321");
     expect(adapterInput.context.projectId).toBe(projectId);
     expect(adapterInput.context.timerSelectedIssueId).toBe(issueId);
     expect(adapterInput.context.paperclipWorkspace).toEqual(expect.objectContaining({

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1559,6 +1559,50 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
   });
 
+  it("defaults the project workspace when an existing issue is attached to a project", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const projectWorkspaceId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Workspace project",
+      status: "in_progress",
+    });
+
+    await db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "Primary workspace",
+      isPrimary: true,
+      sharedWorkspaceKey: "workspace-key",
+    });
+
+    const orphan = await svc.create(companyId, {
+      title: "Attach old issue to project",
+      status: "todo",
+      priority: "medium",
+    });
+
+    expect(orphan.projectId).toBeNull();
+    expect(orphan.projectWorkspaceId).toBeNull();
+
+    const attached = await svc.update(orphan.id, { projectId });
+
+    expect(attached).not.toBeNull();
+    expect(attached!.projectId).toBe(projectId);
+    expect(attached!.projectWorkspaceId).toBe(projectWorkspaceId);
+  });
+
   it("captures the assignee default environment when neither issue nor project specifies one", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8664,6 +8664,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return await db
       .select({
         id: issues.id,
+        identifier: issues.identifier,
         projectId: issues.projectId,
       })
       .from(issues)
@@ -8736,7 +8737,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         issueId = timerAssignment.id;
         enrichedContextSnapshot.issueId = timerAssignment.id;
         enrichedContextSnapshot.taskId = timerAssignment.id;
-        enrichedContextSnapshot.taskKey = timerAssignment.id;
+        enrichedContextSnapshot.taskKey = timerAssignment.identifier ?? timerAssignment.id;
         enrichedContextSnapshot.projectId = timerAssignment.projectId;
         enrichedContextSnapshot.timerSelectedIssueId = timerAssignment.id;
       }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8660,6 +8660,31 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     await startNextQueuedRunForAgent(promotedRun.agentId);
   }
 
+  async function resolveTimerWakeAssignment(agent: typeof agents.$inferSelect) {
+    return await db
+      .select({
+        id: issues.id,
+        projectId: issues.projectId,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, agent.companyId),
+          eq(issues.assigneeAgentId, agent.id),
+          inArray(issues.status, ["in_progress", "todo"]),
+          sql`${issues.projectId} is not null`,
+        ),
+      )
+      .orderBy(
+        sql`case ${issues.status} when 'in_progress' then 0 when 'todo' then 1 else 2 end`,
+        sql`case ${issues.priority} when 'critical' then 0 when 'high' then 1 when 'medium' then 2 when 'low' then 3 else 4 end`,
+        desc(issues.updatedAt),
+        asc(issues.id),
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+  }
+
   async function enqueueWakeup(agentId: string, opts: WakeupOptions = {}) {
     const source = opts.source ?? "on_demand";
     const triggerDetail = opts.triggerDetail ?? null;
@@ -8698,6 +8723,25 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
       issueId = readNonEmptyString(enrichedContextSnapshot.issueId) ?? issueId;
     }
+
+    if (
+      source === "timer" &&
+      !issueId &&
+      !readNonEmptyString(enrichedContextSnapshot.projectId) &&
+      !readNonEmptyString(enrichedContextSnapshot.taskId) &&
+      !readNonEmptyString(enrichedContextSnapshot.taskKey)
+    ) {
+      const timerAssignment = await resolveTimerWakeAssignment(agent);
+      if (timerAssignment?.projectId) {
+        issueId = timerAssignment.id;
+        enrichedContextSnapshot.issueId = timerAssignment.id;
+        enrichedContextSnapshot.taskId = timerAssignment.id;
+        enrichedContextSnapshot.taskKey = timerAssignment.id;
+        enrichedContextSnapshot.projectId = timerAssignment.projectId;
+        enrichedContextSnapshot.timerSelectedIssueId = timerAssignment.id;
+      }
+    }
+
     const effectiveTaskKey = readNonEmptyString(enrichedContextSnapshot.taskKey) ?? taskKey;
     const sessionBefore =
       explicitResumeSession?.sessionDisplayId ??

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -466,6 +466,31 @@ async function getProjectDefaultGoalId(
   return row?.goalId ?? null;
 }
 
+async function getDefaultProjectWorkspaceId(
+  db: DbReader,
+  companyId: string,
+  projectId: string | null | undefined,
+) {
+  if (!projectId) return null;
+  const project = await db
+    .select({
+      executionWorkspacePolicy: projects.executionWorkspacePolicy,
+    })
+    .from(projects)
+    .where(and(eq(projects.id, projectId), eq(projects.companyId, companyId)))
+    .then((rows) => rows[0] ?? null);
+  const projectPolicy = parseProjectExecutionWorkspacePolicy(project?.executionWorkspacePolicy);
+  if (projectPolicy?.defaultProjectWorkspaceId) {
+    return projectPolicy.defaultProjectWorkspaceId;
+  }
+  return db
+    .select({ id: projectWorkspaces.id })
+    .from(projectWorkspaces)
+    .where(and(eq(projectWorkspaces.projectId, projectId), eq(projectWorkspaces.companyId, companyId)))
+    .orderBy(desc(projectWorkspaces.isPrimary), asc(projectWorkspaces.createdAt), asc(projectWorkspaces.id))
+    .then((rows) => rows[0]?.id ?? null);
+}
+
 async function getWorkspaceInheritanceIssue(
   db: DbReader,
   companyId: string,
@@ -4179,23 +4204,7 @@ export function issueService(db: Db) {
           }
         }
         if (!projectWorkspaceId && issueData.projectId) {
-          const project = await tx
-            .select({
-              executionWorkspacePolicy: projects.executionWorkspacePolicy,
-            })
-            .from(projects)
-            .where(and(eq(projects.id, issueData.projectId), eq(projects.companyId, companyId)))
-            .then((rows) => rows[0] ?? null);
-          const projectPolicy = parseProjectExecutionWorkspacePolicy(project?.executionWorkspacePolicy);
-          projectWorkspaceId = projectPolicy?.defaultProjectWorkspaceId ?? null;
-          if (!projectWorkspaceId) {
-            projectWorkspaceId = await tx
-              .select({ id: projectWorkspaces.id })
-              .from(projectWorkspaces)
-              .where(and(eq(projectWorkspaces.projectId, issueData.projectId), eq(projectWorkspaces.companyId, companyId)))
-              .orderBy(desc(projectWorkspaces.isPrimary), asc(projectWorkspaces.createdAt), asc(projectWorkspaces.id))
-              .then((rows) => rows[0]?.id ?? null);
-          }
+          projectWorkspaceId = await getDefaultProjectWorkspaceId(tx, companyId, issueData.projectId);
         }
         if (projectWorkspaceId) {
           await assertValidProjectWorkspace(companyId, issueData.projectId, projectWorkspaceId, tx);
@@ -4351,8 +4360,23 @@ export function issueService(db: Db) {
         await assertAssignableUser(existing.companyId, issueData.assigneeUserId);
       }
       const nextProjectId = issueData.projectId !== undefined ? issueData.projectId : existing.projectId;
-      const nextProjectWorkspaceId =
+      let nextProjectWorkspaceId =
         issueData.projectWorkspaceId !== undefined ? issueData.projectWorkspaceId : existing.projectWorkspaceId;
+      if (
+        issueData.projectId !== undefined &&
+        issueData.projectId !== null &&
+        issueData.projectWorkspaceId === undefined &&
+        (existing.projectId !== issueData.projectId || nextProjectWorkspaceId == null)
+      ) {
+        nextProjectWorkspaceId = await getDefaultProjectWorkspaceId(
+          dbOrTx,
+          existing.companyId,
+          issueData.projectId,
+        );
+        if (nextProjectWorkspaceId) {
+          patch.projectWorkspaceId = nextProjectWorkspaceId;
+        }
+      }
       const nextExecutionWorkspaceId =
         issueData.executionWorkspaceId !== undefined ? issueData.executionWorkspaceId : existing.executionWorkspaceId;
       const nextExecutionWorkspacePreference =


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Scheduled routines and assignment wakes need enough project context to run inside a real repository workspace.
> - Existing issue updates could leave project issues without a default project workspace, and timer wakes could select assigned work without binding that workspace back into the run context.
> - That made otherwise valid work fail in a non-git default cwd with `fatal: not a git repository` adapter errors.
> - This pull request carries the project workspace through issue updates, run invocation context, and timer heartbeat assignment.
> - The benefit is that routine and assignment-driven work can resume in the intended project workspace instead of stranding assigned issues.

## What Changed

- Default the issue execution workspace from the project's primary workspace when project membership is updated.
- Pass Paperclip run ids through the CLI client context so execution metadata stays connected to the originating run.
- Bind timer heartbeats to assigned project issues and include project/workspace context in the selected wake.
- Add focused server and CLI tests covering workspace inheritance, run id propagation, and timer assignment context.

## Verification

- `git diff --check origin/master...HEAD` — clean.
- `pnpm run preflight:workspace-links` — passed.
- `pnpm exec vitest run cli/src/__tests__/common.test.ts server/src/__tests__/heartbeat-timer-assignment.test.ts server/src/__tests__/issues-service.test.ts` — 3 files, 56 tests passed on 2026-05-24 recheck.
- `pnpm typecheck` — passed on 2026-05-24 recheck.
- `pnpm build` — passed on 2026-05-24 recheck; existing Vite bundle-size warnings only.
- GitHub PR checks for run `26293704730` are green.

## Risks

- Low to moderate risk: this changes control-plane context resolution for timer and assignment wakes.
- Main behavioral risk is selecting a project workspace where an unscoped wake previously fell back to the default agent cwd. That is intentional for assigned project work and covered by tests.
- No lockfile change, no migration, no UI change, and no dependency change.

> ROADMAP.md checked. This is a focused reliability fix for scheduled routine/project execution context and does not duplicate planned core feature work.

## Model Used

- OpenAI GPT-5 Codex in Codex desktop, with shell/GitHub CLI tool use and local test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] I will address all Greptile and reviewer comments before requesting merge
