### PR TITLE
fix(heartbeat): per-issue process_lost retry budget circuit breaker (SPC-6120)

### DIFF
--- a/packages/db/src/migrations/0090_issue_process_lost_budget.sql
+++ b/packages/db/src/migrations/0090_issue_process_lost_budget.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "issues" ADD COLUMN IF NOT EXISTS "consecutive_process_lost_count" integer DEFAULT 0 NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -631,6 +631,13 @@
       "when": 1779129600000,
       "tag": "0089_cloud_upstreams",
       "breakpoints": true
+    },
+    {
+      "idx": 90,
+      "version": "7",
+      "when": 1779662400000,
+      "tag": "0090_issue_process_lost_budget",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/issues.ts
+++ b/packages/db/src/schema/issues.ts
@@ -57,6 +57,7 @@ export const issues = pgTable(
     monitorAttemptCount: integer("monitor_attempt_count").notNull().default(0),
     monitorNotes: text("monitor_notes"),
     monitorScheduledBy: text("monitor_scheduled_by"),
+    consecutiveProcessLostCount: integer("consecutive_process_lost_count").notNull().default(0),
     executionWorkspaceId: uuid("execution_workspace_id")
       .references((): AnyPgColumn => executionWorkspaces.id, { onDelete: "set null" }),
     executionWorkspacePreference: text("execution_workspace_preference"),

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -73,6 +73,8 @@ vi.mock("../adapters/index.ts", async () => {
 
 import {
   heartbeatService,
+  PROCESS_LOST_BUDGET_EXHAUSTED_REASON,
+  PROCESS_LOST_PER_ISSUE_RETRY_BUDGET,
   redactDetectedSuccessfulRunProgressSummaryForBoard,
 } from "../services/heartbeat.ts";
 import {
@@ -973,6 +975,76 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .then((rows) => rows[0] ?? null);
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
     expect(issue?.checkoutRunId).toBe(runId);
+  });
+
+  it("blocks the issue and skips retry when consecutive process_lost budget is exhausted", async () => {
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: 999_999_999,
+    });
+    await db
+      .update(issues)
+      .set({ consecutiveProcessLostCount: PROCESS_LOST_PER_ISSUE_RETRY_BUDGET - 1 })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.status).toBe("failed");
+    expect(runs[0]?.errorCode).toBe("process_lost");
+    expect(runs[0]?.error).toContain(`budget=${PROCESS_LOST_PER_ISSUE_RETRY_BUDGET}`);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+    expect(issue?.consecutiveProcessLostCount).toBe(PROCESS_LOST_PER_ISSUE_RETRY_BUDGET);
+    expect(issue?.executionRunId).toBeNull();
+
+    const events = await db
+      .select()
+      .from(heartbeatRunEvents)
+      .where(eq(heartbeatRunEvents.runId, runId));
+    const exhaustionEvent = events.find((event) => {
+      const payload = (event.payload as Record<string, unknown> | null) ?? {};
+      return payload.reason === PROCESS_LOST_BUDGET_EXHAUSTED_REASON;
+    });
+    expect(exhaustionEvent).toBeTruthy();
+  });
+
+  it("increments the issue process_lost counter without blocking while below budget", async () => {
+    const { agentId, runId, issueId } = await seedRunFixture({
+      processPid: 999_999_999,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+    expect(result.runIds).toEqual([runId]);
+
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+    expect(issue?.consecutiveProcessLostCount).toBe(1);
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(retryRun?.status).toBe("queued");
   });
 
   it("releases active environment leases when an orphaned run is reaped", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -231,6 +231,8 @@ const MAX_TURN_CONTINUATION_MAX_ATTEMPTS_CAP = 10;
 const MAX_TURN_CONTINUATION_DEFAULT_DELAY_MS = 1_000;
 const MAX_TURN_CONTINUATION_MAX_DELAY_MS = 5 * 60 * 1000;
 const MAX_TURN_CONTINUATION_LIVE_RUN_STATUSES = ["scheduled_retry", "queued", "running"] as const;
+export const PROCESS_LOST_BUDGET_EXHAUSTED_REASON = "harness_process_lost_budget_exhausted";
+export const PROCESS_LOST_PER_ISSUE_RETRY_BUDGET = 5;
 type CodexTransientFallbackMode =
   | "same_session"
   | "safer_invocation"
@@ -6561,6 +6563,59 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
+  async function incrementIssueProcessLostBudget(
+    companyId: string,
+    issueId: string,
+  ): Promise<{ count: number; exhausted: boolean }> {
+    const [updated] = await db
+      .update(issues)
+      .set({
+        consecutiveProcessLostCount: sql`${issues.consecutiveProcessLostCount} + 1`,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(issues.companyId, companyId), eq(issues.id, issueId)))
+      .returning({ count: issues.consecutiveProcessLostCount });
+    if (!updated) return { count: 0, exhausted: false };
+    return {
+      count: updated.count,
+      exhausted: updated.count >= PROCESS_LOST_PER_ISSUE_RETRY_BUDGET,
+    };
+  }
+
+  async function blockIssueForProcessLostBudgetExhaustion(
+    companyId: string,
+    issueId: string,
+    consecutiveCount: number,
+  ): Promise<void> {
+    await db
+      .update(issues)
+      .set({ status: "blocked", updatedAt: new Date() })
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.id, issueId),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      );
+    logger.warn(
+      { companyId, issueId, consecutiveCount, reason: PROCESS_LOST_BUDGET_EXHAUSTED_REASON },
+      "issue blocked: process_lost retry budget exhausted",
+    );
+  }
+
+  async function resetIssueProcessLostBudget(companyId: string, issueId: string): Promise<void> {
+    await db
+      .update(issues)
+      .set({ consecutiveProcessLostCount: 0, updatedAt: new Date() })
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.id, issueId),
+          gt(issues.consecutiveProcessLostCount, 0),
+        ),
+      );
+  }
+
   async function reapOrphanedRuns(opts?: { staleThresholdMs?: number }) {
     const staleThresholdMs = opts?.staleThresholdMs ?? 0;
     const now = new Date();
@@ -6621,11 +6676,30 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         });
       }
 
-      const shouldRetry = tracksLocalChild && (!!run.processPid || !!run.processGroupId) && (run.processLossRetryCount ?? 0) < 1;
+      const runContext = parseObject(run.contextSnapshot);
+      const contextIssueId = readNonEmptyString(runContext.issueId);
+      let budgetCount = 0;
+      let budgetExhausted = false;
+      if (contextIssueId) {
+        const budget = await incrementIssueProcessLostBudget(run.companyId, contextIssueId);
+        budgetCount = budget.count;
+        budgetExhausted = budget.exhausted;
+      }
+      const shouldRetry =
+        !budgetExhausted &&
+        tracksLocalChild &&
+        (!!run.processPid || !!run.processGroupId) &&
+        (run.processLossRetryCount ?? 0) < 1;
       const baseMessage = buildProcessLossMessage(run, descendantOnlyCleanup ? { descendantOnly: true } : undefined);
+      const budgetSuffix = budgetExhausted
+        ? `; issue blocked after ${budgetCount} consecutive process_lost failures (budget=${PROCESS_LOST_PER_ISSUE_RETRY_BUDGET})`
+        : "";
 
+      const finalErrorMessage = shouldRetry
+        ? `${baseMessage}; retrying once`
+        : `${baseMessage}${budgetSuffix}`;
       let finalizedRun = await setRunStatus(run.id, "failed", {
-        error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        error: finalErrorMessage,
         errorCode: "process_lost",
         finishedAt: now,
         resultJson: mergeRunStopMetadataForAgent(
@@ -6634,13 +6708,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           {
             resultJson: parseObject(run.resultJson),
             errorCode: "process_lost",
-            errorMessage: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+            errorMessage: finalErrorMessage,
           },
         ),
       });
       await setWakeupStatus(run.wakeupRequestId, "failed", {
         finishedAt: now,
-        error: shouldRetry ? `${baseMessage}; retrying once` : baseMessage,
+        error: finalErrorMessage,
       });
       if (!finalizedRun) finalizedRun = await getRun(run.id);
       if (!finalizedRun) continue;
@@ -6660,6 +6734,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           retriedRun = await enqueueProcessLossRetry(finalizedRun, agent, now);
         }
       } else {
+        if (budgetExhausted && contextIssueId) {
+          await blockIssueForProcessLostBudgetExhaustion(run.companyId, contextIssueId, budgetCount);
+        }
         await releaseIssueExecutionAndPromote(finalizedRun);
       }
 
@@ -6669,12 +6746,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         level: "error",
         message: shouldRetry
           ? `${baseMessage}; queued retry ${retriedRun?.id ?? ""}`.trim()
-          : baseMessage,
+          : `${baseMessage}${budgetSuffix}`,
         payload: {
           ...(run.processPid ? { processPid: run.processPid } : {}),
           ...(run.processGroupId ? { processGroupId: run.processGroupId } : {}),
           ...(descendantOnlyCleanup ? { descendantOnlyCleanup: true } : {}),
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
+          ...(contextIssueId ? { consecutiveProcessLostCount: budgetCount } : {}),
+          ...(budgetExhausted ? { processLostBudgetExhausted: true, reason: PROCESS_LOST_BUDGET_EXHAUSTED_REASON } : {}),
         },
       });
 
@@ -7977,6 +8056,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
       if (persistedRun) {
         persistedRun = await classifyAndPersistRunLiveness(persistedRun, persistedResultJson) ?? persistedRun;
+      }
+      if (outcome === "succeeded" && issueId) {
+        await resetIssueProcessLostBudget(run.companyId, issueId);
       }
 
       await setWakeupStatus(run.wakeupRequestId, outcome === "succeeded" ? "completed" : status, {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1635,6 +1635,7 @@ const issueListSelect = {
   monitorAttemptCount: issues.monitorAttemptCount,
   monitorNotes: issues.monitorNotes,
   monitorScheduledBy: issues.monitorScheduledBy,
+  consecutiveProcessLostCount: issues.consecutiveProcessLostCount,
   executionWorkspaceId: issues.executionWorkspaceId,
   executionWorkspacePreference: issues.executionWorkspacePreference,
   executionWorkspaceSettings: sql<null>`null`,


### PR DESCRIPTION
## Summary

- The 2026-05-24 process_lost storm (SPC-6113) burned 433 wasted run cycles in 47 minutes because the existing `processLossRetryCount < 1` cap is per-run; every fresh retry resets it to 0 and a new infra-side `process_lost` immediately re-queues.
- New per-issue counter `issues.consecutive_process_lost_count` (migration `0090_issue_process_lost_budget.sql`) is incremented on every `process_lost` by the reaper and reset to 0 on any successful run for the same issue.
- When the counter reaches `PROCESS_LOST_PER_ISSUE_RETRY_BUDGET = 5`, the reaper skips the retry queue, flips the issue to `status='blocked'`, and tags the lifecycle event payload with `reason='harness_process_lost_budget_exhausted'` so HoOps sees a single blocked issue instead of a retry storm.

## Scope

This is Fix 3 from SPC-6120's 5-fix plan. Landing it first bounds the storm at its endpoint regardless of which retry path queues it. Fixes 1 (persist `scheduledRetryAttempt`), 2 (capture process-death reason in lease), 4 (tag infra-side process_lost in monitoring), 5 (workspace cleanup on process_lost) ship as child issues for defense-in-depth.

## Test plan

- [x] `pnpm --filter @paperclipai/server typecheck` clean
- [x] `vitest run src/__tests__/heartbeat-process-recovery.test.ts` — new tests pass:
  - [x] budget exhaustion → issue blocked, no retry queued, exhaustion event emitted with `consecutiveProcessLostCount: 5` + `reason: harness_process_lost_budget_exhausted`
  - [x] budget below threshold → counter increments to 1, retry still queued
- [x] Existing regression tests still pass (queues one retry / blocks on retry exhaustion / lease release)
- [ ] Reviewer: confirm `0090_issue_process_lost_budget.sql` is idempotent against the gamma DB (uses `ADD COLUMN IF NOT EXISTS … DEFAULT 0 NOT NULL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)