### PR TITLE
docs(systemd): add Linux service install guide + sample unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,9 @@ This starts the API server at `http://localhost:3100`. An embedded PostgreSQL da
 
 > **Requirements:** Node.js 20+, pnpm 9.15+
 
+To keep Paperclip running after you log out — start on boot, restart on
+crash — see [Running Paperclip as a systemd service](doc/SYSTEMD.md).
+
 <br/>
 
 ## FAQ

--- a/deploy/systemd/paperclip.service
+++ b/deploy/systemd/paperclip.service
@@ -1,0 +1,51 @@
+[Unit]
+# Sample systemd user unit for Paperclip.
+#
+# Install location:   ~/.config/systemd/user/paperclip.service
+# Enable lingering:   sudo loginctl enable-linger "$USER"
+# Reload + start:     systemctl --user daemon-reload && systemctl --user enable --now paperclip.service
+# Logs:               journalctl --user -u paperclip.service -f
+#
+# Before installing, set the two values flagged with TODO below.
+Description=Paperclip server (paperclipai run)
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=300
+StartLimitBurst=10
+
+[Service]
+Type=simple
+
+# TODO: Set this to the absolute path you run Paperclip from.
+#       For an npm install this is typically a directory that contains
+#       paperclip's working files; for a source checkout it is the repo root.
+WorkingDirectory=%h/paperclip
+
+Environment=NODE_ENV=production
+# Optional: pin a specific instance home. Defaults to %h/.paperclip when unset.
+# Environment=PAPERCLIP_HOME=%h/.paperclip
+
+# TODO: Pick one ExecStart line for your install method and remove the others.
+#
+# 1) npm-installed CLI (recommended for production)
+ExecStart=/usr/bin/env npx --yes paperclipai run
+#
+# 2) Source checkout — invoke the CLI through pnpm so tsx hooks load
+# ExecStart=/usr/bin/env pnpm paperclipai run
+#
+# 3) Source checkout — invoke tsx directly (no pnpm dependency at runtime)
+# ExecStart=/usr/bin/env node %h/paperclip/cli/node_modules/tsx/dist/cli.mjs %h/paperclip/cli/src/index.ts run
+
+Restart=always
+RestartSec=5
+TimeoutStopSec=30
+KillMode=mixed
+KillSignal=SIGTERM
+
+# Journal captures stdout/stderr by default. To mirror to a file instead, swap
+# the two lines below for `append:` targets and ensure the directory exists.
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -131,6 +131,12 @@ pnpm paperclipai run
 2. `paperclipai doctor` with repair enabled
 3. starts the server when checks pass
 
+## Run as a systemd service (Linux)
+
+To keep Paperclip alive across reboots and shell logouts, install the sample
+unit file at `deploy/systemd/paperclip.service`. See
+[`doc/SYSTEMD.md`](SYSTEMD.md) for the install + verify walkthrough.
+
 ## Docker Quickstart (No local Node install)
 
 Build and run Paperclip in Docker:

--- a/doc/SYSTEMD.md
+++ b/doc/SYSTEMD.md
@@ -1,0 +1,197 @@
+# Running Paperclip as a systemd service (Linux)
+
+This guide shows how to run a single Paperclip instance under `systemd` on a
+Linux host so it starts on boot, restarts on crash, and stays alive after the
+shell that started it exits.
+
+It complements the existing [Podman Quadlet guide](DOCKER.md#podman-quadlet-systemd)
+— use this guide when you do not want to run Paperclip inside a container.
+
+A ready-to-customize unit file ships at
+[`deploy/systemd/paperclip.service`](../deploy/systemd/paperclip.service). The
+steps below walk through installing it as a **user-level** unit, which keeps
+Paperclip's state, ports, and processes scoped to the same UNIX user that
+already owns `~/.paperclip`.
+
+> Tracks: [#467](https://github.com/paperclipai/paperclip/issues/467).
+
+## Why user units
+
+Paperclip's embedded PostgreSQL data directory, secrets, storage, and logs all
+live under `~/.paperclip` for the user that ran `paperclipai onboard`. A
+systemd **user** unit inherits that user's HOME, file permissions, and tailnet
+state without `sudo`, which avoids permission drift between interactive runs
+(`paperclipai run`) and supervised runs.
+
+If you need Paperclip to start before any user logs in — for example, on a
+headless server with multiple operators — enable lingering for the dedicated
+account (see step 2). The service will then come up at boot and survive
+disconnects.
+
+System-wide units (in `/etc/systemd/system/`) are also possible but are out of
+scope here because they require a dedicated runtime user, explicit `User=`,
+and careful handling of `XDG_RUNTIME_DIR`. Once the user-unit flow works for
+you, lifting it to a system unit is a small change.
+
+## Prerequisites
+
+- Linux with `systemd` (any reasonably modern distro)
+- Node.js 20+ and pnpm 9.15+ on `PATH` (matches the rest of the project)
+- Paperclip already initialized for the target user (`paperclipai onboard`
+  completed at least once, so `~/.paperclip/instances/<id>/config.json`
+  exists)
+- `paperclipai doctor` reports `All checks passed!` for the same user
+
+Confirm the manual run works first:
+
+```bash
+paperclipai run
+```
+
+Stop it with `Ctrl+C` once the server prints its listen URL. The service we
+install below performs the same boot sequence with no TTY.
+
+## 1. Drop the unit in place
+
+Copy the template into the user systemd directory:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp deploy/systemd/paperclip.service ~/.config/systemd/user/paperclip.service
+```
+
+If you do not have a Paperclip checkout handy, fetch the file directly:
+
+```bash
+curl -fsSL \
+  https://raw.githubusercontent.com/paperclipai/paperclip/master/deploy/systemd/paperclip.service \
+  -o ~/.config/systemd/user/paperclip.service
+```
+
+Open the unit and edit the two values flagged with `TODO`:
+
+- `WorkingDirectory=` — absolute path Paperclip should run from. For an
+  `npx paperclipai` install this is typically `%h/paperclip` (i.e.
+  `~/paperclip`); for a source checkout it is the repo root.
+- The `ExecStart=` line — uncomment one of the three options and delete the
+  others depending on how Paperclip is installed on this host:
+
+  | Install style | Recommended `ExecStart` |
+  | ------------- | ----------------------- |
+  | `npm install -g paperclipai` or `npx` | `/usr/bin/env npx --yes paperclipai run` |
+  | Source checkout, pnpm available at runtime | `/usr/bin/env pnpm paperclipai run` |
+  | Source checkout, no pnpm at runtime | `/usr/bin/env node %h/paperclip/cli/node_modules/tsx/dist/cli.mjs %h/paperclip/cli/src/index.ts run` |
+
+The third form is useful when the service runs under a restricted PATH and
+you want to avoid resolving the `pnpm` shim per restart.
+
+## 2. Enable lingering (optional but recommended)
+
+By default, user units shut down when the user logs out. For a long-running
+server you almost always want the unit to start at boot and survive logouts:
+
+```bash
+sudo loginctl enable-linger "$USER"
+```
+
+Verify with `loginctl show-user "$USER" | grep Linger` — you should see
+`Linger=yes`.
+
+## 3. Enable and start
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now paperclip.service
+```
+
+Check status:
+
+```bash
+systemctl --user status paperclip.service
+```
+
+You should see `Active: active (running)` once the embedded PostgreSQL cluster
+is ready (a few seconds on cold start).
+
+## 4. Verify
+
+Tail the logs while the service finishes its first boot:
+
+```bash
+journalctl --user -u paperclip.service -f
+```
+
+You should see Paperclip's startup banner, the embedded PostgreSQL ready line,
+and the `Server listening on …` line.
+
+Hit the health endpoint from the same host:
+
+```bash
+curl -sf http://127.0.0.1:3100/api/health
+```
+
+If you configured Paperclip to bind to a tailnet IP, substitute that IP and
+port.
+
+## Common operations
+
+| Action | Command |
+| ------ | ------- |
+| Restart the service | `systemctl --user restart paperclip.service` |
+| Stop the service | `systemctl --user stop paperclip.service` |
+| Disable autostart | `systemctl --user disable paperclip.service` |
+| View recent logs | `journalctl --user -u paperclip.service -n 200 --no-pager` |
+| Follow logs | `journalctl --user -u paperclip.service -f` |
+| Show effective unit | `systemctl --user cat paperclip.service` |
+| Show resource usage | `systemctl --user status paperclip.service` |
+
+## Updating Paperclip
+
+For `npx`-based installs, run `npx --yes paperclipai@latest run` once manually
+to populate the cache, then `systemctl --user restart paperclip.service`.
+
+For source checkouts:
+
+```bash
+cd ~/paperclip
+git pull
+pnpm install
+pnpm build
+systemctl --user restart paperclip.service
+```
+
+If a release changes the database schema, run `pnpm db:migrate` before
+restarting.
+
+## Troubleshooting
+
+- **`Failed with result 'exit-code'` immediately on start** — run the same
+  command from `ExecStart=` in your shell. The most common causes are a
+  missing `WorkingDirectory`, a `node` binary not on the systemd `PATH`, or
+  `paperclipai doctor` failing because `~/.paperclip` was created by a
+  different user.
+- **`Cannot find module '.../server/src/app.js'`** — Paperclip's CLI loads
+  the server through `tsx`. If you start the service with `node …/cli/dist/…`
+  the loader hook is not registered. Use the `pnpm paperclipai run` or
+  explicit `tsx` `ExecStart=` lines from the template instead.
+- **`Start request repeated too quickly`** — `StartLimitBurst` tripped after
+  ten failed restarts in five minutes. Fix the underlying error, then run
+  `systemctl --user reset-failed paperclip.service` before starting again.
+- **Service runs but the port is unreachable from other hosts** — check the
+  `server.bind` and `server.host` values in
+  `~/.paperclip/instances/<id>/config.json`. Binding to `tailnet` requires
+  `tailscaled` to already be up at start; if it is not, the unit will still
+  start but the listener will only appear once the interface is available.
+- **Disk-related crash loops (`ENOSPC`)** — Paperclip's adapters copy runtime
+  configuration into `/tmp` between heartbeats. If `/tmp` fills up the
+  service will restart but every run will fail the same way. Clean stale
+  paths under `/tmp` (or mount more space) and the loop clears itself.
+
+## Related
+
+- [`deploy/systemd/paperclip.service`](../deploy/systemd/paperclip.service)
+  — the sample unit file.
+- [Podman Quadlet (systemd)](DOCKER.md#podman-quadlet-systemd) — the
+  container-based alternative.
+- [DEVELOPING.md](DEVELOPING.md) — local development, worktree management,
+  CLI reference.


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Production deployments need the server process to start on boot and stay alive after the operator's shell exits
> - The repository already provides a Podman Quadlet path (`docker/quadlet/`) but no documented way to run the plain Node process under systemd
> - Issue [#467](https://github.com/paperclipai/paperclip/issues/467) (open since March) asks for exactly that, and the docs-only PR [#555](https://github.com/paperclipai/paperclip/pull/555) has been stalled since then
> - The capability already exists — `paperclipai run` is a long-running foreground process and systemd can supervise it — but operators are reinventing the wheel each time and hitting the same pitfalls (no-TTY tsx loader, ENOSPC, lingering)
> - This pull request adds a sample unit file and an install guide so the existing capability becomes a documented, copy-pasteable path
> - The benefit is one less surprise for new self-hosters and a clean answer to the most-requested deployment question in the issue tracker, with no behavior change to the runtime

## What Changed

- New `deploy/systemd/paperclip.service` template covering the three common install styles (`npx`, source checkout via `pnpm`, source checkout via direct `tsx`) with inline `TODO` markers for the two values an operator must edit.
- New `doc/SYSTEMD.md` walkthrough: install, enable lingering, start, verify, common ops, updating, and a troubleshooting section for the failure modes that bit me on first install (no-TTY `tsx` loader, `Start request repeated too quickly`, `ENOSPC` crash loops, tailnet bind ordering).
- `README.md`: one-line link from the install snippet so first-time self-hosters discover the systemd path without having to search.
- `doc/DEVELOPING.md`: one-paragraph cross-link next to the Docker Quickstart / Quadlet sections.

No code, no manifest, no lockfile, no Dockerfile changes — strictly docs + a sample unit.

## Verification

Both pieces were validated on the host that motivated this change (Ubuntu 24, source checkout, tailnet bind, embedded Postgres):

1. Drop the unit into `~/.config/systemd/user/paperclip.service`, fill in the two `TODO` values.
2. `sudo loginctl enable-linger "$USER"` then `systemctl --user daemon-reload && systemctl --user enable --now paperclip.service`.
3. `systemctl --user status paperclip.service` → `Active: active (running)` within ~10 s.
4. `journalctl --user -u paperclip.service -f` shows the Paperclip banner, embedded PostgreSQL ready line, and Better Auth init.
5. `curl -sf http://<bind-ip>:3100/api/health` → `{"status":"ok",...}`.

Sanity-checked the doc against the failure paths in the troubleshooting section by reproducing them on the same host before writing them up.

## Risks

Low. Pure docs and a sample file under a new `deploy/systemd/` path. No existing files are removed, no runtime, build, or CI behavior changes. The README/DEVELOPING edits are additive paragraphs. Worst case for a reader is that they follow the guide on an unsupported distro and the service does not start — at which point they are no worse off than before this PR existed.

## Model Used

Claude Opus 4.7 (1M context window, extended thinking enabled, tool use including Bash/Read/Edit/Write/Grep). Human-reviewed, edited, and verified on the target host.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work (docs-only path; no roadmap item covers it)
- [x] I have run tests locally and they pass (no test-impacting changes; CI policy job covers lockfile/Dockerfile invariants)
- [x] I have added or updated tests where applicable (n/a — docs only)
- [x] If this change affects the UI, I have included before/after screenshots (n/a)
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes #467. Supersedes #555 (docs-only) by also shipping the sample unit file.
