### PR TITLE
fix: allow sibling pipeline handoff for SDLC subtasks (LAC-2054)

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -835,6 +835,19 @@ describe("agent issue mutation checkout ownership", () => {
     expect(res.status).toBe(403);
   });
 
+  it("rejects sibling handoff on non-comment POST routes (e.g. release)", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "backlog", assigneeAgentId: ownerAgentId, parentId: parentIssueId }),
+    );
+    mockIssueService.count.mockResolvedValue(1);
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/release`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+  });
+
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: null }));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -13,6 +13,7 @@ const recoveryActionId = "77777777-7777-4777-8777-777777777777";
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  count: vi.fn(),
   create: vi.fn(),
   createChild: vi.fn(),
   getAttachmentById: vi.fn(),
@@ -290,6 +291,7 @@ describe("agent issue mutation checkout ownership", () => {
     mockCompanyService.getById.mockReset();
     mockIssueService.addComment.mockReset();
     mockIssueService.assertCheckoutOwner.mockReset();
+    mockIssueService.count.mockReset();
     mockIssueService.create.mockReset();
     mockIssueService.createChild.mockReset();
     mockIssueService.getAttachmentById.mockReset();
@@ -366,6 +368,7 @@ describe("agent issue mutation checkout ownership", () => {
     ]);
     mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: null });
     mockCompanyService.getById.mockResolvedValue({ id: companyId, issuePrefix: "PAP" });
+    mockIssueService.count.mockResolvedValue(0);
     mockIssueService.getById.mockResolvedValue(makeIssue());
     mockIssueService.getByIdentifier.mockResolvedValue(null);
     mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
@@ -718,6 +721,118 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
     expect(mockIssueService.update).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
+  });
+
+  const parentIssueId = "88888888-8888-4888-8888-888888888888";
+
+  it("allows sibling agent to PATCH status to todo on a backlog sibling issue", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "backlog", assigneeAgentId: ownerAgentId, parentId: parentIssueId }),
+    );
+    mockIssueService.count.mockResolvedValue(1);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "todo" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.count).toHaveBeenCalledWith(companyId, {
+      parentId: parentIssueId,
+      assigneeAgentId: peerAgentId,
+    });
+  });
+
+  it("allows sibling agent to PATCH status to todo on a blocked sibling issue", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId, parentId: parentIssueId }),
+    );
+    mockIssueService.count.mockResolvedValue(1);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "todo" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+  });
+
+  it("allows sibling agent to comment on a backlog sibling issue", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "backlog", assigneeAgentId: ownerAgentId, parentId: parentIssueId }),
+    );
+    mockIssueService.count.mockResolvedValue(1);
+
+    const res = await request(await createApp(peerActor()))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "Handoff: review complete" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+  });
+
+  it("rejects sibling handoff when actor has no sibling issue under the same parent", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "backlog", assigneeAgentId: ownerAgentId, parentId: parentIssueId }),
+    );
+    mockIssueService.count.mockResolvedValue(0);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+  });
+
+  it("rejects sibling handoff PATCH with fields beyond status and comment", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "backlog", assigneeAgentId: ownerAgentId, parentId: parentIssueId }),
+    );
+    mockIssueService.count.mockResolvedValue(1);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "todo", title: "Hijacked" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("Agent cannot mutate another agent's issue");
+  });
+
+  it("rejects sibling handoff PATCH setting status to anything other than todo", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "backlog", assigneeAgentId: ownerAgentId, parentId: parentIssueId }),
+    );
+    mockIssueService.count.mockResolvedValue(1);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "in_progress" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects sibling handoff on in_progress sibling issue", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId, parentId: parentIssueId }),
+    );
+    mockIssueService.count.mockResolvedValue(1);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(409);
+  });
+
+  it("rejects sibling handoff on issues without a parent", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "backlog", assigneeAgentId: ownerAgentId, parentId: null }),
+    );
+    mockIssueService.count.mockResolvedValue(1);
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "todo" });
+
+    expect(res.status).toBe(403);
   });
 
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1311,10 +1311,38 @@ export function issueRoutes(
     return decision.allowed;
   }
 
+  async function isSiblingPipelineHandoff(
+    req: Request,
+    actorAgentId: string,
+    issue: { id: string; companyId: string; parentId?: string | null; status: string },
+  ): Promise<boolean> {
+    if (!issue.parentId) return false;
+
+    if (issue.status !== "backlog" && issue.status !== "blocked") return false;
+
+    if (req.method === "PATCH") {
+      const body = req.body as Record<string, unknown>;
+      if (body.status !== "todo") return false;
+      const mutationKeys = Object.keys(body).filter(
+        (k) => body[k] !== undefined && k !== "status" && k !== "comment",
+      );
+      if (mutationKeys.length > 0) return false;
+    } else if (req.method !== "POST") {
+      return false;
+    }
+
+    const siblingCount = await svc.count(issue.companyId, {
+      parentId: issue.parentId,
+      assigneeAgentId: actorAgentId,
+    });
+
+    return siblingCount > 0;
+  }
+
   async function assertAgentIssueMutationAllowed(
     req: Request,
     res: Response,
-    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null },
+    issue: { id: string; companyId: string; status: string; assigneeAgentId: string | null; parentId?: string | null },
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -1327,6 +1355,9 @@ export function issueRoutes(
     }
     if (issue.assigneeAgentId !== actorAgentId) {
       if (await hasActiveCheckoutManagementOverride(actorAgentId, issue.companyId, issue.assigneeAgentId)) {
+        return true;
+      }
+      if (await isSiblingPipelineHandoff(req, actorAgentId, issue)) {
         return true;
       }
       if (issue.status === "in_progress") {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1327,7 +1327,9 @@ export function issueRoutes(
         (k) => body[k] !== undefined && k !== "status" && k !== "comment",
       );
       if (mutationKeys.length > 0) return false;
-    } else if (req.method !== "POST") {
+    } else if (req.method === "POST" && req.path.endsWith("/comments")) {
+      // allow sibling to post a comment
+    } else {
       return false;
     }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies in an SDLC pipeline (code → review → QA → merge)
> - Each pipeline phase is a subtask issue assigned to a different agent; phases are linked by blocker chains so the next agent auto-wakes when the previous phase's issue reaches `done`
> - The previous fix ([LAC-2052](/LAC/issues/LAC-2052)) updated agent instructions to PATCH the next sibling's status to `todo` as a fallback when blocker chains don't fire
> - But the server's ownership check (`assertAgentIssueMutationAllowed`) rejects any cross-agent mutation with 403, making the fallback instructions unfollowable
> - This PR adds a parent-sibling carve-out: agents may PATCH a sibling issue's status to `todo` or post a comment when both issues share the same `parentId` and the target is in `backlog` or `blocked`
> - The carve-out is tightly scoped — only `status → todo` PATCH (with optional `comment`), and only `POST /issues/:id/comments`; all other cross-agent mutations remain blocked

## What Changed

- **`server/src/routes/issues.ts`**: Added `isSiblingPipelineHandoff()` before `assertAgentIssueMutationAllowed()`. Checks: target has `parentId`, target is in `backlog`/`blocked`, PATCH body is only `status: "todo"` (+ optional `comment`), POST path ends with `/comments`, and actor owns at least one sibling issue under the same parent.
- **`server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts`**: 9 new test cases covering allow and deny scenarios for the sibling carve-out, including a regression test for non-comment POST routes.

## Verification

```bash
npx vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
# 23 tests, all passing
```

Manual: agent completes Code Review subtask → `PATCH /api/issues/{qa-sibling-id} { "status": "todo" }` → QA agent wakes (previously 403, now 200).

## Risks

- **Scoped — low blast radius**: only allows `status → todo` PATCH and comments; no title, description, assignee, or other field changes pass through.
- **Requires parentId**: top-level issues (no parent) are unaffected.
- **Requires actor to own a sibling**: an agent without any issue under the same parent cannot use this path.
- **DB query on every denied cross-agent mutation for sibling targets**: one extra `count()` call only when the target has a `parentId` and status is `backlog`/`blocked`.

## Model Used

- Provider: Anthropic
- Model: claude-sonnet-4-6
- Context: 200K tokens, tool use, multi-step reasoning

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge