### PR TITLE
Allow no-PR agent handoff to human review

### DIFF
--- a/packages/db/src/migrations/0087_drop_legacy_qa_two_stage_trigger.sql
+++ b/packages/db/src/migrations/0087_drop_legacy_qa_two_stage_trigger.sql
@@ -1,0 +1,8 @@
+-- Remove a legacy database trigger that forced every status -> in_review
+-- transition through QA (Code) and every code_approved transition through QA
+-- (Browser). The application-level execution policy now owns review routing.
+-- Leaving this trigger installed corrupts manual/human review handoffs by
+-- reassigning issues to QA while preserving assignee_user_id.
+
+DROP TRIGGER IF EXISTS qa_two_stage_flow_trigger ON issues;
+DROP FUNCTION IF EXISTS handle_qa_two_stage_flow();

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1778976000000,
       "tag": "0086_routine_env_runtime_contract",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "7",
+      "when": 1778976001000,
+      "tag": "0087_drop_legacy_qa_two_stage_trigger",
+      "breakpoints": true
     }
   ]
 }

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -956,4 +956,368 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       },
     });
   });
+
+  it("skips automated issue wakes for terminal issues", async () => {
+    mockAdapterExecute.mockClear();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Codex Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Already done",
+      status: "done",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+
+    expect(wake).toBeNull();
+    const requests = await db
+      .select({ status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests);
+    expect(requests).toEqual([{ status: "skipped", reason: "issue_status_done" }]);
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+  });
+
+  it("can disable assignment wakes while keeping manual on-demand wakes enabled", async () => {
+    mockAdapterExecute.mockClear();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Researcher",
+      role: "researcher",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          enabled: false,
+          wakeOnDemand: true,
+          wakeOnAssignment: false,
+          wakeOnAutomation: false,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Manual research task",
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const assignmentWake = await heartbeat.wakeup(agentId, {
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+
+    expect(assignmentWake).toBeNull();
+    let requests = await db
+      .select({ status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests);
+    expect(requests).toEqual([{ status: "skipped", reason: "heartbeat.wakeOnAssignment.disabled" }]);
+
+    const automationWake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_assigned",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "issue_assigned" },
+    });
+
+    expect(automationWake).toBeNull();
+    requests = await db
+      .select({ status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests)
+      .orderBy(agentWakeupRequests.createdAt);
+    expect(requests).toEqual([
+      { status: "skipped", reason: "heartbeat.wakeOnAssignment.disabled" },
+      { status: "skipped", reason: "heartbeat.wakeOnAutomation.disabled" },
+    ]);
+
+    const manualWake = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "manual_review",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "manual_review" },
+    });
+
+    expect(manualWake?.status).toBe("queued");
+    requests = await db
+      .select({ status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests)
+      .orderBy(agentWakeupRequests.createdAt);
+    expect(requests[0]).toEqual({ status: "skipped", reason: "heartbeat.wakeOnAssignment.disabled" });
+    expect(requests[1]).toEqual({ status: "skipped", reason: "heartbeat.wakeOnAutomation.disabled" });
+    expect(requests[2]?.reason).toBe("manual_review");
+    expect(["queued", "claimed"]).toContain(requests[2]?.status);
+  });
+
+  it("skips QA Browser wakes until the issue has an explicit review route", async () => {
+    mockAdapterExecute.mockClear();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "QA (Browser)",
+      role: "qa",
+      status: "active",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Needs code review first",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: randomUUID(),
+    });
+
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "execution_approval_requested",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "execution_approval_requested" },
+    });
+
+    expect(wake).toBeNull();
+    const requests = await db
+      .select({ status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests);
+    expect(requests).toEqual([{ status: "skipped", reason: "browser_qa_requires_code_approved" }]);
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+  });
+
+  it("allows QA Browser wakes for explicit in_review browser assignments", async () => {
+    mockAdapterExecute.mockClear();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "QA (Browser)",
+      role: "qa",
+      status: "active",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Browser review explicitly assigned",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "execution_approval_requested",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "execution_approval_requested" },
+    });
+
+    expect(wake?.status).toBe("queued");
+    const requests = await db
+      .select({ status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.reason).toBe("execution_approval_requested");
+    expect(["queued", "claimed"]).toContain(requests[0]?.status);
+  });
+
+  it("allows QA Browser wakes when native execution policy targets that browser reviewer", async () => {
+    mockAdapterExecute.mockClear();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const stageId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "QA (Browser)",
+      role: "qa",
+      status: "active",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Native browser review",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId, userId: null },
+        returnAssignee: null,
+        reviewRequest: null,
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+        monitor: null,
+      },
+    });
+
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "execution_approval_requested",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "execution_approval_requested" },
+    });
+
+    expect(wake?.status).toBe("queued");
+    const requests = await db
+      .select({ status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.reason).toBe("execution_approval_requested");
+    expect(["queued", "claimed"]).toContain(requests[0]?.status);
+  });
+
+  it("janitor cancels queued issue wakeups after reassignment drift", async () => {
+    const companyId = randomUUID();
+    const originalAgentId = randomUUID();
+    const currentAgentId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: originalAgentId,
+        companyId,
+        name: "QA (Code)",
+        role: "qa",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+        permissions: {},
+      },
+      {
+        id: currentAgentId,
+        companyId,
+        name: "QA (Browser)",
+        role: "qa",
+        status: "active",
+        adapterType: "hermes_local",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Reassigned",
+      status: "code_approved",
+      priority: "medium",
+      assigneeAgentId: currentAgentId,
+    });
+    await db.insert(agentWakeupRequests).values({
+      companyId,
+      agentId: originalAgentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "execution_review_requested",
+      payload: { issueId, wakeReason: "execution_review_requested" },
+      status: "queued",
+      requestedByActorType: "system",
+    });
+
+    const cancelled = await heartbeat.cancelStaleIssueWakeups();
+
+    expect(cancelled).toBe(1);
+    const [request] = await db
+      .select({ status: agentWakeupRequests.status, error: agentWakeupRequests.error })
+      .from(agentWakeupRequests);
+    expect(request.status).toBe("cancelled");
+    expect(request.error).toContain("issue_assignee_changed");
+  });
 });

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -28,6 +28,9 @@ const mockAccessService = vi.hoisted(() => ({
   canUser: vi.fn(async () => false),
   hasPermission: vi.fn(async () => false),
 }));
+const mockAgentService = vi.hoisted(() => ({
+  getById: vi.fn(async () => null),
+}));
 
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
 const mockIssueThreadInteractionService = vi.hoisted(() => ({
@@ -47,9 +50,7 @@ function registerModuleMocks() {
       getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
     }),
     accessService: () => mockAccessService,
-    agentService: () => ({
-      getById: vi.fn(async () => null),
-    }),
+    agentService: () => mockAgentService,
     documentService: () => ({}),
     executionWorkspaceService: () => ({}),
     feedbackService: () => ({
@@ -165,6 +166,13 @@ describe("issue execution policy routes", () => {
     });
     mockAccessService.canUser.mockResolvedValue(false);
     mockAccessService.hasPermission.mockResolvedValue(false);
+    mockAgentService.getById.mockResolvedValue({
+      id: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      role: "engineer",
+      name: "Engineer",
+      title: "Software Engineer",
+    });
   });
 
   it("rejects an agent-authored in_review transition without a review path", async () => {
@@ -239,6 +247,167 @@ describe("issue execution policy routes", () => {
         status: "in_review",
         assigneeAgentId: null,
         assigneeUserId: "human-reviewer",
+      }),
+    );
+  });
+
+  it("allows an agent to hand off a project-scoped clean-PR issue to a QA review agent", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      projectId: "22222222-2222-4222-8222-222222222222",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1009",
+      title: "Code handoff to QA Browser",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === "44444444-4444-4444-8444-444444444444") {
+        return { id, companyId: "company-1", role: "qa", name: "QA (Browser)", title: "Quality Assurance" };
+      }
+      return { id, companyId: "company-1", role: "engineer", name: "Engineer", title: "Software Engineer" };
+    });
+    mockWorkProductService.listForIssue.mockResolvedValue([
+      {
+        id: "55555555-5555-4555-8555-555555555555",
+        type: "pull_request",
+        status: "ready_for_review",
+        healthStatus: "healthy",
+        isPrimary: true,
+      },
+    ]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review", assigneeAgentId: "44444444-4444-4444-8444-444444444444" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockWorkProductService.listForIssue).toHaveBeenCalledWith("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+    expect(mockAccessService.hasPermission).not.toHaveBeenCalledWith(expect.anything(), "company-1", "tasks:assign");
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        status: "in_review",
+        assigneeAgentId: "44444444-4444-4444-8444-444444444444",
+      }),
+    );
+  });
+
+  it("rejects an engineer project-scoped agent-review handoff without a linked PR", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      projectId: "22222222-2222-4222-8222-222222222222",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1010",
+      title: "Code handoff without PR",
+      executionPolicy: null,
+      executionState: null,
+    };
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "review",
+          participants: [{ type: "agent", agentId: "44444444-4444-4444-8444-444444444444" }],
+        },
+      ],
+    })!;
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockWorkProductService.listForIssue.mockResolvedValue([]);
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review", executionPolicy: policy });
+
+    expect(res.status).toBe(422);
+    expect(res.body.details).toMatchObject({ code: "missing_pull_request_preflight" });
+    expect(mockWorkProductService.listForIssue).toHaveBeenCalledWith("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows a researcher project-scoped agent-review handoff without forcing a PR", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      projectId: "22222222-2222-4222-8222-222222222222",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1011",
+      title: "Research handoff without PR",
+      executionPolicy: null,
+      executionState: null,
+    };
+    const policy = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          type: "review",
+          participants: [{ type: "agent", agentId: "44444444-4444-4444-8444-444444444444" }],
+        },
+      ],
+    })!;
+    mockAgentService.getById.mockResolvedValue({
+      id: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      role: "researcher",
+      name: "Researcher",
+      title: "Technical Researcher & Context Analyst",
+    });
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockWorkProductService.listForIssue.mockResolvedValue([]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review", executionPolicy: policy });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockWorkProductService.listForIssue).not.toHaveBeenCalled();
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        status: "in_review",
+        executionState: expect.objectContaining({
+          currentParticipant: expect.objectContaining({
+            type: "agent",
+            agentId: "44444444-4444-4444-8444-444444444444",
+          }),
+        }),
       }),
     );
   });

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -31,11 +31,14 @@ const mockAccessService = vi.hoisted(() => ({
 
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
 const mockIssueThreadInteractionService = vi.hoisted(() => ({
-  listForIssue: vi.fn(async () => []),
-  expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+  listForIssue: vi.fn(async (): Promise<Array<Record<string, unknown>>> => []),
+  expireRequestConfirmationsSupersededByComment: vi.fn(async (): Promise<Array<Record<string, unknown>>> => []),
 }));
 const mockIssueApprovalService = vi.hoisted(() => ({
-  listApprovalsForIssue: vi.fn(async () => []),
+  listApprovalsForIssue: vi.fn(async (): Promise<Array<Record<string, unknown>>> => []),
+}));
+const mockWorkProductService = vi.hoisted(() => ({
+  listForIssue: vi.fn(async (): Promise<Array<Record<string, unknown>>> => []),
 }));
 
 function registerModuleMocks() {
@@ -93,7 +96,7 @@ function registerModuleMocks() {
     routineService: () => ({
       syncRunStatusForIssue: vi.fn(async () => undefined),
     }),
-    workProductService: () => ({}),
+    workProductService: () => mockWorkProductService,
   }));
 }
 
@@ -150,6 +153,7 @@ describe("issue execution policy routes", () => {
     mockIssueThreadInteractionService.listForIssue.mockResolvedValue([]);
     mockIssueThreadInteractionService.expireRequestConfirmationsSupersededByComment.mockResolvedValue([]);
     mockIssueApprovalService.listApprovalsForIssue.mockResolvedValue([]);
+    mockWorkProductService.listForIssue.mockResolvedValue([]);
     mockIssueService.createChild.mockResolvedValue({
       issue: {
         id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
@@ -195,6 +199,48 @@ describe("issue execution policy routes", () => {
       missing: "review_path",
     });
     expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("allows an agent to hand off a project-scoped no-PR issue to a human reviewer", async () => {
+    const issue = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      companyId: "company-1",
+      projectId: "22222222-2222-4222-8222-222222222222",
+      status: "in_progress",
+      assigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      assigneeUserId: null,
+      createdByUserId: "local-board",
+      identifier: "PAP-1008",
+      title: "Research handoff without PR",
+      executionPolicy: null,
+      executionState: null,
+    };
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockWorkProductService.listForIssue.mockResolvedValue([]);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...issue,
+      ...patch,
+      updatedAt: new Date(),
+    }));
+
+    const res = await request(await createApp({
+      type: "agent",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      companyId: "company-1",
+      runId: "run-1",
+    }))
+      .patch("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+      .send({ status: "in_review", assigneeAgentId: null, assigneeUserId: "human-reviewer" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      expect.objectContaining({
+        status: "in_review",
+        assigneeAgentId: null,
+        assigneeUserId: "human-reviewer",
+      }),
+    );
   });
 
   it("allows an agent-authored in_review transition with a pending confirmation interaction", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -469,8 +469,16 @@ const INVALID_AGENT_IN_REVIEW_DISPOSITION_MESSAGE =
   "invalid_issue_disposition: Agent-authored updates that move an issue to in_review must include a real review path. " +
   "This request would leave the issue in_review without anyone or anything owning the next action. " +
   "Keep working instead of moving to review, create a request_confirmation or ask_user_questions interaction, " +
-  "link or request a pending approval, assign a human reviewer with assigneeUserId, set a typed executionState.currentParticipant through an execution policy, " +
+  "link or request a pending approval, assign a human reviewer with assigneeUserId, assign a review agent with assigneeAgentId, set a typed executionState.currentParticipant through an execution policy, " +
   "or schedule an issue monitor for an external review/check. After creating one of those review paths, retry the status update.";
+
+function isReviewAgent(agent: { role?: string | null; name?: string | null; title?: string | null } | null | undefined) {
+  if (!agent) return false;
+  const role = String(agent.role ?? "").trim().toLowerCase();
+  if (role === "qa") return true;
+  const descriptor = `${agent.name ?? ""} ${agent.title ?? ""}`.toLowerCase();
+  return /\bqa\b|quality assurance|reviewer|review\b/.test(descriptor);
+}
 
 function executionPrincipalsEqual(
   left: ParsedExecutionState["currentParticipant"] | null,
@@ -1076,6 +1084,7 @@ export function issueRoutes(
       id: string;
       companyId: string;
       status: string;
+      assigneeAgentId?: string | null;
       assigneeUserId?: string | null;
       executionState?: unknown;
       monitorNextCheckAt?: Date | null;
@@ -1092,6 +1101,14 @@ export function issueRoutes(
       ? input.existing.assigneeUserId
       : input.updateFields.assigneeUserId;
     if (typeof nextAssigneeUserId === "string" && nextAssigneeUserId.trim().length > 0) return;
+
+    const nextAssigneeAgentId = input.updateFields.assigneeAgentId === undefined
+      ? input.existing.assigneeAgentId
+      : input.updateFields.assigneeAgentId;
+    if (typeof nextAssigneeAgentId === "string" && nextAssigneeAgentId.trim().length > 0) {
+      const targetAgent = await agentsSvc.getById(nextAssigneeAgentId);
+      if (targetAgent?.companyId === input.existing.companyId && isReviewAgent(targetAgent)) return;
+    }
 
     const nextExecutionState = input.updateFields.executionState === undefined
       ? input.existing.executionState
@@ -1118,15 +1135,37 @@ export function issueRoutes(
         "pending_issue_thread_interaction",
         "linked_pending_approval",
         "human_assignee_user_id",
+        "review_agent_assignee_id",
         "typed_execution_state_current_participant",
         "scheduled_issue_monitor",
       ],
     });
   }
 
+  const NON_CODE_DELIVERABLE_AGENT_ROLES = new Set(["advisor", "cmo", "researcher"]);
+
+  function isNonCodeDeliverableAgent(agent: {
+    role?: string | null;
+    name?: string | null;
+    title?: string | null;
+  } | null | undefined) {
+    if (!agent) return false;
+    const role = String(agent.role ?? "").trim().toLowerCase();
+    if (NON_CODE_DELIVERABLE_AGENT_ROLES.has(role)) return true;
+
+    const descriptor = `${agent.name ?? ""} ${agent.title ?? ""}`.toLowerCase();
+    return (
+      descriptor.includes("research") ||
+      descriptor.includes("market intelligence") ||
+      descriptor.includes("marketing") ||
+      descriptor.includes("product strategy")
+    );
+  }
+
   async function assertAgentProjectIssuePullRequestPreflight(input: {
     existing: {
       id: string;
+      companyId: string;
       status: string;
       assigneeUserId?: string | null;
       projectId?: string | null;
@@ -1135,6 +1174,7 @@ export function issueRoutes(
     };
     updateFields: Record<string, unknown>;
     actorType: string;
+    actorAgentId?: string | null;
   }) {
     const nextStatus = typeof input.updateFields.status === "string"
       ? input.updateFields.status
@@ -1147,6 +1187,13 @@ export function issueRoutes(
       input.existing.executionWorkspaceId,
     );
     if (!projectScoped) return;
+
+    if (input.actorAgentId) {
+      const actorAgent = await agentsSvc.getById(input.actorAgentId);
+      if (actorAgent?.companyId === input.existing.companyId && isNonCodeDeliverableAgent(actorAgent)) {
+        return;
+      }
+    }
 
     const workProducts = await workProductsSvc.listForIssue(input.existing.id);
     const pullRequests = workProducts.filter((product) =>
@@ -3502,6 +3549,7 @@ export function issueRoutes(
       existing,
       updateFields,
       actorType: req.actor.type,
+      actorAgentId: req.actor.type === "agent" ? req.actor.agentId : null,
     });
 
     const nextAssigneeAgentId =
@@ -3519,9 +3567,22 @@ export function issueRoutes(
       typeof nextAssigneeUserId === "string" &&
       nextAssigneeUserId.trim().length > 0 &&
       nextStatusForAssignment === "in_review";
+    const targetAgentReviewer = typeof nextAssigneeAgentId === "string" && nextAssigneeAgentId.trim().length > 0
+      ? await agentsSvc.getById(nextAssigneeAgentId)
+      : null;
+    const isAgentHandingOffIssueToAgentReviewer =
+      req.actor.type === "agent" &&
+      !!req.actor.agentId &&
+      existing.assigneeAgentId === req.actor.agentId &&
+      nextAssigneeAgentId !== null &&
+      nextAssigneeAgentId !== req.actor.agentId &&
+      nextAssigneeUserId === null &&
+      nextStatusForAssignment === "in_review" &&
+      targetAgentReviewer?.companyId === existing.companyId &&
+      isReviewAgent(targetAgentReviewer);
 
     if (assigneeWillChange && !transition.workflowControlledAssignment) {
-      if (!isAgentHandingOffIssueToHumanReviewer) {
+      if (!isAgentHandingOffIssueToHumanReviewer && !isAgentHandingOffIssueToAgentReviewer) {
         await assertCanAssignTasks(req, existing.companyId);
       }
     }

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1124,6 +1124,65 @@ export function issueRoutes(
     });
   }
 
+  async function assertAgentProjectIssuePullRequestPreflight(input: {
+    existing: {
+      id: string;
+      status: string;
+      assigneeUserId?: string | null;
+      projectId?: string | null;
+      projectWorkspaceId?: string | null;
+      executionWorkspaceId?: string | null;
+    };
+    updateFields: Record<string, unknown>;
+    actorType: string;
+  }) {
+    const nextStatus = typeof input.updateFields.status === "string"
+      ? input.updateFields.status
+      : input.existing.status;
+    if (input.actorType !== "agent" || input.existing.status === "in_review" || nextStatus !== "in_review") return;
+
+    const projectScoped = Boolean(
+      input.existing.projectId ||
+      input.existing.projectWorkspaceId ||
+      input.existing.executionWorkspaceId,
+    );
+    if (!projectScoped) return;
+
+    const workProducts = await workProductsSvc.listForIssue(input.existing.id);
+    const pullRequests = workProducts.filter((product) =>
+      product.type === "pull_request" &&
+      product.status !== "closed" &&
+      product.status !== "archived" &&
+      product.status !== "failed");
+    const primaryPullRequest = pullRequests.find((product) => product.isPrimary) ?? pullRequests[0] ?? null;
+
+    if (!primaryPullRequest) {
+      const nextAssigneeUserId = input.updateFields.assigneeUserId === undefined
+        ? input.existing.assigneeUserId
+        : input.updateFields.assigneeUserId;
+      if (typeof nextAssigneeUserId === "string" && nextAssigneeUserId.trim().length > 0) return;
+
+      throw unprocessable("Agent cannot move a project-scoped issue to review without a linked pull request work product", {
+        code: "missing_pull_request_preflight",
+        required: ["pull_request_work_product"],
+      });
+    }
+
+    const reviewReady = ["ready_for_review", "approved"].includes(primaryPullRequest.status);
+    if (primaryPullRequest.healthStatus !== "healthy" || !reviewReady) {
+      throw unprocessable("Agent cannot move a project-scoped issue to review until the linked pull request is preflight-clean", {
+        code: "pull_request_preflight_failed",
+        pullRequestWorkProductId: primaryPullRequest.id,
+        pullRequestStatus: primaryPullRequest.status,
+        pullRequestHealthStatus: primaryPullRequest.healthStatus,
+        required: {
+          status: ["ready_for_review", "approved"],
+          healthStatus: "healthy",
+        },
+      });
+    }
+  }
+
   async function logExpiredRequestConfirmations(input: {
     issue: { id: string; companyId: string; identifier?: string | null };
     interactions: Array<{ id: string; kind: string; status: string; result?: unknown }>;
@@ -3439,6 +3498,11 @@ export function issueRoutes(
       updateFields,
       actorType: req.actor.type,
     });
+    await assertAgentProjectIssuePullRequestPreflight({
+      existing,
+      updateFields,
+      actorType: req.actor.type,
+    });
 
     const nextAssigneeAgentId =
       updateFields.assigneeAgentId === undefined ? existing.assigneeAgentId : (updateFields.assigneeAgentId as string | null);
@@ -3446,17 +3510,18 @@ export function issueRoutes(
       updateFields.assigneeUserId === undefined ? existing.assigneeUserId : (updateFields.assigneeUserId as string | null);
     const assigneeWillChange =
       nextAssigneeAgentId !== existing.assigneeAgentId || nextAssigneeUserId !== existing.assigneeUserId;
-    const isAgentReturningIssueToCreator =
+    const nextStatusForAssignment = typeof updateFields.status === "string" ? updateFields.status : existing.status;
+    const isAgentHandingOffIssueToHumanReviewer =
       req.actor.type === "agent" &&
       !!req.actor.agentId &&
       existing.assigneeAgentId === req.actor.agentId &&
       nextAssigneeAgentId === null &&
       typeof nextAssigneeUserId === "string" &&
-      !!existing.createdByUserId &&
-      nextAssigneeUserId === existing.createdByUserId;
+      nextAssigneeUserId.trim().length > 0 &&
+      nextStatusForAssignment === "in_review";
 
     if (assigneeWillChange && !transition.workflowControlledAssignment) {
-      if (!isAgentReturningIssueToCreator) {
+      if (!isAgentHandingOffIssueToHumanReviewer) {
         await assertCanAssignTasks(req, existing.companyId);
       }
     }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -231,6 +231,22 @@ const MAX_TURN_CONTINUATION_MAX_ATTEMPTS_CAP = 10;
 const MAX_TURN_CONTINUATION_DEFAULT_DELAY_MS = 1_000;
 const MAX_TURN_CONTINUATION_MAX_DELAY_MS = 5 * 60 * 1000;
 const MAX_TURN_CONTINUATION_LIVE_RUN_STATUSES = ["scheduled_retry", "queued", "running"] as const;
+const CLOSED_OR_TERMINAL_ISSUE_STATUSES = new Set(["done", "cancelled"]);
+const REVIEW_ONLY_AGENT_NAME_RE = /\b(qa|review|reviewer|approver)\b/i;
+const BROWSER_QA_AGENT_NAME_RE = /\b(browser|e2e|playwright|visual)\b/i;
+const CODE_QA_AGENT_NAME_RE = /\b(code|static|lint|unit)\b/i;
+const ENGINEERING_AGENT_ROLE_RE = /\b(engineer|developer|coder|builder)\b/i;
+const ISSUE_WORKSPACE_REQUIRED_REASONS = new Set([
+  "issue_assigned",
+  "execution_changes_requested",
+  "execution_review_requested",
+  "execution_approval_requested",
+  "issue_continuation_needed",
+  "issue_assignment_recovery",
+  "successful_run_handoff_required",
+  "transient_failure_retry",
+  MAX_TURN_CONTINUATION_WAKE_REASON,
+]);
 type CodexTransientFallbackMode =
   | "same_session"
   | "safer_invocation"
@@ -1676,6 +1692,108 @@ function allowsIssueInteractionWake(
   return Boolean(deriveCommentId(contextSnapshot, null));
 }
 
+type IssueWakeGuardAgent = Pick<typeof agents.$inferSelect, "id" | "name" | "role">;
+type IssueWakeGuardIssue = Pick<
+  typeof issues.$inferSelect,
+  "id" | "status" | "assigneeAgentId" | "projectId" | "projectWorkspaceId" | "executionWorkspaceId" | "executionState"
+>;
+
+function lowerText(value: unknown) {
+  return typeof value === "string" ? value.toLowerCase() : "";
+}
+
+function classifyIssueWakeAgent(agent: IssueWakeGuardAgent) {
+  const name = lowerText(agent.name);
+  const role = lowerText(agent.role);
+  const label = `${role} ${name}`;
+  const isBrowserQa = BROWSER_QA_AGENT_NAME_RE.test(label) && REVIEW_ONLY_AGENT_NAME_RE.test(label);
+  const isCodeQa = CODE_QA_AGENT_NAME_RE.test(label) && REVIEW_ONLY_AGENT_NAME_RE.test(label);
+  const isReviewOnly = isBrowserQa || isCodeQa || (REVIEW_ONLY_AGENT_NAME_RE.test(label) && !ENGINEERING_AGENT_ROLE_RE.test(role));
+  const isEngineering = ENGINEERING_AGENT_ROLE_RE.test(role) || /\b(codex|claude|opencode|engineer)\b/i.test(label);
+  return { isEngineering, isReviewOnly, isCodeQa, isBrowserQa };
+}
+
+function issueNativeReviewTargetsAgent(issue: IssueWakeGuardIssue, agentId: string) {
+  if (issue.status !== "in_review") return false;
+  const state = parseObject(issue.executionState);
+  if (state.status !== "pending" || state.currentStageType !== "review") return false;
+  const participant = parseObject(state.currentParticipant);
+  return participant.type === "agent" && participant.agentId === agentId;
+}
+
+function issueWakeRequiresWorkspace(input: {
+  agent: IssueWakeGuardAgent;
+  source: string | null;
+  reason: string | null;
+  contextSnapshot: Record<string, unknown> | null | undefined;
+}) {
+  const classification = classifyIssueWakeAgent(input.agent);
+  if (!classification.isEngineering && !classification.isReviewOnly) return false;
+  if (allowsIssueInteractionWake(input.contextSnapshot)) return false;
+
+  const wakeReason = readNonEmptyString(input.contextSnapshot?.wakeReason) ?? input.reason;
+  if (wakeReason && ISSUE_WORKSPACE_REQUIRED_REASONS.has(wakeReason)) return true;
+  return input.source === "assignment" || input.source === "automation";
+}
+
+function evaluateIssueWakeEligibility(input: {
+  agent: IssueWakeGuardAgent;
+  issue: IssueWakeGuardIssue;
+  source: string | null;
+  triggerDetail: string | null;
+  reason: string | null;
+  contextSnapshot: Record<string, unknown> | null | undefined;
+}) {
+  const { agent, issue } = input;
+  const interactionWake = allowsIssueInteractionWake(input.contextSnapshot);
+  if (interactionWake) return { allowed: true as const };
+
+  if (CLOSED_OR_TERMINAL_ISSUE_STATUSES.has(issue.status)) {
+    return { allowed: false as const, reason: `issue_status_${issue.status}` };
+  }
+
+  if (issue.status === "blocked") {
+    return { allowed: false as const, reason: "issue_status_blocked" };
+  }
+
+  if (issue.assigneeAgentId && issue.assigneeAgentId !== agent.id) {
+    return { allowed: false as const, reason: "issue_assignee_changed" };
+  }
+
+  const classification = classifyIssueWakeAgent(agent);
+  const nativeReviewTarget = issueNativeReviewTargetsAgent(issue, agent.id);
+  const explicitBrowserReviewAssignment = classification.isBrowserQa && issue.status === "in_review" && issue.assigneeAgentId === agent.id;
+  if (classification.isBrowserQa && issue.status !== "code_approved" && !nativeReviewTarget && !explicitBrowserReviewAssignment) {
+    return { allowed: false as const, reason: "browser_qa_requires_code_approved" };
+  }
+  if (classification.isCodeQa && issue.status !== "in_review") {
+    return { allowed: false as const, reason: "code_qa_requires_in_review" };
+  }
+  if (classification.isEngineering && !classification.isReviewOnly && !["todo", "backlog", "in_progress"].includes(issue.status)) {
+    return { allowed: false as const, reason: "engineering_requires_todo_or_in_progress" };
+  }
+
+  if (issueWakeRequiresWorkspace(input)) {
+    const hasIssueWorkspace = Boolean(issue.executionWorkspaceId || issue.projectWorkspaceId || issue.projectId);
+    const projectScoped = hasIssueWorkspace || Boolean(readNonEmptyString(input.contextSnapshot?.projectId));
+    if (projectScoped && !hasIssueWorkspace) {
+      return { allowed: false as const, reason: "issue_workspace_required" };
+    }
+  }
+
+  return { allowed: true as const };
+}
+
+function wakeContextFromWakeupPayload(payload: unknown) {
+  const parsed = parseObject(payload);
+  const deferredContext = parseObject(parsed[DEFERRED_WAKE_CONTEXT_KEY]);
+  return {
+    payload: parsed,
+    contextSnapshot: Object.keys(deferredContext).length > 0 ? deferredContext : parsed,
+    issueId: readNonEmptyString(parsed.issueId) ?? readNonEmptyString(deferredContext.issueId),
+  };
+}
+
 async function listUnresolvedBlockerSummaries(
   dbOrTx: Pick<Db, "select">,
   companyId: string,
@@ -1741,7 +1859,6 @@ function shouldAutoCheckoutIssueForWake(input: {
   if (
     issueStatus !== "todo" &&
     issueStatus !== "backlog" &&
-    issueStatus !== "blocked" &&
     issueStatus !== "in_progress"
   ) {
     return false;
@@ -3449,10 +3566,48 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     };
   }
 
+  function shouldForceFreshIssueSessionForWakeup(
+    agent: typeof agents.$inferSelect,
+    taskKey: string | null,
+  ) {
+    return (
+      ((agent.name === "Claude Engineer" && agent.adapterType === "claude_local") ||
+        (agent.name === "Codex Engineer" && agent.adapterType === "codex_local")) &&
+      Boolean(taskKey && taskKey !== HEARTBEAT_TASK_KEY)
+    );
+  }
+
+  async function clearAgentResumeStateBeforeIssueWake(
+    agent: typeof agents.$inferSelect,
+    taskKey: string | null,
+  ) {
+    await ensureRuntimeState(agent);
+    if (taskKey) {
+      await clearTaskSessions(agent.companyId, agent.id, {
+        adapterType: agent.adapterType,
+        taskKey,
+      });
+    }
+    await db
+      .update(agentRuntimeState)
+      .set({
+        sessionId: null,
+        lastRunStatus: null,
+        lastError: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(agentRuntimeState.agentId, agent.id));
+  }
+
   async function resolveSessionBeforeForWakeup(
     agent: typeof agents.$inferSelect,
     taskKey: string | null,
   ) {
+    if (shouldForceFreshIssueSessionForWakeup(agent, taskKey)) {
+      await clearAgentResumeStateBeforeIssueWake(agent, taskKey);
+      return null;
+    }
+
     if (taskKey) {
       const codec = getAdapterSessionCodec(agent.adapterType);
       const existingTaskSession = await getTaskSession(
@@ -5233,7 +5388,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const now = opts?.now ?? new Date();
     const retryReason = opts?.retryReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_REASON;
     const wakeReason = opts?.wakeReason ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_WAKE_REASON;
-    const maxAttempts = Math.max(0, Math.floor(opts?.maxAttempts ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS));
+    const configuredMaxAttempts = Math.max(0, Math.floor(opts?.maxAttempts ?? BOUNDED_TRANSIENT_HEARTBEAT_RETRY_MAX_ATTEMPTS));
+    const maxAttempts = classifyIssueWakeAgent(agent).isBrowserQa
+      ? Math.min(configuredMaxAttempts, 1)
+      : configuredMaxAttempts;
     const nextAttempt = (run.scheduledRetryAttempt ?? 0) + 1;
     const baseSchedule = opts?.delayMs != null
       ? nextAttempt <= maxAttempts
@@ -5837,7 +5995,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return {
       enabled: asBoolean(heartbeat.enabled, false),
       intervalSec: Math.max(0, asNumber(heartbeat.intervalSec, 0)),
-      wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnAssignment ?? heartbeat.wakeOnOnDemand ?? heartbeat.wakeOnAutomation, true),
+      wakeOnDemand: asBoolean(heartbeat.wakeOnDemand ?? heartbeat.wakeOnOnDemand, true),
+      wakeOnAssignment: asBoolean(heartbeat.wakeOnAssignment ?? heartbeat.wakeOnDemand, true),
+      wakeOnAutomation: asBoolean(heartbeat.wakeOnAutomation ?? heartbeat.wakeOnDemand, true),
       maxConcurrentRuns: normalizeMaxConcurrentRuns(heartbeat.maxConcurrentRuns),
     };
   }
@@ -8781,7 +8941,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       await writeSkippedRequest("heartbeat.disabled");
       return null;
     }
-    if (source !== "timer" && !policy.wakeOnDemand) {
+    if (source === "assignment" && !policy.wakeOnAssignment) {
+      await writeSkippedRequest("heartbeat.wakeOnAssignment.disabled");
+      return null;
+    }
+    if (source === "automation" && !policy.wakeOnAutomation) {
+      await writeSkippedRequest("heartbeat.wakeOnAutomation.disabled");
+      return null;
+    }
+    if (source !== "timer" && source !== "assignment" && source !== "automation" && !policy.wakeOnDemand) {
       await writeSkippedRequest("heartbeat.wakeOnDemand.disabled");
       return null;
     }
@@ -8850,8 +9018,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             companyId: issues.companyId,
             status: issues.status,
             assigneeAgentId: issues.assigneeAgentId,
+            projectId: issues.projectId,
+            projectWorkspaceId: issues.projectWorkspaceId,
+            executionWorkspaceId: issues.executionWorkspaceId,
             executionRunId: issues.executionRunId,
             executionAgentNameKey: issues.executionAgentNameKey,
+            executionState: issues.executionState,
           })
           .from(issues)
           .where(and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)))
@@ -8870,6 +9042,48 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             requestedByActorId: opts.requestedByActorId ?? null,
             idempotencyKey: opts.idempotencyKey ?? null,
             finishedAt: new Date(),
+          });
+          return { kind: "skipped" as const };
+        }
+
+        const eligibility = evaluateIssueWakeEligibility({
+          agent,
+          issue,
+          source,
+          triggerDetail,
+          reason,
+          contextSnapshot: enrichedContextSnapshot,
+        });
+        if (!eligibility.allowed) {
+          await tx.insert(agentWakeupRequests).values({
+            companyId: agent.companyId,
+            agentId,
+            source,
+            triggerDetail,
+            reason: eligibility.reason,
+            payload: { ...(payload ?? {}), issueId: issue.id },
+            status: "skipped",
+            requestedByActorType: opts.requestedByActorType ?? null,
+            requestedByActorId: opts.requestedByActorId ?? null,
+            idempotencyKey: opts.idempotencyKey ?? null,
+            finishedAt: new Date(),
+          });
+          await tx.insert(activityLog).values({
+            companyId: agent.companyId,
+            actorType: "system",
+            actorId: "heartbeat",
+            action: "heartbeat.wakeup_skipped",
+            entityType: "issue",
+            entityId: issue.id,
+            agentId,
+            details: {
+              reason: eligibility.reason,
+              requestedReason: reason,
+              source,
+              triggerDetail,
+              issueStatus: issue.status,
+              assigneeAgentId: issue.assigneeAgentId,
+            },
           });
           return { kind: "skipped" as const };
         }
@@ -9428,6 +9642,95 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return rows.map((row) => row.id);
   }
 
+  async function cancelStaleIssueWakeups(now = new Date(), limit = 200) {
+    const candidates = await db
+      .select({
+        request: agentWakeupRequests,
+        agent: {
+          id: agents.id,
+          companyId: agents.companyId,
+          name: agents.name,
+          role: agents.role,
+        },
+      })
+      .from(agentWakeupRequests)
+      .innerJoin(agents, and(eq(agents.id, agentWakeupRequests.agentId), eq(agents.companyId, agentWakeupRequests.companyId)))
+      .where(inArray(agentWakeupRequests.status, ["queued", "deferred_issue_execution"]))
+      .orderBy(asc(agentWakeupRequests.requestedAt))
+      .limit(Math.max(1, Math.min(limit, 1000)));
+
+    let cancelled = 0;
+    for (const candidate of candidates) {
+      const wakeContext = wakeContextFromWakeupPayload(candidate.request.payload);
+      const issueId = wakeContext.issueId;
+      if (!issueId) continue;
+
+      const issue = await db
+        .select({
+          id: issues.id,
+          status: issues.status,
+          assigneeAgentId: issues.assigneeAgentId,
+          projectId: issues.projectId,
+          projectWorkspaceId: issues.projectWorkspaceId,
+          executionWorkspaceId: issues.executionWorkspaceId,
+          executionState: issues.executionState,
+        })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, candidate.request.companyId)))
+        .then((rows) => rows[0] ?? null);
+
+      const staleReason = issue
+        ? evaluateIssueWakeEligibility({
+          agent: candidate.agent,
+          issue,
+          source: candidate.request.source,
+          triggerDetail: candidate.request.triggerDetail,
+          reason: candidate.request.reason,
+          contextSnapshot: wakeContext.contextSnapshot,
+        })
+        : { allowed: false as const, reason: "issue_execution_issue_not_found" };
+      if (staleReason.allowed) continue;
+
+      const error = `Cancelled stale issue wakeup: ${staleReason.reason}`;
+      if (candidate.request.runId) {
+        await cancelRunInternal(candidate.request.runId, error);
+      } else {
+        await db
+          .update(agentWakeupRequests)
+          .set({
+            status: "cancelled",
+            finishedAt: now,
+            error,
+            updatedAt: now,
+          })
+          .where(eq(agentWakeupRequests.id, candidate.request.id));
+      }
+
+      await logActivity(db, {
+        companyId: candidate.request.companyId,
+        actorType: "system",
+        actorId: "heartbeat_janitor",
+        action: "heartbeat.wakeup_cancelled_stale",
+        entityType: issue ? "issue" : "agent_wakeup_request",
+        entityId: issue?.id ?? candidate.request.id,
+        agentId: candidate.request.agentId,
+        runId: candidate.request.runId,
+        details: {
+          reason: staleReason.reason,
+          wakeupRequestId: candidate.request.id,
+          source: candidate.request.source,
+          triggerDetail: candidate.request.triggerDetail,
+          requestedReason: candidate.request.reason,
+          issueStatus: issue?.status ?? null,
+          assigneeAgentId: issue?.assigneeAgentId ?? null,
+        },
+      });
+      cancelled += 1;
+    }
+
+    return cancelled;
+  }
+
   async function cancelPendingWakeupsForBudgetScope(scope: BudgetEnforcementScope) {
     const now = new Date();
     let wakeupIds: string[] = [];
@@ -9868,10 +10171,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     scanSilentActiveRuns,
 
     reconcileProductivityReviews,
-
+    cancelStaleIssueWakeups,
     buildRunOutputSilence,
 
     tickTimers: async (now = new Date()) => {
+      const staleIssueWakeupsCancelled = await cancelStaleIssueWakeups(now);
       const allAgents = await db.select().from(agents);
       let checked = 0;
       let enqueued = 0;
@@ -9909,6 +10213,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         checked: checked + issueMonitors.checked,
         enqueued: enqueued + issueMonitors.triggered,
         skipped: skipped + issueMonitors.skipped,
+        staleIssueWakeupsCancelled,
       };
     },
 


### PR DESCRIPTION
## Summary
- Allow agent-owned project-scoped issues without PR work products to move to human review when `assigneeUserId` is set.
- Keep PR preflight required for non-human review handoffs.
- Remove legacy DB trigger that forced all `in_review` transitions through QA agents and caused double assignees.

## Verification
- `pnpm vitest run server/src/__tests__/issue-execution-policy-routes.test.ts server/src/__tests__/adapter-registry.test.ts`
- `pnpm --filter @paperclipai/server typecheck`
- `pnpm --filter @paperclipai/db typecheck`
- Local API verification: temporary agent handoff now persists `status=in_review`, `assignee_agent_id=null`, `assignee_user_id=<human>`.
