### PR TITLE
feat: warn when issue set to blocked without blockedByIssueIds

### DIFF
--- a/server/src/__tests__/issue-blocked-warning-routes.test.ts
+++ b/server/src/__tests__/issue-blocked-warning-routes.test.ts
@@ -1,0 +1,212 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockIssueService = vi.hoisted(() => ({
+  getAncestors: vi.fn(),
+  getById: vi.fn(),
+  getByIdentifier: vi.fn(async () => null),
+  getComment: vi.fn(),
+  getCommentCursor: vi.fn(),
+  getRelationSummaries: vi.fn(),
+  getDependencyReadiness: vi.fn(async () => ({ unresolvedBlockerCount: 0 })),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  listWakeableBlockedDependents: vi.fn(async () => []),
+  getWakeableParentAfterChildCompletion: vi.fn(async () => null),
+  findMentionedAgents: vi.fn(async () => []),
+  getCurrentScheduledRetry: vi.fn(async () => null),
+}));
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => ({
+    getIssueDocumentPayload: vi.fn(async () => ({})),
+  }),
+  executionWorkspaceService: () => ({
+    getById: vi.fn(),
+  }),
+  feedbackService: () => ({}),
+  goalService: () => ({
+    getById: vi.fn(),
+    getDefaultCompanyGoal: vi.fn(),
+  }),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  getIssueContinuationSummaryDocument: vi.fn(async () => null),
+  instanceSettingsService: () => ({
+    get: vi.fn(),
+    listCompanyIds: vi.fn(),
+  }),
+  issueApprovalService: () => ({}),
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueRecoveryActionService: () => ({
+    getActiveForIssue: vi.fn(async () => null),
+    listActiveForIssues: vi.fn(async () => new Map()),
+  }),
+  issueThreadInteractionService: () => ({
+    listForIssue: vi.fn(async () => []),
+    expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+    expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+  }),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({
+    getById: vi.fn(),
+    listByIds: vi.fn(async () => []),
+  }),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({
+    listForIssue: vi.fn(async () => []),
+  }),
+}));
+
+const BLOCKER_ID = "00000000-0000-4000-8000-000000000001";
+const ISSUE_ID = "00000000-0000-4000-8000-000000000010";
+const AGENT_ID = "00000000-0000-4000-8000-000000000020";
+const COMPANY_ID = "company-1";
+
+const baseIssue = {
+  id: ISSUE_ID,
+  companyId: COMPANY_ID,
+  identifier: "PAP-500",
+  title: "Test issue",
+  description: null,
+  priority: "medium",
+  parentId: null,
+  assigneeAgentId: AGENT_ID,
+  assigneeUserId: null,
+  createdByAgentId: null,
+  createdByUserId: null,
+  executionWorkspaceId: null,
+  labels: [],
+  labelIds: [],
+};
+
+async function createApp() {
+  const [{ issueRoutes }, { errorHandler }] = await Promise.all([
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("blocked-without-blockers warning", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doUnmock("../routes/issues.js");
+    vi.doUnmock("../routes/authz.js");
+    vi.doUnmock("../middleware/index.js");
+    vi.clearAllMocks();
+    mockIssueService.getAncestors.mockResolvedValue([]);
+    mockIssueService.getComment.mockResolvedValue(null);
+    mockIssueService.getCommentCursor.mockResolvedValue({
+      totalComments: 0,
+      latestCommentId: null,
+      latestCommentAt: null,
+    });
+    mockIssueService.getRelationSummaries.mockResolvedValue({ blockedBy: [], blocks: [] });
+  });
+
+  it("returns a warning when setting status to blocked without blockedByIssueIds", async () => {
+    mockIssueService.getById.mockResolvedValue({ ...baseIssue, status: "in_progress" });
+    mockIssueService.update.mockResolvedValue({ ...baseIssue, status: "blocked" });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "blocked" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.warnings).toBeDefined();
+    expect(res.body.warnings).toHaveLength(1);
+    expect(res.body.warnings[0]).toContain("blockedByIssueIds");
+  });
+
+  it("does not return a warning when setting status to blocked with blockedByIssueIds", async () => {
+    mockIssueService.getById.mockResolvedValue({ ...baseIssue, status: "in_progress" });
+    mockIssueService.update.mockResolvedValue({ ...baseIssue, status: "blocked" });
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [{ id: BLOCKER_ID, identifier: "PAP-501", title: "Blocker", status: "todo" }],
+      blocks: [],
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "blocked", blockedByIssueIds: [BLOCKER_ID] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.warnings).toBeUndefined();
+  });
+
+  it("does not return a warning when issue already has blockers", async () => {
+    mockIssueService.getById.mockResolvedValue({ ...baseIssue, status: "blocked" });
+    mockIssueService.update.mockResolvedValue({ ...baseIssue, status: "blocked" });
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [{ id: BLOCKER_ID, identifier: "PAP-501", title: "Blocker", status: "todo" }],
+      blocks: [],
+    });
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-1",
+      body: "still blocked",
+      createdAt: new Date().toISOString(),
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ comment: "still blocked" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.warnings).toBeUndefined();
+  });
+
+  it("does not return a warning when status is not blocked", async () => {
+    mockIssueService.getById.mockResolvedValue({ ...baseIssue, status: "in_progress" });
+    mockIssueService.update.mockResolvedValue({ ...baseIssue, status: "done" });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${ISSUE_ID}`)
+      .send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.warnings).toBeUndefined();
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3790,6 +3790,28 @@ export function issueRoutes(
         blocks: updatedRelations.blocks,
       };
     }
+
+    const warnings: string[] = [];
+    if (issue.status === "blocked") {
+      const hasBlockersInRequest =
+        Array.isArray(req.body.blockedByIssueIds) && (req.body.blockedByIssueIds as string[]).length > 0;
+      if (!hasBlockersInRequest) {
+        const relations = updatedRelations ?? await svc.getRelationSummaries(issue.id);
+        if (relations.blockedBy.length === 0) {
+          warnings.push(
+            "Issue set to blocked without blockedByIssueIds. " +
+            "This makes the issue invisible to the dependency auto-wake system " +
+            "and may cause it to stall indefinitely. " +
+            "Include blockedByIssueIds to enable automatic unblocking.",
+          );
+          logger.warn(
+            { issueId: issue.id, identifier: issue.identifier, companyId: issue.companyId, actor: actor.actorType },
+            "issue set to blocked without blockedByIssueIds",
+          );
+        }
+      }
+    }
+
     await routinesSvc.syncRunStatusForIssue(issue.id);
 
     if (actor.runId) {
@@ -4361,7 +4383,11 @@ export function issueRoutes(
       }
     })();
 
-    res.json({ ...issueResponse, comment });
+    const response: Record<string, unknown> = { ...issueResponse, comment };
+    if (warnings.length > 0) {
+      response.warnings = warnings;
+    }
+    res.json(response);
   });
 
   router.delete("/issues/:id", async (req, res) => {


### PR DESCRIPTION
## Summary

- Adds a `warnings` array to `PATCH /api/issues/:id` response when the issue ends up in `blocked` status without any first-class `blockedByIssueIds`
- Logs a server-side warning for observability
- Does **not** reject the request (Option B from the issue) — system code paths (recovery guard) that legitimately set blocked without knowing the blocker continue to work
- Includes 4 tests covering: warning present, warning absent with blockers, warning absent with existing blockers, warning absent for non-blocked status

## Context

100% of blocked tickets (21/21) had empty `blockedByIssueIds` as of 2026-04-24, making them invisible to the dependency auto-wake system. This soft warning surfaces the gap in the API response so callers can act on it.

Resolves GSTA-8670.

## Test plan

- [x] New test: `issue-blocked-warning-routes.test.ts` — 4 tests all pass
- [x] Existing test: `issue-dependency-wakeups-routes.test.ts` — still passes
- [ ] CI pipeline validates

Co-Authored-By: Paperclip <noreply@paperclip.ing>