### PR TITLE
fix(recovery): skip stale-active-run detector when source issue is done/cancelled

### DIFF
--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1354,6 +1354,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
+    if (sourceIssue && ["done", "cancelled"].includes(sourceIssue.status)) {
+      return { kind: "skipped" as const };
+    }
     const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
     if (sourceIssue && isRecoveryOriginIssue(sourceIssue)) {
       await logActivity(db, {


### PR DESCRIPTION
## Thinking Path

The stale-active-run detector (scanSilentActiveRuns in server/src/services/recovery/service.ts) was creating evaluation issues for runs whose source issue had already reached done or cancelled state. This generated 1675+ consecutive false-positive evaluation issues for a killed QA run (run id 008d9f2f) whose parent HNT-1206 was marked done.

## What Changed

Added a 3-line early-exit guard in scanSilentActiveRuns, immediately after resolveStaleRunSourceIssue():

if (sourceIssue && ["done", "cancelled"].includes(sourceIssue.status)) {
  return { kind: "skipped" as const };
}

This fires before the detector checks silence thresholds or creates evaluation issues. A run whose source issue is already terminal should not produce stale-run evaluations.

## Verification

- The fix is a pure guard: returns skipped before any silence check or evaluation creation when sourceIssue is done/cancelled
- Structurally identical to other skipped returns in the same function (lines 1355, 1376)
- No behavior change for runs where source issue is active or null
- Fix was implemented and tested in HNT-1682 (Paperclip platform fix for HeartnThread false-positive cascade)

## Risks

None: this is a strict narrowing that only prevents detections that should not have been created.

## Model Used

None — human-authored fix.