### PR TITLE
fix(server): drain live heartbeat runs on shutdown so same-agent checkout can reenter

### DIFF
--- a/server/src/__tests__/heartbeat-shutdown-drain.test.ts
+++ b/server/src/__tests__/heartbeat-shutdown-drain.test.ts
@@ -1,0 +1,216 @@
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { drainStaleHeartbeatRunsOnShutdown } from "../services/heartbeat-shutdown-drain.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat shutdown drain tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+describeEmbeddedPostgres("drainStaleHeartbeatRunsOnShutdown", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-shutdown-drain-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seed() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Producer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  it("returns a zero result when no live runs exist", async () => {
+    const result = await drainStaleHeartbeatRunsOnShutdown(db);
+    expect(result).toEqual({ runsTerminated: 0, issuesUnlocked: 0 });
+  });
+
+  it("cancels every live heartbeat run and clears the issue locks they hold", async () => {
+    const { companyId, agentId } = await seed();
+    const liveRunId = randomUUID();
+    const queuedRunId = randomUUID();
+    const retryRunId = randomUUID();
+    const succeededRunId = randomUUID();
+    await db.insert(heartbeatRuns).values([
+      {
+        id: liveRunId,
+        companyId,
+        agentId,
+        status: "running",
+        invocationSource: "manual",
+        startedAt: new Date(),
+      },
+      {
+        id: queuedRunId,
+        companyId,
+        agentId,
+        status: "queued",
+        invocationSource: "manual",
+      },
+      {
+        id: retryRunId,
+        companyId,
+        agentId,
+        status: "scheduled_retry",
+        invocationSource: "manual",
+      },
+      {
+        id: succeededRunId,
+        companyId,
+        agentId,
+        status: "succeeded",
+        invocationSource: "manual",
+        finishedAt: new Date(),
+      },
+    ]);
+
+    const issueWithExecutionLock = randomUUID();
+    const issueWithCheckoutOnlyLock = randomUUID();
+    const issueOnTerminalRun = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: issueWithExecutionLock,
+        companyId,
+        title: "Locked by execution",
+        status: "in_progress",
+        priority: "high",
+        assigneeAgentId: agentId,
+        checkoutRunId: liveRunId,
+        executionRunId: liveRunId,
+        executionAgentNameKey: "producer",
+        executionLockedAt: new Date(),
+      },
+      {
+        id: issueWithCheckoutOnlyLock,
+        companyId,
+        title: "Locked by checkout only",
+        status: "in_progress",
+        priority: "high",
+        assigneeAgentId: agentId,
+        checkoutRunId: queuedRunId,
+        executionRunId: null,
+      },
+      {
+        id: issueOnTerminalRun,
+        companyId,
+        title: "Already terminal",
+        status: "in_progress",
+        priority: "high",
+        assigneeAgentId: agentId,
+        checkoutRunId: succeededRunId,
+        executionRunId: succeededRunId,
+      },
+    ]);
+
+    const result = await drainStaleHeartbeatRunsOnShutdown(db);
+    expect(result).toEqual({ runsTerminated: 3, issuesUnlocked: 2 });
+
+    const liveCount = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.status, "running"))
+      .then((rows) => rows.length);
+    expect(liveCount).toBe(0);
+
+    const cancelledRow = await db
+      .select({
+        status: heartbeatRuns.status,
+        errorCode: heartbeatRuns.errorCode,
+        finishedAt: heartbeatRuns.finishedAt,
+      })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, liveRunId))
+      .then((rows) => rows[0]);
+    expect(cancelledRow?.status).toBe("cancelled");
+    expect(cancelledRow?.errorCode).toBe("server_shutdown_stale_lock_cleanup");
+    expect(cancelledRow?.finishedAt).not.toBeNull();
+
+    const executionLockedRow = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionAgentNameKey: issues.executionAgentNameKey,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueWithExecutionLock))
+      .then((rows) => rows[0]);
+    expect(executionLockedRow).toEqual({
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+
+    const checkoutOnlyRow = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueWithCheckoutOnlyLock))
+      .then((rows) => rows[0]);
+    expect(checkoutOnlyRow).toEqual({ checkoutRunId: null, executionRunId: null });
+
+    const terminalRow = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueOnTerminalRun))
+      .then((rows) => rows[0]);
+    expect(terminalRow).toEqual({
+      checkoutRunId: succeededRunId,
+      executionRunId: succeededRunId,
+    });
+  });
+});

--- a/server/src/__tests__/issues-checkout-stale-lock-takeover.test.ts
+++ b/server/src/__tests__/issues-checkout-stale-lock-takeover.test.ts
@@ -1,0 +1,232 @@
+import { randomUUID } from "node:crypto";
+import { eq, and } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { sql } from "drizzle-orm";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  instanceSettings,
+  issueComments,
+  issueInboxArchives,
+  issueRelations,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { issueService } from "../services/issues.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres stale-lock takeover tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+async function ensureIssueRelationsTable(db: ReturnType<typeof createDb>) {
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS "issue_relations" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      "company_id" uuid NOT NULL,
+      "issue_id" uuid NOT NULL,
+      "related_issue_id" uuid NOT NULL,
+      "type" text NOT NULL,
+      "created_by_agent_id" uuid,
+      "created_by_user_id" text,
+      "created_at" timestamptz NOT NULL DEFAULT now(),
+      "updated_at" timestamptz NOT NULL DEFAULT now()
+    );
+  `));
+}
+
+describeEmbeddedPostgres("issueService.checkout stale-lock takeover", () => {
+  let db!: ReturnType<typeof createDb>;
+  let svc!: ReturnType<typeof issueService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issues-stale-lock-takeover-");
+    db = createDb(tempDb.connectionString);
+    svc = issueService(db);
+    await ensureIssueRelationsTable(db);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueInboxArchives);
+    await db.delete(activityLog);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(instanceSettings);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedSameAgentReentryScene() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const priorRunId = randomUUID();
+    const newRunId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Producer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    // Prior run already cancelled (e.g. by the graceful shutdown drain) but
+    // the issue row still references it as the active checkoutRunId.
+    // The new run is the live one the actor brings to the checkout call.
+    await db.insert(heartbeatRuns).values([
+      {
+        id: priorRunId,
+        companyId,
+        agentId,
+        status: "cancelled",
+        invocationSource: "manual",
+        finishedAt: new Date(),
+        errorCode: "server_shutdown_stale_lock_cleanup",
+      },
+      {
+        id: newRunId,
+        companyId,
+        agentId,
+        status: "running",
+        invocationSource: "manual",
+        startedAt: new Date(),
+      },
+    ]);
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Producer-1 dogfood reentry",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: priorRunId,
+      executionRunId: priorRunId,
+      executionAgentNameKey: "producer",
+      executionLockedAt: new Date(),
+    });
+
+    return { companyId, agentId, priorRunId, newRunId, issueId };
+  }
+
+  it("lets the same agent take over a stale lock and writes an audit row", async () => {
+    const { companyId, agentId, priorRunId, newRunId, issueId } =
+      await seedSameAgentReentryScene();
+
+    const result = await svc.checkout(issueId, agentId, ["in_progress"], newRunId);
+    expect(result?.id).toBe(issueId);
+    expect(result?.checkoutRunId).toBe(newRunId);
+    expect(result?.executionRunId).toBe(newRunId);
+
+    const audit = await db
+      .select({
+        action: activityLog.action,
+        actorType: activityLog.actorType,
+        actorId: activityLog.actorId,
+        agentId: activityLog.agentId,
+        runId: activityLog.runId,
+        entityType: activityLog.entityType,
+        entityId: activityLog.entityId,
+        details: activityLog.details,
+      })
+      .from(activityLog)
+      .where(
+        and(
+          eq(activityLog.companyId, companyId),
+          eq(activityLog.entityId, issueId),
+          eq(activityLog.action, "issue.stale_lock_takeover"),
+        ),
+      )
+      .then((rows) => rows[0]);
+
+    expect(audit).toBeTruthy();
+    expect(audit).toMatchObject({
+      action: "issue.stale_lock_takeover",
+      actorType: "agent",
+      actorId: agentId,
+      agentId,
+      runId: newRunId,
+      entityType: "issue",
+      entityId: issueId,
+      details: {
+        priorCheckoutRunId: priorRunId,
+        actorRunId: newRunId,
+        source: "adoptStaleCheckoutRun",
+      },
+    });
+  });
+
+  it("refuses to take over the lock for a different (non-assignee) agent — cross-agent regression", async () => {
+    const { companyId, priorRunId, newRunId, issueId } = await seedSameAgentReentryScene();
+
+    const intruderId = randomUUID();
+    await db.insert(agents).values({
+      id: intruderId,
+      companyId,
+      name: "Intruder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await expect(
+      svc.checkout(issueId, intruderId, ["in_progress"], newRunId),
+    ).rejects.toMatchObject({ status: 409 });
+
+    const row = await db
+      .select({
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    // The intruder must not own the checkout lock; the assignee/lock binding
+    // is preserved. (`executionRunId` may legitimately be cleared because the
+    // prior run is in a terminal state — the gate is the `checkoutRunId`
+    // assignee binding, not the execution lock byproduct.)
+    expect(row?.assigneeAgentId).not.toBe(intruderId);
+    expect(row?.checkoutRunId).toBe(priorRunId);
+    expect(row?.checkoutRunId).not.toBe(newRunId);
+
+    const audit = await db
+      .select({ id: activityLog.id })
+      .from(activityLog)
+      .where(eq(activityLog.action, "issue.stale_lock_takeover"))
+      .then((rows) => rows.length);
+    expect(audit).toBe(0);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ import { stdin, stdout } from "node:process";
 import { pathToFileURL } from "node:url";
 import type { Request as ExpressRequest, RequestHandler } from "express";
 import { and, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
 import {
   createDb,
   ensurePostgresDatabase,
@@ -39,6 +40,7 @@ import {
   routineService,
 } from "./services/index.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
+import { drainStaleHeartbeatRunsOnShutdown } from "./services/heartbeat-shutdown-drain.js";
 import { buildRuntimeApiCandidateUrls, choosePrimaryRuntimeApiUrl } from "./runtime-api.js";
 import { createPluginWorkerManager } from "./services/plugin-worker-manager.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
@@ -923,6 +925,21 @@ export async function startServer(): Promise<StartedServer> {
       if (telemetryClient) {
         telemetryClient.stop();
         await telemetryClient.flush();
+      }
+
+      // Mark every still-live heartbeat run as cancelled and clear the
+      // `executionRunId` / `checkoutRunId` locks they hold on issues. Without
+      // this, a clean shutdown leaves the run row in "running" status and the
+      // next checkout from the same agent hits a 409 because the prior lock
+      // is still considered live. Bounded to 5s so a DB hang cannot wedge
+      // process exit; best-effort logging only.
+      try {
+        await Promise.race([
+          drainStaleHeartbeatRunsOnShutdown(db as Db),
+          new Promise<null>((resolve) => setTimeout(() => resolve(null), 5000)),
+        ]);
+      } catch (err) {
+        logger.warn({ err, signal }, "stale heartbeat-run drain on shutdown threw");
       }
 
       const appShutdown = (app as { locals?: { paperclipShutdown?: () => void } }).locals?.paperclipShutdown;

--- a/server/src/services/heartbeat-shutdown-drain.ts
+++ b/server/src/services/heartbeat-shutdown-drain.ts
@@ -1,0 +1,90 @@
+import { inArray } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRuns, issues } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+
+const LIVE_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
+
+const SHUTDOWN_DRAIN_ERROR = "Server shutdown — stale heartbeat-run lock cleanup.";
+const SHUTDOWN_DRAIN_ERROR_CODE = "server_shutdown_stale_lock_cleanup";
+
+export interface DrainStaleHeartbeatRunsResult {
+  runsTerminated: number;
+  issuesUnlocked: number;
+}
+
+/**
+ * On graceful shutdown (SIGINT/SIGTERM), terminate every still-live
+ * heartbeat run row (queued / running / scheduled_retry) and clear the
+ * `executionRunId` / `checkoutRunId` locks pointing at those runs on the
+ * `issues` table. Without this, a clean shutdown leaves the run row in
+ * "running" status and the next checkout from the same agent hits a 409
+ * because the prior lock is still considered live.
+ *
+ * Best-effort: returns `null` on any DB failure and never throws.
+ */
+export async function drainStaleHeartbeatRunsOnShutdown(
+  db: Db,
+): Promise<DrainStaleHeartbeatRunsResult | null> {
+  try {
+    const now = new Date();
+    const liveRuns = await db
+      .select({ id: heartbeatRuns.id })
+      .from(heartbeatRuns)
+      .where(inArray(heartbeatRuns.status, [...LIVE_HEARTBEAT_RUN_STATUSES]));
+    if (liveRuns.length === 0) {
+      return { runsTerminated: 0, issuesUnlocked: 0 };
+    }
+    const liveRunIds = liveRuns.map((r) => r.id);
+
+    const unlockedByExecution = await db
+      .update(issues)
+      .set({
+        checkoutRunId: null,
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        updatedAt: now,
+      })
+      .where(inArray(issues.executionRunId, liveRunIds))
+      .returning({ id: issues.id });
+
+    // Also clear `checkoutRunId` locks pointing at these runs but whose
+    // `executionRunId` was already null (so the previous UPDATE skipped them).
+    const unlockedByCheckoutOnly = await db
+      .update(issues)
+      .set({
+        checkoutRunId: null,
+        updatedAt: now,
+      })
+      .where(inArray(issues.checkoutRunId, liveRunIds))
+      .returning({ id: issues.id });
+
+    const terminated = await db
+      .update(heartbeatRuns)
+      .set({
+        status: "cancelled",
+        finishedAt: now,
+        error: SHUTDOWN_DRAIN_ERROR,
+        errorCode: SHUTDOWN_DRAIN_ERROR_CODE,
+        updatedAt: now,
+      })
+      .where(inArray(heartbeatRuns.id, liveRunIds))
+      .returning({ id: heartbeatRuns.id });
+
+    const result: DrainStaleHeartbeatRunsResult = {
+      runsTerminated: terminated.length,
+      issuesUnlocked: unlockedByExecution.length + unlockedByCheckoutOnly.length,
+    };
+    logger.info(result, "Cleared stale heartbeat-run locks on shutdown");
+    return result;
+  } catch (err) {
+    logger.warn({ err }, "Stale heartbeat-run drain on shutdown failed");
+    return null;
+  }
+}
+
+export const __INTERNAL_FOR_TESTS = {
+  LIVE_HEARTBEAT_RUN_STATUSES,
+  SHUTDOWN_DRAIN_ERROR_CODE,
+};

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -52,6 +52,7 @@ import {
 } from "@paperclipai/shared";
 import { conflict, HttpError, notFound, unprocessable } from "../errors.js";
 import { logger } from "../middleware/logger.js";
+import { logActivity } from "./activity-log.js";
 import { parseObject } from "../adapters/utils.js";
 import {
   defaultIssueExecutionWorkspaceSettingsForProject,
@@ -3347,12 +3348,41 @@ export function issueService(db: Db) {
       )
       .returning({
         id: issues.id,
+        companyId: issues.companyId,
         status: issues.status,
         assigneeAgentId: issues.assigneeAgentId,
         checkoutRunId: issues.checkoutRunId,
         executionRunId: issues.executionRunId,
       })
       .then((rows) => rows[0] ?? null);
+
+    if (adopted) {
+      // Audit trail for stale-lock takeover so operators can reconstruct what
+      // happened when an issue silently changed `checkoutRunId` ownership.
+      // Best-effort: a logging failure must never block checkout adoption.
+      try {
+        await logActivity(db, {
+          companyId: adopted.companyId,
+          actorType: "agent",
+          actorId: input.actorAgentId,
+          agentId: input.actorAgentId,
+          runId: input.actorRunId,
+          action: "issue.stale_lock_takeover",
+          entityType: "issue",
+          entityId: input.issueId,
+          details: {
+            priorCheckoutRunId: input.expectedCheckoutRunId,
+            actorRunId: input.actorRunId,
+            source: "adoptStaleCheckoutRun",
+          },
+        });
+      } catch (err) {
+        logger.warn(
+          { err, issueId: input.issueId },
+          "stale lock takeover audit log failed",
+        );
+      }
+    }
 
     return adopted;
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each running heartbeat is bound to an issue via `issues.checkoutRunId` / `issues.executionRunId` and a row in `heartbeat_runs`
> - When the Paperclip server is stopped with SIGINT/SIGTERM, the run row is left in `running` status because nothing transitions it to terminal
> - On the next launch, the same agent calls `POST /api/issues/:id/checkout` to reenter the issue it was already working on, but `adoptStaleCheckoutRun` only treats terminal/missing runs as stale, so the previous "running" run still looks live and the checkout 409s
> - This PR drains every still-live `heartbeat_runs` row during graceful shutdown (cancelling the run + clearing the issue locks it held), and adds an audit row when stale-lock takeover does fire so the silent ownership change is reconstructable
> - The benefit is single-agent restart loops (a producer agent reentering its own issue after a server restart) recover cleanly, while the same-assignee/cross-agent safety gate stays exactly where it was

## What Changed

- New `server/src/services/heartbeat-shutdown-drain.ts` exporting `drainStaleHeartbeatRunsOnShutdown(db)`. Walks every `heartbeat_runs` row in `queued` / `running` / `scheduled_retry`, clears the `checkoutRunId` / `executionRunId` locks on every issue that pointed at one of those runs, then marks the runs `cancelled` with `errorCode: "server_shutdown_stale_lock_cleanup"`. Returns `{runsTerminated, issuesUnlocked}` for the log line; on error returns `null` and logs at WARN.
- `server/src/index.ts` calls the drain from the SIGINT/SIGTERM shutdown handler, immediately before `paperclipShutdown()`, bounded by a 5s `Promise.race` timeout so a DB hang cannot wedge process exit. Errors are caught — drain is best-effort, never blocks the rest of shutdown.
- `server/src/services/issues.ts → adoptStaleCheckoutRun` now writes an `issue.stale_lock_takeover` audit row via `logActivity` on successful adoption. Audit logging is best-effort (`try/catch` around the call), and `returning(...)` now also fetches `companyId` so the audit row can be written without an extra query. No behavior change to the gate itself: the takeover is still restricted to the issue's existing `assigneeAgentId`.

## Verification

```bash
pnpm install --frozen-lockfile
pnpm --filter @paperclipai/plugin-sdk ensure-build-deps
pnpm --filter @paperclipai/server typecheck

cd server
pnpm exec vitest run \
  src/__tests__/heartbeat-shutdown-drain.test.ts \
  src/__tests__/issues-checkout-stale-lock-takeover.test.ts \
  src/__tests__/issue-stale-execution-lock-routes.test.ts \
  src/__tests__/issues-checkout-wakeup.test.ts
# → 4 test files, 11 tests, all passing
```

New tests:
- `heartbeat-shutdown-drain.test.ts` — (a) no-op when no live runs, (b) cancels live runs across `running` / `queued` / `scheduled_retry`, clears both the `executionRunId`-anchored lock and the `checkoutRunId`-only lock, and leaves issues whose run is already terminal untouched.
- `issues-checkout-stale-lock-takeover.test.ts` — (a) same agent re-entering an issue whose `checkoutRunId` points at a now-cancelled run successfully takes over the lock and writes an `issue.stale_lock_takeover` audit row with the expected `priorCheckoutRunId` / `actorRunId` details; (b) a different (non-assignee) agent making the same call still gets a 409, the lock binding is preserved, and no audit row is written.

Manual smoke (matches the original repro):
1. Start the server, check out an issue from an agent run, leave it `running`.
2. `SIGTERM` the server. The drain logs `Cleared stale heartbeat-run locks on shutdown {runsTerminated: N, issuesUnlocked: M}`.
3. Restart the server and the same agent calls `POST /api/issues/:id/checkout` with a new `checkoutRunId` — succeeds (200) instead of 409.

## Risks

- Low risk for the drain itself: it only updates `issues` / `heartbeat_runs` rows in `live` status, runs at the start of the shutdown handler, and is fully guarded — any failure logs at WARN and is swallowed.
- The 5s `Promise.race` cap means a very slow `UPDATE` could be cut short. That is intentional — half-finished cleanup is better than wedged shutdown. The next launch is still safe because `clearExecutionRunIfTerminal` + the existing `adoptStaleCheckoutRun` flow handles whatever the drain leaves behind.
- `adoptStaleCheckoutRun`'s gate is unchanged (same `assigneeAgentId` + same `expectedCheckoutRunId` UPDATE WHERE) — the only added side effect is an audit row in `activity_log`. The cross-agent regression test pins this.
- No schema/migration changes. No public API changes. No new env vars.

## Model Used

- Claude Opus 4.7 (Anthropic, model id `claude-opus-4-7`), 200K context, no extended thinking mode. Code authored and tested by the model under human supervision; the human kicked off the work, reviewed the diff, and ran the test commands above before opening the PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (n/a — server-only)
- [x] I have updated relevant documentation to reflect my changes (n/a — internal behavior fix)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
