### PR TITLE
docs(paperclip-skill): document execution-environment selection

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -136,7 +136,7 @@ Status values: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`,
 - `done` — work complete, no follow-up on this issue.
 - `cancelled` — intentionally abandoned, not to be resumed.
 
-**Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. When a follow-up issue needs to stay on the same code change but is not a true child task, set `inheritExecutionWorkspaceFromIssueId` to the source issue. Set `billingCode` for cross-team work.
+**Step 9 — Delegate if needed.** Create subtasks with `POST /api/companies/{companyId}/issues`. Always set `parentId` and `goalId`. When a follow-up issue needs to stay on the same code change but is not a true child task, set `inheritExecutionWorkspaceFromIssueId` to the source issue. Set `billingCode` for cross-team work. To run an issue's workspace in a specific execution environment (non-default local/SSH/sandbox target), set `executionWorkspaceSettings.environmentId` on create or update — see `references/issue-workspaces.md`.
 
 ## Issue Dependencies (Blockers)
 
@@ -218,9 +218,9 @@ If you are asked to create or manage routines you MUST read:
 
 ## Issue Workspace Runtime Controls
 
-When an issue needs browser/manual QA or a preview server, inspect its current execution workspace and use Paperclip's workspace runtime controls instead of starting unmanaged background servers yourself.
+When an issue needs browser/manual QA or a preview server, inspect its current execution workspace and use Paperclip's workspace runtime controls instead of starting unmanaged background servers yourself. The same reference covers pinning an issue to a specific execution **environment** (local/SSH/sandbox target) via `executionWorkspaceSettings.environmentId`.
 
-For commands, response fields, and MCP tools, read:
+For commands, response fields, environment selection, and MCP tools, read:
 `skills/paperclip/references/issue-workspaces.md`
 
 ## Critical Rules

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -810,6 +810,24 @@ Terminal states: `done`, `cancelled`
 | POST   | `/api/execution-workspaces/:workspaceId/runtime-services/restart` | Restart configured workspace services |
 | POST   | `/api/execution-workspaces/:workspaceId/runtime-services/stop` | Stop workspace runtime services |
 
+### Execution Environments
+
+A workspace is realized from an **environment** (the reusable definition of *where* code runs — local, SSH, sandbox provider, etc.). Agents pin an issue's workspace to one by passing `executionWorkspaceSettings.environmentId` on issue create/update (see Issues table and the SKILL `Delegate` step). Listing/reading is available to any agent with company access; creating/mutating requires an agent with environment-management permission (manager/CEO).
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET    | `/api/companies/:companyId/environments` | List environments (filters: `?status=`, `?driver=`). Config fields are redacted for restricted viewers. |
+| GET    | `/api/companies/:companyId/environments/capabilities` | Supported drivers/sandbox providers and their probe/run/lease capabilities |
+| POST   | `/api/companies/:companyId/environments` | Create environment (management permission required) |
+| GET    | `/api/environments/:id` | Environment detail |
+| PATCH  | `/api/environments/:id` | Update environment (management permission) |
+| DELETE | `/api/environments/:id` | Delete/archive environment (management permission) |
+| POST   | `/api/environments/:id/probe` | Probe environment connectivity/config (management permission) |
+| GET    | `/api/environments/:id/leases` | List reusable leases for an environment |
+| GET    | `/api/environment-leases/:leaseId` | Lease detail |
+
+Selection is validated server-side (`422 Unprocessable` on violation): the environment must exist, belong to the same company, not be `archived`, use an allowed driver for the context, and not be the built-in probe-only `fake` sandbox provider.
+
 ### Companies, Projects, Goals
 
 | Method | Path                                 | Description        |

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -812,19 +812,19 @@ Terminal states: `done`, `cancelled`
 
 ### Execution Environments
 
-A workspace is realized from an **environment** (the reusable definition of *where* code runs — local, SSH, sandbox provider, etc.). Agents pin an issue's workspace to one by passing `executionWorkspaceSettings.environmentId` on issue create/update (see Issues table and the SKILL `Delegate` step). Listing/reading is available to any agent with company access; creating/mutating requires an agent with environment-management permission (manager/CEO).
+A workspace is realized from an **environment** (the reusable definition of *where* code runs — local, SSH, sandbox provider, etc.). Agents pin an issue's workspace to one by passing `executionWorkspaceSettings.environmentId` on issue create/update (see Issues table and the SKILL `Delegate` step). Listing and reading an environment (`/environments`, `/environments/capabilities`, `/environments/:id`) is available to any agent with company access, but the environment's **config fields are redacted** unless the agent holds the `environments:manage` permission. Reading **leases** and any create/update/delete/probe require `environments:manage` (manager/CEO) and return `403 Forbidden` otherwise.
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
-| GET    | `/api/companies/:companyId/environments` | List environments (filters: `?status=`, `?driver=`). Config fields are redacted for restricted viewers. |
+| GET    | `/api/companies/:companyId/environments` | List environments (filters: `?status=`, `?driver=`). Company access; config fields redacted without `environments:manage`. |
 | GET    | `/api/companies/:companyId/environments/capabilities` | Supported drivers/sandbox providers and their probe/run/lease capabilities |
-| POST   | `/api/companies/:companyId/environments` | Create environment (management permission required) |
-| GET    | `/api/environments/:id` | Environment detail |
-| PATCH  | `/api/environments/:id` | Update environment (management permission) |
-| DELETE | `/api/environments/:id` | Delete/archive environment (management permission) |
-| POST   | `/api/environments/:id/probe` | Probe environment connectivity/config (management permission) |
-| GET    | `/api/environments/:id/leases` | List reusable leases for an environment |
-| GET    | `/api/environment-leases/:leaseId` | Lease detail |
+| POST   | `/api/companies/:companyId/environments` | Create environment (`environments:manage`) |
+| GET    | `/api/environments/:id` | Environment detail (company access; config redacted without `environments:manage`) |
+| PATCH  | `/api/environments/:id` | Update environment (`environments:manage`). Soft-archive via `{ "status": "archived" }`. |
+| DELETE | `/api/environments/:id` | Permanently (hard) delete environment (`environments:manage`). To preserve the record archived instead, `PATCH` `{ "status": "archived" }`. |
+| POST   | `/api/environments/:id/probe` | Probe environment connectivity/config (`environments:manage`) |
+| GET    | `/api/environments/:id/leases` | List reusable leases (`environments:manage`) |
+| GET    | `/api/environment-leases/:leaseId` | Lease detail (`environments:manage`) |
 
 Selection is validated server-side (`422 Unprocessable` on violation): the environment must exist, belong to the same company, not be `archived`, use an allowed driver for the context, and not be the built-in probe-only `fake` sandbox provider.
 

--- a/skills/paperclip/references/issue-workspaces.md
+++ b/skills/paperclip/references/issue-workspaces.md
@@ -20,6 +20,31 @@ Read `currentExecutionWorkspace`:
 
 If `currentExecutionWorkspace` is `null`, the issue does not currently have a realized execution workspace. For child/follow-up work, create the child with `parentId` or use `inheritExecutionWorkspaceFromIssueId` so Paperclip preserves workspace continuity.
 
+## Choose the Execution Environment
+
+A workspace is realized from an **environment** — the reusable definition of *where* an issue's code runs (local checkout, SSH host, sandbox provider, etc.). When an issue should run somewhere other than the company default, pin it at create/update time:
+
+```json
+PATCH /api/issues/{issueId}
+{ "executionWorkspaceSettings": { "environmentId": "<environment-id>" } }
+```
+
+The same `executionWorkspaceSettings.environmentId` field is accepted on `POST /api/companies/{companyId}/issues`. Leave it unset to inherit the default (or the parent's environment for child issues). Selection is validated server-side and returns `422 Unprocessable` if the environment is missing, belongs to another company, is `archived`, uses a driver not allowed in this context, or is the built-in probe-only `fake` sandbox provider.
+
+Discover what you can pin to (any agent with company access can read these):
+
+```sh
+# Active environments for the company (filter with ?status=active or ?driver=ssh).
+curl -sS -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/environments?status=active"
+
+# Supported drivers / sandbox providers and their capabilities.
+curl -sS -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/environments/capabilities"
+```
+
+Creating or editing environments (`POST/PATCH/DELETE /api/environments/...`, `/probe`) requires an agent with environment-management permission (manager/CEO). See `references/api-reference.md` → **Execution Environments** for the full route table.
+
 ## Control Services
 
 Prefer Paperclip-managed runtime service controls over manual `pnpm dev &` or ad-hoc background processes. These endpoints keep service state, URLs, logs, and ownership visible to other agents and the board.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents run in heartbeats and coordinate through the control-plane API documented in the bundled `paperclip` skill
> - Issues execute inside isolated execution workspaces, which are realized from reusable execution **environments** (local / SSH / sandbox provider)
> - An agent can pin an issue's workspace to a specific environment via `executionWorkspaceSettings.environmentId` on issue create/update, and can read the environments catalog with ordinary company-access credentials
> - But the `paperclip` skill never documented that field or the `/environments` routes, so an agent had no way to discover or use environment selection from the skill — it could only ever inherit the default
> - This PR documents environment selection in the skill: the Delegate step, the issue-workspaces reference, and the API reference
> - The benefit is that manager/CEO agents can correctly target a non-default environment when creating or delegating issues, instead of silently falling back to the company default

## What Changed

- `skills/paperclip/SKILL.md`: Step 9 (Delegate) now documents `executionWorkspaceSettings.environmentId`; the "Issue Workspace Runtime Controls" pointer now flags environment selection so the topic is discoverable from the main skill.
- `skills/paperclip/references/issue-workspaces.md`: new **Choose the Execution Environment** section — the pin payload, discovery `curl`s (`/environments`, `/environments/capabilities`), the server-side `422` validation rules, and the management-permission note for create/edit.
- `skills/paperclip/references/api-reference.md`: new **Execution Environments** route table (list, capabilities, CRUD, probe, leases) plus a short note on the `executionWorkspaceSettings.environmentId` selection contract.

## Verification

- Documentation only — no code paths are touched.
- Field and route accuracy were cross-checked against `master`:
  - `server/src/routes/environments.ts` — list/capabilities are gated by `assertCompanyAccess` (agent-readable); create/patch/delete/probe require environment-management permission.
  - `server/src/routes/environment-selection.ts` — `assertEnvironmentSelectionForCompany` enforces the documented `422` rules (missing / cross-company / `archived` / disallowed driver / probe-only `fake` sandbox provider).
  - `server/src/routes/issues.ts` — `executionWorkspaceSettings.environmentId` is validated via `assertIssueEnvironmentSelection` on issue create, subtask create, and update.
- Markdown renders cleanly; intra-skill reference paths resolve.

## Risks

- Low risk. Docs-only; no behavioral, schema, or API change. Worst case is a doc wording tweak in review.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. This PR documents existing shipped behavior; it is not a feature change.

## Model Used

- **Claude (Anthropic) — `claude-opus-4-7` (Opus 4.7)**, 1M-token context window, extended thinking enabled, tool use (filesystem + git). Authored via Claude Code. The route/field claims were verified directly against the server source on `master` rather than from model recall.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (it documents existing behavior)
- [ ] I have run tests locally and they pass — *docs-only change, no code paths affected; relying on CI*
- [ ] I have added or updated tests where applicable — *not applicable (documentation)*
- [ ] If this change affects the UI, I have included before/after screenshots — *not applicable*
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
