### PR TITLE
ui(onboarding): friendly error surface + retry for the wizard

### DIFF
--- a/ui/src/api/client.ts
+++ b/ui/src/api/client.ts
@@ -12,12 +12,33 @@ export class ApiError extends Error {
   }
 }
 
+// Module-scoped header registry. Components mount/unmount headers via
+// `setRequestHeader(name, value)` / `setRequestHeader(name, null)`. Used by
+// OnboardingWizard.tsx to tag every wizard-time fetch with
+// `X-Paperclip-Onboarding: 1` so the server's auto-file middleware can scope
+// 5xx incident filing to the onboarding surface without each api module
+// growing a per-call header option.
+const extraHeaders = new Map<string, string>();
+
+export function setRequestHeader(name: string, value: string | null): void {
+  const key = name.toLowerCase();
+  if (value === null) extraHeaders.delete(key);
+  else extraHeaders.set(key, value);
+}
+
+function applyExtraHeaders(headers: Headers): void {
+  for (const [name, value] of extraHeaders) {
+    if (!headers.has(name)) headers.set(name, value);
+  }
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const headers = new Headers(init?.headers ?? undefined);
   const body = init?.body;
   if (!(body instanceof FormData) && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
   }
+  applyExtraHeaders(headers);
 
   const res = await fetch(`${BASE}${path}`, {
     headers,

--- a/ui/src/components/OnboardingError.test.tsx
+++ b/ui/src/components/OnboardingError.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OnboardingError } from "./OnboardingError";
+import type { CategorizedOnboardingError } from "../lib/onboarding-error";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: ReturnType<typeof createRoot> | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) {
+    act(() => root?.unmount());
+  }
+  root = null;
+  container?.remove();
+  container = null;
+});
+
+function render(element: ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root?.render(element));
+  return container;
+}
+
+function make(
+  partial: Partial<CategorizedOnboardingError> & { class: CategorizedOnboardingError["class"] },
+): CategorizedOnboardingError {
+  return {
+    status: null,
+    serverMessage: null,
+    incidentId: null,
+    fields: [],
+    ...partial,
+  };
+}
+
+describe("OnboardingError", () => {
+  it("renders nothing when error is null", () => {
+    const node = render(<OnboardingError error={null} />);
+    expect(node.textContent).toBe("");
+    expect(node.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("suppresses rendering for adapter_environment", () => {
+    const node = render(
+      <OnboardingError error={make({ class: "adapter_environment" })} />,
+    );
+    expect(node.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("renders unknown_server_error with friendly copy and a retry button", () => {
+    const onRetry = vi.fn();
+    const node = render(
+      <OnboardingError
+        error={make({ class: "unknown_server_error", status: 500 })}
+        onRetry={onRetry}
+      />,
+    );
+
+    const alert = node.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert?.getAttribute("data-class")).toBe("unknown_server_error");
+    expect(node.textContent).toContain("Something went wrong on our side");
+    expect(node.textContent).not.toContain("Internal server error");
+
+    const retry = node.querySelector(
+      '[data-testid="onboarding-error-retry"]',
+    ) as HTMLButtonElement | null;
+    expect(retry).not.toBeNull();
+
+    act(() => {
+      retry?.click();
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces incidentId in the body when present", () => {
+    const node = render(
+      <OnboardingError
+        error={make({
+          class: "unknown_server_error",
+          status: 500,
+          incidentId: "GST-77",
+        })}
+        onRetry={() => {}}
+      />,
+    );
+    expect(node.textContent).toContain("GST-77");
+  });
+
+  it("renders name_conflict with retry, never echoing the raw server message", () => {
+    const node = render(
+      <OnboardingError
+        error={make({
+          class: "name_conflict",
+          status: 409,
+          serverMessage: "Agent shortname 'CEO' is already in use in this company",
+        })}
+        onRetry={() => {}}
+      />,
+    );
+    expect(node.textContent).toContain("That name is taken");
+    expect(node.textContent).not.toContain("shortname");
+  });
+
+  it("renders validation as inline (no banner) and lists each field message", () => {
+    const node = render(
+      <OnboardingError
+        error={make({
+          class: "validation",
+          status: 400,
+          fields: [
+            { path: "name", message: "Required" },
+            { path: "model", message: "Must be provider/model" },
+          ],
+        })}
+        onRetry={() => {}}
+      />,
+    );
+    const alert = node.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    // No banner class on inline variant
+    expect(alert?.className).not.toContain("border-destructive");
+    expect(node.textContent).toContain("name: Required");
+    expect(node.textContent).toContain("model: Must be provider/model");
+    // Inline variant has no retry button
+    expect(
+      node.querySelector('[data-testid="onboarding-error-retry"]'),
+    ).toBeNull();
+  });
+
+  it("renders network with check-connection copy", () => {
+    const node = render(
+      <OnboardingError
+        error={make({ class: "network", serverMessage: "Failed to fetch" })}
+        onRetry={() => {}}
+      />,
+    );
+    expect(node.textContent).toContain("Couldn't reach Paperclip");
+    expect(node.textContent).not.toContain("Failed to fetch");
+  });
+
+  it("disables the retry button when retrying is true", () => {
+    const node = render(
+      <OnboardingError
+        error={make({ class: "unknown_server_error" })}
+        onRetry={() => {}}
+        retrying
+      />,
+    );
+    const retry = node.querySelector(
+      '[data-testid="onboarding-error-retry"]',
+    ) as HTMLButtonElement | null;
+    expect(retry).not.toBeNull();
+    expect(retry?.disabled).toBe(true);
+    expect(retry?.textContent).toBe("Retrying...");
+  });
+
+  it("omits the retry button when no onRetry is provided", () => {
+    const node = render(
+      <OnboardingError error={make({ class: "unknown_server_error" })} />,
+    );
+    expect(node.querySelector('[role="alert"]')).not.toBeNull();
+    expect(
+      node.querySelector('[data-testid="onboarding-error-retry"]'),
+    ).toBeNull();
+  });
+});

--- a/ui/src/components/OnboardingError.tsx
+++ b/ui/src/components/OnboardingError.tsx
@@ -1,0 +1,57 @@
+import { Button } from "@/components/ui/button";
+import type { CategorizedOnboardingError } from "../lib/onboarding-error";
+import { getOnboardingErrorCopy } from "../lib/onboarding-error-copy";
+
+export interface OnboardingErrorProps {
+  error: CategorizedOnboardingError | null;
+  onRetry?: (() => void) | null;
+  retrying?: boolean;
+}
+
+export function OnboardingError({ error, onRetry, retrying = false }: OnboardingErrorProps) {
+  if (!error) return null;
+
+  // Step 2's adapter environment surface owns its own rendering — we suppress.
+  if (error.class === "adapter_environment") return null;
+
+  const copy = getOnboardingErrorCopy(error);
+
+  if (copy.variant === "inline") {
+    return (
+      <div role="alert" data-testid="onboarding-error" data-class={error.class}>
+        <p className="text-xs text-destructive">{copy.body}</p>
+      </div>
+    );
+  }
+
+  const showRetry = Boolean(copy.retryLabel && onRetry);
+
+  return (
+    <div
+      role="alert"
+      data-testid="onboarding-error"
+      data-class={error.class}
+      className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 space-y-1.5"
+    >
+      {copy.title && (
+        <p className="text-xs font-medium text-destructive">{copy.title}</p>
+      )}
+      <p className="text-xs text-destructive/90 leading-relaxed">{copy.body}</p>
+      {showRetry && (
+        <div className="pt-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 px-2.5 text-xs"
+            onClick={onRetry ?? undefined}
+            disabled={retrying}
+            data-testid="onboarding-error-retry"
+          >
+            {retrying ? "Retrying..." : copy.retryLabel}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -10,6 +10,12 @@ import { agentsApi } from "../api/agents";
 import { approvalsApi } from "../api/approvals";
 import { issuesApi } from "../api/issues";
 import { projectsApi } from "../api/projects";
+import { setRequestHeader } from "../api/client";
+import {
+  categorizeOnboardingError,
+  type CategorizedOnboardingError,
+} from "../lib/onboarding-error";
+import { OnboardingError } from "./OnboardingError";
 import { queryKeys } from "../lib/queryKeys";
 import { Dialog, DialogPortal } from "@/components/ui/dialog";
 import {
@@ -100,7 +106,7 @@ export function OnboardingWizard() {
 
   const [step, setStep] = useState<Step>(initialStep);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<CategorizedOnboardingError | null>(null);
   const [modelOpen, setModelOpen] = useState(false);
   const [modelSearch, setModelSearch] = useState("");
 
@@ -158,6 +164,15 @@ export function OnboardingWizard() {
   useEffect(() => {
     setRouteDismissed(false);
   }, [location.pathname]);
+
+  // Tag every fetch fired while the wizard is mounted so the server-side
+  // onboarding-incident middleware can scope auto-file decisions. Server has a
+  // route allowlist fallback if this header is missing.
+  useEffect(() => {
+    if (!effectiveOnboardingOpen) return;
+    setRequestHeader("X-Paperclip-Onboarding", "1");
+    return () => setRequestHeader("X-Paperclip-Onboarding", null);
+  }, [effectiveOnboardingOpen]);
 
   // Sync step and company when onboarding opens with options.
   // Keep this independent from company-list refreshes so Step 1 completion
@@ -376,8 +391,11 @@ export function OnboardingWizard() {
       setAdapterEnvResult(result);
       return result;
     } catch (err) {
+      const category = categorizeOnboardingError(err);
       setAdapterEnvError(
-        err instanceof Error ? err.message : "Adapter environment test failed"
+        category.class === "network"
+          ? "Couldn't reach Paperclip to run the adapter probe. Check your connection and try again."
+          : "Adapter environment test failed. Try again, or check the adapter config."
       );
       return null;
     } finally {
@@ -415,7 +433,7 @@ export function OnboardingWizard() {
 
       setStep(2);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create company");
+      setError(categorizeOnboardingError(err));
     } finally {
       setLoading(false);
     }
@@ -428,9 +446,19 @@ export function OnboardingWizard() {
     try {
       if (adapterType === "opencode_local") {
         if (!isValidOpenCodeModelId(model)) {
-          setError(
-            "OpenCode requires an explicit model in provider/model format."
-          );
+          setError({
+            class: "validation",
+            status: null,
+            serverMessage: null,
+            incidentId: null,
+            fields: [
+              {
+                path: "model",
+                message:
+                  "OpenCode requires an explicit model in provider/model format."
+              }
+            ]
+          });
           return;
         }
       }
@@ -463,7 +491,7 @@ export function OnboardingWizard() {
       });
       setStep(3);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create agent");
+      setError(categorizeOnboardingError(err));
     } finally {
       setLoading(false);
     }
@@ -503,16 +531,12 @@ export function OnboardingWizard() {
 
       const result = await runAdapterEnvironmentTest(configWithUnset);
       if (result?.status === "fail") {
-        setError(
+        setAdapterEnvError(
           "Retried with ANTHROPIC_API_KEY unset in adapter config, but the environment test is still failing."
         );
       }
     } catch (err) {
-      setError(
-        err instanceof Error
-          ? err.message
-          : "Failed to unset ANTHROPIC_API_KEY and retry."
-      );
+      setError(categorizeOnboardingError(err));
     } finally {
       setUnsetAnthropicLoading(false);
     }
@@ -577,10 +601,27 @@ export function OnboardingWizard() {
           : `/issues/${issueRef}`
       );
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create task");
+      setError(categorizeOnboardingError(err));
     } finally {
       setLoading(false);
     }
+  }
+
+  function retryCurrentStep() {
+    if (loading) return;
+    if (step === 1) {
+      if (companyName.trim()) void handleStep1Next();
+      return;
+    }
+    if (step === 2) {
+      if (agentName.trim()) void handleStep2Next();
+      return;
+    }
+    if (step === 3) {
+      if (taskTitle.trim()) void handleStep3Next();
+      return;
+    }
+    if (step === 4) void handleLaunch();
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -1178,7 +1219,11 @@ export function OnboardingWizard() {
               {/* Error */}
               {error && (
                 <div className="mt-3">
-                  <p className="text-xs text-destructive">{error}</p>
+                  <OnboardingError
+                    error={error}
+                    onRetry={retryCurrentStep}
+                    retrying={loading}
+                  />
                 </div>
               )}
 

--- a/ui/src/lib/onboarding-error-copy.ts
+++ b/ui/src/lib/onboarding-error-copy.ts
@@ -1,0 +1,89 @@
+import type { CategorizedOnboardingError, OnboardingErrorClass } from "./onboarding-error";
+
+export interface OnboardingErrorCopy {
+  /**
+   * Visual treatment hint. "inline" renders without a banner background
+   * (used for field-level validation). "banner" renders with the standard
+   * destructive banner.
+   */
+  variant: "inline" | "banner";
+  title: string | null;
+  body: string;
+  retryLabel: string | null;
+  secondaryLabel: string | null;
+}
+
+const DEFAULT_RETRY = "Try again";
+
+function joinFieldMessages(error: CategorizedOnboardingError): string {
+  if (error.fields.length === 0) {
+    return error.serverMessage ?? "Please check the form and try again.";
+  }
+  return error.fields
+    .map((f) => (f.path ? `${f.path}: ${f.message}` : f.message))
+    .join(" • ");
+}
+
+export function getOnboardingErrorCopy(error: CategorizedOnboardingError): OnboardingErrorCopy {
+  switch (error.class as OnboardingErrorClass) {
+    case "validation":
+      return {
+        variant: "inline",
+        title: null,
+        body: joinFieldMessages(error),
+        retryLabel: null,
+        secondaryLabel: null,
+      };
+
+    case "name_conflict":
+      return {
+        variant: "banner",
+        title: "That name is taken",
+        body: "Pick a different name and try again.",
+        retryLabel: DEFAULT_RETRY,
+        secondaryLabel: null,
+      };
+
+    case "adapter_environment":
+      // Step 2's AdapterEnvironmentResult renders this case. OnboardingError
+      // suppresses rendering so we don't double up.
+      return {
+        variant: "banner",
+        title: null,
+        body: "",
+        retryLabel: null,
+        secondaryLabel: null,
+      };
+
+    case "unknown_server_error": {
+      const incident = error.incidentId
+        ? ` We've logged it as ${error.incidentId}.`
+        : " We've logged it.";
+      return {
+        variant: "banner",
+        title: "Something went wrong on our side",
+        body: `Something went wrong while saving.${incident} You can retry, or try a different name.`,
+        retryLabel: DEFAULT_RETRY,
+        secondaryLabel: null,
+      };
+    }
+
+    case "network":
+      return {
+        variant: "banner",
+        title: "Couldn't reach Paperclip",
+        body: "Check your connection and try again.",
+        retryLabel: DEFAULT_RETRY,
+        secondaryLabel: null,
+      };
+
+    default:
+      return {
+        variant: "banner",
+        title: "Something went wrong",
+        body: "Please try again.",
+        retryLabel: DEFAULT_RETRY,
+        secondaryLabel: null,
+      };
+  }
+}

--- a/ui/src/lib/onboarding-error.test.ts
+++ b/ui/src/lib/onboarding-error.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { ApiError } from "../api/client";
+import { categorizeOnboardingError } from "./onboarding-error";
+
+describe("categorizeOnboardingError", () => {
+  describe("ApiError → 5xx", () => {
+    it("classifies 500 with generic body as unknown_server_error", () => {
+      const err = new ApiError("Internal server error", 500, {
+        error: "Internal server error",
+      });
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("unknown_server_error");
+      expect(result.status).toBe(500);
+      expect(result.serverMessage).toBe("Internal server error");
+      expect(result.incidentId).toBeNull();
+      expect(result.fields).toEqual([]);
+    });
+
+    it("extracts incidentId from a 500 body when present", () => {
+      const err = new ApiError("Internal server error", 503, {
+        error: "Internal server error",
+        incidentId: "PAP-9012",
+      });
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("unknown_server_error");
+      expect(result.incidentId).toBe("PAP-9012");
+    });
+
+    it("accepts issueIdentifier alias for incidentId", () => {
+      const err = new ApiError("Internal server error", 500, {
+        error: "Internal server error",
+        issueIdentifier: "GST-99",
+      });
+      const result = categorizeOnboardingError(err);
+      expect(result.incidentId).toBe("GST-99");
+    });
+  });
+
+  describe("ApiError → 409", () => {
+    it("classifies 409 as name_conflict", () => {
+      const err = new ApiError(
+        "Agent shortname 'CEO' is already in use in this company",
+        409,
+        { error: "Agent shortname 'CEO' is already in use in this company" },
+      );
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("name_conflict");
+      expect(result.status).toBe(409);
+      expect(result.serverMessage).toBe(
+        "Agent shortname 'CEO' is already in use in this company",
+      );
+    });
+  });
+
+  describe("ApiError → 4xx validation", () => {
+    it("classifies 400 with Zod details as validation and extracts fields", () => {
+      const err = new ApiError("Validation error", 400, {
+        error: "Validation error",
+        details: [
+          { path: ["name"], message: "Required", code: "invalid_type" },
+          { path: ["budget", "monthlyCents"], message: "Must be positive" },
+        ],
+      });
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("validation");
+      expect(result.status).toBe(400);
+      expect(result.fields).toEqual([
+        { path: "name", message: "Required" },
+        { path: "budget.monthlyCents", message: "Must be positive" },
+      ]);
+    });
+
+    it("treats 422 with no details as validation but with empty fields", () => {
+      const err = new ApiError("Cannot create", 422, { error: "Cannot create" });
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("validation");
+      expect(result.fields).toEqual([]);
+    });
+
+    it("skips Zod entries that have no message", () => {
+      const err = new ApiError("Validation error", 400, {
+        error: "Validation error",
+        details: [
+          { path: ["a"] },
+          { path: ["b"], message: "Bad" },
+          "not-a-record",
+        ],
+      });
+      const result = categorizeOnboardingError(err);
+      expect(result.fields).toEqual([{ path: "b", message: "Bad" }]);
+    });
+  });
+
+  describe("Network", () => {
+    it("classifies a TypeError (fetch threw) as network", () => {
+      const err = new TypeError("Failed to fetch");
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("network");
+      expect(result.status).toBeNull();
+      expect(result.serverMessage).toBe("Failed to fetch");
+    });
+
+    it("classifies an aborted DOMException as network", () => {
+      const err = new DOMException("aborted", "AbortError");
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("network");
+    });
+  });
+
+  describe("Catch-all", () => {
+    it("classifies an unknown Error as unknown_server_error", () => {
+      const err = new Error("boom");
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("unknown_server_error");
+      expect(result.serverMessage).toBe("boom");
+    });
+
+    it("handles non-Error throws without crashing", () => {
+      const result = categorizeOnboardingError("string-thrown");
+      expect(result.class).toBe("unknown_server_error");
+      expect(result.serverMessage).toBeNull();
+      expect(result.fields).toEqual([]);
+    });
+  });
+
+  describe("Never leaks raw err.message into the unknown_server_error body field", () => {
+    it("keeps the categorized class invariant even when server returns weird body shapes", () => {
+      const err = new ApiError("oops", 500, "not-json");
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("unknown_server_error");
+      // serverMessage falls back to ApiError.message when body is not a record
+      expect(result.serverMessage).toBe("oops");
+      expect(result.incidentId).toBeNull();
+    });
+  });
+});

--- a/ui/src/lib/onboarding-error.test.ts
+++ b/ui/src/lib/onboarding-error.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "../api/client";
 import { categorizeOnboardingError } from "./onboarding-error";
 
@@ -92,12 +92,24 @@ describe("categorizeOnboardingError", () => {
   });
 
   describe("Network", () => {
-    it("classifies a TypeError (fetch threw) as network", () => {
+    it("classifies a TypeError with 'Failed to fetch' as network (Chrome)", () => {
       const err = new TypeError("Failed to fetch");
       const result = categorizeOnboardingError(err);
       expect(result.class).toBe("network");
       expect(result.status).toBeNull();
       expect(result.serverMessage).toBe("Failed to fetch");
+    });
+
+    it("classifies a TypeError with 'NetworkError' as network (Firefox)", () => {
+      const err = new TypeError("NetworkError when attempting to fetch resource.");
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("network");
+    });
+
+    it("classifies a TypeError with 'Load failed' as network (Safari)", () => {
+      const err = new TypeError("Load failed");
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("network");
     });
 
     it("classifies an aborted DOMException as network", () => {
@@ -108,6 +120,16 @@ describe("categorizeOnboardingError", () => {
   });
 
   describe("Catch-all", () => {
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore();
+    });
+
     it("classifies an unknown Error as unknown_server_error", () => {
       const err = new Error("boom");
       const result = categorizeOnboardingError(err);
@@ -120,6 +142,38 @@ describe("categorizeOnboardingError", () => {
       expect(result.class).toBe("unknown_server_error");
       expect(result.serverMessage).toBeNull();
       expect(result.fields).toEqual([]);
+    });
+
+    it("classifies a non-network TypeError (JS bug) as unknown_server_error", () => {
+      const err = new TypeError("Cannot read properties of null (reading 'foo')");
+      const result = categorizeOnboardingError(err);
+      expect(result.class).toBe("unknown_server_error");
+      expect(result.serverMessage).toBe(
+        "Cannot read properties of null (reading 'foo')",
+      );
+    });
+
+    it("logs uncategorized errors via console.error so the 'We've logged it' copy is honest", () => {
+      const err = new Error("boom");
+      categorizeOnboardingError(err);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[onboarding] uncategorized error",
+        err,
+      );
+    });
+
+    it("logs non-fetch TypeErrors that fall through to the catch-all", () => {
+      const err = new TypeError("Cannot read properties of null");
+      categorizeOnboardingError(err);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[onboarding] uncategorized error",
+        err,
+      );
+    });
+
+    it("does not log when the error is correctly classified as network", () => {
+      categorizeOnboardingError(new TypeError("Failed to fetch"));
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/ui/src/lib/onboarding-error.ts
+++ b/ui/src/lib/onboarding-error.ts
@@ -92,11 +92,13 @@ export function categorizeOnboardingError(err: unknown): CategorizedOnboardingEr
   }
 
   // fetch() throws TypeError (or DOMException for abort) when the network
-  // is unreachable — no response was produced.
-  if (
-    err instanceof TypeError ||
-    (typeof DOMException !== "undefined" && err instanceof DOMException)
-  ) {
+  // is unreachable — no response was produced. Narrow TypeError by message so a
+  // plain JS null-deref doesn't get misclassified as "Couldn't reach Paperclip."
+  const isFetchNetworkError =
+    err instanceof TypeError && /fetch|network|load failed/i.test(err.message);
+  const isAbortError =
+    typeof DOMException !== "undefined" && err instanceof DOMException;
+  if (isFetchNetworkError || isAbortError) {
     return {
       class: "network",
       status: null,
@@ -109,6 +111,8 @@ export function categorizeOnboardingError(err: unknown): CategorizedOnboardingEr
   // Catch-all: treat as unknown server error so the user still gets a retry
   // affordance rather than a dead-end. We never leak the raw message into the
   // banner — copy is sourced from `onboarding-error-copy.ts`.
+  // Log so the "We've logged it." copy is honest and DevTools/Sentry get a signal.
+  console.error("[onboarding] uncategorized error", err);
   return {
     class: "unknown_server_error",
     status: null,

--- a/ui/src/lib/onboarding-error.ts
+++ b/ui/src/lib/onboarding-error.ts
@@ -1,0 +1,119 @@
+import { ApiError } from "../api/client";
+
+export type OnboardingErrorClass =
+  | "validation"
+  | "name_conflict"
+  | "adapter_environment"
+  | "unknown_server_error"
+  | "network";
+
+export interface ValidationFieldError {
+  path: string;
+  message: string;
+}
+
+export interface CategorizedOnboardingError {
+  class: OnboardingErrorClass;
+  status: number | null;
+  serverMessage: string | null;
+  incidentId: string | null;
+  fields: ValidationFieldError[];
+}
+
+interface AnyRecord {
+  [key: string]: unknown;
+}
+
+function isRecord(value: unknown): value is AnyRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractIncidentId(body: unknown): string | null {
+  if (!isRecord(body)) return null;
+  const candidate = body.incidentId ?? body.issueIdentifier ?? body.issueId;
+  return typeof candidate === "string" && candidate.length > 0 ? candidate : null;
+}
+
+function extractServerMessage(body: unknown): string | null {
+  if (!isRecord(body)) return null;
+  if (typeof body.error === "string" && body.error.length > 0) return body.error;
+  if (typeof body.message === "string" && body.message.length > 0) return body.message;
+  return null;
+}
+
+function extractZodFieldErrors(body: unknown): ValidationFieldError[] {
+  if (!isRecord(body)) return [];
+  const details = body.details;
+  if (!Array.isArray(details)) return [];
+  const out: ValidationFieldError[] = [];
+  for (const entry of details) {
+    if (!isRecord(entry)) continue;
+    const message = typeof entry.message === "string" ? entry.message : null;
+    if (!message) continue;
+    const path = Array.isArray(entry.path)
+      ? entry.path.filter((p) => typeof p === "string" || typeof p === "number").join(".")
+      : typeof entry.path === "string"
+        ? entry.path
+        : "";
+    out.push({ path, message });
+  }
+  return out;
+}
+
+/**
+ * Categorize any error thrown from an onboarding API call into one of the
+ * `OnboardingErrorClass` buckets so the UI can render friendly copy + retry.
+ *
+ * Never returns raw `err.message` for rendering — `serverMessage` is exposed
+ * only so callers can show it as supplemental detail when desired.
+ */
+export function categorizeOnboardingError(err: unknown): CategorizedOnboardingError {
+  if (err instanceof ApiError) {
+    const status = err.status;
+    const serverMessage = extractServerMessage(err.body) ?? err.message ?? null;
+    const incidentId = extractIncidentId(err.body);
+
+    if (status >= 500) {
+      return { class: "unknown_server_error", status, serverMessage, incidentId, fields: [] };
+    }
+    if (status === 409) {
+      return { class: "name_conflict", status, serverMessage, incidentId, fields: [] };
+    }
+    if (status >= 400 && status < 500) {
+      return {
+        class: "validation",
+        status,
+        serverMessage,
+        incidentId,
+        fields: extractZodFieldErrors(err.body),
+      };
+    }
+    return { class: "unknown_server_error", status, serverMessage, incidentId, fields: [] };
+  }
+
+  // fetch() throws TypeError (or DOMException for abort) when the network
+  // is unreachable — no response was produced.
+  if (
+    err instanceof TypeError ||
+    (typeof DOMException !== "undefined" && err instanceof DOMException)
+  ) {
+    return {
+      class: "network",
+      status: null,
+      serverMessage: err instanceof Error ? err.message : null,
+      incidentId: null,
+      fields: [],
+    };
+  }
+
+  // Catch-all: treat as unknown server error so the user still gets a retry
+  // affordance rather than a dead-end. We never leak the raw message into the
+  // banner — copy is sourced from `onboarding-error-copy.ts`.
+  return {
+    class: "unknown_server_error",
+    status: null,
+    serverMessage: err instanceof Error ? err.message : null,
+    incidentId: null,
+    fields: [],
+  };
+}


### PR DESCRIPTION
ui(onboarding): friendly error surface + retry for the wizard

Replaces raw err.message rendering in OnboardingWizard's 4 steps with a
categorized error surface and retry affordance. Errors flow through
categorizeOnboardingError(err) which maps ApiError status / network
failures into: validation | name_conflict | adapter_environment |
unknown_server_error | network.

All copy lives in ui/src/lib/onboarding-error-copy.ts. The wizard sets
X-Paperclip-Onboarding: 1 on every fetch fired while mounted; server-side
GST-5b's incident-reporter middleware uses this to scope auto-file
decisions (has a route allowlist fallback).

## Test plan

- pnpm --filter @paperclipai/ui exec vitest run \
    src/lib/onboarding-error.test.ts src/components/OnboardingError.test.tsx
- pnpm --filter @paperclipai/ui exec tsc --noEmit
- Manual: visit /onboarding, force a 5xx (use name "pdeo" on an instance
  with PDE already taken) → confirm friendly copy + retry button.