### PR TITLE
fix(scripts): use unlinkSync for symlink removal in link-plugin-dev-sdk

### DIFF
--- a/scripts/link-plugin-dev-sdk.mjs
+++ b/scripts/link-plugin-dev-sdk.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, lstatSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, lstatSync, symlinkSync, unlinkSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -20,7 +20,7 @@ mkdirSync(scopeDir, { recursive: true });
 try {
   const stat = lstatSync(linkTarget);
   if (stat.isSymbolicLink()) {
-    rmSync(linkTarget, { force: true });
+    unlinkSync(linkTarget);
   } else {
     console.log("  i Keeping existing installed @paperclipai/plugin-sdk directory in place");
     process.exit(0);


### PR DESCRIPTION
## Problem

`pnpm install` fails on Node 25+ during the `plugin-workspace-diff` postinstall hook:

```
Error: Path is a directory: node_modules/@paperclipai/plugin-sdk
    at rmSync (node:fs:1212:18)
    at link-plugin-dev-sdk.mjs:23
  code: 'ERR_FS_EISDIR'
```

Node 25 tightened `rmSync` semantics. With `{ force: true }` (no `recursive`) it now refuses to delete a symlink that resolves to a directory — throws `ERR_FS_EISDIR` instead of removing the symlink itself. Older Node versions removed the link.

The script's intent is "remove the stale symlink, then create a fresh one." `rmSync` is the wrong primitive for that — it follows the link.

## Fix

Swap `rmSync(linkTarget, { force: true })` → `unlinkSync(linkTarget)`. `unlinkSync` is the dedicated primitive for removing symlinks: always operates on the link itself, never the target. Also drops the now-unused `rmSync` import.

Two-line change, no behavior change on older Node versions.

## Repro

- Node 25.2.1, fresh checkout, `pnpm install` → fails
- After patch → `pnpm install` clean (4.4s)

## Notes

`package.json` declares `"engines": { "node": ">=20" }`, so Node 25 is in-policy. Without this fix the entire repo is unbuildable on current Node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)