### PR TITLE
fix: allow board review-stage reconciliation

### DIFF
--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -598,6 +598,49 @@ describe("issue execution policy transitions", () => {
       // No error — just no patch modifications
       expect(result.patch).toEqual({});
     });
+
+    it("board operator can reconcile a stuck active review stage back to the return assignee", () => {
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: {
+            status: "pending",
+            currentStageId: reviewStageId,
+            currentStageIndex: 0,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: qaAgentId },
+            returnAssignee: { type: "agent", agentId: coderAgentId },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: null,
+          },
+        },
+        policy,
+        requestedStatus: "in_progress",
+        requestedAssigneePatch: { assigneeAgentId: coderAgentId },
+        actor: { userId: boardUserId },
+        commentBody: "Operator reconciliation: reviewer already requested changes but the runtime failed to patch state.",
+      });
+
+      expect(result.patch.status).toBe("in_progress");
+      expect(result.patch.assigneeAgentId).toBe(coderAgentId);
+      expect(result.patch.executionState).toMatchObject({
+        status: "changes_requested",
+        currentStageId: reviewStageId,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: qaAgentId },
+        returnAssignee: { type: "agent", agentId: coderAgentId },
+        lastDecisionOutcome: "changes_requested",
+      });
+      expect(result.decision).toMatchObject({
+        stageId: reviewStageId,
+        stageType: "review",
+        outcome: "changes_requested",
+      });
+    });
   });
 
   describe("comment requirements", () => {

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -65,6 +65,10 @@ const MONITOR_INVALID_MESSAGE = "Monitor can only be scheduled on issues assigne
 const MONITOR_BOUNDS_EXHAUSTED_MESSAGE = "Monitor bounds are already exhausted";
 export const REDACTED_ISSUE_MONITOR_EXTERNAL_REF = "[redacted]";
 
+function isBoardActor(actor: ActorLike) {
+  return Boolean(actor.userId) && !actor.agentId;
+}
+
 function normalizeMonitorNotes(notes: string | null | undefined) {
   if (typeof notes !== "string") return null;
   const trimmed = notes.trim();
@@ -690,7 +694,7 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
       };
     }
 
-    if (principalsEqual(currentParticipant, actor)) {
+    if ((actor && principalsEqual(currentParticipant, actor)) || isBoardActor(input.actor)) {
       if (requestedStatus === "done") {
         if (!input.commentBody?.trim()) {
           throw unprocessable("Approving a review or approval stage requires a comment");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that keeps autonomous company work auditable and recoverable.
> - Issue execution policies make review and approval stages first-class workflow gates.
> - Active reviewers/approvers are correctly protected from ordinary non-participant agent mutation.
> - The board operator is a different authority: V1 explicitly allows the board to intervene anywhere.
> - A reviewer runtime can land a review comment but fail the actual Paperclip PATCH because of local adapter permissions or a sandbox prompt.
> - Before this change, a board/operator PATCH to reconcile that stuck stage hit the same active-participant guard and returned 422.
> - This pull request lets board actors reconcile active execution stages while preserving agent non-participant protection and decision audit output.
> - The benefit is that operators can safely repair stuck review/change-request handoffs without direct DB mutation or bypassing issue activity logs.

## What Changed

- Added a board-actor recognition path to issue execution policy transitions.
- Allowed board actors to advance/reconcile an active review/approval stage using the existing stage transition logic.
- Added regression coverage for a board operator returning a stuck review stage to the original executor after changes were requested.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-execution-policy.test.ts` — 51 tests passed.
- `git diff --check` — passed.

## Risks

- Low-to-medium risk: this intentionally broadens board/operator authority in execution-stage transitions.
- Agent non-participants remain blocked by the existing active reviewer/approver guard.
- Board actors still use the same transition path, comment requirements, decision records, and issue activity logging rather than direct DB writes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex via Hermes, model `gpt-5.5`, with tool use and local test execution.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
