### PR TITLE
docs: add TweetClaw OpenClaw routine guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -16,7 +16,7 @@
   "topbarLinks": [
     {
       "name": "GitHub",
-      "url": "https://github.com/paperclip-ai/paperclip"
+      "url": "https://github.com/paperclipai/paperclip"
     }
   ],
   "navigation": {
@@ -68,6 +68,13 @@
               "guides/agent-developer/comments-and-communication",
               "guides/agent-developer/handling-approvals",
               "guides/agent-developer/cost-reporting"
+            ]
+          },
+          {
+            "group": "OpenClaw",
+            "pages": [
+              "guides/openclaw-docker-setup",
+              "guides/openclaw-tweetclaw-routine"
             ]
           }
         ]
@@ -121,6 +128,7 @@
               "api/agents",
               "api/issues",
               "api/approvals",
+              "api/routines",
               "api/goals-and-projects",
               "api/costs",
               "api/secrets",
@@ -146,6 +154,6 @@
     ]
   },
   "footerSocials": {
-    "github": "https://github.com/paperclip-ai/paperclip"
+    "github": "https://github.com/paperclipai/paperclip"
   }
 }

--- a/docs/guides/openclaw-docker-setup.md
+++ b/docs/guides/openclaw-docker-setup.md
@@ -93,6 +93,10 @@ Then restart Paperclip and rerun the smoke script.
 pnpm paperclipai allowed-hostname <host>
 ```
 
+## Related Workflow: TweetClaw Routines
+
+After the OpenClaw gateway agent is onboarded, you can assign recurring X/Twitter signal review to it with [OpenClaw TweetClaw Routine](/guides/openclaw-tweetclaw-routine). That workflow keeps Paperclip as the issue, approval, and audit layer while the OpenClaw agent uses TweetClaw to search tweets, search tweet replies, export followers, monitor tweets, process webhooks, and prepare reviewed post or reply follow-up work.
+
 ## Prerequisites
 
 - **Docker Desktop v29+** (with Docker Sandbox support)

--- a/docs/guides/openclaw-tweetclaw-routine.md
+++ b/docs/guides/openclaw-tweetclaw-routine.md
@@ -1,0 +1,126 @@
+---
+title: OpenClaw TweetClaw Routine
+summary: Schedule X/Twitter signal review through an OpenClaw gateway agent
+---
+
+This guide shows how to run a recurring Paperclip routine against an OpenClaw gateway agent that has the TweetClaw plugin installed.
+
+Use this pattern when a company needs repeatable X/Twitter work such as:
+
+- search tweets for launch feedback, customer mentions, competitors, or incidents
+- search tweet replies for complaints, support signals, or product questions
+- export followers or look up users before a campaign review
+- monitor tweets and turn webhook events into Paperclip issues
+- draft post tweets, post tweet replies, direct messages, media work, or giveaway draw follow-ups for board review
+
+Paperclip stays the control plane. OpenClaw runs the agent. TweetClaw supplies the X/Twitter tools inside OpenClaw.
+
+## Prerequisites
+
+- A Paperclip company with an agent using the `openclaw_gateway` adapter.
+- The OpenClaw gateway has completed the Paperclip invite and approval flow.
+- The gateway can run OpenClaw plugin commands.
+- An Xquik API key for account-backed TweetClaw actions.
+
+Keep API keys out of Paperclip issue text, routine descriptions, screenshots, and OpenClaw chat prompts. Store the key in OpenClaw plugin config. If your gateway deployment reads tool credentials from runtime environment, bind the secret through Paperclip routine env instead of pasting it into the routine prompt.
+
+## Install TweetClaw in OpenClaw
+
+Run these commands in the OpenClaw environment used by the gateway agent:
+
+```bash
+openclaw plugins install clawhub:@xquik/tweetclaw
+openclaw config set plugins.entries.tweetclaw.config.apiKey "$XQUIK_API_KEY"
+openclaw config set tools.alsoAllow '["explore", "tweetclaw"]'
+openclaw plugins inspect tweetclaw --runtime --json
+openclaw skills info tweetclaw
+```
+
+The ClawHub source tracks TweetClaw through Xquik's verified publisher scope.
+TweetClaw is an open-source MIT plugin powered by Xquik's hosted, closed-source
+service. Xquik is an independent third-party service and is not affiliated with
+X Corp. The `explore` tool lets the agent inspect the endpoint catalog without
+making live API calls. The `tweetclaw` tool invokes selected X/Twitter endpoints
+and remains subject to OpenClaw tool approval prompts.
+
+## Create the Paperclip Routine
+
+Create a routine assigned to the OpenClaw gateway agent:
+
+```json
+{
+  "title": "Weekly X/Twitter Signal Review",
+  "description": "Search X/Twitter for current product, competitor, and customer-support signals.",
+  "assigneeAgentId": "{openclawGatewayAgentId}",
+  "projectId": "{marketingOrSupportProjectId}",
+  "goalId": "{growthOrSupportGoalId}",
+  "priority": "medium",
+  "status": "active",
+  "concurrencyPolicy": "coalesce_if_active",
+  "catchUpPolicy": "skip_missed"
+}
+```
+
+Then add a schedule trigger:
+
+```json
+{
+  "kind": "schedule",
+  "cronExpression": "0 9 * * 1",
+  "timezone": "America/Los_Angeles"
+}
+```
+
+For event-driven monitoring, add a webhook trigger and point TweetClaw monitor notifications at the generated Paperclip trigger URL.
+
+## Routine Prompt
+
+Use a focused prompt so each run leaves an auditable Paperclip issue:
+
+```text
+Use TweetClaw from this OpenClaw session to run a read-only X/Twitter signal review.
+
+Search tweets and tweet replies for:
+- our product name
+- our support handle
+- our top 3 competitor names
+- this week's launch keywords
+
+Return:
+- the exact search queries used
+- up to 10 source tweet URLs with author handles and timestamps
+- short labels for customer support, product feedback, competitor signal, launch response, or risk
+- a concise recommendation for the next Paperclip issue
+
+Do not post tweets, post tweet replies, send direct messages, upload media, download private media, create monitors, create webhooks, or run giveaway draws during this routine. If you recommend one of those actions, create a separate Paperclip issue that asks the board operator to approve the action and includes the source links.
+```
+
+## Output Checklist
+
+Each routine run should leave a comment or work product with:
+
+- source tweet URLs and reply URLs
+- the TweetClaw endpoint or catalog result used
+- the query terms, account handles, and time window
+- a short risk note for any recommended write, direct message, monitor, webhook, media, or giveaway draw action
+- the next Paperclip issue to approve or perform follow-up work
+
+## Approval Boundaries
+
+Default to read-only work inside recurring routines.
+
+Use a separate issue-thread confirmation or board-owned issue before actions that affect an X/Twitter account, including post tweets, post tweet replies, direct messages, media upload, authenticated media download, monitor creation, webhook creation, profile changes, or giveaway draws.
+
+OpenClaw also prompts before write-like TweetClaw tool calls. Review the structured request before allowing the tool call.
+
+## Verification
+
+After setup:
+
+1. Manually run the routine from Paperclip.
+2. Confirm the run is assigned to the OpenClaw gateway agent.
+3. Confirm the OpenClaw transcript contains `explore` and, when needed, read-only `tweetclaw` tool calls.
+4. Confirm the Paperclip issue includes source links and no secret values.
+5. Confirm no X/Twitter write, direct message, media, monitor, webhook, profile, or giveaway draw action occurred without a separate approval path.
+
+See [Routines](/api/routines), [Adapters Overview](/adapters/overview), and [Running OpenClaw in Docker](/guides/openclaw-docker-setup) for the underlying Paperclip and OpenClaw setup details.

--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -71,10 +71,14 @@ Structured gateway event logs use:
 
 UI/CLI parsers consume these lines to render transcript updates.
 
+## Workflow Recipes
+
+- [OpenClaw TweetClaw X/Twitter Routine](../../../docs/guides/openclaw-tweetclaw-routine.md) shows how to assign recurring X/Twitter signal review to an OpenClaw gateway agent that has TweetClaw installed.
+
 ## No-remote-git contract
 
 Like every Paperclip adapter, this one must treat the local execution-workspace
-cwd as the only persistence boundary across runs — no `git push` from runtime
+cwd as the only persistence boundary across runs - no `git push` from runtime
 code, no assuming a `git remote` exists. The gateway transport here doesn't
 touch the workspace directly, but if you extend the adapter to ship code to
 the OpenClaw side, use the round-trip helpers in `@paperclipai/adapter-utils`


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for managing AI agents at work.
> - Its OpenClaw gateway adapter connects Paperclip agents to OpenClaw runtimes.
> - Scheduled routines give recurring agent work issue history and auditability.
> - Operators lacked a concrete, approval-aware X/Twitter monitoring routine example.
> - TweetClaw provides an OpenClaw plugin for X/Twitter search, monitoring, exports, webhooks, and reviewed actions.
> - This pull request documents a secure TweetClaw routine and repairs related documentation discovery problems.
> - The benefit is a reusable workflow with clear credential and approval boundaries.

## Linked Issues or Issue Description

- No existing issue covers this documentation gap. A search for `TweetClaw` found no related public issue or pull request besides this one.
- **Problem:** The OpenClaw docs explain gateway setup but do not show how to configure a recurring X/Twitter workflow through routines.
- **Current behavior:** Operators must infer the routine payload, prompt boundaries, plugin setup, and review requirements from separate references.
- **Expected behavior:** The docs provide one complete, read-only-first routine recipe with explicit approval boundaries and discoverable API references.
- **Steps to observe:** Open the OpenClaw Docker guide or adapter README on the current default branch and look for a TweetClaw routine example.
- **Environment:** The problem affects the published documentation and repository README, independent of operating system or deployment mode.

## What Changed

- Added an OpenClaw TweetClaw routine guide with current install commands, routine JSON, a read-only prompt, output checks, and approval boundaries.
- Added an OpenClaw guide group to the documentation navigation.
- Added `api/routines` to the API Reference navigation, satisfying the Greptile review.
- Linked the recipe from the OpenClaw Docker guide and gateway adapter README.
- Fixed 2 existing GitHub documentation links that returned 404 because they used the former organization name.
- Clarified that TweetClaw is MIT licensed while the hosted Xquik service is closed source and independent of X Corp.

## Verification

- Parsed `docs/docs.json` successfully.
- Verified every documentation navigation target exists.
- Verified changed local Markdown links resolve.
- Verified the current TweetClaw README install and runtime-inspection commands.
- Ran `git diff --check`.
- Inspected the final public 1-commit diff and GitHub signature.

## Risks

- Low risk. This change affects documentation only.
- The workflow requires a configured OpenClaw gateway agent and Xquik credentials.
- The documented routine defaults to read-only work and requires explicit review before any account action.
- No UI changes or screenshots apply.
- `ROADMAP.md` does not describe overlapping planned core work.

## Model Used

- OpenAI Codex using `gpt-5.6-sol`, agentic reasoning, shell execution, repository inspection, and GitHub tooling. The context-window size is not exposed by this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
