### PR TITLE
Bound missing_disposition recovery to maxAttempts=3 with auto-escalation (IGG-159)

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -729,7 +729,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       returnOwnerAgentId: input.agentId,
       cause: input.cause ?? "stranded_assigned_issue",
       attemptCount: 1,
-      maxAttempts: null,
+      maxAttempts: input.kind === "missing_disposition" ? 3 : null,
     });
     expect(action.evidence).toMatchObject({
       sourceIssueId: input.issueId,
@@ -1730,6 +1730,96 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       latestRunStatus: "succeeded",
       missingDisposition: "clear_next_step",
     });
+  });
+
+  it("auto-resolves a missing_disposition recovery that has hit maxAttempts and wakes previousOwnerAgentId", async () => {
+    const { companyId, agentId, runId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      runErrorCode: "adapter_failed",
+      runError: "stuck",
+    });
+    const sourceRunId = randomUUID();
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "finish_successful_run_handoff",
+          sourceRunId,
+          resumeFromRunId: sourceRunId,
+          handoffRequired: true,
+          handoffReason: "successful_run_missing_state",
+          missingDisposition: "clear_next_step",
+          handoffAttempt: 1,
+          maxHandoffAttempts: 1,
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    // Pre-seed an active missing_disposition action that has already reached
+    // its bounded retry limit. The next reconcile should auto-escalate it
+    // instead of firing a fourth attempt against the same recovery owner.
+    const existingActionId = randomUUID();
+    await db.insert(issueRecoveryActions).values({
+      id: existingActionId,
+      companyId,
+      sourceIssueId: issueId,
+      recoveryIssueId: null,
+      kind: "missing_disposition",
+      status: "active",
+      ownerType: "agent",
+      ownerAgentId: agentId,
+      ownerUserId: null,
+      previousOwnerAgentId: agentId,
+      returnOwnerAgentId: agentId,
+      cause: "successful_run_missing_state",
+      fingerprint: ["source_scoped_recovery", companyId, issueId, "successful_run_missing_state"].join(":"),
+      evidence: { sourceIssueId: issueId, recoveryCause: "successful_run_missing_state" },
+      nextAction: "Choose and record a valid issue disposition without copying transcript content.",
+      wakePolicy: { type: "wake_owner", reason: "source_scoped_recovery_action", ownerAgentId: agentId },
+      monitorPolicy: null,
+      attemptCount: 3,
+      maxAttempts: 3,
+      timeoutAt: null,
+      lastAttemptAt: new Date(),
+    });
+
+    const wakeupsBefore = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId))
+      .then((rows) => rows.length);
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.reconcileStrandedAssignedIssues();
+
+    const resolved = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.id, existingActionId))
+      .then((rows) => rows[0] ?? null);
+    expect(resolved?.status).toBe("resolved");
+    expect(resolved?.outcome).toBe("escalated");
+    expect(resolved?.attemptCount).toBe(3);
+    expect(resolved?.resolutionNote).toContain("maxAttempts=3");
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    const exhaustionComment = comments.find((row) => (row.body ?? "").includes("bounded retry limit"));
+    expect(exhaustionComment).toBeTruthy();
+    expect(exhaustionComment?.body).toContain(existingActionId);
+
+    const activity = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
+    expect(activity.some((event) => event.action === "issue.missing_disposition_recovery_exhausted")).toBe(true);
+
+    const wakeupsAfter = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    const exhaustionWake = wakeupsAfter.find((wakeup) => wakeup.reason === "missing_disposition_recovery_exhausted");
+    expect(exhaustionWake).toBeTruthy();
+    expect(wakeupsAfter.length).toBeGreaterThan(wakeupsBefore);
   });
 
   it("clears the detached warning when the run reports activity again", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -70,6 +70,15 @@ const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
+export const DEFAULT_MISSING_DISPOSITION_RECOVERY_MAX_ATTEMPTS = 3;
+
+function resolveMissingDispositionRecoveryMaxAttempts(): number {
+  const raw = process.env.PAPERCLIP_MISSING_DISPOSITION_RECOVERY_MAX_ATTEMPTS;
+  if (!raw) return DEFAULT_MISSING_DISPOSITION_RECOVERY_MAX_ATTEMPTS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_MISSING_DISPOSITION_RECOVERY_MAX_ATTEMPTS;
+  return parsed;
+}
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
   "codex_local",
@@ -2025,7 +2034,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           reason: "no_invokable_recovery_owner",
         },
       monitorPolicy: null,
-      maxAttempts: null,
+      maxAttempts: recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON
+        ? resolveMissingDispositionRecoveryMaxAttempts()
+        : null,
       lastAttemptAt: now,
     });
 
@@ -2175,6 +2186,106 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       .then((rows) => rows.map((row) => row.blockerIssueId));
   }
 
+  async function autoEscalateExhaustedMissingDispositionRecovery(input: {
+    issue: typeof issues.$inferSelect;
+    previousStatus: "todo" | "in_progress";
+    latestRun: LatestIssueRun;
+    recoveryAction: NonNullable<Awaited<ReturnType<typeof recoveryActionsSvc.getActiveForIssue>>>;
+  }) {
+    const { recoveryAction } = input;
+    const resolutionNote =
+      `Auto-escalated after reaching maxAttempts=${recoveryAction.maxAttempts} for missing_disposition recovery.`;
+
+    await recoveryActionsSvc.resolveActiveForIssue({
+      companyId: input.issue.companyId,
+      sourceIssueId: input.issue.id,
+      actionId: recoveryAction.id,
+      status: "resolved",
+      outcome: "escalated",
+      resolutionNote,
+    });
+
+    const prefix = await getCompanyIssuePrefix(input.issue.companyId);
+    const previousOwner = recoveryAction.previousOwnerAgentId
+      ? await getAgent(recoveryAction.previousOwnerAgentId)
+      : null;
+    const recoveryOwner = recoveryAction.ownerAgentId ? await getAgent(recoveryAction.ownerAgentId) : null;
+
+    const commentBody = [
+      "Paperclip stopped retrying `missing_disposition` recovery for this issue after reaching the bounded retry limit.",
+      "",
+      `- Recovery action: \`${recoveryAction.id}\``,
+      `- Attempts: ${recoveryAction.attemptCount}/${recoveryAction.maxAttempts}`,
+      `- Recovery owner: ${agentUiLink(recoveryOwner, prefix)}`,
+      `- Previous owner: ${agentUiLink(previousOwner, prefix)}`,
+      "- Outcome: `escalated` — automatic recovery will not fire again for this loop.",
+      "",
+      "Next action: the previous owner should record the correct disposition or open a follow-up issue. Tune `PAPERCLIP_MISSING_DISPOSITION_RECOVERY_MAX_ATTEMPTS` if a higher bound is needed.",
+    ].join("\n");
+
+    await issuesSvc.addComment(input.issue.id, commentBody, {}, {
+      authorType: "system",
+    });
+
+    await logActivity(db, {
+      companyId: input.issue.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: null,
+      runId: null,
+      action: "issue.missing_disposition_recovery_exhausted",
+      entityType: "issue",
+      entityId: input.issue.id,
+      details: {
+        identifier: input.issue.identifier,
+        previousStatus: input.previousStatus,
+        source: "recovery.missing_disposition_max_attempts_reached",
+        recoveryCause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+        latestRunId: input.latestRun?.id ?? null,
+        latestRunStatus: input.latestRun?.status ?? null,
+        latestRunErrorCode: input.latestRun?.errorCode ?? null,
+        recoveryActionId: recoveryAction.id,
+        recoveryOwnerAgentId: recoveryAction.ownerAgentId,
+        previousOwnerAgentId: recoveryAction.previousOwnerAgentId,
+        returnOwnerAgentId: recoveryAction.returnOwnerAgentId,
+        attemptCount: recoveryAction.attemptCount,
+        maxAttempts: recoveryAction.maxAttempts,
+        outcome: "escalated",
+      },
+    });
+
+    if (recoveryAction.previousOwnerAgentId && previousOwner && isAgentInvokable(previousOwner)) {
+      await deps.enqueueWakeup(recoveryAction.previousOwnerAgentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "missing_disposition_recovery_exhausted",
+        idempotencyKey: `missing_disposition_recovery_exhausted:${recoveryAction.id}`,
+        payload: withRecoveryModelProfileHint({
+          issueId: input.issue.id,
+          sourceIssueId: input.issue.id,
+          recoveryActionId: recoveryAction.id,
+          recoveryCause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+          attemptCount: recoveryAction.attemptCount,
+          maxAttempts: recoveryAction.maxAttempts,
+        }, "status_only"),
+        requestedByActorType: "system",
+        requestedByActorId: null,
+        contextSnapshot: withRecoveryModelProfileHint({
+          issueId: input.issue.id,
+          taskId: input.issue.id,
+          wakeReason: "missing_disposition_recovery_exhausted",
+          skipIssueComment: true,
+          source: "issue_recovery_action",
+          recoveryActionId: recoveryAction.id,
+          sourceIssueId: input.issue.id,
+          recoveryCause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+        }, "status_only"),
+      });
+    }
+
+    return input.issue;
+  }
+
   async function escalateStrandedAssignedIssue(input: {
     issue: typeof issues.$inferSelect;
     previousStatus: "todo" | "in_progress";
@@ -2192,6 +2303,24 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     const recoveryCause = input.recoveryCause ?? "stranded_assigned_issue";
+
+    if (recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON) {
+      const existing = await recoveryActionsSvc.getActiveForIssue(input.issue.companyId, input.issue.id);
+      if (
+        existing &&
+        existing.kind === "missing_disposition" &&
+        existing.maxAttempts != null &&
+        existing.attemptCount >= existing.maxAttempts
+      ) {
+        return autoEscalateExhaustedMissingDispositionRecovery({
+          issue: input.issue,
+          previousStatus: input.previousStatus,
+          latestRun: input.latestRun,
+          recoveryAction: existing,
+        });
+      }
+    }
+
     const recoveryAction = await ensureSourceScopedStrandedRecoveryAction({
       issue: input.issue,
       previousStatus: input.previousStatus,


### PR DESCRIPTION
## Summary

Bounds the `missing_disposition` recovery engine to `maxAttempts=3` (configurable via `PAPERCLIP_MISSING_DISPOSITION_RECOVERY_MAX_ATTEMPTS`) and auto-escalates on breach instead of looping forever.

Origin incident: recovery action `a56d7b2a` looped 3× on IGG-40 (long-running Brigadir B2B daily digest handle, DoD = "stays in_progress indefinitely"), each iteration reassigning to Jarvis → blocked by scope-discipline hook → PATCH back → repeat. Other recovery causes (`maxAttempts=null`) are unaffected.

Changes in `server/src/services/recovery/service.ts`:

- `ensureSourceScopedStrandedRecoveryAction` stamps `maxAttempts` on `missing_disposition` actions only.
- `escalateStrandedAssignedIssue` checks the existing active action before upserting. When `kind=missing_disposition` and `attemptCount >= maxAttempts`, it skips the normal escalation flow and calls `autoEscalateExhaustedMissingDispositionRecovery`, which:
  - resolves the action with `status=resolved, outcome=escalated`
  - posts a system comment naming the recovery action, attempt budget, recovery owner, and previous owner
  - logs `issue.missing_disposition_recovery_exhausted` with full provenance
  - wakes `previousOwnerAgentId` so the rightful owner can record the correct disposition or open a follow-up issue

## Why

Tracks IGG-159 — companion to IGG-158 (resolve/inspect HTTP endpoints). Both come from the IGG-156 plan to fix the IGG-40 recovery loop documented in IGG-91. Bounded retry is the universal safety net even if classification logic misses an edge case.

## Test plan

- [x] New fixture in `server/src/__tests__/heartbeat-process-recovery.test.ts` pre-seeds an active `missing_disposition` action at the retry limit and verifies:
  - action transitions to `resolved`/`escalated`
  - exhaustion comment is posted
  - `missing_disposition_recovery_exhausted` activity event is recorded
  - `previousOwnerAgentId` receives a wake
- [x] `expectSourceScopedStrandedRecoveryAction` updated so callers asserting on `missing_disposition` kind see `maxAttempts=3` instead of `null`.
- [ ] Smoke against live instance: next `missing_disposition` loop on a long-running handle hits the cap and auto-escalates.

## Refs

- IGG-156 (parent plan)
- IGG-159 (this work)
- IGG-91 (originating incident)
