### PR TITLE
Fix the blocked-issue UX loop on the board

### DIFF
--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -137,6 +137,11 @@ export interface IssueRelationIssueSummary {
   priority: IssuePriority;
   assigneeAgentId: string | null;
   assigneeUserId: string | null;
+  // HUM-126 Fix 2: optional display labels so the blocked-issue banner can show
+  // "who to ping" without the client doing a second round trip. Producers that
+  // don't have this resolved (e.g. legacy paths) can omit it.
+  assigneeAgentName?: string | null;
+  assigneeUserName?: string | null;
   terminalBlockers?: IssueRelationIssueSummary[];
   activeRecoveryAction?: IssueRecoveryAction | null;
 }

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -781,7 +781,7 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
-  it("does not move dependency-blocked issues to todo via POST comments", async () => {
+  it("does not move dependency-blocked issues to todo via POST comments and skips the assignee wake when the assignee is not mentioned (HUM-126 Fix 3)", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       issueId: "11111111-1111-4111-8111-111111111111",
@@ -798,21 +798,12 @@ describe.sequential("issue comment reopen routes", () => {
 
     expect(res.status).toBe(201);
     expect(mockIssueService.update).not.toHaveBeenCalled();
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_commented",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          mutation: "comment",
-        }),
-        contextSnapshot: expect.objectContaining({
-          issueId: "11111111-1111-4111-8111-111111111111",
-          wakeCommentId: "comment-1",
-          wakeReason: "issue_commented",
-        }),
-      }),
-    ));
+    // Previously this test asserted that a generic comment on a still-blocked
+    // issue woke the assignee with `issue_commented`. That wake is exactly the
+    // loop HUM-126 Fix 3 is closing — the assignee runs against a gated issue,
+    // exits in ~5s, and the harness loops. The wake must NOT fire here.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("does not implicitly reopen closed issues via POST comments when no agent is assigned", async () => {
@@ -987,7 +978,7 @@ describe.sequential("issue comment reopen routes", () => {
     expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
-  it("does not move dependency-blocked issues to todo via the PATCH comment path", async () => {
+  it("does not move dependency-blocked issues to todo via the PATCH comment path and skips the assignee wake when the assignee is not mentioned (HUM-126 Fix 3)", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue("blocked"));
     mockIssueService.getDependencyReadiness.mockResolvedValue({
       issueId: "11111111-1111-4111-8111-111111111111",
@@ -1018,16 +1009,10 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       expect.objectContaining({ status: "todo" }),
     );
-    await waitForWakeup(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_commented",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          mutation: "comment",
-        }),
-      }),
-    ));
+    // Previously this asserted an `issue_commented` wake fired for the
+    // assignee. HUM-126 Fix 3 closes that loop — the wake must not fire here.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("wakes the assignee when an assigned blocked issue moves back to todo", async () => {

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -13,6 +13,7 @@ const mockIssueService = vi.hoisted(() => ({
   listWakeableBlockedDependents: vi.fn(),
   getWakeableParentAfterChildCompletion: vi.fn(),
   getCurrentScheduledRetry: vi.fn(),
+  getDependencyReadiness: vi.fn(),
 }));
 
 const mockHeartbeatService = vi.hoisted(() => ({
@@ -219,6 +220,9 @@ describe("issue update comment wakeups", () => {
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
     mockIssueService.getCurrentScheduledRetry.mockResolvedValue(null);
+    // Default to "at least one unresolved blocker so the issue is still really
+    // blocked" — the loop scenario we're fixing. Tests that reopen will override.
+    mockIssueService.getDependencyReadiness.mockResolvedValue({ unresolvedBlockerCount: 1 });
   });
 
   it("includes the new comment in assignment wakes from issue updates", async () => {
@@ -309,6 +313,62 @@ describe("issue update comment wakeups", () => {
           wakeReason: "issue_commented",
           source: "issue.comment",
         }),
+      }),
+    );
+  });
+
+  it("skips the assignee comment wake on blocked issues when the assignee is not mentioned", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "blocked",
+    });
+    const updated = { ...existing };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-3",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "just leaving a note, no work needed",
+    });
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ comment: "just leaving a note, no work needed" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
+  });
+
+  it("still wakes the assignee on blocked issues when the comment @-mentions them", async () => {
+    const existing = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "blocked",
+    });
+    const updated = { ...existing };
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-4",
+      issueId: existing.id,
+      companyId: existing.companyId,
+      body: "@assignee can you triage this even though it's blocked?",
+    });
+    mockIssueService.findMentionedAgents.mockResolvedValue([ASSIGNEE_AGENT_ID]);
+
+    const res = await request(await createApp())
+      .patch(`/api/issues/${existing.id}`)
+      .send({ comment: "@assignee can you triage this even though it's blocked?" });
+
+    expect(res.status).toBe(200);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1);
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({
+        reason: "issue_comment_mentioned",
       }),
     );
   });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4236,7 +4236,24 @@ export function issueRoutes(
         const assigneeId = issue.assigneeAgentId;
         const actorIsAgent = actor.actorType === "agent";
         const selfComment = actorIsAgent && actor.actorId === assigneeId;
-        const skipAssigneeCommentWake = selfComment || isClosed;
+
+        let mentionedIds: string[] = [];
+        try {
+          mentionedIds = await svc.findMentionedAgents(issue.companyId, commentBody);
+        } catch (err) {
+          logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
+        }
+        const assigneeMentioned = assigneeId !== null && mentionedIds.includes(assigneeId);
+        // HUM-126 Fix 3: a generic comment on a `blocked` issue should not wake the
+        // assignee unless the comment @-mentions them or actually reopens the issue.
+        // Without this, every comment on a gated issue churned the assignee through a
+        // ~5s "work blocked" run, the harness flagged the short exit, and the wake
+        // looped. Mentioned-agent wakes (including the assignee, if mentioned) and
+        // interaction responses (request_confirmation / ask_user_questions) flow
+        // through separate code paths and are unaffected.
+        const skipBlockedNoMention =
+          issue.status === "blocked" && !reopened && assigneeId !== null && !assigneeMentioned;
+        const skipAssigneeCommentWake = selfComment || isClosed || skipBlockedNoMention;
 
         if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {
@@ -4265,13 +4282,16 @@ export function issueRoutes(
               ...(interruptedRunId ? { interruptedRunId } : {}),
             },
           });
-        }
-
-        let mentionedIds: string[] = [];
-        try {
-          mentionedIds = await svc.findMentionedAgents(issue.companyId, commentBody);
-        } catch (err) {
-          logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
+        } else if (skipBlockedNoMention && !assigneeChanged && assigneeId) {
+          logger.info(
+            {
+              issueId: id,
+              agentId: assigneeId,
+              commentId: comment.id,
+              wakeSkippedReason: "issue_blocked_no_mention",
+            },
+            "skipped assignee comment wake on blocked issue without mention",
+          );
         }
 
         for (const mentionedId of mentionedIds) {
@@ -5323,7 +5343,24 @@ export function issueRoutes(
       const assigneeId = currentIssue.assigneeAgentId;
       const actorIsAgent = actor.actorType === "agent";
       const selfComment = actorIsAgent && actor.actorId === assigneeId;
-      const skipWake = selfComment || isClosed;
+
+      let mentionedIds: string[] = [];
+      try {
+        mentionedIds = await svc.findMentionedAgents(issue.companyId, req.body.body);
+      } catch (err) {
+        logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
+      }
+      const assigneeMentioned = assigneeId !== null && mentionedIds.includes(assigneeId);
+      // HUM-126 Fix 3: a generic comment on a `blocked` issue should not wake the
+      // assignee unless the comment @-mentions them or actually reopens the issue.
+      // Without this, every comment on a gated issue churned the assignee through a
+      // ~5s "work blocked" run, the harness flagged the short exit, and the wake
+      // looped. Mentioned-agent wakes (including the assignee, if mentioned) and
+      // interaction responses (request_confirmation / ask_user_questions) flow
+      // through separate code paths and are unaffected.
+      const skipBlockedNoMention =
+        currentIssue.status === "blocked" && !reopened && assigneeId !== null && !assigneeMentioned;
+      const skipWake = selfComment || isClosed || skipBlockedNoMention;
       if (assigneeId && (reopened || !skipWake)) {
         if (reopened) {
           wakeups.set(assigneeId, {
@@ -5378,13 +5415,16 @@ export function issueRoutes(
             },
           });
         }
-      }
-
-      let mentionedIds: string[] = [];
-      try {
-        mentionedIds = await svc.findMentionedAgents(issue.companyId, req.body.body);
-      } catch (err) {
-        logger.warn({ err, issueId: id }, "failed to resolve @-mentions");
+      } else if (skipBlockedNoMention && assigneeId) {
+        logger.info(
+          {
+            issueId: currentIssue.id,
+            agentId: assigneeId,
+            commentId: comment.id,
+            wakeSkippedReason: "issue_blocked_no_mention",
+          },
+          "skipped assignee comment wake on blocked issue without mention",
+        );
       }
 
       for (const mentionedId of mentionedIds) {

--- a/ui/src/components/IssueBlockedNotice.test.tsx
+++ b/ui/src/components/IssueBlockedNotice.test.tsx
@@ -265,4 +265,49 @@ describe("IssueBlockedNotice", () => {
     expect(indicator?.getAttribute("data-recovery-state")).toBe("needed");
     expect(indicator?.textContent).toContain("Recovery needed");
   });
+
+  it("shows the blocker's assignee and a Ping button on each blocker card", () => {
+    const agentMap = new Map([
+      [
+        "agent-cto",
+        {
+          id: "agent-cto",
+          name: "Compass",
+          // Only the `name` field is read by IssueBlockedNotice; the rest can stay
+          // unset for the test fixture.
+        } as unknown as Parameters<typeof IssueBlockedNotice>[0]["agentMap"] extends Map<string, infer V>
+          ? V
+          : never,
+      ],
+    ]);
+    const node = render(
+      <IssueBlockedNotice
+        issueStatus="blocked"
+        agentMap={agentMap}
+        blockers={[
+          {
+            id: "blocker-1",
+            identifier: "PAP-200",
+            title: "Waiting on review",
+            status: "in_review",
+            priority: "high",
+            assigneeAgentId: "agent-cto",
+            assigneeUserId: null,
+          },
+        ]}
+      />,
+    );
+
+    const card = node.querySelector('[data-testid="issue-blocked-notice-blocker-card"]');
+    expect(card).not.toBeNull();
+    expect(card?.textContent).toContain("Compass");
+    expect(card?.textContent).toContain("In review");
+
+    const ping = card?.querySelector<HTMLAnchorElement>(
+      '[data-testid="issue-blocked-notice-ping-button"]',
+    );
+    expect(ping).not.toBeNull();
+    expect(ping?.getAttribute("href") ?? "").toContain("focus=composer");
+    expect(ping?.getAttribute("aria-label") ?? "").toContain("Compass");
+  });
 });

--- a/ui/src/components/IssueBlockedNotice.tsx
+++ b/ui/src/components/IssueBlockedNotice.tsx
@@ -1,23 +1,65 @@
 import type {
+  Agent,
   IssueBlockerAttention,
   IssueRecoveryAction,
   IssueRelationIssueSummary,
   IssueScheduledRetry,
   SuccessfulRunHandoffState,
 } from "@paperclipai/shared";
-import { AlertTriangle, CheckCircle2, Flag, Loader2, RotateCcw } from "lucide-react";
+import { AlertTriangle, Bell, CheckCircle2, Flag, Loader2, RotateCcw } from "lucide-react";
 import { Link } from "@/lib/router";
 import { Button } from "@/components/ui/button";
 import { createIssueDetailPath } from "../lib/issueDetailBreadcrumb";
 import { formatMonitorOffset } from "../lib/issue-monitor";
+import { formatAssigneeUserLabel } from "../lib/assignees";
 import { useRetryNowMutation } from "../hooks/useRetryNowMutation";
 import { IssueLinkQuicklook } from "./IssueLinkQuicklook";
 import { RetryErrorBand } from "./IssueScheduledRetryCard";
+import { StatusIcon } from "./StatusIcon";
 import { isAssignedBacklogBlocker } from "../lib/issue-blockers";
 import {
   deriveActiveRecoveryDisplayState,
   RECOVERY_CHIP_DEFAULT_TONE,
 } from "../lib/recovery-display";
+
+// HUM-126 Fix 2: the previous banner said "click to find out more" — the user
+// had no idea who to ping. This block resolves the blocker's assignee to a display
+// label so we can render it inline.
+function resolveBlockerAssigneeLabel(args: {
+  blocker: IssueRelationIssueSummary;
+  agentMap?: Map<string, Agent>;
+  currentUserId?: string | null;
+}): { label: string; kind: "agent" | "user" | "unassigned" } {
+  const { blocker, agentMap, currentUserId } = args;
+  if (blocker.assigneeAgentId) {
+    const name =
+      blocker.assigneeAgentName
+      ?? agentMap?.get(blocker.assigneeAgentId)?.name
+      ?? blocker.assigneeAgentId.slice(0, 8);
+    return { label: name, kind: "agent" };
+  }
+  if (blocker.assigneeUserId) {
+    const formatted = formatAssigneeUserLabel(blocker.assigneeUserId, currentUserId);
+    return {
+      label: blocker.assigneeUserName ?? formatted ?? blocker.assigneeUserId.slice(0, 8),
+      kind: "user",
+    };
+  }
+  return { label: "Unassigned", kind: "unassigned" };
+}
+
+function issueStatusLabel(status: IssueRelationIssueSummary["status"]): string {
+  switch (status) {
+    case "in_progress": return "In progress";
+    case "in_review": return "In review";
+    case "todo": return "Todo";
+    case "backlog": return "Backlog";
+    case "blocked": return "Blocked";
+    case "done": return "Done";
+    case "cancelled": return "Cancelled";
+    default: return status;
+  }
+}
 
 function BlockerRecoveryIndicator({ action }: { action: IssueRecoveryAction }) {
   const state = deriveActiveRecoveryDisplayState(action);
@@ -112,6 +154,8 @@ export function IssueBlockedNotice({
   successfulRunHandoff,
   scheduledRetry,
   agentName,
+  agentMap,
+  currentUserId,
 }: {
   issueId?: string | null;
   issueStatus?: string;
@@ -120,6 +164,10 @@ export function IssueBlockedNotice({
   successfulRunHandoff?: SuccessfulRunHandoffState | null;
   scheduledRetry?: IssueScheduledRetry | null;
   agentName?: string | null;
+  // HUM-126 Fix 2: passed through so each blocker chip can show its assignee's
+  // display name without the banner doing its own data fetch.
+  agentMap?: Map<string, Agent>;
+  currentUserId?: string | null;
 }) {
   if (issueStatus === "done" || issueStatus === "cancelled") return null;
   const showSuccessfulRunHandoff = successfulRunHandoff?.required === true;
@@ -178,19 +226,62 @@ export function IssueBlockedNotice({
   const renderBlockerChip = (blocker: IssueRelationIssueSummary) => {
     const issuePathId = blocker.identifier ?? blocker.id;
     const recoveryAction = blocker.activeRecoveryAction ?? null;
+    const assignee = resolveBlockerAssigneeLabel({ blocker, agentMap, currentUserId });
+    const detailPath = createIssueDetailPath(issuePathId);
+    // HUM-126 Fix 2: ping = navigate to the blocking issue with a focus signal so
+    // the chat thread auto-scrolls + focuses the composer. Cheaper than a modal,
+    // and reuses the composer's existing draft/assignee logic.
+    const pingPath = `${detailPath}?focus=composer`;
     return (
-      <IssueLinkQuicklook
+      <div
         key={blocker.id}
-        issuePathId={issuePathId}
-        to={createIssueDetailPath(issuePathId)}
-        className="inline-flex max-w-full items-center gap-1 rounded-md border border-amber-300/70 bg-background/80 px-2 py-1 font-mono text-xs text-amber-950 transition-colors hover:border-amber-500 hover:bg-amber-100 hover:underline dark:border-amber-500/40 dark:bg-background/40 dark:text-amber-100 dark:hover:bg-amber-500/15"
+        data-testid="issue-blocked-notice-blocker-card"
+        className="flex w-full max-w-md flex-col gap-1 rounded-md border border-amber-300/70 bg-background/80 px-2.5 py-2 text-xs text-amber-950 dark:border-amber-500/40 dark:bg-background/40 dark:text-amber-100"
       >
-        <span>{blocker.identifier ?? blocker.id.slice(0, 8)}</span>
-        <span className="max-w-[18rem] truncate font-sans text-[11px] text-amber-800 dark:text-amber-200">
-          {blocker.title}
-        </span>
-        {recoveryAction ? <BlockerRecoveryIndicator action={recoveryAction} /> : null}
-      </IssueLinkQuicklook>
+        <div className="flex items-center justify-between gap-2">
+          <IssueLinkQuicklook
+            issuePathId={issuePathId}
+            to={detailPath}
+            className="inline-flex min-w-0 flex-1 items-center gap-1.5 truncate font-mono text-xs text-amber-950 transition-colors hover:underline dark:text-amber-100"
+          >
+            <span className="shrink-0">{blocker.identifier ?? blocker.id.slice(0, 8)}</span>
+            <span className="min-w-0 truncate font-sans text-[11px] text-amber-800 dark:text-amber-200">
+              {blocker.title}
+            </span>
+          </IssueLinkQuicklook>
+          {recoveryAction ? <BlockerRecoveryIndicator action={recoveryAction} /> : null}
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2 text-[11px] text-amber-900 dark:text-amber-100">
+            <span className="inline-flex items-center gap-1 rounded-full border border-amber-300/70 bg-amber-100/80 px-1.5 py-0.5 font-medium dark:border-amber-500/40 dark:bg-amber-500/15">
+              <StatusIcon status={blocker.status} />
+              <span>{issueStatusLabel(blocker.status)}</span>
+            </span>
+            <span className="inline-flex items-center gap-1">
+              <span className="text-amber-800/80 dark:text-amber-200/80">Assigned to</span>
+              {blocker.assigneeAgentId ? (
+                <Link
+                  to={`/agents/${blocker.assigneeAgentId}`}
+                  className="font-medium hover:underline"
+                >
+                  {assignee.label}
+                </Link>
+              ) : (
+                <span className="font-medium">{assignee.label}</span>
+              )}
+            </span>
+          </div>
+          <Link
+            to={pingPath}
+            data-testid="issue-blocked-notice-ping-button"
+            aria-label={`Ping ${assignee.label} on ${blocker.identifier ?? "the blocking issue"}`}
+            className="inline-flex shrink-0 items-center gap-1 rounded-md border border-amber-300/80 bg-background/90 px-2 py-1 text-[11px] font-medium text-amber-950 transition-colors hover:border-amber-500 hover:bg-amber-100 dark:border-amber-500/50 dark:bg-background/50 dark:text-amber-100 dark:hover:bg-amber-500/15"
+          >
+            <Bell className="h-3 w-3" aria-hidden />
+            <span>Ping</span>
+          </Link>
+        </div>
+      </div>
     );
   };
 

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -3157,6 +3157,22 @@ const IssueChatComposer = forwardRef<IssueChatComposerHandle, IssueChatComposerP
     setBody(loadDraft(draftKey));
   }, [draftKey]);
 
+  // HUM-126 Fix 2: when navigated to from a blocker chip's "Ping" button, the URL
+  // carries `?focus=composer`. Scroll to and focus the composer once on mount.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("focus") !== "composer") return;
+    focusComposer();
+    params.delete("focus");
+    const remaining = params.toString();
+    const cleaned = `${window.location.pathname}${remaining ? `?${remaining}` : ""}${window.location.hash}`;
+    window.history.replaceState(window.history.state, "", cleaned);
+    // Intentional one-shot on mount — re-running this on every change would yank
+    // the page back to the composer whenever the URL changes for unrelated reasons.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   useEffect(() => {
     if (!draftKey) return;
     if (draftTimer.current) clearTimeout(draftTimer.current);
@@ -4315,6 +4331,8 @@ export function IssueChatThread({
                         ? agentMap?.get(successfulRunHandoff.assigneeAgentId)?.name ?? null
                         : null
                     }
+                    agentMap={agentMap}
+                    currentUserId={currentUserId}
                   />
                   <IssueAssigneePausedNotice agent={assignedAgent} />
                 </div>

--- a/ui/src/components/IssueFiltersPopover.tsx
+++ b/ui/src/components/IssueFiltersPopover.tsx
@@ -348,6 +348,13 @@ export function IssueFiltersPopover({
                 <span className="text-xs text-muted-foreground">Visibility</span>
                 <label className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
                   <Checkbox
+                    checked={state.hideBlocked}
+                    onCheckedChange={(checked) => onChange({ hideBlocked: checked === true })}
+                  />
+                  <span className="text-sm">Hide blocked</span>
+                </label>
+                <label className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
+                  <Checkbox
                     checked={state.liveOnly}
                     onCheckedChange={(checked) => onChange({ liveOnly: checked === true })}
                   />

--- a/ui/src/lib/inbox.test.ts
+++ b/ui/src/lib/inbox.test.ts
@@ -910,6 +910,7 @@ describe("inbox helpers", () => {
           workspaces: [],
           liveOnly: false,
           hideRoutineExecutions: true,
+          hideBlocked: true,
         },
       }).map((issue) => issue.id),
     ).toEqual(["remote-match"]);
@@ -930,6 +931,7 @@ describe("inbox helpers", () => {
           workspaces: [],
           liveOnly: false,
           hideRoutineExecutions: true,
+          hideBlocked: true,
         },
       }),
     ).toEqual([]);
@@ -950,6 +952,7 @@ describe("inbox helpers", () => {
           workspaces: [],
           liveOnly: false,
           hideRoutineExecutions: true,
+          hideBlocked: true,
         },
       }),
     ).toEqual([]);
@@ -1022,6 +1025,7 @@ describe("inbox helpers", () => {
         workspaces: ["workspace-1"],
         liveOnly: true,
         hideRoutineExecutions: false,
+        hideBlocked: true,
       },
     });
     saveInboxFilterPreferences("company-2", {
@@ -1037,6 +1041,7 @@ describe("inbox helpers", () => {
         workspaces: [],
         liveOnly: false,
         hideRoutineExecutions: true,
+        hideBlocked: true,
       },
     });
 
@@ -1053,6 +1058,7 @@ describe("inbox helpers", () => {
         workspaces: ["workspace-1"],
         liveOnly: true,
         hideRoutineExecutions: false,
+        hideBlocked: true,
       },
     });
     expect(loadInboxFilterPreferences("company-2")).toEqual({
@@ -1068,6 +1074,7 @@ describe("inbox helpers", () => {
         workspaces: [],
         liveOnly: false,
         hideRoutineExecutions: true,
+        hideBlocked: true,
       },
     });
   });
@@ -1102,6 +1109,7 @@ describe("inbox helpers", () => {
         workspaces: ["workspace-1"],
         liveOnly: false,
         hideRoutineExecutions: false,
+        hideBlocked: true,
       },
     });
   });

--- a/ui/src/lib/issue-filters.test.ts
+++ b/ui/src/lib/issue-filters.test.ts
@@ -141,6 +141,41 @@ describe("issue filters", () => {
     )).toBe(false);
   });
 
+  it("hides blocked issues and issues with unresolved blockers when hideBlocked is on", () => {
+    const issues = [
+      makeIssue({ id: "todo-no-blockers", status: "todo" }),
+      makeIssue({ id: "blocked-status", status: "blocked" }),
+      makeIssue({
+        id: "todo-with-blockers",
+        status: "todo",
+        blockerAttention: {
+          state: "needs_attention",
+          reason: "active_dependency",
+          unresolvedBlockerCount: 2,
+          coveredBlockerCount: 0,
+          stalledBlockerCount: 0,
+          attentionBlockerCount: 2,
+          sampleBlockerIdentifier: "PAP-2",
+          sampleStalledBlockerIdentifier: null,
+        },
+      }),
+    ];
+
+    expect(applyIssueFilters(issues, { ...defaultIssueFilterState }).map((i) => i.id))
+      .toEqual(["todo-no-blockers"]);
+
+    expect(
+      applyIssueFilters(issues, { ...defaultIssueFilterState, hideBlocked: false }).map((i) => i.id),
+    ).toEqual(["todo-no-blockers", "blocked-status", "todo-with-blockers"]);
+  });
+
+  it("counts hideBlocked only when the user has turned the default off", () => {
+    expect(countActiveIssueFilters({ ...defaultIssueFilterState })).toBe(0);
+    expect(
+      countActiveIssueFilters({ ...defaultIssueFilterState, hideBlocked: false }),
+    ).toBe(1);
+  });
+
   it("keeps non-default project and isolated execution workspaces filterable", () => {
     const featureIssue = makeIssue({
       id: "feature-issue",

--- a/ui/src/lib/issue-filters.ts
+++ b/ui/src/lib/issue-filters.ts
@@ -20,6 +20,10 @@ export type IssueFilterState = {
   workspaces: string[];
   liveOnly?: boolean;
   hideRoutineExecutions: boolean;
+  // HUM-126 Fix 1: when true, hides issues that are blocked (`status === "blocked"`
+  // or have any unresolved upstream blockers). Defaults to true so a user opening
+  // the board for the first time isn't drowning in items they cannot act on.
+  hideBlocked: boolean;
 };
 
 export const defaultIssueFilterState: IssueFilterState = {
@@ -32,6 +36,7 @@ export const defaultIssueFilterState: IssueFilterState = {
   workspaces: [],
   liveOnly: false,
   hideRoutineExecutions: false,
+  hideBlocked: true,
 };
 
 export const issueStatusOrder = ["in_progress", "todo", "backlog", "in_review", "blocked", "done", "cancelled"];
@@ -73,6 +78,9 @@ export function normalizeIssueFilterState(value: unknown): IssueFilterState {
     workspaces: normalizeIssueFilterValueArray(candidate.workspaces),
     liveOnly: candidate.liveOnly === true,
     hideRoutineExecutions: candidate.hideRoutineExecutions === true,
+    // Default ON: missing-from-storage and any non-boolean value reads as `true` so
+    // users who haven't seen the new toggle inherit the new default.
+    hideBlocked: candidate.hideBlocked === false ? false : true,
   };
 }
 
@@ -166,6 +174,13 @@ export function applyIssueFilters(
       return workspaceId != null && state.workspaces.includes(workspaceId);
     });
   }
+  if (state.hideBlocked) {
+    result = result.filter((issue) => {
+      if (issue.status === "blocked") return false;
+      if ((issue.blockerAttention?.unresolvedBlockerCount ?? 0) > 0) return false;
+      return true;
+    });
+  }
   return result;
 }
 
@@ -183,5 +198,9 @@ export function countActiveIssueFilters(
   if (state.workspaces.length > 0) count += 1;
   if (state.liveOnly) count += 1;
   if (enableRoutineVisibilityFilter && state.hideRoutineExecutions) count += 1;
+  // Only count `hideBlocked` when the user has flipped OFF the default — that is
+  // the explicit choice that warrants showing a chip in the bar. Default-on stays
+  // implicit.
+  if (state.hideBlocked === false) count += 1;
   return count;
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Issues are the primary interface between humans and agents — humans drop a comment, agents wake up and work
> - The wake/work loop has a sharp edge when an issue is blocked: every comment on a gated issue triggers a wake for the assignee, the assignee runs against work it cannot make progress on, exits in ~5 seconds, the harness flags the short exit as "missing issue comment" and retries, looping
> - The user-visible side of this is just as bad: the board shows blocked items with no hint of who to ping to unblock them, and there's no way to hide them while you focus on what you *can* move
> - This pull request closes the loop and gives the user the information they need to act
> - The benefit is fewer wasted agent runs, less harness retry churn, and an inbox that surfaces work the user can actually progress

## What Changed

- **Stop waking the assignee on a `blocked` issue when the comment does not @-mention them and did not reopen the issue.** Mentioned-agent wakes (including for the assignee, if mentioned) and interaction-response wakes (`request_confirmation` / `ask_user_questions`) flow through separate code paths and still fire as before. Both comment entry points are covered: `POST /api/issues/:id/comments` and the comment-via-`PATCH /api/issues/:id` path. The skipped path emits a structured log (`wakeSkippedReason: "issue_blocked_no_mention"`) for observability.
- **Add a "Hide blocked" toggle to the issue filter popover, default ON.** Hides issues where `status === "blocked"` or `blockerAttention.unresolvedBlockerCount > 0`. State persists per-user through the existing localStorage flow. Counted as an active filter only when the user explicitly turns the default off.
- **Expand the blocked-issue banner to show, per blocker, a status pill, the assignee's display name (agent name resolved through the existing `agentMap`; user via `formatAssigneeUserLabel`), and a "Ping" button.** The button navigates to the blocking issue with `?focus=composer`, which a new one-shot effect in the chat composer picks up to scroll into view and focus the editor. The query param is then stripped from the URL so reloads don't yank the page back.
- Tests: extended `issue-filters.test.ts` and `IssueBlockedNotice.test.tsx` with coverage for the new behaviors; added two tests to `issue-update-comment-wakeup-routes.test.ts` for the skip and the mention-overrides-skip cases; **rewrote** two tests in `issue-comment-reopen-routes.test.ts` that previously asserted the now-removed wake — they enshrined the exact loop this PR closes. Updated `inbox.test.ts` literals to carry the new `hideBlocked` field.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm typecheck     # all workspaces green
pnpm build         # all workspaces green
pnpm -F @paperclipai/server exec vitest run "src/__tests__/issue"   # 34 files, 355 tests pass
pnpm -F @paperclipai/ui exec vitest run \
  src/lib/issue-filters.test.ts \
  src/components/IssueBlockedNotice.test.tsx \
  src/components/IssueFiltersPopover.test.tsx \
  src/lib/inbox.test.ts                                              # 69 tests pass
```

Manual smoke (board running on `127.0.0.1:3100`):

1. Open the board with a mix of `blocked` and `todo` issues. The board should default to hiding blocked items; the filter popover shows the new "Hide blocked" checkbox. Untick it — the blocked items return.
2. Open a blocked issue. The amber banner now lists each blocker as a card with a status pill ("In review", etc.), an "Assigned to <Name>" row, and a "Ping" button.
3. Click "Ping". You should land on the blocker's issue page with the composer scrolled into view and focused.
4. Post a generic comment on a blocked issue (no `@-mention`). The assignee should *not* get woken. Confirm via `agent_wakeup_requests` table or server logs (`wakeSkippedReason: "issue_blocked_no_mention"`).
5. Post a comment that `@-mentions` the assignee. The mention wake fires as normal.

## Risks

- **Behavioral change for boards that relied on every comment waking the assignee, even when the issue was still blocked.** This was the loop. Two tests in `issue-comment-reopen-routes.test.ts` that asserted the old behavior are rewritten to assert the new one. If a deployment depended on the old wake to surface comments to a blocked-issue assignee, the recommended migration is to `@-mention` the agent — that path still wakes them, and is also the path Zion's plain-language standard already encourages.
- **`hideBlocked: true` is the new persisted default.** Users with no prior view state get blocked items hidden on first load. Users with existing stored view state are upgraded the same way because the normalizer treats a missing/non-boolean `hideBlocked` as `true`. A user who actively wants the old behavior can flip the toggle once.
- **`?focus=composer` writes to `history.replaceState`.** One-shot on mount; cleans itself out of the URL. Should not interact with the router's own navigation tracking.
- Low risk on the shared type addition: `assigneeAgentName` and `assigneeUserName` are optional, all existing producers continue to compile.

## Model Used

- Anthropic Claude Opus 4.7 (1M context), reasoning on, tool use. Provider: Anthropic. Exact model ID: `claude-opus-4-7[1m]`.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — *deferred: this PR replaces the running local Paperclip daemon on the author's machine, screenshots will be attached in a follow-up comment once the daemon is restarted (see HUM-126 in the linked tracker)*
- [x] I have updated relevant documentation to reflect my changes — *no docs touched; behavior is described in code comments at the call sites and in this PR body*
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge