### PR TITLE
fix(server): allow manager wake for direct reports

### DIFF
--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -28,6 +28,13 @@ const mockInstanceSettingsService = vi.hoisted(() => ({
 }));
 
 const routeAgentId = "11111111-1111-4111-8111-111111111111";
+const defaultBoardActor = {
+  type: "board",
+  userId: "local-board",
+  companyIds: ["company-1"],
+  source: "local_implicit",
+  isInstanceAdmin: false,
+} as const;
 
 function registerModuleMocks() {
   vi.doMock("../routes/authz.js", async () => vi.importActual("../routes/authz.js"));
@@ -82,7 +89,10 @@ function registerModuleMocks() {
   }));
 }
 
-async function createApp(db: Record<string, unknown> = {}) {
+async function createApp(
+  db: Record<string, unknown> = {},
+  actor: Record<string, unknown> = defaultBoardActor,
+) {
   const [{ agentRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
     vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
@@ -90,13 +100,7 @@ async function createApp(db: Record<string, unknown> = {}) {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = {
-      type: "board",
-      userId: "local-board",
-      companyIds: ["company-1"],
-      source: "local_implicit",
-      isInstanceAdmin: false,
-    };
+    (req as any).actor = actor;
     next();
   });
   app.use("/api", agentRoutes(db as any));
@@ -260,7 +264,7 @@ describe("agent live run routes", () => {
     expect(res.body).not.toHaveProperty("resultJson");
     expect(res.body).not.toHaveProperty("contextSnapshot");
     expect(res.body).not.toHaveProperty("logRef");
-  }, 10_000);
+  }, 20_000);
 
   it("ignores a stale execution run from another issue and falls back to the assignee's matching run", async () => {
     mockHeartbeatService.getRunIssueSummary.mockResolvedValue({
@@ -605,5 +609,84 @@ describe("agent live run routes", () => {
         actorId: "local-board",
       },
     });
+  });
+
+  it("allows agent-authenticated manager wakeups for direct reports", async () => {
+    const managerId = "99999999-9999-4999-8999-999999999999";
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === routeAgentId) {
+        return {
+          id: routeAgentId,
+          companyId: "company-1",
+          name: "Direct Report",
+          adapterType: "codex_local",
+          reportsTo: managerId,
+        };
+      }
+      return {
+        id,
+        companyId: "company-1",
+        name: "Fallback",
+        adapterType: "codex_local",
+        reportsTo: null,
+      };
+    });
+    mockHeartbeatService.wakeup.mockResolvedValue({
+      id: "run-direct-report-wake",
+      companyId: "company-1",
+      agentId: routeAgentId,
+      status: "queued",
+      invocationSource: "on_demand",
+      triggerDetail: "manual",
+    });
+
+    const res = await requestApp(
+      await createApp(
+        {},
+        {
+          type: "agent",
+          agentId: managerId,
+          companyId: "company-1",
+          source: "agent_key",
+          runId: "run-1",
+        },
+      ),
+      (baseUrl) => request(baseUrl).post(`/api/agents/${routeAgentId}/wakeup`).send({}),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(routeAgentId, expect.objectContaining({
+      requestedByActorType: "agent",
+      requestedByActorId: managerId,
+    }));
+  });
+
+  it("blocks agent-authenticated wakeups for non-direct reports", async () => {
+    const managerId = "99999999-9999-4999-8999-999999999999";
+    mockAgentService.getById.mockResolvedValue({
+      id: routeAgentId,
+      companyId: "company-1",
+      name: "Not Direct Report",
+      adapterType: "codex_local",
+      reportsTo: null,
+    });
+
+    const res = await requestApp(
+      await createApp(
+        {},
+        {
+          type: "agent",
+          agentId: managerId,
+          companyId: "company-1",
+          source: "agent_key",
+          runId: "run-1",
+        },
+      ),
+      (baseUrl) => request(baseUrl).post(`/api/agents/${routeAgentId}/wakeup`).send({}),
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("direct reports");
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 });

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -2,6 +2,8 @@ import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+type RequestActor = NonNullable<Express.Request["actor"]>;
+
 const mockAgentService = vi.hoisted(() => ({
   getById: vi.fn(),
 }));
@@ -91,7 +93,7 @@ function registerModuleMocks() {
 
 async function createApp(
   db: Record<string, unknown> = {},
-  actor: Record<string, unknown> = defaultBoardActor,
+  actor: RequestActor = defaultBoardActor,
 ) {
   const [{ agentRoutes }, { errorHandler }] = await Promise.all([
     vi.importActual<typeof import("../routes/agents.js")>("../routes/agents.js"),
@@ -100,7 +102,7 @@ async function createApp(
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
-    (req as any).actor = actor;
+    req.actor = actor;
     next();
   });
   app.use("/api", agentRoutes(db as any));
@@ -683,6 +685,79 @@ describe("agent live run routes", () => {
         },
       ),
       (baseUrl) => request(baseUrl).post(`/api/agents/${routeAgentId}/wakeup`).send({}),
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain("direct reports");
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("allows agent-authenticated legacy heartbeat invokes for direct reports", async () => {
+    const managerId = "99999999-9999-4999-8999-999999999999";
+    mockAgentService.getById.mockResolvedValue({
+      id: routeAgentId,
+      companyId: "company-1",
+      name: "Direct Report",
+      adapterType: "codex_local",
+      reportsTo: managerId,
+    });
+    mockHeartbeatService.wakeup.mockResolvedValue({
+      id: "run-direct-report-invoke",
+      companyId: "company-1",
+      agentId: routeAgentId,
+      status: "queued",
+      invocationSource: "on_demand",
+      triggerDetail: "manual",
+    });
+
+    const res = await requestApp(
+      await createApp(
+        {},
+        {
+          type: "agent",
+          agentId: managerId,
+          companyId: "company-1",
+          source: "agent_key",
+          runId: "run-1",
+        },
+      ),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/heartbeat/invoke?companyId=company-1`)
+        .send({}),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(202);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(routeAgentId, expect.objectContaining({
+      source: "on_demand",
+      requestedByActorType: "agent",
+      requestedByActorId: managerId,
+    }));
+  });
+
+  it("blocks agent-authenticated legacy heartbeat invokes for non-direct reports", async () => {
+    const managerId = "99999999-9999-4999-8999-999999999999";
+    mockAgentService.getById.mockResolvedValue({
+      id: routeAgentId,
+      companyId: "company-1",
+      name: "Not Direct Report",
+      adapterType: "codex_local",
+      reportsTo: null,
+    });
+
+    const res = await requestApp(
+      await createApp(
+        {},
+        {
+          type: "agent",
+          agentId: managerId,
+          companyId: "company-1",
+          source: "agent_key",
+          runId: "run-1",
+        },
+      ),
+      (baseUrl) => request(baseUrl)
+        .post(`/api/agents/${routeAgentId}/heartbeat/invoke?companyId=company-1`)
+        .send({}),
     );
 
     expect(res.status).toBe(403);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2907,6 +2907,29 @@ export function agentRoutes(
     source: HeartbeatSource | undefined;
     skippedResponse: (agent: NonNullable<Awaited<ReturnType<typeof svc.getById>>>) => unknown | Promise<unknown>;
   };
+  type WakeupTargetAgent = NonNullable<Awaited<ReturnType<typeof svc.getById>>>;
+  const authorizeWakeupTarget = async (
+    req: Request,
+    res: Response,
+    agent: WakeupTargetAgent,
+    id: string,
+  ): Promise<boolean> => {
+    assertCompanyAccess(req, agent.companyId);
+
+    if (req.actor.type === "agent") {
+      const actorAgentId = req.actor.agentId ?? null;
+      const isSelf = actorAgentId === id;
+      const isDirectReport = actorAgentId != null && agent.reportsTo === actorAgentId;
+      if (!isSelf && !isDirectReport) {
+        res.status(403).json({ error: "Agent can only invoke itself or direct reports" });
+        return false;
+      }
+    } else {
+      await assertBoardCanManageAgentsForCompany(req, agent.companyId);
+    }
+
+    return true;
+  };
   const handleWakeupRoute = async (
     req: Request,
     res: Response,
@@ -2918,18 +2941,8 @@ export function agentRoutes(
       res.status(404).json({ error: "Agent not found" });
       return;
     }
-    assertCompanyAccess(req, agent.companyId);
-
-    if (req.actor.type === "agent") {
-      const actorAgentId = req.actor.agentId ?? null;
-      const isSelf = actorAgentId === id;
-      const isDirectReport = actorAgentId != null && agent.reportsTo === actorAgentId;
-      if (!isSelf && !isDirectReport) {
-        res.status(403).json({ error: "Agent can only invoke itself or direct reports" });
-        return;
-      }
-    } else {
-      await assertBoardCanManageAgentsForCompany(req, agent.companyId);
+    if (!await authorizeWakeupTarget(req, res, agent, id)) {
+      return;
     }
 
     const run = await heartbeat.wakeup(id, {
@@ -2989,18 +3002,8 @@ export function agentRoutes(
       res.status(404).json({ error: "Agent not found" });
       return;
     }
-    assertCompanyAccess(req, agent.companyId);
-
-    if (req.actor.type === "agent") {
-      const actorAgentId = req.actor.agentId ?? null;
-      const isSelf = actorAgentId === id;
-      const isDirectReport = actorAgentId != null && agent.reportsTo === actorAgentId;
-      if (!isSelf && !isDirectReport) {
-        res.status(403).json({ error: "Agent can only invoke itself or direct reports" });
-        return;
-      }
-    } else {
-      await assertBoardCanManageAgentsForCompany(req, agent.companyId);
+    if (!await authorizeWakeupTarget(req, res, agent, id)) {
+      return;
     }
 
     const body = (req.body ?? {}) as Partial<{

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2921,8 +2921,11 @@ export function agentRoutes(
     assertCompanyAccess(req, agent.companyId);
 
     if (req.actor.type === "agent") {
-      if (req.actor.agentId !== id) {
-        res.status(403).json({ error: "Agent can only invoke itself" });
+      const actorAgentId = req.actor.agentId ?? null;
+      const isSelf = actorAgentId === id;
+      const isDirectReport = actorAgentId != null && agent.reportsTo === actorAgentId;
+      if (!isSelf && !isDirectReport) {
+        res.status(403).json({ error: "Agent can only invoke itself or direct reports" });
         return;
       }
     } else {
@@ -2989,8 +2992,11 @@ export function agentRoutes(
     assertCompanyAccess(req, agent.companyId);
 
     if (req.actor.type === "agent") {
-      if (req.actor.agentId !== id) {
-        res.status(403).json({ error: "Agent can only invoke itself" });
+      const actorAgentId = req.actor.agentId ?? null;
+      const isSelf = actorAgentId === id;
+      const isDirectReport = actorAgentId != null && agent.reportsTo === actorAgentId;
+      if (!isSelf && !isDirectReport) {
+        res.status(403).json({ error: "Agent can only invoke itself or direct reports" });
         return;
       }
     } else {


### PR DESCRIPTION
## Summary
- allow agent-authenticated wakeups for immediate direct reports on `/agents/:id/wakeup`
- mirror the same self-or-direct-report guard on legacy `/agents/:id/heartbeat/invoke`
- add route tests covering allowed direct-report wakeups and denied non-report wakeups

## Verification
- `pnpm --filter @paperclipai/server exec vitest src/__tests__/agent-live-run-routes.test.ts --run` in `A:\Programming\paperclip\tmp\paperclip-src`