### PR TITLE
feat(authz): grant Heads-of structural tasks:assign for their function subtree

### DIFF
--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -58,7 +58,13 @@ export interface AgentInstructionsBundle {
 
 export interface AgentAccessState {
   canAssignTasks: boolean;
-  taskAssignSource: "simple_default" | "explicit_grant" | "agent_creator" | "ceo_role" | "none";
+  taskAssignSource:
+    | "simple_default"
+    | "explicit_grant"
+    | "agent_creator"
+    | "ceo_role"
+    | "manager_chain"
+    | "none";
   membership: CompanyMembership | null;
   grants: PrincipalPermissionGrant[];
 }

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -46,6 +46,7 @@ const mockAgentService = vi.hoisted(() => ({
   update: vi.fn(),
   updatePermissions: vi.fn(),
   getChainOfCommand: vi.fn(),
+  hasDirectReports: vi.fn(),
   resolveByReference: vi.fn(),
 }));
 
@@ -301,6 +302,7 @@ describe.sequential("agent permission routes", () => {
     mockAgentService.update.mockReset();
     mockAgentService.updatePermissions.mockReset();
     mockAgentService.getChainOfCommand.mockReset();
+    mockAgentService.hasDirectReports.mockReset();
     mockAgentService.resolveByReference.mockReset();
     mockAccessService.canUser.mockReset();
     mockAccessService.decide.mockReset();
@@ -335,6 +337,7 @@ describe.sequential("agent permission routes", () => {
     mockAgentService.getById.mockResolvedValue(baseAgent);
     mockAgentService.list.mockResolvedValue([baseAgent]);
     mockAgentService.getChainOfCommand.mockResolvedValue([]);
+    mockAgentService.hasDirectReports.mockResolvedValue(false);
     mockAgentService.resolveByReference.mockResolvedValue({ ambiguous: false, agent: baseAgent });
     mockAgentService.create.mockResolvedValue(baseAgent);
     mockAgentService.activatePendingApproval.mockResolvedValue({
@@ -1368,6 +1371,26 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(200);
     expect(res.body.access.canAssignTasks).toBe(true);
     expect(res.body.access.taskAssignSource).toBe("simple_default");
+  }, 15_000);
+
+  it("reports manager_chain task assignment for agents with direct reports but no grant or membership", async () => {
+    mockAccessService.getMembership.mockResolvedValue(null);
+    mockAccessService.listPrincipalGrants.mockResolvedValue([]);
+    mockAgentService.hasDirectReports.mockResolvedValue(true);
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.access.canAssignTasks).toBe(true);
+    expect(res.body.access.taskAssignSource).toBe("manager_chain");
   }, 15_000);
 
   it("keeps task assignment enabled when agent creation privilege is enabled", async () => {

--- a/server/src/__tests__/authorization-service.test.ts
+++ b/server/src/__tests__/authorization-service.test.ts
@@ -544,4 +544,98 @@ describeEmbeddedPostgres("authorization service", () => {
       grant: { permissionKey: "tasks:assign" },
     });
   });
+
+  it("allows a Head-of agent to assign within their function subtree without an explicit grant", async () => {
+    const company = await createCompany(db, "HeadOfSubtree");
+    const ceoAgent = await createAgent(db, company.id, { role: "ceo" });
+    const headOfAgent = await createAgent(db, company.id, {
+      role: "general",
+      reportsTo: ceoAgent.id,
+    });
+    const reportAgent = await createAgent(db, company.id, {
+      role: "engineer",
+      reportsTo: headOfAgent.id,
+    });
+
+    const selfAssign = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: headOfAgent.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:assign",
+      resource: { type: "issue", companyId: company.id, assigneeAgentId: headOfAgent.id },
+      scope: { assigneeAgentId: headOfAgent.id },
+    });
+    const reportAssign = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: headOfAgent.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:assign",
+      resource: { type: "issue", companyId: company.id, assigneeAgentId: reportAgent.id },
+      scope: { assigneeAgentId: reportAgent.id },
+    });
+
+    expect(selfAssign.allowed).toBe(true);
+    expect(reportAssign.allowed).toBe(true);
+  });
+
+  it("allows a Head-of self-assignment even when target agent has a restrictive assignment policy", async () => {
+    const company = await createCompany(db, "HeadOfRestricted");
+    const ceoAgent = await createAgent(db, company.id, { role: "ceo" });
+    const headOfAgent = await createAgent(db, company.id, {
+      role: "general",
+      reportsTo: ceoAgent.id,
+      permissions: {
+        authorizationPolicy: {
+          agentVisibility: {
+            mode: "private",
+            hiddenFromDefaultDirectory: true,
+          },
+          assignmentPolicy: { mode: "company_default" },
+          protectedAgent: { requiresApproval: false },
+          managedBy: "permissions-extension",
+        },
+      },
+    });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: headOfAgent.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:assign",
+      resource: { type: "issue", companyId: company.id, assigneeAgentId: headOfAgent.id },
+      scope: { assigneeAgentId: headOfAgent.id },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: true,
+      reason: "allow_manager_chain",
+    });
+  });
+
+  it("denies a Head-of from assigning to an agent outside their function subtree when policy is restricted", async () => {
+    const company = await createCompany(db, "HeadOfCrossFunction");
+    const ceoAgent = await createAgent(db, company.id, { role: "ceo" });
+    const bizopsHead = await createAgent(db, company.id, {
+      role: "general",
+      reportsTo: ceoAgent.id,
+    });
+    const engineeringHead = await createAgent(db, company.id, {
+      role: "engineer",
+      reportsTo: ceoAgent.id,
+      permissions: {
+        authorizationPolicy: {
+          agentVisibility: { mode: "private", hiddenFromDefaultDirectory: true },
+          assignmentPolicy: { mode: "company_default" },
+          protectedAgent: { requiresApproval: false },
+          managedBy: "permissions-extension",
+        },
+      },
+    });
+
+    const decision = await authorizationService(db).decide({
+      actor: { type: "agent", agentId: bizopsHead.id, companyId: company.id, source: "agent_key" },
+      action: "tasks:assign",
+      resource: { type: "issue", companyId: company.id, assigneeAgentId: engineeringHead.id },
+      scope: { assigneeAgentId: engineeringHead.id },
+    });
+
+    expect(decision).toMatchObject({
+      allowed: false,
+      reason: "deny_policy_restricted",
+    });
+  });
 });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -510,6 +510,15 @@ export function agentRoutes(
       };
     }
 
+    if (await svc.hasDirectReports(agent.companyId, agent.id)) {
+      return {
+        canAssignTasks: true,
+        taskAssignSource: "manager_chain" as const,
+        membership,
+        grants,
+      };
+    }
+
     return {
       canAssignTasks: false,
       taskAssignSource: "none" as const,

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -709,6 +709,21 @@ export function agentService(db: Db) {
       return chain;
     },
 
+    hasDirectReports: async (companyId: string, agentId: string) => {
+      const rows = await db
+        .select({ id: agents.id })
+        .from(agents)
+        .where(
+          and(
+            eq(agents.companyId, companyId),
+            eq(agents.reportsTo, agentId),
+            ne(agents.status, "terminated"),
+          ),
+        )
+        .limit(1);
+      return rows.length > 0;
+    },
+
     runningForAgent: (agentId: string) =>
       db
         .select()

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -724,12 +724,26 @@ export function authorizationService(db: Db) {
           explanation: "Task assignment target agent is not active in the target company.",
         });
       }
+      const targetAgentId =
+        input.resource.type === "issue" ? input.resource.assigneeAgentId ?? null : null;
+      const isStructuralManagerChain = targetAgentId
+        ? targetAgentId === actorAgentId ||
+          (await isManagerOf(companyId, actorAgentId, targetAgentId))
+        : false;
       const policyEffect = await assignmentPolicyEffect(input.resource);
       const policyDeny = await denyForAssignmentPolicyIfNeeded(policyEffect);
       if (policyDeny) return policyDeny;
       if (policyEffect.kind === "restricted") {
         const grantDecision = await decideWithTaskAssignmentGrants("agent", actorAgentId);
         if (grantDecision.allowed) return grantDecision;
+        if (isStructuralManagerChain) {
+          return allow({
+            action: input.action,
+            reason: "allow_manager_chain",
+            explanation:
+              "Allowed because the target agent is the actor or reports up to the actor's function.",
+          });
+        }
         return denyRestrictedAssignmentPolicy(policyEffect);
       }
       return allow({

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1716,7 +1716,9 @@ function ConfigurationTab({
           ? "Enabled via explicit company permission grant."
           : taskAssignSource === "simple_default"
             ? "Enabled by simple company-wide task assignment defaults."
-            : "Disabled unless explicitly granted.";
+            : taskAssignSource === "manager_chain"
+              ? "Enabled for direct and indirect reports (function subtree) plus self-assignment."
+              : "Disabled unless explicitly granted.";
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Multi-phase planning under Heads-of (e.g. CTO, BizOps) routinely produces child issues owned by that function
> - Heads-of currently can file issues but, when their agent record lacks an explicit `tasks:assign` grant or active membership (and the target agent has a private/protected authorization policy), the authorization service denies them — including for self-assignment
> - That forces a CEO @-mention purely to set `assigneeAgentId`, adding a routing hop on otherwise routine work and a misleading UI hint ("Disabled unless explicitly granted")
> - This PR adds a structural "manager chain" allow path: a non-CEO agent may always assign to itself and to any agent that reports up to it transitively, even when the target's policy is restricted and no explicit grant is present
> - The benefit is that Heads-of can route work inside their function without paging CEO, while cross-function delegation against a restricted target still requires CEO or an explicit grant — matching the principle of least surprise (if you can direct the function, you can assign within it)

## What Changed

- `server/src/services/authorization.ts`: added an `allow_manager_chain` decision path inside the agent `tasks:assign` flow. When `assignmentPolicyEffect` is `restricted` and no explicit grant matches, allow the decision if the target agent is the actor itself or in the actor's subtree (via the existing `isManagerOf` helper). `requires_approval` and `unknown` policy effects still deny.
- `server/src/services/agents.ts`: exposed a `hasDirectReports(companyId, agentId)` service method using the existing `agents` table to detect manager-with-reports without leaking the table through other routes.
- `server/src/routes/agents.ts`: extended `buildAgentAccessState` with a new `"manager_chain"` source. Surfaces `canAssignTasks: true` for managers/Heads-of who have at least one non-terminated direct report but lack explicit grants or active membership. Ordered after `simple_default` so existing flows are unchanged.
- `packages/shared/src/types/agent.ts`: widened `AgentAccessState.taskAssignSource` union with `"manager_chain"`.
- `ui/src/pages/AgentDetail.tsx`: added a hint for the new source — "Enabled for direct and indirect reports (function subtree) plus self-assignment."
- Tests: three new authorization-service cases (subtree allow, self under restricted policy allow, cross-function under restricted policy deny) and one new route case (manager_chain shows up in agent detail when no grant or membership exists).

## Verification

- `cd server && npx vitest run src/__tests__/authorization-service.test.ts src/__tests__/agent-permissions-routes.test.ts src/__tests__/access-service.test.ts src/__tests__/access-routes-permissions-upgrade.test.ts src/__tests__/authz-company-access.test.ts src/__tests__/permissions-upgrade-boundary-routes.test.ts` — 81+ tests pass, including the three new authorization paths and the new UI access-state case.
- `pnpm --filter @paperclipai/shared build` and `pnpm --filter @paperclipai/server typecheck` + `pnpm --filter @paperclipai/ui typecheck` — all clean.
- Manual cross-check against the original BizOps repro (PLA-56 issue context): Head-of agent with no explicit grant, no active company membership, and target agent carrying a private `authorizationPolicy`. Before: `deny_policy_restricted`. After: `allow_manager_chain` when the target is the actor or in the actor's subtree, still `deny_policy_restricted` for cross-function restricted targets.

## Risks

- Low. The change widens authorization only in one specific corner: agent actor, `tasks:assign`, restricted policy effect, and target inside actor's subtree. It does not loosen the simple-mode default, the explicit-grant path, the `requires_approval` path, or any other action. CEO/instance-admin/board paths are untouched.
- The new `hasDirectReports` query is a `SELECT ... LIMIT 1` against `agents` filtered by `companyId` and `reportsTo` — bounded and indexable on the existing columns.
- UI hint and shared type widen the union, but TS exhaustiveness is enforced and the existing ternary already has a fallback branch.

## Model Used

- Anthropic Claude — `claude-opus-4-7`, extended-thinking-capable; used with tool use (Read, Edit, Bash, Grep) inside the Paperclip Engineer 1 agent loop.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (text-only hint change — happy to add screenshots if requested)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge