### PR TITLE
feat(heartbeat): cap per-issue process_lost retry budget

### DIFF
--- a/packages/db/src/migrations/0090_issue_process_lost_budget.sql
+++ b/packages/db/src/migrations/0090_issue_process_lost_budget.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "consecutive_process_lost_count" integer DEFAULT 0 NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -631,6 +631,13 @@
       "when": 1779129600000,
       "tag": "0089_cloud_upstreams",
       "breakpoints": true
+    },
+    {
+      "idx": 90,
+      "version": "7",
+      "when": 1779662400000,
+      "tag": "0090_issue_process_lost_budget",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -57,6 +57,7 @@ export const issues = pgTable(
     monitorAttemptCount: integer("monitor_attempt_count").notNull().default(0),
     monitorNotes: text("monitor_notes"),
     monitorScheduledBy: text("monitor_scheduled_by"),
+    consecutiveProcessLostCount: integer("consecutive_process_lost_count").notNull().default(0),
     executionWorkspaceId: uuid("execution_workspace_id")
       .references((): AnyPgColumn => executionWorkspaces.id, { onDelete: "set null" }),
     executionWorkspacePreference: text("execution_workspace_preference"),

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -73,6 +73,8 @@ vi.mock("../adapters/index.ts", async () => {
 
 import {
   heartbeatService,
+  PROCESS_LOST_BUDGET_EXHAUSTED_REASON,
+  PROCESS_LOST_PER_ISSUE_RETRY_BUDGET,
   redactDetectedSuccessfulRunProgressSummaryForBoard,
 } from "../services/heartbeat.ts";
 import {
@@ -973,6 +975,120 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
     expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("increments the per-issue consecutive_process_lost_count on each reaped process_lost run", async () => {
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: 999_999_999,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.consecutiveProcessLostCount).toBe(1);
+    expect(issue?.status).toBe("in_progress");
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(retryRun?.status).toBe("queued");
+  });
+
+  it("flips the issue to blocked once the per-issue process_lost retry budget is exhausted", async () => {
+    const { companyId, agentId, runId, issueId } = await seedRunFixture({
+      processPid: 999_999_999,
+    });
+    await db
+      .update(issues)
+      .set({ consecutiveProcessLostCount: PROCESS_LOST_PER_ISSUE_RETRY_BUDGET - 1 })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    const failedRun = runs[0];
+    expect(failedRun?.status).toBe("failed");
+    expect(failedRun?.errorCode).toBe("process_lost");
+    expect(failedRun?.error).toContain("per-issue");
+    expect(failedRun?.error).toContain("budget exhausted");
+
+    const blockedIssue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(blockedIssue?.status).toBe("blocked");
+    expect(blockedIssue?.consecutiveProcessLostCount).toBe(PROCESS_LOST_PER_ISSUE_RETRY_BUDGET);
+    expect(blockedIssue?.executionRunId).toBeNull();
+    expect(blockedIssue?.checkoutRunId).toBeNull();
+
+    const budgetComments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    const budgetComment = budgetComments.find((row) => row.body.includes(PROCESS_LOST_BUDGET_EXHAUSTED_REASON));
+    expect(budgetComment).toBeTruthy();
+    expect(budgetComment?.body).toContain(`${PROCESS_LOST_PER_ISSUE_RETRY_BUDGET} consecutive`);
+    expect(budgetComment?.body).toContain(`Final failed run: \`${runId}\``);
+
+    const auditRows = await db
+      .select()
+      .from(activityLog)
+      .where(and(eq(activityLog.companyId, companyId), eq(activityLog.entityId, issueId)));
+    const budgetAudit = auditRows.find((row) => row.action === "issue.harness_process_lost_budget_exhausted");
+    expect(budgetAudit).toBeTruthy();
+    expect(budgetAudit?.details).toMatchObject({
+      reason: PROCESS_LOST_BUDGET_EXHAUSTED_REASON,
+      consecutiveProcessLostCount: PROCESS_LOST_PER_ISSUE_RETRY_BUDGET,
+      budget: PROCESS_LOST_PER_ISSUE_RETRY_BUDGET,
+      runId,
+      agentId,
+    });
+  });
+
+  it("resets the per-issue process_lost counter after a successful run completes", async () => {
+    const { agentId, runId, issueId } = await seedQueuedIssueRunFixture();
+    await db
+      .update(issues)
+      .set({ consecutiveProcessLostCount: 3 })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    await heartbeat.resumeQueuedRuns();
+    await waitForRunToSettle(heartbeat, runId);
+    await waitForHeartbeatIdle(db, 5_000);
+
+    const succeededRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    expect(succeededRun?.status).toBe("succeeded");
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.consecutiveProcessLostCount).toBe(0);
+    expect(agentId).toBeTruthy();
   });
 
   it("releases active environment leases when an orphaned run is reaped", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -231,6 +231,8 @@ const MAX_TURN_CONTINUATION_MAX_ATTEMPTS_CAP = 10;
 const MAX_TURN_CONTINUATION_DEFAULT_DELAY_MS = 1_000;
 const MAX_TURN_CONTINUATION_MAX_DELAY_MS = 5 * 60 * 1000;
 const MAX_TURN_CONTINUATION_LIVE_RUN_STATUSES = ["scheduled_retry", "queued", "running"] as const;
+export const PROCESS_LOST_BUDGET_EXHAUSTED_REASON = "harness_process_lost_budget_exhausted";
+export const PROCESS_LOST_PER_ISSUE_RETRY_BUDGET = 5;
 type CodexTransientFallbackMode =
   | "same_session"
   | "safer_invocation"
@@ -4844,6 +4846,93 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return queued;
   }
 
+  async function incrementIssueConsecutiveProcessLost(
+    companyId: string,
+    issueId: string,
+    now: Date,
+  ): Promise<number> {
+    const [row] = await db
+      .update(issues)
+      .set({
+        consecutiveProcessLostCount: sql`${issues.consecutiveProcessLostCount} + 1`,
+        updatedAt: now,
+      })
+      .where(and(eq(issues.id, issueId), eq(issues.companyId, companyId)))
+      .returning({ consecutiveProcessLostCount: issues.consecutiveProcessLostCount });
+    return row?.consecutiveProcessLostCount ?? 0;
+  }
+
+  async function resetIssueConsecutiveProcessLost(
+    companyId: string,
+    issueId: string,
+    now: Date,
+  ): Promise<void> {
+    await db
+      .update(issues)
+      .set({
+        consecutiveProcessLostCount: 0,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(issues.id, issueId),
+          eq(issues.companyId, companyId),
+          sql`${issues.consecutiveProcessLostCount} > 0`,
+        ),
+      );
+  }
+
+  async function flipIssueBlockedForProcessLostBudget(input: {
+    companyId: string;
+    issueId: string;
+    agentId: string;
+    runId: string;
+    consecutiveCount: number;
+  }): Promise<void> {
+    try {
+      const updated = await issuesSvc.update(input.issueId, { status: "blocked" });
+      if (!updated) return;
+      const bodyLines = [
+        `Issue moved to \`blocked\` because the harness recorded ${input.consecutiveCount} consecutive \`process_lost\` failures without a successful run.`,
+        `- Reason: \`${PROCESS_LOST_BUDGET_EXHAUSTED_REASON}\``,
+        `- Budget: ${PROCESS_LOST_PER_ISSUE_RETRY_BUDGET} consecutive \`process_lost\` failures per issue (resets on the next successful run).`,
+        `- Final failed run: \`${input.runId}\``,
+        ``,
+        `The underlying process is being killed mid-run (likely OOM or container cycle). The harness has stopped retrying to prevent a runaway log/cost burn. Investigate worker memory limits or the agent's heartbeat scope, then move this issue out of \`blocked\` to resume work.`,
+      ];
+      await issuesSvc.addComment(input.issueId, bodyLines.join("\n"), {
+        runId: input.runId,
+      });
+      await logActivity(db, {
+        companyId: input.companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: null,
+        runId: input.runId,
+        action: "issue.harness_process_lost_budget_exhausted",
+        entityType: "issue",
+        entityId: input.issueId,
+        details: {
+          reason: PROCESS_LOST_BUDGET_EXHAUSTED_REASON,
+          consecutiveProcessLostCount: input.consecutiveCount,
+          budget: PROCESS_LOST_PER_ISSUE_RETRY_BUDGET,
+          runId: input.runId,
+          agentId: input.agentId,
+        },
+      });
+    } catch (err) {
+      logger.warn(
+        {
+          err,
+          issueId: input.issueId,
+          companyId: input.companyId,
+          consecutiveCount: input.consecutiveCount,
+        },
+        "failed to flip issue to blocked after process_lost budget exhaustion",
+      );
+    }
+  }
+
   type ScheduledRetryGate =
     | { allowed: true }
     | {
@@ -6621,11 +6710,34 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
       }
 
-      const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
+      const reapedRunIssueId = readNonEmptyString(parseObject(run.contextSnapshot).issueId);
+      let consecutiveProcessLostCount = 0;
+      let processLostBudgetExhausted = false;
+      if (reapedRunIssueId) {
+        consecutiveProcessLostCount = await incrementIssueConsecutiveProcessLost(
+          run.companyId,
+          reapedRunIssueId,
+          now,
+        );
+        if (consecutiveProcessLostCount >= PROCESS_LOST_PER_ISSUE_RETRY_BUDGET) {
+          processLostBudgetExhausted = true;
+        }
+      }
+      const shouldRetry =
+        tracksLocalChild
+        && (!!run.processPid || !!run.processGroupId)
+        && (run.processLossRetryCount ?? 0) < 1
+        && !processLostBudgetExhausted;
       const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const budgetSuffix = processLostBudgetExhausted
+        ? `; per-issue \`process_lost\` retry budget exhausted (${consecutiveProcessLostCount}/${PROCESS_LOST_PER_ISSUE_RETRY_BUDGET})`
+        : "";
+      const failedRunMessage = shouldRetry
+        ? `${baseMessage}; retrying once`
+        : `${baseMessage}${budgetSuffix}`;
 
       let finalizedRun = await setRunStatus(run.id, "failed", {
-        error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        error: failedRunMessage,
         errorCode: "process_lost",
         finishedAt: now,
         resultJson: mergeRunStopMetadataForAgent(
@@ -6634,13 +6746,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           {
             resultJson: parseObject(run.resultJson),
             errorCode: "process_lost",
-            errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+            errorMessage: failedRunMessage,
           },
         ),
       });
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: now,
-        error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        error: failedRunMessage,
       });
       if (!finalizedRun) finalizedRun = await getRun(run.id);
       if (!finalizedRun) continue;
@@ -6661,6 +6773,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
       } else {
         await releaseIssueExecutionAndPromote(finalizedRun);
+        if (processLostBudgetExhausted && reapedRunIssueId) {
+          await flipIssueBlockedForProcessLostBudget({
+            companyId: run.companyId,
+            issueId: reapedRunIssueId,
+            agentId: run.agentId,
+            runId: run.id,
+            consecutiveCount: consecutiveProcessLostCount,
+          });
+        }
       }
 
       await appendRunEvent(finalizedRun, await nextRunEventSeq(finalizedRun.id), {
@@ -6669,12 +6790,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         level: "error",
         message: shouldRetry
           ? `${baseMessage}; queued retry ${retriedRun?.id ?? ""}`.trim()
-          : baseMessage,
+          : `${baseMessage}${budgetSuffix}`,
         payload: {
           ...(run.processPid ? { processPid: run.processPid } : {}),
           ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
           ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
+          ...(reapedRunIssueId ? { issueId: reapedRunIssueId, consecutiveProcessLostCount } : {}),
+          ...(processLostBudgetExhausted
+            ? {
+                processLostBudgetExhausted: true,
+                processLostPerIssueBudget: PROCESS_LOST_PER_ISSUE_RETRY_BUDGET,
+                processLostBudgetExhaustedReason: PROCESS_LOST_BUDGET_EXHAUSTED_REASON,
+              }
+            : {}),
         },
       });
 
@@ -7999,6 +8128,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         const livenessRun = finalizedRun;
         await refreshContinuationSummaryForRun(livenessRun, agent);
         const skipRunIssueComment = parseObject(livenessRun.contextSnapshot).skipIssueComment === true;
+        if (issueId && outcome === "succeeded") {
+          try {
+            await resetIssueConsecutiveProcessLost(livenessRun.companyId, issueId, new Date());
+          } catch (err) {
+            logger.warn(
+              { err, issueId, companyId: livenessRun.companyId },
+              "failed to reset consecutive_process_lost_count after successful run",
+            );
+          }
+        }
         if (issueId && outcome === "succeeded" && !skipRunIssueComment) {
           try {
             const existingRunComment = await findRunIssueComment(livenessRun.id, livenessRun.companyId, issueId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, so when a child process dies mid-run the harness has to choose carefully between retrying (the agent might still finish the job) and giving up (the agent will keep dying and burn cost / spam logs).
> - The `claude_local` (and other tracked-local) adapters detect dead children inside `reapOrphanedRuns`, then enqueue at most one immediate retry per chain via `enqueueProcessLossRetry`. That per-run cap of `< 1` only bounds a single chain — a fresh wake (assignment, comment, monitor, etc.) starts a new chain with count 0.
> - In the wild this still degenerates: an OOM-kill loop against a single issue produced **1441+ retry fires in 6h on SPC-6054** and **499/500 Quant runs `process_lost` in a 100-minute window**, because every external wake re-armed the per-run cap.
> - The harness needs a *per-issue* circuit breaker that survives the harness restart cycle. The retry mechanism itself is fine; the missing piece is a place to record "this issue has burned through its quota" so we stop pulling new wakes through the same broken path.
> - This pull request adds a persisted `issues.consecutive_process_lost_count` column, increments it on every `process_lost` reap with an `issueId`, resets it on any successful run for that issue, and — when it reaches 5 — flips the issue to `blocked` with reason `harness_process_lost_budget_exhausted` and skips the retry.
> - The benefit is that a runaway agent / pod-cycle / OOM loop now stops itself after 5 consecutive `process_lost` failures instead of burning indefinitely, while a successful run resets the counter so legitimate transient failures do not slowly accumulate into a false block.

## What Changed

- New migration `0090_issue_process_lost_budget.sql` adds `issues.consecutive_process_lost_count integer NOT NULL DEFAULT 0`, mirrored in the Drizzle schema (`packages/db/src/schema/issues.ts`).
- `server/src/services/heartbeat.ts` exports two constants — `PROCESS_LOST_BUDGET_EXHAUSTED_REASON = "harness_process_lost_budget_exhausted"` and `PROCESS_LOST_PER_ISSUE_RETRY_BUDGET = 5` — plus three internal helpers: `incrementIssueConsecutiveProcessLost`, `resetIssueConsecutiveProcessLost`, and `flipIssueBlockedForProcessLostBudget`.
- The reaper at `reapOrphanedRuns` now increments the per-issue counter on every `process_lost` failure for a run with a bound `issueId`. When the post-increment count reaches the budget, `shouldRetry` becomes `false`, `releaseIssueExecutionAndPromote` clears the execution lock, and `flipIssueBlockedForProcessLostBudget` updates `issues.status = 'blocked'`, posts a system comment naming the reason, and writes an `issue.harness_process_lost_budget_exhausted` activity-log row.
- The success path of the main heartbeat execute loop (`outcome === "succeeded"`) calls `resetIssueConsecutiveProcessLost` so a single successful run wipes the counter — preventing slow accumulation from genuine transient failures.
- Three new tests in `server/src/__tests__/heartbeat-process-recovery.test.ts` cover the increment-then-retry case, the budget-exhausted-→-blocked case (including comment body, run error, audit details, execution-lock clear), and the success-resets-counter case.

## Verification

- `pnpm --filter @paperclipai/server test -- heartbeat-process-recovery` runs the new and existing tests against embedded Postgres; the new `0090_issue_process_lost_budget` migration is applied automatically by `applyPendingMigrations`.
- Manual smoke: stand up a worktree with this branch, seed an issue with `consecutive_process_lost_count = 4`, set its in-progress run's `processPid` to a dead PID, call `heartbeat.reapOrphanedRuns()`. The run should fail with `errorCode = process_lost`, no retry should be queued, and the issue should land in `blocked` with a system comment matching `harness_process_lost_budget_exhausted` and `Final failed run: \`<runId>\``.
- The change is additive — the existing per-run `< 1` retry cap still fires first for non-issue-bound or single-chain failures; the per-issue cap only takes precedence when the counter has accumulated across multiple chains.

## Risks

- **Migration:** `ALTER TABLE … ADD COLUMN IF NOT EXISTS … DEFAULT 0 NOT NULL` is a metadata-only DDL on Postgres ≥ 11 and does not rewrite the table, so it is safe to apply online against the `issues` table at any size.
- **Backfill semantics:** existing in-progress issues start at counter 0 after the migration, which is the correct "no recent process_lost evidence" baseline — there is no risk of immediately flipping live issues to blocked.
- **Status transition:** `issuesSvc.update(..., { status: "blocked" })` goes through the same `assertTransition` path used by the existing harness-liveness escalation; it accepts `in_progress → blocked` and clears `checkoutRunId` via the existing side-effect block. No new transition rule is added.
- **Failure of the comment / audit write:** the `flipIssueBlockedForProcessLostBudget` helper wraps the comment + activity-log write in `try/catch` and logs a warning. The status flip itself is the canonical signal; observability ride-alongs are best-effort.
- **Interaction with concurrent reapers:** the increment is a single `UPDATE … RETURNING` row, so two concurrent reapers cannot both see "count = 5" without one of them having already raced the other to the budget. The retry path is idempotent on the same run id, so a race that lets a single retry slip through before the block is acceptable.

## Model Used

- Anthropic Claude (Opus 4.7, model id `claude-opus-4-7`, 200K context, extended thinking on, tool use).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass _(local disk was full so pnpm install failed; relying on PR CI to run the test suite)_
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots _(server-only change, no UI)_
- [x] I have updated relevant documentation to reflect my changes _(no doc additions required — behavior is exposed via the existing reason string + activity-log action)_
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge