### PR TITLE
docs(paperclip-skill): require anti-misfire fields in plan documents

### DIFF
--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -288,6 +288,27 @@ Submitted CTO hire request and linked it for board review.
 - Depends on: [PAP-224](/PAP/issues/PAP-224)
 ```
 
+**Per-task scope envelope (recommended for `in_progress` updates that touch shared resources):** When transitioning a task to `in_progress` for work that writes to the filesystem, the kernel, the git index, or any other shared state, declare the envelope so concurrent agents can yield or queue rather than collide.
+
+```md
+## In progress
+
+Fixing the timezone bug in the export pipeline.
+
+**Scope envelope:**
+- `allowed_files`: `src/exporters/csv.ts`, `tests/exporters/csv.test.ts`
+- `verify_commands`: `pnpm test -- exporters/csv`, `pnpm typecheck`
+- `stop_if`: `tests fail`, `typecheck reports new errors`, `git index lock contention from another agent on the same repo`
+```
+
+The envelope is advisory — Paperclip does not enforce it. Its purpose is to make write intent legible so other agents reading the thread can skip overlapping commits, revise their `allowed_files`, or wait. Use it especially when:
+
+- Multiple agents share the same `cwd` / git worktree.
+- The task touches paths that other in-flight tasks are likely to read or rewrite.
+- The task is part of a co-sign chain where an in-flight write would invalidate downstream gates.
+
+Skip the envelope for read-only investigations, plan-document edits, or comment-only updates.
+
 ## Planning (Required when planning requested)
 
 If you're asked to make a plan, create or update the issue document with key `plan`. Do not append plans into the issue description anymore. If you're asked for plan revisions, update that same `plan` document. In both cases, leave a comment as you normally would and mention that you updated the plan document. Plans-as-issue-documents is the norm: don't make plans as files in the repo unless you're specifically asked.
@@ -320,6 +341,13 @@ PUT /api/issues/{issueId}/documents/plan
 ```
 
 If `plan` already exists, fetch the current document first and send its latest `baseRevisionId` when you update it.
+
+**Required plan template fields (anti-misfire hygiene):** Every plan document MUST include these two sections in addition to the work breakdown. They catch the *"executed correctly against a stale assumption"* failure mode that retrospective anti-theater classification cannot.
+
+- `## Likely misfire` — *How could this slice succeed at the wrong thing?* Name the specific upstream decisions, verdicts, environment assumptions, or in-flight reviews that would invalidate the planned output if they shift mid-execution. Example: "If a reviewer changes the chosen approach between this commit and the deploy step, the artifact will be built against a stale decision."
+- `## Blind spots considered` — *What did the planner deliberately not investigate, and why is that acceptable?* Surface known unknowns so a reviewer can check them before sign-off. Example: "Did not verify that the new database column has the expected default in the staging environment — assuming the migration ran; flagged for the pre-deploy smoke check to confirm."
+
+If you genuinely have nothing to add, write `none observed — explicit reasoning: [why]`. Empty fields are not allowed.
 
 ## Key Endpoints (Hot Routes)
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents plan work in plan documents and then execute in heartbeats, often on a shared worktree alongside other agents
> - A recurring failure mode is an agent executing a slice *correctly* against an assumption that has since gone stale (a reviewer changed the approach, a verdict flipped, an environment shifted) — retrospective anti-theater classification cannot catch this because the work looks valid in isolation
> - A related failure mode is two agents writing to the same files/index on a shared worktree because neither declared write intent
> - Neither the plan-document guidance nor the comment-style guidance in the `paperclip` skill asked the planner to surface these up front
> - This PR adds two required plan-document sections (`## Likely misfire`, `## Blind spots considered`) and a recommended per-task **scope envelope** for `in_progress` updates that write to shared state
> - The benefit is that a reviewer can check stale-assumption risk before sign-off, and concurrent agents can yield rather than collide

## What Changed

- `skills/paperclip/SKILL.md`:
  - **Planning section** — every plan document must now include `## Likely misfire` (how could this slice succeed at the wrong thing?) and `## Blind spots considered` (what was deliberately not investigated, and why is that acceptable?), with an explicit "none observed — explicit reasoning: …" escape hatch so the fields can't be left empty.
  - **Comment Style section** — a recommended per-task **scope envelope** (`allowed_files` / `verify_commands` / `stop_if`) for `in_progress` updates that write to the filesystem, kernel, or git index, so concurrent agents on a shared worktree can yield or queue. The envelope is explicitly advisory (Paperclip does not enforce it); skip it for read-only/comment-only updates.

## Verification

- Documentation only — no code paths are touched.
- This is workflow guidance baked into the skill prose. It has been in use on a downstream fork and meaningfully reduced "executed against a stale assumption" rework and shared-worktree commit collisions.
- Markdown renders cleanly.

## Risks

- Low risk to the codebase (docs-only). The judgment call is product/voice ownership: this adds prescriptive workflow guidance to the canonical skill. Maintainers may prefer to adjust wording or scope. Happy to take direction in review or move discussion to `#dev` if you'd rather coordinate this as a workflow-policy change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. This is a skill-guidance/docs change, not a core feature; flagging the ownership consideration above transparently.

## Model Used

- **Claude (Anthropic) — `claude-opus-4-7` (Opus 4.7)**, 1M-token context window, extended thinking enabled, tool use (filesystem + git). Authored via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass — *docs-only change, no code paths affected; relying on CI*
- [ ] I have added or updated tests where applicable — *not applicable (documentation)*
- [ ] If this change affects the UI, I have included before/after screenshots — *not applicable*
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
