### PR TITLE
fix(server): make logActivity post-commit-safe (PLA-9)

### DIFF
--- a/doc/route-response-rules.md
+++ b/doc/route-response-rules.md
@@ -1,0 +1,65 @@
+# Route response rules
+
+Short, repo-canonical rules for mutating HTTP routes. The bugs that motivated
+these rules are PLA-9 and PLA-12: routes that wrote a side effect, then threw
+in a post-commit step, returned a 5xx to the caller, and triggered client
+retries that produced duplicate rows.
+
+## Rule 1 — Commit the side effect, then format the response
+
+Order every mutating handler as:
+
+1. Validate input.
+2. Resolve required entities (404 if missing).
+3. Perform the irreversible side effect (DB write, filesystem write, etc.).
+4. Best-effort post-commit work (observability, telemetry, plugin events).
+5. Serialize the response.
+
+Steps 1–3 may throw — the error response is the right outcome there. Steps 4–5
+must not throw on top of a successful step 3. If something between the commit
+and the response throws, the caller sees a 5xx for a request whose side effect
+actually succeeded, and a retrying client will create duplicates.
+
+If step 5 (serialization) can fail, the route must either:
+
+- Construct the payload from already-committed state in a way that can't fail
+  (e.g. echo back exactly what was written), or
+- Wrap serialization in a try/catch that returns 201 with a minimal payload
+  rather than a 5xx, since the change has already happened.
+
+## Rule 2 — Observability must never fail the request
+
+`logActivity` is observability bookkeeping. By the time it runs, the side
+effect is already committed. It must never throw. The function is implemented
+to swallow and warn on failure for that reason — do not "fix" that try/catch.
+
+Foreign-key constraints on observability tables (e.g.
+`activity_log.run_id → heartbeat_runs.id`) are best-effort: a stale or
+unknown run id should produce a warning, not a 5xx for the caller. The same
+principle applies to:
+
+- `publishLiveEvent`
+- `publishPluginDomainEvent`
+- `getTelemetryClient()` + `track*` calls
+
+If you add a new post-commit hook, wrap it.
+
+## Rule 3 — Retries must be idempotent at the protocol level
+
+Mutating endpoints that callers can legitimately retry must accept a
+client-supplied idempotency key on the request and dedupe server-side. Do
+not rely on "the client should not retry" — clients do retry, especially on
+5xx. PLA-14 owns the cross-cutting work for this.
+
+## Why these rules exist
+
+- **PLA-9** — `POST /api/companies/:companyId/agent-hires` returned 500 on a
+  successful create because `logActivity` blew up on an FK violation against
+  `heartbeat_runs`. Caller retried; one BizOps hire produced five duplicate
+  agent rows.
+- **PLA-12** — generalize the same shape across other mutating routes.
+- **PLA-14** — add client-supplied idempotency keys so even when a 5xx slips
+  through, the retry is safe.
+
+If you find yourself fixing this same bug in a fourth place, the fix belongs
+in the shared helper, not the route.

--- a/server/src/__tests__/activity-log-resilience.test.ts
+++ b/server/src/__tests__/activity-log-resilience.test.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { activityLog, companies, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { logActivity } from "../services/activity-log.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres activity-log resilience tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("logActivity post-commit resilience (PLA-9)", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-activity-log-resilience-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("does not throw when runId references a non-existent heartbeat run", async () => {
+    // This is the exact bug from PLA-9: a request carrying an X-Paperclip-Run-Id
+    // header whose value is not a real heartbeat_runs.id used to make logActivity
+    // throw a FK violation. Because logActivity ran AFTER the route's side
+    // effect already committed, callers got a 500, retried, and produced
+    // duplicate writes (e.g. 5 duplicate BizOps agents).
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const danglingRunId = randomUUID();
+
+    await expect(
+      logActivity(db, {
+        companyId,
+        actorType: "agent",
+        actorId: randomUUID(),
+        action: "test.regression.pla9",
+        entityType: "agent",
+        entityId: randomUUID(),
+        agentId: null,
+        runId: danglingRunId,
+        details: { note: "dangling run id should not fail the request" },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("writes the row when the runId is null", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await logActivity(db, {
+      companyId,
+      actorType: "user",
+      actorId: "board",
+      action: "test.regression.pla9.null-run",
+      entityType: "company",
+      entityId: companyId,
+      runId: null,
+    });
+
+    const rows = await db.select().from(activityLog);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      companyId,
+      action: "test.regression.pla9.null-run",
+      runId: null,
+    });
+  });
+});

--- a/server/src/services/activity-log.ts
+++ b/server/src/services/activity-log.ts
@@ -63,29 +63,22 @@ export interface LogActivityInput {
 }
 
 export async function logActivity(db: Db, input: LogActivityInput) {
-  const currentUserRedactionOptions = {
-    enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
-  };
-  const sanitizedDetails = input.details ? sanitizeRecord(input.details) : null;
-  const redactedDetails = sanitizedDetails
-    ? redactCurrentUserValue(sanitizedDetails, currentUserRedactionOptions)
-    : null;
-  await db.insert(activityLog).values({
-    companyId: input.companyId,
-    actorType: input.actorType,
-    actorId: input.actorId,
-    action: input.action,
-    entityType: input.entityType,
-    entityId: input.entityId,
-    agentId: input.agentId ?? null,
-    runId: input.runId ?? null,
-    details: redactedDetails,
-  });
-
-  publishLiveEvent({
-    companyId: input.companyId,
-    type: "activity.logged",
-    payload: {
+  // Activity log writes are post-side-effect observability. They must never
+  // fail the calling request: by the time we reach here the work has already
+  // been committed, and a thrown error here would surface as a 500 to the
+  // client after the change has persisted (see PLA-9: FK violation on
+  // activity_log.run_id produced 500s on successful agent-hires, which
+  // triggered client retries and duplicate agent rows).
+  try {
+    const currentUserRedactionOptions = {
+      enabled: (await instanceSettingsService(db).getGeneral()).censorUsernameInLogs,
+    };
+    const sanitizedDetails = input.details ? sanitizeRecord(input.details) : null;
+    const redactedDetails = sanitizedDetails
+      ? redactCurrentUserValue(sanitizedDetails, currentUserRedactionOptions)
+      : null;
+    await db.insert(activityLog).values({
+      companyId: input.companyId,
       actorType: input.actorType,
       actorId: input.actorId,
       action: input.action,
@@ -94,26 +87,53 @@ export async function logActivity(db: Db, input: LogActivityInput) {
       agentId: input.agentId ?? null,
       runId: input.runId ?? null,
       details: redactedDetails,
-    },
-  });
+    });
 
-  const pluginEventType = eventTypeForActivityAction(input.action);
-  if (pluginEventType) {
-    const event: PluginEvent = {
-      eventId: randomUUID(),
-      eventType: pluginEventType,
-      occurredAt: new Date().toISOString(),
-      actorId: input.actorId,
-      actorType: input.actorType,
-      entityId: input.entityId,
-      entityType: input.entityType,
+    publishLiveEvent({
       companyId: input.companyId,
+      type: "activity.logged",
       payload: {
-        ...redactedDetails,
+        actorType: input.actorType,
+        actorId: input.actorId,
+        action: input.action,
+        entityType: input.entityType,
+        entityId: input.entityId,
         agentId: input.agentId ?? null,
         runId: input.runId ?? null,
+        details: redactedDetails,
       },
-    };
-    publishPluginDomainEvent(event);
+    });
+
+    const pluginEventType = eventTypeForActivityAction(input.action);
+    if (pluginEventType) {
+      const event: PluginEvent = {
+        eventId: randomUUID(),
+        eventType: pluginEventType,
+        occurredAt: new Date().toISOString(),
+        actorId: input.actorId,
+        actorType: input.actorType,
+        entityId: input.entityId,
+        entityType: input.entityType,
+        companyId: input.companyId,
+        payload: {
+          ...redactedDetails,
+          agentId: input.agentId ?? null,
+          runId: input.runId ?? null,
+        },
+      };
+      publishPluginDomainEvent(event);
+    }
+  } catch (err) {
+    logger.warn(
+      {
+        err,
+        action: input.action,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        companyId: input.companyId,
+        runId: input.runId ?? null,
+      },
+      "logActivity failed; suppressing to keep post-commit response path stable",
+    );
   }
 }


### PR DESCRIPTION
## Summary

Fix `POST /api/companies/:companyId/agent-hires` (and all other mutating routes) returning HTTP 500 after a successful create, which triggered retry loops and duplicate-agent storms.

**Root cause:** `logActivity()` runs after the main transaction commits. When the incoming `X-Paperclip-Run-Id` header pointed at a `heartbeat_runs` row that no longer existed, `INSERT INTO activity_log (run_id, …)` blew up with PostgresError `23503` (FK violation). The committed side effect (agent row + `AGENTS.md` on disk) was already durable, but the response handler threw before sending 201, the caller retried on the 5xx, and every retry produced another duplicate agent.

**Evidence (PLA-9 in the Paperclip board):** one BizOps hire on 2026-05-23 14:20 produced 5 duplicate agents within 60 seconds: `7062a84e`, `ae43a490`, `d0455b33`, `4eb691cd`, `9a259765`.

## Fix

Pattern fix, not endpoint-specific. `logActivity` is post-commit observability and must never fail the caller:

- `server/src/services/activity-log.ts` — wrap the insert in a single `try/catch`, log a warning on failure, return successfully. Same fix benefits all 170+ callers.

## Tests

- `server/src/__tests__/activity-log-resilience.test.ts` — regression test. Fails on master with `PostgresError 23503`; passes after the fix.

## Docs

- `doc/route-response-rules.md` — short repo-canonical rule: "commit side effect, then format response" and "observability must never fail the request." Referenced by future audits (Paperclip PLA-12 broad route audit, PLA-14 idempotency).

## Test plan

- [ ] CI passes
- [ ] Manual: hire an agent against a stale `X-Paperclip-Run-Id` — endpoint returns 201, no duplicate, warning in logs
- [ ] No regression on the happy path (valid run id)

## Notes

Authored by an autonomous Paperclip agent (Engineer 1). Code review by Head of Engineering inside the Paperclip board. Opened from `jondahl/paperclip` because the agent does not have push access to `paperclipai/paperclip`; the human CEO authorized the fork path via a Paperclip `request_confirmation`.

Co-Authored-By: Paperclip <noreply@paperclip.ing>
