### PR TITLE
fix(heartbeat): skip done-issue reopen when deferred comment wake is exclusively self-authored

### DIFF
--- a/server/src/services/heartbeat-self-comment-wake.test.ts
+++ b/server/src/services/heartbeat-self-comment-wake.test.ts
@@ -10,11 +10,23 @@ const COMMENT_1 = "11111111-1111-1111-1111-111111111111";
 const COMMENT_2 = "22222222-2222-2222-2222-222222222222";
 const COMMENT_3 = "33333333-3333-3333-3333-333333333333";
 
-function rows(...entries: Array<[string, string | null]>): DeferredCommentAuthorRow[] {
-  return entries.map(([id, authorAgentId]) => ({ id, authorAgentId }));
+/**
+ * Test fixture builder. Each entry is `[commentId, authorAgentId, createdByRunAgentId]`
+ * — the two signals the helper consumes per row.
+ */
+function rows(
+  ...entries: Array<[string, string | null, string | null]>
+): DeferredCommentAuthorRow[] {
+  return entries.map(([id, authorAgentId, createdByRunAgentId]) => ({
+    id,
+    authorAgentId,
+    createdByRunAgentId,
+  }));
 }
 
 describe("isExclusivelySelfAuthoredDeferredCommentWake", () => {
+  // -- Boundary cases (no recognition possible) --
+
   it("returns false when no comment IDs are passed (wake is not comment-driven)", () => {
     expect(
       isExclusivelySelfAuthoredDeferredCommentWake({
@@ -30,44 +42,14 @@ describe("isExclusivelySelfAuthoredDeferredCommentWake", () => {
       isExclusivelySelfAuthoredDeferredCommentWake({
         deferredCommentIds: [COMMENT_1],
         assigneeAgentId: null,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A, AGENT_A]),
       }),
     ).toBe(false);
     expect(
       isExclusivelySelfAuthoredDeferredCommentWake({
         deferredCommentIds: [COMMENT_1],
         assigneeAgentId: undefined,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
-      }),
-    ).toBe(false);
-  });
-
-  it("returns true when every deferred comment is authored by the assignee (the loop-blocking case)", () => {
-    expect(
-      isExclusivelySelfAuthoredDeferredCommentWake({
-        deferredCommentIds: [COMMENT_1, COMMENT_2],
-        assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_A]),
-      }),
-    ).toBe(true);
-  });
-
-  it("returns false when at least one deferred comment is human-authored (a real user reply should reopen)", () => {
-    expect(
-      isExclusivelySelfAuthoredDeferredCommentWake({
-        deferredCommentIds: [COMMENT_1, COMMENT_2],
-        assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, null]),
-      }),
-    ).toBe(false);
-  });
-
-  it("returns false when a deferred comment was authored by a different agent (cross-agent mention should reopen)", () => {
-    expect(
-      isExclusivelySelfAuthoredDeferredCommentWake({
-        deferredCommentIds: [COMMENT_1, COMMENT_2],
-        assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_B]),
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A, AGENT_A]),
       }),
     ).toBe(false);
   });
@@ -80,34 +62,122 @@ describe("isExclusivelySelfAuthoredDeferredCommentWake", () => {
       isExclusivelySelfAuthoredDeferredCommentWake({
         deferredCommentIds: [COMMENT_1, COMMENT_2, COMMENT_3],
         assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_A]),
+        deferredCommentAuthors: rows(
+          [COMMENT_1, AGENT_A, AGENT_A],
+          [COMMENT_2, AGENT_A, AGENT_A],
+        ),
       }),
     ).toBe(false);
   });
 
-  it("returns true for the single-comment self-authored DONE-summary case (the exact #3980 / #3935 trigger)", () => {
-    // This is the smoking-gun shape: hermes_local agent posts its DONE summary
-    // comment, the comment-post path enqueues a deferred wake, the promoter
-    // runs, the comment table says authorAgentId === assigneeAgentId →
-    // predicate returns true → caller skips the reopen → loop is broken.
+  // -- Signal 1: author_agent_id (MCP-routed self-comments) --
+
+  it("returns true when every deferred comment is authored by the assignee via author_agent_id (MCP-routed path)", () => {
     expect(
       isExclusivelySelfAuthoredDeferredCommentWake({
-        deferredCommentIds: [COMMENT_1],
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
         assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
+        deferredCommentAuthors: rows(
+          [COMMENT_1, AGENT_A, AGENT_A],
+          [COMMENT_2, AGENT_A, AGENT_A],
+        ),
       }),
     ).toBe(true);
   });
 
-  it("returns false when assignee matches but comment author is null (human-posted to assignee's issue)", () => {
-    // Common shape: human comments on the assigned agent's issue.
-    // authorAgentId is null. Even though the assignee is set, this is a real
-    // human reply and should reopen the done issue per the platform contract.
+  it("returns true for the single-comment MCP-routed DONE-summary case (the exact #3980 / #3935 trigger via MCP path)", () => {
     expect(
       isExclusivelySelfAuthoredDeferredCommentWake({
         deferredCommentIds: [COMMENT_1],
         assigneeAgentId: AGENT_A,
-        deferredCommentAuthors: rows([COMMENT_1, null]),
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A, AGENT_A]),
+      }),
+    ).toBe(true);
+  });
+
+  // -- Signal 2: created_by_run_id (shell-routed self-comments on local_trusted) --
+
+  it("returns true when every deferred comment was created during the assignee's own run, even if author_agent_id is null (shell-routed path on local_trusted)", () => {
+    // This is the exact shape produced by an agent posting via `curl` from
+    // its own terminal on local_trusted: the auth middleware loses the
+    // agent identity (so author_agent_id is null + author_user_id is
+    // 'local-board'), but the run-level comment plumbing still links the
+    // comment to the agent's heartbeat run via created_by_run_id.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows(
+          [COMMENT_1, null, AGENT_A],
+          [COMMENT_2, null, AGENT_A],
+        ),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for mixed self-comments — some MCP-routed (author_agent_id set), some shell-routed (only createdByRunAgentId matches)", () => {
+    // Real-world shape observed in production: an agent posts most comments
+    // via MCP but one or two via shell within the same run. All are still
+    // self-authored — the loop must not fire.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2, COMMENT_3],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows(
+          [COMMENT_1, AGENT_A, AGENT_A], // MCP-routed
+          [COMMENT_2, null, AGENT_A],    // shell-routed
+          [COMMENT_3, AGENT_A, AGENT_A], // MCP-routed
+        ),
+      }),
+    ).toBe(true);
+  });
+
+  // -- Real human / cross-agent comments (must NOT be treated as self) --
+
+  it("returns false when at least one deferred comment is human-authored (a real user reply should reopen)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows(
+          [COMMENT_1, AGENT_A, AGENT_A],
+          [COMMENT_2, null, null], // human comment from the dashboard — neither signal matches
+        ),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when a deferred comment was authored by a different agent (cross-agent mention should reopen)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows(
+          [COMMENT_1, AGENT_A, AGENT_A],
+          [COMMENT_2, AGENT_B, AGENT_B],
+        ),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when assignee matches but comment author is null AND createdByRunAgentId is null (human reply to assignee's issue)", () => {
+    // Common shape: a real human comments on the assigned agent's issue from
+    // the dashboard. Neither signal links the comment to an agent run.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, null, null]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when a comment's createdByRunAgentId is a different agent (a cross-agent run posted on the assignee's issue)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, null, AGENT_B]),
       }),
     ).toBe(false);
   });

--- a/server/src/services/heartbeat-self-comment-wake.test.ts
+++ b/server/src/services/heartbeat-self-comment-wake.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  isExclusivelySelfAuthoredDeferredCommentWake,
+  type DeferredCommentAuthorRow,
+} from "./heartbeat-self-comment-wake.js";
+
+const AGENT_A = "00000000-0000-0000-0000-00000000000a";
+const AGENT_B = "00000000-0000-0000-0000-00000000000b";
+const COMMENT_1 = "11111111-1111-1111-1111-111111111111";
+const COMMENT_2 = "22222222-2222-2222-2222-222222222222";
+const COMMENT_3 = "33333333-3333-3333-3333-333333333333";
+
+function rows(...entries: Array<[string, string | null]>): DeferredCommentAuthorRow[] {
+  return entries.map(([id, authorAgentId]) => ({ id, authorAgentId }));
+}
+
+describe("isExclusivelySelfAuthoredDeferredCommentWake", () => {
+  it("returns false when no comment IDs are passed (wake is not comment-driven)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the issue has no assignee agent", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: null,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
+      }),
+    ).toBe(false);
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: undefined,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when every deferred comment is authored by the assignee (the loop-blocking case)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_A]),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when at least one deferred comment is human-authored (a real user reply should reopen)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, null]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when a deferred comment was authored by a different agent (cross-agent mention should reopen)", () => {
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_B]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the lookup returned fewer rows than IDs requested (missing/deleted comments)", () => {
+    // Conservative: missing rows mean we don't know who authored them.
+    // Better to let the existing predicate decide than to silently skip a
+    // possibly-legitimate reopen.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1, COMMENT_2, COMMENT_3],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A], [COMMENT_2, AGENT_A]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for the single-comment self-authored DONE-summary case (the exact #3980 / #3935 trigger)", () => {
+    // This is the smoking-gun shape: hermes_local agent posts its DONE summary
+    // comment, the comment-post path enqueues a deferred wake, the promoter
+    // runs, the comment table says authorAgentId === assigneeAgentId →
+    // predicate returns true → caller skips the reopen → loop is broken.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, AGENT_A]),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when assignee matches but comment author is null (human-posted to assignee's issue)", () => {
+    // Common shape: human comments on the assigned agent's issue.
+    // authorAgentId is null. Even though the assignee is set, this is a real
+    // human reply and should reopen the done issue per the platform contract.
+    expect(
+      isExclusivelySelfAuthoredDeferredCommentWake({
+        deferredCommentIds: [COMMENT_1],
+        assigneeAgentId: AGENT_A,
+        deferredCommentAuthors: rows([COMMENT_1, null]),
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/src/services/heartbeat-self-comment-wake.ts
+++ b/server/src/services/heartbeat-self-comment-wake.ts
@@ -1,0 +1,96 @@
+/**
+ * Helper for the deferred-comment-wake promotion path in `heartbeat.ts`.
+ *
+ * Background
+ * ----------
+ * When a comment is posted on an issue assigned to an agent, Paperclip queues a
+ * `deferred_issue_execution` wakeup so the agent can react to the new comment.
+ * When that deferred wake is later promoted, the promoter must decide whether
+ * to also reopen the issue if it has reached a terminal status (`done` or
+ * `cancelled`). The original predicate distinguished "real human commenter
+ * wants the issue reopened" from "system follow-up that should respect the
+ * disposition" by reading `agent_wakeup_requests.requested_by_actor_type` —
+ * trusting that actor-type to identify whether the triggering write came from
+ * a user or an agent.
+ *
+ * Why that trust was wrong
+ * ------------------------
+ * On `deploymentMode: "local_trusted"` instances, the auth middleware
+ * (`server/src/middleware/auth.ts`) short-circuits unauthenticated localhost
+ * requests to the `local-board` USER principal. Adapters that present a raw
+ * `Authorization: Bearer <agent authToken>` (notably `hermes-paperclip-adapter`
+ * v0.2.0 on `hermes_local`) do not promote that token to an agent JWT, so the
+ * agent's own writes record `requested_by_actor_type: "user"`. The predicate
+ * then mistakes the agent's own DONE-summary comment for a real human commenter
+ * and reopens the just-completed issue — which causes the agent to wake again,
+ * post another DONE-summary comment, and infinite-loop. See:
+ *   - paperclipai/paperclip#3980 (root cause: identity attribution)
+ *   - paperclipai/paperclip#3935 (symptom: Done -> In Progress oscillation)
+ *   - paperclipai/paperclip#2486 (general class: infinite promotion loops)
+ *   - NousResearch/hermes-paperclip-adapter#92 (adapter-side mirror)
+ *
+ * Why this helper is the right fix
+ * --------------------------------
+ * The comment table holds the authoritative author identity
+ * (`issue_comments.author_agent_id`). It does not lie about who authored the
+ * comment regardless of how the auth middleware classified the request. By
+ * looking up the actual comment authors for the deferred wake's comment IDs
+ * and asking "were these comments exclusively written by the assignee agent
+ * itself?", we get a content-based signal that is independent of the wake's
+ * recorded actor-type and the deployment mode. The original actor-type check
+ * remains as defense-in-depth; this helper adds the missing second check.
+ *
+ * The helper is intentionally pure so it can be unit-tested without database
+ * fixtures. The caller (`heartbeat.ts`) is responsible for the lookup.
+ */
+
+export interface DeferredCommentAuthorRow {
+  /** `issue_comments.id` */
+  id: string;
+  /** `issue_comments.author_agent_id` — null for human-authored comments */
+  authorAgentId: string | null;
+}
+
+export interface SelfAuthoredDeferredCommentWakeInput {
+  /** Comment IDs extracted from the deferred wake's context snapshot. */
+  deferredCommentIds: ReadonlyArray<string>;
+  /**
+   * The issue's current `assignee_agent_id`. Null/undefined means the issue is
+   * not assigned to an agent; in that case the wake cannot be "self-authored"
+   * by anyone, so we return false and let the existing predicate decide.
+   */
+  assigneeAgentId: string | null | undefined;
+  /**
+   * The lookup result of `SELECT id, author_agent_id FROM issue_comments WHERE
+   * id IN (deferredCommentIds)`. The caller performs this lookup; we just
+   * compare. Order does not matter.
+   */
+  deferredCommentAuthors: ReadonlyArray<DeferredCommentAuthorRow>;
+}
+
+/**
+ * Returns `true` only when EVERY deferred-wake comment was authored by the
+ * assignee agent itself (a "self-comment wake"). Such wakes must never reopen
+ * a done/cancelled issue, regardless of the wake's recorded `actor_type`.
+ *
+ * Returns `false` when:
+ *   - There are no deferred comment IDs (the wake isn't comment-driven at all).
+ *   - The issue has no assignee agent (no agent can have authored the comments).
+ *   - The lookup returned fewer rows than IDs requested (missing or deleted
+ *     comments; treat as "unknown" and let the existing predicate decide
+ *     conservatively rather than skipping a possibly-legitimate reopen).
+ *   - At least one comment was authored by someone other than the assignee
+ *     (a real human comment or a different agent's comment is in the batch).
+ */
+export function isExclusivelySelfAuthoredDeferredCommentWake(
+  input: SelfAuthoredDeferredCommentWakeInput,
+): boolean {
+  if (input.deferredCommentIds.length === 0) return false;
+  if (!input.assigneeAgentId) return false;
+  if (input.deferredCommentAuthors.length !== input.deferredCommentIds.length) {
+    return false;
+  }
+  return input.deferredCommentAuthors.every(
+    (row) => row.authorAgentId === input.assigneeAgentId,
+  );
+}

--- a/server/src/services/heartbeat-self-comment-wake.ts
+++ b/server/src/services/heartbeat-self-comment-wake.ts
@@ -40,15 +40,47 @@
  * recorded actor-type and the deployment mode. The original actor-type check
  * remains as defense-in-depth; this helper adds the missing second check.
  *
+ * Two-signal recognition (covers BOTH MCP-routed and shell-routed writes)
+ * ----------------------------------------------------------------------
+ * On `local_trusted` the agent has two materially different write paths:
+ *
+ *   - MCP-routed (`paperclipAddComment` etc.) — the comment row gets
+ *     `author_agent_id = <the agent>`, `author_user_id = NULL`, and
+ *     `created_by_run_id` linked to the current heartbeat run.
+ *   - Shell-routed (`curl` from the agent's terminal with the agent's
+ *     Bearer authToken) — the auth middleware's `local_trusted`
+ *     short-circuit promotes the actor to the `local-board` USER principal,
+ *     so the comment row gets `author_agent_id = NULL`,
+ *     `author_user_id = "local-board"`, and `created_by_run_id` STILL linked
+ *     to the agent's heartbeat run.
+ *
+ * The first signal (`author_agent_id === assigneeAgentId`) catches MCP-routed
+ * self-comments. The second signal (`createdByRunAgentId === assigneeAgentId`)
+ * catches shell-routed self-comments, because while the auth middleware loses
+ * the agent identity, the heartbeat-run reference is set by the run-level
+ * comment plumbing and survives. A comment is self-authored when EITHER signal
+ * fires.
+ *
  * The helper is intentionally pure so it can be unit-tested without database
- * fixtures. The caller (`heartbeat.ts`) is responsible for the lookup.
+ * fixtures. The caller (`heartbeat.ts`) is responsible for the lookup (which
+ * is a single `LEFT JOIN` between `issue_comments` and `heartbeat_runs`).
  */
 
 export interface DeferredCommentAuthorRow {
   /** `issue_comments.id` */
   id: string;
-  /** `issue_comments.author_agent_id` — null for human-authored comments */
+  /**
+   * `issue_comments.author_agent_id` — null for human-authored comments AND
+   * for agent-authored comments that round-tripped through a path which lost
+   * agent identity (see "shell-routed" in the file header).
+   */
   authorAgentId: string | null;
+  /**
+   * `heartbeat_runs.agent_id` joined via `issue_comments.created_by_run_id`.
+   * Null if the comment was not created during an agent run (e.g. a real
+   * human comment posted from the dashboard), or if the run is missing/deleted.
+   */
+  createdByRunAgentId: string | null;
 }
 
 export interface SelfAuthoredDeferredCommentWakeInput {
@@ -61,9 +93,16 @@ export interface SelfAuthoredDeferredCommentWakeInput {
    */
   assigneeAgentId: string | null | undefined;
   /**
-   * The lookup result of `SELECT id, author_agent_id FROM issue_comments WHERE
-   * id IN (deferredCommentIds)`. The caller performs this lookup; we just
-   * compare. Order does not matter.
+   * The lookup result of:
+   *
+   *   SELECT ic.id,
+   *          ic.author_agent_id          AS authorAgentId,
+   *          hr.agent_id                 AS createdByRunAgentId
+   *   FROM   issue_comments ic
+   *   LEFT JOIN heartbeat_runs hr ON hr.id = ic.created_by_run_id
+   *   WHERE  ic.id IN (deferredCommentIds);
+   *
+   * Order does not matter.
    */
   deferredCommentAuthors: ReadonlyArray<DeferredCommentAuthorRow>;
 }
@@ -73,6 +112,12 @@ export interface SelfAuthoredDeferredCommentWakeInput {
  * assignee agent itself (a "self-comment wake"). Such wakes must never reopen
  * a done/cancelled issue, regardless of the wake's recorded `actor_type`.
  *
+ * A single comment counts as self-authored when EITHER:
+ *   - `authorAgentId === assigneeAgentId` (the MCP-routed path preserves
+ *     agent identity), OR
+ *   - `createdByRunAgentId === assigneeAgentId` (the shell-routed path loses
+ *     agent identity at the auth layer but the run linkage survives).
+ *
  * Returns `false` when:
  *   - There are no deferred comment IDs (the wake isn't comment-driven at all).
  *   - The issue has no assignee agent (no agent can have authored the comments).
@@ -80,7 +125,9 @@ export interface SelfAuthoredDeferredCommentWakeInput {
  *     comments; treat as "unknown" and let the existing predicate decide
  *     conservatively rather than skipping a possibly-legitimate reopen).
  *   - At least one comment was authored by someone other than the assignee
- *     (a real human comment or a different agent's comment is in the batch).
+ *     by BOTH signals (i.e. neither `authorAgentId` nor `createdByRunAgentId`
+ *     equals the assignee). This is a real human comment or a comment created
+ *     by a different agent's run.
  */
 export function isExclusivelySelfAuthoredDeferredCommentWake(
   input: SelfAuthoredDeferredCommentWakeInput,
@@ -90,7 +137,10 @@ export function isExclusivelySelfAuthoredDeferredCommentWake(
   if (input.deferredCommentAuthors.length !== input.deferredCommentIds.length) {
     return false;
   }
+  const assigneeAgentId = input.assigneeAgentId;
   return input.deferredCommentAuthors.every(
-    (row) => row.authorAgentId === input.assigneeAgentId,
+    (row) =>
+      row.authorAgentId === assigneeAgentId ||
+      row.createdByRunAgentId === assigneeAgentId,
   );
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8479,13 +8479,29 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // an infinite reopen loop on done issues (#3935,
         // NousResearch/hermes-paperclip-adapter#92). The comment table holds
         // the authoritative author identity regardless of auth attribution.
+        //
+        // We use TWO signals to recognize a self-authored comment, because the
+        // agent has two write paths on local_trusted (each lossy in a different
+        // way):
+        //   1. `issue_comments.author_agent_id` — set by MCP-routed writes;
+        //      NULL on shell-routed (`curl`) writes that round-trip through
+        //      the `local-board` user principal.
+        //   2. `heartbeat_runs.agent_id` joined via
+        //      `issue_comments.created_by_run_id` — set by the run-level
+        //      comment plumbing on BOTH paths, so it survives even when the
+        //      auth middleware loses the agent identity on the shell path.
+        // The helper treats EITHER signal matching the assignee as
+        // "self-authored". See `heartbeat-self-comment-wake.ts` for the
+        // full mechanism writeup.
         const deferredCommentAuthors = deferredCommentIds.length > 0
           ? await tx
               .select({
                 id: issueComments.id,
                 authorAgentId: issueComments.authorAgentId,
+                createdByRunAgentId: heartbeatRuns.agentId,
               })
               .from(issueComments)
+              .leftJoin(heartbeatRuns, eq(heartbeatRuns.id, issueComments.createdByRunId))
               .where(inArray(issueComments.id, deferredCommentIds))
           : [];
         const deferredWakeIsExclusivelySelfAuthored =

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -52,6 +52,7 @@ import { conflict, HttpError, notFound } from "../errors.js";
 import { logger } from "../middleware/logger.js";
 import { publishLiveEvent } from "./live-events.js";
 import { getRunLogStore, type RunLogHandle } from "./run-log-store.js";
+import { isExclusivelySelfAuthoredDeferredCommentWake } from "./heartbeat-self-comment-wake.js";
 import { getServerAdapter, listAdapterModelProfiles, runningProcesses } from "../adapters/index.js";
 import type {
   AdapterExecutionResult,
@@ -8467,10 +8468,41 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+
+        // Look up the actual author of every deferred-wake comment so we can
+        // distinguish self-authored "agent posted its DONE-summary comment"
+        // wakes from real human comments. The `deferred.requestedByActorType`
+        // check below is insufficient on `local_trusted` deployments where the
+        // auth middleware short-circuits agent Bearer-token writes to the
+        // `local-board` user principal (see #3980), making every agent
+        // self-comment look like a human comment to the predicate and causing
+        // an infinite reopen loop on done issues (#3935,
+        // NousResearch/hermes-paperclip-adapter#92). The comment table holds
+        // the authoritative author identity regardless of auth attribution.
+        const deferredCommentAuthors = deferredCommentIds.length > 0
+          ? await tx
+              .select({
+                id: issueComments.id,
+                authorAgentId: issueComments.authorAgentId,
+              })
+              .from(issueComments)
+              .where(inArray(issueComments.id, deferredCommentIds))
+          : [];
+        const deferredWakeIsExclusivelySelfAuthored =
+          isExclusivelySelfAuthoredDeferredCommentWake({
+            deferredCommentIds,
+            assigneeAgentId: issue.assigneeAgentId,
+            deferredCommentAuthors,
+          });
+
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.
+        // Self-authored deferred comment wakes (the agent's own DONE-summary
+        // comment triggering its own follow-up wake) must NOT reopen either —
+        // that creates the loop described in #3980/#3935.
         const shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
+          !deferredWakeIsExclusivelySelfAuthored &&
           (issue.status === "done" || issue.status === "cancelled") &&
           (
             deferred.requestedByActorType === "user" ||

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8493,23 +8493,32 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // The helper treats EITHER signal matching the assignee as
         // "self-authored". See `heartbeat-self-comment-wake.ts` for the
         // full mechanism writeup.
-        const deferredCommentAuthors = deferredCommentIds.length > 0
-          ? await tx
-              .select({
-                id: issueComments.id,
-                authorAgentId: issueComments.authorAgentId,
-                createdByRunAgentId: heartbeatRuns.agentId,
-              })
-              .from(issueComments)
-              .leftJoin(heartbeatRuns, eq(heartbeatRuns.id, issueComments.createdByRunId))
-              .where(inArray(issueComments.id, deferredCommentIds))
-          : [];
-        const deferredWakeIsExclusivelySelfAuthored =
-          isExclusivelySelfAuthoredDeferredCommentWake({
-            deferredCommentIds,
-            assigneeAgentId: issue.assigneeAgentId,
-            deferredCommentAuthors,
-          });
+        // The self-comment guard only matters when the issue is in a terminal
+        // state (done/cancelled) — that's the only condition under which the
+        // predicate below would otherwise fire a reopen. Skip the DB roundtrip
+        // for in-progress / todo / blocked / in_review issues, which is the
+        // common case on every heartbeat tick (per Greptile review on #6576).
+        const issueIsTerminalForReopen =
+          issue.status === "done" || issue.status === "cancelled";
+        const deferredCommentAuthors =
+          issueIsTerminalForReopen && deferredCommentIds.length > 0
+            ? await tx
+                .select({
+                  id: issueComments.id,
+                  authorAgentId: issueComments.authorAgentId,
+                  createdByRunAgentId: heartbeatRuns.agentId,
+                })
+                .from(issueComments)
+                .leftJoin(heartbeatRuns, eq(heartbeatRuns.id, issueComments.createdByRunId))
+                .where(inArray(issueComments.id, deferredCommentIds))
+            : [];
+        const deferredWakeIsExclusivelySelfAuthored = issueIsTerminalForReopen
+          ? isExclusivelySelfAuthoredDeferredCommentWake({
+              deferredCommentIds,
+              assigneeAgentId: issue.assigneeAgentId,
+              deferredCommentAuthors,
+            })
+          : false;
 
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.


### PR DESCRIPTION
## Thinking Path

> 1. Paperclip orchestrates AI agents and uses an issue-status state machine where assigned agents disposition their issues (`done`, `blocked`, `cancelled`, etc.) at the end of each run.
> 2. The heartbeat service owns the post-comment lifecycle: when a comment is posted on a `done`/`cancelled` issue, a deferred wake is queued and later promoted; the promoter decides whether to reopen the issue to `todo`.
> 3. The original promoter predicate at `heartbeat.ts:8418-8428` keyed its reopen decision on `deferred.requestedByActorType === "user"`. On `local_trusted` deployments with `hermes_local`, the auth middleware short-circuits agent writes (Bearer-decoded JWT or not) to the `local-board` USER principal in the `agent_wakeup_requests` row — so every agent self-write looks like a "user" actor to the predicate.
> 4. That misclassification means the agent's own DONE-summary comment re-triggers the predicate, reopens its own just-completed issue, and produces the wake-loop described in #3935 / #3980 (and mirrored adapter-side at NousResearch/hermes-paperclip-adapter#92).
> 5. The fix needs to recognize self-comments by content, not by trusted-but-wrong actor-type metadata. Two independent signals are available even when auth attribution fails: `issue_comments.author_agent_id` (set on MCP-routed writes that preserve agent identity) and `heartbeat_runs.agent_id` joined via `issue_comments.created_by_run_id` (set on shell-routed writes whose JWT-claim run_id flowed through `auth.ts` before the local-board short-circuit overwrote actor-type).
> 6. Adding a content-based AND-clause to the existing predicate is strictly additive — the original actor-type and wake-reason checks still fire — and confined to the previously-buggy path (`done`/`cancelled` issue + exclusively self-authored deferred-comment wake).
> 7. Greptile flagged that the DB lookup driving the content guard fires unconditionally; gating it on `issue.status === "done" || "cancelled"` keeps it off the hot heartbeat path for normal in-progress issues.
> 8. Validated locally end-to-end (RKT-1 through RKT-8, see Verification): the predicate-path loop is structurally extinguished. Honest scope note: this PR closes the deferred-comment-wake reopen path only — see Risks for the unrelated `routes/issues.ts:4245` immediate-reopen path that intentionally remains.

## What Changed

- **Commit 1 (`476ab27e`)** — new pure helper `isExclusivelySelfAuthoredDeferredCommentWake()` in `server/src/services/heartbeat-self-comment-wake.ts` + 8 unit tests in the sibling `.test.ts`. The helper takes the deferred-wake comment IDs and the assignee agent and returns `true` only when every comment's `author_agent_id === assigneeAgentId`. Caller in `heartbeat.ts` (the deferred-wake promoter) AND-clauses `!isExclusivelySelfAuthoredDeferredCommentWake(...)` into the existing reopen predicate. Original actor-type check left in place as defense-in-depth.
- **Commit 2 (`4c261a83`)** — extends recognition to shell-routed self-comments where `author_agent_id` is null (auth-middleware short-circuit) but the heartbeat-run linkage survives. SELECT becomes a LEFT JOIN on `heartbeat_runs` to fetch `agent_id` alongside `author_agent_id`. Helper now matches when EITHER signal fires. Tests grow from 8 to 11 cases (added shell-routed-only and mixed MCP+shell cases).
- **Commit 3 (`5353d110`)** — addresses Greptile P2: moves the `deferredCommentAuthors` DB lookup behind `issueIsTerminalForReopen` (`status === "done" || "cancelled"`) so the JOIN doesn't fire on every heartbeat tick for normal in-progress / todo / blocked / in_review issues. No semantic change; just removes a hot-path DB roundtrip.

3 files touched: `server/src/services/heartbeat.ts` (predicate + lookup guard), `server/src/services/heartbeat-self-comment-wake.ts` (new), `server/src/services/heartbeat-self-comment-wake.test.ts` (new).

## Verification

**Unit tests:** 11/11 pass on the head commit:
```
$ pnpm exec vitest run server/src/services/heartbeat-self-comment-wake.test.ts
 ✓ src/services/heartbeat-self-comment-wake.test.ts (11 tests) 3ms
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

**Local end-to-end on a `hermes_local` + `local_trusted` install** (Paperclip `e3c875c1` master + this PR cherry-picked, Hermes `57a61057f`):

| Issue | Setup | Result |
|---|---|---|
| RKT-1 through RKT-5 | Fresh single-issue smoke test under operator-set MCP-preferring promptTemplate | 1 run per issue, `done` disposition, comments authored by agent (`authorType=agent`), no recovery comments, no loop |
| RKT-3 | "Edit a file that doesn't exist" — forces `blocked` disposition | 1 run, agent explicitly chose `blocked` with rationale comment, system respected the disposition (no `Stale disposition warning`), no loop |
| RKT-8 | Baseline under the same setup | 1 run, clean `done`, ~26s end-to-end |
| RKT-8 (probed post-baseline) | After RKT-8 completed, posted a comment with `X-Paperclip-Run-Id` header but no `Authorization` to simulate run-linked-but-auth-failed self-write | Issue did briefly reopen via `routes/issues.ts:4245` (which is OUT OF SCOPE for this PR — see Risks). Re-run completed cleanly in ~33s. No infinite loop, no `Stale disposition warning`. |

Pre-cherry-pick reproduction on the same install (`master @ e3c875c1`, no PR commits applied) showed the classic loop signature: 3+ runs in 5 min on a single issue, repeated `Paperclip needs a disposition before this issue can continue` system comments, eventual system-forced `status=blocked` via recovery handoff.

## Risks

- **Low risk for the deferred-comment-wake-promotion path.** No schema change, no API change. Both content-signal checks are additive AND-clauses on top of the existing predicate; behavior shift is strictly confined to the previously-buggy case (`done`/`cancelled` + exclusively self-authored deferred wake).
- **DB cost: one LEFT JOIN inside an already-joining transaction**, gated by commit 3 to only fire when the issue is terminal. Conservative fallback: if the comment-author lookup returns fewer rows than IDs (deleted comments), the helper returns `false` and the existing predicate decides, rather than silently skipping a possibly-legitimate reopen.
- **Honest scope: this PR does NOT close the immediate-comment-reopen path at `server/src/routes/issues.ts:4245`.** That code path auto-reopens a `done`/`cancelled` issue when a comment is posted by an actor other than the assignee agent (its `selfComment` check uses `actor.actorType === "agent" && actor.actorId === assigneeId` — same flaw the heartbeat predicate had). In real-world operation that path serves human commenters reopening done issues, which is intentional behavior; only the unrealistic `X-Paperclip-Run-Id-without-Bearer` header combination would trigger it for an agent self-comment (no current adapter version emits that combination organically). Documenting here so reviewers know it's deliberately out of scope; if anyone wants symmetric coverage, that would be a sibling PR.
- **No regression on existing reopen flows.** Real human commenters reopening done issues still triggers reopen via the existing predicate (their comments don't match either self-signal).

## Model Used

- **Claude Opus 4.6 (1M context)** for commits 1+2 (root-cause analysis, helper design, unit-test authoring) per the original commit trailers
- **Claude Opus 4.7 (1M context)** for commit 3 and this PR-description rewrite (Greptile fix + scope clarification + verification evidence), Anthropic SDK, extended thinking mode used for the third-path investigation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (11/11 in `heartbeat-self-comment-wake.test.ts` on head commit `5353d110`)
- [x] I have added or updated tests where applicable (8 → 11 unit tests across commits 1+2)
- [ ] If this change affects the UI, I have included before/after screenshots *(N/A — server-side only)*
- [x] I have updated relevant documentation to reflect my changes *(the helper file's docstring documents the full root cause + two-signal recognition mechanism and references the closed/related issues)*
- [x] I have considered and documented any risks above (including the honest out-of-scope note on the immediate-comment-reopen path)
- [x] I will address all Greptile and reviewer comments before requesting merge

---

Closes #3980 (deferred-wake-promotion reopen path). Closes #3935 (its symptom class). Related: #2486, NousResearch/hermes-paperclip-adapter#92.
