### PR TITLE
Suppress productivity reviews during process_lost storms (SPC-6123)

### DIFF
--- a/server/src/__tests__/productivity-review-service.test.ts
+++ b/server/src/__tests__/productivity-review-service.test.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS,
   DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
   DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS,
+  PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_SUPPRESSED_ACTION,
   PRODUCTIVITY_REVIEW_REFRESH_COMMENT_PREFIX,
   PRODUCTIVITY_REVIEW_ORIGIN_KIND,
   productivityReviewService,
@@ -120,6 +121,9 @@ describeEmbeddedPostgres("productivity review service", () => {
     count: number;
     now: Date;
     withRunComments?: boolean;
+    runStatus?: "succeeded" | "failed" | "cancelled" | "timed_out";
+    errorCode?: string | null;
+    resultJson?: Record<string, unknown> | null;
   }) {
     const runs: Array<typeof heartbeatRuns.$inferInsert> = [];
     for (let index = 0; index < input.count; index += 1) {
@@ -129,7 +133,7 @@ describeEmbeddedPostgres("productivity review service", () => {
         id: runId,
         companyId: input.companyId,
         agentId: input.agentId,
-        status: "succeeded",
+        status: input.runStatus ?? "succeeded",
         invocationSource: "assignment",
         triggerDetail: "system",
         startedAt: createdAt,
@@ -137,6 +141,8 @@ describeEmbeddedPostgres("productivity review service", () => {
         contextSnapshot: { issueId: input.issueId, taskId: input.issueId },
         livenessState: "advanced",
         nextAction: "Continue processing the next batch.",
+        errorCode: input.errorCode ?? null,
+        resultJson: input.resultJson ?? null,
         createdAt,
         updatedAt: createdAt,
       });
@@ -562,5 +568,131 @@ describeEmbeddedPostgres("productivity review service", () => {
     expect(result.failed).toBe(0);
     const [review] = await listProductivityReviews(seeded.companyId);
     expect(review?.requestDepth).toBe(MAX_ISSUE_REQUEST_DEPTH);
+  });
+
+  it("suppresses productivity reviews and emits an infra alert when terminal runs are dominated by process_lost", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+      runStatus: "failed",
+      errorCode: "process_lost",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(result.processLostStormSuppressed).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+
+    const alerts = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_SUPPRESSED_ACTION));
+    expect(alerts).toHaveLength(1);
+    const details = alerts[0]?.details as {
+      processLostCount?: number;
+      terminalRunCount?: number;
+      processLostRatio?: number;
+      suppressedTrigger?: string;
+      sampleProcessLostRunIds?: string[];
+    } | null;
+    expect(alerts[0]?.entityId).toBe(seeded.issueId);
+    expect(alerts[0]?.agentId).toBe(seeded.coderId);
+    expect(details?.processLostCount).toBe(DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS);
+    expect(details?.terminalRunCount).toBe(DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS);
+    expect(details?.processLostRatio).toBe(1);
+    expect(details?.suppressedTrigger).toBe("no_comment_streak");
+    expect(details?.sampleProcessLostRunIds?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("detects process_lost storms from resultJson.stopReason when errorCode is missing", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+      runStatus: "failed",
+      resultJson: { stopReason: "process_lost" },
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.created).toBe(0);
+    expect(result.processLostStormSuppressed).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(0);
+  });
+
+  it("does not suppress when process_lost ratio is below the storm threshold", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    // 7 process_lost + 3 other-failure terminal runs = 70% — below 80% threshold.
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 7,
+      now,
+      runStatus: "failed",
+      errorCode: "process_lost",
+    });
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: 3,
+      now: new Date(now.getTime() - 7 * 60_000),
+      runStatus: "failed",
+      errorCode: "adapter_failed",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.processLostStormSuppressed).toBe(0);
+    expect(result.created).toBe(1);
+    expect(await listProductivityReviews(seeded.companyId)).toHaveLength(1);
+  });
+
+  it("does not suppress non-storm failure mixes that still satisfy the no-comment streak trigger", async () => {
+    const now = new Date("2026-04-28T12:00:00.000Z");
+    const seeded = await seedAssignedIssue();
+    await insertRuns({
+      companyId: seeded.companyId,
+      agentId: seeded.coderId,
+      issueId: seeded.issueId,
+      count: DEFAULT_PRODUCTIVITY_REVIEW_NO_COMMENT_STREAK_RUNS,
+      now,
+      runStatus: "failed",
+      errorCode: "adapter_failed",
+    });
+
+    const result = await productivityReviewService(db).reconcileProductivityReviews({
+      now,
+      companyId: seeded.companyId,
+    });
+
+    expect(result.processLostStormSuppressed).toBe(0);
+    expect(result.created).toBe(1);
+    const alerts = await db
+      .select()
+      .from(activityLog)
+      .where(eq(activityLog.action, PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_SUPPRESSED_ACTION));
+    expect(alerts).toHaveLength(0);
   });
 });

--- a/server/src/services/productivity-review.ts
+++ b/server/src/services/productivity-review.ts
@@ -30,6 +30,10 @@ export const DEFAULT_PRODUCTIVITY_REVIEW_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_REFRESH_COMMENTS = 3;
 export const DEFAULT_PRODUCTIVITY_REVIEW_CREATION_WINDOW_MS = 24 * 60 * 60 * 1000;
 export const DEFAULT_PRODUCTIVITY_REVIEW_MAX_CREATIONS_PER_WINDOW = 3;
+export const PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_RATIO = 0.8;
+export const PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_MIN_TERMINAL_RUNS = 5;
+export const PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_SUPPRESSED_ACTION =
+  "issue.productivity_review_suppressed_process_lost_storm";
 
 const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
 const ACTIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
@@ -55,6 +59,13 @@ type ProductivityReviewThresholds = {
   maxCreationsPerWindow: number;
 };
 
+type ProcessLostStormSignal = {
+  processLostCount: number;
+  terminalRunCount: number;
+  ratio: number;
+  latestProcessLostRunIds: string[];
+};
+
 type ProductivityReviewEvidence = {
   trigger: ProductivityReviewTrigger;
   triggerReasons: string[];
@@ -77,6 +88,7 @@ type ProductivityReviewEvidence = {
   nextAction: string | null;
   thresholds: ProductivityReviewThresholds;
   generatedAt: Date;
+  processLostStorm: ProcessLostStormSignal | null;
 };
 
 type EnqueueWakeup = (
@@ -94,6 +106,12 @@ type EnqueueWakeup = (
 
 function productivityReviewFingerprint(sourceIssueId: string) {
   return `productivity-review:${sourceIssueId}`;
+}
+
+function isProcessLostRun(run: HeartbeatRunRow) {
+  if (run.errorCode === "process_lost") return true;
+  const resultStopReason = (run.resultJson as { stopReason?: unknown } | null | undefined)?.stopReason;
+  return typeof resultStopReason === "string" && resultStopReason === "process_lost";
 }
 
 function issueRunScopeSql(issueId: string) {
@@ -429,6 +447,18 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       noCommentStreak += 1;
     }
 
+    const processLostRuns = terminalRuns.filter(isProcessLostRun);
+    const processLostStorm: ProcessLostStormSignal | null =
+      terminalRuns.length >= PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_MIN_TERMINAL_RUNS &&
+      processLostRuns.length / terminalRuns.length >= PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_RATIO
+        ? {
+          processLostCount: processLostRuns.length,
+          terminalRunCount: terminalRuns.length,
+          ratio: processLostRuns.length / terminalRuns.length,
+          latestProcessLostRunIds: processLostRuns.slice(0, 5).map((run) => run.id),
+        }
+        : null;
+
     const [
       runCountLastHour,
       runCountLastSixHours,
@@ -519,6 +549,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       nextAction: latestRuns.find((run) => run.nextAction)?.nextAction ?? null,
       thresholds,
       generatedAt: now,
+      processLostStorm,
     };
   }
 
@@ -758,6 +789,47 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
     return { kind: "created" as const, reviewIssueId: review.id };
   }
 
+  async function emitProcessLostStormAlert(evidence: ProductivityReviewEvidence) {
+    const storm = evidence.processLostStorm;
+    if (!storm) return;
+    await logActivity(db, {
+      companyId: evidence.sourceIssue.companyId,
+      actorType: "system",
+      actorId: "system",
+      action: PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_SUPPRESSED_ACTION,
+      entityType: "issue",
+      entityId: evidence.sourceIssue.id,
+      agentId: evidence.sourceAgent.id,
+      details: {
+        source: "productivity_review.reconcile",
+        sourceIssueId: evidence.sourceIssue.id,
+        sourceIssueIdentifier: evidence.sourceIssue.identifier,
+        assigneeAgentId: evidence.sourceAgent.id,
+        suppressedTrigger: evidence.trigger,
+        noCommentStreak: evidence.noCommentStreak,
+        processLostCount: storm.processLostCount,
+        terminalRunCount: storm.terminalRunCount,
+        processLostRatio: storm.ratio,
+        processLostThreshold: PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_RATIO,
+        sampleProcessLostRunIds: storm.latestProcessLostRunIds,
+        reason: "process_lost storm detected; suppressing productivity review to surface infra event instead",
+      },
+    });
+    logger.warn(
+      {
+        companyId: evidence.sourceIssue.companyId,
+        sourceIssueId: evidence.sourceIssue.id,
+        sourceIssueIdentifier: evidence.sourceIssue.identifier,
+        assigneeAgentId: evidence.sourceAgent.id,
+        suppressedTrigger: evidence.trigger,
+        processLostCount: storm.processLostCount,
+        terminalRunCount: storm.terminalRunCount,
+        processLostRatio: storm.ratio,
+      },
+      "productivity review suppressed: process_lost storm",
+    );
+  }
+
   async function reconcileProductivityReviews(opts?: {
     now?: Date;
     companyId?: string;
@@ -788,6 +860,7 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       existing: 0,
       snoozed: 0,
       creationCapped: 0,
+      processLostStormSuppressed: 0,
       skipped: 0,
       failed: 0,
       reviewIssueIds: [] as string[],
@@ -816,6 +889,11 @@ export function productivityReviewService(db: Db, deps?: { enqueueWakeup?: Enque
       const evidence = await collectEvidence(candidate, sourceAgent, thresholds, now);
       if (!evidence) {
         result.skipped += 1;
+        continue;
+      }
+      if (evidence.processLostStorm) {
+        await emitProcessLostStormAlert(evidence);
+        result.processLostStormSuppressed += 1;
         continue;
       }
       let prefix = prefixCache.get(candidate.companyId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The productivity-review subsystem watches assigned issues and, when an agent looks stuck, hands the work off to a manager for a Productivity Review
> - During a host-side `process_lost` storm (SIGKILL of in-flight agent runs), the no_comment_streak trigger cannot tell "agent making no progress" from "all agents being killed by the host"
> - In the 2026-05-24 storm post-mortem (SPC-6112), this caused a cascade: SPC-6082 → HoEM productivity review → HoEM ALSO killed mid-flight → CTO productivity review → manual diagnosis burned a heartbeat on incorrect adapterConfig
> - This pull request adds a storm guard: when ≥80% of recent terminal runs on an issue carry `errorCode='process_lost'` (or merged `resultJson.stopReason='process_lost'`), the reconciler suppresses the review and emits a structured `issue.productivity_review_suppressed_process_lost_storm` activity-log entry instead
> - The benefit is that the next host event surfaces as an infra alert to operators rather than burning manager-agent budgets diagnosing a kill they cannot fix

## What Changed

- Add `PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_RATIO=0.8` and `PRODUCTIVITY_REVIEW_PROCESS_LOST_STORM_MIN_TERMINAL_RUNS=5` constants in `server/src/services/productivity-review.ts`.
- Detect process_lost runs in `collectEvidence` using both `heartbeat_runs.error_code` and `result_json.stopReason`; populate `evidence.processLostStorm` when the storm threshold is met.
- In `reconcileProductivityReviews`, when a storm is detected, emit `issue.productivity_review_suppressed_process_lost_storm` via `logActivity` (so it streams through the existing admin-monitor activity feed) and skip the create/update path. Tracked via new `result.processLostStormSuppressed` counter.
- Add 4 embedded-Postgres tests covering: dominant `errorCode=process_lost` storm, `resultJson.stopReason=process_lost` storm (defense-in-depth signal), 70% process_lost (below threshold — review still fires), and adapter_failed-only failures (storm guard does not engage on non-storm failures).

## Verification

- `pnpm --filter @paperclipai/server typecheck` — clean.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/productivity-review-service.test.ts` — 15/15 tests pass (4 new + 11 pre-existing).
- Manual reasoning matches SPC-6112 post-mortem: SPC-6082 had 65+ consecutive `process_lost` runs → would now trip the 80% guard at the 5-terminal-run minimum sample point and emit an infra alert instead of a Productivity Review issue.

## Risks

- **Low risk.** Strict additive change: storm guard only fires when a productivity-review trigger qualifies AND ≥80% of sampled terminal runs are process_lost AND there are ≥5 terminal runs in the window. Non-storm trigger paths are unchanged. Activity-log entry uses a new action name so no existing dashboards are affected. No schema change. The new counter on the result object is additive; only consumers in `server/src/index.ts` use `created/updated/failed` and are unaffected.
- Edge case: a storm that resolves between reconciles will see the ratio drop below 0.8 and the normal productivity-review path will resume — by design.
- Continuation-hold semantics intentionally untouched; the storm only suppresses NEW review creation/refresh, which is what the issue asked for.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`), extended thinking, tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run typecheck and tests locally
- [x] I have added tests covering the new behavior
- [x] The PR description includes verification steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)