### PR TITLE
fix(recovery): skip recovery for issues with scheduled future monitors

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -2914,6 +2914,62 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("skips successful-run handoff when issue has a future monitorNextCheckAt", async () => {
+    const { companyId, agentId, runId, issueId } = await seedQueuedIssueRunFixture();
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+    await db.update(issues).set({ monitorNextCheckAt: futureDate }).where(eq(issues.id, issueId));
+
+    mockAdapterExecute.mockImplementationOnce(async (ctx: { runId: string }) => {
+      await db.insert(issueComments).values({
+        companyId,
+        issueId,
+        authorAgentId: agentId,
+        createdByRunId: ctx.runId,
+        body: "Parked post awaiting publish-runner routine.",
+      });
+      return {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        errorMessage: null,
+        summary: "Parked post awaiting publish-runner routine.",
+        provider: "test",
+        model: "test-model",
+      };
+    });
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForRunToSettle(heartbeat, runId, 5_000);
+    await waitForHeartbeatIdle(db, 5_000);
+
+    const handoffWakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId))
+      .then((rows) => rows.filter((w) => w.reason === "finish_successful_run_handoff"));
+    expect(handoffWakeups).toHaveLength(0);
+  });
+
+  it("skips stranded sweep when issue has a future monitorNextCheckAt", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+    });
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+    await db.update(issues).set({ monitorNextCheckAt: futureDate }).where(eq(issues.id, issueId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.successfulRunHandoffEscalated).toBe(0);
+    expect(result.escalated).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+  });
+
   it("does not reconcile user-assigned work through the agent stranded-work recovery path", async () => {
     const { issueId, runId } = await seedStrandedIssueFixture({
       status: "todo",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4027,6 +4027,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         assigneeUserId: issues.assigneeUserId,
         executionState: issues.executionState,
         projectId: issues.projectId,
+        monitorNextCheckAt: issues.monitorNextCheckAt,
       })
       .from(issues)
       .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
@@ -4186,6 +4187,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       taskKey,
       hasActiveExecutionPath: Boolean(activeExecutionPath),
       hasQueuedWake: Boolean(queuedWake),
+      hasScheduledMonitor: Boolean(issue?.monitorNextCheckAt && issue.monitorNextCheckAt.getTime() > Date.now()),
       hasPendingInteractionOrApproval: Boolean(pendingInteraction || pendingApproval),
       hasExplicitBlockerPath: Boolean(explicitBlocker),
       hasOpenRecoveryIssue: Boolean(openRecoveryIssue),

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -2015,6 +2015,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
 
+      if (issue.monitorNextCheckAt && issue.monitorNextCheckAt.getTime() > Date.now()) {
+        result.skipped += 1;
+        continue;
+      }
+
       if (await isAutomaticRecoverySuppressedByPauseHold(db, issue.companyId, issue.id, treeControlSvc)) {
         result.skipped += 1;
         continue;

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -48,6 +48,7 @@ function decide(overrides: Partial<Parameters<typeof decideSuccessfulRunHandoff>
     taskKey: "issue-1",
     hasActiveExecutionPath: false,
     hasQueuedWake: false,
+    hasScheduledMonitor: false,
     hasPendingInteractionOrApproval: false,
     hasExplicitBlockerPath: false,
     hasOpenRecoveryIssue: false,
@@ -121,6 +122,13 @@ describe("successful run handoff decision", () => {
     expect(decide({ hasExplicitBlockerPath: true })).toEqual({
       kind: "skip",
       reason: "explicit blocker path owns the next action",
+    });
+  });
+
+  it("skips when issue has a scheduled future monitor", () => {
+    expect(decide({ hasScheduledMonitor: true })).toEqual({
+      kind: "skip",
+      reason: "issue has a scheduled future monitor",
     });
   });
 

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -338,6 +338,7 @@ export function decideSuccessfulRunHandoff(input: {
   taskKey: string | null;
   hasActiveExecutionPath: boolean;
   hasQueuedWake: boolean;
+  hasScheduledMonitor: boolean;
   hasPendingInteractionOrApproval: boolean;
   hasExplicitBlockerPath: boolean;
   hasOpenRecoveryIssue: boolean;
@@ -372,6 +373,7 @@ export function decideSuccessfulRunHandoff(input: {
   }
   if (input.hasActiveExecutionPath) return { kind: "skip", reason: "issue already has an active execution path" };
   if (input.hasQueuedWake) return { kind: "skip", reason: "issue already has a queued or deferred wake" };
+  if (input.hasScheduledMonitor) return { kind: "skip", reason: "issue has a scheduled future monitor" };
   if (input.hasPendingInteractionOrApproval) {
     return { kind: "skip", reason: "pending interaction or approval owns the next action" };
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and the recovery subsystem exists to rescue issues whose execution path has genuinely stalled.
> - Some issues are deliberately parked with a future `monitorNextCheckAt` — e.g. LinkedIn content-calendar posts waiting for a publish-runner routine to fire on schedule.
> - `issue-graph-liveness.ts` already had `hasScheduledMonitor()` to recognize this state and skip recovery, but two other recovery paths did not check it.
> - As a result, the post-run handoff decision and the periodic stranded-issue sweep treated scheduled-future issues as stranded and pulled them into false-positive recovery loops.
> - This pull request teaches both of those paths to recognize a scheduled future monitor and skip recovery, mirroring the existing liveness behavior.
> - The benefit is that deliberately-parked issues (RR-1547, RR-1548, RR-1776, RR-1777) stop churning through recovery and wait for their scheduled monitor as intended.

## What Changed

- Add `hasScheduledMonitor` boolean to `decideSuccessfulRunHandoff()` — skips handoff when the issue has a scheduled future monitor.
- Select `monitorNextCheckAt` in the `handleSuccessfulRunHandoff()` issue query and pass it into the decision function.
- Add a `monitorNextCheckAt > now` guard in `reconcileStrandedAssignedIssues()`, applied after the existing `hasActiveExecutionPath` check.

## Verification

- Unit test: `"skips when issue has a scheduled future monitor"` in `successful-run-handoff.test.ts`.
- Integration test: `"skips successful-run handoff when issue has a future monitorNextCheckAt"` in `heartbeat-process-recovery.test.ts`.
- Integration test: `"skips stranded sweep when issue has a future monitorNextCheckAt"` in `heartbeat-process-recovery.test.ts`.
- All 15 unit tests pass; all 46 integration tests pass; TypeScript compiles clean with no new errors.

## Risks

- Low risk, narrowly scoped. The guard only adds a skip condition; it never initiates new recovery actions.
- If a `monitorNextCheckAt` timestamp is stale or in the past, the guard does not fire and behavior is unchanged from today (recovery proceeds as before).
- If the guard fires during what would otherwise be a legitimate recovery window, the issue simply waits for its already-scheduled monitor to run; the monitor is the recovery mechanism in that case, so no liveness is lost.
- No schema changes, no migrations, no breaking API changes. Mirrors the already-trusted `hasScheduledMonitor()` semantics from `issue-graph-liveness.ts`.

Fixes RR-1768 (parent: RR-1763). Unblocks RR-1547, RR-1548, RR-1776, RR-1777.

## Model Used

- Claude, `claude-opus-4-7`, 1M context window, extended thinking with tool use / code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — backend recovery logic only)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
