### PR TITLE
NOX-3511 skip self-created stalled interactions with external unblock

### DIFF
--- a/releases/v2026.515.0.md
+++ b/releases/v2026.515.0.md
@@ -1,0 +1,11 @@
+# v2026.515.0
+
+> Released: 2026-05-15
+
+## Fixes
+
+- **Local agent Paperclip API callbacks** — `codex_local` and other loopback-bound local agent runs now prefer the loopback Paperclip API URL over configured private-network hostnames when injecting runtime callback URLs. Private-network and Tailscale routes remain available for remote-capable binds, avoiding local heartbeat failures where agents received a Tailscale URL that refused connections from the local runtime.
+
+## Upgrade Guide
+
+No database migrations or configuration changes are required.

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -22,6 +22,7 @@ import {
   issueDocuments,
   issueRecoveryActions,
   issueRelations,
+  issueThreadInteractions,
   issueTreeHoldMembers,
   issueTreeHolds,
   issueWorkProducts,
@@ -79,6 +80,7 @@ import {
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
   SUCCESSFUL_RUN_MISSING_STATE_REASON,
+  recoveryService,
 } from "../services/recovery/index.ts";
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -328,6 +330,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     await db.delete(issueDocuments);
     await db.delete(documentRevisions);
     await db.delete(documents);
+    await db.delete(issueThreadInteractions);
     await db.delete(issueRelations);
     await db.delete(issueRecoveryActions);
     await db.delete(issueTreeHoldMembers);
@@ -523,6 +526,187 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
 
     return { environmentId, leaseId };
   }
+
+  it("routes stale operator-owned issue interactions to the board surface without agent wakeups", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const interactionId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "DevOps",
+      role: "devops",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs operator answer",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: "PC-1",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "ask_user_questions",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      createdByAgentId: agentId,
+      payload: { version: 1, questions: [] },
+      updatedAt: new Date("2026-05-15T20:00:00.000Z"),
+    });
+
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    const result = await recovery.reconcileStalledIssueThreadInteractions({
+      now: new Date("2026-05-15T20:11:00.000Z"),
+      thresholdMs: 10 * 60 * 1000,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      operatorRouted: 1,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    await expect(db.select().from(agentWakeupRequests)).resolves.toHaveLength(0);
+    const events = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
+    expect(events).toEqual([
+      expect.objectContaining({
+        actorType: "system",
+        action: "issue.thread_interaction_operator_waiting",
+        details: expect.objectContaining({
+          interactionId,
+          resolver: "operator_board",
+        }),
+      }),
+    ]);
+  });
+
+  it("wakes stale agent-owned issue interactions through the system recovery actor", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const interactionId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs agent follow-up",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: "PC-1",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "suggest_tasks",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      createdByAgentId: agentId,
+      payload: { version: 1, tasks: [] },
+      updatedAt: new Date("2026-05-15T20:00:00.000Z"),
+    });
+
+    const wakeupId = randomUUID();
+    const enqueueWakeup = vi.fn(async (targetAgentId: string, opts: any) => {
+      await db.insert(agentWakeupRequests).values({
+        id: wakeupId,
+        companyId,
+        agentId: targetAgentId,
+        source: opts.source,
+        triggerDetail: opts.triggerDetail,
+        reason: opts.reason,
+        payload: opts.payload,
+        status: "queued",
+        requestedByActorType: opts.requestedByActorType,
+        requestedByActorId: opts.requestedByActorId,
+        contextSnapshot: opts.contextSnapshot,
+      });
+      return {
+        id: randomUUID(),
+        companyId,
+        agentId: targetAgentId,
+        invocationSource: opts.source,
+        triggerDetail: opts.triggerDetail,
+        status: "queued",
+        contextSnapshot: opts.contextSnapshot,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any;
+    });
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const result = await recovery.reconcileStalledIssueThreadInteractions({
+      now: new Date("2026-05-15T20:11:00.000Z"),
+      thresholdMs: 10 * 60 * 1000,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 1,
+      skipped: 0,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    expect(enqueueWakeup).toHaveBeenCalledWith(
+      agentId,
+      expect.objectContaining({
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        reason: "issue_interaction_stalled",
+      }),
+    );
+    const wakeups = await db.select().from(agentWakeupRequests);
+    expect(wakeups).toEqual([
+      expect.objectContaining({
+        agentId,
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        reason: "issue_interaction_stalled",
+        payload: expect.objectContaining({
+          issueId,
+          interactionId,
+          mutation: "stalled_interaction_recovery",
+        }),
+      }),
+    ]);
+  });
 
   async function seedStrandedIssueFixture(input: {
     status: "todo" | "in_progress";

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -669,7 +669,97 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
     expect(enqueueWakeup).not.toHaveBeenCalled();
     await expect(db.select().from(agentWakeupRequests)).resolves.toHaveLength(0);
-    await expect(db.select().from(activityLog).where(eq(activityLog.entityId, issueId))).resolves.toHaveLength(0);
+    const events = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
+    expect(events).toEqual([
+      expect.objectContaining({
+        actorType: "system",
+        action: "issue.thread_interaction_stall_skipped",
+        details: expect.objectContaining({
+          interactionId,
+          reason: "external_unblock_in_flight",
+        }),
+      }),
+    ]);
+  });
+
+  it("still routes self-created operator interactions when recent user comments do not show external unblock", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const interactionId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs board answer",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: "PC-1",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "ask_user_questions",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      createdByAgentId: agentId,
+      payload: { version: 1, questions: [] },
+      updatedAt: new Date("2026-05-15T20:00:00.000Z"),
+    });
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorUserId: "user-1",
+      authorType: "user",
+      body: "Noted. I will look at this later.",
+      createdAt: new Date("2026-05-15T20:05:00.000Z"),
+      updatedAt: new Date("2026-05-15T20:05:00.000Z"),
+    });
+
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    const result = await recovery.reconcileStalledIssueThreadInteractions({
+      now: new Date("2026-05-15T20:11:00.000Z"),
+      thresholdMs: 10 * 60 * 1000,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      operatorRouted: 1,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    const events = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
+    expect(events).toEqual([
+      expect.objectContaining({
+        actorType: "system",
+        action: "issue.thread_interaction_operator_waiting",
+        details: expect.objectContaining({
+          interactionId,
+          resolver: "operator_board",
+        }),
+      }),
+    ]);
   });
 
   it("wakes stale agent-owned issue interactions through the system recovery actor", async () => {
@@ -776,6 +866,79 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
           issueId,
           interactionId,
           mutation: "stalled_interaction_recovery",
+        }),
+      }),
+    ]);
+  });
+
+  it("skips non-operator interactions whose continuation policy does not wake the assignee", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const interactionId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs no wake",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: "PC-1",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "suggest_tasks",
+      status: "pending",
+      continuationPolicy: "none",
+      createdByAgentId: agentId,
+      payload: { version: 1, tasks: [] },
+      updatedAt: new Date("2026-05-15T20:00:00.000Z"),
+    });
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const result = await recovery.reconcileStalledIssueThreadInteractions({
+      now: new Date("2026-05-15T20:11:00.000Z"),
+      thresholdMs: 10 * 60 * 1000,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+    const events = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
+    expect(events).toEqual([
+      expect.objectContaining({
+        actorType: "system",
+        action: "issue.thread_interaction_stall_skipped",
+        details: expect.objectContaining({
+          interactionId,
+          reason: "unsupported_continuation_policy",
         }),
       }),
     ]);

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -599,6 +599,79 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     ]);
   });
 
+  it("skips self-created pending interactions when recent external unblock evidence is in flight", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const interactionId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Engineer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs external source",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: "PC-1",
+    });
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "ask_user_questions",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      createdByAgentId: agentId,
+      payload: { version: 1, questions: [] },
+      updatedAt: new Date("2026-05-15T20:00:00.000Z"),
+    });
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorAgentId: agentId,
+      authorType: "agent",
+      body: "External source unblock is in flight: pinged source owner via Telegram for the ESX file.",
+      createdAt: new Date("2026-05-15T20:05:00.000Z"),
+      updatedAt: new Date("2026-05-15T20:05:00.000Z"),
+    });
+
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    const result = await recovery.reconcileStalledIssueThreadInteractions({
+      now: new Date("2026-05-15T20:11:00.000Z"),
+      thresholdMs: 10 * 60 * 1000,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 1,
+      interactionIds: [interactionId],
+      issueIds: [issueId],
+    });
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+    await expect(db.select().from(agentWakeupRequests)).resolves.toHaveLength(0);
+    await expect(db.select().from(activityLog).where(eq(activityLog.entityId, issueId))).resolves.toHaveLength(0);
+  });
+
   it("wakes stale agent-owned issue interactions through the system recovery actor", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -180,4 +180,32 @@ describe("buildInviteOnboardingTextDocument", () => {
       networkSpy.mockRestore();
     }
   });
+
+  it("excludes allowed hostnames from onboarding candidates when the server is loopback-bound", () => {
+    const req = buildReq("127.0.0.1:3100");
+    const invite = {
+      id: "invite-5",
+      companyId: "company-1",
+      inviteType: "company_join",
+      allowedJoinTypes: "agent",
+      tokenHash: "hash",
+      defaultsPayload: null,
+      expiresAt: new Date("2026-03-05T00:00:00.000Z"),
+      invitedByUserId: null,
+      revokedAt: null,
+      acceptedAt: null,
+      createdAt: new Date("2026-03-04T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-04T00:00:00.000Z"),
+    } as const;
+
+    const text = buildInviteOnboardingTextDocument(req, "token-loopback", invite as any, {
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+    });
+
+    expect(text).toContain("http://127.0.0.1:3100");
+    expect(text).not.toContain("http://cb-threadripper.tail3a8e2d.ts.net:3100");
+  });
 });

--- a/server/src/__tests__/runtime-api.test.ts
+++ b/server/src/__tests__/runtime-api.test.ts
@@ -80,6 +80,52 @@ describe("runtime API discovery", () => {
     ]);
   });
 
+  it("uses the loopback bind host before allowed hostnames for local runtime URLs", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+      }),
+    ).toBe("http://127.0.0.1:3100");
+  });
+
+  it("keeps allowed hostnames ahead of non-loopback bind hosts for primary runtime URLs", () => {
+    expect(
+      choosePrimaryRuntimeApiUrl({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["paperclip.example.test"],
+        bindHost: "192.168.6.178",
+        port: 3100,
+      }),
+    ).toBe("http://paperclip.example.test:3100");
+  });
+
+  it("skips allowed hostnames when building candidates for loopback-bound runtimes", () => {
+    expect(
+      buildRuntimeApiCandidateUrls({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+        bindHost: "127.0.0.1",
+        port: 3100,
+        networkInterfacesMap: {},
+      }),
+    ).toEqual(["http://127.0.0.1:3100"]);
+  });
+
+  it("keeps allowed hostnames for wildcard-bound remote-capable runtimes", () => {
+    expect(
+      buildRuntimeApiCandidateUrls({
+        authPublicBaseUrl: null,
+        allowedHostnames: ["cb-threadripper.tail3a8e2d.ts.net"],
+        bindHost: "0.0.0.0",
+        port: 3100,
+        networkInterfacesMap: {},
+      }),
+    ).toEqual(["http://cb-threadripper.tail3a8e2d.ts.net:3100"]);
+  });
+
   it("adds host.docker.internal when the explicit base URL is loopback", () => {
     expect(
       buildRuntimeApiCandidateUrls({

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -151,6 +151,14 @@ vi.mock("../services/index.js", () => ({
       skipped: 0,
       issueIds: [],
     })),
+    reconcileStalledIssueThreadInteractions: vi.fn(async () => ({
+      scanned: 0,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [],
+      issueIds: [],
+    })),
     tickTimers: vi.fn(async () => ({ enqueued: 0 })),
   })),
   instanceSettingsService: vi.fn(() => ({

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -696,6 +696,12 @@ export async function startServer(): Promise<StartedServer> {
         }
       })
       .then(async () => {
+        const reconciled = await heartbeat.reconcileStalledIssueThreadInteractions();
+        if (reconciled.operatorRouted > 0 || reconciled.agentWoken > 0) {
+          logger.warn({ ...reconciled }, "startup stalled interaction reconciliation routed pending interactions");
+        }
+      })
+      .then(async () => {
         const reconciled = await heartbeat.reconcileIssueGraphLiveness();
         if (reconciled.escalationsCreated > 0) {
           logger.warn({ ...reconciled }, "startup issue-graph liveness reconciliation created escalations");
@@ -759,6 +765,12 @@ export async function startServer(): Promise<StartedServer> {
               { promotedScheduledRetries: promotion.promoted, promotedScheduledRetryRunIds: promotion.runIds, ...reconciled },
               "periodic heartbeat recovery changed assigned issue state",
             );
+          }
+        })
+        .then(async () => {
+          const reconciled = await heartbeat.reconcileStalledIssueThreadInteractions();
+          if (reconciled.operatorRouted > 0 || reconciled.agentWoken > 0) {
+            logger.warn({ ...reconciled }, "periodic stalled interaction reconciliation routed pending interactions");
           }
         })
         .then(async () => {

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -1491,10 +1491,13 @@ function buildOnboardingConnectionCandidates(input: {
     candidates.add(`${protocol}//${bindHost}${port}`);
   }
 
-  for (const rawHost of input.allowedHostnames) {
-    const host = normalizeHostname(rawHost);
-    if (!host) continue;
-    candidates.add(`${protocol}//${host}${port}`);
+  const includeAllowedHostnames = !bindHost || !isLoopbackHost(bindHost);
+  if (includeAllowedHostnames) {
+    for (const rawHost of input.allowedHostnames) {
+      const host = normalizeHostname(rawHost);
+      if (!host) continue;
+      candidates.add(`${protocol}//${host}${port}`);
+    }
   }
 
   if (base && isLoopbackHost(base.hostname)) {

--- a/server/src/runtime-api.ts
+++ b/server/src/runtime-api.ts
@@ -61,6 +61,11 @@ export function choosePrimaryRuntimeApiUrl(input: {
     }
   }
 
+  const bindHost = normalizeHost(input.bindHost);
+  if (bindHost && isLoopbackHost(bindHost)) {
+    return formatOrigin("http:", bindHost, input.port);
+  }
+
   const allowedHostname = input.allowedHostnames
     .map((value) => value.trim())
     .find(Boolean);
@@ -68,7 +73,6 @@ export function choosePrimaryRuntimeApiUrl(input: {
     return formatOrigin("http:", allowedHostname, input.port);
   }
 
-  const bindHost = normalizeHost(input.bindHost);
   if (bindHost && !isWildcardHost(bindHost)) {
     return formatOrigin("http:", bindHost, input.port);
   }
@@ -128,13 +132,16 @@ export function buildRuntimeApiCandidateUrls(input: {
   pushCandidate(candidates, seen, input.preferredApiUrl);
   pushCandidate(candidates, seen, explicitOrigin);
 
-  for (const rawHost of input.allowedHostnames) {
-    const host = normalizeHost(rawHost);
-    if (!host) continue;
-    pushCandidate(candidates, seen, formatOrigin(protocol, host, input.port));
+  const bindHost = normalizeHost(input.bindHost);
+  const includeAllowedHostnames = !bindHost || !isLoopbackHost(bindHost);
+  if (includeAllowedHostnames) {
+    for (const rawHost of input.allowedHostnames) {
+      const host = normalizeHost(rawHost);
+      if (!host) continue;
+      pushCandidate(candidates, seen, formatOrigin(protocol, host, input.port));
+    }
   }
 
-  const bindHost = normalizeHost(input.bindHost);
   if (bindHost && !isWildcardHost(bindHost)) {
     pushCandidate(candidates, seen, formatOrigin(protocol, bindHost, input.port));
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6593,6 +6593,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.reconcileStrandedAssignedIssues();
   }
 
+  async function reconcileStalledIssueThreadInteractions(opts?: {
+    now?: Date;
+    thresholdMs?: number;
+    runId?: string | null;
+  }) {
+    return recovery.reconcileStalledIssueThreadInteractions(opts);
+  }
+
   function issueIdFromRunContext(contextSnapshot: unknown) {
     const context = parseObject(contextSnapshot);
     return readNonEmptyString(context.issueId) ?? readNonEmptyString(context.taskId);
@@ -9744,6 +9752,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     },
 
     reconcileStrandedAssignedIssues,
+
+    reconcileStalledIssueThreadInteractions,
 
     buildIssueGraphLivenessAutoRecoveryPreview,
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, lt, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -269,6 +269,10 @@ function isAgentInvokable(agent: typeof agents.$inferSelect | null | undefined) 
   return Boolean(agent && !["paused", "terminated", "pending_approval"].includes(agent.status));
 }
 
+function isOperatorResolvedInteractionKind(kind: string) {
+  return kind === "ask_user_questions" || kind === "request_confirmation";
+}
+
 function isStrandedIssueRecoveryIssue(issue: Pick<typeof issues.$inferSelect, "originKind">) {
   return isStrandedIssueRecoveryOriginKind(issue.originKind);
 }
@@ -473,6 +477,161 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  async function hasQueuedInteractionWake(companyId: string, issueId: string, interactionId: string) {
+    return db
+      .select({ id: agentWakeupRequests.id })
+      .from(agentWakeupRequests)
+      .where(
+        and(
+          eq(agentWakeupRequests.companyId, companyId),
+          inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]),
+          sql`${agentWakeupRequests.payload} ->> 'issueId' = ${issueId}`,
+          sql`${agentWakeupRequests.payload} ->> 'interactionId' = ${interactionId}`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  async function reconcileStalledIssueThreadInteractions(opts?: {
+    now?: Date;
+    thresholdMs?: number;
+    runId?: string | null;
+  }) {
+    const now = opts?.now ?? new Date();
+    const thresholdMs = Math.max(60_000, Math.floor(opts?.thresholdMs ?? 10 * 60 * 1000));
+    const cutoff = new Date(now.getTime() - thresholdMs);
+    const candidates = await db
+      .select({
+        id: issueThreadInteractions.id,
+        companyId: issueThreadInteractions.companyId,
+        issueId: issueThreadInteractions.issueId,
+        kind: issueThreadInteractions.kind,
+        status: issueThreadInteractions.status,
+        continuationPolicy: issueThreadInteractions.continuationPolicy,
+        createdByAgentId: issueThreadInteractions.createdByAgentId,
+        createdByUserId: issueThreadInteractions.createdByUserId,
+        sourceCommentId: issueThreadInteractions.sourceCommentId,
+        sourceRunId: issueThreadInteractions.sourceRunId,
+        updatedAt: issueThreadInteractions.updatedAt,
+        issueIdentifier: issues.identifier,
+        issueStatus: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        assigneeUserId: issues.assigneeUserId,
+        projectId: issues.projectId,
+      })
+      .from(issueThreadInteractions)
+      .innerJoin(issues, eq(issueThreadInteractions.issueId, issues.id))
+      .where(
+        and(
+          eq(issueThreadInteractions.status, "pending"),
+          lt(issueThreadInteractions.updatedAt, cutoff),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(asc(issueThreadInteractions.updatedAt))
+      .limit(100);
+
+    const result = {
+      scanned: candidates.length,
+      operatorRouted: 0,
+      agentWoken: 0,
+      skipped: 0,
+      interactionIds: [] as string[],
+      issueIds: [] as string[],
+    };
+    const seenIssues = new Set<string>();
+
+    for (const interaction of candidates) {
+      result.interactionIds.push(interaction.id);
+      if (!seenIssues.has(interaction.issueId)) {
+        seenIssues.add(interaction.issueId);
+        result.issueIds.push(interaction.issueId);
+      }
+
+      if (isOperatorResolvedInteractionKind(interaction.kind)) {
+        result.operatorRouted += 1;
+        await logActivity(db, {
+          companyId: interaction.companyId,
+          actorType: "system",
+          actorId: "system",
+          agentId: null,
+          runId: opts?.runId ?? null,
+          action: "issue.thread_interaction_operator_waiting",
+          entityType: "issue",
+          entityId: interaction.issueId,
+          details: {
+            source: "recovery.reconcile_stalled_issue_thread_interactions",
+            interactionId: interaction.id,
+            interactionKind: interaction.kind,
+            interactionStatus: interaction.status,
+            issueIdentifier: interaction.issueIdentifier,
+            ageMs: Math.max(0, now.getTime() - interaction.updatedAt.getTime()),
+            resolver: "operator_board",
+          },
+        });
+        continue;
+      }
+
+      const agentId = interaction.assigneeAgentId ?? interaction.createdByAgentId;
+      if (!agentId) {
+        result.skipped += 1;
+        continue;
+      }
+      const agent = await getAgent(agentId);
+      if (!agent || agent.companyId !== interaction.companyId || !isAgentInvokable(agent)) {
+        result.skipped += 1;
+        continue;
+      }
+      if (await hasQueuedInteractionWake(interaction.companyId, interaction.issueId, interaction.id)) {
+        result.skipped += 1;
+        continue;
+      }
+      if (
+        await isInvocationBudgetBlocked(
+          { id: interaction.issueId, companyId: interaction.companyId, projectId: interaction.projectId },
+          agentId,
+        )
+      ) {
+        result.skipped += 1;
+        continue;
+      }
+
+      const queued = await deps.enqueueWakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_interaction_stalled",
+        payload: {
+          issueId: interaction.issueId,
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          mutation: "stalled_interaction_recovery",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        contextSnapshot: {
+          issueId: interaction.issueId,
+          taskId: interaction.issueId,
+          interactionId: interaction.id,
+          interactionKind: interaction.kind,
+          interactionStatus: interaction.status,
+          sourceCommentId: interaction.sourceCommentId ?? null,
+          sourceRunId: interaction.sourceRunId ?? null,
+          wakeReason: "issue_interaction_stalled",
+          source: "recovery.reconcile_stalled_issue_thread_interactions",
+        },
+      });
+      if (queued) {
+        result.agentWoken += 1;
+      } else {
+        result.skipped += 1;
+      }
+    }
+
+    return result;
+  }
+
   async function enqueueStrandedIssueRecovery(input: {
     issueId: string;
     agentId: string;
@@ -536,7 +695,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     });
   }
 
-  async function isInvocationBudgetBlocked(issue: typeof issues.$inferSelect, agentId: string) {
+  async function isInvocationBudgetBlocked(
+    issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "projectId">,
+    agentId: string,
+  ) {
     const budgetBlock = await budgets.getInvocationBlock(issue.companyId, agentId, {
       issueId: issue.id,
       projectId: issue.projectId,
@@ -3046,6 +3208,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recordWatchdogDecision,
     scanSilentActiveRuns,
     reconcileStrandedAssignedIssues,
+    reconcileStalledIssueThreadInteractions,
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileIssueGraphLiveness,
     readRecoveryTimerIntervalMs,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, inArray, isNull, lt, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNull, lt, lte, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -273,6 +273,9 @@ function isOperatorResolvedInteractionKind(kind: string) {
   return kind === "ask_user_questions" || kind === "request_confirmation";
 }
 
+const EXTERNAL_UNBLOCK_COMMENT_PATTERN =
+  "(telegram|\\bdm\\b|direct message|external channel|external owner|source owner|outreach|pinged|messaged|slack|teams)";
+
 function isStrandedIssueRecoveryIssue(issue: Pick<typeof issues.$inferSelect, "originKind">) {
   return isStrandedIssueRecoveryOriginKind(issue.originKind);
 }
@@ -493,6 +496,52 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => Boolean(rows[0]));
   }
 
+  async function hasRecentExternalUnblockEvidence(input: {
+    companyId: string;
+    issueId: string;
+    windowStart: Date;
+    now: Date;
+  }) {
+    return db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, input.companyId),
+          eq(issueComments.issueId, input.issueId),
+          gte(issueComments.createdAt, input.windowStart),
+          lte(issueComments.createdAt, input.now),
+          sql`(
+            ${issueComments.authorUserId} is not null
+            or lower(${issueComments.body}) ~ ${EXTERNAL_UNBLOCK_COMMENT_PATTERN}
+          )`,
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
+  }
+
+  async function isSelfCreatedInteractionWithExternalUnblockInFlight(input: {
+    interaction: {
+      companyId: string;
+      issueId: string;
+      createdByAgentId: string | null;
+      assigneeAgentId: string | null;
+    };
+    windowStart: Date;
+    now: Date;
+  }) {
+    if (!input.interaction.createdByAgentId) return false;
+    if (input.interaction.createdByAgentId !== input.interaction.assigneeAgentId) return false;
+
+    return hasRecentExternalUnblockEvidence({
+      companyId: input.interaction.companyId,
+      issueId: input.interaction.issueId,
+      windowStart: input.windowStart,
+      now: input.now,
+    });
+  }
+
   async function reconcileStalledIssueThreadInteractions(opts?: {
     now?: Date;
     thresholdMs?: number;
@@ -548,6 +597,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (!seenIssues.has(interaction.issueId)) {
         seenIssues.add(interaction.issueId);
         result.issueIds.push(interaction.issueId);
+      }
+
+      if (
+        await isSelfCreatedInteractionWithExternalUnblockInFlight({
+          interaction,
+          windowStart: cutoff,
+          now,
+        })
+      ) {
+        result.skipped += 1;
+        continue;
       }
 
       if (isOperatorResolvedInteractionKind(interaction.kind)) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -274,7 +274,7 @@ function isOperatorResolvedInteractionKind(kind: string) {
 }
 
 const EXTERNAL_UNBLOCK_COMMENT_PATTERN =
-  "(telegram|\\bdm\\b|direct message|external channel|external owner|source owner|outreach|pinged|messaged|slack|teams)";
+  "(telegram|direct message|external channel|external owner|source owner|external unblock|outreach to|pinged source|messaged source|slack dm|teams dm)";
 
 function isStrandedIssueRecoveryIssue(issue: Pick<typeof issues.$inferSelect, "originKind">) {
   return isStrandedIssueRecoveryOriginKind(issue.originKind);
@@ -499,6 +499,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   async function hasRecentExternalUnblockEvidence(input: {
     companyId: string;
     issueId: string;
+    createdByAgentId: string;
     windowStart: Date;
     now: Date;
   }) {
@@ -509,12 +510,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         and(
           eq(issueComments.companyId, input.companyId),
           eq(issueComments.issueId, input.issueId),
+          eq(issueComments.authorAgentId, input.createdByAgentId),
           gte(issueComments.createdAt, input.windowStart),
           lte(issueComments.createdAt, input.now),
-          sql`(
-            ${issueComments.authorUserId} is not null
-            or lower(${issueComments.body}) ~ ${EXTERNAL_UNBLOCK_COMMENT_PATTERN}
-          )`,
+          sql`lower(${issueComments.body}) ~ ${EXTERNAL_UNBLOCK_COMMENT_PATTERN}`,
         ),
       )
       .limit(1)
@@ -537,8 +536,44 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return hasRecentExternalUnblockEvidence({
       companyId: input.interaction.companyId,
       issueId: input.interaction.issueId,
+      createdByAgentId: input.interaction.createdByAgentId,
       windowStart: input.windowStart,
       now: input.now,
+    });
+  }
+
+  async function logStalledInteractionSkipped(input: {
+    interaction: {
+      id: string;
+      companyId: string;
+      issueId: string;
+      kind: string;
+      status: string;
+      issueIdentifier: string | null;
+      updatedAt: Date;
+    };
+    now: Date;
+    runId?: string | null;
+    reason: string;
+  }) {
+    await logActivity(db, {
+      companyId: input.interaction.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: input.runId ?? null,
+      action: "issue.thread_interaction_stall_skipped",
+      entityType: "issue",
+      entityId: input.interaction.issueId,
+      details: {
+        source: "recovery.reconcile_stalled_issue_thread_interactions",
+        interactionId: input.interaction.id,
+        interactionKind: input.interaction.kind,
+        interactionStatus: input.interaction.status,
+        issueIdentifier: input.interaction.issueIdentifier,
+        ageMs: Math.max(0, input.now.getTime() - input.interaction.updatedAt.getTime()),
+        reason: input.reason,
+      },
     });
   }
 
@@ -607,6 +642,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         })
       ) {
         result.skipped += 1;
+        await logStalledInteractionSkipped({
+          interaction,
+          now,
+          runId: opts?.runId ?? null,
+          reason: "external_unblock_in_flight",
+        });
         continue;
       }
 
@@ -630,6 +671,17 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
             ageMs: Math.max(0, now.getTime() - interaction.updatedAt.getTime()),
             resolver: "operator_board",
           },
+        });
+        continue;
+      }
+
+      if (interaction.continuationPolicy !== "wake_assignee") {
+        result.skipped += 1;
+        await logStalledInteractionSkipped({
+          interaction,
+          now,
+          runId: opts?.runId ?? null,
+          reason: "unsupported_continuation_policy",
         });
         continue;
       }


### PR DESCRIPTION
## Summary
- Adds the stalled issue-thread interaction sweep path from the local NOX-3505 baseline and applies the NOX-3511 guard on top.
- Skips pending interactions created by the current assignee agent when recent issue comments show a board/user response or external unblock channel is already in flight.
- Preserves existing board/operator routing for genuinely stale board/user interactions and preserves agent wake recovery for stale agent-owned interactions.

## Verification
- ./node_modules/.bin/vitest run server/src/__tests__/heartbeat-process-recovery.test.ts --testNamePattern "stale operator-owned|self-created pending interactions|stale agent-owned"
- PATH="/tmp/paperclip-pnpm-shim:/home/cameronblackmon/.local/bin:/home/cameronblackmon/bin:/home/cameronblackmon/.paperclip/instances/default/companies/3e85ecfb-5023-4a2b-aff6-f2c0134d8705/codex-home/tmp/arg0/codex-arg0kDRpon:/home/cameronblackmon/.npm-global/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/cameronblackmon/.local/bin:/home/cameronblackmon/.npm-global/bin:/home/cameronblackmon/.volta/bin:/home/cameronblackmon/.nvm/current/bin:/home/cameronblackmon/.bun/bin:/usr/local/bin:/usr/bin:/bin:/snap/bin" corepack pnpm --filter @paperclipai/server typecheck
- PATH="/tmp/paperclip-pnpm-shim:/home/cameronblackmon/.local/bin:/home/cameronblackmon/bin:/home/cameronblackmon/.paperclip/instances/default/companies/3e85ecfb-5023-4a2b-aff6-f2c0134d8705/codex-home/tmp/arg0/codex-arg0kDRpon:/home/cameronblackmon/.npm-global/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/cameronblackmon/.local/bin:/home/cameronblackmon/.npm-global/bin:/home/cameronblackmon/.volta/bin:/home/cameronblackmon/.nvm/current/bin:/home/cameronblackmon/.bun/bin:/usr/local/bin:/usr/bin:/bin:/snap/bin" corepack pnpm --filter @paperclipai/server build

## Notes
- Fork-local focused PR: https://github.com/cablackmon/paperclip/pull/1, base , head .
- That fork-local PR has not received Codex Code Review since 2026-05-20, so this upstream PR is opened to trigger the required review path.
- The upstream diff includes the local NOX-3505 sweep baseline because that sweep code was present in the local Paperclip source tree but not yet available on upstream .