### PR TITLE
feat(server): preCommentHooks action=exec with allowlist (Spur-3b, stacked on #5170)

### DIFF
--- a/server/src/__tests__/pre-comment-hook.test.ts
+++ b/server/src/__tests__/pre-comment-hook.test.ts
@@ -19,6 +19,7 @@ import {
   buildAuditBlock,
   evaluatePreCommentHooks,
   parsePreCommentHooks,
+  type ExecOnExitVerdict,
   type PreCommentHookConfig,
   type PreCommentHookContext,
 } from "../services/pre-comment-hook.js";
@@ -265,6 +266,7 @@ describe("buildAuditBlock", () => {
       {
         hookIndex: 0,
         action: "block" as const,
+        resolvedAction: "block" as const,
         message: "phantom",
         matchedBy: { agentId: true, statusTransition: true, bodyMatches: true },
         trigger: { agentId: CCO_AGENT_ID, statusTransition: "to_done", bodyMatches: "\\b[0-9a-f]{7,40}\\b" },
@@ -278,5 +280,280 @@ describe("buildAuditBlock", () => {
     expect(block).toContain(`agentId=${CCO_AGENT_ID}`);
     expect(block).toContain("statusTransition=to_done");
     expect(block).toContain("message=phantom");
+  });
+
+  it("includes exec block details for action=exec matches", () => {
+    const ctx = makeCtx({ body: "Done at deadbeef" });
+    const matches = [
+      {
+        hookIndex: 1,
+        action: "exec" as const,
+        resolvedAction: "pass" as const,
+        message: null,
+        matchedBy: { agentId: true, statusTransition: true, bodyMatches: true },
+        trigger: { agentId: CCO_AGENT_ID, statusTransition: "to_done" },
+        exec: {
+          status: "exit" as const,
+          exitCode: 0,
+          signal: null,
+          stdout: "real_on_main",
+          stderr: "",
+          durationMs: 42,
+          verdict: "pass+append_audit" as ExecOnExitVerdict,
+          verdictSource: "exit:0",
+        },
+      },
+    ];
+    const block = buildAuditBlock(matches, ctx);
+    expect(block).toContain("action=exec");
+    expect(block).toContain("resolvedAction=pass");
+    expect(block).toContain("exec status=exit");
+    expect(block).toContain("exitCode=0");
+    expect(block).toContain("verdict=pass+append_audit");
+    expect(block).toContain("verdictSource=exit:0");
+    expect(block).toContain("exec stdout:");
+    expect(block).toContain("real_on_main");
+  });
+});
+
+describe("parsePreCommentHooks — action=exec", () => {
+  it("parses well-formed exec hook with command/stdin/onExit/timeoutMs", () => {
+    const cfg = {
+      preCommentHooks: [
+        {
+          trigger: { agentId: CCO_AGENT_ID, statusTransition: "to_done", bodyMatches: "\\b[0-9a-f]{7,40}\\b" },
+          action: "exec",
+          command: ["/usr/bin/node", "/abs/cco-hash-verify.mjs", "--json"],
+          stdin: "comment.body",
+          onExit: { "0": "pass+append_audit", "1": "block", "2": "block+escalate" },
+          timeoutMs: 15000,
+        },
+      ],
+    };
+    const parsed = parsePreCommentHooks(cfg);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].action).toBe("exec");
+    expect(parsed[0].command).toEqual(["/usr/bin/node", "/abs/cco-hash-verify.mjs", "--json"]);
+    expect(parsed[0].stdin).toBe("comment.body");
+    expect(parsed[0].onExit).toEqual({ "0": "pass+append_audit", "1": "block", "2": "block+escalate" });
+    expect(parsed[0].timeoutMs).toBe(15000);
+  });
+
+  it("clamps timeoutMs to hard ceiling and drops invalid onExit verdicts", () => {
+    const cfg = {
+      preCommentHooks: [
+        {
+          trigger: { agentId: CCO_AGENT_ID },
+          action: "exec",
+          command: ["/usr/bin/node", "/abs/script.mjs"],
+          onExit: { "0": "pass+append_audit", "1": "frobnicate", "2": "block" },
+          timeoutMs: 999_999,
+        },
+      ],
+    };
+    const parsed = parsePreCommentHooks(cfg);
+    expect(parsed[0].timeoutMs).toBeLessThanOrEqual(60_000);
+    expect(parsed[0].onExit).toEqual({ "0": "pass+append_audit", "2": "block" });
+  });
+
+  it("drops invalid stdin values and empty command arrays", () => {
+    const cfg = {
+      preCommentHooks: [
+        { action: "exec", command: [], stdin: "comment.body" },
+        { action: "exec", command: ["/abs/x.mjs"], stdin: "stdout.body" },
+      ],
+    };
+    const parsed = parsePreCommentHooks(cfg);
+    expect(parsed[0].command).toBeUndefined();
+    expect(parsed[1].command).toEqual(["/abs/x.mjs"]);
+    expect(parsed[1].stdin).toBeUndefined();
+  });
+});
+
+describe("evaluatePreCommentHooks — action=exec", () => {
+  beforeEach(() => {
+    mockLogActivity.mockReset();
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("denies exec when command[0] is not on allowlist (fail-closed)", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { agentId: CCO_AGENT_ID, statusTransition: "to_done" },
+        action: "exec",
+        command: ["/usr/bin/node", "/forbidden/script.mjs"],
+        onExit: { "0": "pass+append_audit", default: "block" },
+        timeoutMs: 5000,
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "Done at deadbeef" }),
+      { execAllowlist: new Set(["/allowed/elsewhere.mjs"]) },
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].action).toBe("exec");
+    expect(result.matches[0].resolvedAction).toBe("block");
+    expect(result.matches[0].exec?.status).toBe("denied");
+    expect(result.matches[0].exec?.verdictSource).toBe("denied");
+  });
+
+  it("exec exit 0 maps to pass+append_audit (non-blocking, stdout captured)", async () => {
+    const allowed = "/usr/bin/true";
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { agentId: CCO_AGENT_ID },
+        action: "exec",
+        command: [allowed],
+        onExit: { "0": "pass+append_audit", default: "block" },
+        timeoutMs: 5000,
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "ok" }),
+      { execAllowlist: new Set([allowed]) },
+    );
+    expect(result.blocked).toBe(false);
+    expect(result.matches[0].exec?.status).toBe("exit");
+    expect(result.matches[0].exec?.exitCode).toBe(0);
+    expect(result.matches[0].resolvedAction).toBe("pass");
+  });
+
+  it("exec non-zero exit maps to block per onExit", async () => {
+    const allowed = "/usr/bin/false";
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { agentId: CCO_AGENT_ID },
+        action: "exec",
+        command: [allowed],
+        onExit: { "0": "pass+append_audit", "1": "block" },
+        timeoutMs: 5000,
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "ok" }),
+      { execAllowlist: new Set([allowed]) },
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.matches[0].exec?.exitCode).toBe(1);
+    expect(result.matches[0].exec?.verdictSource).toBe("exit:1");
+    expect(result.matches[0].resolvedAction).toBe("block");
+  });
+
+  it("default mapping applies when exit code has no explicit entry", async () => {
+    const allowed = "/usr/bin/false";
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { agentId: CCO_AGENT_ID },
+        action: "exec",
+        command: [allowed],
+        onExit: { "0": "pass+append_audit", default: "block" },
+        timeoutMs: 5000,
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "ok" }),
+      { execAllowlist: new Set([allowed]) },
+    );
+    expect(result.matches[0].exec?.verdictSource).toBe("default");
+    expect(result.matches[0].resolvedAction).toBe("block");
+  });
+
+  it("block+escalate maps to resolvedAction=escalate and contributes to blocked", async () => {
+    const allowed = "/usr/bin/false";
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { agentId: CCO_AGENT_ID },
+        action: "exec",
+        command: [allowed],
+        onExit: { "1": "block+escalate", default: "block" },
+        timeoutMs: 5000,
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "ok" }),
+      { execAllowlist: new Set([allowed]) },
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.matches[0].resolvedAction).toBe("escalate");
+  });
+
+  it("timeout maps to block with verdictSource=timeout", async () => {
+    const allowed = "/usr/bin/sleep";
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { agentId: CCO_AGENT_ID },
+        action: "exec",
+        command: [allowed, "10"],
+        onExit: { "0": "pass+append_audit" },
+        timeoutMs: 100,
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "ok" }),
+      { execAllowlist: new Set([allowed]) },
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.matches[0].exec?.status).toBe("timeout");
+    expect(result.matches[0].exec?.verdictSource).toBe("timeout");
+    expect(result.matches[0].resolvedAction).toBe("block");
+  });
+
+  it("exec hook does NOT run if trigger does not match", async () => {
+    const allowed = "/usr/bin/true";
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { agentId: "different-agent" },
+        action: "exec",
+        command: [allowed],
+        onExit: { "0": "pass+append_audit" },
+        timeoutMs: 5000,
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "Done at deadbeef" }),
+      { execAllowlist: new Set([allowed]) },
+    );
+    expect(result.blocked).toBe(false);
+    expect(result.matches).toEqual([]);
+  });
+
+  it("exec stdout is captured into audit block on pass+append_audit", async () => {
+    // /bin/echo writes its arg to stdout then exits 0.
+    const allowed = "/bin/echo";
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { agentId: CCO_AGENT_ID },
+        action: "exec",
+        command: [allowed, "real_on_main:deadbeef"],
+        onExit: { "0": "pass+append_audit" },
+        timeoutMs: 5000,
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "Done at deadbeef" }),
+      { execAllowlist: new Set([allowed]) },
+    );
+    expect(result.matches[0].resolvedAction).toBe("pass");
+    expect(result.matches[0].exec?.stdout).toContain("real_on_main:deadbeef");
+    const audit = buildAuditBlock(result.matches, makeCtx({ body: "Done at deadbeef" }));
+    expect(audit).toContain("real_on_main:deadbeef");
+    expect(audit).toContain("verdict=pass+append_audit");
   });
 });

--- a/server/src/__tests__/pre-comment-hook.test.ts
+++ b/server/src/__tests__/pre-comment-hook.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("../services/activity-log.js", () => ({
+  logActivity: mockLogActivity,
+}));
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import {
+  buildAuditBlock,
+  evaluatePreCommentHooks,
+  parsePreCommentHooks,
+  type PreCommentHookConfig,
+  type PreCommentHookContext,
+} from "../services/pre-comment-hook.js";
+
+const CCO_AGENT_ID = "02cbe529-20be-4963-9742-a4548680f111";
+
+function makeCtx(overrides: Partial<PreCommentHookContext> = {}): PreCommentHookContext {
+  return {
+    companyId: "company-1",
+    issueId: "issue-1",
+    agentId: CCO_AGENT_ID,
+    body: "",
+    source: "update",
+    statusTransition: "to_done",
+    ...overrides,
+  };
+}
+
+describe("parsePreCommentHooks", () => {
+  it("returns [] when adapterConfig is null/undefined/non-object", () => {
+    expect(parsePreCommentHooks(null)).toEqual([]);
+    expect(parsePreCommentHooks(undefined)).toEqual([]);
+    expect(parsePreCommentHooks("not-an-object")).toEqual([]);
+    expect(parsePreCommentHooks([])).toEqual([]);
+  });
+
+  it("returns [] when preCommentHooks is missing or not an array", () => {
+    expect(parsePreCommentHooks({})).toEqual([]);
+    expect(parsePreCommentHooks({ preCommentHooks: "nope" })).toEqual([]);
+    expect(parsePreCommentHooks({ preCommentHooks: { trigger: {} } })).toEqual([]);
+  });
+
+  it("parses well-formed entries and ignores unknown action values", () => {
+    const cfg = {
+      preCommentHooks: [
+        {
+          trigger: {
+            agentId: CCO_AGENT_ID,
+            statusTransition: "to_done",
+            bodyMatches: "\\b[0-9a-f]{7,40}\\b",
+          },
+          action: "block",
+          message: "phantom hash check",
+        },
+        {
+          trigger: { agentId: CCO_AGENT_ID },
+          action: "frobnicate",
+        },
+      ],
+    };
+    const parsed = parsePreCommentHooks(cfg);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]).toEqual({
+      trigger: {
+        agentId: CCO_AGENT_ID,
+        statusTransition: "to_done",
+        bodyMatches: "\\b[0-9a-f]{7,40}\\b",
+      },
+      action: "block",
+      message: "phantom hash check",
+    });
+    expect(parsed[1].action).toBeUndefined();
+  });
+});
+
+describe("evaluatePreCommentHooks", () => {
+  beforeEach(() => {
+    mockLogActivity.mockReset();
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  it("(c) backwards-compat: no hooks → not blocked, no audit", async () => {
+    const result = await evaluatePreCommentHooks({} as any, [], makeCtx({ body: "Done at 916caac" }));
+    expect(result.blocked).toBe(false);
+    expect(result.matches).toEqual([]);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("(a) phantom-hash-block: matching hook with action=block blocks", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: {
+          agentId: CCO_AGENT_ID,
+          statusTransition: "to_done",
+          bodyMatches: "\\b[0-9a-f]{7,40}\\b",
+        },
+        action: "block",
+        message: "phantom hash detector",
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "Done at 916caac on master." }),
+    );
+    expect(result.blocked).toBe(true);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].action).toBe("block");
+    expect(result.matches[0].message).toBe("phantom hash detector");
+    expect(result.matches[0].hookIndex).toBe(0);
+    expect(mockLogActivity).toHaveBeenCalledTimes(1);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: "issue.pre_comment_hook_blocked",
+        actorType: "system",
+        actorId: "pre_comment_hook",
+      }),
+    );
+  });
+
+  it("(b) real-hash-pass: hook with bodyMatches that doesn't match → not blocked", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: {
+          agentId: CCO_AGENT_ID,
+          statusTransition: "to_done",
+          bodyMatches: "PHANTOM",
+        },
+        action: "block",
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ body: "Real done at bb9d9b4." }),
+    );
+    expect(result.blocked).toBe(false);
+    expect(result.matches).toEqual([]);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+
+  it("does not match when agentId differs", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { agentId: CCO_AGENT_ID, bodyMatches: ".+" },
+        action: "block",
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ agentId: "some-other-agent", body: "anything" }),
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  it("does not match when statusTransition differs", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { statusTransition: "to_done", bodyMatches: ".+" },
+        action: "block",
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ statusTransition: "to_in_progress", body: "anything" }),
+    );
+    expect(result.blocked).toBe(false);
+  });
+
+  it("matches when statusTransition is 'any'", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      {
+        trigger: { statusTransition: "any", bodyMatches: ".+" },
+        action: "block",
+      },
+    ];
+    const result = await evaluatePreCommentHooks(
+      {} as any,
+      hooks,
+      makeCtx({ statusTransition: null, body: "anything" }),
+    );
+    expect(result.blocked).toBe(true);
+  });
+
+  it("matches when bodyMatches is unset (treat as 'always match')", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { agentId: CCO_AGENT_ID }, action: "block" },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "" }));
+    expect(result.blocked).toBe(true);
+  });
+
+  it("warn action does not block but is recorded as a match and logged", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { agentId: CCO_AGENT_ID, bodyMatches: ".+" }, action: "warn" },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "x" }));
+    expect(result.blocked).toBe(false);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].action).toBe("warn");
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.pre_comment_hook_warned" }),
+    );
+  });
+
+  it("escalate action does not block in iteration 1 but is recorded", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { agentId: CCO_AGENT_ID, bodyMatches: ".+" }, action: "escalate" },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "x" }));
+    expect(result.blocked).toBe(false);
+    expect(mockLogActivity).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: "issue.pre_comment_hook_escalated" }),
+    );
+  });
+
+  it("any blocking hook in a list of mixed actions blocks the comment", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { bodyMatches: "x" }, action: "warn" },
+      { trigger: { bodyMatches: "x" }, action: "block" },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "x" }));
+    expect(result.blocked).toBe(true);
+    expect(result.matches).toHaveLength(2);
+  });
+
+  it("invalid regex pattern is skipped (does not throw, does not block)", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { bodyMatches: "[unterminated" }, action: "block" },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "x" }));
+    expect(result.blocked).toBe(false);
+  });
+
+  it("entries without an action are inert (no match, no log)", async () => {
+    const hooks: PreCommentHookConfig[] = [
+      { trigger: { bodyMatches: ".+" } },
+    ];
+    const result = await evaluatePreCommentHooks({} as any, hooks, makeCtx({ body: "x" }));
+    expect(result.blocked).toBe(false);
+    expect(mockLogActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildAuditBlock", () => {
+  it("emits a single-block format with one line per match", () => {
+    const ctx = makeCtx({ body: "Done at 916caac" });
+    const matches = [
+      {
+        hookIndex: 0,
+        action: "block" as const,
+        message: "phantom",
+        matchedBy: { agentId: true, statusTransition: true, bodyMatches: true },
+        trigger: { agentId: CCO_AGENT_ID, statusTransition: "to_done", bodyMatches: "\\b[0-9a-f]{7,40}\\b" },
+      },
+    ];
+    const block = buildAuditBlock(matches, ctx);
+    expect(block).toContain("<!-- pre-comment-hook v1");
+    expect(block).toContain("<!-- /pre-comment-hook -->");
+    expect(block).toContain("hook[0]");
+    expect(block).toContain("action=block");
+    expect(block).toContain(`agentId=${CCO_AGENT_ID}`);
+    expect(block).toContain("statusTransition=to_done");
+    expect(block).toContain("message=phantom");
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3669,6 +3669,33 @@ export function issueRoutes(
       }
     }
 
+    // preCommentHooks pre-commit guard: when this PATCH carries a commentBody, evaluate
+    // the hook BEFORE svc.update commits the status change. Previously the hook ran AFTER
+    // svc.update, which (when a hook returned action:block) left the status transition
+    // persisted while the caller saw a 422. On retry the status would already match the
+    // proposed value, statusTransition would resolve to "none", and the hook would no
+    // longer fire — bypassing the guard. Now the proposed statusTransition is computed
+    // from updateFields against existing.status and the hook decides before any DB write.
+    if (commentBody) {
+      const proposedStatus =
+        typeof (updateFields as { status?: unknown }).status === "string"
+          ? ((updateFields as { status: string }).status)
+          : existing.status;
+      const proposedStatusTransition =
+        proposedStatus !== existing.status ? `to_${proposedStatus}` : "none";
+      if (
+        !(await runPreCommentHooksForActor(res, actor, {
+          companyId: existing.companyId,
+          issueId: existing.id,
+          body: commentBody,
+          source: "update",
+          statusTransition: proposedStatusTransition,
+        }))
+      ) {
+        return;
+      }
+    }
+
     let issue;
     try {
       if (transition.decision && decisionId) {
@@ -4068,18 +4095,8 @@ export function issueRoutes(
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
-      const statusTransition = issue.status !== existing.status ? `to_${issue.status}` : "none";
-      if (
-        !(await runPreCommentHooksForActor(res, actor, {
-          companyId: issue.companyId,
-          issueId: issue.id,
-          body: commentBody,
-          source: "update",
-          statusTransition,
-        }))
-      ) {
-        return;
-      }
+      // preCommentHooks already evaluated above (pre-svc.update guard); proceed directly
+      // to addComment. See the pre-commit guard block earlier in this handler.
       comment = await svc.addComment(id, commentBody, {
         agentId: actor.agentId ?? undefined,
         userId: actor.actorType === "user" ? actor.actorId : undefined,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -109,6 +109,12 @@ import {
   setIssueExecutionPolicyMonitorScheduledBy,
 } from "../services/issue-execution-policy.js";
 import { parseIssueExecutionWorkspaceSettings } from "../services/execution-workspace-policy.js";
+import {
+  buildAuditBlock as buildPreCommentHookAuditBlock,
+  evaluatePreCommentHooks,
+  parsePreCommentHooks,
+  type PreCommentHookContext,
+} from "../services/pre-comment-hook.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
@@ -1100,6 +1106,34 @@ export function issueRoutes(
       ...attachment,
       contentPath: `/api/attachments/${attachment.id}/content`,
     };
+  }
+
+  async function runPreCommentHooksForActor(
+    res: Response,
+    actor: ReturnType<typeof getActorInfo>,
+    ctx: Omit<PreCommentHookContext, "agentId">,
+  ): Promise<boolean> {
+    if (!actor.agentId) return true;
+    const agent = await agentsSvc.getById(actor.agentId);
+    if (!agent) return true;
+    const hooks = parsePreCommentHooks(agent.adapterConfig);
+    if (hooks.length === 0) return true;
+    const evalCtx: PreCommentHookContext = { ...ctx, agentId: actor.agentId };
+    const result = await evaluatePreCommentHooks(db, hooks, evalCtx);
+    if (result.blocked) {
+      res.status(422).json({
+        error: "Comment blocked by pre-comment hook",
+        auditBlock: buildPreCommentHookAuditBlock(result.matches, evalCtx),
+        matches: result.matches.map((m) => ({
+          hookIndex: m.hookIndex,
+          action: m.action,
+          message: m.message,
+          trigger: m.trigger,
+        })),
+      });
+      return false;
+    }
+    return true;
   }
 
   function parseBooleanQuery(value: unknown) {
@@ -4034,6 +4068,18 @@ export function issueRoutes(
     if (commentBody) {
       const commentReferenceSummaryBefore = updateReferenceSummaryAfter
         ?? await issueReferencesSvc.listIssueReferenceSummary(issue.id);
+      const statusTransition = issue.status !== existing.status ? `to_${issue.status}` : "none";
+      if (
+        !(await runPreCommentHooksForActor(res, actor, {
+          companyId: issue.companyId,
+          issueId: issue.id,
+          body: commentBody,
+          source: "update",
+          statusTransition,
+        }))
+      ) {
+        return;
+      }
       comment = await svc.addComment(id, commentBody, {
         agentId: actor.agentId ?? undefined,
         userId: actor.actorType === "user" ? actor.actorId : undefined,
@@ -5197,6 +5243,18 @@ export function issueRoutes(
           });
         }
       }
+    }
+
+    if (
+      !(await runPreCommentHooksForActor(res, actor, {
+        companyId: currentIssue.companyId,
+        issueId: currentIssue.id,
+        body: typeof req.body.body === "string" ? req.body.body : "",
+        source: "comment",
+        statusTransition: null,
+      }))
+    ) {
+      return;
     }
 
     const comment = await svc.addComment(id, req.body.body, {

--- a/server/src/services/pre-comment-hook.ts
+++ b/server/src/services/pre-comment-hook.ts
@@ -156,6 +156,24 @@ export async function evaluatePreCommentHooks(
   const auditBlock = buildAuditBlock(matches, ctx);
 
   for (const m of matches) {
+    // When the overall evaluation blocks AND this individual match is warn/escalate
+    // (co-fired alongside a block), the conventional "warned"/"escalated" log key would
+    // mislead operators into thinking the comment was allowed. Re-route to a disposition-
+    // aware key so the activity log reflects the actual outcome.
+    let activityKey: string;
+    if (m.action === "block" && blocked) {
+      activityKey = "issue.pre_comment_hook_blocked";
+    } else if (blocked) {
+      // Block co-fired with this non-blocking match → log as suppressed/matched-only,
+      // not warned/escalated (the comment was actually blocked).
+      activityKey = "issue.pre_comment_hook_matched";
+    } else if (m.action === "warn") {
+      activityKey = "issue.pre_comment_hook_warned";
+    } else if (m.action === "escalate") {
+      activityKey = "issue.pre_comment_hook_escalated";
+    } else {
+      activityKey = "issue.pre_comment_hook_matched";
+    }
     try {
       await logActivity(db, {
         companyId: ctx.companyId,
@@ -163,13 +181,7 @@ export async function evaluatePreCommentHooks(
         actorId: "pre_comment_hook",
         agentId: ctx.agentId ?? null,
         runId: null,
-        action: blocked && m.action === "block"
-          ? "issue.pre_comment_hook_blocked"
-          : m.action === "warn"
-          ? "issue.pre_comment_hook_warned"
-          : m.action === "escalate"
-          ? "issue.pre_comment_hook_escalated"
-          : "issue.pre_comment_hook_matched",
+        action: activityKey,
         entityType: "issue",
         entityId: ctx.issueId,
         details: {

--- a/server/src/services/pre-comment-hook.ts
+++ b/server/src/services/pre-comment-hook.ts
@@ -1,8 +1,14 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
 import type { Db } from "@paperclipai/db";
 import { logger } from "../middleware/logger.js";
 import { logActivity } from "./activity-log.js";
 
-export type PreCommentHookAction = "block" | "warn" | "escalate";
+export type PreCommentHookAction = "block" | "warn" | "escalate" | "exec";
+
+export type ExecOnExitVerdict = "pass+append_audit" | "block" | "block+escalate" | "warn";
+
+export type ResolvedAction = "block" | "warn" | "escalate" | "pass";
 
 export interface PreCommentHookTrigger {
   agentId?: string;
@@ -14,6 +20,22 @@ export interface PreCommentHookConfig {
   trigger?: PreCommentHookTrigger;
   action?: PreCommentHookAction;
   message?: string;
+  /** When action === "exec": absolute path command and args. */
+  command?: string[];
+  /** What to feed via stdin. Currently supported: "comment.body" or omit. */
+  stdin?: "comment.body";
+  /**
+   * Mapping of stringified exit codes to verdicts. Special key "default" applies
+   * when an exit code has no explicit mapping. Verdicts:
+   *   - "pass+append_audit": comment passes through; exec stdout appended to audit block
+   *   - "warn": non-blocking; logged as warn
+   *   - "block": comment blocked
+   *   - "block+escalate": blocked and additionally escalated (separate activity log entry)
+   * Default mapping when omitted entirely: { "0": "pass+append_audit", "default": "block" }.
+   */
+  onExit?: Record<string, ExecOnExitVerdict>;
+  /** Hard timeout for the exec process. Default 30000. Hard upper bound 60000. */
+  timeoutMs?: number;
 }
 
 export interface PreCommentHookContext {
@@ -25,9 +47,25 @@ export interface PreCommentHookContext {
   statusTransition: string | null;
 }
 
+export interface ExecOutcome {
+  /** "exit" if process terminated normally with a code, "timeout" if killed by us, "spawn_error" if spawn failed, "denied" if command not on allowlist. */
+  status: "exit" | "timeout" | "spawn_error" | "denied";
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  /** ms the child took to terminate (timeout counter included). */
+  durationMs: number;
+  verdict: ExecOnExitVerdict;
+  /** "exit", "default", "timeout", "spawn_error", "denied" or "no_action" — which onExit-key produced verdict. */
+  verdictSource: string;
+}
+
 export interface PreCommentHookMatch {
   hookIndex: number;
   action: PreCommentHookAction;
+  /** Resolved action after exec evaluation (for non-exec hooks this equals `action`). "pass" only possible for exec. */
+  resolvedAction: ResolvedAction;
   message: string | null;
   matchedBy: {
     agentId: boolean;
@@ -35,6 +73,8 @@ export interface PreCommentHookMatch {
     bodyMatches: boolean;
   };
   trigger: PreCommentHookTrigger;
+  /** Only populated for exec actions. */
+  exec?: ExecOutcome;
 }
 
 export interface PreCommentHookEvaluation {
@@ -42,7 +82,49 @@ export interface PreCommentHookEvaluation {
   matches: PreCommentHookMatch[];
 }
 
-const VALID_ACTIONS: ReadonlySet<PreCommentHookAction> = new Set(["block", "warn", "escalate"]);
+const VALID_ACTIONS: ReadonlySet<PreCommentHookAction> = new Set([
+  "block",
+  "warn",
+  "escalate",
+  "exec",
+]);
+
+const VALID_EXEC_VERDICTS: ReadonlySet<ExecOnExitVerdict> = new Set([
+  "pass+append_audit",
+  "warn",
+  "block",
+  "block+escalate",
+]);
+
+/** Hard ceiling regardless of config. */
+const EXEC_TIMEOUT_HARD_MAX_MS = 60_000;
+/** Default timeout when omitted. */
+const EXEC_TIMEOUT_DEFAULT_MS = 30_000;
+/** Capture stdout/stderr up to this many bytes; remainder is silently dropped. */
+const EXEC_STREAM_CAPTURE_MAX_BYTES = 16_384;
+
+const DEFAULT_ON_EXIT: Readonly<Record<string, ExecOnExitVerdict>> = Object.freeze({
+  "0": "pass+append_audit",
+  default: "block",
+});
+
+/**
+ * Server-side command allowlist for `action: exec`. Comma- or colon-separated
+ * absolute paths read from `PAPERCLIP_PRE_COMMENT_HOOK_EXEC_ALLOWLIST`. The
+ * resolved (path.resolve) `command[0]` MUST equal one of the allowlist entries
+ * exactly, or the hook is denied. Empty allowlist (or env-var missing) means
+ * `action: exec` is universally denied — fail-closed by default. Operators
+ * must opt-in per-deployment by listing the exact binary paths permitted.
+ */
+function readExecAllowlist(): ReadonlySet<string> {
+  const raw = process.env.PAPERCLIP_PRE_COMMENT_HOOK_EXEC_ALLOWLIST ?? "";
+  const entries = raw
+    .split(/[,:]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && path.isAbsolute(s))
+    .map((s) => path.resolve(s));
+  return new Set(entries);
+}
 
 function asArray(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
@@ -54,6 +136,30 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function parseCommand(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const parts = raw.filter((p): p is string => typeof p === "string" && p.length > 0);
+  if (parts.length === 0) return undefined;
+  return parts;
+}
+
+function parseOnExit(raw: unknown): Record<string, ExecOnExitVerdict> | undefined {
+  if (!isPlainObject(raw)) return undefined;
+  const out: Record<string, ExecOnExitVerdict> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof key !== "string" || key.length === 0) continue;
+    if (typeof value !== "string") continue;
+    if (!(VALID_EXEC_VERDICTS as Set<string>).has(value)) continue;
+    out[key] = value as ExecOnExitVerdict;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function parseTimeout(raw: unknown): number | undefined {
+  if (typeof raw !== "number" || !Number.isFinite(raw) || raw <= 0) return undefined;
+  return Math.min(Math.floor(raw), EXEC_TIMEOUT_HARD_MAX_MS);
 }
 
 export function parsePreCommentHooks(adapterConfig: unknown): PreCommentHookConfig[] {
@@ -73,7 +179,15 @@ export function parsePreCommentHooks(adapterConfig: unknown): PreCommentHookConf
         ? (actionRaw as PreCommentHookAction)
         : undefined;
     const message = asString(entry.message) ?? null;
-    return { trigger, action, message: message ?? undefined };
+    const cfg: PreCommentHookConfig = { trigger, action, message: message ?? undefined };
+    if (action === "exec") {
+      cfg.command = parseCommand(entry.command);
+      const stdinRaw = asString(entry.stdin);
+      if (stdinRaw === "comment.body") cfg.stdin = "comment.body";
+      cfg.onExit = parseOnExit(entry.onExit);
+      cfg.timeoutMs = parseTimeout(entry.timeoutMs);
+    }
+    return cfg;
   });
 }
 
@@ -86,7 +200,18 @@ function compileBodyRegex(pattern: string): RegExp | null {
   }
 }
 
-function matchHook(hook: PreCommentHookConfig, ctx: PreCommentHookContext): PreCommentHookMatch | null {
+interface CandidateMatch {
+  hookIndex: number;
+  hook: PreCommentHookConfig;
+  matchedBy: PreCommentHookMatch["matchedBy"];
+  trigger: PreCommentHookTrigger;
+}
+
+function matchHookCandidate(
+  hook: PreCommentHookConfig,
+  hookIndex: number,
+  ctx: PreCommentHookContext,
+): CandidateMatch | null {
   if (!hook.action) return null;
   const trigger = hook.trigger ?? {};
   const matchedBy = {
@@ -102,13 +227,153 @@ function matchHook(hook: PreCommentHookConfig, ctx: PreCommentHookContext): PreC
   if (!matchedBy.agentId || !matchedBy.statusTransition || !matchedBy.bodyMatches) {
     return null;
   }
-  return {
-    hookIndex: -1,
-    action: hook.action,
-    message: hook.message ?? null,
-    matchedBy,
-    trigger,
-  };
+  return { hookIndex, hook, matchedBy, trigger };
+}
+
+function truncateForAudit(s: string): string {
+  if (s.length <= EXEC_STREAM_CAPTURE_MAX_BYTES) return s;
+  return s.slice(0, EXEC_STREAM_CAPTURE_MAX_BYTES) + `\n…[truncated, ${s.length - EXEC_STREAM_CAPTURE_MAX_BYTES} bytes dropped]`;
+}
+
+function resolveExecVerdict(
+  outcome: Pick<ExecOutcome, "status" | "exitCode">,
+  onExit: Record<string, ExecOnExitVerdict>,
+): { verdict: ExecOnExitVerdict; source: string } {
+  if (outcome.status === "denied") return { verdict: "block", source: "denied" };
+  if (outcome.status === "spawn_error") return { verdict: "block", source: "spawn_error" };
+  if (outcome.status === "timeout") return { verdict: "block", source: "timeout" };
+  // status === "exit"
+  const key = outcome.exitCode === null ? "default" : String(outcome.exitCode);
+  if (onExit[key]) return { verdict: onExit[key], source: `exit:${key}` };
+  if (onExit["default"]) return { verdict: onExit["default"], source: "default" };
+  return { verdict: "block", source: "no_mapping" };
+}
+
+function verdictToResolvedAction(verdict: ExecOnExitVerdict): ResolvedAction {
+  if (verdict === "pass+append_audit") return "pass";
+  if (verdict === "warn") return "warn";
+  if (verdict === "block") return "block";
+  if (verdict === "block+escalate") return "escalate";
+  return "block";
+}
+
+async function runExecHook(
+  hook: PreCommentHookConfig,
+  ctx: PreCommentHookContext,
+  allowlist: ReadonlySet<string>,
+): Promise<ExecOutcome> {
+  const startedAt = Date.now();
+  const cmd = hook.command;
+  if (!cmd || cmd.length === 0) {
+    return {
+      status: "spawn_error",
+      exitCode: null,
+      signal: null,
+      stdout: "",
+      stderr: "missing command",
+      durationMs: 0,
+      verdict: "block",
+      verdictSource: "spawn_error",
+    };
+  }
+  const resolvedCmd = path.isAbsolute(cmd[0]) ? path.resolve(cmd[0]) : cmd[0];
+  if (!path.isAbsolute(resolvedCmd) || !allowlist.has(resolvedCmd)) {
+    return {
+      status: "denied",
+      exitCode: null,
+      signal: null,
+      stdout: "",
+      stderr: `command not on allowlist: ${resolvedCmd}`,
+      durationMs: 0,
+      verdict: "block",
+      verdictSource: "denied",
+    };
+  }
+  const args = cmd.slice(1);
+  const timeoutMs = hook.timeoutMs ?? EXEC_TIMEOUT_DEFAULT_MS;
+
+  return new Promise<ExecOutcome>((resolve) => {
+    let settled = false;
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    let killedByTimeout = false;
+
+    const child = spawn(resolvedCmd, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: { ...process.env, PAPERCLIP_HOOK_SOURCE: ctx.source, PAPERCLIP_HOOK_AGENT_ID: ctx.agentId ?? "" },
+    });
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      killedByTimeout = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // ignore — child may already have exited
+      }
+    }, timeoutMs);
+
+    child.stdout?.setEncoding("utf8").on("data", (chunk: string) => {
+      if (stdoutBuf.length < EXEC_STREAM_CAPTURE_MAX_BYTES) {
+        stdoutBuf += chunk;
+      }
+    });
+    child.stderr?.setEncoding("utf8").on("data", (chunk: string) => {
+      if (stderrBuf.length < EXEC_STREAM_CAPTURE_MAX_BYTES) {
+        stderrBuf += chunk;
+      }
+    });
+
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        status: "spawn_error",
+        exitCode: null,
+        signal: null,
+        stdout: truncateForAudit(stdoutBuf),
+        stderr: truncateForAudit(stderrBuf || String(err)),
+        durationMs: Date.now() - startedAt,
+        verdict: "block",
+        verdictSource: "spawn_error",
+      });
+    });
+
+    child.on("close", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const status: ExecOutcome["status"] = killedByTimeout ? "timeout" : "exit";
+      const partialOutcome = { status, exitCode: code ?? null };
+      const { verdict, source } = resolveExecVerdict(
+        partialOutcome,
+        hook.onExit ?? DEFAULT_ON_EXIT,
+      );
+      resolve({
+        status,
+        exitCode: code ?? null,
+        signal: signal ?? null,
+        stdout: truncateForAudit(stdoutBuf),
+        stderr: truncateForAudit(stderrBuf),
+        durationMs: Date.now() - startedAt,
+        verdict,
+        verdictSource: source,
+      });
+    });
+
+    if (hook.stdin === "comment.body") {
+      try {
+        child.stdin?.write(ctx.body, "utf8", () => {
+          try { child.stdin?.end(); } catch { /* ignore */ }
+        });
+      } catch {
+        // ignore — child may have exited before stdin write
+      }
+    } else {
+      try { child.stdin?.end(); } catch { /* ignore */ }
+    }
+  });
 }
 
 export function buildAuditBlock(
@@ -117,18 +382,37 @@ export function buildAuditBlock(
 ): string {
   const header = `<!-- pre-comment-hook v1 source=${ctx.source} agent=${ctx.agentId ?? "none"} -->`;
   const footer = "<!-- /pre-comment-hook -->";
-  const lines = matches.map((m) => {
+  const lines: string[] = [];
+  for (const m of matches) {
     const trig = m.trigger;
     const parts = [
       `hook[${m.hookIndex}]`,
       `action=${m.action}`,
+      m.action === "exec" ? `resolvedAction=${m.resolvedAction}` : null,
       trig.agentId ? `agentId=${trig.agentId}` : null,
       trig.statusTransition ? `statusTransition=${trig.statusTransition}` : null,
       trig.bodyMatches ? `bodyMatches=${trig.bodyMatches}` : null,
       m.message ? `message=${m.message}` : null,
     ].filter(Boolean);
-    return `- ${parts.join(" ")}`;
-  });
+    lines.push(`- ${parts.join(" ")}`);
+    if (m.exec) {
+      const ex = m.exec;
+      lines.push(
+        `  exec status=${ex.status} exitCode=${ex.exitCode ?? "n/a"} signal=${ex.signal ?? "n/a"} durationMs=${ex.durationMs} verdict=${ex.verdict} verdictSource=${ex.verdictSource}`,
+      );
+      if (ex.verdict === "pass+append_audit" && ex.stdout.length > 0) {
+        lines.push("  exec stdout:");
+        for (const line of ex.stdout.split("\n")) {
+          lines.push(`    ${line}`);
+        }
+      } else if (ex.stderr.length > 0 && (ex.status !== "exit" || ex.exitCode !== 0)) {
+        lines.push("  exec stderr:");
+        for (const line of ex.stderr.split("\n")) {
+          lines.push(`    ${line}`);
+        }
+      }
+    }
+  }
   return [header, ...lines, footer].join("\n");
 }
 
@@ -136,40 +420,82 @@ export async function evaluatePreCommentHooks(
   db: Db,
   hooks: PreCommentHookConfig[],
   ctx: PreCommentHookContext,
+  options?: { execAllowlist?: ReadonlySet<string> },
 ): Promise<PreCommentHookEvaluation> {
   if (!hooks || hooks.length === 0) {
     return { blocked: false, matches: [] };
   }
-  const matches: PreCommentHookMatch[] = [];
+  const candidates: CandidateMatch[] = [];
   for (let i = 0; i < hooks.length; i++) {
-    const hook = hooks[i];
-    const m = matchHook(hook, ctx);
-    if (m) {
-      matches.push({ ...m, hookIndex: i });
-    }
+    const c = matchHookCandidate(hooks[i], i, ctx);
+    if (c) candidates.push(c);
   }
-  if (matches.length === 0) {
-    return { blocked: false, matches };
+  if (candidates.length === 0) {
+    return { blocked: false, matches: [] };
   }
 
-  const blocked = matches.some((m) => m.action === "block");
+  const allowlist = options?.execAllowlist ?? readExecAllowlist();
+
+  const matches: PreCommentHookMatch[] = [];
+  for (const c of candidates) {
+    if (c.hook.action === "exec") {
+      const exec = await runExecHook(c.hook, ctx, allowlist);
+      const resolvedAction = verdictToResolvedAction(exec.verdict);
+      matches.push({
+        hookIndex: c.hookIndex,
+        action: "exec",
+        resolvedAction,
+        message: c.hook.message ?? null,
+        matchedBy: c.matchedBy,
+        trigger: c.trigger,
+        exec,
+      });
+    } else {
+      const action = c.hook.action!;
+      matches.push({
+        hookIndex: c.hookIndex,
+        action,
+        resolvedAction: action === "escalate" ? "escalate" : action,
+        message: c.hook.message ?? null,
+        matchedBy: c.matchedBy,
+        trigger: c.trigger,
+      });
+    }
+  }
+
+  // Blocking is purely action=block (PR #5170 contract: escalate alone does NOT block).
+  // Exec verdict block+escalate is a special combo that also blocks (in addition to its
+  // escalation signal); we check via exec.verdict rather than collapsing into resolvedAction.
+  const blocked = matches.some(
+    (m) =>
+      m.resolvedAction === "block" ||
+      (m.exec && m.exec.verdict === "block+escalate"),
+  );
   const auditBlock = buildAuditBlock(matches, ctx);
 
   for (const m of matches) {
-    // When the overall evaluation blocks AND this individual match is warn/escalate
-    // (co-fired alongside a block), the conventional "warned"/"escalated" log key would
-    // mislead operators into thinking the comment was allowed. Re-route to a disposition-
-    // aware key so the activity log reflects the actual outcome.
+    // When the overall evaluation blocks AND this individual match is non-blocking
+    // (warn/escalate co-fired alongside a block), the conventional "warned"/"escalated"
+    // log key would mislead operators into thinking the comment was allowed. Re-route
+    // to a disposition-aware key so the activity log reflects the actual outcome.
+    // For exec actions, use m.resolvedAction (verdict-mapped) instead of m.action.
+    // block+escalate is the only exec-verdict combo that BOTH blocks AND escalates —
+    // log as escalated (louder signal) rather than blocked.
+    const isBlockEscalateCombo =
+      m.action === "exec" && m.exec?.verdict === "block+escalate";
+    const isBlockingMatch = m.resolvedAction === "block" || isBlockEscalateCombo;
     let activityKey: string;
-    if (m.action === "block" && blocked) {
+    if (isBlockEscalateCombo && blocked) {
+      activityKey = "issue.pre_comment_hook_escalated";
+    } else if (isBlockingMatch && blocked) {
       activityKey = "issue.pre_comment_hook_blocked";
     } else if (blocked) {
       // Block co-fired with this non-blocking match → log as suppressed/matched-only,
       // not warned/escalated (the comment was actually blocked).
       activityKey = "issue.pre_comment_hook_matched";
-    } else if (m.action === "warn") {
+    } else if (m.resolvedAction === "warn") {
       activityKey = "issue.pre_comment_hook_warned";
-    } else if (m.action === "escalate") {
+    } else if (m.resolvedAction === "escalate") {
       activityKey = "issue.pre_comment_hook_escalated";
     } else {
       activityKey = "issue.pre_comment_hook_matched";
@@ -189,9 +515,20 @@ export async function evaluatePreCommentHooks(
           statusTransition: ctx.statusTransition,
           hookIndex: m.hookIndex,
           action: m.action,
+          resolvedAction: m.resolvedAction,
           trigger: m.trigger,
           message: m.message,
           auditBlock,
+          exec: m.exec
+            ? {
+                status: m.exec.status,
+                exitCode: m.exec.exitCode,
+                signal: m.exec.signal,
+                durationMs: m.exec.durationMs,
+                verdict: m.exec.verdict,
+                verdictSource: m.exec.verdictSource,
+              }
+            : undefined,
         },
       });
     } catch (err) {

--- a/server/src/services/pre-comment-hook.ts
+++ b/server/src/services/pre-comment-hook.ts
@@ -1,0 +1,191 @@
+import type { Db } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+import { logActivity } from "./activity-log.js";
+
+export type PreCommentHookAction = "block" | "warn" | "escalate";
+
+export interface PreCommentHookTrigger {
+  agentId?: string;
+  statusTransition?: string;
+  bodyMatches?: string;
+}
+
+export interface PreCommentHookConfig {
+  trigger?: PreCommentHookTrigger;
+  action?: PreCommentHookAction;
+  message?: string;
+}
+
+export interface PreCommentHookContext {
+  companyId: string;
+  issueId: string;
+  agentId: string | null;
+  body: string;
+  source: "comment" | "update";
+  statusTransition: string | null;
+}
+
+export interface PreCommentHookMatch {
+  hookIndex: number;
+  action: PreCommentHookAction;
+  message: string | null;
+  matchedBy: {
+    agentId: boolean;
+    statusTransition: boolean;
+    bodyMatches: boolean;
+  };
+  trigger: PreCommentHookTrigger;
+}
+
+export interface PreCommentHookEvaluation {
+  blocked: boolean;
+  matches: PreCommentHookMatch[];
+}
+
+const VALID_ACTIONS: ReadonlySet<PreCommentHookAction> = new Set(["block", "warn", "escalate"]);
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function parsePreCommentHooks(adapterConfig: unknown): PreCommentHookConfig[] {
+  if (!isPlainObject(adapterConfig)) return [];
+  const raw = adapterConfig.preCommentHooks;
+  return asArray(raw).map((entry): PreCommentHookConfig => {
+    if (!isPlainObject(entry)) return {};
+    const triggerRaw = isPlainObject(entry.trigger) ? entry.trigger : {};
+    const trigger: PreCommentHookTrigger = {
+      agentId: asString(triggerRaw.agentId),
+      statusTransition: asString(triggerRaw.statusTransition),
+      bodyMatches: asString(triggerRaw.bodyMatches),
+    };
+    const actionRaw = asString(entry.action);
+    const action: PreCommentHookAction | undefined =
+      actionRaw && (VALID_ACTIONS as Set<string>).has(actionRaw)
+        ? (actionRaw as PreCommentHookAction)
+        : undefined;
+    const message = asString(entry.message) ?? null;
+    return { trigger, action, message: message ?? undefined };
+  });
+}
+
+function compileBodyRegex(pattern: string): RegExp | null {
+  try {
+    return new RegExp(pattern);
+  } catch (err) {
+    logger.warn({ err, pattern }, "preCommentHooks: invalid bodyMatches regex, skipping hook");
+    return null;
+  }
+}
+
+function matchHook(hook: PreCommentHookConfig, ctx: PreCommentHookContext): PreCommentHookMatch | null {
+  if (!hook.action) return null;
+  const trigger = hook.trigger ?? {};
+  const matchedBy = {
+    agentId: !trigger.agentId || trigger.agentId === ctx.agentId,
+    statusTransition: !trigger.statusTransition || trigger.statusTransition === "any" || trigger.statusTransition === ctx.statusTransition,
+    bodyMatches: true as boolean,
+  };
+  if (trigger.bodyMatches) {
+    const re = compileBodyRegex(trigger.bodyMatches);
+    if (!re) return null;
+    matchedBy.bodyMatches = re.test(ctx.body);
+  }
+  if (!matchedBy.agentId || !matchedBy.statusTransition || !matchedBy.bodyMatches) {
+    return null;
+  }
+  return {
+    hookIndex: -1,
+    action: hook.action,
+    message: hook.message ?? null,
+    matchedBy,
+    trigger,
+  };
+}
+
+export function buildAuditBlock(
+  matches: PreCommentHookMatch[],
+  ctx: PreCommentHookContext,
+): string {
+  const header = `<!-- pre-comment-hook v1 source=${ctx.source} agent=${ctx.agentId ?? "none"} -->`;
+  const footer = "<!-- /pre-comment-hook -->";
+  const lines = matches.map((m) => {
+    const trig = m.trigger;
+    const parts = [
+      `hook[${m.hookIndex}]`,
+      `action=${m.action}`,
+      trig.agentId ? `agentId=${trig.agentId}` : null,
+      trig.statusTransition ? `statusTransition=${trig.statusTransition}` : null,
+      trig.bodyMatches ? `bodyMatches=${trig.bodyMatches}` : null,
+      m.message ? `message=${m.message}` : null,
+    ].filter(Boolean);
+    return `- ${parts.join(" ")}`;
+  });
+  return [header, ...lines, footer].join("\n");
+}
+
+export async function evaluatePreCommentHooks(
+  db: Db,
+  hooks: PreCommentHookConfig[],
+  ctx: PreCommentHookContext,
+): Promise<PreCommentHookEvaluation> {
+  if (!hooks || hooks.length === 0) {
+    return { blocked: false, matches: [] };
+  }
+  const matches: PreCommentHookMatch[] = [];
+  for (let i = 0; i < hooks.length; i++) {
+    const hook = hooks[i];
+    const m = matchHook(hook, ctx);
+    if (m) {
+      matches.push({ ...m, hookIndex: i });
+    }
+  }
+  if (matches.length === 0) {
+    return { blocked: false, matches };
+  }
+
+  const blocked = matches.some((m) => m.action === "block");
+  const auditBlock = buildAuditBlock(matches, ctx);
+
+  for (const m of matches) {
+    try {
+      await logActivity(db, {
+        companyId: ctx.companyId,
+        actorType: "system",
+        actorId: "pre_comment_hook",
+        agentId: ctx.agentId ?? null,
+        runId: null,
+        action: blocked && m.action === "block"
+          ? "issue.pre_comment_hook_blocked"
+          : m.action === "warn"
+          ? "issue.pre_comment_hook_warned"
+          : m.action === "escalate"
+          ? "issue.pre_comment_hook_escalated"
+          : "issue.pre_comment_hook_matched",
+        entityType: "issue",
+        entityId: ctx.issueId,
+        details: {
+          source: ctx.source,
+          statusTransition: ctx.statusTransition,
+          hookIndex: m.hookIndex,
+          action: m.action,
+          trigger: m.trigger,
+          message: m.message,
+          auditBlock,
+        },
+      });
+    } catch (err) {
+      logger.warn({ err, issueId: ctx.issueId }, "preCommentHooks: failed to log activity");
+    }
+  }
+
+  return { blocked, matches };
+}


### PR DESCRIPTION
**STATUS: DRAFT — DO NOT MERGE UNTIL #5170 IS MERGED FIRST.**

This PR stacks on top of [#5170](https://github.com/paperclipai/paperclip/pull/5170) (`feat(server): add agent.adapterConfig.preCommentHooks block-action hook`). It adds the third action type `exec` to the `preCommentHooks` schema, complementing PR #5170's `block`/`warn`/`escalate` regex-only set.

## What this PR adds

Extends `agent.adapterConfig.preCommentHooks[]` with `action: "exec"` that spawns a child process before comment/status-PATCH and branches on the process exit code via an `onExit` map.

### Schema

```jsonc
{
  "trigger": { "agentId": "<uuid>", "statusTransition": "to_done", "bodyMatches": "<regex>" },
  "action": "exec",
  "command": ["/abs/path/to/node", "/abs/path/to/script.mjs", "--json"],
  "stdin": "comment.body",
  "onExit": {
    "0": "pass+append_audit",
    "1": "block",
    "2": "block+escalate",
    "default": "block"
  },
  "timeoutMs": 30000
}
```

### Verdicts

- `pass+append_audit`: comment passes; exec stdout appended to audit block
- `warn`: non-blocking; logged as warn
- `block`: comment blocked (422)
- `block+escalate`: blocked + separate `issue.pre_comment_hook_escalated` activity log entry

### Trust boundary

- Server-side allowlist via `PAPERCLIP_PRE_COMMENT_HOOK_EXEC_ALLOWLIST` (colon- or comma-separated absolute paths). Empty/missing = exec universally **denied** (fail-closed). Resolved `command[0]` must equal an allowlist entry exactly. Relative paths denied.
- Hard timeout ceiling 60s regardless of config; default 30s.
- Stdout/stderr capture capped at 16KiB; excess silently dropped.
- `spawn_error` / `timeout` / `denied` all map to `verdict=block`.

## Backwards-compat with #5170

- Non-exec actions (`block`/`warn`/`escalate`) behavior unchanged.
- Critically: `escalate` alone is **non-blocking** (logged but no 422); exec verdict `block+escalate` is the only construct that combines blocking + escalation. `blocked`-check explicitly differentiates via `exec.verdict`.
- `evaluatePreCommentHooks` signature gets optional `options.execAllowlist` param for testability; defaults to env-var reader.
- `PreCommentHookMatch` grows a required `resolvedAction` field (for non-exec this just mirrors `action`; for exec it's the exit-code-mapped verdict).

## Tests

28 tests total — 20 baseline (preserved + 1 updated for `resolvedAction`) + 8 new exec-coverage:

1. denies exec when command[0] not on allowlist (fail-closed)
2. exec exit 0 maps to `pass+append_audit`
3. exec non-zero exit maps to block per `onExit`
4. default mapping applies when exit code has no explicit entry
5. `block+escalate` maps to `resolvedAction=escalate` and contributes to blocked
6. timeout maps to block with `verdictSource=timeout`
7. exec hook does NOT run if trigger does not match
8. exec stdout is captured into audit block on `pass+append_audit`

**All 28/28 PASS** on local pnpm-monorepo build (vitest 3.2.4) in ~530ms (includes real subprocess spawning for `/bin/echo`, `/usr/bin/sleep`, `/usr/bin/true`, `/usr/bin/false`).

## Context

This Spur-3b commit is part of an internal Psynora Anti-Phantom-Commit-Hash governance program — see internal tracking PSY-1481. The intended exec-target CLI is `cco-hash-verify.mjs` which performs 4-layer git-verification (rev-parse / merge-base / rev-list / push-output-zitat) per Psynora Spec §13.10.

The combined #5170 + this PR delivers:
- Spec §4.3 full CLI-exec semantics (rather than regex-only) so phantom-hash claims can actually be verified via `git rev-parse`.
- Configurable per-agent enforcement via `adapterConfig`.

## Merge order

1. Merge [#5170](https://github.com/paperclipai/paperclip/pull/5170) (Spur-3a — regex-only foundation).
2. Rebase this PR onto the updated master if needed (currently `mergeable_state=clean`).
3. Merge this PR (Spur-3b — exec-action extension).

Squash-merge recommended for both.
