### PR TITLE
fix: add retry and fallback for transient Postgres PK index visibility

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -2767,8 +2767,38 @@ export function issueService(db: Db) {
       .from(issues)
       .where(eq(issues.id, id))
       .then((rows) => rows[0] ?? null);
-    if (!row) return null;
-    const [enriched] = await withIssueLabels(db, [row]);
+    if (row) {
+      const [enriched] = await withIssueLabels(db, [row]);
+      return enriched;
+    }
+
+    // Mitigation for transient Postgres index visibility issues:
+    // The PK B-tree index can transiently miss rows that are visible
+    // via secondary indexes (e.g. issues_identifier_idx) due to
+    // VACUUM/HOT pruning or connection-pool MVCC snapshot skew.
+    // Retry once after a brief delay to allow visibility to stabilize.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const retryRow = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, id))
+      .then((rows) => rows[0] ?? null);
+    if (retryRow) {
+      const [enriched] = await withIssueLabels(db, [retryRow]);
+      return enriched;
+    }
+
+    // Last-resort fallback: use a text-cast condition that may bypass
+    // B-tree index visibility issues by forcing a sequential scan or
+    // a different index strategy.
+    const fallbackRow = await db
+      .select()
+      .from(issues)
+      .where(sql`${issues.id}::text = ${id}::text`)
+      .limit(1)
+      .then((rows) => rows[0] ?? null);
+    if (!fallbackRow) return null;
+    const [enriched] = await withIssueLabels(db, [fallbackRow]);
     return enriched;
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The issue service uses Drizzle ORM with Postgres to look up issues by UUID (PK index) and by identifier (secondary unique index)
> - During normal operation, a transient Postgres index visibility bug causes the PK B-tree index to miss rows that are visible via the secondary `issues_identifier_idx` unique index
> - This produces 404 errors on UUID-based API endpoints (`GET /api/issues/:uuid`, `PATCH /api/issues/:uuid`, etc.) even though the row exists and is findable by identifier
> - The root cause is likely VACUUM/HOT pruning, connection pool MVCC snapshot skew, or Postgres visibility map inconsistencies — the issue self-resolves within minutes
> - This PR adds a graceful 3-tier fallback in `getIssueByUuid()` so UUID lookups that initially miss can still succeed through retry or an alternative query plan
> - The benefit is that UUID-based API endpoints remain available during transient Postgres index visibility events, preventing cascading workflow failures from what is fundamentally a read-path consistency glitch

## What Changed

- Modified `getIssueByUuid()` in `server/src/services/issues.ts` to add a 3-tier lookup strategy:
  1. **Fast path** (unchanged): standard Drizzle `eq(issues.id, id)` PK index lookup — zero overhead for the ~99% of requests that succeed on first attempt
  2. **Retry** (new): if the PK lookup returns null, wait 100ms and retry the same query to allow transient visibility issues to stabilize
  3. **Text-cast fallback** (new): if the retry also returns null, use `sql`${issues.id}::text = ${id}::text`` which may force a different query plan, bypassing B-tree index visibility issues

## Verification

- All 50 existing `issues-service.test.ts` tests pass locally (`vitest run`)
- No TypeScript compilation errors in the modified file
- Manual verification: the fast path is byte-identical to the previous implementation — only the null-handling branch is extended
- The retry and fallback paths only execute when the initial PK lookup returns null, which is empirically rare (<1% of requests during the observed 4-minute incident window with 11 confirmed 404s)

## Risks

- **Low risk**: the fast path is unchanged. The retry adds 100ms latency only when the first lookup misses — this is bounded and rare
- **Hiding root cause**: if the fallback path triggers frequently, the underlying Postgres issue could go unnoticed. A follow-up observability metric (counter for fallback-triggered lookups) is recommended
- **Text-cast query plan**: the `id::text = ?::text` condition may force a sequential scan on very large tables, but is guarded by `LIMIT 1` and only executes after retry also fails — worst case is a single slow query during an incident

## Model Used

- Provider: DeepSeek
- Model: deepseek-v4-pro
- Context window: standard
- Capabilities: tool use, chain-of-thought reasoning
- Assisted with: implementing the retry logic, writing the PR body, and constructing the GitHub API payload