### PR TITLE
AGE-224 Extract OpenCode runtime provider adapter layer

### DIFF
--- a/docs/specs/agent-backend-separation-provider-abstraction.md
+++ b/docs/specs/agent-backend-separation-provider-abstraction.md
@@ -1,0 +1,243 @@
+# Architecture Blueprint: Agent Runtime / Backend Separation and Provider Abstraction
+
+Status: Proposed (AGE-223)
+Owner: Backend Engineer #1
+Date: 2026-05-24
+
+## 1) Goal
+
+Split the agent runtime from the Paperclip backend control plane while keeping model/provider logic loosely coupled so we can:
+
+- keep Azure working now (current default in OpenCode paths),
+- add OpenAI/Gemini/Grok/AWS Bedrock without backend rewrites,
+- ship the runtime into a separate repo (`agentos-agents`) with a stable integration contract.
+
+## 2) Current-state audit (coupling points)
+
+The codebase already has strong adapter interfaces, but backend and runtime concerns are still intertwined at multiple seams.
+
+### 2.1 Hard coupling between backend and concrete runtimes
+
+1. `server/src/adapters/registry.ts`
+   - Backend imports every concrete runtime package (`@paperclipai/adapter-claude-local`, `@paperclipai/adapter-opencode-local`, etc.) and wires model catalogs, execute handlers, skill sync, and env checks directly.
+   - Effect: adding/removing providers and runtime families is a backend deployment concern.
+
+2. `server/src/routes/agents.ts`
+   - Backend route layer imports adapter-specific constants and validators (for example `DEFAULT_OPENCODE_LOCAL_MODEL`, `requireOpenCodeModelId`).
+   - Effect: API behavior and validation are partly runtime-specific instead of contract-driven.
+
+3. `server/src/services/feedback.ts`
+   - Feedback parsing imports adapter-specific stream parsers directly.
+   - Effect: run-observability path is coupled to concrete runtime implementations.
+
+### 2.2 Provider logic mixed into runtime executors
+
+1. `packages/adapters/opencode-local/src/server/execute.ts`
+   - Provider is inferred from `provider/model` strings (`parseModelProvider`) and billing fallback logic is embedded in executor.
+   - Effect: provider semantics are repeated per adapter family and are not standardized.
+
+2. `packages/adapters/opencode-local/src/index.ts`
+   - Default model is currently Azure (`azure/gpt-5.3-codex`) and provider/model format is adapter-defined.
+   - Effect: provider defaults live in package internals rather than a system-level provider policy.
+
+### 2.3 Data contract is runtime-friendly, but not yet runtime-isolated
+
+- `packages/adapter-utils/src/types.ts` provides strong abstractions (`ServerAdapterModule`, model/profile discovery, session codec, runtime command spec).
+- This is the right base contract, but it is consumed in-process by backend code today.
+- Effect: interface exists, process boundary does not.
+
+## 3) What we should preserve from existing OpenCode patterns
+
+OpenCode already shows patterns we should standardize across all providers:
+
+1. Provider/model identity is explicit (`provider/model`), not implicit.
+2. Model discovery is runtime-owned (`opencode models`) and surfaced to backend as data.
+3. Backend sends context and wake metadata; runtime owns CLI/process specifics.
+4. Runtime validates model availability close to execution target (including remote targets).
+
+These are good patterns; the redesign should generalize them instead of replacing them.
+
+## 4) Target architecture
+
+## 4.1 Boundary split
+
+### A. Backend control plane (this repo)
+
+Owns:
+
+- org, issue, approval, budget, policy, and scheduling state,
+- wake decisions and issue lifecycle transitions,
+- run ledger, cost ingestion, and activity log persistence,
+- authorization and tenancy boundaries.
+
+Does not own:
+
+- provider SDK calls,
+- model routing decisions inside runtime,
+- CLI/session mechanics for concrete agent tools.
+
+### B. Runtime execution plane (`agentos-agents`)
+
+Owns:
+
+- adapter implementations,
+- provider adapters and model discovery,
+- session encoding/decoding and resume behavior,
+- prompt assembly and runtime process orchestration.
+
+Exposes:
+
+- a versioned runtime API/SDK contract consumed by backend.
+
+### C. Shared contracts package (versioned)
+
+Create a shared package (`@agentos/runtime-contracts`, name provisional) for:
+
+- execution request/response schemas,
+- provider/model descriptor schema,
+- capability flags,
+- event/log envelopes,
+- error families and retry hints.
+
+Backend and runtime both depend on this contract package; neither depends on the other repo's internals.
+
+## 4.2 Provider abstraction model
+
+Define a provider-neutral runtime interface:
+
+```ts
+interface ProviderAdapter {
+  id: string; // azure | openai | gemini | grok | bedrock | ...
+  listModels(ctx: ProviderContext): Promise<ModelDescriptor[]>;
+  validateModel(modelId: string, ctx: ProviderContext): Promise<ValidationResult>;
+  executeTurn(req: ProviderExecutionRequest): Promise<ProviderExecutionResult>;
+  quotaWindows?(ctx: ProviderContext): Promise<QuotaWindow[]>;
+}
+```
+
+Key rule: backend never switches on provider IDs. It only consumes normalized descriptors and execution results.
+
+## 4.3 Integration contract between backend and runtime
+
+Runtime gateway operations (logical contract, transport can be in-proc first then out-of-proc):
+
+1. `ExecuteRun` - execute one heartbeat run
+2. `ListModels` - discover models for adapter/provider
+3. `RefreshModels` - bypass runtime caches
+4. `TestEnvironment` - adapter/env diagnostics
+5. `ParseRunOutput` - normalize stdout/stderr/transcript events
+6. `SyncSkills` - runtime-specific skill sync
+
+All operations return standardized metadata:
+
+- `provider`, `model`, `biller`, `session`, `usage`, `errorFamily`, `retryHint`.
+
+## 4.4 Repo split plan (`agentos-agents`)
+
+Move to new repo:
+
+- `packages/adapters/*`
+- runtime-facing portions of `packages/adapter-utils`
+- parser/CLI formatters currently imported by backend for feedback rendering.
+
+Keep in backend repo:
+
+- server routes/services/db/migrations,
+- issue lifecycle/policy engines,
+- auth/billing/activity and control-plane APIs.
+
+Add in backend repo:
+
+- `server/src/runtime-gateway/` boundary module that is the only backend entry point to runtime execution.
+
+## 5) Migration sequence (incremental + reversible)
+
+### Phase 0: Contract freeze in current repo
+
+- Introduce `runtime-gateway` interface and route all existing adapter calls through it.
+- Replace direct adapter imports in route/service layers with gateway calls.
+- Keep implementation in-process for zero behavior change.
+
+### Phase 1: Provider abstraction inside runtime layer
+
+- Introduce `ProviderAdapter` abstraction for OpenCode/Pi/Codex/Cursor paths where applicable.
+- Normalize model descriptors and provider metadata.
+- Keep existing `provider/model` IDs for compatibility.
+
+### Phase 2: Extract runtime to `agentos-agents`
+
+- Move runtime packages and publish versioned runtime bundle.
+- Backend consumes runtime through contract package + gateway adapter.
+- Initially run via local process bridge (same host), then allow remote runtime workers.
+
+### Phase 3: Backend cleanup and compatibility lock
+
+- Remove backend imports of runtime-specific constants/validators/parsers.
+- Keep adapter type identifiers and API fields backward-compatible.
+- Add compatibility tests that assert provider swaps require no backend code changes.
+
+## 6) Compatibility strategy (Azure now, others later)
+
+1. Preserve current model IDs and defaults (`azure/...` remains valid).
+2. Keep provider routing in runtime config, not backend business logic.
+3. Store provider/model in run metadata as plain data for analytics and billing attribution.
+4. Add provider onboarding checklist with no backend code touch requirement:
+   - implement `ProviderAdapter`
+   - register provider in runtime catalog
+   - pass contract conformance tests
+   - optional billing/quota hooks
+
+Provider targets:
+
+- now: Azure (existing default paths)
+- next: OpenAI, Gemini, Grok, AWS Bedrock
+
+## 7) Dependency graph for downstream implementation
+
+```mermaid
+flowchart TD
+  AGE223[AGE-223 Blueprint] --> AGE224[AGE-224 Extract runtime to agentos-agents]
+  AGE223 --> AGE225[AGE-225 Decouple backend integration + version-sync contract]
+  AGE224 --> AGE225
+```
+
+Execution dependencies:
+
+1. `AGE-223` (this doc) - defines architecture contract and migration order.
+2. `AGE-224` - runtime extraction and provider adapter layer in `agentos-agents`.
+3. `AGE-225` - backend runtime-gateway integration, version-sync contract, and data-path migration.
+
+Parallelization guidance:
+
+- `AGE-224` and `AGE-225` can begin contract stubs in parallel,
+- but final merge of `AGE-225` depends on runtime contract artifacts from `AGE-224`.
+
+## 8) Risks and rollback plan
+
+### Risks
+
+1. Contract drift between backend and runtime versions.
+2. Session resume regressions across process boundary.
+3. Model discovery latency/regression when moving remote.
+4. Billing metadata mismatch across providers.
+
+### Mitigations
+
+1. Semantic versioning + compatibility matrix in CI.
+2. Golden run fixtures for session/resume behavior.
+3. Cache + refresh semantics in `ListModels`/`RefreshModels` contract.
+4. Contract-level required fields: `provider`, `model`, `biller`, `usage`.
+
+### Rollback
+
+1. Keep in-process runtime gateway implementation behind feature flag (`RUNTIME_GATEWAY_MODE=inproc|external`).
+2. If external runtime fails, switch flag back to `inproc` without schema rollback.
+3. Preserve old adapter registry path for one release as emergency fallback.
+
+## 9) Verification checklist (provider swap without backend changes)
+
+- [ ] Backend run orchestration compiles/runs without importing any concrete provider package.
+- [ ] Switching agent model from `azure/...` to `openai/...` changes runtime config only.
+- [ ] `ListModels` and `ExecuteRun` responses include normalized provider/model metadata.
+- [ ] Cost/billing ingest path accepts provider-agnostic usage payloads unchanged.
+- [ ] At least one conformance test runs same backend test suite against 2+ provider adapters with zero backend code changes.

--- a/docs/specs/agent-runtime-extraction-migration-notes.md
+++ b/docs/specs/agent-runtime-extraction-migration-notes.md
@@ -1,0 +1,36 @@
+# AGE-224 Migration Notes: runtime extraction and provider adapter layer
+
+Date: 2026-05-24
+Owner: Backend Engineer 2
+
+## What changed in this repo
+
+- Added runtime-focused provider abstraction module at `packages/adapters/opencode-local/src/runtime/provider-adapters.ts`.
+- Standardized provider/model normalization and alias mapping (`oai -> openai`, `google -> gemini`, `xai -> grok`).
+- Added provider capability negotiation helpers so runtime provider behavior is data-driven.
+- Added runtime contract version marker: `agentos-agents/v1`.
+- Updated OpenCode execution metadata path to use runtime provider resolver instead of ad-hoc parsing in executor.
+- Added model configuration resolution helper to keep baseline Azure fallback path stable.
+
+## Backend integration points (stable contract expectations)
+
+Backend and downstream gateway code should treat these fields as the stable runtime-facing contract from OpenCode execution results:
+
+- `provider` (normalized provider id)
+- `model` (normalized `provider/model` id)
+- `biller` (provider-compatible billing source)
+- `resultJson.runtimeContractVersion` (`agentos-agents/v1`)
+- `resultJson.providerCapabilities` (capabilities confirmed for selected provider)
+- `resultJson.missingProviderCapabilities` (required-but-missing capabilities)
+
+This keeps backend logic provider-neutral: runtime emits normalized metadata and capability negotiation outcomes; backend consumes them as plain data.
+
+## Future split guidance (`agentos-agents`)
+
+The following files are extraction-ready and can move into `agentos-agents` with minimal coupling risk:
+
+- `packages/adapters/opencode-local/src/runtime/provider-adapters.ts`
+- `packages/adapters/opencode-local/src/server/models.ts` (model config/model discovery normalization helpers)
+- OpenCode server module exports from `packages/adapters/opencode-local/src/server/index.ts`
+
+During split, keep `agentos-agents/v1` contract version semantics unchanged unless backend gateway compatibility layer is updated in lockstep.

--- a/packages/adapters/opencode-local/src/runtime/provider-adapters.test.ts
+++ b/packages/adapters/opencode-local/src/runtime/provider-adapters.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  negotiateProviderCapabilities,
+  normalizeProviderModelId,
+  parseProviderModelId,
+  resolveOpenCodeProvider,
+} from "./provider-adapters.js";
+
+describe("opencode provider adapters", () => {
+  it("normalizes provider aliases for model configuration resolution", () => {
+    expect(normalizeProviderModelId("xai/grok-4")).toBe("grok/grok-4");
+    expect(normalizeProviderModelId("google/gemini-2.5-pro")).toBe("gemini/gemini-2.5-pro");
+  });
+
+  it("parses provider and model from provider/model id", () => {
+    expect(parseProviderModelId("azure/gpt-5.3-codex")).toEqual({
+      provider: "azure",
+      model: "gpt-5.3-codex",
+    });
+    expect(parseProviderModelId("not-a-model")).toBeNull();
+  });
+
+  it("resolves provider metadata for execution result contract", () => {
+    const resolved = resolveOpenCodeProvider({
+      modelId: "oai/gpt-5.4",
+      env: {},
+    });
+
+    expect(resolved.modelId).toBe("openai/gpt-5.4");
+    expect(resolved.provider).toBe("openai");
+    expect(resolved.biller).toBe("openai");
+    expect(resolved.contractVersion).toBe("agentos-agents/v1");
+  });
+
+  it("negotiates required capabilities by provider", () => {
+    const result = negotiateProviderCapabilities({
+      provider: "anthropic",
+      required: ["session_resume", "reasoning_variants"],
+    });
+    expect(result.satisfied).toEqual(["session_resume"]);
+    expect(result.missing).toEqual(["reasoning_variants"]);
+  });
+});

--- a/packages/adapters/opencode-local/src/runtime/provider-adapters.ts
+++ b/packages/adapters/opencode-local/src/runtime/provider-adapters.ts
@@ -1,0 +1,134 @@
+import { inferOpenAiCompatibleBiller } from "@paperclipai/adapter-utils";
+
+export const OPENCODE_RUNTIME_CONTRACT_VERSION = "agentos-agents/v1";
+
+export type OpenCodeProviderCapability =
+  | "model_discovery"
+  | "session_resume"
+  | "reasoning_variants"
+  | "usage_accounting";
+
+export type OpenCodeProviderDescriptor = {
+  id: string;
+  aliases: string[];
+  capabilities: OpenCodeProviderCapability[];
+};
+
+export type ResolvedOpenCodeProvider = {
+  modelId: string | null;
+  provider: string | null;
+  biller: string;
+  capabilities: OpenCodeProviderCapability[];
+  contractVersion: string;
+};
+
+const BASE_CAPABILITIES: OpenCodeProviderCapability[] = [
+  "model_discovery",
+  "session_resume",
+  "usage_accounting",
+];
+
+const PROVIDER_REGISTRY: OpenCodeProviderDescriptor[] = [
+  {
+    id: "azure",
+    aliases: ["azure"],
+    capabilities: [...BASE_CAPABILITIES, "reasoning_variants"],
+  },
+  {
+    id: "openai",
+    aliases: ["openai", "oai"],
+    capabilities: [...BASE_CAPABILITIES, "reasoning_variants"],
+  },
+  {
+    id: "anthropic",
+    aliases: ["anthropic", "claude"],
+    capabilities: BASE_CAPABILITIES,
+  },
+  {
+    id: "gemini",
+    aliases: ["gemini", "google"],
+    capabilities: [...BASE_CAPABILITIES, "reasoning_variants"],
+  },
+  {
+    id: "grok",
+    aliases: ["grok", "xai"],
+    capabilities: [...BASE_CAPABILITIES, "reasoning_variants"],
+  },
+  {
+    id: "bedrock",
+    aliases: ["bedrock", "aws"],
+    capabilities: BASE_CAPABILITIES,
+  },
+];
+
+const providerAliasToId = new Map<string, string>();
+for (const provider of PROVIDER_REGISTRY) {
+  for (const alias of provider.aliases) {
+    providerAliasToId.set(alias.toLowerCase(), provider.id);
+  }
+}
+
+function normalizeProviderId(input: string): string {
+  const normalized = input.trim().toLowerCase();
+  return providerAliasToId.get(normalized) ?? normalized;
+}
+
+export function parseProviderModelId(model: string | null | undefined): {
+  provider: string;
+  model: string;
+} | null {
+  if (typeof model !== "string") return null;
+  const trimmed = model.trim();
+  const slashIndex = trimmed.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === trimmed.length - 1) return null;
+  const provider = normalizeProviderId(trimmed.slice(0, slashIndex));
+  const modelName = trimmed.slice(slashIndex + 1).trim();
+  if (!provider || !modelName) return null;
+  return { provider, model: modelName };
+}
+
+export function normalizeProviderModelId(model: string | null | undefined): string | null {
+  const parsed = parseProviderModelId(model);
+  if (!parsed) return null;
+  return `${parsed.provider}/${parsed.model}`;
+}
+
+export function listOpenCodeProviderRegistry(): OpenCodeProviderDescriptor[] {
+  return PROVIDER_REGISTRY.map((entry) => ({
+    id: entry.id,
+    aliases: [...entry.aliases],
+    capabilities: [...entry.capabilities],
+  }));
+}
+
+export function negotiateProviderCapabilities(input: {
+  provider: string | null;
+  required: OpenCodeProviderCapability[];
+}): { satisfied: OpenCodeProviderCapability[]; missing: OpenCodeProviderCapability[] } {
+  const providerId = input.provider?.trim().toLowerCase() ?? "";
+  const descriptor = PROVIDER_REGISTRY.find((entry) => entry.id === providerId);
+  const supported = new Set(descriptor?.capabilities ?? BASE_CAPABILITIES);
+  const required = Array.from(new Set(input.required));
+  const satisfied = required.filter((capability) => supported.has(capability));
+  const missing = required.filter((capability) => !supported.has(capability));
+  return { satisfied, missing };
+}
+
+export function resolveOpenCodeProvider(input: {
+  modelId: string | null;
+  env: Record<string, string>;
+}): ResolvedOpenCodeProvider {
+  const normalizedModelId = normalizeProviderModelId(input.modelId);
+  const parsed = parseProviderModelId(normalizedModelId);
+  const provider = parsed?.provider ?? null;
+  const descriptor = provider
+    ? PROVIDER_REGISTRY.find((entry) => entry.id === provider)
+    : null;
+  return {
+    modelId: normalizedModelId,
+    provider,
+    biller: inferOpenAiCompatibleBiller(input.env, null) ?? provider ?? "unknown",
+    capabilities: [...(descriptor?.capabilities ?? BASE_CAPABILITIES)],
+    contractVersion: OPENCODE_RUNTIME_CONTRACT_VERSION,
+  };
+}

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetIsRemote,
   adapterExecutionTargetRemoteCwd,
@@ -49,10 +49,15 @@ import {
   ensureOpenCodeModelConfiguredAndAvailable,
   parseOpenCodeModelsOutput,
   requireOpenCodeModelId,
+  resolveOpenCodeModelConfig,
 } from "./models.js";
 import { removeMaintainerOnlySkillSymlinks } from "@paperclipai/adapter-utils/server-utils";
 import { prepareOpenCodeRuntimeConfig } from "./runtime-config.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
+import {
+  negotiateProviderCapabilities,
+  resolveOpenCodeProvider,
+} from "../runtime/provider-adapters.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -63,17 +68,6 @@ function firstNonEmptyLine(text: string): string {
       .map((line) => line.trim())
       .find(Boolean) ?? ""
   );
-}
-
-function parseModelProvider(model: string | null): string | null {
-  if (!model) return null;
-  const trimmed = model.trim();
-  if (!trimmed.includes("/")) return null;
-  return trimmed.slice(0, trimmed.indexOf("/")).trim() || null;
-}
-
-function resolveOpenCodeBiller(env: Record<string, string>, provider: string | null): string {
-  return inferOpenAiCompatibleBiller(env, null) ?? provider ?? "unknown";
 }
 
 const REMOTE_OPENCODE_MODELS_PROBE_DEFAULT_TIMEOUT_SEC = 20;
@@ -207,7 +201,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
   );
   const command = asString(config.command, "opencode");
-  const model = asString(config.model, "").trim();
+  const model = resolveOpenCodeModelConfig({
+    configuredModel: config.model,
+    fallbackModel: "azure/gpt-5.3-codex",
+  });
   const variant = asString(config.variant, "").trim();
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
@@ -634,6 +631,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         stderrLine ||
         `OpenCode exited with code ${synthesizedExitCode ?? -1}`;
       const modelId = model || null;
+      const providerMetadata = resolveOpenCodeProvider({
+        modelId,
+        env: runtimeEnv,
+      });
+      const capabilityNegotiation = negotiateProviderCapabilities({
+        provider: providerMetadata.provider,
+        required: ["model_discovery", "session_resume", "usage_accounting"],
+      });
 
       return {
         exitCode: synthesizedExitCode,
@@ -648,14 +653,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         sessionId: resolvedSessionId,
         sessionParams: resolvedSessionParams,
         sessionDisplayId: resolvedSessionId,
-        provider: parseModelProvider(modelId),
-        biller: resolveOpenCodeBiller(runtimeEnv, parseModelProvider(modelId)),
-        model: modelId,
+        provider: providerMetadata.provider,
+        biller: providerMetadata.biller,
+        model: providerMetadata.modelId,
         billingType: "unknown",
         costUsd: attempt.parsed.costUsd,
         resultJson: {
           stdout: attempt.proc.stdout,
           stderr: attempt.proc.stderr,
+          runtimeContractVersion: providerMetadata.contractVersion,
+          providerCapabilities: capabilityNegotiation.satisfied,
+          missingProviderCapabilities: capabilityNegotiation.missing,
         },
         summary: attempt.parsed.summary,
         clearSession: Boolean(clearSessionOnMissingSession && !attempt.parsed.sessionId),

--- a/packages/adapters/opencode-local/src/server/index.ts
+++ b/packages/adapters/opencode-local/src/server/index.ts
@@ -71,3 +71,11 @@ export {
   resetOpenCodeModelsCacheForTests,
 } from "./models.js";
 export { parseOpenCodeJsonl, isOpenCodeUnknownSessionError } from "./parse.js";
+export {
+  OPENCODE_RUNTIME_CONTRACT_VERSION,
+  listOpenCodeProviderRegistry,
+  negotiateProviderCapabilities,
+  normalizeProviderModelId,
+  parseProviderModelId,
+  resolveOpenCodeProvider,
+} from "../runtime/provider-adapters.js";

--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   ensureOpenCodeModelConfiguredAndAvailable,
   listOpenCodeModels,
+  resolveOpenCodeModelConfig,
   requireOpenCodeModelId,
   resetOpenCodeModelsCacheForTests,
 } from "./models.js";
@@ -25,6 +26,18 @@ describe("openCode models", () => {
 
   it("accepts a provider/model id without running discovery", () => {
     expect(requireOpenCodeModelId("openai/gpt-5.2-codex")).toBe("openai/gpt-5.2-codex");
+  });
+
+  it("normalizes provider aliases in configured model ids", () => {
+    expect(resolveOpenCodeModelConfig({ configuredModel: "oai/gpt-5.4", fallbackModel: "azure/gpt-5.3-codex" })).toBe(
+      "openai/gpt-5.4",
+    );
+  });
+
+  it("falls back to baseline azure model when configured model is missing", () => {
+    expect(resolveOpenCodeModelConfig({ configuredModel: "", fallbackModel: "azure/gpt-5.3-codex" })).toBe(
+      "azure/gpt-5.3-codex",
+    );
   });
 
   it("rejects malformed provider/model ids before discovery", () => {

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -7,6 +7,7 @@ import {
   runChildProcess,
 } from "@paperclipai/adapter-utils/server-utils";
 import { isValidOpenCodeModelId } from "../index.js";
+import { normalizeProviderModelId, parseProviderModelId } from "../runtime/provider-adapters.js";
 
 const MODELS_CACHE_TTL_MS = 60_000;
 const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
@@ -65,13 +66,23 @@ export function parseOpenCodeModelsOutput(stdout: string): AdapterModel[] {
     const line = raw.trim();
     if (!line) continue;
     const firstToken = line.split(/\s+/)[0]?.trim() ?? "";
-    if (!firstToken.includes("/")) continue;
-    const provider = firstToken.slice(0, firstToken.indexOf("/")).trim();
-    const model = firstToken.slice(firstToken.indexOf("/") + 1).trim();
-    if (!provider || !model) continue;
-    parsed.push({ id: `${provider}/${model}`, label: `${provider}/${model}` });
+    const parsedModel = parseProviderModelId(firstToken);
+    if (!parsedModel) continue;
+    const modelId = `${parsedModel.provider}/${parsedModel.model}`;
+    parsed.push({ id: modelId, label: modelId });
   }
   return dedupeModels(parsed);
+}
+
+export function resolveOpenCodeModelConfig(input: {
+  configuredModel: unknown;
+  fallbackModel: string;
+}): string {
+  const configuredModel = asString(input.configuredModel, "").trim();
+  const normalizedConfigured = normalizeProviderModelId(configuredModel);
+  if (normalizedConfigured) return normalizedConfigured;
+  const normalizedFallback = normalizeProviderModelId(input.fallbackModel);
+  return normalizedFallback ?? input.fallbackModel;
 }
 
 function normalizeEnv(input: unknown): Record<string, string> {


### PR DESCRIPTION
## What
- add runtime provider adapter layer for OpenCode (registry, model normalization, capability negotiation)
- wire execution metadata to normalized provider contract output
- add focused tests for provider swapping/model config resolution and migration notes

## Verification
- pnpm vitest packages/adapters/opencode-local/src/runtime/provider-adapters.test.ts packages/adapters/opencode-local/src/server/models.test.ts
- pnpm vitest packages/adapters/opencode-local/src/server/execute.remote.test.ts
- pnpm --filter @paperclipai/adapter-opencode-local typecheck

Issue: AGE-224