### PR TITLE
fix(ui/import): seed CEO model into per-agent adapter overrides

### DIFF
--- a/ui/src/pages/CompanyImport.tsx
+++ b/ui/src/pages/CompanyImport.tsx
@@ -702,6 +702,12 @@ export function CompanyImport() {
     const ceo = companyAgents.find((a) => a.role === "ceo");
     return ceo?.adapterType ?? "claude_local";
   }, [companyAgents]);
+  const ceoAdapterModel = useMemo(() => {
+    if (!companyAgents) return "";
+    const ceo = companyAgents.find((a) => a.role === "ceo");
+    const model = ceo?.adapterConfig?.model;
+    return typeof model === "string" ? model : "";
+  }, [companyAgents]);
 
   const localZipHelpText =
     "Upload a .zip exported directly from Paperclip. Re-zipped archives created by Finder, Explorer, or other zip tools may not import correctly.";
@@ -761,14 +767,25 @@ export function CompanyImport() {
       setSkippedSlugs(new Set());
       setConfirmedSlugs(new Set());
 
-      // Initialize adapter overrides — default all agents to the CEO's adapter type
+      // Initialize adapter overrides — default all agents to the CEO's adapter type.
+      // Also seed adapterConfigValues with the CEO's model so opencode_local
+      // (which requires adapterConfig.model) doesn't fail server-side validation
+      // when the user accepts defaults without expanding "configure adapter".
       const defaultAdapters: Record<string, string> = {};
+      const defaultConfigs: Record<string, CreateConfigValues> = {};
       for (const agent of result.manifest.agents) {
         defaultAdapters[agent.slug] = ceoAdapterType;
+        if (ceoAdapterModel) {
+          defaultConfigs[agent.slug] = {
+            ...defaultCreateValues,
+            adapterType: ceoAdapterType,
+            model: ceoAdapterModel,
+          };
+        }
       }
       setAdapterOverrides(defaultAdapters);
       setAdapterExpandedSlugs(new Set());
-      setAdapterConfigValues({});
+      setAdapterConfigValues(defaultConfigs);
 
       // Check all files by default, then uncheck COMPANY.md for existing company
       const allFiles = new Set(Object.keys(result.files));


### PR DESCRIPTION
## Summary

Company Import seeded each imported agent's adapter override with the target company CEO's `adapterType` but never copied the CEO's `adapterConfig`. When the CEO ran `opencode_local`, importing failed unless the user manually expanded "configure adapter" on every imported agent and picked a model.

Failure message:

> Invalid opencode_local adapterConfig: OpenCode requires `adapterConfig.model` in provider/model format.

## Repro

1. Active company in sidebar has a CEO on `opencode_local` (with a valid model).
2. Open Company → Import, upload any exported `.zip` (e.g. a 14-agent newsletter company).
3. Run preview, accept defaults, click Import.
4. Import fails on the first agent — server rejects model-less `opencode_local` `adapterConfig`.

Workarounds today: expand "configure adapter" for **every** agent and pick a model, or switch every dropdown to a non-opencode adapter.

## Fix

`ui/src/pages/CompanyImport.tsx`:

- Read `ceo.adapterConfig.model` alongside `ceo.adapterType`.
- When seeding `adapterOverrides`, also seed `adapterConfigValues[slug]` with `{ ...defaultCreateValues, adapterType: ceoAdapterType, model: ceoAdapterModel }` so `buildFinalAdapterOverrides()` emits a complete `adapterConfig` (including `model`) for `opencode_local`.
- Only seeded when CEO has a model — preserves prior behavior for adapters that don't need a model and for the no-CEO case.

## Test plan

- [ ] With sidebar company on `opencode_local` + valid `model`: import a `.zip` company → succeeds without expanding any adapter row.
- [ ] With sidebar company on `claude_local`: import behaves as before.
- [ ] User manually changes one agent's adapter dropdown or expands "configure adapter" → user edits still win (default seed is overridden by `handleAdapterConfigChange`).
- [ ] Existing-company import with target CEO that already has `opencode_local` + model → no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)