### PR TITLE
Fix silence-detector run-storm: coalesce + backoff + auto-cancel + override

### DIFF
--- a/doc/silence-detector-smoke.md
+++ b/doc/silence-detector-smoke.md
@@ -1,0 +1,158 @@
+# Silence-detector run-storm fix — manual smoke playbook
+
+This playbook walks QA through verifying the silence-detector fix in a live
+instance. The four properties under test:
+
+1. **Coalesce** — one open review issue per silent run.
+2. **24h closed window + backoff** — closing a review false-positive does not
+   trigger a new review during the backoff cool-down, and the multiplier grows
+   on repeat closes.
+3. **Auto-cancel at critical + dead pid** — the run is cancelled (not escalated)
+   when the process is already gone and silence age is past 4h.
+4. **Operator override** — a board comment "cancel this run" on a review issue
+   reliably terminates the run and cancels sibling reviews.
+
+> All steps reference a single test agent (`Coder`) in a fresh company. Replace
+> placeholders (`<RUN_ID>`, `<COMPANY_PREFIX>`, `<PID>`) with the values shown
+> in your instance.
+
+## Prereqs
+
+- Local Paperclip server running on `:3100`.
+- `psql` configured against the same database (or use the in-app activity-log
+  viewer instead).
+- An agent named `Coder` with adapter `codex_local` (any local adapter that
+  exits silently is fine for the simulation).
+
+## 1. Bootstrap a silent run
+
+1. Pick or create an issue assigned to `Coder` (the **source issue**).
+2. Trigger a heartbeat for that issue.
+3. As soon as the run starts, before any output is produced, kill the
+   underlying process by hand:
+
+   ```bash
+   ps aux | grep <agent-binary>
+   kill -9 <PID>
+   ```
+
+4. **Do not** clean up the in-memory `runningProcesses` entry — the test is
+   that the silence detector will notice the missing handle on its own.
+
+## 2. Verify coalesce — one review issue per run
+
+1. Wait until silence age > 1h. (For impatience, you can fast-forward by
+   tampering with `heartbeatRuns.processStartedAt` directly in psql — set it
+   to `now() - interval '70 minutes'`.)
+2. Trigger `scanSilentActiveRuns` either by waiting for the recovery timer
+   tick or by invoking it manually via the dev console.
+3. Confirm that **exactly one** issue is created with
+   `originKind = 'stale_active_run_evaluation'` for the silent run id:
+
+   ```sql
+   SELECT identifier, status, priority, created_at
+   FROM issues
+   WHERE origin_kind = 'stale_active_run_evaluation'
+     AND origin_id = '<RUN_ID>';
+   ```
+
+4. Trigger the scan again immediately. The previous issue should still be the
+   only one. Activity log should show `heartbeat.output_stale_detected` once
+   and no additional row.
+
+## 3. Verify 24h closed window + backoff
+
+1. Close the review issue from §2 as `done` with comment "False positive".
+2. Trigger another scan immediately. Verify in the activity log:
+
+   ```sql
+   SELECT action, created_at, details
+   FROM activity_log
+   WHERE run_id = '<RUN_ID>'
+     AND action = 'heartbeat.output_stale_dedup_suppressed'
+   ORDER BY created_at DESC LIMIT 5;
+   ```
+
+   You should see exactly one suppressed entry.
+
+3. Inspect the silence-state row — multiplier should be 2 after one
+   false-positive close:
+
+   ```sql
+   SELECT consecutive_false_positives, backoff_multiplier,
+          last_closed_at, next_eligible_scan_at
+   FROM heartbeat_run_silence_state
+   WHERE run_id = '<RUN_ID>';
+   ```
+
+4. Fast-forward the system clock past `next_eligible_scan_at`. Run another
+   scan. A **new** review issue should be created (the backoff cool-down has
+   elapsed). Close that one false-positive too. Repeat one more time. After
+   three close cycles, `backoff_multiplier` should be 8, capped by the
+   schema-defined ceiling.
+5. Snooze the run via the watchdog UI (or `POST /api/heartbeat-runs/:id/snooze`).
+   Verify the silence-state row resets: `backoff_multiplier = 1`,
+   `consecutive_false_positives = 0`, `next_eligible_scan_at = NULL`.
+
+## 4. Verify auto-cancel at critical + dead pid
+
+1. Re-prepare a silent run with the underlying process already killed.
+2. Advance `processStartedAt` so that `silence_age_ms >= 4h` (the critical
+   threshold).
+3. Ensure no in-memory handle exists for the run (the server restart from
+   §1 already did this; otherwise inspect `runningProcesses` via the dev
+   diagnostics endpoint).
+4. Trigger one scan. Expected outcome — **no new review issue**, run status
+   transitions to `cancelled` with `errorCode = 'silence_auto_cancel'`, and
+   activity log shows `heartbeat.output_stale_auto_cancelled`:
+
+   ```sql
+   SELECT status, error_code, finished_at
+   FROM heartbeat_runs WHERE id = '<RUN_ID>';
+   SELECT action, details
+   FROM activity_log
+   WHERE run_id = '<RUN_ID>' AND action = 'heartbeat.output_stale_auto_cancelled';
+   ```
+
+5. Confirm the source issue's execution lock was released:
+
+   ```sql
+   SELECT execution_run_id, execution_locked_at FROM issues WHERE id = '<SOURCE_ISSUE_ID>';
+   ```
+
+   Both columns must be `NULL`.
+
+## 5. Verify operator override
+
+1. Reproduce a silent run as in §1. Allow the silence detector to create one
+   review issue (§2).
+2. Comment on that review issue as a board user — body must match the
+   grammar `/(cancel|kill|abort)\s+(this\s+)?run/i`. Example:
+   `Please **cancel this run** immediately.`
+3. Within a second or two of posting, expect:
+   - `heartbeat_runs.status = 'cancelled'`, `error_code = 'operator_override'`
+   - Source issue execution lock cleared.
+   - A confirmation comment posted by the system on the review issue,
+     starting with `## Operator override accepted`.
+   - `heartbeat.output_stale_operator_override` row in the activity log.
+4. Negative case: post the same comment as an `agent` actor (not board).
+   The run should NOT be cancelled and no confirmation comment should be
+   posted.
+
+## Rollback
+
+The schema migration `0091_heartbeat_run_silence_state` is additive and
+reversible:
+
+```sql
+DROP TABLE IF EXISTS heartbeat_run_silence_state;
+```
+
+If you need to revert behavior in production, restore the prior version of
+`server/src/services/recovery/service.ts` and the surrounding wiring.
+Existing review issues are unaffected.
+
+## Reporting issues
+
+Attach the activity-log slice for the affected `run_id` plus the
+`heartbeat_run_silence_state` row contents when reporting any regression.

--- a/packages/db/src/migrations/0091_heartbeat_run_silence_state.sql
+++ b/packages/db/src/migrations/0091_heartbeat_run_silence_state.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS "heartbeat_run_silence_state" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"run_id" uuid NOT NULL,
+	"consecutive_false_positives" integer DEFAULT 0 NOT NULL,
+	"backoff_multiplier" integer DEFAULT 1 NOT NULL,
+	"last_evaluation_issue_id" uuid,
+	"last_closed_at" timestamp with time zone,
+	"next_eligible_scan_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'heartbeat_run_silence_state_company_id_companies_id_fk') THEN
+		ALTER TABLE "heartbeat_run_silence_state" ADD CONSTRAINT "heartbeat_run_silence_state_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'heartbeat_run_silence_state_run_id_heartbeat_runs_id_fk') THEN
+		ALTER TABLE "heartbeat_run_silence_state" ADD CONSTRAINT "heartbeat_run_silence_state_run_id_heartbeat_runs_id_fk" FOREIGN KEY ("run_id") REFERENCES "public"."heartbeat_runs"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'heartbeat_run_silence_state_last_evaluation_issue_id_issues_id_fk') THEN
+		ALTER TABLE "heartbeat_run_silence_state" ADD CONSTRAINT "heartbeat_run_silence_state_last_evaluation_issue_id_issues_id_fk" FOREIGN KEY ("last_evaluation_issue_id") REFERENCES "public"."issues"("id") ON DELETE set null ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "heartbeat_run_silence_state_company_run_uq" ON "heartbeat_run_silence_state" USING btree ("company_id","run_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "heartbeat_run_silence_state_next_eligible_idx" ON "heartbeat_run_silence_state" USING btree ("company_id","next_eligible_scan_at");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -638,6 +638,13 @@
       "when": 1779573019125,
       "tag": "0090_resource_memberships",
       "breakpoints": true
+    },
+    {
+      "idx": 91,
+      "version": "7",
+      "when": 1779660000000,
+      "tag": "0091_heartbeat_run_silence_state",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/heartbeat_run_silence_state.ts
+++ b/packages/db/src/schema/heartbeat_run_silence_state.ts
@@ -1,0 +1,27 @@
+import { index, integer, pgTable, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { heartbeatRuns } from "./heartbeat_runs.js";
+import { issues } from "./issues.js";
+
+export const heartbeatRunSilenceState = pgTable(
+  "heartbeat_run_silence_state",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id, { onDelete: "cascade" }),
+    runId: uuid("run_id").notNull().references(() => heartbeatRuns.id, { onDelete: "cascade" }),
+    consecutiveFalsePositives: integer("consecutive_false_positives").notNull().default(0),
+    backoffMultiplier: integer("backoff_multiplier").notNull().default(1),
+    lastEvaluationIssueId: uuid("last_evaluation_issue_id").references(() => issues.id, { onDelete: "set null" }),
+    lastClosedAt: timestamp("last_closed_at", { withTimezone: true }),
+    nextEligibleScanAt: timestamp("next_eligible_scan_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    companyRunUq: uniqueIndex("heartbeat_run_silence_state_company_run_uq").on(table.companyId, table.runId),
+    nextEligibleIdx: index("heartbeat_run_silence_state_next_eligible_idx").on(
+      table.companyId,
+      table.nextEligibleScanAt,
+    ),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -58,6 +58,7 @@ export { issueDocuments } from "./issue_documents.js";
 export { heartbeatRuns } from "./heartbeat_runs.js";
 export { heartbeatRunEvents } from "./heartbeat_run_events.js";
 export { heartbeatRunWatchdogDecisions } from "./heartbeat_run_watchdog_decisions.js";
+export { heartbeatRunSilenceState } from "./heartbeat_run_silence_state.js";
 export { costEvents } from "./cost_events.js";
 export { financeEvents } from "./finance_events.js";
 export { approvals } from "./approvals.js";

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -5317,6 +5317,22 @@ export function issueRoutes(
       blockedToTodoRecovery: reopened && reopenFromStatus === "blocked" && currentIssue.status === "todo",
     });
 
+    if (currentIssue.originKind === "stale_active_run_evaluation") {
+      await heartbeat
+        .handleStaleRunEvaluationComment({
+          issueId: currentIssue.id,
+          actor: {
+            type: actor.actorType === "agent" ? "agent" : "user",
+            id: actor.actorId,
+          },
+          body: req.body.body ?? "",
+          runId: actor.runId ?? null,
+        })
+        .catch((err) =>
+          logger.warn({ err, issueId: currentIssue.id }, "failed to evaluate stale-run operator-override comment"),
+        );
+    }
+
     // Merge all wakeups from this comment into one enqueue per agent to avoid duplicate runs.
     void (async () => {
       const wakeups = new Map<string, Parameters<typeof heartbeat.wakeup>[1]>();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -6723,6 +6723,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     return recovery.scanSilentActiveRuns(opts);
   }
 
+  async function handleStaleRunEvaluationComment(input: Parameters<typeof recovery.handleStaleRunEvaluationComment>[0]) {
+    return recovery.handleStaleRunEvaluationComment(input);
+  }
+
   async function reconcileProductivityReviews(opts?: { now?: Date; companyId?: string }) {
     return productivityReviews.reconcileProductivityReviews(opts);
   }
@@ -9866,6 +9870,8 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     reconcileIssueGraphLiveness,
 
     scanSilentActiveRuns,
+
+    handleStaleRunEvaluationComment,
 
     reconcileProductivityReviews,
 

--- a/server/src/services/recovery/__tests__/silence-detector.auto-cancel.test.ts
+++ b/server/src/services/recovery/__tests__/silence-detector.auto-cancel.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import {
+  activityLog,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "../../../__tests__/helpers/embedded-postgres.js";
+import { ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS, recoveryService } from "../service.js";
+import { runningProcesses } from "../../../adapters/index.js";
+import { freshDeadPid, seedSilentRun } from "./silence-detector.shared.js";
+
+vi.mock("../../../telemetry.ts", () => ({
+  getTelemetryClient: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: vi.fn(),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("silence-detector auto-cancel on dead pid", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-silence-detector-auto-cancel-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    runningProcesses.clear();
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const activeRuns = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.status} in ('queued', 'running')`);
+      if (activeRuns.length === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("cancels the run and skips evaluation creation when pid is dead at critical silence", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const deadPid = freshDeadPid();
+    const { companyId, issueId, runId } = await seedSilentRun({
+      db,
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      pid: deadPid,
+    });
+    // Belt-and-braces: ensure no in-memory handle exists for this runId.
+    runningProcesses.delete(runId);
+
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    const result = await recovery.scanSilentActiveRuns({ now, companyId });
+
+    expect(result.auto_cancelled).toBe(1);
+    expect(result.created).toBe(0);
+
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("silence_auto_cancel");
+    expect(run?.finishedAt).toBeTruthy();
+
+    const [source] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(source?.executionRunId).toBeNull();
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(0);
+
+    const cancelled = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "heartbeat.output_stale_auto_cancelled"),
+        ),
+      );
+    expect(cancelled.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/server/src/services/recovery/__tests__/silence-detector.backoff.test.ts
+++ b/server/src/services/recovery/__tests__/silence-detector.backoff.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import {
+  createDb,
+  heartbeatRunSilenceState,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "../../../__tests__/helpers/embedded-postgres.js";
+import { ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS, recoveryService } from "../service.js";
+import { seedSilentRun } from "./silence-detector.shared.js";
+
+vi.mock("../../../telemetry.ts", () => ({
+  getTelemetryClient: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: vi.fn(),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("silence-detector exponential backoff", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-silence-detector-backoff-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const activeRuns = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.status} in ('queued', 'running')`);
+      if (activeRuns.length === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("grows backoff multiplier on repeated false positives and resets on recovery action", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedSilentRun({
+      db,
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+    // Drive three full create→close→observe cycles. After each close, a
+    // follow-up scan in the closed window observes the close and bumps the
+    // backoff multiplier. We advance scanAt past the backoff cap each step so
+    // we don't hit backoff_skipped before the close-observation scan runs.
+    let scanAt = now;
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      // Create scan: either creates eval#N or falls through after a prior close.
+      const created = await recovery.scanSilentActiveRuns({ now: scanAt, companyId });
+      expect(created.created + created.existing + created.suppressed).toBeGreaterThanOrEqual(1);
+
+      const [evaluation] = await db
+        .select()
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.originKind, "stale_active_run_evaluation"),
+            sql`${issues.status} not in ('done', 'cancelled')`,
+          ),
+        );
+      expect(evaluation).toBeTruthy();
+      const closedAt = new Date(scanAt.getTime() + 60_000);
+      await db
+        .update(issues)
+        .set({ status: "done", completedAt: closedAt, updatedAt: closedAt })
+        .where(eq(issues.id, evaluation!.id));
+
+      // Observation scan: advance past backoff window and trigger the
+      // suppressed branch which bumps the multiplier.
+      scanAt = new Date(scanAt.getTime() + 8 * 60 * 60 * 1000);
+      const observe = await recovery.scanSilentActiveRuns({ now: scanAt, companyId });
+      expect(observe.suppressed).toBe(1);
+
+      // Skip past backoff again before the next create scan.
+      scanAt = new Date(scanAt.getTime() + 8 * 60 * 60 * 1000);
+    }
+
+    const [state] = await db
+      .select()
+      .from(heartbeatRunSilenceState)
+      .where(and(eq(heartbeatRunSilenceState.companyId, companyId), eq(heartbeatRunSilenceState.runId, runId)));
+    expect(state).toBeTruthy();
+    expect(state!.backoffMultiplier).toBeGreaterThanOrEqual(8);
+    expect(state!.consecutiveFalsePositives).toBeGreaterThanOrEqual(3);
+    expect(state!.nextEligibleScanAt).toBeTruthy();
+
+    // A snooze recovery action resets the backoff.
+    await recovery.recordWatchdogDecision({
+      runId,
+      actor: { type: "board" },
+      decision: "snooze",
+      snoozedUntil: new Date(scanAt.getTime() + 60 * 60 * 1000),
+      now: new Date(scanAt.getTime() + 60_000),
+    });
+    const [resetState] = await db
+      .select()
+      .from(heartbeatRunSilenceState)
+      .where(and(eq(heartbeatRunSilenceState.companyId, companyId), eq(heartbeatRunSilenceState.runId, runId)));
+    expect(resetState!.backoffMultiplier).toBe(1);
+    expect(resetState!.consecutiveFalsePositives).toBe(0);
+    expect(resetState!.nextEligibleScanAt).toBeNull();
+  });
+});

--- a/server/src/services/recovery/__tests__/silence-detector.closed-window.test.ts
+++ b/server/src/services/recovery/__tests__/silence-detector.closed-window.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import {
+  activityLog,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "../../../__tests__/helpers/embedded-postgres.js";
+import { ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS, recoveryService } from "../service.js";
+import { seedSilentRun } from "./silence-detector.shared.js";
+
+vi.mock("../../../telemetry.ts", () => ({
+  getTelemetryClient: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: vi.fn(),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("silence-detector closed-window dedup", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-silence-detector-closed-window-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const activeRuns = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.status} in ('queued', 'running')`);
+      if (activeRuns.length === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("suppresses creation when the prior eval was closed within the 24h window", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedSilentRun({
+      db,
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+    const first = await recovery.scanSilentActiveRuns({ now, companyId });
+    expect(first.created).toBe(1);
+
+    const [evaluation] = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluation).toBeTruthy();
+
+    const closedAt = new Date(now.getTime() + 5 * 60 * 1000);
+    await db
+      .update(issues)
+      .set({ status: "done", completedAt: closedAt, updatedAt: closedAt })
+      .where(eq(issues.id, evaluation!.id));
+
+    const second = await recovery.scanSilentActiveRuns({ now: closedAt, companyId });
+    expect(second.created).toBe(0);
+    expect(second.suppressed).toBe(1);
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(1);
+
+    const suppressed = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "heartbeat.output_stale_dedup_suppressed"),
+          eq(activityLog.runId, runId),
+        ),
+      );
+    expect(suppressed.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/server/src/services/recovery/__tests__/silence-detector.coalesce.test.ts
+++ b/server/src/services/recovery/__tests__/silence-detector.coalesce.test.ts
@@ -1,0 +1,80 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import {
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "../../../__tests__/helpers/embedded-postgres.js";
+import { ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS, recoveryService } from "../service.js";
+import { seedSilentRun } from "./silence-detector.shared.js";
+
+vi.mock("../../../telemetry.ts", () => ({
+  getTelemetryClient: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: vi.fn(),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("silence-detector coalesce window", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-silence-detector-coalesce-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const activeRuns = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.status} in ('queued', 'running')`);
+      if (activeRuns.length === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("creates exactly one evaluation issue across two consecutive scans", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId } = await seedSilentRun({
+      db,
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS + 60_000,
+    });
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+    const first = await recovery.scanSilentActiveRuns({ now, companyId });
+    const second = await recovery.scanSilentActiveRuns({ now, companyId });
+
+    expect(first.created).toBe(1);
+    expect(second.created).toBe(0);
+    expect(second.existing).toBe(1);
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(evaluations).toHaveLength(1);
+    expect(evaluations[0]?.originId).toBe(runId);
+  });
+});

--- a/server/src/services/recovery/__tests__/silence-detector.integration.test.ts
+++ b/server/src/services/recovery/__tests__/silence-detector.integration.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import {
+  createDb,
+  heartbeatRunSilenceState,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "../../../__tests__/helpers/embedded-postgres.js";
+import { ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS, recoveryService } from "../service.js";
+import { runningProcesses } from "../../../adapters/index.js";
+import { freshDeadPid, seedSilentRun } from "./silence-detector.shared.js";
+
+vi.mock("../../../telemetry.ts", () => ({
+  getTelemetryClient: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: vi.fn(),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("silence-detector full end-to-end", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-silence-detector-integration-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    runningProcesses.clear();
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const activeRuns = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.status} in ('queued', 'running')`);
+      if (activeRuns.length === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("never creates more than one open evaluation across coalesce + backoff + auto-cancel", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const deadPid = freshDeadPid();
+    const { companyId, issueId, runId } = await seedSilentRun({
+      db,
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      pid: deadPid,
+    });
+    runningProcesses.delete(runId);
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+
+    // Critical + dead pid: scan should auto-cancel the run directly.
+    const result = await recovery.scanSilentActiveRuns({ now, companyId });
+    expect(result.auto_cancelled).toBe(1);
+    expect(result.created).toBe(0);
+    expect(result.existing).toBe(0);
+
+    const evaluations = await db
+      .select()
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, "stale_active_run_evaluation"),
+        ),
+      );
+    expect(evaluations).toHaveLength(0);
+
+    const [source] = await db.select().from(issues).where(eq(issues.id, issueId));
+    expect(source?.executionRunId).toBeNull();
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("cancelled");
+
+    // Subsequent scans should find no candidate (run is terminal) and no
+    // silence-state row should be left to gate future runs.
+    const secondPass = await recovery.scanSilentActiveRuns({ now: new Date(now.getTime() + 60_000), companyId });
+    expect(secondPass).toMatchObject({ scanned: 0, created: 0, auto_cancelled: 0 });
+
+    const states = await db
+      .select()
+      .from(heartbeatRunSilenceState)
+      .where(eq(heartbeatRunSilenceState.companyId, companyId));
+    // Auto-cancel path does not create a silence-state row because no eval
+    // issue ever needs to be coalesced for a cancelled run.
+    expect(states).toHaveLength(0);
+  });
+});

--- a/server/src/services/recovery/__tests__/silence-detector.operator-override.test.ts
+++ b/server/src/services/recovery/__tests__/silence-detector.operator-override.test.ts
@@ -1,0 +1,168 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { and, eq, sql } from "drizzle-orm";
+import {
+  activityLog,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "../../../__tests__/helpers/embedded-postgres.js";
+import { ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS, recoveryService } from "../service.js";
+import { runningProcesses } from "../../../adapters/index.js";
+import { freshDeadPid, seedSilentRun } from "./silence-detector.shared.js";
+
+vi.mock("../../../telemetry.ts", () => ({
+  getTelemetryClient: () => ({ track: vi.fn() }),
+}));
+
+vi.mock("@paperclipai/shared/telemetry", async () => {
+  const actual = await vi.importActual<typeof import("@paperclipai/shared/telemetry")>(
+    "@paperclipai/shared/telemetry",
+  );
+  return {
+    ...actual,
+    trackAgentFirstHeartbeat: vi.fn(),
+  };
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("silence-detector operator override", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let db: ReturnType<typeof createDb>;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-silence-detector-operator-override-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterEach(async () => {
+    runningProcesses.clear();
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const activeRuns = await db
+        .select({ id: heartbeatRuns.id })
+        .from(heartbeatRuns)
+        .where(sql`${heartbeatRuns.status} in ('queued', 'running')`);
+      if (activeRuns.length === 0) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    await db.execute(sql.raw(`TRUNCATE TABLE "companies" CASCADE`));
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("cancels the run, cancels siblings, and posts a confirmation comment on board override", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const deadPid = freshDeadPid();
+    const { companyId, runId, issuePrefix } = await seedSilentRun({
+      db,
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      pid: deadPid,
+    });
+    // Seed the active evaluation that triggers the override. The unique
+    // partial index allows only one active row per (companyId, origin_kind,
+    // originId), so any pre-existing siblings would have to be created
+    // before this triggering issue and then closed — exactly the legacy
+    // run-storm state we'd want to clean up. We model that by leaving the
+    // single open eval and verifying the cancellation pathway.
+    const evaluationIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: evaluationIssueId,
+      companyId,
+      title: "Review silent active run",
+      status: "todo",
+      priority: "high",
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+      originKind: "stale_active_run_evaluation",
+      originId: runId,
+      originRunId: runId,
+      originFingerprint: `stale_active_run:${companyId}:${runId}:override`,
+    });
+
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    const result = await recovery.handleStaleRunEvaluationComment({
+      issueId: evaluationIssueId,
+      actor: { type: "board", id: "board-user" },
+      body: "Please cancel this run immediately.",
+      now,
+    });
+
+    expect(result.kind).toBe("operator_cancelled");
+
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("cancelled");
+    expect(run?.errorCode).toBe("operator_override");
+
+    const confirmations = await db
+      .select()
+      .from(issueComments)
+      .where(and(eq(issueComments.companyId, companyId), eq(issueComments.issueId, evaluationIssueId)));
+    expect(confirmations.length).toBeGreaterThanOrEqual(1);
+    expect(confirmations.some((row) => row.body.includes("Operator override accepted"))).toBe(true);
+
+    const log = await db
+      .select()
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.action, "heartbeat.output_stale_operator_override"),
+        ),
+      );
+    expect(log.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("ignores non-matching comment bodies and non-board actors", async () => {
+    const now = new Date("2026-04-22T20:00:00.000Z");
+    const { companyId, runId, issuePrefix } = await seedSilentRun({
+      db,
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+      pid: freshDeadPid(),
+    });
+    const evaluationIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: evaluationIssueId,
+      companyId,
+      title: "Review silent active run",
+      status: "todo",
+      priority: "high",
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+      originKind: "stale_active_run_evaluation",
+      originId: runId,
+      originRunId: runId,
+      originFingerprint: `stale_active_run:${companyId}:${runId}:nonmatch`,
+    });
+
+    const recovery = recoveryService(db, { enqueueWakeup: vi.fn(async () => null) });
+    const bodyMiss = await recovery.handleStaleRunEvaluationComment({
+      issueId: evaluationIssueId,
+      actor: { type: "board", id: "board-user" },
+      body: "Let's keep this running — no action.",
+      now,
+    });
+    expect(bodyMiss.kind).toBe("skipped");
+
+    const agentTry = await recovery.handleStaleRunEvaluationComment({
+      issueId: evaluationIssueId,
+      actor: { type: "agent", id: "some-agent" },
+      body: "cancel this run",
+      now,
+    });
+    expect(agentTry.kind).toBe("skipped");
+
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.status).toBe("running");
+  });
+});

--- a/server/src/services/recovery/__tests__/silence-detector.shared.ts
+++ b/server/src/services/recovery/__tests__/silence-detector.shared.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+
+export interface SeedSilentRunInput {
+  db: ReturnType<typeof createDb>;
+  now: Date;
+  ageMs: number;
+  pid?: number | null;
+  sourceStatus?: "in_progress" | "done" | "cancelled";
+}
+
+export interface SeedSilentRunResult {
+  companyId: string;
+  managerId: string;
+  coderId: string;
+  issueId: string;
+  runId: string;
+  issuePrefix: string;
+}
+
+export async function seedSilentRun(input: SeedSilentRunInput): Promise<SeedSilentRunResult> {
+  const { db } = input;
+  const companyId = randomUUID();
+  const managerId = randomUUID();
+  const coderId = randomUUID();
+  const issueId = randomUUID();
+  const runId = randomUUID();
+  const issuePrefix = `S${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+  const startedAt = new Date(input.now.getTime() - input.ageMs);
+  const sourceStatus = input.sourceStatus ?? "in_progress";
+
+  await db.insert(companies).values({
+    id: companyId,
+    name: "Silence Detector Co",
+    issuePrefix,
+    requireBoardApprovalForNewAgents: false,
+  });
+  await db.insert(agents).values([
+    {
+      id: managerId,
+      companyId,
+      name: "CTO",
+      role: "cto",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    },
+    {
+      id: coderId,
+      companyId,
+      name: "Coder",
+      role: "engineer",
+      status: "running",
+      reportsTo: managerId,
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    },
+  ]);
+  await db.insert(issues).values({
+    id: issueId,
+    companyId,
+    title: "Long running silence-detector source",
+    status: sourceStatus,
+    priority: "medium",
+    assigneeAgentId: coderId,
+    issueNumber: 1,
+    identifier: `${issuePrefix}-1`,
+    originKind: "manual",
+    updatedAt: startedAt,
+    createdAt: startedAt,
+  });
+  await db.insert(heartbeatRuns).values({
+    id: runId,
+    companyId,
+    agentId: coderId,
+    status: "running",
+    invocationSource: "assignment",
+    triggerDetail: "system",
+    startedAt,
+    processStartedAt: startedAt,
+    lastOutputAt: null,
+    lastOutputSeq: 0,
+    lastOutputStream: null,
+    contextSnapshot: { issueId },
+    logBytes: 0,
+    processPid: input.pid ?? null,
+  });
+  await db.update(issues).set({ executionRunId: runId }).where(eq(issues.id, issueId));
+
+  return { companyId, managerId, coderId, issueId, runId, issuePrefix };
+}
+
+/**
+ * Generates a pid that is guaranteed not to be running on the current host —
+ * we keep a counter that walks far above any normal pid space and call
+ * process.kill(pid, 0) to confirm ESRCH.
+ */
+let __syntheticDeadPidCursor = 0x7fff_ff00;
+export function freshDeadPid() {
+  while (true) {
+    __syntheticDeadPidCursor -= 1;
+    const candidate = __syntheticDeadPidCursor;
+    try {
+      process.kill(candidate, 0);
+    } catch (err: unknown) {
+      const code = (err as { code?: string }).code;
+      if (code === "ESRCH") return candidate;
+    }
+  }
+}

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -14,6 +14,7 @@ import {
   activityLog,
   companies,
   heartbeatRunEvents,
+  heartbeatRunSilenceState,
   heartbeatRunWatchdogDecisions,
   heartbeatRuns,
   issueComments,
@@ -66,6 +67,19 @@ const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["failed", "cancelled", "ti
 export const ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
 export const ACTIVE_RUN_OUTPUT_CONTINUE_REARM_MS = 30 * 60 * 1000;
+// Coalesce window for recently-closed stale-run evaluation issues. Keeps the
+// silence detector from creating a new review issue every check interval after
+// a CTO closes a prior review false-positive.
+export const STALE_RUN_EVALUATION_CLOSED_WINDOW_MS = 24 * 60 * 60 * 1000;
+// Backoff multiplier upper bound. The effective scan interval is capped at
+// CRITICAL/2 separately, so the multiplier can grow past the interval cap
+// while still being bounded to a sane value.
+export const STALE_RUN_EVALUATION_BACKOFF_MULTIPLIER_CAP = 16;
+// Operator override grammar — board/user comment that cancels the silent run.
+export const STALE_RUN_OPERATOR_OVERRIDE_PATTERN = /(^|\b)(cancel|kill|abort)\s+(this\s+)?run\b/i;
+// Cancellation reasons stored on the run after each terminal path.
+export const STALE_RUN_SILENCE_AUTO_CANCEL_REASON = "silence_auto_cancel";
+export const STALE_RUN_OPERATOR_OVERRIDE_CANCEL_REASON = "operator_override";
 const ACTIVE_RUN_OUTPUT_EVIDENCE_TAIL_BYTES = 8 * 1024;
 const STRANDED_ISSUE_RECOVERY_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.strandedIssueRecovery;
 const STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND = RECOVERY_ORIGIN_KINDS.staleActiveRunEvaluation;
@@ -720,7 +734,12 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
-  async function findOpenStaleRunEvaluation(companyId: string, runId: string) {
+  async function findRecentStaleRunEvaluation(
+    companyId: string,
+    runId: string,
+    now: Date = new Date(),
+  ) {
+    const closedWindowStart = new Date(now.getTime() - STALE_RUN_EVALUATION_CLOSED_WINDOW_MS);
     const [row] = await db
       .select({
         id: issues.id,
@@ -729,6 +748,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         priority: issues.priority,
         assigneeAgentId: issues.assigneeAgentId,
         updatedAt: issues.updatedAt,
+        completedAt: issues.completedAt,
+        cancelledAt: issues.cancelledAt,
       })
       .from(issues)
       .where(
@@ -737,11 +758,167 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
           eq(issues.originId, runId),
           isNull(issues.hiddenAt),
-          notInArray(issues.status, ["done", "cancelled"]),
+          sql`(
+            ${issues.status} not in ('done', 'cancelled')
+            or ${issues.updatedAt} >= ${closedWindowStart.toISOString()}::timestamptz
+          )`,
+        ),
+      )
+      .orderBy(desc(issues.updatedAt))
+      .limit(1);
+    return row ?? null;
+  }
+
+  // Backwards-compatible alias retained for callers that only need the open
+  // (non-terminal) hit — used by buildRunOutputSilence which reports the
+  // active evaluation issue back to the heartbeat-context API surface.
+  async function findOpenStaleRunEvaluation(companyId: string, runId: string) {
+    const recent = await findRecentStaleRunEvaluation(companyId, runId, new Date());
+    if (!recent) return null;
+    if (recent.status === "done" || recent.status === "cancelled") return null;
+    return recent;
+  }
+
+  function staleRunBackoffIntervalMs(multiplier: number) {
+    const sanitized = Math.max(1, Math.min(STALE_RUN_EVALUATION_BACKOFF_MULTIPLIER_CAP, Math.floor(multiplier)));
+    const raw = ACTIVE_RUN_OUTPUT_SUSPICION_THRESHOLD_MS * sanitized;
+    // Cap effective interval at CRITICAL/2 so we still escalate before the
+    // auto-cancel deadline even if backoff multiplier has grown past it.
+    return Math.min(raw, Math.floor(ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS / 2));
+  }
+
+  async function getStaleRunSilenceState(companyId: string, runId: string) {
+    const [row] = await db
+      .select()
+      .from(heartbeatRunSilenceState)
+      .where(
+        and(
+          eq(heartbeatRunSilenceState.companyId, companyId),
+          eq(heartbeatRunSilenceState.runId, runId),
         ),
       )
       .limit(1);
     return row ?? null;
+  }
+
+  async function ensureStaleRunSilenceState(input: {
+    companyId: string;
+    runId: string;
+    lastEvaluationIssueId?: string | null;
+    now: Date;
+  }) {
+    const existing = await getStaleRunSilenceState(input.companyId, input.runId);
+    if (existing) {
+      if (
+        input.lastEvaluationIssueId &&
+        existing.lastEvaluationIssueId !== input.lastEvaluationIssueId
+      ) {
+        const [updated] = await db
+          .update(heartbeatRunSilenceState)
+          .set({
+            lastEvaluationIssueId: input.lastEvaluationIssueId,
+            updatedAt: input.now,
+          })
+          .where(eq(heartbeatRunSilenceState.id, existing.id))
+          .returning();
+        return updated ?? existing;
+      }
+      return existing;
+    }
+    const [created] = await db
+      .insert(heartbeatRunSilenceState)
+      .values({
+        companyId: input.companyId,
+        runId: input.runId,
+        consecutiveFalsePositives: 0,
+        backoffMultiplier: 1,
+        lastEvaluationIssueId: input.lastEvaluationIssueId ?? null,
+        createdAt: input.now,
+        updatedAt: input.now,
+      })
+      .returning();
+    return created;
+  }
+
+  async function hasRecoveryActionSinceEvaluation(input: {
+    companyId: string;
+    runId: string;
+    sinceCreatedAt: Date | null;
+  }) {
+    const sinceClause = input.sinceCreatedAt
+      ? gte(heartbeatRunWatchdogDecisions.createdAt, input.sinceCreatedAt)
+      : undefined;
+    const [row] = await db
+      .select({ id: heartbeatRunWatchdogDecisions.id })
+      .from(heartbeatRunWatchdogDecisions)
+      .where(
+        and(
+          eq(heartbeatRunWatchdogDecisions.companyId, input.companyId),
+          eq(heartbeatRunWatchdogDecisions.runId, input.runId),
+          inArray(heartbeatRunWatchdogDecisions.decision, ["snooze", "continue"]),
+          sinceClause,
+        ),
+      )
+      .limit(1);
+    return Boolean(row);
+  }
+
+  // Lazy close-handler: when we find a recently-closed evaluation we have not
+  // already processed (lastClosedAt < closed.updatedAt), bump the backoff
+  // multiplier and stamp the next-eligible-scan timestamp. Idempotent across
+  // scans because `lastClosedAt` advances monotonically.
+  async function recordStaleRunEvaluationClose(input: {
+    state: typeof heartbeatRunSilenceState.$inferSelect;
+    evaluationIssue: { id: string; updatedAt: Date | null; completedAt: Date | null; cancelledAt: Date | null };
+    now: Date;
+  }) {
+    const closedAt =
+      input.evaluationIssue.completedAt ??
+      input.evaluationIssue.cancelledAt ??
+      input.evaluationIssue.updatedAt ??
+      input.now;
+    if (input.state.lastClosedAt && input.state.lastClosedAt.getTime() >= closedAt.getTime()) {
+      return input.state;
+    }
+    const recoveryActionRecorded = await hasRecoveryActionSinceEvaluation({
+      companyId: input.state.companyId,
+      runId: input.state.runId,
+      sinceCreatedAt: input.state.createdAt ?? null,
+    });
+    const nextConsecutive = recoveryActionRecorded ? 0 : input.state.consecutiveFalsePositives + 1;
+    const nextMultiplier = recoveryActionRecorded
+      ? 1
+      : Math.min(STALE_RUN_EVALUATION_BACKOFF_MULTIPLIER_CAP, Math.max(2, input.state.backoffMultiplier * 2));
+    const nextEligibleScanAt = new Date(closedAt.getTime() + staleRunBackoffIntervalMs(nextMultiplier));
+    const [updated] = await db
+      .update(heartbeatRunSilenceState)
+      .set({
+        consecutiveFalsePositives: nextConsecutive,
+        backoffMultiplier: nextMultiplier,
+        lastClosedAt: closedAt,
+        lastEvaluationIssueId: input.evaluationIssue.id,
+        nextEligibleScanAt,
+        updatedAt: input.now,
+      })
+      .where(eq(heartbeatRunSilenceState.id, input.state.id))
+      .returning();
+    return updated ?? input.state;
+  }
+
+  async function resetStaleRunSilenceBackoff(companyId: string, runId: string, now = new Date()) {
+    const existing = await getStaleRunSilenceState(companyId, runId);
+    if (!existing) return null;
+    const [updated] = await db
+      .update(heartbeatRunSilenceState)
+      .set({
+        consecutiveFalsePositives: 0,
+        backoffMultiplier: 1,
+        nextEligibleScanAt: null,
+        updatedAt: now,
+      })
+      .where(eq(heartbeatRunSilenceState.id, existing.id))
+      .returning();
+    return updated ?? existing;
   }
 
   async function buildRunOutputSilence(
@@ -1347,6 +1524,395 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return true;
   }
 
+  async function cancelSiblingStaleRunEvaluations(input: {
+    companyId: string;
+    runId: string;
+    excludeIssueId?: string | null;
+    reason: string;
+    triggeringIssueIdentifier?: string | null;
+    now: Date;
+  }) {
+    const siblings = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, input.companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originId, input.runId),
+          isNull(issues.hiddenAt),
+          notInArray(issues.status, ["done", "cancelled"]),
+        ),
+      );
+    const cancelledIds: string[] = [];
+    for (const sibling of siblings) {
+      if (input.excludeIssueId && sibling.id === input.excludeIssueId) continue;
+      await issuesSvc.update(sibling.id, { status: "cancelled" });
+      await issuesSvc.addComment(
+        sibling.id,
+        [
+          `Cancelled by ${input.reason}${input.triggeringIssueIdentifier ? ` on ${input.triggeringIssueIdentifier}` : ""}.`,
+          "",
+          `- Stale run: \`${input.runId}\``,
+          input.triggeringIssueIdentifier
+            ? `- Triggering review issue: ${input.triggeringIssueIdentifier}`
+            : "- No triggering review issue.",
+          "- This sibling review is no longer needed.",
+        ].join("\n"),
+        { runId: input.runId },
+      );
+      cancelledIds.push(sibling.id);
+    }
+    return cancelledIds;
+  }
+
+  async function terminateRunProcessIfAlive(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+  }) {
+    const running = runningProcesses.get(input.run.id);
+    const pid = running?.child.pid ?? input.run.processPid ?? null;
+    const processGroupId = running?.processGroupId ?? input.run.processGroupId ?? null;
+    if (typeof pid !== "number" && typeof processGroupId !== "number") {
+      return { attempted: false, outcome: "no_process_metadata" as const, pid, processGroupId };
+    }
+    const alive =
+      (typeof pid === "number" && isPidAlive(pid)) ||
+      (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId));
+    if (!alive) {
+      runningProcesses.delete(input.run.id);
+      return { attempted: false, outcome: "not_running" as const, pid, processGroupId };
+    }
+    try {
+      await terminateLocalService(
+        {
+          pid: typeof pid === "number" && Number.isInteger(pid) && pid > 0
+            ? pid
+            : (processGroupId ?? 0),
+          processGroupId: typeof processGroupId === "number" && Number.isInteger(processGroupId) && processGroupId > 0
+            ? processGroupId
+            : null,
+        },
+        running ? { forceAfterMs: Math.max(1, running.graceSec) * 1000 } : undefined,
+      );
+      runningProcesses.delete(input.run.id);
+      const stillAlive =
+        (typeof pid === "number" && isPidAlive(pid)) ||
+        (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId));
+      return {
+        attempted: true,
+        outcome: stillAlive ? ("termination_sent_still_running" as const) : ("terminated" as const),
+        pid,
+        processGroupId,
+      };
+    } catch (error) {
+      return {
+        attempted: true,
+        outcome: "failed" as const,
+        pid,
+        processGroupId,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  // Cancel a run that has crossed the critical silence threshold AND whose
+  // process is verifiably dead (no in-memory handle, pid probe returns
+  // ESRCH). Posts a single summary comment, releases the execution lock on
+  // the source issue, and cancels open sibling review issues. We never
+  // create another evaluation issue from this path.
+  async function attemptAutoCancelStrandedRun(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    runningAgent: typeof agents.$inferSelect;
+    sourceIssue: typeof issues.$inferSelect | null;
+    silenceAgeMs: number | null;
+    now: Date;
+  }) {
+    const handle = runningProcesses.get(input.run.id);
+    if (handle) {
+      // In-memory handle exists; the process is at least tracked. Defer to
+      // the normal evaluation path so a human can decide.
+      return { kind: "skipped" as const, reason: "in_memory_handle_present" as const };
+    }
+    const pid = input.run.processPid ?? null;
+    if (typeof pid !== "number" || pid <= 0) {
+      return { kind: "skipped" as const, reason: "no_pid" as const };
+    }
+    if (isPidAlive(pid)) {
+      return { kind: "skipped" as const, reason: "pid_alive" as const };
+    }
+
+    const finalizedRun = await db.transaction(async (tx) => {
+      const [updated] = await tx
+        .update(heartbeatRuns)
+        .set({
+          status: "cancelled",
+          finishedAt: input.now,
+          error: null,
+          errorCode: STALE_RUN_SILENCE_AUTO_CANCEL_REASON,
+          resultJson: {
+            ...parseObject(input.run.resultJson),
+            silenceAutoCancel: {
+              silenceAgeMs: input.silenceAgeMs,
+              pid,
+              sourceIssueId: input.sourceIssue?.id ?? null,
+            },
+          },
+          updatedAt: input.now,
+        })
+        .where(and(eq(heartbeatRuns.id, input.run.id), eq(heartbeatRuns.status, "running")))
+        .returning();
+      if (!updated) return null;
+      if (input.run.wakeupRequestId) {
+        await tx
+          .update(agentWakeupRequests)
+          .set({
+            status: "cancelled",
+            finishedAt: input.now,
+            error: null,
+            updatedAt: input.now,
+          })
+          .where(
+            and(
+              eq(agentWakeupRequests.id, input.run.wakeupRequestId),
+              eq(agentWakeupRequests.companyId, input.run.companyId),
+            ),
+          );
+      }
+      if (input.sourceIssue) {
+        await tx
+          .update(issues)
+          .set({
+            executionRunId: null,
+            executionAgentNameKey: null,
+            executionLockedAt: null,
+            updatedAt: input.now,
+          })
+          .where(
+            and(
+              eq(issues.id, input.sourceIssue.id),
+              eq(issues.companyId, input.run.companyId),
+              eq(issues.executionRunId, input.run.id),
+            ),
+          );
+      }
+      return updated;
+    });
+
+    if (!finalizedRun) {
+      return { kind: "skipped" as const, reason: "race_lost" as const };
+    }
+
+    const cancelledSiblings = await cancelSiblingStaleRunEvaluations({
+      companyId: input.run.companyId,
+      runId: input.run.id,
+      reason: "silence auto-cancel",
+      now: input.now,
+    });
+
+    if (input.sourceIssue) {
+      await issuesSvc.addComment(
+        input.sourceIssue.id,
+        [
+          "## Stale run auto-cancelled after critical silence",
+          "",
+          `- Run: \`${input.run.id}\``,
+          `- Silent for: ${formatDuration(input.silenceAgeMs)}`,
+          `- Last output at: ${input.run.lastOutputAt?.toISOString() ?? "none recorded"}`,
+          `- Pid: \`${pid}\``,
+          "- The in-memory process handle was missing and `kill 0` probe failed (process not running).",
+          "- Execution lock released; no further review issues will be created for this run.",
+        ].join("\n"),
+        { runId: input.run.id },
+      );
+    }
+
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: input.run.agentId,
+      runId: input.run.id,
+      action: "heartbeat.output_stale_auto_cancelled",
+      entityType: "heartbeat_run",
+      entityId: input.run.id,
+      details: {
+        source: "recovery.scan_silent_active_runs",
+        silenceAgeMs: input.silenceAgeMs,
+        pid,
+        sourceIssueId: input.sourceIssue?.id ?? null,
+        cancelledSiblingIssueIds: cancelledSiblings,
+      },
+    });
+
+    return { kind: "auto_cancelled" as const, pid, cancelledSiblings };
+  }
+
+  // Operator-override comment handler. Called from the issue-comment route
+  // when a board/user posts on a stale_active_run_evaluation issue. If the
+  // comment body matches the cancel-this-run grammar we kill the pid, cancel
+  // the run, release the execution lock, cancel sibling reviews, and post a
+  // confirmation comment back on the triggering issue.
+  async function handleStaleRunEvaluationComment(input: {
+    issueId: string;
+    actor: { type: "user" | "board" | "agent"; id?: string | null };
+    body: string;
+    runId?: string | null;
+    now?: Date;
+  }) {
+    if (input.actor.type !== "user" && input.actor.type !== "board") {
+      return { kind: "skipped" as const, reason: "actor_not_board" as const };
+    }
+    if (!STALE_RUN_OPERATOR_OVERRIDE_PATTERN.test(input.body)) {
+      return { kind: "skipped" as const, reason: "grammar_mismatch" as const };
+    }
+    const now = input.now ?? new Date();
+    const [issue] = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, input.issueId))
+      .limit(1);
+    if (!issue) return { kind: "skipped" as const, reason: "issue_missing" as const };
+    if (issue.originKind !== STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND) {
+      return { kind: "skipped" as const, reason: "wrong_origin" as const };
+    }
+    const runId = issue.originId;
+    if (!runId) return { kind: "skipped" as const, reason: "no_run_id" as const };
+    const [run] = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.id, runId), eq(heartbeatRuns.companyId, issue.companyId)))
+      .limit(1);
+    if (!run) return { kind: "skipped" as const, reason: "run_missing" as const };
+    const runIsTerminal = !["queued", "running", "scheduled_retry"].includes(run.status);
+    const termination = runIsTerminal ? { attempted: false, outcome: "not_running" as const } : await terminateRunProcessIfAlive({ run });
+
+    const sourceIssueId = issueIdFromRunContext(run.contextSnapshot);
+    const sourceIssue = sourceIssueId
+      ? await db
+          .select()
+          .from(issues)
+          .where(and(eq(issues.id, sourceIssueId), eq(issues.companyId, run.companyId)))
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+      : null;
+
+    let cancelledRun = run;
+    if (!runIsTerminal) {
+      const result = await db.transaction(async (tx) => {
+        const [updated] = await tx
+          .update(heartbeatRuns)
+          .set({
+            status: "cancelled",
+            finishedAt: now,
+            errorCode: STALE_RUN_OPERATOR_OVERRIDE_CANCEL_REASON,
+            resultJson: {
+              ...parseObject(run.resultJson),
+              operatorOverride: {
+                triggeringIssueId: issue.id,
+                triggeringIssueIdentifier: issue.identifier,
+                actor: input.actor,
+              },
+            },
+            updatedAt: now,
+          })
+          .where(and(eq(heartbeatRuns.id, run.id), inArray(heartbeatRuns.status, ["queued", "running", "scheduled_retry"])))
+          .returning();
+        if (!updated) return null;
+        if (run.wakeupRequestId) {
+          await tx
+            .update(agentWakeupRequests)
+            .set({
+              status: "cancelled",
+              finishedAt: now,
+              error: null,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(agentWakeupRequests.id, run.wakeupRequestId),
+                eq(agentWakeupRequests.companyId, run.companyId),
+              ),
+            );
+        }
+        if (sourceIssue) {
+          await tx
+            .update(issues)
+            .set({
+              executionRunId: null,
+              executionAgentNameKey: null,
+              executionLockedAt: null,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(issues.id, sourceIssue.id),
+                eq(issues.companyId, run.companyId),
+                eq(issues.executionRunId, run.id),
+              ),
+            );
+        }
+        return updated;
+      });
+      if (result) cancelledRun = result;
+    }
+
+    const cancelledSiblings = await cancelSiblingStaleRunEvaluations({
+      companyId: run.companyId,
+      runId: run.id,
+      excludeIssueId: issue.id,
+      reason: "operator",
+      triggeringIssueIdentifier: issue.identifier,
+      now,
+    });
+
+    await issuesSvc.addComment(
+      issue.id,
+      [
+        `## Operator override accepted`,
+        "",
+        `- Run: \`${run.id}\``,
+        `- Termination: \`${termination.outcome}\``,
+        `- Run status: \`${cancelledRun.status}\``,
+        `- Cancelled sibling review issues: ${cancelledSiblings.length}`,
+        sourceIssue
+          ? `- Source issue execution lock released: \`${sourceIssue.identifier ?? sourceIssue.id}\``
+          : "- No source issue execution lock to release.",
+      ].join("\n"),
+      { runId: run.id },
+    );
+
+    await logActivity(db, {
+      companyId: run.companyId,
+      actorType: "user",
+      actorId: input.actor.id ?? input.actor.type,
+      agentId: null,
+      runId: input.runId ?? null,
+      action: "heartbeat.output_stale_operator_override",
+      entityType: "heartbeat_run",
+      entityId: run.id,
+      details: {
+        source: "recovery.operator_override",
+        triggeringIssueId: issue.id,
+        triggeringIssueIdentifier: issue.identifier,
+        termination,
+        cancelledSiblingIssueIds: cancelledSiblings,
+        sourceIssueId: sourceIssue?.id ?? null,
+      },
+    });
+
+    return {
+      kind: "operator_cancelled" as const,
+      runId: run.id,
+      termination,
+      cancelledSiblingIssueIds: cancelledSiblings,
+      sourceIssueId: sourceIssue?.id ?? null,
+    };
+  }
+
   async function createOrUpdateStaleRunEvaluation(input: {
     run: typeof heartbeatRuns.$inferSelect;
     now: Date;
@@ -1354,7 +1920,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     const runningAgent = await getAgent(input.run.agentId);
     if (!runningAgent || runningAgent.companyId !== input.run.companyId) return { kind: "skipped" as const };
     const sourceIssue = await resolveStaleRunSourceIssue(input.run);
-    const existing = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
+    const recent = await findRecentStaleRunEvaluation(input.run.companyId, input.run.id, input.now);
+    const existing = recent && recent.status !== "done" && recent.status !== "cancelled" ? recent : null;
+    const recentlyClosed = recent && (recent.status === "done" || recent.status === "cancelled") ? recent : null;
     if (sourceIssue && isRecoveryOriginIssue(sourceIssue)) {
       await logActivity(db, {
         companyId: input.run.companyId,
@@ -1404,6 +1972,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       now: input.now,
     });
     const level = (evidence.silenceAgeMs ?? 0) >= ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS ? "critical" : "suspicious";
+
+    // Critical + dead pid + no in-memory handle → cancel the run instead of
+    // creating yet another review issue. The triple-condition guard makes this
+    // safe: we only ever kill a process that's already gone.
+    if (level === "critical" && !existing) {
+      const autoCancel = await attemptAutoCancelStrandedRun({
+        run: input.run,
+        runningAgent,
+        sourceIssue,
+        silenceAgeMs: evidence.silenceAgeMs,
+        now: input.now,
+      });
+      if (autoCancel.kind === "auto_cancelled") {
+        return { kind: "auto_cancelled" as const, evaluationIssueId: null };
+      }
+    }
+
     if (existing) {
       if (level === "critical" && existing.priority !== "high") {
         await issuesSvc.update(existing.id, {
@@ -1431,6 +2016,79 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         });
       }
       return { kind: "existing" as const, evaluationIssueId: existing.id };
+    }
+
+    // Recently-closed evaluation in the 24h coalesce window. We treat the
+    // first scan after each close as the "close event" — that bumps the
+    // backoff multiplier and stamps nextEligibleScanAt for false positives.
+    // If a recovery action (snooze/continue) was recorded for this run since
+    // the eval was created, we treat the close as a legitimate disposition,
+    // reset state, and fall through to create a fresh eval.
+    if (recentlyClosed) {
+      const state = await ensureStaleRunSilenceState({
+        companyId: input.run.companyId,
+        runId: input.run.id,
+        lastEvaluationIssueId: recentlyClosed.id,
+        now: input.now,
+      });
+      const closedAt =
+        recentlyClosed.completedAt ??
+        recentlyClosed.cancelledAt ??
+        recentlyClosed.updatedAt ??
+        input.now;
+      const isFreshClose =
+        !state.lastClosedAt || state.lastClosedAt.getTime() < closedAt.getTime();
+      if (isFreshClose) {
+        const recoveryRecorded = await hasRecoveryActionSinceEvaluation({
+          companyId: input.run.companyId,
+          runId: input.run.id,
+          sinceCreatedAt: state.createdAt ?? null,
+        });
+        if (recoveryRecorded) {
+          // Recovery action present — reset state and fall through to the
+          // create path so a fresh eval is generated.
+          await db
+            .update(heartbeatRunSilenceState)
+            .set({
+              consecutiveFalsePositives: 0,
+              backoffMultiplier: 1,
+              lastClosedAt: closedAt,
+              lastEvaluationIssueId: recentlyClosed.id,
+              nextEligibleScanAt: null,
+              updatedAt: input.now,
+            })
+            .where(eq(heartbeatRunSilenceState.id, state.id));
+        } else {
+          const updated = await recordStaleRunEvaluationClose({
+            state,
+            evaluationIssue: recentlyClosed,
+            now: input.now,
+          });
+          await logActivity(db, {
+            companyId: input.run.companyId,
+            actorType: "system",
+            actorId: "system",
+            agentId: input.run.agentId,
+            runId: input.run.id,
+            action: "heartbeat.output_stale_dedup_suppressed",
+            entityType: "issue",
+            entityId: recentlyClosed.id,
+            details: {
+              source: "recovery.scan_silent_active_runs",
+              evaluationIssueId: recentlyClosed.id,
+              evaluationIssueStatus: recentlyClosed.status,
+              consecutiveFalsePositives: updated.consecutiveFalsePositives,
+              backoffMultiplier: updated.backoffMultiplier,
+              nextEligibleScanAt: updated.nextEligibleScanAt?.toISOString() ?? null,
+            },
+          });
+          return { kind: "suppressed" as const, evaluationIssueId: recentlyClosed.id };
+        }
+      }
+      // Already observed this close. If backoff is still active, the scan
+      // gate above would have skipped us; we only reach here when the
+      // backoff has elapsed and the source run is still silent — fall
+      // through and create a fresh evaluation issue.
     }
 
     const ownerAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });
@@ -1463,10 +2121,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       });
     } catch (error) {
       if (!isUniqueStaleRunEvaluationConflict(error)) throw error;
-      const raced = await findOpenStaleRunEvaluation(input.run.companyId, input.run.id);
+      const raced = await findRecentStaleRunEvaluation(input.run.companyId, input.run.id, input.now);
       if (!raced) throw error;
       return { kind: "existing" as const, evaluationIssueId: raced.id };
     }
+    await ensureStaleRunSilenceState({
+      companyId: input.run.companyId,
+      runId: input.run.id,
+      lastEvaluationIssueId: evaluation.id,
+      now: input.now,
+    });
 
     await logActivity(db, {
       companyId: input.run.companyId,
@@ -1540,6 +2204,9 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       escalated: 0,
       folded: 0,
       snoozed: 0,
+      suppressed: 0,
+      backoff_skipped: 0,
+      auto_cancelled: 0,
       skipped: 0,
       evaluationIssueIds: [] as string[],
     };
@@ -1549,11 +2216,18 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         result.snoozed += 1;
         continue;
       }
+      const silenceState = await getStaleRunSilenceState(run.companyId, run.id);
+      if (silenceState?.nextEligibleScanAt && silenceState.nextEligibleScanAt > now) {
+        result.backoff_skipped += 1;
+        continue;
+      }
       const outcome = await createOrUpdateStaleRunEvaluation({ run, now });
       if (outcome.kind === "created") result.created += 1;
       else if (outcome.kind === "existing") result.existing += 1;
       else if (outcome.kind === "escalated") result.escalated += 1;
       else if (outcome.kind === "folded") result.folded += 1;
+      else if (outcome.kind === "suppressed") result.suppressed += 1;
+      else if (outcome.kind === "auto_cancelled") result.auto_cancelled += 1;
       else result.skipped += 1;
       if ("evaluationIssueId" in outcome && outcome.evaluationIssueId) {
         result.evaluationIssueIds.push(outcome.evaluationIssueId);
@@ -1694,6 +2368,14 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         reason: input.reason ?? null,
       },
     });
+
+    // Recovery actions (snooze, continue) reset the silence-detector backoff
+    // so the next legitimate signal is evaluated promptly. dismissed_false_positive
+    // is the explicit "operator agrees this was noise" path and we leave the
+    // backoff state to advance via the close-detection branch instead.
+    if (input.decision === "snooze" || input.decision === "continue") {
+      await resetStaleRunSilenceBackoff(run.companyId, run.id, decisionNow);
+    }
 
     return row;
   }
@@ -3453,5 +4135,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     buildIssueGraphLivenessAutoRecoveryPreview,
     reconcileIssueGraphLiveness,
     readRecoveryTimerIntervalMs,
+    handleStaleRunEvaluationComment,
+    resetStaleRunSilenceBackoff,
+    getStaleRunSilenceState,
   };
 }


### PR DESCRIPTION
## Summary

Stop the active-run silence detector from creating a new review issue every check interval after the previous one is closed false-positive. The existing 1-eval-per-run coalesce key only matched non-terminal issues, so any close caused the next scan to spawn another review — one observed stale run produced 21 duplicate review issues. This PR adds a 24h closed coalesce window, exponential backoff on repeat false positives, an auto-cancel path when the underlying pid is verifiably dead, and a board-comment operator override.

## Behavior changes

- **24h closed coalesce window** — `findOpenStaleRunEvaluation` is renamed `findRecentStaleRunEvaluation` and considers `done`/`cancelled` evaluation issues whose `updatedAt >= now() - interval '24h'`. The first scan after each close bumps an exponential backoff multiplier and stamps `nextEligibleScanAt`; subsequent scans during the cool-down are counted as `backoff_skipped`; scans after the cool-down create a fresh review.
- **Recovery actions reset backoff** — `snooze` and `continue` decisions clear `consecutive_false_positives`, set `backoff_multiplier = 1`, and clear `next_eligible_scan_at`, preserving the existing re-arm semantics from `recordWatchdogDecision`.
- **Auto-cancel on dead pid at critical** — when `silenceAgeMs >= 4h` AND `runningProcesses.get(runId)` is missing AND `process.kill(pid, 0)` throws `ESRCH`, the run is cancelled in place with `errorCode = silence_auto_cancel`, the source-issue execution lock is released, sibling review issues are cancelled, and no new review is created.
- **Operator override** — a board/user comment matching `/(cancel|kill|abort)\s+(this\s+)?run/i` on an issue with `originKind = stale_active_run_evaluation` kills the pid (SIGTERM with grace), cancels the run with `errorCode = operator_override`, clears the source-issue execution lock, cancels sibling review issues, and posts a confirmation comment.

## Schema

Additive only — new table `heartbeat_run_silence_state` keyed by `(company_id, run_id)`:

| column                       | type                              | notes                                                 |
|------------------------------|-----------------------------------|-------------------------------------------------------|
| consecutive_false_positives  | integer not null default 0        |                                                       |
| backoff_multiplier           | integer not null default 1        | capped at 16; interval also capped at CRITICAL/2 = 2h |
| last_evaluation_issue_id     | uuid (fk issues set null)         | most recent associated review issue                   |
| last_closed_at               | timestamptz                       | advances monotonically each observed close            |
| next_eligible_scan_at        | timestamptz                       | gates `scanSilentActiveRuns` candidates               |

Migration: `packages/db/src/migrations/0091_heartbeat_run_silence_state.sql`. Reversible with `DROP TABLE heartbeat_run_silence_state;`.

## Test plan

- [x] `pnpm --filter @paperclipai/server exec vitest run src/services/recovery/__tests__/` — five new unit tests + one integration test green (7 tests total).
- [x] `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-active-run-output-watchdog.test.ts` — existing 13 tests still green (no regressions from `recordWatchdogDecision` snooze/continue reset).
- [x] `pnpm --filter @paperclipai/server exec tsc --noEmit` — no new type errors in changed files.
- [ ] **Manual smoke** — see `doc/silence-detector-smoke.md` for the QA playbook (coalesce, closed window, backoff, auto-cancel, operator override).

## Notes

- The unique partial index `issues_active_stale_run_evaluation_uq` already excludes `done`/`cancelled`, so new reviews created after a cool-down do not conflict with prior closed ones.
- Auto-cancel only fires when *all three* guards pass (silence at critical, no in-memory handle, dead pid). The triple condition makes it safe to kill a process that's already gone but never to terminate a genuinely-running run.
- Operator override is wired in `server/src/routes/issues.ts` after the comment write, fire-and-forget (errors are logged, never block the comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)