### PR TITLE
fix(claude-local): flush partial usageJson on SIGKILL / timeout

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -77,6 +77,13 @@ export interface AdapterExecutionResult {
   errorMeta?: Record<string, unknown>;
   usage?: UsageSummary;
   /**
+   * True when `usage` was recovered from streamed-but-not-finalized output —
+   * e.g. the child was SIGKILLed or timed out before emitting a terminal
+   * result frame. Consumers should record the partial telemetry but treat the
+   * numbers as a floor, not a closed total.
+   */
+  usagePartial?: boolean;
+  /**
    * Legacy single session id output. Prefer `sessionParams` + `sessionDisplayId`.
    */
   sessionId?: string | null;

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -789,6 +789,15 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           }
         : undefined;
 
+    const partialUsageFromStream =
+      parsedStream.usagePartial && parsedStream.usage
+        ? {
+            usage: parsedStream.usage,
+            usagePartial: true as const,
+            partialUsageMessages: parsedStream.partialUsageMessages ?? 0,
+          }
+        : null;
+
     if (proc.timedOut) {
       return {
         exitCode: proc.exitCode,
@@ -797,6 +806,16 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         errorMessage: `Timed out after ${timeoutSec}s`,
         errorCode: "timeout",
         errorMeta,
+        ...(partialUsageFromStream
+          ? {
+              usage: partialUsageFromStream.usage,
+              usagePartial: true,
+              resultJson: {
+                usagePartial: true,
+                partialUsageMessages: partialUsageFromStream.partialUsageMessages,
+              },
+            }
+          : {}),
         clearSession: Boolean(opts.clearSessionOnMissingSession),
       };
     }
@@ -834,6 +853,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         errorFamily: transientUpstream ? "transient_upstream" : null,
         retryNotBefore: transientRetryNotBefore ? transientRetryNotBefore.toISOString() : null,
         errorMeta,
+        ...(partialUsageFromStream
+          ? { usage: partialUsageFromStream.usage, usagePartial: true }
+          : {}),
         resultJson: {
           stdout: proc.stdout,
           stderr: proc.stderr,

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -2,7 +2,118 @@ import { describe, expect, it } from "vitest";
 import {
   extractClaudeRetryNotBefore,
   isClaudeTransientUpstreamError,
+  parseClaudeStreamJson,
 } from "./parse.js";
+
+const assistantEvent = (
+  inputTokens: number,
+  outputTokens: number,
+  cacheRead = 0,
+  text = "ok",
+) =>
+  JSON.stringify({
+    type: "assistant",
+    session_id: "sess-1",
+    message: {
+      content: [{ type: "text", text }],
+      usage: {
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        cache_read_input_tokens: cacheRead,
+      },
+    },
+  });
+
+const initEvent = JSON.stringify({
+  type: "system",
+  subtype: "init",
+  session_id: "sess-1",
+  model: "claude-opus-4-7",
+});
+
+describe("parseClaudeStreamJson — partial usage on SIGKILL", () => {
+  it("recovers usage from streamed assistant messages when no terminal result frame arrived", () => {
+    const stdout = [
+      initEvent,
+      assistantEvent(1000, 200, 50, "step 1"),
+      assistantEvent(1100, 250, 60, "step 2"),
+      assistantEvent(1200, 300, 70, "step 3"),
+    ].join("\n");
+
+    const parsed = parseClaudeStreamJson(stdout);
+
+    expect(parsed.resultJson).toBeNull();
+    expect(parsed.usagePartial).toBe(true);
+    expect(parsed.partialUsageMessages).toBe(3);
+    expect(parsed.usage).toEqual({
+      inputTokens: 3300,
+      outputTokens: 750,
+      cachedInputTokens: 180,
+    });
+    expect(parsed.summary).toBe("step 1\n\nstep 2\n\nstep 3");
+    expect(parsed.sessionId).toBe("sess-1");
+    expect(parsed.model).toBe("claude-opus-4-7");
+  });
+
+  it("returns null usage when no assistant messages were streamed before death", () => {
+    const stdout = initEvent + "\n";
+    const parsed = parseClaudeStreamJson(stdout);
+    expect(parsed.usagePartial).toBe(false);
+    expect(parsed.partialUsageMessages).toBe(0);
+    expect(parsed.usage).toBeNull();
+    expect(parsed.resultJson).toBeNull();
+  });
+
+  it("skips assistant messages with zero usage so usagePartial stays false on no-op streams", () => {
+    const stdout = [
+      initEvent,
+      assistantEvent(0, 0, 0, "thinking..."),
+    ].join("\n");
+    const parsed = parseClaudeStreamJson(stdout);
+    expect(parsed.usagePartial).toBe(false);
+    expect(parsed.usage).toBeNull();
+  });
+
+  it("uses the terminal result frame's usage when the run completes normally and flags usagePartial=false", () => {
+    const finalEvent = JSON.stringify({
+      type: "result",
+      session_id: "sess-1",
+      result: "done",
+      usage: { input_tokens: 5000, output_tokens: 1000, cache_read_input_tokens: 200 },
+      total_cost_usd: 0.123,
+    });
+    const stdout = [
+      initEvent,
+      assistantEvent(1000, 200, 50),
+      assistantEvent(2000, 400, 100),
+      finalEvent,
+    ].join("\n");
+
+    const parsed = parseClaudeStreamJson(stdout);
+    expect(parsed.usagePartial).toBe(false);
+    expect(parsed.usage).toEqual({
+      inputTokens: 5000,
+      outputTokens: 1000,
+      cachedInputTokens: 200,
+    });
+    expect(parsed.costUsd).toBe(0.123);
+    expect(parsed.resultJson).not.toBeNull();
+  });
+
+  it("handles a mid-token kill that truncates the final ndjson line", () => {
+    const stdout =
+      [initEvent, assistantEvent(800, 150, 40, "step 1")].join("\n") +
+      '\n{"type":"assistant","session_id":"sess-1","message":{"co';
+    const parsed = parseClaudeStreamJson(stdout);
+    expect(parsed.usagePartial).toBe(true);
+    expect(parsed.partialUsageMessages).toBe(1);
+    expect(parsed.usage).toEqual({
+      inputTokens: 800,
+      outputTokens: 150,
+      cachedInputTokens: 40,
+    });
+  });
+});
 
 describe("isClaudeTransientUpstreamError", () => {
   it("classifies the 'out of extra usage' subscription window failure as transient", () => {

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -19,6 +19,12 @@ export function parseClaudeStreamJson(stdout: string) {
   let model = "";
   let finalResult: Record<string, unknown> | null = null;
   const assistantTexts: string[] = [];
+  const partialUsage: UsageSummary = {
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+  };
+  let partialUsageMessages = 0;
 
   for (const rawLine of stdout.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -36,6 +42,17 @@ export function parseClaudeStreamJson(stdout: string) {
     if (type === "assistant") {
       sessionId = asString(event.session_id, sessionId ?? "") || sessionId;
       const message = parseObject(event.message);
+      const messageUsage = parseObject(message.usage);
+      const inputTokens = asNumber(messageUsage.input_tokens, 0);
+      const outputTokens = asNumber(messageUsage.output_tokens, 0);
+      const cachedInputTokens = asNumber(messageUsage.cache_read_input_tokens, 0);
+      if (inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0) {
+        partialUsage.inputTokens += inputTokens;
+        partialUsage.outputTokens += outputTokens;
+        partialUsage.cachedInputTokens =
+          (partialUsage.cachedInputTokens ?? 0) + cachedInputTokens;
+        partialUsageMessages += 1;
+      }
       const content = Array.isArray(message.content) ? message.content : [];
       for (const entry of content) {
         if (typeof entry !== "object" || entry === null || Array.isArray(entry)) continue;
@@ -55,11 +72,14 @@ export function parseClaudeStreamJson(stdout: string) {
   }
 
   if (!finalResult) {
+    const hasPartialUsage = partialUsageMessages > 0;
     return {
       sessionId,
       model,
       costUsd: null as number | null,
-      usage: null as UsageSummary | null,
+      usage: hasPartialUsage ? partialUsage : (null as UsageSummary | null),
+      usagePartial: hasPartialUsage,
+      partialUsageMessages,
       summary: assistantTexts.join("\n\n").trim(),
       resultJson: null as Record<string, unknown> | null,
     };
@@ -80,6 +100,8 @@ export function parseClaudeStreamJson(stdout: string) {
     model,
     costUsd,
     usage,
+    usagePartial: false,
+    partialUsageMessages,
     summary,
     resultJson: finalResult,
   };

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7941,6 +7941,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               model: readNonEmptyString(adapterResult.model) ?? "unknown",
               ...(adapterResult.costUsd != null ? { costUsd: adapterResult.costUsd } : {}),
               billingType: normalizeLedgerBillingType(adapterResult.billingType),
+              ...(adapterResult.usagePartial ? { usagePartial: true } : {}),
             } as Record<string, unknown>)
           : null;
 


### PR DESCRIPTION
## Summary

When the `claude_local` child PID dies mid-heartbeat (SIGKILL — OOMKill or pod cycle) the harness today discards every streamed `assistant.usage` block and writes `usageJson: null` on the failed run row, masking real LLM cost. Diagnosed in [SPC-6097](https://work.standardpower.co/SPC/issues/SPC-6097), requirement in [SPC-6116](https://work.standardpower.co/SPC/issues/SPC-6116) / parent [SPC-6111](https://work.standardpower.co/SPC/issues/SPC-6111). One Quant run survived 90s and streamed 34 assistant messages with usage blocks before the kill — all lost today.

This PR recovers that partial telemetry without buffering across harness restarts (per the SPC-6116 non-goal):

- `parseClaudeStreamJson` accumulates `assistant.message.usage` (input / output / cache_read) across the stream. When no terminal `result` frame arrives it returns the summed totals, plus `usagePartial: true` and the count of contributing messages.
- `AdapterExecutionResult` gains an optional `usagePartial` flag (with JSDoc framing it as a floor, not a closed total).
- The claude-local `toAdapterResult` carries partial usage into both failure paths that previously dropped it — `proc.timedOut` and `!parsed` (no terminal frame, the typical SIGKILL outcome).
- `heartbeat.ts` stamps `usagePartial: true` onto `usageJson` so consumers (billing, observability) can distinguish partial vs full telemetry.

Normal completion stays unchanged: the terminal-frame usage wins and `usagePartial` is false/absent.

### Atomicity

The flush rides the existing single-statement `setRunStatus` UPDATE — a second SIGKILL during flush cannot corrupt the row. No new write path.

### Acceptance criteria (from SPC-6116)

- [x] Mid-heartbeat kill of a Quant-class run now produces a non-null `usageJson`.
- [x] `usagePartial: true` is set on partially-flushed rows.
- [x] Normal completion still writes `usageJson` correctly with `usagePartial` false/absent.

## Test plan

- [x] `vitest run parse.test.ts` — 14/14 green, including 5 new tests for partial-usage accumulation, zero-message streams, zero-usage messages, normal completion, and mid-token truncated-line recovery.
- [x] `tsc --noEmit` clean for `packages/adapter-utils`, `packages/adapters/claude-local`, and `server`.
- [ ] Reviewer to spot-check that no other adapter callsite relies on `parsedStream` not carrying a `usagePartial` key (it's an additive property, so this is belt-and-suspenders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)