### PR TITLE
fix(recovery): exempt ledger:append-only issues from stranded-assigned-issue recovery

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -27,6 +27,7 @@ import {
   issueTreeHolds,
   issueWorkProducts,
   issues,
+  labels,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -2119,6 +2120,12 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       status: "todo",
       runStatus: "failed",
       retryReason: "assignment_recovery",
+    });
+    await db.insert(labels).values({
+      id: "50fe2282-f62b-4f47-9d9c-1655370032e5",
+      companyId,
+      name: "ledger:append-only",
+      color: "#6b7280",
     });
     await db.insert(issueLabels).values({
       companyId,

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -20,6 +20,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueLabels,
   issueRecoveryActions,
   issueRelations,
   issueTreeHoldMembers,
@@ -2111,6 +2112,137 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(comments[0]?.body).toContain("Latest retry failure details were withheld from the issue thread");
     expect(comments[0]?.body).toContain(`Recovery action: \`${recoveryAction.id}\``);
     expect(comments[0]?.body).toContain("Recovery owner: [CodexCoder]");
+  });
+
+  it("skips reconciliation for ledger append-only issues", async () => {
+    const { companyId, issueId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+    });
+    await db.insert(issueLabels).values({
+      companyId,
+      issueId,
+      labelId: "50fe2282-f62b-4f47-9d9c-1655370032e5",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.assignmentDispatched).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("todo");
+    const actions = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(actions).toHaveLength(0);
+  });
+
+  it("skips reconciliation for recovery-exempt issues by description marker", async () => {
+    const { issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    await db
+      .update(issues)
+      .set({ description: "<!-- recovery-exempt: true -->\nPersistent ledger." })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.assignmentDispatched).toBe(0);
+    expect(result.dispatchRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    const actions = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(actions).toHaveLength(0);
+  });
+
+  it("prefers the prior non-PMO owner in reconciliation when the current assignee is the PMO Director", async () => {
+    const { companyId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "todo",
+      runStatus: "failed",
+      retryReason: "assignment_recovery",
+    });
+    const previousOwnerId = randomUUID();
+    const pmoDirectorId = "a6fdaf7e-3307-45c6-b68a-a4dc14a34028";
+    await db.insert(agents).values([
+      {
+        id: previousOwnerId,
+        companyId,
+        name: "Victor Obi",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: pmoDirectorId,
+        companyId,
+        name: "Nadia Chen",
+        role: "manager",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db
+      .update(issues)
+      .set({ assigneeAgentId: pmoDirectorId })
+      .where(eq(issues.id, issueId));
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "user",
+      actorId: "board-user",
+      agentId: null,
+      runId: null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        identifier: "reassigned",
+        assigneeAgentId: pmoDirectorId,
+        _previous: {
+          assigneeAgentId: previousOwnerId,
+        },
+      },
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const action = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(action).toMatchObject({
+      previousOwnerAgentId: previousOwnerId,
+      returnOwnerAgentId: previousOwnerId,
+    });
+    const recoveryWakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.reason, "source_scoped_recovery_action"));
+    expect(recoveryWakeups.some((wakeup) => (wakeup.payload as Record<string, unknown> | null)?.recoveryActionId === action?.id)).toBe(true);
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.assigneeAgentId).not.toBeNull();
+    expect(issue?.assigneeAgentId).not.toBe(pmoDirectorId);
+    expect(issue?.assigneeAgentId).toBe(previousOwnerId);
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(runs[0]?.id).toBe(runId);
   });
 
   it("blocks an already stranded recovery issue without creating a recovery child", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -13,6 +13,7 @@ import {
   environments,
   heartbeatRuns,
   issueComments,
+  issueLabels,
   issueRecoveryActions,
   issueRelations,
   issues,
@@ -192,6 +193,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       status: "in_progress",
       priority: "medium",
       assigneeAgentId: coderId,
+      description: null,
       issueNumber: 1,
       identifier: `${prefix}-1`,
     });
@@ -442,6 +444,141 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, sourceIssue.id));
     expect(comments).toHaveLength(1);
     expect(comments[0]?.body).toContain("Recovery action:");
+  });
+
+  it("skips stranded recovery for ledger append-only labeled issues", async () => {
+    const { companyId, coderId, sourceIssue } = await seedCompany();
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+    await db.insert(issueLabels).values({
+      companyId,
+      issueId: sourceIssue.id,
+      labelId: "50fe2282-f62b-4f47-9d9c-1655370032e5",
+    });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const actionRows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssue.id));
+    expect(actionRows).toHaveLength(0);
+    const [unchangedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssue.id));
+    expect(unchangedIssue?.status).toBe("in_progress");
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
+  it("skips stranded recovery for issues marked recovery-exempt in the description", async () => {
+    const { coderId, sourceIssueId } = await seedCompany();
+    await db
+      .update(issues)
+      .set({ description: "<!-- recovery-exempt: true -->\nPersistent ledger." })
+      .where(eq(issues.id, sourceIssueId));
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue!,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: coderId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const actionRows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssueId));
+    expect(actionRows).toHaveLength(0);
+    const [unchangedIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    expect(unchangedIssue?.status).toBe("in_progress");
+    expect(enqueueWakeup).not.toHaveBeenCalled();
+  });
+
+  it("prefers the prior non-PMO owner when the current assignee is the PMO Director", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    const pmoDirectorId = "a6fdaf7e-3307-45c6-b68a-a4dc14a34028";
+    await db.insert(agents).values({
+      id: pmoDirectorId,
+      companyId,
+      name: "Nadia Chen",
+      role: "manager",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db
+      .update(issues)
+      .set({ assigneeAgentId: pmoDirectorId })
+      .where(eq(issues.id, sourceIssueId));
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "user",
+      actorId: "board-user",
+      agentId: null,
+      runId: null,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: sourceIssueId,
+      details: {
+        identifier: "reassigned",
+        assigneeAgentId: pmoDirectorId,
+        _previous: {
+          assigneeAgentId: coderId,
+        },
+      },
+    });
+    const [sourceIssue] = await db.select().from(issues).where(eq(issues.id, sourceIssueId));
+    const enqueueWakeup = vi.fn(async () => null);
+    const recovery = recoveryService(db, { enqueueWakeup });
+
+    await recovery.escalateStrandedAssignedIssue({
+      issue: sourceIssue!,
+      previousStatus: "in_progress",
+      latestRun: {
+        id: randomUUID(),
+        agentId: pmoDirectorId,
+        status: "failed",
+        error: "adapter failed",
+        errorCode: "adapter_failed",
+        contextSnapshot: { retryReason: "issue_continuation_needed" },
+        livenessState: "needs_followup",
+      },
+      comment: "Automatic continuation recovery failed.",
+    });
+
+    const [actionRow] = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, sourceIssueId));
+    expect(actionRow).toMatchObject({
+      ownerAgentId: managerId,
+      previousOwnerAgentId: coderId,
+      returnOwnerAgentId: coderId,
+    });
   });
 
   it("does not create nested recovery artifacts when issue-backed fallback work itself fails", async () => {

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -17,6 +17,7 @@ import {
   issueRecoveryActions,
   issueRelations,
   issues,
+  labels,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -450,6 +451,12 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const { companyId, coderId, sourceIssue } = await seedCompany();
     const enqueueWakeup = vi.fn(async () => null);
     const recovery = recoveryService(db, { enqueueWakeup });
+    await db.insert(labels).values({
+      id: "50fe2282-f62b-4f47-9d9c-1655370032e5",
+      companyId,
+      name: "ledger:append-only",
+      color: "#6b7280",
+    });
     await db.insert(issueLabels).values({
       companyId,
       issueId: sourceIssue.id,

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -18,6 +18,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueApprovals,
+  issueLabels,
   issueRecoveryActions,
   issueRelations,
   issueThreadInteractions,
@@ -79,6 +80,9 @@ const SESSIONED_LOCAL_ADAPTERS = new Set([
   "opencode_local",
   "pi_local",
 ]);
+const LEDGER_APPEND_ONLY_LABEL_ID = "50fe2282-f62b-4f47-9d9c-1655370032e5";
+const RECOVERY_EXEMPT_DESCRIPTION_MARKER = "<!-- recovery-exempt: true -->";
+const PMO_DIRECTOR_AGENT_ID = "a6fdaf7e-3307-45c6-b68a-a4dc14a34028";
 
 type RecoveryWakeupOptions = {
   source?: "timer" | "assignment" | "on_demand" | "automation";
@@ -1743,7 +1747,60 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     ].join("\n");
   }
 
+  async function issueHasStrandedRecoveryExemption(issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "description">) {
+    if (issue.description?.includes(RECOVERY_EXEMPT_DESCRIPTION_MARKER)) return true;
+    const [labelRow] = await db
+      .select({ issueId: issueLabels.issueId })
+      .from(issueLabels)
+      .where(
+        and(
+          eq(issueLabels.companyId, issue.companyId),
+          eq(issueLabels.issueId, issue.id),
+          eq(issueLabels.labelId, LEDGER_APPEND_ONLY_LABEL_ID),
+        ),
+      )
+      .limit(1);
+    return Boolean(labelRow);
+  }
+
+  async function findPriorNonPmoOwnerAgentId(issue: Pick<typeof issues.$inferSelect, "id" | "companyId" | "assigneeAgentId">) {
+    const rows = await db
+      .select({ details: activityLog.details })
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, issue.companyId),
+          eq(activityLog.entityType, "issue"),
+          eq(activityLog.entityId, issue.id),
+          eq(activityLog.action, "issue.updated"),
+        ),
+      )
+      .orderBy(desc(activityLog.createdAt), desc(activityLog.id))
+      .limit(100);
+
+    for (const row of rows) {
+      const details = parseObject(row.details);
+      const currentAssigneeAgentId = readNonEmptyString(details.assigneeAgentId);
+      const previous = parseObject(details._previous);
+      const previousAssigneeAgentId = readNonEmptyString(previous.assigneeAgentId);
+      if (
+        issue.assigneeAgentId &&
+        currentAssigneeAgentId === issue.assigneeAgentId &&
+        previousAssigneeAgentId &&
+        previousAssigneeAgentId !== issue.assigneeAgentId &&
+        previousAssigneeAgentId !== PMO_DIRECTOR_AGENT_ID
+      ) {
+        return previousAssigneeAgentId;
+      }
+    }
+
+    return issue.assigneeAgentId && issue.assigneeAgentId !== PMO_DIRECTOR_AGENT_ID
+      ? issue.assigneeAgentId
+      : null;
+  }
+
   async function resolveStrandedIssueRecoveryOwnerAgentId(issue: typeof issues.$inferSelect) {
+    const preferredReturnOwnerAgentId = await findPriorNonPmoOwnerAgentId(issue);
     const candidateIds: string[] = [];
     if (issue.assigneeAgentId) {
       const assignee = await getAgent(issue.assigneeAgentId);
@@ -1761,6 +1818,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .where(and(eq(agents.companyId, issue.companyId), inArray(agents.role, ["cto", "ceo"])))
       .orderBy(sql`case when ${agents.role} = 'cto' then 0 else 1 end`, asc(agents.createdAt));
     candidateIds.push(...roleCandidates.map((agent) => agent.id));
+    if (preferredReturnOwnerAgentId) candidateIds.push(preferredReturnOwnerAgentId);
     if (issue.assigneeAgentId) candidateIds.push(issue.assigneeAgentId);
 
     const seen = new Set<string>();
@@ -1989,6 +2047,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";
+    const preferredReturnOwnerAgentId = await findPriorNonPmoOwnerAgentId(input.issue);
     const ownerAgentId = await resolveStrandedIssueRecoveryOwnerAgentId(input.issue);
     const now = new Date();
     const action = await recoveryActionsSvc.upsertSourceScoped({
@@ -1997,8 +2056,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       kind: strandedRecoveryActionKind(recoveryCause),
       ownerType: ownerAgentId ? "agent" : "board",
       ownerAgentId,
-      previousOwnerAgentId: input.issue.assigneeAgentId,
-      returnOwnerAgentId: input.issue.assigneeAgentId,
+      previousOwnerAgentId: preferredReturnOwnerAgentId ?? input.issue.assigneeAgentId,
+      returnOwnerAgentId: preferredReturnOwnerAgentId ?? input.issue.assigneeAgentId,
       cause: recoveryCause,
       fingerprint: strandedRecoveryActionFingerprint({
         issue: input.issue,
@@ -2183,6 +2242,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     recoveryCause?: StrandedRecoveryCause;
     successfulRunHandoffEvidence?: SuccessfulRunHandoffRecoveryEvidence | null;
   }) {
+    if (await issueHasStrandedRecoveryExemption(input.issue)) {
+      return input.issue;
+    }
+
     if (isStrandedIssueRecoveryIssue(input.issue)) {
       return escalateStrandedRecoveryIssueInPlace({
         issue: input.issue,
@@ -2372,6 +2435,11 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
       const agent = await getAgent(agentId);
       if (!agent || agent.companyId !== issue.companyId || !isAgentInvokable(agent)) {
+        result.skipped += 1;
+        continue;
+      }
+
+      if (await issueHasStrandedRecoveryExemption(issue)) {
         result.skipped += 1;
         continue;
       }


### PR DESCRIPTION
## Summary

The stranded-assigned-issue recovery cycle was incorrectly reassigning [PRO-5172](https://app.paperclip.ing/PRO/issues/PRO-5172) — a T1 Sweep Ledger designed to stay `in_progress` forever — because the recovery logic had no way to distinguish a genuinely abandoned issue from a long-lived append-only ledger.

This PR adds a label-based (and description-marker-based) exemption so append-only ledgers are skipped entirely by the recovery cycle.

## Changes

### `server/src/services/recovery/service.ts`
- Add `issueHasStrandedRecoveryExemption()`: returns `true` when an issue carries the `ledger:append-only` label (`50fe2282-f62b-4f47-9d9c-1655370032e5`) or has `<!-- recovery-exempt: true -->` in its description.
- Apply the exemption gate in **both** execution paths:
  - `escalateStrandedAssignedIssueImpl` (direct escalation)
  - `reconcileStrandedAssignedIssues` (periodic sweep)
- Add `findPriorNonPmoOwnerAgentId()` defence-in-depth: when recovery fires on a non-exempt issue whose current assignee is the PMO Director, use the prior non-PMO owner for `previousOwnerAgentId` / `returnOwnerAgentId` so the issue returns to the real owner.

### `server/src/__tests__/issue-recovery-actions.test.ts`
New regression tests:
- Label-based exemption blocks `escalateStrandedAssignedIssue`
- Description-marker exemption blocks `escalateStrandedAssignedIssue`
- Prior non-PMO owner is preferred for `previousOwnerAgentId` / `returnOwnerAgentId`

### `server/src/__tests__/heartbeat-process-recovery.test.ts`
New regression tests:
- Label-based exemption skips `reconcileStrandedAssignedIssues`
- Description-marker exemption skips `reconcileStrandedAssignedIssues`
- Prior non-PMO owner preference in the reconciliation sweep

## Related

- PRO-5271: Code fix issue this PR resolves
- PRO-5263: Parent implementation issue
- PRO-5260: Top-level incident
- PRO-5172: Append-only ledger issue that was misfiring