### PR TITLE
fix(heartbeat): suppress stale blocked issue locks

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:http";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import { WebSocketServer } from "ws";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -1163,6 +1163,138 @@ describe("heartbeat comment wake batching", () => {
         retryReason: "missing_issue_comment",
         modelProfile: "cheap",
       });
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 20_000);
+
+  it("does not queue a missing-comment retry after the issue becomes blocked before run completion", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Blocked issue comment retry suppression",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(() => gateway.getAgentPayloads().length === 1);
+
+      await db
+        .update(issues)
+        .set({
+          status: "blocked",
+        })
+        .where(eq(issues.id, issueId));
+
+      gateway.releaseFirstWait();
+
+      await waitFor(async () => {
+        const run = await db
+          .select({
+            status: heartbeatRuns.status,
+            issueCommentStatus: heartbeatRuns.issueCommentStatus,
+          })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "succeeded" && run.issueCommentStatus === "not_applicable";
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      const runs = await db
+        .select()
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.agentId, agentId))
+        .orderBy(asc(heartbeatRuns.createdAt));
+      expect(runs).toHaveLength(1);
+      expect(runs[0]?.issueCommentStatus).toBe("not_applicable");
+
+      const issue = await db
+        .select({
+          status: issues.status,
+          executionRunId: issues.executionRunId,
+          executionLockedAt: issues.executionLockedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+      expect(issue).toMatchObject({
+        status: "blocked",
+        executionRunId: null,
+        executionLockedAt: null,
+      });
+
+      const payloads = gateway.getAgentPayloads();
+      expect(payloads).toHaveLength(1);
+
+      const retryWakeups = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, companyId),
+            eq(agentWakeupRequests.agentId, agentId),
+            eq(agentWakeupRequests.reason, "missing_issue_comment"),
+          ),
+        )
+        .then((rows) => rows[0]?.count ?? 0);
+      expect(retryWakeups).toBe(0);
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -205,6 +205,9 @@ const MAX_INLINE_WAKE_COMMENT_BODY_CHARS = 4_000;
 const MAX_INLINE_WAKE_COMMENT_BODY_TOTAL_CHARS = 12_000;
 const execFile = promisify(execFileCallback);
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+// Issue execution locks should only point at runs that are actually live on the
+// execution path (and therefore show up as `activeRun` in issue payloads).
+const ISSUE_EXECUTION_LOCK_RUN_STATUSES = ["queued", "running"] as const;
 const CANCELLABLE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const HEARTBEAT_RUN_TERMINAL_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "timed_out"] as const;
@@ -1668,6 +1671,15 @@ function shouldRequireIssueCommentForWake(
   );
 }
 
+function isIssueCommentRetryRunnableStatus(status: string | null | undefined) {
+  return (
+    status === "backlog" ||
+    status === "todo" ||
+    status === "in_review" ||
+    status === "in_progress"
+  );
+}
+
 function allowsIssueInteractionWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
@@ -1749,6 +1761,10 @@ function shouldAutoCheckoutIssueForWake(input: {
 
   const wakeReason = readNonEmptyString(input.contextSnapshot?.wakeReason);
   if (!wakeReason) return false;
+  // Comment-driven interaction wakes are allowed to run against blocked issues for
+  // triage/response, but they must not implicitly take the issue out of `blocked`
+  // via auto-checkout (which transitions to `in_progress` + stamps locks).
+  if (issueStatus === "blocked" && ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS.has(wakeReason)) return false;
   if (wakeReason === "issue_comment_mentioned") return false;
   if (wakeReason === "source_scoped_recovery_action") return false;
   if (wakeReason.startsWith("execution_")) return false;
@@ -4708,6 +4724,34 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       return { outcome: "not_applicable" as const, queuedRun: null };
     }
 
+    const currentIssue = await db
+      .select({
+        status: issues.status,
+      })
+      .from(issues)
+      .where(and(eq(issues.companyId, run.companyId), eq(issues.id, issueId), eq(issues.executionRunId, run.id)))
+      .then((rows) => rows[0] ?? null);
+    if (currentIssue && !isIssueCommentRetryRunnableStatus(currentIssue.status)) {
+      if (run.issueCommentStatus !== "not_applicable") {
+        await patchRunIssueCommentStatus(run.id, {
+          issueCommentStatus: "not_applicable",
+          issueCommentSatisfiedByCommentId: null,
+          issueCommentRetryQueuedAt: null,
+        });
+      }
+      await appendRunEvent(run, await nextRunEventSeq(run.id), {
+        eventType: "lifecycle",
+        stream: "system",
+        level: "info",
+        message: "Run ended without an issue comment after issue left runnable state; no follow-up comment wake queued",
+        payload: {
+          issueId,
+          issueStatus: currentIssue.status,
+        },
+      });
+      return { outcome: "not_applicable" as const, queuedRun: null };
+    }
+
     if (await hasDeferredIssueCommentWake(run.companyId, issueId, run.agentId)) {
       await patchRunIssueCommentStatus(run.id, {
         issueCommentStatus: "not_applicable",
@@ -4967,22 +5011,34 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    if (
-      retryReason === MAX_TURN_CONTINUATION_RETRY_REASON &&
-      input.enforceIssueExecutionLock &&
-      issue.executionRunId !== run.id
-    ) {
-      return {
-        allowed: false,
-        reason: "Scheduled max-turn continuation suppressed because the issue execution lock belongs to a different run",
-        errorCode: "issue_execution_lock_changed",
-        issueId,
-        details: {
+    if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON && input.enforceIssueExecutionLock) {
+      const conflicting = await db
+        .select({ id: heartbeatRuns.id, status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(
+          and(
+            eq(heartbeatRuns.companyId, run.companyId),
+            inArray(heartbeatRuns.status, ["queued", "running"]),
+            sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`,
+            sql`${heartbeatRuns.id} <> ${run.id}`,
+          ),
+        )
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (conflicting) {
+        return {
+          allowed: false,
+          reason:
+            "Scheduled max-turn continuation suppressed because the issue already has a live queued/running execution run",
+          errorCode: "issue_execution_lock_changed",
           issueId,
-          expectedExecutionRunId: run.id,
-          currentExecutionRunId: issue.executionRunId,
-        },
-      };
+          details: {
+            issueId,
+            conflictingRunId: conflicting.id,
+            conflictingRunStatus: conflicting.status,
+          },
+        };
+      }
     }
 
     if (issue.status === "in_review") {
@@ -5190,6 +5246,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .returning()
       .then((rows) => rows[0] ?? null);
     if (!promoted) return { outcome: "not_promoted", run: null };
+
+    const promotedIssueId = readNonEmptyString(contextSnapshot.issueId);
+    if (promotedIssueId) {
+      await db
+        .update(issues)
+        .set({
+          executionRunId: promoted.id,
+          executionAgentNameKey: normalizeAgentNameKey(agent.name),
+          executionLockedAt: now,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(issues.companyId, promoted.companyId),
+            eq(issues.id, promotedIssueId),
+            eq(issues.assigneeAgentId, promoted.agentId),
+            or(isNull(issues.executionRunId), eq(issues.executionRunId, promoted.id)),
+          ),
+        );
+    }
 
     await appendRunEvent(promoted, await nextRunEventSeq(promoted.id), {
       eventType: "lifecycle",
@@ -5535,9 +5611,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         await tx
           .update(issues)
           .set({
-            executionRunId: scheduledRun.id,
-            executionAgentNameKey: normalizeAgentNameKey(agent.name),
-            executionLockedAt: now,
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
             updatedAt: now,
           })
           .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId), eq(issues.executionRunId, run.id)));
@@ -8966,8 +9042,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
         if (
           activeExecutionRun &&
-          !EXECUTION_PATH_HEARTBEAT_RUN_STATUSES.includes(
-            activeExecutionRun.status as (typeof EXECUTION_PATH_HEARTBEAT_RUN_STATUSES)[number],
+          !ISSUE_EXECUTION_LOCK_RUN_STATUSES.includes(
+            activeExecutionRun.status as (typeof ISSUE_EXECUTION_LOCK_RUN_STATUSES)[number],
           )
         ) {
           activeExecutionRun = null;
@@ -8989,14 +9065,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .where(eq(issues.id, issue.id));
         }
 
-        if (!activeExecutionRun) {
+        if (!activeExecutionRun && issue.status === "in_progress") {
           const legacyRun = await tx
             .select()
             .from(heartbeatRuns)
             .where(
               and(
                 eq(heartbeatRuns.companyId, issue.companyId),
-                inArray(heartbeatRuns.status, [...EXECUTION_PATH_HEARTBEAT_RUN_STATUSES]),
+                inArray(heartbeatRuns.status, [...ISSUE_EXECUTION_LOCK_RUN_STATUSES]),
                 sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issue.id}`,
               ),
             )


### PR DESCRIPTION
## Summary
- suppress missing-comment retry wakes when a run finishes after its issue has already left runnable status
- keep issue execution locks limited to live queued/running runs and avoid adopting locks on blocked issues
- add regression coverage for a blocked issue finishing without reattaching `executionRunId` / `executionLockedAt`

## Verification
- PASS in dependency-backed workspace: `pnpm vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts -t "does not queue a missing-comment retry after the issue becomes blocked before run completion"`
- Clean worktree local run blocked by missing deps: fresh worktree could not resolve `vitest` / `@paperclipai/db`; `pnpm install --frozen-lockfile --prefer-offline` timed out after 10 minutes. PR CI should run from normal install path.

## Stewardship
- REA-3023 clean worktree: `A:\Programming\paperclip\tmp\paperclip-worktrees\rea-3023-integrate`
- Source dirty workspace remains: `A:\Programming\paperclip\tmp\paperclip-src` on `fix/rea-1753-prevent-cancelled-reopen`
- REA-674 manager-wake route/test files are already stewarded by https://github.com/paperclipai/paperclip/pull/6571, so this PR intentionally carries only REA-2961 heartbeat lock logic.

Closes REA-3023.