### PR TITLE
feat(server): grantable agents:pause and agents:terminate (PLA-54)

### DIFF
--- a/docs/api/agents.md
+++ b/docs/api/agents.md
@@ -85,6 +85,11 @@ POST /api/agents/{agentId}/pause
 
 Temporarily stops heartbeats for the agent.
 
+Requires the `agents:pause` permission key. Granted by default to the `owner` and `admin`
+roles via human-role default grants. CEO agents (`role === "ceo"`) retain the
+existing legacy authority and may pause agents in their own company without an
+explicit grant.
+
 ## Resume Agent
 
 ```
@@ -100,6 +105,22 @@ POST /api/agents/{agentId}/terminate
 ```
 
 Permanently deactivates the agent. **Irreversible.**
+
+Requires the `agents:terminate` permission key. Granted by default to the
+`owner` and `admin` roles. CEO agents may terminate agents in their own
+company via the legacy authority path.
+
+## Permission Keys for Agent Mutations
+
+| Key                | Default grants (human roles) | Unlocks                                                                 |
+| ------------------ | ---------------------------- | ----------------------------------------------------------------------- |
+| `agents:create`    | `owner`, `admin`             | Create agents in the company.                                           |
+| `agents:pause`     | `owner`, `admin`             | Pause an agent in the actor's company via `POST /api/agents/{id}/pause`. |
+| `agents:terminate` | `owner`, `admin`             | Terminate an agent in the actor's company via `POST /api/agents/{id}/terminate`. |
+
+A CEO agent (`role === "ceo"`) also passes the `agents:create`, `agents:pause`,
+and `agents:terminate` checks via legacy authority, even without explicit
+grants. Cross-company calls are always rejected.
 
 ## Create API Key
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -653,6 +653,8 @@ export type JoinRequestStatus = (typeof JOIN_REQUEST_STATUSES)[number];
 
 export const PERMISSION_KEYS = [
   "agents:create",
+  "agents:pause",
+  "agents:terminate",
   "environments:manage",
   "users:invite",
   "users:manage_permissions",

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -47,6 +47,8 @@ const mockAgentService = vi.hoisted(() => ({
   updatePermissions: vi.fn(),
   getChainOfCommand: vi.fn(),
   resolveByReference: vi.fn(),
+  pause: vi.fn(),
+  terminate: vi.fn(),
 }));
 
 const mockAccessService = vi.hoisted(() => ({
@@ -73,6 +75,7 @@ const mockHeartbeatService = vi.hoisted(() => ({
   resetRuntimeSession: vi.fn(),
   getRun: vi.fn(),
   cancelRun: vi.fn(),
+  cancelActiveForAgent: vi.fn(),
 }));
 
 const mockIssueApprovalService = vi.hoisted(() => ({
@@ -302,6 +305,8 @@ describe.sequential("agent permission routes", () => {
     mockAgentService.updatePermissions.mockReset();
     mockAgentService.getChainOfCommand.mockReset();
     mockAgentService.resolveByReference.mockReset();
+    mockAgentService.pause.mockReset();
+    mockAgentService.terminate.mockReset();
     mockAccessService.canUser.mockReset();
     mockAccessService.decide.mockReset();
     mockAccessService.hasPermission.mockReset();
@@ -316,6 +321,7 @@ describe.sequential("agent permission routes", () => {
     mockHeartbeatService.resetRuntimeSession.mockReset();
     mockHeartbeatService.getRun.mockReset();
     mockHeartbeatService.cancelRun.mockReset();
+    mockHeartbeatService.cancelActiveForAgent.mockReset();
     mockIssueApprovalService.linkManyForApproval.mockReset();
     mockIssueService.list.mockReset();
     mockSecretService.normalizeAdapterConfigForPersistence.mockReset();
@@ -1437,6 +1443,170 @@ describe.sequential("agent permission routes", () => {
       inboxArchivedByUserId: "board-user",
       status: "backlog,todo,in_progress,in_review,blocked,done",
       limit: 500,
+    });
+  });
+
+  describe("agents:pause / agents:terminate permission gates", () => {
+    function mockDecideReturning(allowed: boolean, action: string) {
+      mockAccessService.decide.mockImplementation(async (input: { action?: string }) => ({
+        allowed: input.action === action ? allowed : false,
+        reason: allowed ? "allow_explicit_grant" : "deny_missing_grant",
+        explanation: allowed ? "Allowed by test grant" : `Missing permission: ${input.action ?? "action"}`,
+      }));
+    }
+
+    function targetAgent() {
+      return { ...baseAgent };
+    }
+
+    it("allows pause when access.decide grants agents:pause for the actor (board user)", async () => {
+      mockAgentService.getById.mockResolvedValue(targetAgent());
+      mockAgentService.pause.mockResolvedValue(targetAgent());
+      mockDecideReturning(true, "agents:pause");
+
+      const app = await createApp({
+        type: "board",
+        userId: "ceo-human",
+        source: "session",
+        isInstanceAdmin: false,
+        companyIds: [companyId],
+      });
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).post(`/api/agents/${agentId}/pause`).send({}),
+      );
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(mockAccessService.decide).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "agents:pause" }),
+      );
+      expect(mockAgentService.pause).toHaveBeenCalledWith(agentId);
+      expect(mockHeartbeatService.cancelActiveForAgent).toHaveBeenCalledWith(agentId);
+    });
+
+    it("allows terminate when access.decide grants agents:terminate for the actor (board user)", async () => {
+      mockAgentService.getById.mockResolvedValue(targetAgent());
+      mockAgentService.terminate.mockResolvedValue(targetAgent());
+      mockDecideReturning(true, "agents:terminate");
+
+      const app = await createApp({
+        type: "board",
+        userId: "head-of-people-human",
+        source: "session",
+        isInstanceAdmin: false,
+        companyIds: [companyId],
+      });
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).post(`/api/agents/${agentId}/terminate`).send({}),
+      );
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(mockAccessService.decide).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "agents:terminate" }),
+      );
+    });
+
+    it("allows a CEO-authenticated agent to pause via access.decide allow", async () => {
+      mockAgentService.getById.mockResolvedValue(targetAgent());
+      mockAgentService.pause.mockResolvedValue(targetAgent());
+      mockDecideReturning(true, "agents:pause");
+
+      const app = await createApp({
+        type: "agent",
+        agentId: "ceo-agent-id",
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      });
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).post(`/api/agents/${agentId}/pause`).send({}),
+      );
+
+      expect(res.status, JSON.stringify(res.body)).toBe(200);
+      expect(mockAccessService.decide).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "agents:pause",
+          actor: expect.objectContaining({ type: "agent", agentId: "ceo-agent-id" }),
+        }),
+      );
+    });
+
+    it("rejects pause for an IC engineer agent without the grant (no access.decide allow)", async () => {
+      mockAgentService.getById.mockResolvedValue(targetAgent());
+      mockDecideReturning(false, "agents:pause");
+
+      const app = await createApp({
+        type: "agent",
+        agentId: "ic-engineer-id",
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      });
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).post(`/api/agents/${agentId}/pause`).send({}),
+      );
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toContain("agents:pause");
+      expect(mockAgentService.pause).not.toHaveBeenCalled();
+      expect(mockHeartbeatService.cancelActiveForAgent).not.toHaveBeenCalled();
+    });
+
+    it("rejects terminate for an IC engineer agent without the grant", async () => {
+      mockAgentService.getById.mockResolvedValue(targetAgent());
+      mockDecideReturning(false, "agents:terminate");
+
+      const app = await createApp({
+        type: "agent",
+        agentId: "ic-engineer-id",
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      });
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).post(`/api/agents/${agentId}/terminate`).send({}),
+      );
+
+      expect(res.status).toBe(403);
+      expect(res.body.error).toContain("agents:terminate");
+      expect(mockAgentService.terminate).not.toHaveBeenCalled();
+    });
+
+    it("rejects pause when the target agent belongs to a different company than the actor", async () => {
+      const otherCompany = "44444444-4444-4444-8444-444444444444";
+      mockAgentService.getById.mockResolvedValue({ ...targetAgent(), companyId: otherCompany });
+      mockDecideReturning(true, "agents:pause");
+
+      const app = await createApp({
+        type: "agent",
+        agentId: "ceo-agent-id",
+        companyId,
+        source: "agent_key",
+        runId: "run-1",
+      });
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).post(`/api/agents/${agentId}/pause`).send({}),
+      );
+
+      expect(res.status).toBe(403);
+      expect(mockAgentService.pause).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the target agent does not exist", async () => {
+      mockAgentService.getById.mockResolvedValue(null);
+
+      const app = await createApp({
+        type: "board",
+        userId: "ceo-human",
+        source: "session",
+        isInstanceAdmin: false,
+        companyIds: [companyId],
+      });
+      const res = await requestApp(app, (baseUrl) =>
+        request(baseUrl).post(`/api/agents/${agentId}/pause`).send({}),
+      );
+
+      expect(res.status).toBe(404);
+      expect(mockAccessService.decide).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -397,6 +397,105 @@ describeEmbeddedPostgres("authorization service", () => {
     });
   });
 
+  it("allows CEO agent to pause and terminate via legacy authority", async () => {
+    const company = await createCompany(db, "LegacyPauseTerminate");
+    const ceoAgent = await createAgent(db, company.id, { role: "ceo" });
+    const targetAgent = await createAgent(db, company.id, { role: "engineer" });
+
+    for (const action of ["agents:pause", "agents:terminate"] as const) {
+      const decision = await authorizationService(db).decide({
+        actor: { type: "agent", agentId: ceoAgent.id, companyId: company.id, source: "agent_jwt" },
+        action,
+        resource: { type: "agent", companyId: company.id, agentId: targetAgent.id },
+      });
+      expect(decision, action).toMatchObject({
+        allowed: true,
+        reason: "allow_legacy_agent_creator",
+      });
+    }
+  });
+
+  it("denies pause/terminate for an engineer IC agent without explicit grant", async () => {
+    const company = await createCompany(db, "ICDenyPauseTerminate");
+    const actorAgent = await createAgent(db, company.id, { role: "engineer" });
+    const targetAgent = await createAgent(db, company.id, { role: "engineer" });
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "agent",
+      principalId: actorAgent.id,
+      status: "active",
+      membershipRole: "member",
+    });
+
+    for (const action of ["agents:pause", "agents:terminate"] as const) {
+      const decision = await authorizationService(db).decide({
+        actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_jwt" },
+        action,
+        resource: { type: "agent", companyId: company.id, agentId: targetAgent.id },
+      });
+      expect(decision.allowed, action).toBe(false);
+      expect(decision.reason, action).toBe("deny_missing_grant");
+    }
+  });
+
+  it("allows pause/terminate via explicit principal grants", async () => {
+    const company = await createCompany(db, "ExplicitPauseTerminate");
+    const actorAgent = await createAgent(db, company.id, { role: "engineer" });
+    const targetAgent = await createAgent(db, company.id, { role: "engineer" });
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "agent",
+      principalId: actorAgent.id,
+      status: "active",
+      membershipRole: "member",
+    });
+    await db.insert(principalPermissionGrants).values([
+      {
+        companyId: company.id,
+        principalType: "agent",
+        principalId: actorAgent.id,
+        permissionKey: "agents:pause",
+        grantedByUserId: null,
+      },
+      {
+        companyId: company.id,
+        principalType: "agent",
+        principalId: actorAgent.id,
+        permissionKey: "agents:terminate",
+        grantedByUserId: null,
+      },
+    ]);
+
+    for (const action of ["agents:pause", "agents:terminate"] as const) {
+      const decision = await authorizationService(db).decide({
+        actor: { type: "agent", agentId: actorAgent.id, companyId: company.id, source: "agent_jwt" },
+        action,
+        resource: { type: "agent", companyId: company.id, agentId: targetAgent.id },
+      });
+      expect(decision.allowed, action).toBe(true);
+      expect(decision.reason, action).toBe("allow_explicit_grant");
+      expect(decision.grant?.permissionKey, action).toBe(action);
+    }
+  });
+
+  it("denies pause/terminate across company boundaries even for a CEO agent", async () => {
+    const sourceCompany = await createCompany(db, "CrossPauseSource");
+    const targetCompany = await createCompany(db, "CrossPauseTarget");
+    const ceoAgent = await createAgent(db, sourceCompany.id, { role: "ceo" });
+    const targetAgent = await createAgent(db, targetCompany.id, { role: "engineer" });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: ceoAgent.id, companyId: sourceCompany.id, source: "agent_jwt" },
+      action: "agents:terminate",
+      resource: { type: "agent", companyId: targetCompany.id, agentId: targetAgent.id },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      reason: "deny_company_boundary",
+    });
+  });
+
   it("allows scoped assignment inside a granted project and denies other projects", async () => {
     const company = await createCompany(db, "ProjectScope");
     const project = await createProject(db, company.id, "Allowed");

--- a/server/src/__tests__/invite-join-grants.test.ts
+++ b/server/src/__tests__/invite-join-grants.test.ts
@@ -68,6 +68,8 @@ describe("human invite roles", () => {
   it("maps owner to the full management grant set", () => {
     expect(grantsForHumanRole("owner")).toEqual([
       { permissionKey: "agents:create", scope: null },
+      { permissionKey: "agents:pause", scope: null },
+      { permissionKey: "agents:terminate", scope: null },
       { permissionKey: "environments:manage", scope: null },
       { permissionKey: "users:invite", scope: null },
       { permissionKey: "users:manage_permissions", scope: null },
@@ -79,6 +81,8 @@ describe("human invite roles", () => {
   it("maps admin to management grants including environment management", () => {
     expect(grantsForHumanRole("admin")).toEqual([
       { permissionKey: "agents:create", scope: null },
+      { permissionKey: "agents:pause", scope: null },
+      { permissionKey: "agents:terminate", scope: null },
       { permissionKey: "environments:manage", scope: null },
       { permissionKey: "users:invite", scope: null },
       { permissionKey: "tasks:assign", scope: null },

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2692,11 +2692,22 @@ export function agentRoutes(
   });
 
   router.post("/agents/:id/pause", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
-    if (!(await getAccessibleAgent(req, res, id))) {
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Agent not found" });
       return;
     }
+    assertCompanyAccess(req, existing.companyId);
+    const decision = await access.decide({
+      actor: req.actor,
+      action: "agents:pause",
+      resource: { type: "agent", companyId: existing.companyId, agentId: existing.id },
+    });
+    if (!decision.allowed) {
+      throw forbidden(decision.explanation);
+    }
+
     const agent = await svc.pause(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
@@ -2707,8 +2718,8 @@ export function agentRoutes(
 
     await logActivity(db, {
       companyId: agent.companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
+      actorType: req.actor.type === "agent" ? "agent" : "user",
+      actorId: req.actor.type === "agent" ? (req.actor.agentId ?? "agent") : (req.actor.userId ?? "board"),
       action: "agent.paused",
       entityType: "agent",
       entityId: agent.id,
@@ -2777,11 +2788,22 @@ export function agentRoutes(
   });
 
   router.post("/agents/:id/terminate", async (req, res) => {
-    assertBoard(req);
     const id = req.params.id as string;
-    if (!(await getAccessibleAgent(req, res, id))) {
+    const existing = await svc.getById(id);
+    if (!existing) {
+      res.status(404).json({ error: "Agent not found" });
       return;
     }
+    assertCompanyAccess(req, existing.companyId);
+    const decision = await access.decide({
+      actor: req.actor,
+      action: "agents:terminate",
+      resource: { type: "agent", companyId: existing.companyId, agentId: existing.id },
+    });
+    if (!decision.allowed) {
+      throw forbidden(decision.explanation);
+    }
+
     const agent = await svc.terminate(id);
     if (!agent) {
       res.status(404).json({ error: "Agent not found" });
@@ -2792,8 +2814,8 @@ export function agentRoutes(
 
     await logActivity(db, {
       companyId: agent.companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
+      actorType: req.actor.type === "agent" ? "agent" : "user",
+      actorId: req.actor.type === "agent" ? (req.actor.agentId ?? "agent") : (req.actor.userId ?? "board"),
       action: "agent.terminated",
       entityType: "agent",
       entityId: agent.id,

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -782,6 +782,8 @@ export function authorizationService(db: Db) {
 
     if (
       (input.action === "agents:create" ||
+        input.action === "agents:pause" ||
+        input.action === "agents:terminate" ||
         input.action === "agent_config:read" ||
         input.action === "agent_config:update" ||
         input.action === "tasks:manage_active_checkouts") &&

--- a/server/src/services/company-member-roles.ts
+++ b/server/src/services/company-member-roles.ts
@@ -28,6 +28,8 @@ export function grantsForHumanRole(
     case "owner":
       return [
         { permissionKey: "agents:create", scope: null },
+        { permissionKey: "agents:pause", scope: null },
+        { permissionKey: "agents:terminate", scope: null },
         { permissionKey: "environments:manage", scope: null },
         { permissionKey: "users:invite", scope: null },
         { permissionKey: "users:manage_permissions", scope: null },
@@ -37,6 +39,8 @@ export function grantsForHumanRole(
     case "admin":
       return [
         { permissionKey: "agents:create", scope: null },
+        { permissionKey: "agents:pause", scope: null },
+        { permissionKey: "agents:terminate", scope: null },
         { permissionKey: "environments:manage", scope: null },
         { permissionKey: "users:invite", scope: null },
         { permissionKey: "tasks:assign", scope: null },


### PR DESCRIPTION
## Summary

Closes [PLA-54](/PLA/issues/PLA-54). Replaces the hardcoded `assertBoard(req)` checks on `/api/agents/{id}/pause` and `/api/agents/{id}/terminate` with grantable, principal-aware `access.decide` checks. Mirrors the existing `agents:create` wiring.

- New permission keys: `agents:pause`, `agents:terminate` in `PERMISSION_KEYS`.
- Default grants for `owner` and `admin` human roles (lines 30 / 39 of `company-member-roles.ts`, where `agents:create` already lives).
- Legacy CEO agent escape extended in `authorization.ts` to cover both keys, so a `role === \"ceo\"` agent can still offboard without an explicit grant.
- Routes do company-scope check + `access.decide` and reject on deny. Cross-company calls still return `403/404` as before.
- Docs: `docs/api/agents.md` gains a permission-keys table for agent mutations.

## Verification

```
pnpm exec vitest run server/src/__tests__/authorization-service.test.ts
   ✓ 19 tests (incl. 4 new: CEO legacy allow, IC deny, explicit grant allow, cross-company deny)
pnpm exec vitest run server/src/__tests__/agent-permissions-routes.test.ts
   ✓ 51 tests (incl. 7 new pause/terminate route gate tests)
pnpm exec vitest run server/src/__tests__/agent-cross-tenant-authz-routes.test.ts
   ✓ 1 test (still enforces cross-tenant boundary)
pnpm exec vitest run server/src/__tests__/invite-join-grants.test.ts
   ✓ 9 tests (owner/admin grant lists updated)
```

## Feature flag / rollback

No new feature flag. Behavior is gated by `access.decide`, which honors local-implicit board, instance admin, owner/admin role grants, and the CEO agent legacy escape — all paths that already work for `agents:create`. Rollback is a straight revert of this PR.

## One-way doors / risks

- **Existing companies need a one-time role-grant resync** to pick up `agents:pause` / `agents:terminate` for their `owner` / `admin` members (today they have only the original `agents:create` set). This PR does **not** run that backfill (out of scope per the issue). Cloud / multi-user companies that depend on owner/admin board users for pause/terminate will lose access until a resync runs.
- Local implicit board (single-user dev install) is unaffected — short-circuits to allow.

## Test plan

- [x] Unit tests above pass
- [x] CEO agent can pause + terminate (legacy allow path)
- [x] Agent with explicit grant can pause + terminate
- [x] IC engineer agent without grant → 403
- [x] Cross-company → 403
- [x] Non-existent target → 404
- [ ] Reviewer: confirm one-time backfill plan for cloud companies is out-of-scope and tracked separately

cc @head-of-engineering