### PR TITLE
fix: force fresh sessions for comment wakes

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -509,6 +509,11 @@ describe.sequential("issue comment reopen routes", () => {
         payload: expect.objectContaining({
           reopenedFrom: "done",
         }),
+        contextSnapshot: expect.objectContaining({
+          wakeReason: "issue_reopened_via_comment",
+          forceFreshSession: true,
+          commentWakeFreshnessGuard: true,
+        }),
       }),
     ));
   });
@@ -573,6 +578,8 @@ describe.sequential("issue comment reopen routes", () => {
           wakeCommentId: "comment-1",
           wakeReason: "issue_reopened_via_comment",
           reopenedFrom: "blocked",
+          forceFreshSession: true,
+          commentWakeFreshnessGuard: true,
         }),
       }),
     ));
@@ -641,6 +648,35 @@ describe.sequential("issue comment reopen routes", () => {
         contextSnapshot: expect.objectContaining({
           wakeReason: "issue_commented",
           source: "issue.comment",
+          forceFreshSession: true,
+          commentWakeFreshnessGuard: true,
+        }),
+      }),
+    ));
+  });
+
+  it("forces fresh sessions for POST comment mention wakeups", async () => {
+    mockIssueService.getById.mockResolvedValue(makeIssue("todo"));
+    mockIssueService.findMentionedAgents.mockResolvedValue(["33333333-3333-4333-8333-333333333333"]);
+
+    const res = await request(await installActor(createApp()))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "@CodexCoder please check this too." });
+
+    expect(res.status).toBe(201);
+    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      "33333333-3333-4333-8333-333333333333",
+      expect.objectContaining({
+        reason: "issue_comment_mentioned",
+        payload: expect.objectContaining({
+          issueId: "11111111-1111-4111-8111-111111111111",
+          commentId: "comment-1",
+        }),
+        contextSnapshot: expect.objectContaining({
+          wakeReason: "issue_comment_mentioned",
+          source: "comment.mention",
+          forceFreshSession: true,
+          commentWakeFreshnessGuard: true,
         }),
       }),
     ));

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -308,6 +308,8 @@ describe("issue update comment wakeups", () => {
           wakeCommentId: "comment-2",
           wakeReason: "issue_commented",
           source: "issue.comment",
+          forceFreshSession: true,
+          commentWakeFreshnessGuard: true,
         }),
       }),
     );

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4260,6 +4260,8 @@ export function issueRoutes(
               wakeCommentId: comment.id,
               source: reopened ? "issue.comment.reopen" : "issue.comment",
               wakeReason: reopened ? "issue_reopened_via_comment" : "issue_commented",
+              forceFreshSession: true,
+              commentWakeFreshnessGuard: true,
               ...(reopened ? { reopenedFrom: reopenFromStatus } : {}),
               ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
@@ -4290,6 +4292,8 @@ export function issueRoutes(
               wakeCommentId: comment.id,
               wakeReason: "issue_comment_mentioned",
               source: "comment.mention",
+              forceFreshSession: true,
+              commentWakeFreshnessGuard: true,
             },
           });
         }
@@ -5348,6 +5352,8 @@ export function issueRoutes(
               source: "issue.comment.reopen",
               wakeReason: "issue_reopened_via_comment",
               reopenedFrom: reopenFromStatus,
+              forceFreshSession: true,
+              commentWakeFreshnessGuard: true,
               ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
@@ -5373,6 +5379,8 @@ export function issueRoutes(
               wakeCommentId: comment.id,
               source: "issue.comment",
               wakeReason: "issue_commented",
+              forceFreshSession: true,
+              commentWakeFreshnessGuard: true,
               ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
@@ -5404,6 +5412,8 @@ export function issueRoutes(
             wakeCommentId: comment.id,
             wakeReason: "issue_comment_mentioned",
             source: "comment.mention",
+            forceFreshSession: true,
+            commentWakeFreshnessGuard: true,
           },
         });
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies.
> - Issue comments are one of the main human-to-agent control surfaces: they can add follow-up instructions, reopen completed/blocked work, or @-mention another agent into the thread.
> - The heartbeat service can reuse task sessions unless the wake context explicitly requests a fresh session.
> - For human comment/reopen/mention wakes, reusing the previous session can cause the adapter to continue from stale context and miss the new human instruction.
> - Production Hermes/Paperclip operations hit this class of failure: Paperclip correctly received a fresh issue comment, but the resumed Hermes context acted on older conclusions instead of the new comment.
> - This pull request marks comment-triggered wakes with a fresh-session guard at the route boundary, where the wake reason and comment id are known.
> - The benefit is safer human follow-up handling without changing non-comment wake semantics or generic session reuse behavior.

## What Changed

- Added `forceFreshSession: true` and `commentWakeFreshnessGuard: true` to context snapshots for PATCH-comment wakes that notify the assignee.
- Added the same freshness markers for PATCH-comment @-mention wakes.
- Added the same freshness markers for POST-comment assignee wakes, including implicit reopen via comment.
- Added the same freshness markers for POST-comment @-mention wakes.
- Updated route tests to assert the freshness markers for ordinary comments, reopen-via-comment, and mention wakeups.

## Verification

- `git diff --check`: passed.
- `pnpm install --frozen-lockfile`: completed; emitted existing plugin SDK bin-link warnings during install.
- `pnpm --filter @paperclipai/plugin-sdk ensure-build-deps`: passed.
- `pnpm --filter @paperclipai/server exec tsc --noEmit --pretty false`: passed.
- `pnpm exec vitest run server/src/__tests__/issue-update-comment-wakeup-routes.test.ts -t 'wakes the assignee on comment-only issue updates' --testTimeout=20000 --reporter=verbose`: failed locally by timing out. The timeout affected the existing route test harness on this checkout; it did not produce an assertion failure specific to this change.
- `pnpm exec vitest run server/src/__tests__/issue-comment-reopen-routes.test.ts server/src/__tests__/issue-update-comment-wakeup-routes.test.ts`: failed locally by timing out every test in those route files.
- GitHub Actions PR run `26374583252`: passed all PR checks, including policy, Typecheck + Release Registry, General tests, serialized server suites 1/4–4/4, Build, Canary Dry Run, e2e, verify, and Greptile Review.

## Risks

- Low-to-moderate behavioral risk: comment/reopen/mention wakes now intentionally prefer a fresh adapter session instead of reusing prior task-session context.
- This may trade away some continuity for comment-triggered wakes, but the comment id and wake reason stay in the context snapshot and the issue thread remains available as canonical state.
- Non-comment wakes are unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex via Hermes Agent, model `gpt-5.5`, with terminal/file/GitHub tool use.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass — targeted route Vitest runs timed out locally; server typecheck passed as listed above
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — N/A, server route behavior only
- [x] I have updated relevant documentation to reflect my changes — N/A, no user-facing command or doc behavior changed
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Commit: 2d3c7ab5236b087f4a44fc78335b71d229753927