### PR TITLE
Auto-file onboarding 5xx errors as issues (GST-9)

### DIFF
--- a/server/src/__tests__/onboarding-incident-reporter.test.ts
+++ b/server/src/__tests__/onboarding-incident-reporter.test.ts
@@ -1,0 +1,334 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import express from "express";
+import request from "supertest";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { companies, createDb, issueComments, issueLabels, issues, labels } from "@paperclipai/db";
+import { errorHandler } from "../middleware/index.js";
+import { onboardingIncidentReporter } from "../middleware/onboarding-incident-reporter.js";
+import {
+  AUTO_FILED_ONBOARDING_5XX_LABEL_NAME,
+  AUTO_FILED_ONBOARDING_5XX_ORIGIN_KIND,
+  onboardingIncidentsService,
+} from "../services/onboarding-incidents.js";
+import { HttpError } from "../errors.js";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres onboarding incident tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+type Db = ReturnType<typeof createDb>;
+type RecordSettlement = {
+  incidentId: string;
+  ok: boolean;
+  error?: unknown;
+  outcome?: { filed: string; issueId?: string };
+};
+
+interface IncidentBarrier {
+  onSettled(value: RecordSettlement): void;
+  wait(): Promise<RecordSettlement>;
+}
+
+interface AppHandle {
+  app: express.Express;
+  incidentDir: string;
+  cleanup: () => Promise<void>;
+  waitForNextIncident(): Promise<RecordSettlement>;
+}
+
+function buildIncidentBarrier(): IncidentBarrier {
+  const queue: RecordSettlement[] = [];
+  const waiters: Array<(value: RecordSettlement) => void> = [];
+  return {
+    onSettled(value) {
+      const waiter = waiters.shift();
+      if (waiter) waiter(value);
+      else queue.push(value);
+    },
+    wait() {
+      const next = queue.shift();
+      if (next) return Promise.resolve(next);
+      return new Promise((resolve) => waiters.push(resolve));
+    },
+  };
+}
+
+function buildApp(
+  db: Db,
+  incidentDir: string,
+  opts: {
+    actor?: express.Request["actor"];
+    barrier?: IncidentBarrier;
+  } = {},
+): express.Express {
+  const incidents = onboardingIncidentsService(db, { incidentDir });
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.actor = opts.actor
+      ?? ({
+        type: "board",
+        userId: "user-1",
+        userName: "Test Board User",
+        userEmail: null,
+        isInstanceAdmin: true,
+        source: "session",
+      } as express.Request["actor"]);
+    next();
+  });
+  app.use(
+    onboardingIncidentReporter({
+      incidents,
+      onRecordSettled: opts.barrier?.onSettled,
+    }),
+  );
+
+  app.post("/api/companies", (_req, _res, next) => {
+    next(new HttpError(500, "Internal server error"));
+  });
+  app.post("/api/companies/:companyId/projects", (_req, _res, next) => {
+    next(new HttpError(500, "Internal server error"));
+  });
+  app.post("/api/probe-non-onboarding", (_req, _res, next) => {
+    next(new HttpError(500, "Internal server error"));
+  });
+
+  app.use(errorHandler);
+  return app;
+}
+
+async function withTempIncidentDir(): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-incidents-"));
+  return {
+    dir,
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function newAppHandle(
+  db: Db,
+  opts: { actor?: express.Request["actor"] } = {},
+): Promise<AppHandle> {
+  return (async () => {
+    const tmp = await withTempIncidentDir();
+    const barrier = buildIncidentBarrier();
+    const app = buildApp(db, tmp.dir, { ...opts, barrier });
+    return {
+      app,
+      incidentDir: tmp.dir,
+      cleanup: tmp.cleanup,
+      waitForNextIncident: () => barrier.wait(),
+    };
+  })();
+}
+
+async function insertCompany(db: Db, name = "Acme Inc") {
+  const [row] = await db
+    .insert(companies)
+    .values({ name, issuePrefix: name.slice(0, 3).toUpperCase() })
+    .returning();
+  return row;
+}
+
+describeEmbeddedPostgres("onboarding-incident-reporter middleware + service", () => {
+  let db: Db;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let handle: AppHandle;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-onboarding-incident-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  beforeEach(async () => {
+    handle = await newAppHandle(db);
+  });
+
+  afterEach(async () => {
+    await handle.cleanup();
+    await db.delete(issueComments);
+    await db.delete(issueLabels);
+    await db.delete(issues);
+    await db.delete(labels);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("files an auto-issue on an onboarding 5xx when a company exists in the URL", async () => {
+    const company = await insertCompany(db);
+
+    const response = await request(handle.app)
+      .post(`/api/companies/${company.id}/projects`)
+      .set("X-Paperclip-Onboarding", "1")
+      .set("Authorization", "Bearer secret-token")
+      .send({ name: "First project", password: "do-not-store" });
+
+    expect(response.status).toBe(500);
+    expect(response.body.incidentId).toMatch(/^[0-9a-f-]{36}$/);
+
+    const settled = await handle.waitForNextIncident();
+    if (settled.error) throw settled.error;
+    expect(settled.ok).toBe(true);
+    expect(settled.outcome?.filed).toBe("issue");
+
+    const filed = await db.select().from(issues).where(eq(issues.companyId, company.id));
+    expect(filed).toHaveLength(1);
+    expect(filed[0].title).toContain("Onboarding 5xx");
+    expect(filed[0].originKind).toBe(AUTO_FILED_ONBOARDING_5XX_ORIGIN_KIND);
+    expect(filed[0].priority).toBe("high");
+    expect(filed[0].status).toBe("backlog");
+    expect(filed[0].description ?? "").not.toContain("do-not-store");
+    expect(filed[0].description ?? "").not.toContain("secret-token");
+    expect(filed[0].description ?? "").toContain("[redacted]");
+
+    const labelRows = await db
+      .select()
+      .from(labels)
+      .where(eq(labels.companyId, company.id));
+    expect(labelRows.map((l) => l.name)).toContain(AUTO_FILED_ONBOARDING_5XX_LABEL_NAME);
+  });
+
+  it("dedups within 24h and posts a counter comment instead of a second issue", async () => {
+    const company = await insertCompany(db, "Beta Co");
+
+    await request(handle.app)
+      .post(`/api/companies/${company.id}/projects`)
+      .set("X-Paperclip-Onboarding", "1")
+      .send({ name: "First" });
+    {
+      const settled = await handle.waitForNextIncident();
+      if (settled.error) throw settled.error;
+    }
+
+    await request(handle.app)
+      .post(`/api/companies/${company.id}/projects`)
+      .set("X-Paperclip-Onboarding", "1")
+      .send({ name: "First" });
+    {
+      const settled = await handle.waitForNextIncident();
+      if (settled.error) throw settled.error;
+    }
+
+    const filed = await db.select().from(issues).where(eq(issues.companyId, company.id));
+    expect(filed).toHaveLength(1);
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, filed[0].id));
+    expect(comments.length).toBeGreaterThanOrEqual(1);
+    expect(comments.some((c) => c.body?.includes("Repeat hit"))).toBe(true);
+  });
+
+  it("defers to disk when the request had no companyId in the URL", async () => {
+    const response = await request(handle.app)
+      .post("/api/companies")
+      .send({ name: "pdeo" });
+
+    expect(response.status).toBe(500);
+    expect(response.body.incidentId).toMatch(/^[0-9a-f-]{36}$/);
+
+    const settled = await handle.waitForNextIncident();
+    if (settled.error) throw settled.error;
+
+    const dirEntries = await fs.readdir(handle.incidentDir);
+    const incidents = dirEntries.filter((e) => e.endsWith(".json"));
+    expect(incidents).toHaveLength(1);
+    const raw = await fs.readFile(path.join(handle.incidentDir, incidents[0]), "utf8");
+    const parsed = JSON.parse(raw);
+    expect(parsed.routePattern).toBe("/api/companies");
+    expect(parsed.createdByUserId).toBe("user-1");
+    expect(parsed.error.message).toBe("Internal server error");
+  });
+
+  it("ingests pending incidents for the same creator on next POST /api/companies", async () => {
+    await request(handle.app).post("/api/companies").send({ name: "pdeo" });
+    {
+      const settled = await handle.waitForNextIncident();
+      if (settled.error) throw settled.error;
+    }
+    const beforeIngest = await fs.readdir(handle.incidentDir);
+    expect(beforeIngest.filter((e) => e.endsWith(".json"))).toHaveLength(1);
+
+    const incidents = onboardingIncidentsService(db, { incidentDir: handle.incidentDir });
+    const company = await insertCompany(db, "Pdeo Two");
+    const result = await incidents.ingestPendingIncidents(company.id, {
+      creatorUserId: "user-1",
+      actorSource: "session",
+    });
+    expect(result.ingestedCount).toBe(1);
+    expect(result.skippedCount).toBe(0);
+
+    const filed = await db.select().from(issues).where(eq(issues.companyId, company.id));
+    expect(filed).toHaveLength(1);
+    expect(filed[0].description ?? "").toContain("ingested on first successful company creation");
+
+    const afterIngest = await fs.readdir(handle.incidentDir);
+    expect(afterIngest.filter((e) => e.endsWith(".json"))).toHaveLength(0);
+  });
+
+  it("does NOT ingest incidents that belong to a different user", async () => {
+    await handle.cleanup();
+    handle = await newAppHandle(db, {
+      actor: {
+        type: "board",
+        userId: "user-other",
+        userName: "Other",
+        userEmail: null,
+        isInstanceAdmin: true,
+        source: "session",
+      } as express.Request["actor"],
+    });
+
+    await request(handle.app).post("/api/companies").send({ name: "pdeo" });
+    {
+      const settled = await handle.waitForNextIncident();
+      if (settled.error) throw settled.error;
+    }
+
+    const incidents = onboardingIncidentsService(db, { incidentDir: handle.incidentDir });
+    const company = await insertCompany(db, "Different User");
+    const result = await incidents.ingestPendingIncidents(company.id, {
+      creatorUserId: "user-1",
+      actorSource: "session",
+    });
+    expect(result.ingestedCount).toBe(0);
+    expect(result.skippedCount).toBe(1);
+
+    const filed = await db.select().from(issues).where(eq(issues.companyId, company.id));
+    expect(filed).toHaveLength(0);
+
+    const remaining = await fs.readdir(handle.incidentDir);
+    expect(remaining.filter((e) => e.endsWith(".json"))).toHaveLength(1);
+  });
+
+  it("does not record non-onboarding 5xx responses", async () => {
+    const response = await request(handle.app)
+      .post("/api/probe-non-onboarding")
+      .send({});
+    expect(response.status).toBe(500);
+    expect(response.body.incidentId).toBeUndefined();
+
+    // Give any (incorrect) recorder enough time to fire — it must not.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const entries = await fs.readdir(handle.incidentDir).catch(() => []);
+    expect(entries.filter((e) => e.endsWith(".json"))).toHaveLength(0);
+    const issueRows = await db.select().from(issues);
+    expect(issueRows).toHaveLength(0);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,7 +5,8 @@ import { fileURLToPath } from "node:url";
 import type { Db } from "@paperclipai/db";
 import type { DeploymentExposure, DeploymentMode } from "@paperclipai/shared";
 import type { StorageService } from "./storage/types.js";
-import { httpLogger, errorHandler } from "./middleware/index.js";
+import { httpLogger, errorHandler, onboardingIncidentReporter } from "./middleware/index.js";
+import { onboardingIncidentsService } from "./services/onboarding-incidents.js";
 import { actorMiddleware } from "./middleware/auth.js";
 import { boardMutationGuard } from "./middleware/board-mutation-guard.js";
 import { privateHostnameGuard, resolvePrivateHostnameAllowSet } from "./middleware/private-hostname-guard.js";
@@ -184,6 +185,8 @@ export async function createApp(
       resolveSession: opts.resolveSession,
     }),
   );
+  const onboardingIncidents = onboardingIncidentsService(db);
+  app.use(onboardingIncidentReporter({ incidents: onboardingIncidents }));
   app.use("/api/auth", authRoutes(db));
   if (opts.betterAuthHandler) {
     app.all("/api/auth/{*authPath}", opts.betterAuthHandler);

--- a/server/src/middleware/index.ts
+++ b/server/src/middleware/index.ts
@@ -1,3 +1,4 @@
 export { logger, httpLogger } from "./logger.js";
 export { errorHandler } from "./error-handler.js";
 export { validate } from "./validate.js";
+export { onboardingIncidentReporter, classifyOnboardingRequest } from "./onboarding-incident-reporter.js";

--- a/server/src/middleware/onboarding-incident-reporter.ts
+++ b/server/src/middleware/onboarding-incident-reporter.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto";
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import type { OnboardingIncidentsService } from "../services/onboarding-incidents.js";
+import { logger } from "./logger.js";
+
+const ONBOARDING_REFERER_PREFIX = "/onboarding";
+const ONBOARDING_HEADER = "x-paperclip-onboarding";
+
+type RoutePattern = { method: string; pattern: RegExp; canonical: string };
+
+const ONBOARDING_ROUTE_PATTERNS: RoutePattern[] = [
+  routePattern("POST", "/api/companies"),
+  routePattern("POST", "/api/companies/:companyId/goals"),
+  routePattern("POST", "/api/companies/:companyId/agents"),
+  routePattern("POST", "/api/companies/:companyId/agents/:agentId/adapter-environment-test"),
+  routePattern("POST", "/api/companies/:companyId/projects"),
+  routePattern("POST", "/api/companies/:companyId/issues"),
+];
+
+function routePattern(method: string, canonical: string): RoutePattern {
+  const escaped = canonical
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\/:([A-Za-z0-9_]+)/g, "/[^/]+");
+  return {
+    method: method.toUpperCase(),
+    pattern: new RegExp(`^${escaped}(?:\\?.*)?$`),
+    canonical,
+  };
+}
+
+function pathOnly(url: string | undefined): string {
+  if (!url) return "";
+  const idx = url.indexOf("?");
+  return idx >= 0 ? url.slice(0, idx) : url;
+}
+
+function refererPath(headerValue: string | undefined): string | null {
+  if (!headerValue) return null;
+  try {
+    const parsed = new URL(headerValue, "http://localhost");
+    return parsed.pathname;
+  } catch {
+    return null;
+  }
+}
+
+const COMPANY_ID_RE = /^\/api\/companies\/([0-9a-fA-F-]{32,36})(?:[\/?].*)?$/;
+
+function resolveCompanyIdFromUrl(originalUrl: string): string | null {
+  const path = pathOnly(originalUrl);
+  const match = COMPANY_ID_RE.exec(path);
+  return match ? match[1] : null;
+}
+
+function matchOnboardingRoute(method: string, url: string): RoutePattern | null {
+  const upper = method.toUpperCase();
+  const path = pathOnly(url);
+  for (const route of ONBOARDING_ROUTE_PATTERNS) {
+    if (route.method !== upper) continue;
+    if (route.pattern.test(path)) return route;
+  }
+  return null;
+}
+
+function isOnboardingHeaderTruthy(value: string | string[] | undefined): boolean {
+  const flat = Array.isArray(value) ? value[0] : value;
+  if (!flat) return false;
+  const normalized = flat.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+}
+
+interface OnboardingClassification {
+  isOnboarding: boolean;
+  routePattern: string;
+}
+
+export function classifyOnboardingRequest(req: Request): OnboardingClassification {
+  const allowlistHit = matchOnboardingRoute(req.method, req.originalUrl);
+  const headerHit = isOnboardingHeaderTruthy(req.header(ONBOARDING_HEADER) as string | undefined);
+  const refPath = refererPath(req.header("referer"));
+  const refererHit = refPath ? refPath.startsWith(ONBOARDING_REFERER_PREFIX) : false;
+  const isOnboarding = Boolean(allowlistHit) || headerHit || refererHit;
+  const routePattern = allowlistHit?.canonical ?? pathOnly(req.originalUrl) ?? req.path;
+  return { isOnboarding, routePattern };
+}
+
+interface ErrorContextSnapshot {
+  error: { name?: string; message: string; stack?: string };
+  reqBody: unknown;
+}
+
+function readErrorContext(res: Response): ErrorContextSnapshot | null {
+  const ctx = (res as unknown as { __errorContext?: { error?: ErrorContextSnapshot["error"]; reqBody?: unknown } }).__errorContext;
+  if (!ctx || !ctx.error) return null;
+  return { error: ctx.error, reqBody: ctx.reqBody };
+}
+
+export interface OnboardingIncidentReporterDeps {
+  incidents: OnboardingIncidentsService;
+  generateIncidentId?: () => string;
+  /**
+   * Test-only hook fired after a recordIncident call resolves or rejects.
+   * Lets vitest await the finish-hook side effect deterministically.
+   */
+  onRecordSettled?: (result: {
+    incidentId: string;
+    ok: boolean;
+    error?: unknown;
+    outcome?: { filed: string; issueId?: string };
+  }) => void;
+}
+
+export function onboardingIncidentReporter(deps: OnboardingIncidentReporterDeps): RequestHandler {
+  const generateIncidentId = deps.generateIncidentId ?? randomUUID;
+  return (req: Request, res: Response, next: NextFunction) => {
+    const classification = classifyOnboardingRequest(req);
+    if (!classification.isOnboarding) {
+      next();
+      return;
+    }
+
+    const incidentId = generateIncidentId();
+    res.locals.onboardingIncidentId = incidentId;
+
+    const originalJson = res.json.bind(res);
+    let jsonInjected = false;
+    res.json = function patchedJson(body: unknown) {
+      if (
+        !jsonInjected
+        && res.statusCode >= 500
+        && body
+        && typeof body === "object"
+        && !Array.isArray(body)
+        && !(body instanceof Buffer)
+      ) {
+        jsonInjected = true;
+        const next = { ...(body as Record<string, unknown>) };
+        if (!("incidentId" in next)) next.incidentId = incidentId;
+        return originalJson(next);
+      }
+      return originalJson(body);
+    };
+
+    res.on("finish", () => {
+      if (res.statusCode < 500) return;
+      const ctx = readErrorContext(res);
+      const errorPayload = ctx?.error ?? {
+        name: "Error",
+        message: `HTTP ${res.statusCode}`,
+        stack: undefined,
+      };
+      const reqBody = ctx?.reqBody ?? req.body ?? null;
+      const companyId = resolveCompanyIdFromUrl(req.originalUrl);
+
+      void deps.incidents
+        .recordIncident({
+          incidentId,
+          method: req.method,
+          routePattern: classification.routePattern,
+          requestUrl: req.originalUrl,
+          reqBody,
+          reqHeaders: req.headers as Record<string, string | string[] | undefined>,
+          error: {
+            name: errorPayload.name,
+            message: errorPayload.message,
+            stack: errorPayload.stack,
+          },
+          companyId,
+          createdByUserId: req.actor?.userId ?? null,
+          actorSource: req.actor?.source ?? null,
+        })
+        .then((outcome) => {
+          deps.onRecordSettled?.({
+            incidentId,
+            ok: true,
+            outcome: { filed: outcome.filed, issueId: outcome.issueId },
+          });
+        })
+        .catch((err) => {
+          logger.error({ err, incidentId }, "Onboarding incident recorder threw");
+          deps.onRecordSettled?.({ incidentId, ok: false, error: err });
+        });
+    });
+
+    next();
+  };
+}

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -23,7 +23,9 @@ import {
   companyService,
   feedbackService,
   logActivity,
+  onboardingIncidentsService,
 } from "../services/index.js";
+import { logger } from "../middleware/logger.js";
 import type { StorageService } from "../storage/types.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 import { COMPANY_IMPORT_ROUTE_PATH } from "./company-import-paths.js";
@@ -36,6 +38,7 @@ export function companyRoutes(db: Db, storage?: StorageService) {
   const access = accessService(db);
   const budgets = budgetService(db);
   const feedback = feedbackService(db);
+  const onboardingIncidents = onboardingIncidentsService(db);
   const importJobs = new Map<string, ImportJobRecord>();
   const importJobTerminalRetentionMs = 5 * 60 * 1000;
 
@@ -322,6 +325,14 @@ export function companyRoutes(db: Db, storage?: StorageService) {
         },
         req.actor.userId ?? "board",
       );
+    }
+    try {
+      await onboardingIncidents.ingestPendingIncidents(company.id, {
+        creatorUserId: req.actor.userId ?? null,
+        actorSource: req.actor.source ?? null,
+      });
+    } catch (err) {
+      logger.warn({ err, companyId: company.id }, "Failed to ingest pending onboarding incidents");
     }
     res.status(201).json(company);
   });

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -68,5 +68,11 @@ export { workProductService } from "./work-products.js";
 export { logActivity, type LogActivityInput } from "./activity-log.js";
 export { notifyHireApproved, type NotifyHireApprovedInput } from "./hire-hook.js";
 export { publishLiveEvent, subscribeCompanyLiveEvents } from "./live-events.js";
+export {
+  onboardingIncidentsService,
+  AUTO_FILED_ONBOARDING_5XX_ORIGIN_KIND,
+  AUTO_FILED_ONBOARDING_5XX_LABEL_NAME,
+  type OnboardingIncidentsService,
+} from "./onboarding-incidents.js";
 export { reconcilePersistedRuntimeServicesOnStartup, restartDesiredRuntimeServicesOnStartup } from "./workspace-runtime.js";
 export { createStorageServiceFromConfig, getStorageService } from "../storage/index.js";

--- a/server/src/services/onboarding-incidents.ts
+++ b/server/src/services/onboarding-incidents.ts
@@ -1,0 +1,447 @@
+import { createHash, randomUUID } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { Db } from "@paperclipai/db";
+import { resolvePaperclipInstanceRoot } from "../home-paths.js";
+import { redactCurrentUserValue } from "../log-redaction.js";
+import { logger } from "../middleware/logger.js";
+import { issueService } from "./issues.js";
+
+const INCIDENT_DIR_NAME = "onboarding-incidents";
+const INCIDENT_FILE_VERSION = 1;
+const INCIDENT_FILE_EXT = ".json";
+const INCIDENT_DECAY_MS = 30 * 24 * 60 * 60 * 1000;
+const INCIDENT_DECAY_SCAN_LIMIT = 100;
+const INCIDENT_INGEST_PER_REQUEST_LIMIT = 25;
+const STORED_BODY_MAX_BYTES = 8 * 1024;
+const STORED_HEADER_VALUE_MAX_BYTES = 256;
+const DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
+const SENSITIVE_HEADERS = new Set([
+  "authorization",
+  "cookie",
+  "x-paperclip-api-key",
+  "x-paperclip-board-key",
+]);
+const SENSITIVE_BODY_KEYS = new Set([
+  "password",
+  "passwordconfirmation",
+  "secret",
+  "token",
+  "apikey",
+  "api_key",
+  "accesstoken",
+  "refreshtoken",
+]);
+
+export const AUTO_FILED_ONBOARDING_5XX_ORIGIN_KIND = "auto_filed_onboarding_5xx";
+export const AUTO_FILED_ONBOARDING_5XX_LABEL_NAME = "auto-filed:onboarding-5xx";
+const AUTO_FILED_ONBOARDING_5XX_LABEL_COLOR = "#ef4444";
+
+export interface OnboardingIncidentRecord {
+  version: number;
+  incidentId: string;
+  capturedAt: string;
+  method: string;
+  routePattern: string;
+  requestUrl: string;
+  dedupHash: string;
+  createdByUserId: string | null;
+  actorSource: string | null;
+  error: { name: string; message: string; stack: string | null };
+  redactedBody: unknown;
+  redactedHeaders: Record<string, string>;
+  bodyTruncated: { truncated: false } | { truncated: true; originalByteSize: number };
+}
+
+export interface RecordIncidentInput {
+  incidentId: string;
+  capturedAt?: Date;
+  method: string;
+  routePattern: string;
+  requestUrl: string;
+  reqBody: unknown;
+  reqHeaders: Record<string, string | string[] | undefined>;
+  error: { name?: string | null; message?: string | null; stack?: string | null };
+  companyId?: string | null;
+  createdByUserId: string | null;
+  actorSource: string | null;
+}
+
+export interface RecordIncidentResult {
+  incidentId: string;
+  dedupHash: string;
+  filed: "issue" | "deferred" | "deduped" | "skipped";
+  issueId?: string;
+}
+
+export interface OnboardingIncidentsServiceOptions {
+  incidentDir?: string;
+  now?: () => Date;
+}
+
+export interface OnboardingIncidentsService {
+  recordIncident(input: RecordIncidentInput): Promise<RecordIncidentResult>;
+  ingestPendingIncidents(
+    companyId: string,
+    opts: { creatorUserId: string | null; actorSource: string | null },
+  ): Promise<{ ingestedCount: number; skippedCount: number }>;
+  __testOnly: {
+    getIncidentDir(): string;
+    decayOnce(): Promise<{ deletedCount: number; inspectedCount: number }>;
+  };
+}
+
+export function onboardingIncidentsService(
+  db: Db,
+  options: OnboardingIncidentsServiceOptions = {},
+): OnboardingIncidentsService {
+  const incidentDir = options.incidentDir
+    ?? path.join(resolvePaperclipInstanceRoot(), INCIDENT_DIR_NAME);
+  const now = options.now ?? (() => new Date());
+  const issues = issueService(db);
+
+  async function ensureIncidentDir() {
+    await fs.mkdir(incidentDir, { recursive: true, mode: 0o700 });
+  }
+
+  function buildDedupHash(method: string, routePattern: string, errorName: string, errorMessage: string) {
+    return createHash("sha256")
+      .update(`${method.toUpperCase()} ${routePattern} ${errorName} ${errorMessage}`)
+      .digest("hex");
+  }
+
+  function redactHeaders(reqHeaders: Record<string, string | string[] | undefined>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(reqHeaders)) {
+      if (value == null) continue;
+      const normalized = key.toLowerCase();
+      if (SENSITIVE_HEADERS.has(normalized)) continue;
+      const flattened = Array.isArray(value) ? value.join(", ") : String(value);
+      const masked = redactCurrentUserValue(flattened);
+      out[normalized] = masked.length > STORED_HEADER_VALUE_MAX_BYTES
+        ? `${masked.slice(0, STORED_HEADER_VALUE_MAX_BYTES)}…`
+        : masked;
+    }
+    return out;
+  }
+
+  function redactBody(body: unknown): unknown {
+    if (body == null) return body;
+    const masked = redactCurrentUserValue(body);
+    return stripSensitiveBodyKeys(masked);
+  }
+
+  function stripSensitiveBodyKeys(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(stripSensitiveBodyKeys);
+    if (value && typeof value === "object" && Object.getPrototypeOf(value) === Object.prototype) {
+      const next: Record<string, unknown> = {};
+      for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+        if (SENSITIVE_BODY_KEYS.has(key.toLowerCase())) {
+          next[key] = "[redacted]";
+          continue;
+        }
+        next[key] = stripSensitiveBodyKeys(entry);
+      }
+      return next;
+    }
+    return value;
+  }
+
+  function serializeBodyWithCap(body: unknown): {
+    serialized: string;
+    truncation: OnboardingIncidentRecord["bodyTruncated"];
+  } {
+    let serialized: string;
+    try {
+      serialized = JSON.stringify(body, null, 2) ?? "null";
+    } catch {
+      serialized = "\"[unserializable body]\"";
+    }
+    const byteSize = Buffer.byteLength(serialized, "utf8");
+    if (byteSize <= STORED_BODY_MAX_BYTES) {
+      return { serialized, truncation: { truncated: false } };
+    }
+    const truncatedBuffer = Buffer.from(serialized, "utf8").subarray(0, STORED_BODY_MAX_BYTES);
+    return {
+      serialized: `${truncatedBuffer.toString("utf8")}\n[truncated ${byteSize - STORED_BODY_MAX_BYTES} bytes]`,
+      truncation: { truncated: true, originalByteSize: byteSize },
+    };
+  }
+
+  function buildIncidentRecord(input: RecordIncidentInput): OnboardingIncidentRecord {
+    const errorName = (input.error.name ?? "Error").slice(0, 200);
+    const errorMessage = (input.error.message ?? "").slice(0, 2_000);
+    const stack = input.error.stack ? redactCurrentUserValue(input.error.stack).slice(0, 8_000) : null;
+    const redactedBody = redactBody(input.reqBody);
+    const { truncation } = serializeBodyWithCap(redactedBody);
+    return {
+      version: INCIDENT_FILE_VERSION,
+      incidentId: input.incidentId,
+      capturedAt: (input.capturedAt ?? now()).toISOString(),
+      method: input.method.toUpperCase(),
+      routePattern: input.routePattern,
+      requestUrl: input.requestUrl,
+      dedupHash: buildDedupHash(input.method, input.routePattern, errorName, errorMessage),
+      createdByUserId: input.createdByUserId,
+      actorSource: input.actorSource,
+      error: { name: errorName, message: errorMessage, stack },
+      redactedBody,
+      redactedHeaders: redactHeaders(input.reqHeaders),
+      bodyTruncated: truncation,
+    };
+  }
+
+  function renderIssueBody(record: OnboardingIncidentRecord, opts: { includeDeferredNote?: boolean } = {}) {
+    const { serialized } = serializeBodyWithCap(record.redactedBody);
+    const headerLines = Object.entries(record.redactedHeaders)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, value]) => `- \`${key}\`: ${value}`)
+      .join("\n");
+    const headersSection = headerLines.length > 0 ? headerLines : "_(none)_";
+    const deferredNote = opts.includeDeferredNote
+      ? "\n\n> Originally captured before any company existed; ingested on first successful company creation.\n"
+      : "";
+    return `## Onboarding 5xx auto-filed
+
+- **Route:** \`${record.method} ${record.routePattern}\`
+- **Request URL:** \`${record.requestUrl}\`
+- **Error:** \`${record.error.name}\` — ${record.error.message || "_(no message)_"}
+- **Captured at:** ${record.capturedAt}
+- **Incident ID:** \`${record.incidentId}\`
+- **Dedup hash:** \`${record.dedupHash}\`${deferredNote}
+
+### Stack
+\`\`\`
+${record.error.stack ?? "(no stack)"}
+\`\`\`
+
+### Redacted request body
+\`\`\`json
+${serialized}
+\`\`\`
+
+### Redacted request headers
+${headersSection}
+`;
+  }
+
+  async function getOrCreateLabel(companyId: string): Promise<string | null> {
+    try {
+      const existing = await issues.listLabels(companyId);
+      const match = existing.find((row) => row.name === AUTO_FILED_ONBOARDING_5XX_LABEL_NAME);
+      if (match) return match.id;
+      const created = await issues.createLabel(companyId, {
+        name: AUTO_FILED_ONBOARDING_5XX_LABEL_NAME,
+        color: AUTO_FILED_ONBOARDING_5XX_LABEL_COLOR,
+      });
+      return created?.id ?? null;
+    } catch (err) {
+      logger.warn({ err, companyId }, "Failed to upsert onboarding-5xx label");
+      return null;
+    }
+  }
+
+  async function findDedupIssue(companyId: string, dedupHash: string) {
+    const cutoff = new Date(now().getTime() - DEDUP_WINDOW_MS);
+    const rows = await issues.list(companyId, {
+      originKind: AUTO_FILED_ONBOARDING_5XX_ORIGIN_KIND,
+      originId: dedupHash,
+      limit: 5,
+    });
+    if (!Array.isArray(rows)) return null;
+    for (const candidate of rows) {
+      const createdAt = candidate.createdAt instanceof Date
+        ? candidate.createdAt
+        : new Date(candidate.createdAt as string);
+      if (createdAt.getTime() >= cutoff.getTime()) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  async function fileIssueForRecord(
+    companyId: string,
+    record: OnboardingIncidentRecord,
+    opts: { includeDeferredNote?: boolean } = {},
+  ): Promise<{ issueId: string; mode: "issue" | "deduped" }> {
+    const existing = await findDedupIssue(companyId, record.dedupHash);
+    if (existing) {
+      try {
+        await issues.addComment(
+          existing.id,
+          `Repeat hit at ${record.capturedAt}. Same route (\`${record.method} ${record.routePattern}\`) and error (\`${record.error.name}\`). Incident ID: \`${record.incidentId}\`.`,
+          { agentId: undefined, userId: undefined, runId: null },
+          { authorType: "system" },
+        );
+      } catch (err) {
+        logger.warn({ err, issueId: existing.id }, "Failed to post dedup counter comment");
+      }
+      return { issueId: existing.id, mode: "deduped" };
+    }
+
+    const labelId = await getOrCreateLabel(companyId);
+    const title = `Onboarding 5xx: ${record.method} ${record.routePattern} → ${record.error.name}`;
+    const description = renderIssueBody(record, opts);
+    const created = await issues.create(companyId, {
+      title: title.length > 240 ? `${title.slice(0, 237)}...` : title,
+      description,
+      priority: "high",
+      status: "backlog",
+      originKind: AUTO_FILED_ONBOARDING_5XX_ORIGIN_KIND,
+      originId: record.dedupHash,
+      ...(labelId ? { labelIds: [labelId] } : {}),
+    });
+    return { issueId: created.id, mode: "issue" };
+  }
+
+  async function writeIncidentFile(record: OnboardingIncidentRecord) {
+    await ensureIncidentDir();
+    const filename = `${Date.parse(record.capturedAt)}-${record.incidentId}${INCIDENT_FILE_EXT}`;
+    const finalPath = path.join(incidentDir, filename);
+    const tmpPath = `${finalPath}.tmp`;
+    await fs.writeFile(tmpPath, JSON.stringify(record, null, 2), { mode: 0o600 });
+    await fs.rename(tmpPath, finalPath);
+    return finalPath;
+  }
+
+  async function decayOnce(): Promise<{ deletedCount: number; inspectedCount: number }> {
+    let deletedCount = 0;
+    let inspectedCount = 0;
+    try {
+      const entries = await fs.readdir(incidentDir).catch((err) => {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return [] as string[];
+        throw err;
+      });
+      const cutoff = now().getTime() - INCIDENT_DECAY_MS;
+      for (const entry of entries) {
+        if (inspectedCount >= INCIDENT_DECAY_SCAN_LIMIT) break;
+        if (!entry.endsWith(INCIDENT_FILE_EXT)) continue;
+        inspectedCount += 1;
+        const entryPath = path.join(incidentDir, entry);
+        const stat = await fs.stat(entryPath).catch(() => null);
+        if (!stat) continue;
+        if (stat.mtimeMs < cutoff) {
+          await fs.unlink(entryPath).catch((err) => {
+            logger.warn({ err, entryPath }, "Failed to decay onboarding incident file");
+          });
+          deletedCount += 1;
+        }
+      }
+    } catch (err) {
+      logger.warn({ err }, "Onboarding incident decay sweep failed");
+    }
+    return { deletedCount, inspectedCount };
+  }
+
+  return {
+    async recordIncident(input) {
+      const record = buildIncidentRecord(input);
+      void decayOnce();
+
+      if (input.companyId) {
+        try {
+          const filed = await fileIssueForRecord(input.companyId, record);
+          return {
+            incidentId: record.incidentId,
+            dedupHash: record.dedupHash,
+            filed: filed.mode,
+            issueId: filed.issueId,
+          };
+        } catch (err) {
+          logger.error(
+            { err, companyId: input.companyId, incidentId: record.incidentId },
+            "Failed to auto-file onboarding 5xx issue",
+          );
+          return {
+            incidentId: record.incidentId,
+            dedupHash: record.dedupHash,
+            filed: "skipped",
+          };
+        }
+      }
+
+      try {
+        await writeIncidentFile(record);
+        return {
+          incidentId: record.incidentId,
+          dedupHash: record.dedupHash,
+          filed: "deferred",
+        };
+      } catch (err) {
+        logger.error(
+          { err, incidentId: record.incidentId },
+          "Failed to write deferred onboarding incident file",
+        );
+        return {
+          incidentId: record.incidentId,
+          dedupHash: record.dedupHash,
+          filed: "skipped",
+        };
+      }
+    },
+
+    async ingestPendingIncidents(companyId, opts) {
+      let ingestedCount = 0;
+      let skippedCount = 0;
+      let entries: string[];
+      try {
+        entries = await fs.readdir(incidentDir);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return { ingestedCount, skippedCount };
+        logger.warn({ err, companyId }, "Failed to scan onboarding incident dir for ingest");
+        return { ingestedCount, skippedCount };
+      }
+      const incidentFiles = entries.filter((entry) => entry.endsWith(INCIDENT_FILE_EXT));
+      for (const entry of incidentFiles) {
+        if (ingestedCount >= INCIDENT_INGEST_PER_REQUEST_LIMIT) break;
+        const entryPath = path.join(incidentDir, entry);
+        let parsed: OnboardingIncidentRecord | null = null;
+        try {
+          const raw = await fs.readFile(entryPath, "utf8");
+          parsed = JSON.parse(raw) as OnboardingIncidentRecord;
+        } catch (err) {
+          logger.warn({ err, entryPath }, "Skipping unreadable onboarding incident file");
+          continue;
+        }
+        if (!parsed || parsed.version !== INCIDENT_FILE_VERSION) {
+          skippedCount += 1;
+          continue;
+        }
+        if (!isIncidentEligibleForCreator(parsed, opts)) {
+          skippedCount += 1;
+          continue;
+        }
+        try {
+          await fileIssueForRecord(companyId, parsed, { includeDeferredNote: true });
+          await fs.unlink(entryPath).catch((err) => {
+            logger.warn({ err, entryPath }, "Failed to delete ingested incident file");
+          });
+          ingestedCount += 1;
+        } catch (err) {
+          logger.error({ err, entryPath, companyId }, "Failed to ingest deferred incident");
+          skippedCount += 1;
+        }
+      }
+      return { ingestedCount, skippedCount };
+    },
+
+    __testOnly: {
+      getIncidentDir: () => incidentDir,
+      decayOnce,
+    },
+  };
+}
+
+function isIncidentEligibleForCreator(
+  record: OnboardingIncidentRecord,
+  opts: { creatorUserId: string | null; actorSource: string | null },
+): boolean {
+  if (record.createdByUserId && opts.creatorUserId) {
+    return record.createdByUserId === opts.creatorUserId;
+  }
+  if (record.createdByUserId == null && opts.creatorUserId == null) {
+    return record.actorSource === "local_implicit" && opts.actorSource === "local_implicit";
+  }
+  return false;
+}

--- a/server/src/services/onboarding-incidents.ts
+++ b/server/src/services/onboarding-incidents.ts
@@ -13,6 +13,7 @@ const INCIDENT_FILE_EXT = ".json";
 const INCIDENT_DECAY_MS = 30 * 24 * 60 * 60 * 1000;
 const INCIDENT_DECAY_SCAN_LIMIT = 100;
 const INCIDENT_INGEST_PER_REQUEST_LIMIT = 25;
+const INCIDENT_INGEST_SCAN_LIMIT = 100;
 const STORED_BODY_MAX_BYTES = 8 * 1024;
 const STORED_HEADER_VALUE_MAX_BYTES = 256;
 const DEDUP_WINDOW_MS = 24 * 60 * 60 * 1000;
@@ -161,9 +162,9 @@ export function onboardingIncidentsService(
     if (byteSize <= STORED_BODY_MAX_BYTES) {
       return { serialized, truncation: { truncated: false } };
     }
-    const truncatedBuffer = Buffer.from(serialized, "utf8").subarray(0, STORED_BODY_MAX_BYTES);
+    const truncated = truncateUtf8ByBytes(serialized, STORED_BODY_MAX_BYTES);
     return {
-      serialized: `${truncatedBuffer.toString("utf8")}\n[truncated ${byteSize - STORED_BODY_MAX_BYTES} bytes]`,
+      serialized: `${truncated}\n[truncated ${byteSize - STORED_BODY_MAX_BYTES} bytes]`,
       truncation: { truncated: true, originalByteSize: byteSize },
     };
   }
@@ -393,8 +394,11 @@ ${headersSection}
         return { ingestedCount, skippedCount };
       }
       const incidentFiles = entries.filter((entry) => entry.endsWith(INCIDENT_FILE_EXT));
+      let processedCount = 0;
       for (const entry of incidentFiles) {
         if (ingestedCount >= INCIDENT_INGEST_PER_REQUEST_LIMIT) break;
+        if (processedCount >= INCIDENT_INGEST_SCAN_LIMIT) break;
+        processedCount += 1;
         const entryPath = path.join(incidentDir, entry);
         let parsed: OnboardingIncidentRecord | null = null;
         try {
@@ -431,6 +435,26 @@ ${headersSection}
       decayOnce,
     },
   };
+}
+
+// Trim a UTF-8 byte buffer back to the last complete code point so the cut
+// never lands inside a multi-byte sequence (which would emit U+FFFD on decode).
+function truncateUtf8ByBytes(input: string, maxBytes: number): string {
+  const buffer = Buffer.from(input, "utf8");
+  if (buffer.length <= maxBytes) return input;
+  let end = maxBytes;
+  while (end > 0 && (buffer[end - 1] & 0xc0) === 0x80) end -= 1;
+  if (end > 0) {
+    const start = buffer[end - 1];
+    const need =
+      (start & 0x80) === 0 ? 1
+        : (start & 0xe0) === 0xc0 ? 2
+          : (start & 0xf0) === 0xe0 ? 3
+            : (start & 0xf8) === 0xf0 ? 4
+              : 1;
+    if (need > maxBytes - (end - 1)) end -= 1;
+  }
+  return buffer.subarray(0, end).toString("utf8");
 }
 
 function isIncidentEligibleForCreator(


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and onboarding (`POST /api/companies`, goals, agents, projects, issues) is the very first surface a human touches
> - When an onboarding endpoint 5xx's, the wizard renders a generic "Internal server error" with no incident id, no trail in any company, and no signal back to the operating team — see GST-5 forensics
> - This is a silent-failure UX gap: the error is captured in stderr logs only, so the human sees a dead end and the company that should own the bug never gets the issue filed
> - GST-9 closes the loop server-side: classify onboarding traffic, intercept 5xx, redact + dedup, file a backlogged issue into the relevant Paperclip company, and surface an `incidentId` to the browser for GST-5a to render
> - The hard part is `POST /api/companies` itself — there is no company yet to file into, so the incident is deferred to disk under `<instance-root>/onboarding-incidents/` and ingested on the next successful company creation by the same user
> - Cross-user leak guard, atomic disk writes, 30-day decay, and a 24h dedup window keep the deferred-ingest pattern safe to run in production
> - This PR is additive and isolated: no existing onboarding code path is changed, and every callsite swallows failures so the user-facing onboarding response is never blocked by telemetry

## What Changed

- New middleware `server/src/middleware/onboarding-incident-reporter.ts` — classifies onboarding requests (allowlist / `X-Paperclip-Onboarding` header / `Referer: /onboarding`), patches `res.json` to inject `incidentId` on 5xx, and records the incident asynchronously on the `finish` event.
- New service `server/src/services/onboarding-incidents.ts` — redacts sensitive headers + body keys, SHA-256 dedups within 24h, files into the company immediately when one exists, defers to disk (atomic `writeFile + rename`) otherwise, and ingests deferred files on the next successful `POST /api/companies` by the same user. 30-day decay sweep is opportunistic per record.
- `server/src/app.ts` wires `onboardingIncidentReporter` right after `actorMiddleware`.
- `server/src/routes/companies.ts` calls `ingestPendingIncidents` inside `POST /api/companies` after company creation, in a try/catch so company creation is never blocked.
- 6 integration tests in `server/src/__tests__/onboarding-incident-reporter.test.ts` covering happy-path filing, dedup, defer-and-ingest, cross-user leak guard, and the negative non-onboarding case. All against embedded Postgres.
- Follow-up commit (`f8b57be`) resolves Greptile P2 review: truncate body cap on the last complete UTF-8 code point so the stored body never ends in U+FFFD, and bound deferred-ingest scan to 100 files per request so a noisy directory cannot turn `POST /api/companies` into an O(files) disk walk.

### Onboarding endpoint classification

Any one of:
1. `Referer` header path starts with `/onboarding`, OR
2. `X-Paperclip-Onboarding: 1` header is set (the wizard sets this; see GST-5a), OR
3. Route matches the explicit allowlist: `POST /api/companies`, `POST /api/companies/:companyId/goals`, `POST /api/companies/:companyId/agents`, `POST /api/companies/:companyId/agents/:agentId/adapter-environment-test`, `POST /api/companies/:companyId/projects`, `POST /api/companies/:companyId/issues`.

### Architectural decisions (locked in GST-9 plan doc)

- **Defer-and-ingest** over a hidden system company. Files live under `<instance-root>/onboarding-incidents/<ts>-<uuid>.json` (0600, atomic rename), decay after 30 days, capped at 100 inspected per opportunistic sweep.
- **Cross-user leak guard:** ingestion requires `incident.createdByUserId === newCompany.creatorUserId`, OR both sides are `local_implicit` with no user identity. Anything else stays on disk for a later matching creator.
- **De-dup window:** `sha256(method + route + error.name + error.message)` within 24h; repeat hits drop a counter comment on the existing issue instead of creating a duplicate. Race-tolerant — parallel hits may occasionally double-file, accepted.
- **Middleware placement:** right after `actorMiddleware`, patches `res.json` so the 5xx body returned to the browser carries `incidentId`, and uses `res.on("finish")` to read the error context attached by `errorHandler` and record asynchronously. Standard Express "post-error" pattern; the brief's literal "after errorHandler" wording isn't semantically possible.
- **Redaction:** request body runs through `redactCurrentUserValue` (OS username + home), then sensitive keys (`password`, `secret`, `token`, `apiKey`, `accessToken`, …) → `[redacted]`. Headers `authorization`, `cookie`, `x-paperclip-api-key`, `x-paperclip-board-key` are stripped. Body truncated to 8 KiB on a UTF-8 code-point boundary; header values to 256 bytes.

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/onboarding-incident-reporter.test.ts` — 6/6 passing against embedded Postgres.
- Manual smoke (reviewer / QA, post-merge): force a 5xx on `POST /api/companies` (e.g. `{"name":"pdeo"}` against an instance with PDE taken). Confirm the response body has `incidentId`. Onboard a different name successfully → confirm the deferred incident is ingested as a backlogged issue in the new company and the disk file is gone.

## Risks

- **Label upsert race (accepted).** Two parallel first-time labelers can 23505 on `labels_company_name_idx`; second incident is still filed without the label. Operator-visible, rare.
- **Dedup race (accepted).** Two parallel 5xx hits with the same `{method, route, error.name, error.message}` in the same 24h window can both miss the dedup lookup and create two issues. Acceptable for auto-filing.
- **Orphan `.tmp` files.** A process crash between `writeFile` and `rename` leaves `<id>.tmp` behind. Decay only sweeps `.json`. Operator-visible; low priority.
- **Disk-space growth.** Deferred files accumulate if a single-user instance keeps 5xx'ing on `POST /api/companies`. 30-day decay sweep bounds this; per-request ingest scan is now capped at 100 files (commit `f8b57be`) so a noisy directory cannot block onboarding.
- **`__testOnly` exposed on the production interface.** Considered carving it into a separate test seam; cost/benefit did not warrant the extra file. Documented in Staff Engineer self-review.

## Model Used

- Claude (Anthropic), `claude-opus-4-7` (1M context), extended-thinking on, tool use enabled, harness: Claude Code via Paperclip Release Engineer adapter (`claude_local`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A, server-only change; UI surface lives in GST-5a
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

---

Refs: GST-9, GST-5 plan.
