### PR TITLE
Release stale checkoutRunId on run termination + server shutdown

### DIFF
--- a/doc/spec/agent-runs.md
+++ b/doc/spec/agent-runs.md
@@ -696,6 +696,7 @@ All wakeup/run state mutations must create `activity_log` entries:
 - `heartbeat.failed`
 - `heartbeat.cancelled`
 - `runtime_state.updated`
+- `stale_lock_takeover` — written when the checkout endpoint takes over an issue whose `checkoutRunId` (or `executionRunId`) points to a terminal-or-missing prior heartbeat run owned by the same agent. The `details` payload includes `issueId`, `actorAgentId`, `actorRunId`, `priorRunId`, `priorRunStatus`, and `trigger` (`"checkout"` or `"assert_checkout_owner"`). This is the safety-net counterpart to the server-shutdown run-termination hook; a sudden spike in `stale_lock_takeover` rows is a leading indicator that the termination hook is not firing for some failure mode (typically SIGKILL or process panic).
 
 ## 14. Heartbeat Service Implementation Plan
 

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -283,4 +283,236 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       },
     });
   });
+
+  // ---- GAT-205 / stale checkout-run lock takeover (Option 1 safety net) ----
+
+  it("writes a stale_lock_takeover audit row when same-agent checkout adopts a terminal-prior checkoutRunId", async () => {
+    const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Stale checkout lock takeover",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: failedRunId,
+      executionRunId: failedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["in_progress"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: issueId,
+      assigneeAgentId: agentId,
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+    });
+
+    const audit = await db
+      .select({
+        action: activityLog.action,
+        actorType: activityLog.actorType,
+        actorId: activityLog.actorId,
+        agentId: activityLog.agentId,
+        runId: activityLog.runId,
+        details: activityLog.details,
+      })
+      .from(activityLog)
+      .where(eq(activityLog.action, "stale_lock_takeover"))
+      .then((rows) => rows[0]);
+    expect(audit).toMatchObject({
+      action: "stale_lock_takeover",
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId: currentRunId,
+      details: {
+        issueId,
+        actorAgentId: agentId,
+        actorRunId: currentRunId,
+        priorRunId: failedRunId,
+        priorRunStatus: "failed",
+        trigger: "checkout",
+      },
+    });
+  });
+
+  it("does not adopt when the prior checkoutRunId belongs to a different agent (cross-agent contention stays 409)", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const otherAgentId = randomUUID();
+    const otherRunId = randomUUID();
+    await db.insert(agents).values({
+      id: otherAgentId,
+      companyId,
+      name: "OtherAgent",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    // Other agent's run is `failed` (terminal) but the issue assignee is `agentId` — the
+    // current agent should NOT be able to take over a checkout lock owned by a foreign
+    // agent's run even when that foreign run is terminal: the assignee guard is the
+    // authoritative cross-agent boundary.
+    await db.insert(heartbeatRuns).values({
+      id: otherRunId,
+      companyId,
+      agentId: otherAgentId,
+      status: "failed",
+      invocationSource: "manual",
+      finishedAt: new Date(),
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Cross-agent contention",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: otherAgentId,
+      checkoutRunId: otherRunId,
+      executionRunId: otherRunId,
+      executionAgentNameKey: "otheragent",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["in_progress"] });
+
+    // The current agent is not the assignee and lacks task-assignment privileges in this
+    // test app, so the response must not succeed and must not adopt the prior lock.
+    expect(res.status).not.toBe(200);
+
+    const auditCount = await db
+      .select({ count: activityLog.id })
+      .from(activityLog)
+      .where(eq(activityLog.action, "stale_lock_takeover"));
+    expect(auditCount).toHaveLength(0);
+
+    const row = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        assigneeAgentId: issues.assigneeAgentId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    // The foreign agent must NOT become the owner. `executionRunId` may be cleared by
+    // `clearExecutionRunIfTerminal` (a separate, agent-agnostic hygiene path that runs at
+    // the top of checkout) but `checkoutRunId` and `assigneeAgentId` must stay pinned to
+    // the original owner — that is the cross-agent boundary the test is guarding.
+    expect(row).toEqual({ checkoutRunId: otherRunId, assigneeAgentId: otherAgentId });
+  });
+
+  it("rejects checkout when the prior checkoutRunId belongs to a non-terminal (still-active) same-agent run", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    // Add a second run owned by the SAME agent that is still `running` (not terminal).
+    // The checkout endpoint must refuse to take over because the prior run is active.
+    const concurrentRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: concurrentRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Concurrent active prior run",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: concurrentRunId,
+      executionRunId: concurrentRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["in_progress"] });
+
+    expect(res.status).toBe(409);
+
+    // Lock must remain pointed at the still-active prior run.
+    const row = await db
+      .select({ checkoutRunId: issues.checkoutRunId, executionRunId: issues.executionRunId })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({ checkoutRunId: concurrentRunId, executionRunId: concurrentRunId });
+
+    const audit = await db
+      .select({ action: activityLog.action })
+      .from(activityLog)
+      .where(eq(activityLog.action, "stale_lock_takeover"));
+    expect(audit).toHaveLength(0);
+  });
+
+  it("allows takeover when the prior run is `terminated` (server-shutdown hook ran)", async () => {
+    // Exercises the integration with Change 1: after the run-termination hook marks a
+    // dying run as `terminated` (a new terminal status), a fresh same-agent wake should
+    // be able to take over without 409.
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const terminatedRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: terminatedRunId,
+      companyId,
+      agentId,
+      status: "terminated",
+      invocationSource: "manual",
+      finishedAt: new Date(),
+      error: "Run terminated during server shutdown",
+      errorCode: "server_shutdown",
+    });
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Adopt after shutdown-hook termination",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: terminatedRunId,
+      executionRunId: terminatedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/checkout`)
+      .send({ agentId, expectedStatuses: ["in_progress"] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: issueId,
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+    });
+
+    const audit = await db
+      .select({ action: activityLog.action, details: activityLog.details })
+      .from(activityLog)
+      .where(eq(activityLog.action, "stale_lock_takeover"))
+      .then((rows) => rows[0]);
+    expect(audit).toMatchObject({
+      action: "stale_lock_takeover",
+      details: { priorRunId: terminatedRunId, priorRunStatus: "terminated", trigger: "checkout" },
+    });
+  });
 });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -716,8 +716,13 @@ export async function startServer(): Promise<StartedServer> {
       logger.error({ err }, "startup reconciliation of cloud upstream runs failed");
     });
   
+  // The scheduler-bound heartbeat service tracks active executions in-memory; keep a
+  // reference accessible from the SIGTERM/SIGINT shutdown handler below so it can call
+  // `terminateInFlightRunsForShutdown` and release stale issue locks (GAT-205).
+  let schedulerHeartbeat: ReturnType<typeof heartbeatService> | null = null;
   if (config.heartbeatSchedulerEnabled) {
     const heartbeat = heartbeatService(db as any, { pluginWorkerManager });
+    schedulerHeartbeat = heartbeat;
     const routines = routineService(db as any, { pluginWorkerManager });
   
     // Reap orphaned running runs at startup while in-memory execution state is empty,
@@ -923,6 +928,23 @@ export async function startServer(): Promise<StartedServer> {
       if (telemetryClient) {
         telemetryClient.stop();
         await telemetryClient.flush();
+      }
+
+      // GAT-205 Option 3 — release any in-flight heartbeat run locks before exit so
+      // subsequent same-agent wakes are not blocked by stale checkoutRunId/executionRunId
+      // entries. Best-effort; failures must not block process exit.
+      if (schedulerHeartbeat) {
+        try {
+          const result = await schedulerHeartbeat.terminateInFlightRunsForShutdown(signal);
+          if (result.terminatedRunCount > 0 || result.releasedIssueCount > 0) {
+            logger.info(
+              { signal, ...result },
+              "Released in-flight heartbeat run locks during server shutdown",
+            );
+          }
+        } catch (err) {
+          logger.warn({ err, signal }, "Failed to release in-flight heartbeat run locks during shutdown");
+        }
       }
 
       const appShutdown = (app as { locals?: { paperclipShutdown?: () => void } }).locals?.paperclipShutdown;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8275,12 +8275,19 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       if (issue.executionRunId && issue.executionRunId !== run.id) return null;
 
       if (issue.executionRunId === run.id) {
+        // Also clear checkoutRunId when it matches the terminating run. Historically the
+        // run-termination hook only cleared executionRunId, leaving a stale checkoutRunId
+        // behind; subsequent same-agent wakes were rejected by the checkout endpoint with
+        // `Issue run ownership conflict` because the prior run id still occupied the lock
+        // even though the run itself had ended. See GAT-205 for the failure trace.
+        const shouldClearCheckoutRunId = issue.checkoutRunId === run.id;
         await tx
           .update(issues)
           .set({
             executionRunId: null,
             executionAgentNameKey: null,
             executionLockedAt: null,
+            ...(shouldClearCheckoutRunId ? { checkoutRunId: null } : {}),
             updatedAt: new Date(),
           })
           .where(eq(issues.id, issue.id));
@@ -9955,6 +9962,91 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .orderBy(desc(heartbeatRuns.startedAt))
         .limit(1);
       return run ?? null;
+    },
+
+    /**
+     * Server-shutdown hook (GAT-205 Option 3, "Run-termination hook").
+     *
+     * Called from the process-level SIGTERM/SIGINT handler before exit. For every
+     * heartbeat run this process believes is still in-flight, we:
+     *   1. Mark `runs.status = 'terminated'` (a new terminal status, distinct from
+     *      `cancelled`/`timed_out`, that observers can read as "reaped by shutdown")
+     *      so subsequent same-agent wakes know the lock is releasable.
+     *   2. Clear `checkoutRunId`, `executionRunId`, `executionLockedAt` on every issue
+     *      where `executionRunId == run.id` so a fresh process is not blocked by stale
+     *      locks left behind by a dying process.
+     *
+     * The Option 1 checkout-time safety net (see `adoptStaleCheckoutRun`) covers the
+     * SIGKILL/panic case where this hook never gets to run.
+     */
+    terminateInFlightRunsForShutdown: async (reason?: string): Promise<{
+      terminatedRunCount: number;
+      releasedIssueCount: number;
+      runIds: string[];
+    }> => {
+      const inFlightRunIds = Array.from(activeRunExecutions);
+      if (inFlightRunIds.length === 0) {
+        return { terminatedRunCount: 0, releasedIssueCount: 0, runIds: [] };
+      }
+
+      const now = new Date();
+      const errorMessage = reason
+        ? `Run terminated during server shutdown: ${reason}`
+        : "Run terminated during server shutdown";
+
+      let terminatedRunCount = 0;
+      let releasedIssueCount = 0;
+
+      for (const runId of inFlightRunIds) {
+        try {
+          const updatedRun = await db
+            .update(heartbeatRuns)
+            .set({
+              status: "terminated",
+              finishedAt: now,
+              error: errorMessage,
+              errorCode: "server_shutdown",
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(heartbeatRuns.id, runId),
+                inArray(heartbeatRuns.status, ["queued", "running", "scheduled_retry"]),
+              ),
+            )
+            .returning({ id: heartbeatRuns.id, companyId: heartbeatRuns.companyId })
+            .then((rows) => rows[0] ?? null);
+
+          if (!updatedRun) continue;
+          terminatedRunCount += 1;
+
+          const released = await db
+            .update(issues)
+            .set({
+              checkoutRunId: null,
+              executionRunId: null,
+              executionAgentNameKey: null,
+              executionLockedAt: null,
+              updatedAt: now,
+            })
+            .where(
+              and(
+                eq(issues.companyId, updatedRun.companyId),
+                eq(issues.executionRunId, runId),
+              ),
+            )
+            .returning({ id: issues.id });
+          releasedIssueCount += released.length;
+        } catch (err) {
+          logger.warn({ err, runId }, "failed to terminate in-flight run during shutdown");
+        }
+      }
+
+      return {
+        terminatedRunCount,
+        releasedIssueCount,
+        runIds: inFlightRunIds,
+      };
     },
   };
 }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -65,6 +65,7 @@ import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from ".
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { redactSensitiveText } from "../redaction.js";
+import { logActivity } from "./activity-log.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
 import { getRunLogStore } from "./run-log-store.js";
 import { getDefaultCompanyGoal } from "./goals.js";
@@ -332,7 +333,17 @@ function sameRunLock(checkoutRunId: string | null, actorRunId: string | null) {
   return checkoutRunId == null;
 }
 
-const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set(["succeeded", "failed", "cancelled", "timed_out"]);
+// `terminated` is written by the run-termination hook (graceful exit / timeout / SIGTERM)
+// when the server detects an in-flight run is being cut short and clears its issue locks.
+// It is intentionally distinct from `cancelled`/`timed_out` so observers can tell apart
+// a run that was actively reaped from one the agent chose to stop.
+export const TERMINAL_HEARTBEAT_RUN_STATUSES = new Set([
+  "succeeded",
+  "failed",
+  "cancelled",
+  "timed_out",
+  "terminated",
+]);
 const ISSUE_LIST_DESCRIPTION_MAX_CHARS = 1200;
 const ISSUE_LIST_DESCRIPTION_MAX_BYTES = ISSUE_LIST_DESCRIPTION_MAX_CHARS * 4;
 
@@ -3319,14 +3330,58 @@ export function issueService(db: Db) {
     return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
   }
 
+  async function readHeartbeatRunStatus(runId: string): Promise<string | null> {
+    const run = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0] ?? null);
+    return run?.status ?? null;
+  }
+
+  async function writeStaleLockTakeoverAuditLog(input: {
+    companyId: string;
+    issueId: string;
+    actorAgentId: string;
+    actorRunId: string;
+    priorRunId: string | null;
+    priorRunStatus: string | null;
+    trigger: "checkout" | "assert_checkout_owner";
+  }) {
+    await logActivity(db, {
+      companyId: input.companyId,
+      actorType: "agent",
+      actorId: input.actorAgentId,
+      action: "stale_lock_takeover",
+      entityType: "issue",
+      entityId: input.issueId,
+      agentId: input.actorAgentId,
+      runId: input.actorRunId,
+      details: {
+        issueId: input.issueId,
+        actorAgentId: input.actorAgentId,
+        actorRunId: input.actorRunId,
+        priorRunId: input.priorRunId,
+        priorRunStatus: input.priorRunStatus,
+        trigger: input.trigger,
+      },
+    }).catch((err) => {
+      logger.warn({ err, issueId: input.issueId }, "failed to write stale_lock_takeover audit row");
+    });
+  }
+
   async function adoptStaleCheckoutRun(input: {
     issueId: string;
     actorAgentId: string;
     actorRunId: string;
     expectedCheckoutRunId: string;
+    companyId: string;
+    trigger: "checkout" | "assert_checkout_owner";
   }) {
     const stale = await isTerminalOrMissingHeartbeatRun(input.expectedCheckoutRunId);
     if (!stale) return null;
+
+    const priorRunStatus = await readHeartbeatRunStatus(input.expectedCheckoutRunId);
 
     const now = new Date();
     const adopted = await db
@@ -3354,6 +3409,18 @@ export function issueService(db: Db) {
       })
       .then((rows) => rows[0] ?? null);
 
+    if (adopted) {
+      await writeStaleLockTakeoverAuditLog({
+        companyId: input.companyId,
+        issueId: input.issueId,
+        actorAgentId: input.actorAgentId,
+        actorRunId: input.actorRunId,
+        priorRunId: input.expectedCheckoutRunId,
+        priorRunStatus,
+        trigger: input.trigger,
+      });
+    }
+
     return adopted;
   }
 
@@ -3361,6 +3428,9 @@ export function issueService(db: Db) {
     issueId: string;
     actorAgentId: string;
     actorRunId: string;
+    companyId: string;
+    trigger: "checkout" | "assert_checkout_owner";
+    priorExecutionRunId?: string | null;
   }) {
     const now = new Date();
     const adopted = await db
@@ -3388,6 +3458,19 @@ export function issueService(db: Db) {
         executionRunId: issues.executionRunId,
       })
       .then((rows) => rows[0] ?? null);
+
+    if (adopted && input.priorExecutionRunId && input.priorExecutionRunId !== input.actorRunId) {
+      const priorRunStatus = await readHeartbeatRunStatus(input.priorExecutionRunId);
+      await writeStaleLockTakeoverAuditLog({
+        companyId: input.companyId,
+        issueId: input.issueId,
+        actorAgentId: input.actorAgentId,
+        actorRunId: input.actorRunId,
+        priorRunId: input.priorExecutionRunId,
+        priorRunStatus,
+        trigger: input.trigger,
+      });
+    }
 
     return adopted;
   }
@@ -4778,6 +4861,8 @@ export function issueService(db: Db) {
           actorAgentId: agentId,
           actorRunId: checkoutRunId,
           expectedCheckoutRunId: current.checkoutRunId,
+          companyId: issueCompany.companyId,
+          trigger: "checkout",
         });
         if (adopted) {
           const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
@@ -4813,6 +4898,7 @@ export function issueService(db: Db) {
       const current = await db
         .select({
           id: issues.id,
+          companyId: issues.companyId,
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
           checkoutRunId: issues.checkoutRunId,
@@ -4843,6 +4929,9 @@ export function issueService(db: Db) {
           issueId: id,
           actorAgentId,
           actorRunId,
+          companyId: current.companyId,
+          trigger: "assert_checkout_owner",
+          priorExecutionRunId: current.executionRunId,
         });
 
         if (adopted) {
@@ -4865,6 +4954,8 @@ export function issueService(db: Db) {
           actorAgentId,
           actorRunId,
           expectedCheckoutRunId: current.checkoutRunId,
+          companyId: current.companyId,
+          trigger: "assert_checkout_owner",
         });
 
         if (adopted) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and the heartbeat run lifecycle owns the per-issue execution lock (`assigneeAgentId` + `checkoutRunId` + `executionRunId` + `executionLockedAt`) that makes the same-agent assumption safe.
> - Inside the heartbeat subsystem, the run-termination hook (`releaseIssueExecutionAndPromote`) is the single point where a finished run is supposed to hand its issue lock back to the system, and the checkout endpoint is the safety net that detects and recovers from a missed hand-back.
> - In practice the hook only clears `executionRunId`/`executionLockedAt` and leaves `checkoutRunId` pointing at the (now terminal) prior run. The next same-agent wake hits `POST /api/issues/:id/checkout` and is rejected with `409 Issue run ownership conflict` even though the prior run is unambiguously dead. There is no equivalent hook at all when the server itself is shutting down with in-flight runs, so a SIGTERM during a long run reliably wedges its issues.
> - The downstream effect is that an agent assigned to an issue effectively cannot recover from its own prior run ending without explicit `release` — every subsequent `checkout`/`release`/`comment` call 409s, which is a chain-reliability problem rather than a one-off incident.
> - This pull request closes both halves of the gap: the in-band run-termination hook now also clears `checkoutRunId`, the SIGTERM/SIGINT shutdown handler runs an equivalent terminate-and-release pass for in-flight runs, and the existing checkout safety net now emits a first-class `stale_lock_takeover` audit row so operators can see when the safety net is catching cases the in-band hook missed.
> - The benefit is that same-agent wakes resume cleanly after any run termination (graceful, timeout, SIGTERM, and via the safety net even SIGKILL/panic) without changing any agent SDK contract or cross-agent concurrency guarantees.

## What Changed

- **Root-cause fix** — `releaseIssueExecutionAndPromote` (`server/src/services/heartbeat.ts`) now also clears `checkoutRunId` when it equals the terminating run, so the in-band release hook actually releases the full lock instead of only the execution half.
- **Server-shutdown hook** — new `terminateInFlightRunsForShutdown(reason)` method on the heartbeat service iterates the `activeRunExecutions` set, marks each still-live run with `runs.status = 'terminated'` (a new terminal status, distinct from `cancelled`/`timed_out` so observers can tell apart "reaped on shutdown" from "agent or user stopped"), and clears every `checkoutRunId`/`executionRunId`/`executionLockedAt` it owns. The process-level SIGINT/SIGTERM handler in `server/src/index.ts` now calls this before stopping embedded Postgres and exiting.
- **Treat `terminated` as terminal** — `TERMINAL_HEARTBEAT_RUN_STATUSES` in `server/src/services/issues.ts` is now exported and includes `'terminated'`, so the existing `adoptStaleCheckoutRun` / `adoptUnownedCheckoutRun` safety nets recognise shutdown-reaped runs as adoptable.
- **`stale_lock_takeover` audit row** — both adopt helpers now write a structured `activity_log` row (`{ issueId, actorAgentId, actorRunId, priorRunId, priorRunStatus, trigger }`) whenever the checkout-time safety net adopts a stale lock. This gives operators a first-class signal for "how often is the safety net firing", which is the leading indicator that the in-band termination hook is failing in some new failure mode (SIGKILL, process panic, etc.).
- **Audit log doc** — `doc/spec/agent-runs.md` registers `stale_lock_takeover` under §13.2 alongside the existing `heartbeat.*` mutation actions, with the full payload schema and the operational interpretation.
- **Tests** — `server/src/__tests__/issue-stale-execution-lock-routes.test.ts` adds four cases covering the new behaviour: takeover writes the audit row (`checkout` trigger), cross-agent contention is still rejected and never adopts, same-agent + still-`running` prior run is still rejected with 409 and never adopts, and a `terminated`-status prior run is adopted cleanly through the existing checkout path.

## Verification

- `cd server && npx vitest run src/__tests__/issue-stale-execution-lock-routes.test.ts` — 7/7 passing (3 pre-existing + 4 new).
- `cd server && npx tsc --noEmit` — clean for every file touched by this PR. (There are pre-existing `unknown`/implicit-any errors elsewhere in `routes/plugins.ts` and `services/plugin-host-services.ts` that are unrelated to this change.)
- Manual repro of the original failure mode (see #issue link) is mechanically encoded by the new "writes a stale_lock_takeover audit row when same-agent checkout adopts a terminal-prior checkoutRunId" test: an issue with `checkoutRunId == priorRunId` and prior run status `failed` is reopened by the same agent on a fresh run and the lock now flips to the new run with an audit trail.

## Risks

- **Lower risk than it looks.** The in-band fix only adds `checkoutRunId: null` to an update that already targets the same row under the existing assignee+run guard, so it strictly widens what gets released on the success path and never touches a foreign run's lock.
- **`terminated` is a new run status string.** Anything that exhaustively switches on `heartbeat_runs.status` (UI badges, exports, plugin event handlers) will see this new value. The plugin lifecycle event mapper already returns `null` for unknown statuses (`publishRunLifecyclePluginEvent`), so no spurious events are emitted. UI handling is best-effort — worst case it renders as the raw string until callers add a friendly label.
- **Shutdown hook is best-effort.** Failures inside `terminateInFlightRunsForShutdown` are caught and logged; they never block process exit. If the database is already gone (embedded Postgres torn down before the handler ran), the hook degrades to a warning instead of blocking shutdown.
- **`stale_lock_takeover` audit row volume.** In healthy operation this should be ~0 rows. If volume goes non-zero in production, that is a leading indicator that the in-band hook isn't firing for some failure mode and warrants investigation rather than rate-limiting.
- **No migration required.** No DB schema changes; `heartbeat_runs.status` is already plain `text` and the new value is forward-compatible with the existing `TERMINAL_HEARTBEAT_RUN_STATUSES` consumers.

## Model Used

- Claude Opus 4.7 (`claude-opus-4-7`) running inside the Claude Code CLI v2 with the Paperclip plugin orchestrating heartbeat-driven execution. Extended-thinking mode enabled, full tool access (Read/Edit/Write/Bash/Grep/Glob) against the local clone; no MCP plugin tools were used to author the patch.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (`vitest run src/__tests__/issue-stale-execution-lock-routes.test.ts`)
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — n/a, server-only change
- [x] I have updated relevant documentation to reflect my changes (`doc/spec/agent-runs.md` §13.2)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge