### PR TITLE
Fix stale closeout comment wake reopening

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -625,7 +625,7 @@ describe("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("promotes deferred comment wakes after the active run closes the issue", async () => {
+  it("promotes deferred comment wakes after the active run closes the issue without reopening it", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -781,7 +781,7 @@ describe("heartbeat comment wake batching", () => {
         );
       }, 90_000);
 
-      const reopenedIssue = await db
+      const closedIssue = await db
         .select({
           status: issues.status,
           completedAt: issues.completedAt,
@@ -790,10 +790,10 @@ describe("heartbeat comment wake batching", () => {
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
 
-      expect(reopenedIssue).toMatchObject({
-        status: "in_progress",
-        completedAt: null,
+      expect(closedIssue).toMatchObject({
+        status: "done",
       });
+      expect(closedIssue?.completedAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toMatchObject({
@@ -805,7 +805,7 @@ describe("heartbeat comment wake batching", () => {
             id: issueId,
             identifier: `${issuePrefix}-1`,
             title: "Reopen after deferred comment",
-            status: "in_progress",
+            status: "done",
             priority: "medium",
           },
         },

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -312,4 +312,35 @@ describe("issue update comment wakeups", () => {
       }),
     );
   });
+
+  it("does not wake the assignee when an update comment closes the issue", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "in_progress",
+    });
+    const updated = makeIssue({
+      ...existing,
+      status: "done",
+      completedAt: new Date(),
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-3",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "closeout summary",
+    });
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({
+        status: "done",
+        comment: "closeout summary",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4236,7 +4236,7 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+        const skipAssigneeCommentWake = selfComment || isClosed || isClosedIssueStatus(issue.status);
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8366,11 +8366,21 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        const issueClosedAt =
+          issue.status === "done"
+            ? issue.completedAt
+            : issue.status === "cancelled"
+              ? issue.cancelledAt
+              : null;
+        const issueClosedAfterDeferredWake =
+          issueClosedAt !== null &&
+          issueClosedAt.getTime() >= deferred.requestedAt.getTime();
         // Only human/comment-reopen interactions should revive completed issues;
         // system follow-ups such as retry or cleanup wakes must not reopen closed work.
         const shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
           (issue.status === "done" || issue.status === "cancelled") &&
+          !issueClosedAfterDeferredWake &&
           (
             deferred.requestedByActorType === "user" ||
             deferredWakeReason === "issue_reopened_via_comment"


### PR DESCRIPTION
## Summary
- suppress assignee comment wakes when an issue update comment leaves the issue in a terminal state
- prevent deferred comment wakes created before a terminal close from reopening the issue after completion
- update regression coverage for closeout-comment and deferred-comment wake behavior

## Verification
- pnpm exec vitest run server/src/__tests__/issue-update-comment-wakeup-routes.test.ts server/src/__tests__/heartbeat-comment-wake-batching.test.ts
- BYO-694 readback: done, checkoutRunId null, executionRunId null, executionState null
- BYO repo was read-only for this issue; pre-existing BYO diffs remain unrelated
