### PR TITLE
Harden terminal issue wake and retry gates

### DIFF
--- a/server/src/__tests__/heartbeat-terminal-wake-retry.test.ts
+++ b/server/src/__tests__/heartbeat-terminal-wake-retry.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildScheduledRetryTerminalSuppression,
+  shouldAllowTerminalQueuedRunWake,
+  shouldPromoteDeferredCommentWakeForTerminalIssue,
+} from "../services/heartbeat.js";
+
+describe("heartbeat terminal issue wake/retry gates", () => {
+  it("does not allow a plain comment wake to start a queued run for done/cancelled issues", () => {
+    expect(shouldAllowTerminalQueuedRunWake({
+      issueStatus: "done",
+      contextSnapshot: { wakeCommentId: "comment-1", wakeReason: "issue_commented" },
+    })).toBe(false);
+
+    expect(shouldAllowTerminalQueuedRunWake({
+      issueStatus: "cancelled",
+      contextSnapshot: { wakeCommentId: "comment-1", wakeReason: "issue_commented" },
+    })).toBe(false);
+  });
+
+  it("allows terminal issue wakes only when explicit reopen/follow-up intent is present", () => {
+    expect(shouldAllowTerminalQueuedRunWake({
+      issueStatus: "done",
+      contextSnapshot: { wakeCommentId: "comment-1", explicitReopenIntent: true },
+    })).toBe(true);
+
+    expect(shouldAllowTerminalQueuedRunWake({
+      issueStatus: "cancelled",
+      contextSnapshot: { wakeCommentId: "comment-1" },
+      payload: { followUpRequested: true },
+    })).toBe(true);
+  });
+
+  it("does not promote deferred terminal comment wakes without explicit reopen intent", () => {
+    expect(shouldPromoteDeferredCommentWakeForTerminalIssue({
+      issueStatus: "done",
+      contextSnapshot: { wakeCommentId: "comment-1", wakeReason: "issue_commented" },
+      payload: { commentId: "comment-1" },
+      requestedByActorType: "user",
+    })).toBe(false);
+
+    expect(shouldPromoteDeferredCommentWakeForTerminalIssue({
+      issueStatus: "done",
+      contextSnapshot: { wakeCommentId: "comment-1", wakeReason: "issue_reopened_via_comment" },
+      payload: { commentId: "comment-1", explicitReopenIntent: true },
+      requestedByActorType: "user",
+    })).toBe(true);
+  });
+
+  it("suppresses scheduled retries before scheduling/starting when an issue is terminal", () => {
+    expect(buildScheduledRetryTerminalSuppression({ issueStatus: "done", issueId: "issue-1" })).toEqual({
+      allowed: false,
+      reason: "Scheduled retry suppressed because issue reached terminal status (done)",
+      errorCode: "issue_terminal_status",
+      issueId: "issue-1",
+      details: { issueId: "issue-1", currentStatus: "done" },
+    });
+
+    expect(buildScheduledRetryTerminalSuppression({ issueStatus: "cancelled", issueId: "issue-1" })).toEqual({
+      allowed: false,
+      reason: "Scheduled retry suppressed because issue reached terminal status (cancelled)",
+      errorCode: "issue_cancelled",
+      issueId: "issue-1",
+      details: { issueId: "issue-1", currentStatus: "cancelled" },
+    });
+
+    expect(buildScheduledRetryTerminalSuppression({ issueStatus: "in_progress", issueId: "issue-1" })).toEqual({
+      allowed: true,
+    });
+  });
+});

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -374,7 +374,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via the PATCH comment path when reassigning to an agent", async () => {
+  it("does not implicitly reopen terminal issues via the PATCH comment path when reassigning to an agent", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -390,20 +390,19 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({
         assigneeAgentId: "33333333-3333-4333-8333-333333333333",
-        status: "todo",
         actorAgentId: null,
         actorUserId: "local-board",
       }),
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ status: "todo" }),
     );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         action: "issue.updated",
-        details: expect.objectContaining({
-          reopened: true,
-          reopenedFrom: "done",
-          status: "todo",
-        }),
+        details: expect.not.objectContaining({ reopened: true }),
       }),
     );
   });
@@ -486,7 +485,7 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
-  it("implicitly reopens closed issues via POST comments when an agent is assigned", async () => {
+  it("does not implicitly reopen terminal issues via POST comments", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("done"));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
       ...makeIssue("done"),
@@ -498,19 +497,14 @@ describe.sequential("issue comment reopen routes", () => {
       .send({ body: "hello" });
 
     expect(res.status).toBe(201);
-    expect(mockIssueService.update).toHaveBeenCalledWith(
-      "11111111-1111-4111-8111-111111111111",
-      { status: "todo" },
+    expect(mockIssueService.update).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ status: "todo" }),
     );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          reopenedFrom: "done",
-        }),
-      }),
-    ));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ reason: "issue_reopened_via_comment" }),
+    );
   });
 
   it("rejects non-assignee agent POST comments on closed issues", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -613,16 +613,17 @@ function isClosedIssueStatus(status: string | null | undefined): status is "done
   return status === "done" || status === "cancelled";
 }
 
-function shouldImplicitlyMoveCommentedIssueToTodo(input: {
+export function shouldImplicitlyMoveCommentedIssueToTodo(input: {
   issueStatus: string | null | undefined;
   assigneeAgentId: string | null | undefined;
   actorType: "agent" | "user";
   actorId: string;
 }) {
-  // Only human comments should implicitly reopen finished work.
-  // Agent-authored comments remain communicative unless reopen was explicit.
+  // Plain comments are communicative on terminal issues. Reopening done/cancelled
+  // work requires the explicit `reopen` or `resume` request flag handled by the route.
   if (input.actorType !== "user") return false;
-  if (!isClosedIssueStatus(input.issueStatus) && input.issueStatus !== "blocked") return false;
+  if (isClosedIssueStatus(input.issueStatus)) return false;
+  if (input.issueStatus !== "blocked") return false;
   if (typeof input.assigneeAgentId !== "string" || input.assigneeAgentId.length === 0) return false;
   return true;
 }
@@ -3873,8 +3874,8 @@ export function issueRoutes(
         ...updateFields,
         identifier: issue.identifier,
         ...(commentBody ? { source: "comment" } : {}),
-        ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
-        ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus } : {}),
+        ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
+        ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus, explicitReopenIntent: true } : {}),
         ...(scheduledRetrySupersededByComment
           ? {
               scheduledRetrySupersededByComment: true,
@@ -4097,8 +4098,8 @@ export function issueRoutes(
           bodySnippet: comment.body.slice(0, 120),
           identifier: issue.identifier,
           issueTitle: issue.title,
-          ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
-          ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus, source: "comment" } : {}),
+          ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
+          ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus, source: "comment", explicitReopenIntent: true } : {}),
           ...(scheduledRetrySupersededByComment
             ? {
                 scheduledRetrySupersededByComment: true,
@@ -4185,7 +4186,7 @@ export function issueRoutes(
             issueId: issue.id,
             ...(comment ? { commentId: comment.id } : {}),
             mutation: "update",
-            ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+            ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
             ...(interruptedRunId ? { interruptedRunId } : {}),
           },
           requestedByActorType: actor.actorType,
@@ -4200,7 +4201,7 @@ export function issueRoutes(
                 }
               : {}),
             source: "issue.update",
-            ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+            ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
             ...(interruptedRunId ? { interruptedRunId } : {}),
           },
         });
@@ -4218,7 +4219,7 @@ export function issueRoutes(
           payload: {
             issueId: issue.id,
             mutation: "update",
-            ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+            ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
             ...(interruptedRunId ? { interruptedRunId } : {}),
           },
           requestedByActorType: actor.actorType,
@@ -4226,7 +4227,7 @@ export function issueRoutes(
           contextSnapshot: {
             issueId: issue.id,
             source: "issue.status_change",
-            ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+            ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
             ...(interruptedRunId ? { interruptedRunId } : {}),
           },
         });
@@ -4247,8 +4248,8 @@ export function issueRoutes(
               issueId: id,
               commentId: comment.id,
               mutation: "comment",
-              ...(reopened ? { reopenedFrom: reopenFromStatus } : {}),
-              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+              ...(reopened ? { reopenedFrom: reopenFromStatus, explicitReopenIntent: true } : {}),
+              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
             requestedByActorType: actor.actorType,
@@ -4260,8 +4261,8 @@ export function issueRoutes(
               wakeCommentId: comment.id,
               source: reopened ? "issue.comment.reopen" : "issue.comment",
               wakeReason: reopened ? "issue_reopened_via_comment" : "issue_commented",
-              ...(reopened ? { reopenedFrom: reopenFromStatus } : {}),
-              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+              ...(reopened ? { reopenedFrom: reopenFromStatus, explicitReopenIntent: true } : {}),
+              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
           });
@@ -5198,7 +5199,7 @@ export function issueRoutes(
         entityId: currentIssue.id,
         details: {
           status: "todo",
-          ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus } : {}),
+          ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus, explicitReopenIntent: true } : {}),
           ...(scheduledRetrySupersededByComment
             ? {
                 scheduledRetrySupersededByComment: true,
@@ -5207,7 +5208,7 @@ export function issueRoutes(
               }
             : {}),
           source: "comment",
-          ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+          ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
           identifier: currentIssue.identifier,
         },
       });
@@ -5274,8 +5275,8 @@ export function issueRoutes(
         bodySnippet: comment.body.slice(0, 120),
         identifier: currentIssue.identifier,
         issueTitle: currentIssue.title,
-        ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
-        ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus, source: "comment" } : {}),
+        ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
+        ...(reopened ? { reopened: true, reopenedFrom: reopenFromStatus, source: "comment", explicitReopenIntent: true } : {}),
         ...(scheduledRetrySupersededByComment
           ? {
               scheduledRetrySupersededByComment: true,
@@ -5334,8 +5335,9 @@ export function issueRoutes(
               issueId: currentIssue.id,
               commentId: comment.id,
               reopenedFrom: reopenFromStatus,
+              explicitReopenIntent: true,
               mutation: "comment",
-              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
             requestedByActorType: actor.actorType,
@@ -5348,7 +5350,8 @@ export function issueRoutes(
               source: "issue.comment.reopen",
               wakeReason: "issue_reopened_via_comment",
               reopenedFrom: reopenFromStatus,
-              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+              explicitReopenIntent: true,
+              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
           });
@@ -5361,7 +5364,7 @@ export function issueRoutes(
               issueId: currentIssue.id,
               commentId: comment.id,
               mutation: "comment",
-              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
             requestedByActorType: actor.actorType,
@@ -5373,7 +5376,7 @@ export function issueRoutes(
               wakeCommentId: comment.id,
               source: "issue.comment",
               wakeReason: "issue_commented",
-              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true } : {}),
+              ...(resumeRequested === true ? { resumeIntent: true, followUpRequested: true, explicitReopenIntent: true } : {}),
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
           });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -494,6 +494,70 @@ export function computeBoundedTransientHeartbeatRetrySchedule(
   };
 }
 
+function isTerminalIssueStatus(status: string | null | undefined): status is "done" | "cancelled" {
+  return status === "done" || status === "cancelled";
+}
+
+export function hasExplicitTerminalIssueReopenIntent(
+  contextSnapshot: unknown,
+  payload: unknown = null,
+) {
+  const context = parseObject(contextSnapshot);
+  const parsedPayload = parseObject(payload);
+  return context.explicitReopenIntent === true
+    || context.reopenIntent === true
+    || parsedPayload.explicitReopenIntent === true
+    || parsedPayload.reopenIntent === true
+    || parsedPayload.reopen === true
+    || context.resumeIntent === true
+    || context.followUpRequested === true
+    || parsedPayload.resumeIntent === true
+    || parsedPayload.followUpRequested === true;
+}
+
+export function shouldAllowTerminalQueuedRunWake(input: {
+  issueStatus: string | null | undefined;
+  contextSnapshot: unknown;
+  payload?: unknown;
+}) {
+  if (!isTerminalIssueStatus(input.issueStatus)) return true;
+  return hasExplicitTerminalIssueReopenIntent(input.contextSnapshot, input.payload ?? null);
+}
+
+export function shouldPromoteDeferredCommentWakeForTerminalIssue(input: {
+  issueStatus: string | null | undefined;
+  contextSnapshot: unknown;
+  payload?: unknown;
+  requestedByActorType?: string | null;
+}) {
+  if (!isTerminalIssueStatus(input.issueStatus)) return false;
+  const context = parseObject(input.contextSnapshot);
+  const payload = parseObject(input.payload ?? null);
+  const commentIds = new Set(
+    [
+      ...extractWakeCommentIds(context),
+      readNonEmptyString(payload.commentId),
+      readNonEmptyString(payload.wakeCommentId),
+    ].filter((value): value is string => typeof value === "string" && value.length > 0),
+  );
+  if (commentIds.size === 0) return false;
+  return hasExplicitTerminalIssueReopenIntent(context, payload);
+}
+
+export function buildScheduledRetryTerminalSuppression(input: {
+  issueStatus: string | null | undefined;
+  issueId: string | null;
+}) {
+  if (!isTerminalIssueStatus(input.issueStatus)) return { allowed: true as const };
+  return {
+    allowed: false as const,
+    reason: `Scheduled retry suppressed because issue reached terminal status (${input.issueStatus})`,
+    errorCode: input.issueStatus === "cancelled" ? "issue_cancelled" as const : "issue_terminal_status" as const,
+    issueId: input.issueId,
+    details: { issueId: input.issueId, currentStatus: input.issueStatus },
+  };
+}
+
 async function resolveRunScopedMentionedSkillKeys(input: {
   db: Db;
   companyId: string;
@@ -4947,14 +5011,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    if (issue.status === "cancelled" || issue.status === "done") {
-      return {
-        allowed: false,
-        reason: `Scheduled retry suppressed because issue reached terminal status (${issue.status})`,
-        errorCode: issue.status === "cancelled" ? "issue_cancelled" : "issue_terminal_status",
-        issueId,
-        details: { issueId, currentStatus: issue.status },
-      };
+    const terminalSuppression = buildScheduledRetryTerminalSuppression({ issueStatus: issue.status, issueId });
+    if (!terminalSuppression.allowed) {
+      return terminalSuppression;
     }
 
     if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON && issue.status !== "in_progress") {
@@ -5287,6 +5346,36 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
+    if (issueId) {
+      const retryIssue = await db
+        .select({ id: issues.id, status: issues.status })
+        .from(issues)
+        .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+        .then((rows) => rows[0] ?? null);
+      const terminalSuppression = retryIssue
+        ? buildScheduledRetryTerminalSuppression({ issueStatus: retryIssue.status, issueId })
+        : { allowed: true as const };
+      if (!terminalSuppression.allowed) {
+        await appendRunEvent(run, await nextRunEventSeq(run.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "info",
+          message: terminalSuppression.reason,
+          payload: {
+            retryReason,
+            scheduledRetryAttempt: nextAttempt,
+            maxAttempts,
+            ...terminalSuppression.details,
+          },
+        });
+        return {
+          outcome: "not_scheduled" as const,
+          reason: terminalSuppression.reason,
+          errorCode: terminalSuppression.errorCode,
+          issueId: terminalSuppression.issueId,
+        };
+      }
+    }
     if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON) {
       const gate = await evaluateScheduledRetryGate({ run, agent, contextSnapshot, retryReason });
       if (!gate.allowed) {
@@ -6180,15 +6269,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       };
     }
 
-    if (issue.status === "done" || issue.status === "cancelled") {
-      if (!resumeIntent && !wakeCommentId) {
-        return {
-          stale: true,
-          errorCode: "issue_terminal_status",
-          reason: `Cancelled because issue reached terminal status (${issue.status}) before the queued run could start`,
-          details: { issueId, currentStatus: issue.status },
-        };
-      }
+    if (
+      isTerminalIssueStatus(issue.status) &&
+      !shouldAllowTerminalQueuedRunWake({ issueStatus: issue.status, contextSnapshot: context, payload: null })
+    ) {
+      return {
+        stale: true,
+        errorCode: "issue_terminal_status",
+        reason: `Cancelled because issue reached terminal status (${issue.status}) before the queued run could start`,
+        details: { issueId, currentStatus: issue.status },
+      };
     }
 
     if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON && issue.status !== "in_progress") {
@@ -8365,16 +8455,27 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           };
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
-        const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
-        // Only human/comment-reopen interactions should revive completed issues;
-        // system follow-ups such as retry or cleanup wakes must not reopen closed work.
-        const shouldReopenDeferredCommentWake =
-          deferredCommentIds.length > 0 &&
-          (issue.status === "done" || issue.status === "cancelled") &&
-          (
-            deferred.requestedByActorType === "user" ||
-            deferredWakeReason === "issue_reopened_via_comment"
-          );
+        // Comment-created wakes are communicative by default. Terminal issues may only be
+        // reopened/promoted when the originating request carried explicit reopen/follow-up intent.
+        const shouldReopenDeferredCommentWake = shouldPromoteDeferredCommentWakeForTerminalIssue({
+          issueStatus: issue.status,
+          contextSnapshot: deferredContextSeed,
+          payload: deferredPayload,
+          requestedByActorType: deferred.requestedByActorType,
+        });
+        if (isTerminalIssueStatus(issue.status) && deferredCommentIds.length > 0 && !shouldReopenDeferredCommentWake) {
+          const now = new Date();
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              finishedAt: now,
+              error: `Deferred comment wake suppressed because issue reached terminal status (${issue.status}) without explicit reopen intent`,
+              updatedAt: now,
+            })
+            .where(eq(agentWakeupRequests.id, deferred.id));
+          continue;
+        }
         let reopenedActivity: LogActivityInput | null = null;
 
         if (shouldReopenDeferredCommentWake) {


### PR DESCRIPTION
## Summary
- Require explicit reopen/follow-up intent before comment wakes can reopen/start terminal issues
- Suppress scheduled retries when an issue is done/cancelled before scheduling or start
- Update and add regressions for terminal comment wake/retry behavior

## Verification
- pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-terminal-wake-retry.test.ts src/__tests__/issue-comment-reopen-routes.test.ts
- pnpm --filter @paperclipai/server typecheck
- pnpm --filter @paperclipai/server build
