### PR TITLE
SDL-1826: Ignore cancelled blocker attention edges

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -255,6 +255,42 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("ignores cancelled historical top-level blockers when a live blocker path is otherwise covered", async () => {
+    const { companyId, agentId } = await createCompany("PBCX");
+    const parentId = await insertIssue({ companyId, identifier: "PBCX-1", title: "Parent", status: "blocked" });
+    const activeChildId = await insertIssue({
+      companyId,
+      identifier: "PBCX-2",
+      title: "Running child",
+      status: "todo",
+      parentId,
+      assigneeAgentId: agentId,
+    });
+    const cancelledBlockerId = await insertIssue({
+      companyId,
+      identifier: "PBCX-3",
+      title: "Cancelled historical blocker",
+      status: "cancelled",
+      assigneeAgentId: agentId,
+    });
+    await block({ companyId, blockerIssueId: activeChildId, blockedIssueId: parentId });
+    await block({ companyId, blockerIssueId: cancelledBlockerId, blockedIssueId: parentId });
+    await activeRun({ companyId, agentId, issueId: activeChildId });
+
+    const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
+
+    expect(parent?.blockerAttention).toMatchObject({
+      state: "covered",
+      reason: "active_child",
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
+      stalledBlockerCount: 0,
+      attentionBlockerCount: 0,
+      sampleBlockerIdentifier: "PBCX-2",
+      sampleStalledBlockerIdentifier: null,
+    });
+  });
+
   it("covers recursive blocker chains when the downstream leaf has active work", async () => {
     const { companyId, agentId } = await createCompany("PBR");
     const parentId = await insertIssue({ companyId, identifier: "PBR-1", title: "Parent", status: "blocked" });
@@ -404,7 +440,7 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
-  it("prefers needs_attention over stalled when the chain also has a hard attention case", async () => {
+  it("ignores cancelled blockers when deciding whether another path is stalled", async () => {
     const { companyId, agentId } = await createCompany("PBQ");
     const parentId = await insertIssue({ companyId, identifier: "PBQ-1", title: "Parent", status: "blocked" });
     const reviewLeafId = await insertIssue({
@@ -427,11 +463,11 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     const parent = (await svc.list(companyId, { status: "blocked" })).find((issue) => issue.id === parentId);
 
     expect(parent?.blockerAttention).toMatchObject({
-      state: "needs_attention",
-      reason: "attention_required",
+      state: "stalled",
+      reason: "stalled_review",
       coveredBlockerCount: 0,
       stalledBlockerCount: 1,
-      attentionBlockerCount: 1,
+      attentionBlockerCount: 0,
       sampleStalledBlockerIdentifier: "PBQ-2",
     });
   });
@@ -476,8 +512,8 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     expect(parent?.blockerAttention).toMatchObject({
       state: "covered",
       reason: "active_dependency",
-      unresolvedBlockerCount: 2,
-      coveredBlockerCount: 2,
+      unresolvedBlockerCount: 1,
+      coveredBlockerCount: 1,
       attentionBlockerCount: 0,
     });
   });

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1488,7 +1488,10 @@ async function listIssueBlockerAttentionMap(
       return { covered: false, stalled: false, sampleBlockerIdentifier: nodeSample, sampleStalledBlockerIdentifier: null };
     }
 
-    const downstream = (edgesByIssueId.get(node.id) ?? []).filter((edge) => nodesById.get(edge.blockerIssueId)?.status !== "done");
+    const downstream = (edgesByIssueId.get(node.id) ?? []).filter((edge) => {
+      const blockerStatus = nodesById.get(edge.blockerIssueId)?.status;
+      return blockerStatus !== "done" && blockerStatus !== "cancelled";
+    });
     if (downstream.length > 0) {
       const nextSeen = new Set(seen);
       nextSeen.add(nodeId);
@@ -1532,7 +1535,10 @@ async function listIssueBlockerAttentionMap(
   };
 
   for (const root of roots) {
-    const topLevelEdges = (edgesByIssueId.get(root.id) ?? []).filter((edge) => nodesById.get(edge.blockerIssueId)?.status !== "done");
+    const topLevelEdges = (edgesByIssueId.get(root.id) ?? []).filter((edge) => {
+      const blockerStatus = nodesById.get(edge.blockerIssueId)?.status;
+      return blockerStatus !== "done" && blockerStatus !== "cancelled";
+    });
     if (topLevelEdges.length === 0) {
       attentionMap.set(root.id, createIssueBlockerAttention({
         state: "needs_attention",


### PR DESCRIPTION
## Summary\n- Excludes cancelled terminal blocker edges from blocker attention rollup\n- Adds regression coverage for cancelled historical blockers\n\n## Verification\n- Submitted implementation commit: 57c65a925592ff7c25a8f93419e66d338b148518\n- Direct push to origin/master was attempted by CEO on 2026-05-25 and rejected by GitHub permissions (403), so this PR is the canonical integration path.\n\n## Paperclip\n- SDL-1826\n