### PR TITLE
Replace phantom gpt-5.3-codex-spark with gpt-5-mini in codex_local cheap profile (IGG-369)

### DIFF
--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -35,7 +35,6 @@ export function isCodexLocalFastModeSupported(model: string | null | undefined):
 export const models = [
   { id: "gpt-5.4", label: "gpt-5.4" },
   { id: DEFAULT_CODEX_LOCAL_MODEL, label: DEFAULT_CODEX_LOCAL_MODEL },
-  { id: "gpt-5.3-codex-spark", label: "gpt-5.3-codex-spark" },
   { id: "gpt-5", label: "gpt-5" },
   { id: "o3", label: "o3" },
   { id: "o4-mini", label: "o4-mini" },
@@ -51,8 +50,7 @@ export const modelProfiles: AdapterModelProfileDefinition[] = [
     label: "Cheap",
     description: "Use the lowest-cost known Codex local model lane without changing the primary model.",
     adapterConfig: {
-      model: "gpt-5.3-codex-spark",
-      // Spark is the cheap lane by model price; high effort keeps Codex coding behavior usable for delegated work.
+      model: "gpt-5-mini",
       modelReasoningEffort: "high",
     },
     source: "adapter_default",

--- a/server/src/__tests__/adapter-registry.test.ts
+++ b/server/src/__tests__/adapter-registry.test.ts
@@ -205,7 +205,7 @@ describe("server adapter registry", () => {
     await expect(listAdapterModelProfiles("codex_local")).resolves.toEqual([
       expect.objectContaining({
         key: "cheap",
-        adapterConfig: expect.objectContaining({ model: "gpt-5.3-codex-spark" }),
+        adapterConfig: expect.objectContaining({ model: "gpt-5-mini" }),
         source: "adapter_default",
       }),
     ]);
@@ -231,6 +231,17 @@ describe("server adapter registry", () => {
       }),
     ]);
     await expect(listAdapterModelProfiles("pi_local")).resolves.toEqual([]);
+  });
+
+  it("does not advertise the phantom gpt-5.3-codex-spark model in codex_local (IGG-369)", async () => {
+    const models = await listAdapterModels("codex_local");
+    const ids = models.map((entry) => entry.id);
+    expect(ids).not.toContain("gpt-5.3-codex-spark");
+
+    const profiles = await listAdapterModelProfiles("codex_local");
+    const cheap = profiles.find((profile) => profile.key === "cheap");
+    expect(cheap?.adapterConfig.model).not.toBe("gpt-5.3-codex-spark");
+    expect(ids).toContain(cheap?.adapterConfig.model);
   });
 
   it("wraps built-in npm runtime installs with the sandbox-aware install helper", () => {

--- a/server/src/__tests__/heartbeat-model-profile.test.ts
+++ b/server/src/__tests__/heartbeat-model-profile.test.ts
@@ -35,7 +35,7 @@ describe("heartbeat model profile application", () => {
       configSource: "adapter_default",
       fallbackReason: null,
       adapterConfig: {
-        model: "gpt-5.3-codex-spark",
+        model: "gpt-5-mini",
         modelReasoningEffort: "high",
       },
     });


### PR DESCRIPTION
## Summary

- `codex_local` cheap profile previously requested `gpt-5.3-codex-spark`, which OpenAI rejects with `model does not exist` for standard API accounts. Every recovery-flow wake (`RECOVERY_MODEL_PROFILE_KEY = "cheap"`) on a `codex_local` agent failed with `adapter_failed` and stranded the assignment — observed today on IGG-358 across Mechanic-Codex, Mechanic-Agents-Codex, Технарь-B2B-Codex, Designer-Codex.
- Switched the cheap profile to `gpt-5-mini` (already in the registered picker catalog and serves on the company-default key per the issue author's verification) and removed the phantom `gpt-5.3-codex-spark` id from `models[]` so the picker stops advertising it.
- Updated the two existing assertions that pinned the broken model (`adapter-registry.test.ts`, `heartbeat-model-profile.test.ts`) and added a regression test that asserts `gpt-5.3-codex-spark` is not in the catalog and the cheap-profile model is a registered id.

## Fix option

Option A from IGG-369 (preferred): replace with a real model + drop the phantom id from the picker.

## Test plan

- [x] `vitest run server/src/__tests__/adapter-registry.test.ts server/src/__tests__/heartbeat-model-profile.test.ts` — 24 tests pass
- [ ] Recovery wake on a live `codex_local` agent against the company OpenAI key succeeds end-to-end (acceptance smoke from IGG-369 — verify `latestRunErrorCode` is not `adapter_failed` for model-not-found)
- [ ] No regression in normal heartbeat runs for `codex_local` agents

## References

- Paperclip issue: IGG-369
- Parent diagnosis: IGG-358