### PR TITLE
fix: resolve symlinks in instructions bundle file listing

### DIFF
--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -176,22 +176,26 @@ async function listFilesRecursive(rootPath: string): Promise<string[]> {
   async function walk(currentPath: string, relativeDir: string) {
     const entries = await fs.readdir(currentPath, { withFileTypes: true }).catch(() => []);
     for (const entry of entries) {
-      if (shouldIgnoreInstructionsEntry(entry)) continue;
       const absolutePath = path.join(currentPath, entry.name);
+      const stat = await fs.stat(absolutePath).catch(() => null);
+      if (!stat) continue;
+      const resolvedEntry = { name: entry.name, isDirectory: () => stat.isDirectory(), isFile: () => stat.isFile() };
+      if (shouldIgnoreInstructionsEntry(resolvedEntry)) continue;
       const relativePath = normalizeRelativeFilePath(
         relativeDir ? path.posix.join(relativeDir, entry.name) : entry.name,
       );
-      if (entry.isDirectory()) {
+      if (stat.isDirectory()) {
         await walk(absolutePath, relativePath);
         continue;
       }
-      if (!entry.isFile()) continue;
+      if (!stat.isFile()) continue;
       output.push(relativePath);
     }
   }
 
   await walk(rootPath, "");
   return output.sort((left, right) => left.localeCompare(right));
+}
 }
 
 async function readFileSummary(rootPath: string, relativePath: string, entryFile: string): Promise<AgentInstructionsFileSummary> {

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -172,23 +172,29 @@ function shouldIgnoreInstructionsEntry(entry: { name: string; isDirectory(): boo
 
 async function listFilesRecursive(rootPath: string): Promise<string[]> {
   const output: string[] = [];
+  const visitedRealPaths = new Set<string>();
 
   async function walk(currentPath: string, relativeDir: string) {
+    const realCurrentPath = await fs.realpath(currentPath).catch(() => currentPath);
+    if (visitedRealPaths.has(realCurrentPath)) return;
+    visitedRealPaths.add(realCurrentPath);
+
     const entries = await fs.readdir(currentPath, { withFileTypes: true }).catch(() => []);
     for (const entry of entries) {
       const absolutePath = path.join(currentPath, entry.name);
-      const stat = await fs.stat(absolutePath).catch(() => null);
-      if (!stat) continue;
-      const resolvedEntry = { name: entry.name, isDirectory: () => stat.isDirectory(), isFile: () => stat.isFile() };
+      const isSymlink = entry.isSymbolicLink();
+      const isDir = isSymlink ? (await fs.stat(absolutePath).catch(() => null))?.isDirectory() ?? false : entry.isDirectory();
+      const isFile = isSymlink ? (await fs.stat(absolutePath).catch(() => null))?.isFile() ?? false : entry.isFile();
+      const resolvedEntry = { name: entry.name, isDirectory: () => isDir, isFile: () => isFile };
       if (shouldIgnoreInstructionsEntry(resolvedEntry)) continue;
       const relativePath = normalizeRelativeFilePath(
         relativeDir ? path.posix.join(relativeDir, entry.name) : entry.name,
       );
-      if (stat.isDirectory()) {
+      if (isDir) {
         await walk(absolutePath, relativePath);
         continue;
       }
-      if (!stat.isFile()) continue;
+      if (!isFile) continue;
       output.push(relativePath);
     }
   }

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -202,7 +202,6 @@ async function listFilesRecursive(rootPath: string): Promise<string[]> {
   await walk(rootPath, "");
   return output.sort((left, right) => left.localeCompare(right));
 }
-}
 
 async function readFileSummary(rootPath: string, relativePath: string, entryFile: string): Promise<AgentInstructionsFileSummary> {
   const absolutePath = resolvePathWithinRoot(rootPath, relativePath);


### PR DESCRIPTION
## Problem

`listFilesRecursive` in `server/src/services/agent-instructions.ts` uses `Dirent.isFile()` and `Dirent.isDirectory()` to classify directory entries. These methods return `false` for symbolic links, causing symlinked files to be silently skipped.

This breaks the **external instructions bundle mode** when agent companies share instruction files (AGENTS.md, SOUL.md, TOOLS.md) across companies via symlinks.

## Root Cause

`Dirent.isFile()` and `Dirent.isDirectory()` do not follow symlinks — they report the link itself, not the target. Symlinked files are neither `isFile()` nor `isDirectory()`, so they fall through both checks and are silently ignored.

## Fix

Use `fs.stat()` (which follows symlinks) to resolve the actual file type before classifying entries.

## Use Case

Agent company packages that share L1-L3 agent definitions across multiple companies via symlinks (e.g. a shared organizational structure reused by different product teams). Without this fix, Paperclip creates empty instruction files instead of reading through the symlinks.

## Testing

- Verified locally: symlinked AGENTS.md, SOUL.md, TOOLS.md are now correctly listed in the instructions bundle
- The `instructions-bundle` API endpoint returns all files (previously returned only non-symlinked files)
- No behavioral change for non-symlinked files