### PR TITLE
fix(heartbeat): inherit execution workspace on scheduled_retry

### DIFF
--- a/server/src/__tests__/heartbeat-retry-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-retry-scheduling.test.ts
@@ -9,10 +9,12 @@ import {
   companies,
   createDb,
   environmentLeases,
+  executionWorkspaces,
   heartbeatRunEvents,
   heartbeatRuns,
   issueRelations,
   issues,
+  projects,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -50,6 +52,8 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
     await db.delete(environmentLeases);
     await db.delete(issueRelations);
     await db.delete(issues);
+    await db.delete(executionWorkspaces);
+    await db.delete(projects);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
     await db.delete(agentRuntimeState);
@@ -309,6 +313,136 @@ describeEmbeddedPostgres("heartbeat bounded retry scheduling", () => {
       .where(eq(heartbeatRuns.id, scheduled.run.id))
       .then((rows) => rows[0] ?? null);
     expect(promotedRun?.status).toBe("queued");
+  });
+
+  it("copies execution workspace fields from the issue into scheduled retry context", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const sourceRunId = randomUUID();
+    const issueId = randomUUID();
+    const projectId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const now = new Date("2026-05-25T18:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "TWS",
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ClaudeCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Atendevet",
+      status: "in_progress",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      mode: "shared_workspace",
+      strategyType: "project_primary",
+      name: "ATE-test",
+      status: "active",
+      cwd: "C:\\Users\\lucas\\source\\repos\\Atendevet",
+      providerType: "local_fs",
+      lastUsedAt: now,
+      openedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      projectId,
+      title: "Retry workspace inheritance",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      issueNumber: 1,
+      identifier: "TWS-1",
+      executionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      assigneeAdapterOverrides: { useProjectWorkspace: true },
+      startedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: sourceRunId,
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "failed",
+      error: "upstream overload",
+      errorCode: "adapter_failed",
+      finishedAt: now,
+      contextSnapshot: {
+        issueId,
+        wakeReason: "issue_assigned",
+      },
+      updatedAt: now,
+      createdAt: now,
+    });
+
+    const scheduled = await heartbeat.scheduleBoundedRetry(sourceRunId, {
+      now,
+      random: () => 0.5,
+    });
+
+    expect(scheduled.outcome).toBe("scheduled");
+    if (scheduled.outcome !== "scheduled") return;
+
+    const retryRun = await db
+      .select({
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+        wakeupRequestId: heartbeatRuns.wakeupRequestId,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, scheduled.run.id))
+      .then((rows) => rows[0] ?? null);
+
+    expect(retryRun?.contextSnapshot).toMatchObject({
+      issueId,
+      executionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      retryOfRunId: sourceRunId,
+    });
+
+    const wakeup = await db
+      .select({ payload: agentWakeupRequests.payload })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.id, retryRun?.wakeupRequestId ?? ""))
+      .then((rows) => rows[0] ?? null);
+
+    expect(wakeup?.payload).toMatchObject({
+      issueId,
+      executionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+    });
   });
 
   it("schedules max-turn continuations with distinct retry metadata", async () => {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -16,6 +16,7 @@ import {
   resolveRuntimeSessionParamsForWorkspace,
   stripWorkspaceRuntimeFromExecutionRunConfig,
   shouldResetTaskSessionForWake,
+  shouldReuseIssueExecutionWorkspace,
   type ResolvedWorkspaceForRun,
 } from "../services/heartbeat.ts";
 
@@ -208,6 +209,48 @@ describe("mergeExecutionWorkspaceMetadataForPersistence", () => {
       source: "task_session",
       createdByRuntime: false,
     });
+  });
+});
+
+describe("shouldReuseIssueExecutionWorkspace", () => {
+  it("reuses when issue preference is reuse_existing", () => {
+    expect(
+      shouldReuseIssueExecutionWorkspace({
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceId: "ws-1",
+        existingExecutionWorkspace: { status: "active" },
+      }),
+    ).toBe(true);
+  });
+
+  it("reuses when issue has bound executionWorkspaceId even without reuse_existing preference", () => {
+    expect(
+      shouldReuseIssueExecutionWorkspace({
+        executionWorkspacePreference: null,
+        executionWorkspaceId: "ws-ate-294",
+        existingExecutionWorkspace: { status: "active" },
+      }),
+    ).toBe(true);
+  });
+
+  it("does not reuse archived execution workspaces", () => {
+    expect(
+      shouldReuseIssueExecutionWorkspace({
+        executionWorkspacePreference: "reuse_existing",
+        executionWorkspaceId: "ws-1",
+        existingExecutionWorkspace: { status: "archived" },
+      }),
+    ).toBe(false);
+  });
+
+  it("does not reuse when no workspace is bound", () => {
+    expect(
+      shouldReuseIssueExecutionWorkspace({
+        executionWorkspacePreference: null,
+        executionWorkspaceId: null,
+        existingExecutionWorkspace: null,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -614,6 +614,19 @@ export function stripWorkspaceRuntimeFromExecutionRunConfig(config: Record<strin
   return nextConfig;
 }
 
+export function shouldReuseIssueExecutionWorkspace(input: {
+  executionWorkspacePreference?: string | null;
+  executionWorkspaceId?: string | null;
+  existingExecutionWorkspace?: { status: string } | null;
+}): boolean {
+  return (
+    input.existingExecutionWorkspace !== null &&
+    input.existingExecutionWorkspace !== undefined &&
+    input.existingExecutionWorkspace.status !== "archived" &&
+    (input.executionWorkspacePreference === "reuse_existing" || Boolean(input.executionWorkspaceId))
+  );
+}
+
 export function buildRealizedExecutionWorkspaceFromPersisted(input: {
   base: ExecutionWorkspaceInput;
   workspace: ExecutionWorkspace;
@@ -2500,6 +2513,40 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       .then((rows) => rows[0] ?? null);
   }
 
+  function mergeIssueWorkspaceContextSnapshot(
+    contextSnapshot: Record<string, unknown>,
+    issue: Awaited<ReturnType<typeof getIssueExecutionContext>> | null,
+  ): Record<string, unknown> {
+    if (!issue) return contextSnapshot;
+    const next: Record<string, unknown> = { ...contextSnapshot };
+    if (issue.projectId) next.projectId = issue.projectId;
+    if (issue.projectWorkspaceId) next.projectWorkspaceId = issue.projectWorkspaceId;
+    if (issue.executionWorkspaceId) next.executionWorkspaceId = issue.executionWorkspaceId;
+    if (issue.executionWorkspacePreference) {
+      next.executionWorkspacePreference = issue.executionWorkspacePreference;
+    }
+    return next;
+  }
+
+  function applyContextExecutionWorkspaceFallbackToIssueContext(
+    issueContext: Awaited<ReturnType<typeof getIssueExecutionContext>> | null,
+    context: Record<string, unknown>,
+  ): Awaited<ReturnType<typeof getIssueExecutionContext>> | null {
+    if (!issueContext) return issueContext;
+    if (issueContext.executionWorkspaceId) return issueContext;
+    const executionWorkspaceId = readNonEmptyString(context.executionWorkspaceId);
+    if (!executionWorkspaceId) return issueContext;
+    const contextPreference = context.executionWorkspacePreference;
+    const executionWorkspacePreference =
+      issueContext.executionWorkspacePreference ??
+      (typeof contextPreference === "string" ? contextPreference : null);
+    return {
+      ...issueContext,
+      executionWorkspaceId,
+      executionWorkspacePreference,
+    };
+  }
+
   async function getRoutineEnvForExecutionIssue(
     companyId: string,
     issueContext: Awaited<ReturnType<typeof getIssueExecutionContext>> | null,
@@ -3540,6 +3587,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           .select({
             projectId: issues.projectId,
             projectWorkspaceId: issues.projectWorkspaceId,
+            executionWorkspaceId: issues.executionWorkspaceId,
           })
           .from(issues)
           .where(and(eq(issues.id, issueId), eq(issues.companyId, agent.companyId)))
@@ -3551,6 +3599,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const resolvedProjectId = issueProjectId ?? contextProjectId;
     const useProjectWorkspace = opts?.useProjectWorkspace !== false;
     const workspaceProjectId = useProjectWorkspace ? resolvedProjectId : null;
+    const boundExecutionWorkspaceId =
+      issueProjectRef?.executionWorkspaceId ?? readNonEmptyString(context.executionWorkspaceId);
 
     const unorderedProjectWorkspaceRows = workspaceProjectId
       ? await db
@@ -3575,6 +3625,36 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       repoUrl: readNonEmptyString(workspace.repoUrl),
       repoRef: readNonEmptyString(workspace.repoRef),
     }));
+
+    if (boundExecutionWorkspaceId && useProjectWorkspace) {
+      const boundExecutionWorkspace = await executionWorkspacesSvc.getById(boundExecutionWorkspaceId);
+      const boundCwd = boundExecutionWorkspace
+        ? readNonEmptyString(boundExecutionWorkspace.cwd) ??
+          readNonEmptyString(boundExecutionWorkspace.providerRef)
+        : null;
+      if (
+        boundExecutionWorkspace &&
+        boundExecutionWorkspace.status !== "archived" &&
+        boundCwd
+      ) {
+        const boundCwdExists = await fs
+          .stat(boundCwd)
+          .then((stats) => stats.isDirectory())
+          .catch(() => false);
+        if (boundCwdExists) {
+          return {
+            cwd: boundCwd,
+            source: "project_primary" as const,
+            projectId: boundExecutionWorkspace.projectId ?? resolvedProjectId,
+            workspaceId: boundExecutionWorkspace.projectWorkspaceId ?? preferredProjectWorkspaceId,
+            repoUrl: boundExecutionWorkspace.repoUrl,
+            repoRef: boundExecutionWorkspace.baseRef,
+            workspaceHints,
+            warnings: [],
+          };
+        }
+      }
+    }
 
     if (projectWorkspaceRows.length > 0) {
       const preferredWorkspace = preferredProjectWorkspaceId
@@ -5287,6 +5367,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
     const contextSnapshot = parseObject(run.contextSnapshot);
     const issueId = readNonEmptyString(contextSnapshot.issueId);
+    const issueWorkspaceRow = issueId ? await getIssueExecutionContext(run.companyId, issueId) : null;
+    const retryIssueContextSnapshot = mergeIssueWorkspaceContextSnapshot(contextSnapshot, issueWorkspaceRow);
     if (retryReason === MAX_TURN_CONTINUATION_RETRY_REASON) {
       const gate = await evaluateScheduledRetryGate({ run, agent, contextSnapshot, retryReason });
       if (!gate.allowed) {
@@ -5313,7 +5395,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
     const retryContextSnapshot: Record<string, unknown> = withRecoveryModelProfileHint({
-      ...contextSnapshot,
+      ...retryIssueContextSnapshot,
       retryOfRunId: run.id,
       wakeReason,
       retryReason,
@@ -5485,6 +5567,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           reason: wakeReason,
           payload: withRecoveryModelProfileHint({
             ...(issueId ? { issueId } : {}),
+            ...(issueWorkspaceRow?.projectId ? { projectId: issueWorkspaceRow.projectId } : {}),
+            ...(issueWorkspaceRow?.projectWorkspaceId
+              ? { projectWorkspaceId: issueWorkspaceRow.projectWorkspaceId }
+              : {}),
+            ...(issueWorkspaceRow?.executionWorkspaceId
+              ? { executionWorkspaceId: issueWorkspaceRow.executionWorkspaceId }
+              : {}),
+            ...(issueWorkspaceRow?.executionWorkspacePreference
+              ? { executionWorkspacePreference: issueWorkspaceRow.executionWorkspacePreference }
+              : {}),
             retryOfRunId: run.id,
             retryReason,
             ...(transientRecovery ? { errorFamily: transientRecovery.errorFamily } : {}),
@@ -6916,6 +7008,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const sessionCodec = getAdapterSessionCodec(agent.adapterType);
     const issueId = readNonEmptyString(context.issueId);
     let issueContext = issueId ? await getIssueExecutionContext(agent.companyId, issueId) : null;
+    issueContext = applyContextExecutionWorkspaceFallbackToIssueContext(issueContext, context);
     const issueDependencyReadiness = issueId
       ? await issuesSvc.listDependencyReadiness(agent.companyId, [issueId]).then((rows) => rows.get(issueId) ?? null)
       : null;
@@ -7106,10 +7199,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     }
     const existingExecutionWorkspace =
       issueRef?.executionWorkspaceId ? await executionWorkspacesSvc.getById(issueRef.executionWorkspaceId) : null;
-    const shouldReuseExisting =
-      issueRef?.executionWorkspacePreference === "reuse_existing" &&
-      existingExecutionWorkspace !== null &&
-      existingExecutionWorkspace.status !== "archived";
+    const shouldReuseExisting = shouldReuseIssueExecutionWorkspace({
+      executionWorkspacePreference: issueRef?.executionWorkspacePreference,
+      executionWorkspaceId: issueRef?.executionWorkspaceId,
+      existingExecutionWorkspace,
+    });
     const reusableExecutionWorkspaceConfig = shouldReuseExisting
       ? existingExecutionWorkspace?.config ?? null
       : null;


### PR DESCRIPTION
## Summary

When scheduling `transient_failure` retries, copy `executionWorkspaceId`, `executionWorkspacePreference`, `projectId`, and `projectWorkspaceId` from the issue into `context_snapshot` so retries use `project_primary` instead of `agent_home`.

## Context

- Atendevet/Paperclip issue: scheduled_retry was losing execution workspace context
- Adds unit tests in `heartbeat-retry-scheduling.test.ts` and `heartbeat-workspace-session.test.ts`

## Test plan

- [x] Unit tests for scheduled retry workspace inheritance
- [ ] CI on upstream repo