### PR TITLE
feat: add training calendar surface

### DIFF
--- a/doc/plans/2026-05-25-training-calendar.md
+++ b/doc/plans/2026-05-25-training-calendar.md
@@ -1,0 +1,33 @@
+# Training Calendar Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Add a TrainingPeaks-inspired training calendar surface to Paperclip, with an embedded chat widget and a separate settings page for OAuth/provider/model/integration configuration.
+
+**Architecture:** Keep this first iteration UI-first and company-scoped in the Paperclip board shell. Use typed React components and local UI state/localStorage so the product surface is usable immediately without introducing secrets or unfinished OAuth backends. Leave OAuth actions as explicit provider connect affordances that can later call server routes.
+
+**Tech Stack:** React 19, Vite, TypeScript, Tailwind utility classes, lucide-react icons, existing Paperclip router/nav/layout.
+
+---
+
+## Task 1: Build the training calendar page
+
+- Create `ui/src/pages/TrainingCalendar.tsx`.
+- Render a TrainingPeaks-like week calendar with athlete/workload summary, workout cards, planned/completed status, intensity zones, TSS/duration metrics, and right-side embedded chat widget.
+- The chat widget must live inside the page, not replace Paperclip comments globally.
+
+## Task 2: Build the training configuration page
+
+- Create `ui/src/pages/TrainingSettings.tsx`.
+- Include separate sections for AI providers (OpenAI, Anthropic, Google/Gemini, OpenRouter, Other), OAuth connect buttons, post-login model selection, Garmin and Strava OAuth connect toggles, sync preferences, and clear security copy: no API keys shown/stored in UI.
+
+## Task 3: Wire routes and navigation
+
+- Modify `ui/src/App.tsx` to import and route `/training` and `/training/settings`.
+- Modify `ui/src/components/Sidebar.tsx` to add a Fitness/Training nav section or item.
+- Optionally update mobile nav only if it remains clean.
+
+## Task 4: Verify
+
+- Run `pnpm --filter @paperclipai/ui typecheck`.
+- If feasible, run `pnpm --filter @paperclipai/ui build`.

--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -133,6 +133,9 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     await db.delete(documents);
     await db.delete(issueRelations);
     await db.delete(issueTreeHolds);
+    // A heartbeat run can append final issue comments after the first cleanup pass.
+    // Re-delete comments immediately before issues so FK cleanup stays deterministic.
+    await db.delete(issueComments);
     await db.delete(issues);
     await db.delete(heartbeatRunEvents);
     await db.delete(activityLog);

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -39,6 +39,8 @@ import { CompanySkills } from "./pages/CompanySkills";
 import { Secrets } from "./pages/Secrets";
 import { CompanyExport } from "./pages/CompanyExport";
 import { CompanyImport } from "./pages/CompanyImport";
+import { TrainingCalendar } from "./pages/TrainingCalendar";
+import { TrainingSettings } from "./pages/TrainingSettings";
 import { DesignGuide } from "./pages/DesignGuide";
 import { InstanceGeneralSettings } from "./pages/InstanceGeneralSettings";
 import { InstanceAccess } from "./pages/InstanceAccess";
@@ -81,6 +83,8 @@ function boardRoutes() {
       <Route path="company/settings/secrets" element={<Secrets />} />
       <Route path="company/settings/:settingsRoutePath/*" element={<CompanySettingsPluginPage />} />
       <Route path="skills/*" element={<CompanySkills />} />
+      <Route path="training" element={<TrainingCalendar />} />
+      <Route path="training/settings" element={<TrainingSettings />} />
       <Route path="settings" element={<LegacySettingsRedirect />} />
       <Route path="settings/*" element={<LegacySettingsRedirect />} />
       <Route path="plugins/:pluginId" element={<PluginPage />} />
@@ -306,6 +310,8 @@ export function App() {
           <Route path="routines/:routineId" element={<UnprefixedBoardRedirect />} />
           <Route path="u/:userSlug" element={<UnprefixedBoardRedirect />} />
           <Route path="skills/*" element={<UnprefixedBoardRedirect />} />
+          <Route path="training" element={<UnprefixedBoardRedirect />} />
+          <Route path="training/settings" element={<UnprefixedBoardRedirect />} />
           <Route path="settings" element={<LegacySettingsRedirect />} />
           <Route path="settings/*" element={<LegacySettingsRedirect />} />
           <Route path="agents" element={<UnprefixedBoardRedirect />} />

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Repeat,
   GitBranch,
   Settings,
+  CalendarDays,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { NavLink } from "@/lib/router";
@@ -96,6 +97,7 @@ export function Sidebar() {
         <SidebarSection label="Work">
           <SidebarNavItem to="/issues" label="Issues" icon={CircleDot} />
           <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
+          <SidebarNavItem to="/training" label="Training" icon={CalendarDays} textBadge="New" textBadgeTone="amber" />
           <SidebarNavItem to="/goals" label="Goals" icon={Target} />
           {showWorkspacesLink ? (
             <SidebarNavItem to="/workspaces" label="Workspaces" icon={GitBranch} />

--- a/ui/src/lib/company-routes.ts
+++ b/ui/src/lib/company-routes.ts
@@ -3,6 +3,7 @@ const BOARD_ROUTE_ROOTS = new Set([
   "companies",
   "company",
   "skills",
+  "training",
   "org",
   "agents",
   "projects",

--- a/ui/src/pages/TrainingCalendar.tsx
+++ b/ui/src/pages/TrainingCalendar.tsx
@@ -1,0 +1,501 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "@/lib/router";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { cn } from "@/lib/utils";
+
+type WorkoutType = "Run" | "Bike" | "Swim" | "Strength" | "Recovery" | "Brick";
+type WorkoutStatus = "completed" | "planned" | "missed" | "adapted";
+type WorkoutIntensity = "Z1" | "Z2" | "Tempo" | "Threshold" | "VO2";
+
+type Workout = {
+  id: string;
+  title: string;
+  type: WorkoutType;
+  durationMinutes: number;
+  intensity: WorkoutIntensity;
+  tss: number;
+  status: WorkoutStatus;
+  note: string;
+};
+
+type TrainingDay = {
+  date: string;
+  dayName: string;
+  shortDate: string;
+  readiness: number;
+  workouts: Workout[];
+};
+
+type ChatMessage = {
+  id: number;
+  author: "coach" | "athlete";
+  body: string;
+  timestamp: string;
+};
+
+const week: TrainingDay[] = [
+  {
+    date: "2026-05-25",
+    dayName: "Mon",
+    shortDate: "May 25",
+    readiness: 82,
+    workouts: [
+      {
+        id: "mon-run",
+        title: "Aerobic base run",
+        type: "Run",
+        durationMinutes: 55,
+        intensity: "Z2",
+        tss: 58,
+        status: "completed",
+        note: "Smooth cadence, HR stable.",
+      },
+    ],
+  },
+  {
+    date: "2026-05-26",
+    dayName: "Tue",
+    shortDate: "May 26",
+    readiness: 76,
+    workouts: [
+      {
+        id: "tue-bike",
+        title: "Sweet spot intervals",
+        type: "Bike",
+        durationMinutes: 75,
+        intensity: "Tempo",
+        tss: 86,
+        status: "adapted",
+        note: "Reduced final block after sleep score dipped.",
+      },
+      {
+        id: "tue-strength",
+        title: "Core + mobility",
+        type: "Strength",
+        durationMinutes: 25,
+        intensity: "Z1",
+        tss: 18,
+        status: "completed",
+        note: "Keep movement quality high.",
+      },
+    ],
+  },
+  {
+    date: "2026-05-27",
+    dayName: "Wed",
+    shortDate: "May 27",
+    readiness: 69,
+    workouts: [
+      {
+        id: "wed-swim",
+        title: "Technique swim",
+        type: "Swim",
+        durationMinutes: 45,
+        intensity: "Z2",
+        tss: 42,
+        status: "planned",
+        note: "Drills: catch-up, scull, 6x100 relaxed.",
+      },
+    ],
+  },
+  {
+    date: "2026-05-28",
+    dayName: "Thu",
+    shortDate: "May 28",
+    readiness: 88,
+    workouts: [
+      {
+        id: "thu-run",
+        title: "Threshold repeats",
+        type: "Run",
+        durationMinutes: 65,
+        intensity: "Threshold",
+        tss: 92,
+        status: "planned",
+        note: "3x10 min at controlled threshold.",
+      },
+    ],
+  },
+  {
+    date: "2026-05-29",
+    dayName: "Fri",
+    shortDate: "May 29",
+    readiness: 64,
+    workouts: [
+      {
+        id: "fri-recovery",
+        title: "Recovery spin",
+        type: "Recovery",
+        durationMinutes: 35,
+        intensity: "Z1",
+        tss: 20,
+        status: "planned",
+        note: "Optional if fatigue remains elevated.",
+      },
+    ],
+  },
+  {
+    date: "2026-05-30",
+    dayName: "Sat",
+    shortDate: "May 30",
+    readiness: 73,
+    workouts: [
+      {
+        id: "sat-brick",
+        title: "Bike/run brick",
+        type: "Brick",
+        durationMinutes: 120,
+        intensity: "Tempo",
+        tss: 138,
+        status: "planned",
+        note: "Fuel every 25 minutes; run off the bike easy.",
+      },
+    ],
+  },
+  {
+    date: "2026-05-31",
+    dayName: "Sun",
+    shortDate: "May 31",
+    readiness: 58,
+    workouts: [
+      {
+        id: "sun-long-run",
+        title: "Long run",
+        type: "Run",
+        durationMinutes: 95,
+        intensity: "Z2",
+        tss: 104,
+        status: "missed",
+        note: "Missed last week; reassess before rescheduling.",
+      },
+    ],
+  },
+];
+
+const initialMessages: ChatMessage[] = [
+  {
+    id: 1,
+    author: "coach",
+    body: "Readiness is trending lower into the weekend. Keep Friday truly easy so the brick lands well.",
+    timestamp: "08:15",
+  },
+  {
+    id: 2,
+    author: "athlete",
+    body: "Got it. Should I swap the threshold run if sleep is poor?",
+    timestamp: "08:22",
+  },
+  {
+    id: 3,
+    author: "coach",
+    body: "Yes — if readiness is below 65, convert it to 45 min Z2 and move intervals to next week.",
+    timestamp: "08:24",
+  },
+];
+
+const typeStyles: Record<WorkoutType, string> = {
+  Run: "border-l-sky-500 bg-sky-500/10",
+  Bike: "border-l-violet-500 bg-violet-500/10",
+  Swim: "border-l-cyan-500 bg-cyan-500/10",
+  Strength: "border-l-amber-500 bg-amber-500/10",
+  Recovery: "border-l-emerald-500 bg-emerald-500/10",
+  Brick: "border-l-rose-500 bg-rose-500/10",
+};
+
+const statusStyles: Record<WorkoutStatus, string> = {
+  completed: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  planned: "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300",
+  missed: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300",
+  adapted: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+};
+
+function formatDuration(minutes: number) {
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (hours === 0) return `${remainingMinutes}m`;
+  if (remainingMinutes === 0) return `${hours}h`;
+  return `${hours}h ${remainingMinutes}m`;
+}
+
+function readinessTone(score: number) {
+  if (score >= 80) return "text-emerald-600 dark:text-emerald-300";
+  if (score >= 65) return "text-amber-600 dark:text-amber-300";
+  return "text-red-600 dark:text-red-300";
+}
+
+function statLabel(value: number, suffix = "") {
+  return `${Math.round(value)}${suffix}`;
+}
+
+function WorkoutCard({ workout }: { workout: Workout }) {
+  return (
+    <div className={cn("rounded-md border border-l-4 p-3 shadow-sm", typeStyles[workout.type])}>
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-sm font-semibold leading-tight">{workout.title}</p>
+          <p className="mt-1 text-xs text-muted-foreground">{workout.note}</p>
+        </div>
+        <Badge variant="outline" className={cn("capitalize", statusStyles[workout.status])}>
+          {workout.status}
+        </Badge>
+      </div>
+      <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+        <span>{workout.type}</span>
+        <span>{formatDuration(workout.durationMinutes)}</span>
+        <span>{workout.intensity}</span>
+        <span>{workout.tss} TSS</span>
+      </div>
+    </div>
+  );
+}
+
+function ReadinessBar({ score }: { score: number }) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-xs">
+        <span className="text-muted-foreground">Readiness</span>
+        <span className={cn("font-semibold", readinessTone(score))}>{score}%</span>
+      </div>
+      <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-primary transition-all"
+          style={{ width: `${score}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function TrainingCalendar() {
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
+  const [draft, setDraft] = useState("");
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Training" }]);
+  }, [setBreadcrumbs]);
+
+  const summary = useMemo(() => {
+    const workouts = week.flatMap((day) => day.workouts);
+    const plannedTss = workouts.reduce((total, workout) => total + workout.tss, 0);
+    const completedTss = workouts
+      .filter((workout) => workout.status === "completed" || workout.status === "adapted")
+      .reduce((total, workout) => total + workout.tss, 0);
+    const plannedMinutes = workouts.reduce((total, workout) => total + workout.durationMinutes, 0);
+    const completedMinutes = workouts
+      .filter((workout) => workout.status === "completed" || workout.status === "adapted")
+      .reduce((total, workout) => total + workout.durationMinutes, 0);
+    const averageReadiness =
+      week.reduce((total, day) => total + day.readiness, 0) / Math.max(week.length, 1);
+
+    return {
+      plannedTss,
+      completedTss,
+      plannedMinutes,
+      completedMinutes,
+      averageReadiness,
+      completionRate: (completedTss / Math.max(plannedTss, 1)) * 100,
+    };
+  }, []);
+
+  const sendMessage = () => {
+    const body = draft.trim();
+    if (!body) return;
+
+    setMessages((current) => [
+      ...current,
+      {
+        id: Date.now(),
+        author: "athlete",
+        body,
+        timestamp: "now",
+      },
+    ]);
+    setDraft("");
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p className="text-sm font-medium text-muted-foreground">TrainingPeaks-inspired planning</p>
+          <h1 className="text-3xl font-semibold tracking-tight">Training Calendar</h1>
+          <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+            Weekly view for planned vs completed training load, athlete readiness, and coach chat.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline">Previous week</Button>
+          <Button>This week</Button>
+          <Button variant="outline" asChild>
+            <Link to="/training/settings">Configure</Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card className="rounded-xl">
+          <CardHeader className="pb-0">
+            <CardDescription>Weekly load</CardDescription>
+            <CardTitle className="text-2xl">{summary.plannedTss} TSS</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            {summary.completedTss} TSS completed/adapted so far.
+          </CardContent>
+        </Card>
+        <Card className="rounded-xl">
+          <CardHeader className="pb-0">
+            <CardDescription>Planned vs completed</CardDescription>
+            <CardTitle className="text-2xl">{statLabel(summary.completionRate, "%")}</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            {formatDuration(summary.completedMinutes)} of {formatDuration(summary.plannedMinutes)} done.
+          </CardContent>
+        </Card>
+        <Card className="rounded-xl">
+          <CardHeader className="pb-0">
+            <CardDescription>Athlete readiness</CardDescription>
+            <CardTitle className={cn("text-2xl", readinessTone(summary.averageReadiness))}>
+              {statLabel(summary.averageReadiness, "%")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Average across daily recovery signals.
+          </CardContent>
+        </Card>
+        <Card className="rounded-xl">
+          <CardHeader className="pb-0">
+            <CardDescription>Coach focus</CardDescription>
+            <CardTitle className="text-2xl">Manage fatigue</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Keep Friday easy before Saturday's brick session.
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1fr_360px]">
+        <Card className="rounded-xl">
+          <CardHeader>
+            <CardTitle>Week of May 25</CardTitle>
+            <CardDescription>7-day grid with workout status, intensity, duration, and TSS.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-3 lg:grid-cols-7">
+              {week.map((day) => (
+                <section key={day.date} className="min-h-72 rounded-lg border bg-background/50 p-3">
+                  <div className="mb-3 flex items-start justify-between gap-2">
+                    <div>
+                      <h2 className="font-semibold">{day.dayName}</h2>
+                      <p className="text-xs text-muted-foreground">{day.shortDate}</p>
+                    </div>
+                    <Badge variant="secondary">{day.workouts.length}</Badge>
+                  </div>
+                  <ReadinessBar score={day.readiness} />
+                  <div className="mt-3 space-y-3">
+                    {day.workouts.map((workout) => (
+                      <WorkoutCard key={workout.id} workout={workout} />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-6">
+          <Card className="rounded-xl">
+            <CardHeader>
+              <CardTitle>Load distribution</CardTitle>
+              <CardDescription>TSS by discipline</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {(["Run", "Bike", "Swim", "Strength", "Recovery", "Brick"] as WorkoutType[]).map((type) => {
+                const tss = week
+                  .flatMap((day) => day.workouts)
+                  .filter((workout) => workout.type === type)
+                  .reduce((total, workout) => total + workout.tss, 0);
+                const percentage = (tss / Math.max(summary.plannedTss, 1)) * 100;
+
+                return (
+                  <div key={type} className="space-y-1">
+                    <div className="flex justify-between text-sm">
+                      <span>{type}</span>
+                      <span className="text-muted-foreground">{tss} TSS</span>
+                    </div>
+                    <div className="h-2 overflow-hidden rounded-full bg-muted">
+                      <div className="h-full rounded-full bg-primary" style={{ width: `${percentage}%` }} />
+                    </div>
+                  </div>
+                );
+              })}
+            </CardContent>
+          </Card>
+
+          <Card className="rounded-xl">
+            <CardHeader>
+              <CardTitle>Coach chat</CardTitle>
+              <CardDescription>Local page-only conversation</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="max-h-80 space-y-3 overflow-y-auto rounded-lg border bg-muted/20 p-3">
+                {messages.map((message) => (
+                  <div
+                    key={message.id}
+                    className={cn(
+                      "rounded-lg border p-3 text-sm",
+                      message.author === "athlete"
+                        ? "ml-6 bg-primary text-primary-foreground"
+                        : "mr-6 bg-background"
+                    )}
+                  >
+                    <div className="mb-1 flex items-center justify-between gap-2 text-xs opacity-80">
+                      <span className="font-medium capitalize">{message.author}</span>
+                      <span>{message.timestamp}</span>
+                    </div>
+                    <p>{message.body}</p>
+                  </div>
+                ))}
+              </div>
+              <div className="space-y-2">
+                <Input value="Coach Maia" readOnly aria-label="Coach name" />
+                <Textarea
+                  value={draft}
+                  onChange={(event) => setDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+                      event.preventDefault();
+                      sendMessage();
+                    }
+                  }}
+                  placeholder="Ask about today's workout or request an adjustment..."
+                  aria-label="Chat message"
+                />
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs text-muted-foreground">Ctrl/⌘ + Enter to send</p>
+                  <Button onClick={sendMessage} disabled={!draft.trim()}>
+                    Send message
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TrainingCalendar;

--- a/ui/src/pages/TrainingSettings.tsx
+++ b/ui/src/pages/TrainingSettings.tsx
@@ -1,0 +1,607 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  Bot,
+  CalendarDays,
+  Check,
+  Dumbbell,
+  ExternalLink,
+  HeartPulse,
+  Link2,
+  LockKeyhole,
+  RotateCw,
+  Settings,
+  ShieldCheck,
+  Sparkles,
+  Unplug,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+
+type ProviderId = "openai" | "anthropic" | "gemini" | "openrouter" | "other";
+type IntegrationId = "garmin" | "strava";
+
+type AiProvider = {
+  id: ProviderId;
+  name: string;
+  description: string;
+  models: string[];
+  accent: string;
+};
+
+type AiProviderState = {
+  connected: boolean;
+  model: string;
+  customModel?: string;
+};
+
+type IntegrationState = {
+  connected: boolean;
+  syncCompletedActivities: boolean;
+  syncPlannedWorkouts: boolean;
+  autoSync: boolean;
+  healthMetrics: {
+    sleep: boolean;
+    hrv: boolean;
+    restingHeartRate: boolean;
+    trainingReadiness: boolean;
+  };
+};
+
+type TrainingSettingsState = {
+  providers: Record<ProviderId, AiProviderState>;
+  integrations: Record<IntegrationId, IntegrationState>;
+};
+
+const STORAGE_KEY = "paperclip.trainingSettings.v1";
+
+const AI_PROVIDERS: AiProvider[] = [
+  {
+    id: "openai",
+    name: "OpenAI",
+    description: "Use GPT models for plan generation, workout analysis, and calendar adjustments.",
+    models: ["gpt-4.1", "gpt-4.1-mini", "o4-mini"],
+    accent: "bg-emerald-500/10 text-emerald-700 border-emerald-500/20",
+  },
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    description: "Connect Claude for longer coaching context and conservative training recommendations.",
+    models: ["claude-3.7-sonnet", "claude-3.5-sonnet", "claude-3.5-haiku"],
+    accent: "bg-orange-500/10 text-orange-700 border-orange-500/20",
+  },
+  {
+    id: "gemini",
+    name: "Google Gemini",
+    description: "Use Gemini models for multimodal workout notes and fast calendar summaries.",
+    models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-1.5-pro"],
+    accent: "bg-blue-500/10 text-blue-700 border-blue-500/20",
+  },
+  {
+    id: "openrouter",
+    name: "OpenRouter",
+    description: "Route training workflows through a selected third-party model catalog.",
+    models: ["openai/gpt-4.1", "anthropic/claude-3.7-sonnet", "google/gemini-2.5-pro"],
+    accent: "bg-purple-500/10 text-purple-700 border-purple-500/20",
+  },
+  {
+    id: "other",
+    name: "Other",
+    description: "Reserve a custom provider slot for bring-your-own gateway experiments.",
+    models: ["custom-model"],
+    accent: "bg-slate-500/10 text-slate-700 border-slate-500/20",
+  },
+];
+
+const DEFAULT_INTEGRATION: IntegrationState = {
+  connected: false,
+  syncCompletedActivities: true,
+  syncPlannedWorkouts: true,
+  autoSync: false,
+  healthMetrics: {
+    sleep: true,
+    hrv: true,
+    restingHeartRate: true,
+    trainingReadiness: false,
+  },
+};
+
+function createDefaultState(): TrainingSettingsState {
+  return {
+    providers: AI_PROVIDERS.reduce((acc, provider) => {
+      acc[provider.id] = {
+        connected: false,
+        model: provider.models[0] ?? "custom-model",
+        customModel: provider.id === "other" ? "" : undefined,
+      };
+      return acc;
+    }, {} as Record<ProviderId, AiProviderState>),
+    integrations: {
+      garmin: { ...DEFAULT_INTEGRATION },
+      strava: {
+        ...DEFAULT_INTEGRATION,
+        healthMetrics: {
+          sleep: false,
+          hrv: false,
+          restingHeartRate: true,
+          trainingReadiness: false,
+        },
+      },
+    },
+  };
+}
+
+function loadSettings(): TrainingSettingsState {
+  const defaults = createDefaultState();
+  if (typeof window === "undefined") return defaults;
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaults;
+    const parsed = JSON.parse(raw) as Partial<TrainingSettingsState>;
+
+    return {
+      providers: {
+        ...defaults.providers,
+        ...(parsed.providers ?? {}),
+      },
+      integrations: {
+        garmin: {
+          ...defaults.integrations.garmin,
+          ...(parsed.integrations?.garmin ?? {}),
+          healthMetrics: {
+            ...defaults.integrations.garmin.healthMetrics,
+            ...(parsed.integrations?.garmin?.healthMetrics ?? {}),
+          },
+        },
+        strava: {
+          ...defaults.integrations.strava,
+          ...(parsed.integrations?.strava ?? {}),
+          healthMetrics: {
+            ...defaults.integrations.strava.healthMetrics,
+            ...(parsed.integrations?.strava?.healthMetrics ?? {}),
+          },
+        },
+      },
+    };
+  } catch {
+    return defaults;
+  }
+}
+
+function StatusBadge({ connected }: { connected: boolean }) {
+  return connected ? (
+    <Badge className="gap-1 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/10">
+      <Check className="h-3 w-3" /> Connected
+    </Badge>
+  ) : (
+    <Badge variant="outline" className="gap-1 text-muted-foreground">
+      <Unplug className="h-3 w-3" /> Not connected
+    </Badge>
+  );
+}
+
+function ToggleRow({
+  id,
+  label,
+  description,
+  checked,
+  disabled,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-md border bg-background/60 p-3">
+      <Checkbox
+        id={id}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={(value) => onChange(value === true)}
+      />
+      <div className="grid gap-1 leading-none">
+        <Label htmlFor={id} className="text-sm font-medium">
+          {label}
+        </Label>
+        <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+export function TrainingSettings() {
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const [settings, setSettings] = useState<TrainingSettingsState>(() => loadSettings());
+
+  useEffect(() => {
+    document.title = "Training Settings · Paperclip";
+    setBreadcrumbs([
+      { label: "Training", href: "/training" },
+      { label: "Settings" },
+    ]);
+  }, [setBreadcrumbs]);
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  }, [settings]);
+
+  const connectedProviderCount = useMemo(
+    () => Object.values(settings.providers).filter((provider) => provider.connected).length,
+    [settings.providers],
+  );
+
+  const connectedIntegrationCount = useMemo(
+    () => Object.values(settings.integrations).filter((integration) => integration.connected).length,
+    [settings.integrations],
+  );
+
+  function updateProvider(providerId: ProviderId, patch: Partial<AiProviderState>) {
+    setSettings((current) => ({
+      ...current,
+      providers: {
+        ...current.providers,
+        [providerId]: {
+          ...current.providers[providerId],
+          ...patch,
+        },
+      },
+    }));
+  }
+
+  function updateIntegration(integrationId: IntegrationId, patch: Partial<IntegrationState>) {
+    setSettings((current) => ({
+      ...current,
+      integrations: {
+        ...current.integrations,
+        [integrationId]: {
+          ...current.integrations[integrationId],
+          ...patch,
+        },
+      },
+    }));
+  }
+
+  function updateHealthMetric(
+    integrationId: IntegrationId,
+    key: keyof IntegrationState["healthMetrics"],
+    value: boolean,
+  ) {
+    setSettings((current) => ({
+      ...current,
+      integrations: {
+        ...current.integrations,
+        [integrationId]: {
+          ...current.integrations[integrationId],
+          healthMetrics: {
+            ...current.integrations[integrationId].healthMetrics,
+            [key]: value,
+          },
+        },
+      },
+    }));
+  }
+
+  function resetSettings() {
+    const defaults = createDefaultState();
+    setSettings(defaults);
+  }
+
+  return (
+    <div className="max-w-6xl space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <CalendarDays className="h-5 w-5 text-muted-foreground" />
+            <h1 className="text-xl font-semibold">Training Settings</h1>
+          </div>
+          <p className="max-w-3xl text-sm text-muted-foreground">
+            Configure the standalone training calendar surface. These controls are UI-only placeholders for provider OAuth, model selection, activity sync, and health metric preferences.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={resetSettings} className="gap-2">
+          <RotateCw className="h-4 w-4" /> Reset local settings
+        </Button>
+      </div>
+
+      <Card className="border-amber-500/30 bg-amber-500/5">
+        <CardContent className="flex flex-col gap-3 p-4 md:flex-row md:items-start">
+          <ShieldCheck className="h-5 w-5 shrink-0 text-amber-700" />
+          <div className="space-y-1">
+            <p className="text-sm font-medium">Security note for this UI iteration</p>
+            <p className="text-sm text-muted-foreground">
+              OAuth grants are placeholders in this screen. Connect buttons only update local UI state, model choices and sync preferences are saved in localStorage, and no tokens, API keys, or secrets are requested or shown.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardContent className="flex items-center gap-3 p-4">
+            <Bot className="h-5 w-5 text-muted-foreground" />
+            <div>
+              <p className="text-2xl font-semibold">{connectedProviderCount}</p>
+              <p className="text-xs text-muted-foreground">AI providers connected</p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex items-center gap-3 p-4">
+            <Activity className="h-5 w-5 text-muted-foreground" />
+            <div>
+              <p className="text-2xl font-semibold">{connectedIntegrationCount}</p>
+              <p className="text-xs text-muted-foreground">Fitness integrations connected</p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex items-center gap-3 p-4">
+            <LockKeyhole className="h-5 w-5 text-muted-foreground" />
+            <div>
+              <p className="text-2xl font-semibold">0</p>
+              <p className="text-xs text-muted-foreground">Secrets stored by this page</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <section className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-base font-semibold">AI providers</h2>
+            <p className="text-sm text-muted-foreground">Connect a model source for workout analysis and plan generation.</p>
+          </div>
+          <Badge variant="outline" className="gap-1">
+            <Sparkles className="h-3 w-3" /> Calendar coach
+          </Badge>
+        </div>
+        <div className="grid gap-4 lg:grid-cols-2">
+          {AI_PROVIDERS.map((provider) => {
+            const providerState = settings.providers[provider.id];
+            return (
+              <Card key={provider.id}>
+                <CardHeader className="space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <Badge variant="outline" className={provider.accent}>{provider.name}</Badge>
+                        <StatusBadge connected={providerState.connected} />
+                      </div>
+                      <CardTitle className="text-base">{provider.name}</CardTitle>
+                      <CardDescription>{provider.description}</CardDescription>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={providerState.connected ? "outline" : "default"}
+                      className="gap-2"
+                      onClick={() => updateProvider(provider.id, { connected: !providerState.connected })}
+                    >
+                      {providerState.connected ? <Unplug className="h-4 w-4" /> : <ExternalLink className="h-4 w-4" />}
+                      {providerState.connected ? "Disconnect" : `Connect ${provider.name}`}
+                    </Button>
+                    {!providerState.connected && (
+                      <Button type="button" size="sm" variant="ghost" className="gap-2" disabled>
+                        <Link2 className="h-4 w-4" /> OAuth placeholder
+                      </Button>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor={`${provider.id}-model`}>Model</Label>
+                    <Select
+                      value={providerState.model}
+                      onValueChange={(model) => updateProvider(provider.id, { model })}
+                      disabled={!providerState.connected}
+                    >
+                      <SelectTrigger id={`${provider.id}-model`} className="w-full">
+                        <SelectValue placeholder="Connect provider to choose a model" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {provider.models.map((model) => (
+                          <SelectItem key={model} value={model}>{model}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {provider.id === "other" && (
+                      <Input
+                        value={providerState.customModel ?? ""}
+                        disabled={!providerState.connected}
+                        placeholder="Custom provider/model name"
+                        onChange={(event) => updateProvider(provider.id, { customModel: event.target.value })}
+                      />
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      {providerState.connected
+                        ? "Model preference is available and persisted locally."
+                        : "Model selection unlocks after the placeholder connection is enabled."}
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-base font-semibold">Fitness integrations</h2>
+          <p className="text-sm text-muted-foreground">Choose training data sources and the metrics the calendar may use for recommendations.</p>
+        </div>
+        <div className="grid gap-4 lg:grid-cols-2">
+          <IntegrationCard
+            id="garmin"
+            name="Garmin"
+            description="Import completed workouts, planned workouts, and device-driven recovery signals from Garmin when official access is available."
+            state={settings.integrations.garmin}
+            onPatch={(patch) => updateIntegration("garmin", patch)}
+            onHealthMetric={(key, value) => updateHealthMetric("garmin", key, value)}
+          />
+          <IntegrationCard
+            id="strava"
+            name="Strava"
+            description="Use Strava as a social activity source and fallback sync path for completed endurance workouts."
+            state={settings.integrations.strava}
+            onPatch={(patch) => updateIntegration("strava", patch)}
+            onHealthMetric={(key, value) => updateHealthMetric("strava", key, value)}
+          />
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function IntegrationCard({
+  id,
+  name,
+  description,
+  state,
+  onPatch,
+  onHealthMetric,
+}: {
+  id: IntegrationId;
+  name: string;
+  description: string;
+  state: IntegrationState;
+  onPatch: (patch: Partial<IntegrationState>) => void;
+  onHealthMetric: (key: keyof IntegrationState["healthMetrics"], value: boolean) => void;
+}) {
+  const disabled = !state.connected;
+
+  return (
+    <Card>
+      <CardHeader className="space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="gap-1">
+                {id === "garmin" ? <Dumbbell className="h-3 w-3" /> : <Activity className="h-3 w-3" />}
+                {name}
+              </Badge>
+              <StatusBadge connected={state.connected} />
+            </div>
+            <CardTitle className="text-base">{name}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Button
+          type="button"
+          size="sm"
+          variant={state.connected ? "outline" : "default"}
+          className="gap-2"
+          onClick={() => onPatch({ connected: !state.connected })}
+        >
+          {state.connected ? <Unplug className="h-4 w-4" /> : <ExternalLink className="h-4 w-4" />}
+          {state.connected ? "Disconnect" : `Connect ${name}`}
+        </Button>
+
+        <Separator />
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Settings className="h-4 w-4 text-muted-foreground" /> Sync preferences
+          </div>
+          <div className="grid gap-2">
+            <ToggleRow
+              id={`${id}-completed`}
+              label="Completed activities"
+              description="Import runs, rides, swims, and strength sessions into the training calendar."
+              checked={state.syncCompletedActivities}
+              disabled={disabled}
+              onChange={(syncCompletedActivities) => onPatch({ syncCompletedActivities })}
+            />
+            <ToggleRow
+              id={`${id}-planned`}
+              label="Planned workouts"
+              description="Allow planned calendar workouts to be prepared for export when an API supports it."
+              checked={state.syncPlannedWorkouts}
+              disabled={disabled}
+              onChange={(syncPlannedWorkouts) => onPatch({ syncPlannedWorkouts })}
+            />
+            <ToggleRow
+              id={`${id}-autosync`}
+              label="Automatic background sync"
+              description="Keep calendar data fresh without manual imports. Placeholder only in this iteration."
+              checked={state.autoSync}
+              disabled={disabled}
+              onChange={(autoSync) => onPatch({ autoSync })}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <HeartPulse className="h-4 w-4 text-muted-foreground" /> Health metrics
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2">
+            <ToggleRow
+              id={`${id}-sleep`}
+              label="Sleep"
+              description="Use sleep trends for recovery-aware planning."
+              checked={state.healthMetrics.sleep}
+              disabled={disabled}
+              onChange={(value) => onHealthMetric("sleep", value)}
+            />
+            <ToggleRow
+              id={`${id}-hrv`}
+              label="HRV"
+              description="Factor heart-rate variability into readiness guidance."
+              checked={state.healthMetrics.hrv}
+              disabled={disabled}
+              onChange={(value) => onHealthMetric("hrv", value)}
+            />
+            <ToggleRow
+              id={`${id}-rhr`}
+              label="Resting HR"
+              description="Watch baseline resting heart rate changes."
+              checked={state.healthMetrics.restingHeartRate}
+              disabled={disabled}
+              onChange={(value) => onHealthMetric("restingHeartRate", value)}
+            />
+            <ToggleRow
+              id={`${id}-readiness`}
+              label="Readiness"
+              description="Include vendor readiness scores when available."
+              checked={state.healthMetrics.trainingReadiness}
+              disabled={disabled}
+              onChange={(value) => onHealthMetric("trainingReadiness", value)}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default TrainingSettings;


### PR DESCRIPTION
## Summary
- Add a TrainingPeaks-inspired weekly training calendar page with workload metrics, workout cards, readiness, and an embedded coach chat widget
- Add a separate training settings page for AI provider OAuth placeholders, model selection, Garmin/Strava integration controls, and sync preferences
- Wire company-aware routes and sidebar navigation for /training and /training/settings

## Test Plan
- pnpm --filter @paperclipai/ui typecheck
- pnpm --filter @paperclipai/ui build

## Deployment
- Deployed to Traefik-backed Paperclip at https://paperclip.srv753005.hstgr.cloud/training
- Verified /api/health returns ok and the production JS bundle contains the Training Calendar page