### PR TITLE
Add /api/recovery-actions GET + resolve endpoints (IGG-158)

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -804,6 +804,7 @@ export {
   issueExecutionPolicySchema,
   issueExecutionStateSchema,
   resolveIssueRecoveryActionSchema,
+  resolveRecoveryActionByIdSchema,
   issueReviewRequestSchema,
   issueExecutionWorkspaceSettingsSchema,
   checkoutIssueSchema,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -163,6 +163,7 @@ export {
   issueExecutionStateSchema,
   issueRecoveryActionReadModelSchema,
   resolveIssueRecoveryActionSchema,
+  resolveRecoveryActionByIdSchema,
   issueReviewRequestSchema,
   issueExecutionWorkspaceSettingsSchema,
   checkoutIssueSchema,

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -321,6 +321,13 @@ export const resolveIssueRecoveryActionSchema = z.object({
 
 export type ResolveIssueRecoveryAction = z.infer<typeof resolveIssueRecoveryActionSchema>;
 
+export const resolveRecoveryActionByIdSchema = z.object({
+  outcome: z.enum(ISSUE_RECOVERY_ACTION_OUTCOMES),
+  resolutionNote: multilineTextSchema.optional().nullable(),
+}).strict();
+
+export type ResolveRecoveryActionById = z.infer<typeof resolveRecoveryActionByIdSchema>;
+
 const issueRequestDepthInputSchema = z
   .number()
   .int()

--- a/server/src/__tests__/recovery-action-routes.test.ts
+++ b/server/src/__tests__/recovery-action-routes.test.ts
@@ -1,0 +1,387 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  agentWakeupRequests,
+  activityLog,
+  companies,
+  createDb,
+  environmentLeases,
+  environments,
+  heartbeatRunEvents,
+  heartbeatRuns,
+  issueComments,
+  issueRecoveryActions,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { errorHandler } from "../middleware/index.js";
+import { recoveryActionRoutes } from "../routes/recovery-actions.js";
+import { issueRecoveryActionService } from "../services/issue-recovery-actions.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres recovery action route tests: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("recovery action routes", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-recovery-action-routes-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    await db.delete(issueRecoveryActions);
+    await db.delete(issueComments);
+    await db.delete(environmentLeases);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRunEvents);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(environments);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    const ownerAgentId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const previousOwnerAgentId = randomUUID();
+    const strangerAgentId = randomUUID();
+    const sourceIssueId = randomUUID();
+    const prefix = `RR${companyId.replaceAll("-", "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Recovery Routes Co",
+      issuePrefix: prefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: ownerAgentId,
+        companyId,
+        name: "Recovery Owner",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: assigneeAgentId,
+        companyId,
+        name: "Source Assignee",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: previousOwnerAgentId,
+        companyId,
+        name: "Previous Owner",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: strangerAgentId,
+        companyId,
+        name: "Stranger",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values({
+      id: sourceIssueId,
+      companyId,
+      title: "Stranded source issue",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId,
+      issueNumber: 1,
+      identifier: `${prefix}-1`,
+    });
+    return {
+      companyId,
+      ownerAgentId,
+      assigneeAgentId,
+      previousOwnerAgentId,
+      strangerAgentId,
+      sourceIssueId,
+    };
+  }
+
+  function createApp(actor: any = { type: "board", source: "local_implicit" }) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      (req as any).actor = actor;
+      next();
+    });
+    app.use("/api", recoveryActionRoutes(db));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function seedAction(input: {
+    companyId: string;
+    sourceIssueId: string;
+    ownerAgentId: string;
+    previousOwnerAgentId?: string | null;
+  }) {
+    const svc = issueRecoveryActionService(db);
+    return svc.upsertSourceScoped({
+      companyId: input.companyId,
+      sourceIssueId: input.sourceIssueId,
+      kind: "stranded_assigned_issue",
+      ownerType: "agent",
+      ownerAgentId: input.ownerAgentId,
+      previousOwnerAgentId: input.previousOwnerAgentId ?? null,
+      cause: "stranded_assigned_issue",
+      fingerprint: `route-test:${randomUUID()}`,
+      evidence: { source: "test" },
+      nextAction: "Restore a live execution path.",
+    });
+  }
+
+  it("returns 200 for GET /recovery-actions/:id when the action exists", async () => {
+    const seed = await seedCompany();
+    const action = await seedAction({
+      companyId: seed.companyId,
+      sourceIssueId: seed.sourceIssueId,
+      ownerAgentId: seed.ownerAgentId,
+    });
+    const app = createApp();
+    const res = await request(app).get(`/api/recovery-actions/${action.id}`).expect(200);
+    expect(res.body.action).toMatchObject({
+      id: action.id,
+      companyId: seed.companyId,
+      sourceIssueId: seed.sourceIssueId,
+      status: "active",
+    });
+  });
+
+  it("returns 404 for GET /recovery-actions/:id with an unknown UUID", async () => {
+    await seedCompany();
+    const app = createApp();
+    await request(app).get(`/api/recovery-actions/${randomUUID()}`).expect(404);
+  });
+
+  it("returns 404 for GET /recovery-actions/:id with a non-UUID id", async () => {
+    const app = createApp();
+    await request(app).get(`/api/recovery-actions/not-a-uuid`).expect(404);
+  });
+
+  it("lists active recovery actions scoped to companyId", async () => {
+    const seed = await seedCompany();
+    const action = await seedAction({
+      companyId: seed.companyId,
+      sourceIssueId: seed.sourceIssueId,
+      ownerAgentId: seed.ownerAgentId,
+    });
+    const app = createApp();
+    const res = await request(app)
+      .get(`/api/recovery-actions?companyId=${seed.companyId}`)
+      .expect(200);
+    expect(res.body.actions).toHaveLength(1);
+    expect(res.body.actions[0]).toMatchObject({ id: action.id });
+  });
+
+  it("returns 400 when listing without companyId for a board user", async () => {
+    const app = createApp();
+    await request(app).get(`/api/recovery-actions`).expect(400);
+  });
+
+  it("resolves an active recovery action via POST /recovery-actions/:id/resolve", async () => {
+    const seed = await seedCompany();
+    const action = await seedAction({
+      companyId: seed.companyId,
+      sourceIssueId: seed.sourceIssueId,
+      ownerAgentId: seed.ownerAgentId,
+    });
+    const app = createApp();
+    const res = await request(app)
+      .post(`/api/recovery-actions/${action.id}/resolve`)
+      .send({ outcome: "restored", resolutionNote: "fixed by hand" })
+      .expect(200);
+    expect(res.body.action).toMatchObject({
+      id: action.id,
+      status: "resolved",
+      outcome: "restored",
+      resolutionNote: "fixed by hand",
+    });
+    expect(res.body.action.resolvedAt).toBeTruthy();
+  });
+
+  it("returns 403 when an unrelated agent attempts to resolve the action", async () => {
+    const seed = await seedCompany();
+    const action = await seedAction({
+      companyId: seed.companyId,
+      sourceIssueId: seed.sourceIssueId,
+      ownerAgentId: seed.ownerAgentId,
+    });
+    const app = createApp({
+      type: "agent",
+      agentId: seed.strangerAgentId,
+      companyId: seed.companyId,
+    });
+    await request(app)
+      .post(`/api/recovery-actions/${action.id}/resolve`)
+      .send({ outcome: "restored" })
+      .expect(403);
+  });
+
+  it("allows the source issue assignee agent to resolve", async () => {
+    const seed = await seedCompany();
+    const action = await seedAction({
+      companyId: seed.companyId,
+      sourceIssueId: seed.sourceIssueId,
+      ownerAgentId: seed.ownerAgentId,
+    });
+    const app = createApp({
+      type: "agent",
+      agentId: seed.assigneeAgentId,
+      companyId: seed.companyId,
+    });
+    await request(app)
+      .post(`/api/recovery-actions/${action.id}/resolve`)
+      .send({ outcome: "restored" })
+      .expect(200);
+  });
+
+  it("allows the recovery owner agent to resolve", async () => {
+    const seed = await seedCompany();
+    const action = await seedAction({
+      companyId: seed.companyId,
+      sourceIssueId: seed.sourceIssueId,
+      ownerAgentId: seed.ownerAgentId,
+    });
+    const app = createApp({
+      type: "agent",
+      agentId: seed.ownerAgentId,
+      companyId: seed.companyId,
+    });
+    await request(app)
+      .post(`/api/recovery-actions/${action.id}/resolve`)
+      .send({ outcome: "restored" })
+      .expect(200);
+  });
+
+  it("returns 404 when resolving an unknown action id", async () => {
+    await seedCompany();
+    const app = createApp();
+    await request(app)
+      .post(`/api/recovery-actions/${randomUUID()}/resolve`)
+      .send({ outcome: "restored" })
+      .expect(404);
+  });
+
+  it("rejects a second resolve attempt with 422 (resolved action does not re-fire)", async () => {
+    const seed = await seedCompany();
+    const action = await seedAction({
+      companyId: seed.companyId,
+      sourceIssueId: seed.sourceIssueId,
+      ownerAgentId: seed.ownerAgentId,
+    });
+    const app = createApp();
+    await request(app)
+      .post(`/api/recovery-actions/${action.id}/resolve`)
+      .send({ outcome: "restored" })
+      .expect(200);
+    await request(app)
+      .post(`/api/recovery-actions/${action.id}/resolve`)
+      .send({ outcome: "restored" })
+      .expect(422);
+    expect(
+      await issueRecoveryActionService(db).getActiveForIssue(seed.companyId, seed.sourceIssueId),
+    ).toBeNull();
+  });
+
+  it("wakes previousOwnerAgentId and posts a mention comment when outcome=escalated", async () => {
+    const seed = await seedCompany();
+    const action = await seedAction({
+      companyId: seed.companyId,
+      sourceIssueId: seed.sourceIssueId,
+      ownerAgentId: seed.ownerAgentId,
+      previousOwnerAgentId: seed.previousOwnerAgentId,
+    });
+    const app = createApp();
+    const res = await request(app)
+      .post(`/api/recovery-actions/${action.id}/resolve`)
+      .send({ outcome: "escalated", resolutionNote: "kicking back to original owner" })
+      .expect(200);
+    expect(res.body.action).toMatchObject({
+      id: action.id,
+      status: "resolved",
+      outcome: "escalated",
+      previousOwnerAgentId: seed.previousOwnerAgentId,
+    });
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, seed.previousOwnerAgentId));
+    expect(wakeups.length).toBeGreaterThanOrEqual(1);
+    const escalationWake = wakeups.find((row) => row.reason === "recovery_action_escalated");
+    expect(escalationWake).toBeDefined();
+    expect(escalationWake?.payload).toMatchObject({
+      recoveryActionId: action.id,
+      sourceIssueId: seed.sourceIssueId,
+    });
+
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, seed.sourceIssueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain(`agent://${seed.previousOwnerAgentId}`);
+    expect(comments[0]?.authorType).toBe("system");
+  });
+
+  it("does not wake when outcome=escalated but previousOwnerAgentId is null", async () => {
+    const seed = await seedCompany();
+    const action = await seedAction({
+      companyId: seed.companyId,
+      sourceIssueId: seed.sourceIssueId,
+      ownerAgentId: seed.ownerAgentId,
+      previousOwnerAgentId: null,
+    });
+    const app = createApp();
+    await request(app)
+      .post(`/api/recovery-actions/${action.id}/resolve`)
+      .send({ outcome: "escalated" })
+      .expect(200);
+    const wakeups = await db.select().from(agentWakeupRequests);
+    expect(wakeups).toHaveLength(0);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -20,6 +20,7 @@ import { routineRoutes } from "./routes/routines.js";
 import { environmentRoutes } from "./routes/environments.js";
 import { executionWorkspaceRoutes } from "./routes/execution-workspaces.js";
 import { goalRoutes } from "./routes/goals.js";
+import { recoveryActionRoutes } from "./routes/recovery-actions.js";
 import { approvalRoutes } from "./routes/approvals.js";
 import { secretRoutes } from "./routes/secrets.js";
 import { costRoutes } from "./routes/costs.js";
@@ -219,6 +220,7 @@ export async function createApp(
   api.use(environmentRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(executionWorkspaceRoutes(db));
   api.use(goalRoutes(db));
+  api.use(recoveryActionRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(approvalRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(secretRoutes(db));
   api.use(costRoutes(db, { pluginWorkerManager: workerManager }));

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -7,6 +7,7 @@ export { issueRoutes } from "./issues.js";
 export { issueTreeControlRoutes } from "./issue-tree-control.js";
 export { routineRoutes } from "./routines.js";
 export { goalRoutes } from "./goals.js";
+export { recoveryActionRoutes } from "./recovery-actions.js";
 export { approvalRoutes } from "./approvals.js";
 export { secretRoutes } from "./secrets.js";
 export { costRoutes } from "./costs.js";

--- a/server/src/routes/recovery-actions.ts
+++ b/server/src/routes/recovery-actions.ts
@@ -1,0 +1,220 @@
+import { Router } from "express";
+import { z } from "zod";
+import type { Db } from "@paperclipai/db";
+import { resolveRecoveryActionByIdSchema } from "@paperclipai/shared";
+import { validate } from "../middleware/validate.js";
+import { logger } from "../middleware/logger.js";
+import {
+  agentService,
+  heartbeatService,
+  issueRecoveryActionService,
+  issueService,
+  logActivity,
+} from "../services/index.js";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const listQuerySchema = z.object({
+  companyId: z.string().uuid().optional(),
+  ownerAgentId: z.string().uuid().optional(),
+  sourceIssueId: z.string().uuid().optional(),
+});
+
+export function recoveryActionRoutes(
+  db: Db,
+  opts: { pluginWorkerManager?: PluginWorkerManager } = {},
+) {
+  const router = Router();
+  const svc = issueRecoveryActionService(db);
+  const issuesSvc = issueService(db);
+  const agentsSvc = agentService(db);
+  const heartbeat = heartbeatService(db, { pluginWorkerManager: opts.pluginWorkerManager });
+
+  router.get("/recovery-actions", async (req, res) => {
+    const parsed = listQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ error: "Invalid query", details: parsed.error.issues });
+      return;
+    }
+    let companyId = parsed.data.companyId ?? null;
+    if (!companyId && req.actor.type === "agent") {
+      companyId = req.actor.companyId ?? null;
+    }
+    if (!companyId) {
+      res.status(400).json({ error: "companyId is required" });
+      return;
+    }
+    assertCompanyAccess(req, companyId);
+    const actions = await svc.listActiveByCompany(companyId, {
+      ownerAgentId: parsed.data.ownerAgentId ?? null,
+      sourceIssueId: parsed.data.sourceIssueId ?? null,
+    });
+    res.json({ actions });
+  });
+
+  router.get("/recovery-actions/:id", async (req, res) => {
+    const id = String(req.params.id ?? "").trim();
+    if (!UUID_RE.test(id)) {
+      res.status(404).json({ error: "Recovery action not found" });
+      return;
+    }
+    const action = await svc.getById(id);
+    if (!action) {
+      res.status(404).json({ error: "Recovery action not found" });
+      return;
+    }
+    assertCompanyAccess(req, action.companyId);
+    res.json({ action });
+  });
+
+  router.post(
+    "/recovery-actions/:id/resolve",
+    validate(resolveRecoveryActionByIdSchema),
+    async (req, res) => {
+      const id = String(req.params.id ?? "").trim();
+      if (!UUID_RE.test(id)) {
+        res.status(404).json({ error: "Recovery action not found" });
+        return;
+      }
+      const action = await svc.getById(id);
+      if (!action) {
+        res.status(404).json({ error: "Recovery action not found" });
+        return;
+      }
+      assertCompanyAccess(req, action.companyId);
+
+      if (action.status !== "active" && action.status !== "escalated") {
+        res.status(422).json({
+          error: "Recovery action is already resolved",
+          details: { id: action.id, status: action.status, outcome: action.outcome },
+        });
+        return;
+      }
+
+      const sourceIssue = await issuesSvc.getById(action.sourceIssueId);
+
+      const actor = getActorInfo(req);
+      if (req.actor.type === "agent") {
+        const actorAgentId = actor.agentId;
+        const allowed =
+          !!actorAgentId &&
+          (action.ownerAgentId === actorAgentId ||
+            (sourceIssue?.assigneeAgentId ?? null) === actorAgentId);
+        if (!allowed) {
+          res.status(403).json({
+            error: "Agent cannot resolve this recovery action",
+            details: {
+              recoveryActionId: action.id,
+              ownerAgentId: action.ownerAgentId,
+              sourceAssigneeAgentId: sourceIssue?.assigneeAgentId ?? null,
+              actorAgentId: actorAgentId ?? null,
+            },
+          });
+          return;
+        }
+      } else {
+        assertBoard(req);
+      }
+
+      const { outcome, resolutionNote } = req.body as z.infer<typeof resolveRecoveryActionByIdSchema>;
+      const nextStatus = outcome === "cancelled" ? "cancelled" : "resolved";
+
+      const resolved = await svc.resolveActiveForIssue({
+        companyId: action.companyId,
+        sourceIssueId: action.sourceIssueId,
+        actionId: action.id,
+        status: nextStatus,
+        outcome,
+        resolutionNote: resolutionNote ?? null,
+      });
+      if (!resolved) {
+        res.status(409).json({ error: "Recovery action could not be resolved" });
+        return;
+      }
+
+      await logActivity(db, {
+        companyId: resolved.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "issue.recovery_action_resolved",
+        entityType: "issue",
+        entityId: resolved.sourceIssueId,
+        details: {
+          recoveryActionId: resolved.id,
+          recoveryActionStatus: resolved.status,
+          outcome: resolved.outcome,
+          resolutionNote: resolved.resolutionNote,
+          source: "recovery_action_by_id_resolve",
+        },
+      });
+
+      if (outcome === "escalated" && resolved.previousOwnerAgentId) {
+        const previousOwnerAgentId = resolved.previousOwnerAgentId;
+        const previousOwner = await agentsSvc.getById(previousOwnerAgentId).catch(() => null);
+        const ownerName = previousOwner?.name ?? previousOwnerAgentId;
+
+        if (sourceIssue) {
+          const body = [
+            `Recovery action \`${resolved.id}\` escalated by ${
+              actor.actorType === "agent" ? "agent" : "board user"
+            }.`,
+            "",
+            `- Previous owner: [@${ownerName}](agent://${previousOwnerAgentId})`,
+            resolutionNote ? `- Note: ${resolutionNote}` : null,
+          ]
+            .filter((line): line is string => line !== null)
+            .join("\n");
+          try {
+            await issuesSvc.addComment(
+              sourceIssue.id,
+              body,
+              {},
+              { authorType: "system" },
+            );
+          } catch (err) {
+            logger.warn(
+              { err, recoveryActionId: resolved.id, sourceIssueId: sourceIssue.id },
+              "failed to post escalation comment on source issue",
+            );
+          }
+        }
+
+        try {
+          await heartbeat.wakeup(previousOwnerAgentId, {
+            source: "assignment",
+            triggerDetail: "system",
+            reason: "recovery_action_escalated",
+            idempotencyKey: `recovery_action_escalated:${resolved.id}`,
+            payload: {
+              issueId: resolved.sourceIssueId,
+              sourceIssueId: resolved.sourceIssueId,
+              recoveryActionId: resolved.id,
+            },
+            requestedByActorType: actor.actorType,
+            requestedByActorId: actor.actorId,
+            contextSnapshot: {
+              issueId: resolved.sourceIssueId,
+              taskId: resolved.sourceIssueId,
+              wakeReason: "recovery_action_escalated",
+              source: "recovery_action_by_id_resolve",
+              recoveryActionId: resolved.id,
+            },
+          });
+        } catch (err) {
+          logger.warn(
+            { err, recoveryActionId: resolved.id, previousOwnerAgentId },
+            "failed to wake previous owner agent after recovery escalation",
+          );
+        }
+      }
+
+      res.json({ action: resolved });
+    },
+  );
+
+  return router;
+}

--- a/server/src/services/issue-recovery-actions.ts
+++ b/server/src/services/issue-recovery-actions.ts
@@ -157,6 +157,34 @@ export function issueRecoveryActionService(db: Db) {
     return result;
   }
 
+  async function getById(actionId: string): Promise<IssueRecoveryAction | null> {
+    const row = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, actionId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    return row ? toReadModel(row) : null;
+  }
+
+  async function listActiveByCompany(
+    companyId: string,
+    filters: { ownerAgentId?: string | null; sourceIssueId?: string | null } = {},
+  ): Promise<IssueRecoveryAction[]> {
+    const predicates = [
+      eq(issueRecoveryActions.companyId, companyId),
+      inArray(issueRecoveryActions.status, [...ACTIVE_RECOVERY_ACTION_STATUSES]),
+    ];
+    if (filters.ownerAgentId) predicates.push(eq(issueRecoveryActions.ownerAgentId, filters.ownerAgentId));
+    if (filters.sourceIssueId) predicates.push(eq(issueRecoveryActions.sourceIssueId, filters.sourceIssueId));
+    const rows = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(and(...predicates))
+      .orderBy(desc(issueRecoveryActions.updatedAt));
+    return rows.map(toReadModel);
+  }
+
   async function retryUpsertSourceScoped(
     input: UpsertIssueRecoveryActionInput,
     retryCount: number,
@@ -288,6 +316,8 @@ export function issueRecoveryActionService(db: Db) {
 
   return {
     getActiveForIssue,
+    getById,
+    listActiveByCompany,
     listActiveForIssues,
     resolveActiveForIssue,
     upsertSourceScoped,


### PR DESCRIPTION
## Summary

Adds the HTTP surface for the recovery actions engine. All `/api/recovery-actions/*` routes previously returned 404 ([IGG-91](https://github.com/paperclipai/paperclip/issues)) which left agents and operators with no way to inspect or clear stuck recovery actions other than direct DB access.

New endpoints (server/src/routes/recovery-actions.ts):

- `GET    /api/recovery-actions?companyId=...` — list active per company
- `GET    /api/recovery-actions/:id` — inspect a single action
- `POST   /api/recovery-actions/:id/resolve` — set status=resolved/cancelled

Auth: caller must be `action.ownerAgentId`, the assignee of the source issue, or board.

On `outcome=escalated`, wakes `previousOwnerAgentId` via heartbeat and posts a system comment with a structured agent mention on the source issue. Resolved actions transition out of the active/escalated status set, so the upsert path stops re-firing them.

## Why

Tracks IGG-158 — companion to IGG-159 (bounding `missing_disposition` retries). Both come from the IGG-156 plan to fix the IGG-40 recovery loop documented in IGG-91.

## Test plan

- [x] 13 new route tests in `server/src/__tests__/recovery-action-routes.test.ts` covering happy paths, auth modes (owner / assignee / board), 404 / 403 paths, escalation wake + comment, and the no-refire invariant.
- [ ] Smoke against live instance: `GET /api/recovery-actions?companyId=<igg>` returns 200, not 404.

## Refs

- IGG-156 (parent plan)
- IGG-158 (this work)
- IGG-91 (originating incident)
