### PR TITLE
feat(cli): doctor — surface disk health and Paperclip's own footprint

### DIFF
--- a/cli/src/__tests__/disk-check.test.ts
+++ b/cli/src/__tests__/disk-check.test.ts
@@ -1,0 +1,177 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DISK_FREE_FAIL_PERCENT,
+  DISK_FREE_WARN_PERCENT,
+  FOOTPRINT_WARN_BYTES,
+  computeFootprint,
+  evaluateDiskHealth,
+  formatBytes,
+  readDirectorySizeBytes,
+  type DiskFootprint,
+  type DiskUsage,
+} from "../checks/disk-check.js";
+
+function makeDiskUsage(percentUsed: number, totalBytes = 100_000_000_000): DiskUsage {
+  const usedBytes = Math.round((percentUsed / 100) * totalBytes);
+  const freeBytes = totalBytes - usedBytes;
+  return {
+    totalBytes,
+    freeBytes,
+    usedBytes,
+    percentUsed,
+    percentFree: 100 - percentUsed,
+  };
+}
+
+function makeFootprint(totalBytes = 0, entries: Array<[string, number]> = []): DiskFootprint {
+  return {
+    rootPath: "/tmp/paperclip-test",
+    totalBytes,
+    entries: entries.map(([name, bytes]) => ({ name, path: `/tmp/paperclip-test/${name}`, bytes })),
+  };
+}
+
+describe("formatBytes", () => {
+  it("formats zero and negative as 0 B", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(-1)).toBe("0 B");
+  });
+
+  it("formats small values in bytes", () => {
+    expect(formatBytes(512)).toBe("512 B");
+  });
+
+  it("scales to KiB / MiB / GiB", () => {
+    expect(formatBytes(1024)).toMatch(/^1\.00 KiB$/);
+    expect(formatBytes(5 * 1024 * 1024)).toMatch(/^5\.00 MiB$/);
+    expect(formatBytes(2 * 1024 ** 3)).toMatch(/^2\.00 GiB$/);
+  });
+
+  it("uses fewer decimals for larger magnitudes", () => {
+    expect(formatBytes(123 * 1024)).toBe("123 KiB");
+  });
+});
+
+describe("readDirectorySizeBytes", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-disk-check-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns 0 for empty directories", () => {
+    expect(readDirectorySizeBytes(tmp)).toBe(0);
+  });
+
+  it("sums file sizes recursively", () => {
+    fs.writeFileSync(path.join(tmp, "a.txt"), "hello"); // 5
+    fs.mkdirSync(path.join(tmp, "nested"));
+    fs.writeFileSync(path.join(tmp, "nested", "b.txt"), "world!"); // 6
+    expect(readDirectorySizeBytes(tmp)).toBe(11);
+  });
+
+  it("returns 0 for non-existent paths instead of throwing", () => {
+    expect(readDirectorySizeBytes(path.join(tmp, "does-not-exist"))).toBe(0);
+  });
+});
+
+describe("computeFootprint", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-footprint-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns empty entries when no known subpaths exist", () => {
+    const fp = computeFootprint(tmp);
+    expect(fp.rootPath).toBe(tmp);
+    expect(fp.totalBytes).toBe(0);
+    expect(fp.entries).toEqual([]);
+  });
+
+  it("collects only known subpaths and sorts by descending size", () => {
+    fs.mkdirSync(path.join(tmp, "db"));
+    fs.writeFileSync(path.join(tmp, "db", "huge.bin"), Buffer.alloc(2000));
+    fs.mkdirSync(path.join(tmp, "logs"));
+    fs.writeFileSync(path.join(tmp, "logs", "small.log"), Buffer.alloc(500));
+    fs.mkdirSync(path.join(tmp, "unrelated"));
+    fs.writeFileSync(path.join(tmp, "unrelated", "ignored.bin"), Buffer.alloc(9999));
+
+    const fp = computeFootprint(tmp);
+    expect(fp.totalBytes).toBe(2500);
+    expect(fp.entries.map((e) => e.name)).toEqual(["db", "logs"]);
+    expect(fp.entries[0].bytes).toBe(2000);
+    expect(fp.entries[1].bytes).toBe(500);
+  });
+});
+
+describe("evaluateDiskHealth", () => {
+  it("fails when filesystem free space is below the fail threshold", () => {
+    const result = evaluateDiskHealth(
+      makeDiskUsage(100 - DISK_FREE_FAIL_PERCENT + 1),
+      makeFootprint(),
+    );
+    expect(result.status).toBe("fail");
+    expect(result.repairHint).toMatch(/Free space immediately/);
+  });
+
+  it("warns when free space is below the warn threshold", () => {
+    const result = evaluateDiskHealth(
+      makeDiskUsage(100 - DISK_FREE_WARN_PERCENT + 1),
+      makeFootprint(),
+    );
+    expect(result.status).toBe("warn");
+    expect(result.diskMessage).toMatch(/Free space is below/);
+  });
+
+  it("warns when footprint exceeds the configured threshold even with plenty of disk", () => {
+    const result = evaluateDiskHealth(
+      makeDiskUsage(20),
+      makeFootprint(FOOTPRINT_WARN_BYTES + 1024, [["db", FOOTPRINT_WARN_BYTES + 1024]]),
+    );
+    expect(result.status).toBe("warn");
+    expect(result.diskMessage).toMatch(/footprint exceeds/);
+  });
+
+  it("passes when disk and footprint are both healthy", () => {
+    const result = evaluateDiskHealth(
+      makeDiskUsage(40),
+      makeFootprint(100 * 1024 * 1024, [
+        ["db", 80 * 1024 * 1024],
+        ["logs", 20 * 1024 * 1024],
+      ]),
+    );
+    expect(result.status).toBe("pass");
+    expect(result.repairHint).toBeUndefined();
+    expect(result.footprintMessage).toMatch(/Paperclip footprint/);
+  });
+
+  it("returns warn when filesystem stats are unavailable", () => {
+    const result = evaluateDiskHealth(null, makeFootprint());
+    expect(result.status).toBe("warn");
+    expect(result.diskMessage).toMatch(/Could not read filesystem statistics/);
+  });
+
+  it("renders a footprint breakdown in display order with the largest entry first", () => {
+    const result = evaluateDiskHealth(
+      makeDiskUsage(40),
+      makeFootprint(3 * 1024 * 1024, [
+        ["db", 2 * 1024 * 1024],
+        ["logs", 1 * 1024 * 1024],
+      ]),
+    );
+    expect(result.footprintMessage).toContain("db ");
+    expect(result.footprintMessage.indexOf("db ")).toBeLessThan(result.footprintMessage.indexOf("logs "));
+  });
+});

--- a/cli/src/checks/disk-check.ts
+++ b/cli/src/checks/disk-check.ts
@@ -1,0 +1,211 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolvePaperclipInstanceRoot } from "../config/home.js";
+import type { CheckResult } from "./index.js";
+
+/**
+ * Paperclip silently accumulates a lot on local disk — embedded Postgres WAL,
+ * run-log NDJSON, prompt-cache snapshots — and on the production analysis
+ * that motivated this check, a `No space left on device` from inside the
+ * embedded Postgres surfaced only as repeated INSERT failures in the server
+ * log. This check surfaces both the host filesystem health and Paperclip's
+ * own footprint before that point.
+ */
+
+export const DISK_FREE_FAIL_PERCENT = 5; // <5% free → fail
+export const DISK_FREE_WARN_PERCENT = 15; // <15% free → warn
+export const FOOTPRINT_WARN_BYTES = 5 * 1024 ** 3; // 5 GiB
+
+export interface DiskUsage {
+  totalBytes: number;
+  freeBytes: number;
+  usedBytes: number;
+  percentUsed: number;
+  percentFree: number;
+}
+
+export interface DiskFootprintEntry {
+  name: string;
+  path: string;
+  bytes: number;
+}
+
+export interface DiskFootprint {
+  rootPath: string;
+  totalBytes: number;
+  entries: DiskFootprintEntry[];
+}
+
+/** Footprint subpaths under an instance root, in display order. */
+const FOOTPRINT_SUBPATHS: readonly string[] = [
+  "db",
+  "data",
+  "logs",
+  "companies",
+  "workspaces",
+  "projects",
+] as const;
+
+export function readDiskUsage(targetPath: string): DiskUsage | null {
+  const probe = locateExistingAncestor(targetPath);
+  if (!probe) return null;
+  let stats: ReturnType<typeof fs.statfsSync>;
+  try {
+    stats = fs.statfsSync(probe);
+  } catch {
+    return null;
+  }
+  const blockSize = Number(stats.bsize);
+  const totalBytes = Number(stats.blocks) * blockSize;
+  const freeBytes = Number(stats.bavail) * blockSize;
+  const usedBytes = Math.max(0, totalBytes - freeBytes);
+  const percentUsed = totalBytes > 0 ? (usedBytes / totalBytes) * 100 : 0;
+  const percentFree = Math.max(0, 100 - percentUsed);
+  return { totalBytes, freeBytes, usedBytes, percentUsed, percentFree };
+}
+
+export function readDirectorySizeBytes(dirPath: string): number {
+  let total = 0;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const child = path.join(dirPath, entry.name);
+    try {
+      if (entry.isDirectory()) {
+        total += readDirectorySizeBytes(child);
+      } else if (entry.isFile()) {
+        const stat = fs.statSync(child);
+        total += stat.size;
+      }
+    } catch {
+      // best-effort; permission errors or in-flight deletions are skipped
+    }
+  }
+  return total;
+}
+
+export function computeFootprint(instanceRoot: string): DiskFootprint {
+  const entries: DiskFootprintEntry[] = [];
+  for (const name of FOOTPRINT_SUBPATHS) {
+    const subPath = path.join(instanceRoot, name);
+    if (!fs.existsSync(subPath)) continue;
+    entries.push({ name, path: subPath, bytes: readDirectorySizeBytes(subPath) });
+  }
+  const totalBytes = entries.reduce((sum, entry) => sum + entry.bytes, 0);
+  entries.sort((a, b) => b.bytes - a.bytes);
+  return { rootPath: instanceRoot, totalBytes, entries };
+}
+
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"] as const;
+  let idx = 0;
+  let value = bytes;
+  while (value >= 1024 && idx < units.length - 1) {
+    value /= 1024;
+    idx += 1;
+  }
+  const precision = value >= 100 || idx === 0 ? 0 : value >= 10 ? 1 : 2;
+  return `${value.toFixed(precision)} ${units[idx]}`;
+}
+
+export interface DiskCheckEvaluation {
+  status: CheckResult["status"];
+  diskMessage: string;
+  footprintMessage: string;
+  repairHint?: string;
+}
+
+export function evaluateDiskHealth(
+  disk: DiskUsage | null,
+  footprint: DiskFootprint,
+): DiskCheckEvaluation {
+  const footprintMessage = formatFootprintMessage(footprint);
+
+  if (!disk) {
+    return {
+      status: "warn",
+      diskMessage: "Could not read filesystem statistics for the data directory.",
+      footprintMessage,
+      repairHint:
+        "Make sure the Paperclip data directory exists and is readable, then re-run doctor.",
+    };
+  }
+
+  const usedPct = disk.percentUsed.toFixed(0);
+  const freePct = disk.percentFree.toFixed(0);
+  const diskMessage = `Filesystem ${usedPct}% used (free ${formatBytes(disk.freeBytes)} of ${formatBytes(disk.totalBytes)}).`;
+
+  if (disk.percentFree < DISK_FREE_FAIL_PERCENT) {
+    return {
+      status: "fail",
+      diskMessage: `${diskMessage} Less than ${DISK_FREE_FAIL_PERCENT}% free on the data filesystem.`,
+      footprintMessage,
+      repairHint:
+        "Free space immediately — embedded Postgres will fail INSERT/UPDATE silently when the disk is full.",
+    };
+  }
+
+  if (
+    disk.percentFree < DISK_FREE_WARN_PERCENT ||
+    footprint.totalBytes > FOOTPRINT_WARN_BYTES
+  ) {
+    return {
+      status: "warn",
+      diskMessage: `${diskMessage} Free space is below ${DISK_FREE_WARN_PERCENT}%${
+        footprint.totalBytes > FOOTPRINT_WARN_BYTES
+          ? ` and Paperclip's footprint exceeds ${formatBytes(FOOTPRINT_WARN_BYTES)}`
+          : ""
+      }.`,
+      footprintMessage,
+      repairHint:
+        "Consider archiving old run-logs, taking a db backup with `paperclipai db:backup`, or pointing --data-dir at a larger volume.",
+    };
+  }
+
+  return {
+    status: "pass",
+    diskMessage,
+    footprintMessage,
+  };
+}
+
+function formatFootprintMessage(footprint: DiskFootprint): string {
+  if (footprint.entries.length === 0) {
+    return `No Paperclip data found under ${footprint.rootPath} yet.`;
+  }
+  const breakdown = footprint.entries
+    .slice(0, 4)
+    .map((entry) => `${entry.name} ${formatBytes(entry.bytes)}`)
+    .join(", ");
+  return `Paperclip footprint ${formatBytes(footprint.totalBytes)} (${breakdown}) at ${footprint.rootPath}.`;
+}
+
+function locateExistingAncestor(targetPath: string): string | null {
+  let current = path.resolve(targetPath);
+  while (true) {
+    if (fs.existsSync(current)) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+export function diskCheck(instanceId?: string): CheckResult {
+  const instanceRoot = resolvePaperclipInstanceRoot(instanceId);
+  const disk = readDiskUsage(instanceRoot);
+  const footprint = computeFootprint(instanceRoot);
+  const evaluation = evaluateDiskHealth(disk, footprint);
+
+  return {
+    name: "Disk",
+    status: evaluation.status,
+    message: `${evaluation.diskMessage} ${evaluation.footprintMessage}`.trim(),
+    canRepair: false,
+    repairHint: evaluation.repairHint,
+  };
+}

--- a/cli/src/checks/index.ts
+++ b/cli/src/checks/index.ts
@@ -11,6 +11,7 @@ export { agentJwtSecretCheck } from "./agent-jwt-secret-check.js";
 export { configCheck } from "./config-check.js";
 export { deploymentAuthCheck } from "./deployment-auth-check.js";
 export { databaseCheck } from "./database-check.js";
+export { diskCheck } from "./disk-check.js";
 export { llmCheck } from "./llm-check.js";
 export { logCheck } from "./log-check.js";
 export { portCheck } from "./port-check.js";

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -7,6 +7,7 @@ import {
   configCheck,
   databaseCheck,
   deploymentAuthCheck,
+  diskCheck,
   llmCheck,
   logCheck,
   portCheck,
@@ -119,6 +120,11 @@ export async function doctor(opts: {
   const portResult = await portCheck(config);
   results.push(portResult);
   printResult(portResult);
+
+  // 10. Disk health check (host filesystem + Paperclip's own footprint)
+  const diskResult = diskCheck();
+  results.push(diskResult);
+  printResult(diskResult);
 
   // Summary
   return printSummary(results);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies on a local stack
> - That stack includes an embedded Postgres, prompt cache, run-log NDJSON, workspaces, and per-instance data — all under `~/.paperclip/instances/<id>/`
> - Disk usage grows silently with normal use. When the host filesystem fills up, the embedded Postgres starts returning `No space left on device` for INSERT/UPDATE
> - Today nothing surfaces this. Heartbeats keep dispatching, the server log accumulates the same ENOSPC error, and the operator finds out only when work stops mysteriously
> - `paperclipai doctor` is the natural place to surface this — it already covers config, storage, database, log directory, port, etc.
> - This PR adds a disk-health check to `doctor` so the host-side free space **and** Paperclip's own footprint (per-subpath breakdown) are both visible before they become a hard failure
> - Repair actions are intentionally out of scope for this PR — visibility first, GC/archival next

## What Changed

- New `cli/src/checks/disk-check.ts` implementing:
  - `readDiskUsage(path)` — uses `fs.statfsSync` on the closest existing ancestor of the data directory to compute `total / free / used / percentUsed / percentFree`.
  - `computeFootprint(instanceRoot)` — sums file sizes for known subpaths (`db`, `data`, `logs`, `companies`, `workspaces`, `projects`) and returns a sorted breakdown.
  - `evaluateDiskHealth(disk, footprint)` — pure function that maps the two inputs onto the existing `pass | warn | fail` `CheckResult` shape with a clear, actionable `repairHint`.
  - `diskCheck()` — the integration entry that wires the above to `resolvePaperclipInstanceRoot()`.
- `cli/src/checks/index.ts` — adds `diskCheck` to the existing barrel.
- `cli/src/commands/doctor.ts` — adds the disk check as step 10 in the existing sequence (after the port check) so it runs only when the config is loadable.
- `cli/src/__tests__/disk-check.test.ts` — 15 unit tests covering `formatBytes`, `readDirectorySizeBytes`, `computeFootprint`, and every branch of `evaluateDiskHealth` (fail / warn for low free space / warn for large footprint / pass / null disk usage).

Thresholds:

- `DISK_FREE_FAIL_PERCENT = 5` — less than 5% free triggers `fail`.
- `DISK_FREE_WARN_PERCENT = 15` — less than 15% free triggers `warn`.
- `FOOTPRINT_WARN_BYTES = 5 GiB` — large local footprint triggers `warn` even on a healthy disk.

Repair is **not** wired in this PR. The follow-up that adds `--repair` actions (run-log archival, prompt-cache GC, etc.) can land separately once visibility is merged.

## Verification

1. Unit tests:
   ```
   pnpm exec vitest run cli/src/__tests__/disk-check.test.ts
   # → Test Files  1 passed (1) · Tests  15 passed (15)
   ```
2. CLI typecheck:
   ```
   pnpm --filter paperclipai typecheck
   # → ok (no diagnostics)
   ```
3. Smoke run against a real instance root that happened to be 99% full at the time of authoring (output abbreviated):
   ```
   status: fail
   message: Filesystem 100% used (free 1.03 GiB of 460 GiB). Less than 5% free on the data filesystem.
            Paperclip footprint 275 MiB (projects 138 MiB, db 76.5 MiB, data 50.6 MiB, logs 9.77 MiB)
            at /Users/<redacted>/.paperclip/instances/default.
   hint:    Free space immediately — embedded Postgres will fail INSERT/UPDATE silently when the disk is full.
   ```
   This is exactly the condition that was silently corrupting heartbeat throughput on the author's machine — the check correctly classifies it as `fail` and surfaces the actionable hint.

## Risks

- **Low.** The check is read-only (`fs.statfsSync`, `fs.readdirSync`, `fs.statSync`). It does not mutate any state.
- `readDirectorySizeBytes` recurses through the instance root subpaths. On very large local footprints this is synchronous and could noticeably extend `doctor` wall time. If this becomes a problem we can introduce an `--quick` mode or async recursion; for now it stays simple to match the rest of the checks.
- Heuristic thresholds (5% / 15% / 5 GiB) are conservative starting points and easy to tune in a follow-up if real usage suggests different numbers.
- No public API or config surface changes; nothing to migrate.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

Checked — no `disk`, `doctor`, `footprint`, `storage`, `cleanup`, or `gc` related items in `ROADMAP.md` overlap with this change. This is a small, targeted improvement to an existing diagnostic command, not new core feature work.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`), 1M context, extended thinking enabled. The model authored the check implementation, tests, and PR description after the human collaborator chose the direction and verified the smoke run on their local machine.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A (CLI-only diagnostic output)
- [x] I have updated relevant documentation to reflect my changes — N/A; the existing `doctor` description still applies and the new check is self-describing in its output
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge