### PR TITLE
[claude-local] Parse JSON errors in probe, respect config env overrides, auto-fallback from host API key (#6129)

### DIFF
--- a/packages/adapters/claude-local/src/server/test.ts
+++ b/packages/adapters/claude-local/src/server/test.ts
@@ -20,7 +20,7 @@ import {
   resolveAdapterExecutionTargetCwd,
 } from "@paperclipai/adapter-utils/execution-target";
 import path from "node:path";
-import { detectClaudeLoginRequired, parseClaudeStreamJson } from "./parse.js";
+import { describeClaudeFailure, detectClaudeLoginRequired, parseClaudeStreamJson } from "./parse.js";
 import { isBedrockModelId } from "./models.js";
 import { buildClaudeProbePermissionArgs } from "./permissions.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
@@ -49,7 +49,15 @@ function commandLooksLike(command: string, expected: string): boolean {
   return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
 }
 
-function summarizeProbeDetail(stdout: string, stderr: string): string | null {
+function summarizeProbeDetail(
+  stdout: string,
+  stderr: string,
+  parsedResult?: Record<string, unknown> | null,
+): string | null {
+  if (parsedResult) {
+    const failureDesc = describeClaudeFailure(parsedResult);
+    if (failureDesc) return failureDesc.slice(0, 240);
+  }
   const raw = firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
   if (!raw) return null;
   const clean = raw.replace(/\s+/g, " ").trim();
@@ -145,7 +153,12 @@ export async function testEnvironment(
     (considerHostEnv && isNonEmpty(process.env.ANTHROPIC_BEDROCK_BASE_URL));
 
   const configApiKey = env.ANTHROPIC_API_KEY;
-  const hostApiKey = considerHostEnv ? process.env.ANTHROPIC_API_KEY : undefined;
+  const configExplicitlyDefinesAnthropicKey =
+    Object.prototype.hasOwnProperty.call(envConfig, "ANTHROPIC_API_KEY");
+  const hostApiKey =
+    considerHostEnv && !configExplicitlyDefinesAnthropicKey
+      ? process.env.ANTHROPIC_API_KEY
+      : undefined;
   if (hasBedrock) {
     const source =
       env.CLAUDE_CODE_USE_BEDROCK === "1" ||
@@ -242,9 +255,67 @@ export async function testEnvironment(
         stdout: probe.stdout,
         stderr: probe.stderr,
       });
-      const detail = summarizeProbeDetail(probe.stdout, probe.stderr);
+      let detail = summarizeProbeDetail(probe.stdout, probe.stderr, parsedStream.resultJson);
+      let resolvedProbe = probe;
 
-      if (probe.timedOut) {
+      // Auto-retry: when the probe fails and the host has ANTHROPIC_API_KEY
+      // but the config doesn't explicitly set one, try again without the host
+      // env var so subscription-based auth can be used.
+      const shouldRetryWithoutHostKey =
+        considerHostEnv &&
+        isNonEmpty(process.env.ANTHROPIC_API_KEY) &&
+        !isNonEmpty(configApiKey) &&
+        !configExplicitlyDefinesAnthropicKey &&
+        (probe.exitCode ?? 1) !== 0 &&
+        !probe.timedOut &&
+        !loginMeta.requiresLogin;
+
+      if (shouldRetryWithoutHostKey) {
+        const retryProbe = await runAdapterExecutionTargetProcess(
+          runId,
+          target,
+          command,
+          args,
+          {
+            cwd,
+            env: { ...env, ANTHROPIC_API_KEY: "" },
+            timeoutSec: helloProbeTimeoutSec,
+            graceSec: 5,
+            stdin: "Respond with hello.",
+            onLog: async () => {},
+          },
+        );
+        const retryParsedStream = parseClaudeStreamJson(retryProbe.stdout);
+        const retryLoginMeta = detectClaudeLoginRequired({
+          parsed: retryParsedStream.resultJson,
+          stdout: retryProbe.stdout,
+          stderr: retryProbe.stderr,
+        });
+        const retryDetail = summarizeProbeDetail(
+          retryProbe.stdout,
+          retryProbe.stderr,
+          retryParsedStream.resultJson,
+        );
+
+        if ((retryProbe.exitCode ?? 1) === 0 && !retryLoginMeta.requiresLogin) {
+          checks.push({
+            code: "claude_hello_probe_passed_without_host_key",
+            level: "info",
+            message:
+              "Claude hello probe succeeded after disabling host ANTHROPIC_API_KEY (subscription auth used).",
+            ...(retryDetail ? { detail: retryDetail } : {}),
+            hint: "To avoid this fallback, unset ANTHROPIC_API_KEY in your shell or configure " +
+              "the agent env to explicitly clear it.",
+          });
+        }
+        resolvedProbe = retryProbe;
+        detail = retryDetail;
+        const retryParsed = retryParsedStream.resultJson;
+        parsedStream.resultJson = retryParsed;
+        parsedStream.summary = retryParsedStream.summary;
+      }
+
+      if (resolvedProbe.timedOut) {
         checks.push({
           code: "claude_hello_probe_timed_out",
           level: "warn",
@@ -261,7 +332,7 @@ export async function testEnvironment(
             ? `Run \`claude login\` and complete sign-in at ${loginMeta.loginUrl}, then retry.`
             : "Run `claude login` in this environment, then retry the probe.",
         });
-      } else if ((probe.exitCode ?? 1) === 0) {
+      } else if ((resolvedProbe.exitCode ?? 1) === 0) {
         const summary = parsedStream.summary.trim();
         const hasHello = /\bhello\b/i.test(summary);
         checks.push({


### PR DESCRIPTION
## Thinking Path

Issue #6129 reports three interacting problems with the Claude Local adapter's environment diagnostics when `ANTHROPIC_API_KEY` has zero credits but a valid Claude Pro subscription exists:

1. **Opaque errors** — `summarizeProbeDetail` only reads raw stderr/stdout lines, missing structured JSON error output from the Claude CLI
2. **Lingering warning after Unset** — the env test ignores explicit config overrides, still warning about the host env var even after the user consciously clears it
3. **No subscription fallback** — if the host `ANTHROPIC_API_KEY` has zero credits, the probe fails with no retry attempt, blocking users who have a valid `claude login` subscription

Each fix targets one root cause in `packages/adapters/claude-local/src/server/test.ts`.

## What Changed

- **`summarizeProbeDetail` now parses JSON errors** — accepts the parsed `resultJson` from `parseClaudeStreamJson` and calls `describeClaudeFailure()` first. Structured errors like "Insufficient credits" or "Invalid API key" from the Claude CLI JSON error stream now appear in the UI instead of a generic "hello probe failed".
- **Config env overrides are respected** — new `configExplicitlyDefinesAnthropicKey` check on the raw `envConfig` object. When the adapter config explicitly defines `ANTHROPIC_API_KEY` (even as `""` after clicking Unset), the host `process.env.ANTHROPIC_API_KEY` is ignored for both the diagnostic warning and the probe env.
- **Auto-fallback from host API key to subscription** — after the initial probe fails, if the host has `ANTHROPIC_API_KEY` but the config doesn't explicitly define one, the probe auto-retries with `ANTHROPIC_API_KEY=""` to shadow the host var and fall back to subscription auth. On success, emits a `claude_hello_probe_passed_without_host_key` info check explaining what happened.

## Verification

1. `pnpm -r typecheck` — only pre-existing `ssh.ts` errors in `adapter-utils`, claude-local passes cleanly
2. Manual review of `runChildProcess` env merge: `opts.env` spreads after `process.env`, so `ANTHROPIC_API_KEY=""` correctly overrides the host var
3. `resolveAdapterConfigForRuntime` resolves `{ type: "plain", value: "" }` to `""`, matching the env-override flow used by the Unset button

## Risks

- Low. The retry only fires when all these hold: host has a non-empty API key, config doesn't define one, probe failed with non-zero exit, probe did not time out, and probe did not report login-required.
- If the retry also fails, the original probe's result is discarded and the retry's detail is used instead. This may change the error message shown, but the retry's message is more relevant since it reflects the auth config that will actually be used at runtime.

## Model Used

None — human-authored.

## Checklist

- [x] Behavior matches `doc/SPEC-implementation.md`
- [x] Typecheck passes (claude-local clean)
- [x] Contracts are synced across db/shared/server/ui (no schema/API changes)
- [x] Docs updated (no behavioral changes requiring doc updates)
- [x] PR description follows the PR template with all sections filled in
