### PR TITLE
fix(cli): copy db migrations into dist during CLI bundle build

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "node --input-type=module -e \"import esbuild from 'esbuild'; import config from './esbuild.config.mjs'; await esbuild.build(config);\" && chmod +x dist/index.js",
+    "build": "node --input-type=module -e \"import esbuild from 'esbuild'; import config from './esbuild.config.mjs'; await esbuild.build(config);\" && cp -r ../packages/db/src/migrations dist/migrations && chmod +x dist/index.js",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents; the `paperclipai` CLI is the entry point for all local operations including `worktree:make`
> - `worktree:make` (and `worktree repair`) were failing with `ENOENT: no such file or directory, scandir '.../_npx/.../paperclipai/dist/migrations'`
> - The `@paperclipai/db` package resolves its migrations folder at runtime via `fileURLToPath(new URL('./migrations', import.meta.url))` — relative to the compiled file
> - The CLI uses esbuild to bundle all workspace packages (including `@paperclipai/db`) into a single `dist/index.js`; esbuild bundles TypeScript but does not copy `.sql` files
> - The `@paperclipai/db` build script already does `cp -r src/migrations dist/migrations`, but that output is never copied into the CLI's own `dist/` when bundling
> - The npm-published `paperclipai` package therefore ships without `dist/migrations/`, causing ENOENT on every `npx paperclipai` install
> - This PR adds a single `cp -r ../packages/db/src/migrations dist/migrations` step to the CLI build so the folder is present alongside the bundled `dist/index.js`
> - The `"files": ["dist"]` entry already covers the folder — no other packaging change is needed

## What Changed

- `cli/package.json`: appended `&& cp -r ../packages/db/src/migrations dist/migrations` to the `build` script, after the esbuild step and before `chmod +x`

## Verification

```bash
# Build the CLI
cd cli
pnpm build

# Verify migrations are present
ls dist/migrations/
# Expected: 0000_mature_masked_marvel.sql  0001_fast_northstar.sql  ...

# Confirm worktree:make no longer fails with ENOENT
node dist/index.js worktree:make test-wt --seed-mode skip
node dist/index.js worktree:cleanup test-wt
```

## Risks

Low risk. This change only adds an extra file-copy step at the end of the build. The `dist/migrations/` folder is idempotent (read-only SQL files, generated from `packages/db/src/migrations`). No JS logic is affected.

## Model Used

- Provider: Anthropic
- Model ID: `claude-sonnet-4-6`
- Context window: 200k tokens
- Capabilities: tool use, code execution, file system access
- Mode: agentic (Claude Code via Paperclip)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge