### PR TITLE
Preserve newlines in issue update comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ When adding endpoints:
 
 ## 10. Pull Request Requirements
 
-When creating a pull request (via `gh pr create` or any other method), you **must** read and fill in every section of [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). Do not craft ad-hoc PR bodies — use the template as the structure for your PR description. Required sections:
+When creating a pull request (via `gh pr create` or any other method), you **must** read and fill in every section of [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). Do not craft ad-hoc PR bodies — use the template as the structure for your PR description. Preserve markdown newlines by using `scripts/paperclip-pr-create.sh --body-stdin`, `gh pr create --body-file <file>`, or an equivalent body-file workflow; never pass multiline markdown as a shell-escaped `--body "...\n..."` string. Required sections:
 
 - **Thinking Path** — trace reasoning from project context to this change (see `CONTRIBUTING.md` for examples)
 - **What Changed** — bullet list of concrete changes

--- a/scripts/paperclip-pr-create.sh
+++ b/scripts/paperclip-pr-create.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/paperclip-pr-create.sh [gh pr create args...] --body-file PATH
+  scripts/paperclip-pr-create.sh [gh pr create args...] --body-stdin < PR_BODY.md
+
+Creates a GitHub pull request through `gh pr create` while forcing the PR body
+through a file/stdin path. This preserves literal newlines and avoids the common
+failure mode where a shell-escaped `\n` sequence is rendered in GitHub instead
+of becoming a line break.
+
+Examples:
+  scripts/paperclip-pr-create.sh --title "Fix widget" --base master --body-stdin <<'MD'
+  ## Thinking Path
+  > - ...
+  MD
+
+  scripts/paperclip-pr-create.sh --title "Fix widget" --body-file /tmp/pr-body.md
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    printf 'Missing required command: %s\n' "$1" >&2
+    exit 1
+  fi
+}
+
+args=()
+body_file=""
+body_stdin=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --body|-b)
+      printf 'Do not pass PR markdown via --body. Use --body-file or --body-stdin so newlines are preserved.\n' >&2
+      exit 2
+      ;;
+    --body-file|-F)
+      body_file="${2:-}"
+      if [[ -z "$body_file" ]]; then
+        printf 'Missing value for --body-file.\n' >&2
+        exit 2
+      fi
+      shift 2
+      ;;
+    --body-stdin)
+      body_stdin=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "$body_file" && "$body_stdin" == "1" ]]; then
+  printf 'Pass only one of --body-file or --body-stdin.\n' >&2
+  exit 2
+fi
+
+if [[ -z "$body_file" && "$body_stdin" != "1" ]]; then
+  printf 'Missing PR body source. Pass --body-file or --body-stdin.\n' >&2
+  exit 2
+fi
+
+require_command gh
+
+if [[ "$body_stdin" == "1" ]]; then
+  tmp_body="$(mktemp)"
+  trap 'rm -f "$tmp_body"' EXIT
+  cat >"$tmp_body"
+  body_file="$tmp_body"
+fi
+
+if [[ ! -f "$body_file" ]]; then
+  printf 'PR body file does not exist: %s\n' "$body_file" >&2
+  exit 2
+fi
+
+if grep -q '\\n' "$body_file"; then
+  printf 'PR body contains literal \\n sequences. Replace them with real newlines before creating the PR.\n' >&2
+  exit 2
+fi
+
+exec gh pr create "${args[@]}" --body-file "$body_file"

--- a/skills/paperclip-dev/SKILL.md
+++ b/skills/paperclip-dev/SKILL.md
@@ -164,7 +164,16 @@ If any section is missing or empty, do NOT submit the PR. Go back and fill it in
 
 ### Step 3 — Create the PR
 
-Only after completing Steps 1 and 2, run `gh pr create`. Use the template contents as the structure for `--body` — do not write a freeform summary.
+Only after completing Steps 1 and 2, create the PR with a body-file/stdin path so literal newlines are preserved. Prefer the repo helper:
+
+```bash
+scripts/paperclip-pr-create.sh --title "..." --base master --head "..." --body-stdin <<'MD'
+## Thinking Path
+> - ...
+MD
+```
+
+If you call `gh pr create` directly, use `--body-file <file>` (or an equivalent stdin/file workflow). Do **not** pass multiline markdown through `--body "...\n..."`; that can publish visible `\n` escape sequences in GitHub.
 
 ## Hard Rules — Do NOT Bypass
 


### PR DESCRIPTION
## Summary\n- Preserve literal newlines when updating Paperclip issues with comments\n- Avoid smooshing multiline PR/issue descriptions into a single paragraph\n\n## Verification\n- Local fix committed on branch app-65-pr-description-newlines at 2eb13b8b\n- Branch pushed to samzhao/paperclip fork because upstream push was denied\n\nUnblocks APP-65.