### PR TITLE
Gate stale heartbeat detector on run liveness (OUT-28161/OUT-28163)

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -102,6 +102,8 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     now: Date;
     ageMs: number;
     withOutput?: boolean;
+    lastOutputAgeMs?: number;
+    finishedAt?: Date | null;
     logChunk?: string;
     sourceStatus?: "in_progress" | "done" | "cancelled";
     sourceOriginKind?: string;
@@ -109,12 +111,15 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
   }) {
     const companyId = randomUUID();
     const managerId = randomUUID();
+    const infraId = randomUUID();
     const coderId = randomUUID();
     const issueId = randomUUID();
     const runId = randomUUID();
     const issuePrefix = `W${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
     const startedAt = new Date(opts.now.getTime() - opts.ageMs);
-    const lastOutputAt = opts.withOutput ? new Date(opts.now.getTime() - 5 * 60 * 1000) : null;
+    const lastOutputAt = opts.withOutput || opts.lastOutputAgeMs !== undefined
+      ? new Date(opts.now.getTime() - (opts.lastOutputAgeMs ?? 5 * 60 * 1000))
+      : null;
     const sourceStatus = opts.sourceStatus ?? "in_progress";
     const terminalEvidenceAt = new Date(startedAt.getTime() + 10 * 60 * 1000);
 
@@ -148,6 +153,18 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
         runtimeConfig: {},
         permissions: {},
       },
+      {
+        id: infraId,
+        companyId,
+        name: "Infrastructure Engineer",
+        role: "engineer",
+        title: "Infrastructure & Release Engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
     ]);
     await db.insert(issues).values({
       id: issueId,
@@ -172,10 +189,11 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
       invocationSource: "assignment",
       triggerDetail: "system",
       startedAt,
+      finishedAt: opts.finishedAt ?? null,
       processStartedAt: startedAt,
       lastOutputAt,
-      lastOutputSeq: opts.withOutput ? 3 : 0,
-      lastOutputStream: opts.withOutput ? "stdout" : null,
+      lastOutputSeq: lastOutputAt ? 3 : 0,
+      lastOutputStream: lastOutputAt ? "stdout" : null,
       contextSnapshot: { issueId },
       stdoutExcerpt: "OPENAI_API_KEY=sk-test-secret-value should not leak",
       logBytes: 0,
@@ -227,7 +245,7 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
         updatedAt: terminalEvidenceAt,
       });
     }
-    return { companyId, managerId, coderId, issueId, runId, issuePrefix };
+    return { companyId, managerId, infraId, coderId, issueId, runId, issuePrefix };
   }
 
   it("creates one medium-priority evaluation issue for a suspicious silent run", async () => {
@@ -547,6 +565,167 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
 
     expect(staleResult).toMatchObject({ created: 0, snoozed: 1 });
     expect(noisyResult).toMatchObject({ scanned: 0, created: 0 });
+  });
+
+  it("creates one hourly infra alert for agents with stale heartbeat runs", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, infraId, coderId } = await seedRunningRun({
+      now,
+      ageMs: 35 * 60_000,
+    });
+    await db
+      .update(agents)
+      .set({ lastHeartbeatAt: new Date(now.getTime() - 35 * 60_000) })
+      .where(eq(agents.id, coderId));
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn() });
+
+    const first = await recovery.scanStaleHeartbeatRunAgents({
+      now,
+      companyId,
+      thresholdMs: 30 * 60_000,
+    });
+    const second = await recovery.scanStaleHeartbeatRunAgents({
+      now: new Date(now.getTime() + 10 * 60_000),
+      companyId,
+      thresholdMs: 30 * 60_000,
+    });
+
+    expect(first).toMatchObject({
+      scannedAgents: 1,
+      created: 1,
+      existing: 0,
+      thresholdMs: 30 * 60_000,
+    });
+    expect(second).toMatchObject({
+      created: 0,
+      existing: 1,
+    });
+    expect(first.staleAgents[0]).toMatchObject({
+      agentId: coderId,
+      staleRunCount: 1,
+    });
+
+    const alerts = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_heartbeat_run_agent")));
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]).toMatchObject({
+      priority: "high",
+      assigneeAgentId: infraId,
+      originId: coderId,
+    });
+    expect(alerts[0]?.originFingerprint).toContain(`stale_heartbeat_run_agent:${companyId}:${coderId}:`);
+    expect(alerts[0]?.description).toContain("Stale active run count: 1");
+  });
+
+  it("does not alert when a newly active run is fresher than the stale heartbeat threshold", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId } = await seedRunningRun({
+      now,
+      ageMs: 60_000,
+    });
+    await db
+      .update(agents)
+      .set({ lastHeartbeatAt: new Date(now.getTime() - 35 * 60_000) })
+      .where(eq(agents.id, coderId));
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn() });
+
+    const result = await recovery.scanStaleHeartbeatRunAgents({
+      now,
+      companyId,
+      thresholdMs: 30 * 60_000,
+    });
+
+    expect(result).toMatchObject({
+      scannedAgents: 0,
+      created: 0,
+      existing: 0,
+    });
+
+    const alerts = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_heartbeat_run_agent")));
+    expect(alerts).toHaveLength(0);
+  });
+
+  it("does not alert when an older active run has recent output within the stale heartbeat threshold", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId } = await seedRunningRun({
+      now,
+      ageMs: 35 * 60_000,
+      lastOutputAgeMs: 5 * 60_000,
+    });
+    await db
+      .update(agents)
+      .set({ lastHeartbeatAt: new Date(now.getTime() - 35 * 60_000) })
+      .where(eq(agents.id, coderId));
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn() });
+
+    const result = await recovery.scanStaleHeartbeatRunAgents({
+      now,
+      companyId,
+      thresholdMs: 30 * 60_000,
+    });
+
+    expect(result).toMatchObject({
+      scannedAgents: 0,
+      created: 0,
+      existing: 0,
+    });
+  });
+
+  it("does not alert when an active run already has finishedAt set", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId } = await seedRunningRun({
+      now,
+      ageMs: 35 * 60_000,
+      finishedAt: new Date(now.getTime() - 60_000),
+    });
+    await db
+      .update(agents)
+      .set({ lastHeartbeatAt: new Date(now.getTime() - 35 * 60_000) })
+      .where(eq(agents.id, coderId));
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn() });
+
+    const result = await recovery.scanStaleHeartbeatRunAgents({
+      now,
+      companyId,
+      thresholdMs: 30 * 60_000,
+    });
+
+    expect(result).toMatchObject({
+      scannedAgents: 0,
+      created: 0,
+      existing: 0,
+    });
+  });
+
+  it("still alerts when an older active run has stale output and no finishedAt", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, coderId } = await seedRunningRun({
+      now,
+      ageMs: 35 * 60_000,
+      lastOutputAgeMs: 31 * 60_000,
+    });
+    await db
+      .update(agents)
+      .set({ lastHeartbeatAt: new Date(now.getTime() - 35 * 60_000) })
+      .where(eq(agents.id, coderId));
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn() });
+
+    const result = await recovery.scanStaleHeartbeatRunAgents({
+      now,
+      companyId,
+      thresholdMs: 30 * 60_000,
+    });
+
+    expect(result).toMatchObject({
+      scannedAgents: 1,
+      created: 1,
+      existing: 0,
+    });
   });
 
   it("records watchdog decisions through recovery owner authorization", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -66,9 +66,13 @@ const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "ti
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
+export const STALE_HEARTBEAT_RUN_THRESHOLD_ENV = "PAPERCLIP_STALE_HEARTBEAT_RUN_THRESHOLD_MINUTES";
+export const DEFAULT_STALE_HEARTBEAT_RUN_THRESHOLD_MS = 30 * 60 * 1000;
+const STALE_HEARTBEAT_RUN_ALERT_DEDUPE_MS = 60 * 60 * 1000;
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
+const STALE_HEARTBEAT_RUN_AGENT_ORIGIN_KIND = "stale_heartbeat_run_agent";
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const SESSIONED_LOCAL_ADAPTERS = new Set([
   "claude_local",
@@ -116,6 +120,17 @@ type WatchdogDecisionActor =
   | { type: "board"; userId?: string | null; runId?: string | null }
   | { type: "agent"; agentId?: string | null; runId?: string | null }
   | { type: "none" };
+
+export type StaleHeartbeatRunAgentMetric = {
+  companyId: string;
+  agentId: string;
+  agentName: string;
+  agentTitle: string | null;
+  lastHeartbeatAt: Date | null;
+  staleRunCount: number;
+  oldestRunCreatedAt: Date | null;
+  newestRunCreatedAt: Date | null;
+};
 
 export type RunOutputSilenceSummary = {
   lastOutputAt: Date | null;
@@ -226,6 +241,17 @@ function formatDuration(ms: number | null) {
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = minutes % 60;
   return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}
+
+function formatIsoDate(value: Date | string | null | undefined) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+export function readStaleHeartbeatRunThresholdMs(raw = process.env[STALE_HEARTBEAT_RUN_THRESHOLD_ENV]) {
+  const minutes = asNumber(raw, DEFAULT_STALE_HEARTBEAT_RUN_THRESHOLD_MS / 60_000);
+  return Math.max(60_000, Math.min(24 * 60 * 60 * 1000, Math.floor(minutes * 60_000)));
 }
 
 function formatIssueLinksForComment(relations: Array<{ identifier?: string | null }>) {
@@ -1557,6 +1583,222 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       else result.skipped += 1;
       if ("evaluationIssueId" in outcome && outcome.evaluationIssueId) {
         result.evaluationIssueIds.push(outcome.evaluationIssueId);
+      }
+    }
+
+    return result;
+  }
+
+  async function listStaleHeartbeatRunAgentMetrics(opts?: {
+    now?: Date;
+    companyId?: string;
+    thresholdMs?: number;
+  }): Promise<StaleHeartbeatRunAgentMetric[]> {
+    const now = opts?.now ?? new Date();
+    const thresholdMs = opts?.thresholdMs ?? readStaleHeartbeatRunThresholdMs();
+    const staleBefore = new Date(now.getTime() - thresholdMs);
+    const rows = await db
+      .select({
+        companyId: heartbeatRuns.companyId,
+        agentId: agents.id,
+        agentName: agents.name,
+        agentTitle: agents.title,
+        lastHeartbeatAt: agents.lastHeartbeatAt,
+        staleRunCount: sql<number>`count(${heartbeatRuns.id})::double precision`,
+        oldestRunCreatedAt: sql<Date | null>`min(${heartbeatRuns.createdAt})`,
+        newestRunCreatedAt: sql<Date | null>`max(${heartbeatRuns.createdAt})`,
+      })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+      .where(
+        and(
+          opts?.companyId ? eq(heartbeatRuns.companyId, opts.companyId) : undefined,
+          eq(heartbeatRuns.status, "running"),
+          isNull(heartbeatRuns.finishedAt),
+          sql`coalesce(${heartbeatRuns.startedAt}, ${heartbeatRuns.createdAt}) <= ${staleBefore.toISOString()}::timestamptz`,
+          sql`(${heartbeatRuns.lastOutputAt} is null or ${heartbeatRuns.lastOutputAt} <= ${staleBefore.toISOString()}::timestamptz)`,
+        ),
+      )
+      .groupBy(heartbeatRuns.companyId, agents.id, agents.name, agents.title, agents.lastHeartbeatAt)
+      .orderBy(desc(sql`count(${heartbeatRuns.id})`), asc(agents.name));
+
+    return rows.map((row) => ({
+      companyId: row.companyId,
+      agentId: row.agentId,
+      agentName: row.agentName,
+      agentTitle: row.agentTitle,
+      lastHeartbeatAt: row.lastHeartbeatAt,
+      staleRunCount: Number(row.staleRunCount),
+      oldestRunCreatedAt: row.oldestRunCreatedAt,
+      newestRunCreatedAt: row.newestRunCreatedAt,
+    }));
+  }
+
+  function staleHeartbeatRunAgentFingerprint(input: { companyId: string; agentId: string; now: Date }) {
+    const bucket = Math.floor(input.now.getTime() / STALE_HEARTBEAT_RUN_ALERT_DEDUPE_MS);
+    return `stale_heartbeat_run_agent:${input.companyId}:${input.agentId}:${bucket}`;
+  }
+
+  async function findExistingStaleHeartbeatRunAgentAlert(companyId: string, fingerprint: string) {
+    const [row] = await db
+      .select({ id: issues.id, identifier: issues.identifier, status: issues.status })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_HEARTBEAT_RUN_AGENT_ORIGIN_KIND),
+          eq(issues.originFingerprint, fingerprint),
+          isNull(issues.hiddenAt),
+        ),
+      )
+      .limit(1);
+    return row ?? null;
+  }
+
+  async function resolveInfrastructureRecoveryOwnerAgentId(companyId: string) {
+    const candidates = await db
+      .select()
+      .from(agents)
+      .where(
+        and(
+          eq(agents.companyId, companyId),
+          sql`(
+            lower(coalesce(${agents.title}, '')) like '%infrastructure%release%'
+            or lower(coalesce(${agents.capabilities}, '')) like '%deployment%'
+            or lower(coalesce(${agents.capabilities}, '')) like '%runtime health%'
+          )`,
+        ),
+      )
+      .orderBy(asc(agents.createdAt));
+
+    let best: { agentId: string; load: number } | null = null;
+    for (const candidate of candidates) {
+      if (!isAgentInvokable(candidate)) continue;
+      const budgetBlock = await budgets.getInvocationBlock(companyId, candidate.id, {});
+      if (budgetBlock) continue;
+      const [{ count }] = await db
+        .select({ count: sql<number>`count(*)::double precision` })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.assigneeAgentId, candidate.id),
+            inArray(issues.status, ["todo", "in_progress"]),
+          ),
+        );
+      const load = Number(count);
+      if (!best || load < best.load) best = { agentId: candidate.id, load };
+    }
+    return best?.agentId ?? null;
+  }
+
+  function buildStaleHeartbeatRunAgentDescription(input: {
+    companyId: string;
+    prefix: string;
+    metric: StaleHeartbeatRunAgentMetric;
+    thresholdMs: number;
+    now: Date;
+  }) {
+    return [
+      "Paperclip detected an agent with active heartbeat runs but no recent agent heartbeat timestamp.",
+      "",
+      "## Metric",
+      "",
+      `- Agent: ${input.metric.agentName} (${input.metric.agentTitle ?? "untitled"})`,
+      `- Agent id: \`${input.metric.agentId}\``,
+      `- Stale active run count: ${input.metric.staleRunCount}`,
+      `- Last heartbeat at: ${formatIsoDate(input.metric.lastHeartbeatAt) ?? "none recorded"}`,
+      `- Oldest active run created at: ${formatIsoDate(input.metric.oldestRunCreatedAt) ?? "unknown"}`,
+      `- Newest active run created at: ${formatIsoDate(input.metric.newestRunCreatedAt) ?? "unknown"}`,
+      `- Threshold: ${formatDuration(input.thresholdMs)} (${STALE_HEARTBEAT_RUN_THRESHOLD_ENV})`,
+      `- Checked at: ${input.now.toISOString()}`,
+      "",
+      "## Expected Infra Action",
+      "",
+      "- Inspect the agent run page and run log before restarting anything.",
+      "- Confirm whether the underlying process is still alive and producing useful work.",
+      "- Prefer scoped recovery or cancellation with preserved artifacts over broad service restarts.",
+      "- Close this issue as duplicate/no-op if a newer hourly alert already owns the incident.",
+    ].join("\n");
+  }
+
+  async function scanStaleHeartbeatRunAgents(opts?: { now?: Date; companyId?: string; thresholdMs?: number }) {
+    const now = opts?.now ?? new Date();
+    const thresholdMs = opts?.thresholdMs ?? readStaleHeartbeatRunThresholdMs();
+    const metrics = await listStaleHeartbeatRunAgentMetrics({ ...opts, now, thresholdMs });
+    const result = {
+      scannedAgents: metrics.length,
+      created: 0,
+      existing: 0,
+      skipped: 0,
+      issueIds: [] as string[],
+      thresholdMs,
+      staleAgents: metrics,
+    };
+
+    for (const metric of metrics) {
+      const companyId = metric.companyId;
+      const fingerprint = staleHeartbeatRunAgentFingerprint({ companyId, agentId: metric.agentId, now });
+      const existing = await findExistingStaleHeartbeatRunAgentAlert(companyId, fingerprint);
+      if (existing) {
+        result.existing += 1;
+        result.issueIds.push(existing.id);
+        continue;
+      }
+
+      const [prefix, ownerAgentId] = await Promise.all([
+        getCompanyIssuePrefix(companyId),
+        resolveInfrastructureRecoveryOwnerAgentId(companyId),
+      ]);
+      const issue = await issuesSvc.create(companyId, {
+        title: `Investigate stale heartbeat runs for ${metric.agentName}`,
+        description: buildStaleHeartbeatRunAgentDescription({ companyId, prefix, metric, thresholdMs, now }),
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: ownerAgentId,
+        originKind: STALE_HEARTBEAT_RUN_AGENT_ORIGIN_KIND,
+        originId: metric.agentId,
+        originFingerprint: fingerprint,
+      });
+      result.created += 1;
+      result.issueIds.push(issue.id);
+
+      await logActivity(db, {
+        companyId,
+        actorType: "system",
+        actorId: "system",
+        agentId: ownerAgentId,
+        action: "heartbeat.stale_agent_runs_detected",
+        entityType: "issue",
+        entityId: issue.id,
+        details: {
+          source: "recovery.scan_stale_heartbeat_run_agents",
+          staleAgentId: metric.agentId,
+          staleRunCount: metric.staleRunCount,
+          thresholdMs,
+          fingerprint,
+        },
+      });
+      if (ownerAgentId) {
+        await deps.enqueueWakeup(ownerAgentId, {
+          source: "assignment",
+          triggerDetail: "system",
+          reason: "issue_assigned",
+          payload: {
+            issueId: issue.id,
+            staleAgentId: metric.agentId,
+            staleRunCount: metric.staleRunCount,
+          },
+          requestedByActorType: "system",
+          requestedByActorId: null,
+          contextSnapshot: {
+            issueId: issue.id,
+            taskId: issue.id,
+            wakeReason: "issue_assigned",
+            source: STALE_HEARTBEAT_RUN_AGENT_ORIGIN_KIND,
+            staleAgentId: metric.agentId,
+          },
+        });
       }
     }
 
@@ -3449,6 +3691,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     escalateStrandedAssignedIssue,
     recordWatchdogDecision,
     scanSilentActiveRuns,
+    listStaleHeartbeatRunAgentMetrics,
+    scanStaleHeartbeatRunAgents,
     reconcileStrandedAssignedIssues,
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileIssueGraphLiveness,


### PR DESCRIPTION
## Summary

Ship the focused stale-heartbeat watchdog fix from OUT-28163 for OUT-28161.

Source commit: `df0a6c83` on fork branch `outrec:out-28169-stale-heartbeat-ship`.

Scope is intentionally narrow — only two files:
- `server/src/services/recovery/service.ts`
- `server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts`

The fix gates stale-heartbeat incident creation on run liveness so very-new active runs no longer get flagged as stale before their first heartbeat refresh.

## Context

- Parent: OUT-28161 (CTO review of false positives)
- Implementation: OUT-28163 (done with smoke evidence)
- Ship issue: OUT-28169 — could not push directly to `paperclipai/paperclip` because the runner identity (`outrec`) only has READ on upstream.
- Unblock issue: OUT-34448 / OUT-34451 — CTO opened this PR from the fork as the "equivalent reviewed branch path" per acceptance.

## Verification

Last recorded focused verification on the staged tree:

```
pnpm exec vitest run --project @paperclipai/server \
  server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
```

Result: `18 passed`.

## Test plan

- [ ] Reviewer confirms commit scope is limited to the two files above.
- [ ] Reviewer reruns the focused vitest above on the PR HEAD.
- [ ] Merge to `master` and let normal Paperclip deploy/reload pick up the change (no broad service restart required).