### PR TITLE
Guard deferred comment reopens by freshness

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -759,8 +759,8 @@ describe("heartbeat comment wake batching", () => {
       await db
         .update(issues)
         .set({
-          status: "done",
-          completedAt: terminalAt,
+          status: "cancelled",
+          cancelledAt: terminalAt,
           executionRunId: null,
           executionAgentNameKey: null,
           executionLockedAt: null,
@@ -789,15 +789,16 @@ describe("heartbeat comment wake batching", () => {
         .select({
           status: issues.status,
           completedAt: issues.completedAt,
+          cancelledAt: issues.cancelledAt,
         })
         .from(issues)
         .where(eq(issues.id, issueId))
         .then((rows) => rows[0] ?? null);
 
       expect(reopenedIssue).toMatchObject({
-        status: "done",
+        status: "cancelled",
       });
-      expect(reopenedIssue?.completedAt).not.toBeNull();
+      expect(reopenedIssue?.cancelledAt).not.toBeNull();
 
       const secondPayload = gateway.getAgentPayloads()[1] ?? {};
       expect(secondPayload.paperclip).toMatchObject({
@@ -809,7 +810,7 @@ describe("heartbeat comment wake batching", () => {
             id: issueId,
             identifier: `${issuePrefix}-1`,
             title: "Reopen after deferred comment",
-            status: "done",
+            status: "cancelled",
             priority: "medium",
           },
         },

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -6,7 +6,6 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   agents,
   agentWakeupRequests,
-  activityLog,
   companies,
   createDb,
   heartbeatRuns,
@@ -768,18 +767,6 @@ describe("heartbeat comment wake batching", () => {
           updatedAt: terminalAt,
         })
         .where(eq(issues.id, issueId));
-      await db.insert(activityLog).values({
-        companyId,
-        actorType: "system",
-        actorId: "heartbeat",
-        action: "issue.updated",
-        entityType: "issue",
-        entityId: issueId,
-        agentId,
-        runId: firstRun?.id ?? null,
-        details: { status: "done" },
-        createdAt: terminalAt,
-      });
 
       gateway.releaseFirstWait();
 
@@ -919,18 +906,6 @@ describe("heartbeat comment wake batching", () => {
           updatedAt: terminalAt,
         })
         .where(eq(issues.id, issueId));
-      await db.insert(activityLog).values({
-        companyId,
-        actorType: "system",
-        actorId: "heartbeat",
-        action: "issue.updated",
-        entityType: "issue",
-        entityId: issueId,
-        agentId,
-        runId: firstRun!.id,
-        details: { status: "done" },
-        createdAt: terminalAt,
-      });
 
       const comment = await db
         .insert(issueComments)

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   agents,
   agentWakeupRequests,
+  activityLog,
   companies,
   createDb,
   heartbeatRuns,
@@ -625,7 +626,7 @@ describe("heartbeat comment wake batching", () => {
     }
   }, 120_000);
 
-  it("promotes deferred comment wakes after the active run closes the issue", async () => {
+  it("does not reopen a finished issue when the deferred comment predates terminal completion", async () => {
     const gateway = await createControlledGatewayServer();
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -709,6 +710,8 @@ describe("heartbeat comment wake batching", () => {
         return run?.status === "running";
       });
 
+      const staleCommentAt = new Date("2026-01-01T00:00:00.000Z");
+      const terminalAt = new Date("2026-01-01T00:01:00.000Z");
       const comment2 = await db
         .insert(issueComments)
         .values({
@@ -716,6 +719,8 @@ describe("heartbeat comment wake batching", () => {
           issueId,
           authorUserId: "user-1",
           body: "Please handle this follow-up after you finish",
+          createdAt: staleCommentAt,
+          updatedAt: staleCommentAt,
         })
         .returning()
         .then((rows) => rows[0]);
@@ -756,13 +761,206 @@ describe("heartbeat comment wake batching", () => {
         .update(issues)
         .set({
           status: "done",
-          completedAt: new Date(),
+          completedAt: terminalAt,
           executionRunId: null,
           executionAgentNameKey: null,
           executionLockedAt: null,
-          updatedAt: new Date(),
+          updatedAt: terminalAt,
         })
         .where(eq(issues.id, issueId));
+      await db.insert(activityLog).values({
+        companyId,
+        actorType: "system",
+        actorId: "heartbeat",
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: issueId,
+        agentId,
+        runId: firstRun?.id ?? null,
+        details: { status: "done" },
+        createdAt: terminalAt,
+      });
+
+      gateway.releaseFirstWait();
+
+      await waitFor(() => gateway.getAgentPayloads().length >= 2, 90_000);
+      await waitFor(async () => {
+        const runs = await db
+          .select()
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.agentId, agentId))
+          .orderBy(asc(heartbeatRuns.createdAt));
+        const [initialRun, promotedRun] = runs;
+        return (
+          initialRun?.id === firstRun?.id &&
+          initialRun.status === "succeeded" &&
+          promotedRun?.status === "succeeded"
+        );
+      }, 90_000);
+
+      const reopenedIssue = await db
+        .select({
+          status: issues.status,
+          completedAt: issues.completedAt,
+        })
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0] ?? null);
+
+      expect(reopenedIssue).toMatchObject({
+        status: "done",
+      });
+      expect(reopenedIssue?.completedAt).not.toBeNull();
+
+      const secondPayload = gateway.getAgentPayloads()[1] ?? {};
+      expect(secondPayload.paperclip).toMatchObject({
+        wake: {
+          reason: "issue_commented",
+          commentIds: [comment2.id],
+          latestCommentId: comment2.id,
+          issue: {
+            id: issueId,
+            identifier: `${issuePrefix}-1`,
+            title: "Reopen after deferred comment",
+            status: "done",
+            priority: "medium",
+          },
+        },
+      });
+      expect(String(secondPayload.message ?? "")).toContain("Please handle this follow-up after you finish");
+    } finally {
+      gateway.releaseFirstWait();
+      await gateway.close();
+    }
+  }, 120_000);
+
+  it("reopens a finished issue when the deferred comment is newer than terminal completion", async () => {
+    const gateway = await createControlledGatewayServer();
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const heartbeat = heartbeatService(db);
+
+    try {
+      await db.insert(companies).values({
+        id: companyId,
+        name: "Paperclip",
+        issuePrefix,
+        requireBoardApprovalForNewAgents: false,
+      });
+
+      await db.insert(agents).values({
+        id: agentId,
+        companyId,
+        name: "Gateway Agent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "openclaw_gateway",
+        adapterConfig: {
+          url: gateway.url,
+          headers: {
+            "x-openclaw-token": "gateway-token",
+          },
+          payloadTemplate: {
+            message: "wake now",
+          },
+          waitTimeoutMs: 2_000,
+        },
+        runtimeConfig: {},
+        permissions: {},
+      });
+
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Fresh deferred comment",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      });
+
+      const firstRun = await heartbeat.wakeup(agentId, {
+        source: "assignment",
+        triggerDetail: "system",
+        reason: "issue_assigned",
+        payload: { issueId },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_assigned",
+        },
+        requestedByActorType: "system",
+        requestedByActorId: null,
+      });
+
+      expect(firstRun).not.toBeNull();
+      await waitFor(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, firstRun!.id))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "running";
+      });
+
+      const terminalAt = new Date("2026-01-01T00:01:00.000Z");
+      const freshCommentAt = new Date("2026-01-01T00:02:00.000Z");
+      await db
+        .update(issues)
+        .set({
+          status: "done",
+          completedAt: terminalAt,
+          executionRunId: firstRun!.id,
+          executionAgentNameKey: "gateway-agent",
+          executionLockedAt: terminalAt,
+          updatedAt: terminalAt,
+        })
+        .where(eq(issues.id, issueId));
+      await db.insert(activityLog).values({
+        companyId,
+        actorType: "system",
+        actorId: "heartbeat",
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: issueId,
+        agentId,
+        runId: firstRun!.id,
+        details: { status: "done" },
+        createdAt: terminalAt,
+      });
+
+      const comment = await db
+        .insert(issueComments)
+        .values({
+          companyId,
+          issueId,
+          authorUserId: "user-1",
+          body: "Fresh comment after completion",
+          createdAt: freshCommentAt,
+          updatedAt: freshCommentAt,
+        })
+        .returning()
+        .then((rows) => rows[0]);
+
+      const deferredRun = await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId, commentId: comment.id },
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          commentId: comment.id,
+          wakeReason: "issue_commented",
+        },
+        requestedByActorType: "user",
+        requestedByActorId: "user-1",
+      });
+
+      expect(deferredRun).toBeNull();
 
       gateway.releaseFirstWait();
 
@@ -799,18 +997,18 @@ describe("heartbeat comment wake batching", () => {
       expect(secondPayload.paperclip).toMatchObject({
         wake: {
           reason: "issue_commented",
-          commentIds: [comment2.id],
-          latestCommentId: comment2.id,
+          commentIds: [comment.id],
+          latestCommentId: comment.id,
           issue: {
             id: issueId,
             identifier: `${issuePrefix}-1`,
-            title: "Reopen after deferred comment",
+            title: "Fresh deferred comment",
             status: "in_progress",
             priority: "medium",
           },
         },
       });
-      expect(String(secondPayload.message ?? "")).toContain("Please handle this follow-up after you finish");
+      expect(String(secondPayload.message ?? "")).toContain("Fresh comment after completion");
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8381,7 +8381,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               ),
             )
             .then((rows) => rows[0]?.createdAt ?? null);
-          const latestTerminalCompletion = issue.completedAt ?? null;
+          const latestTerminalCompletion = issue.status === "cancelled"
+            ? issue.cancelledAt ?? issue.completedAt ?? null
+            : issue.completedAt ?? issue.cancelledAt ?? null;
           if (latestDeferredComment && latestTerminalCompletion) {
             const latestDeferredCommentTime =
               latestDeferredComment instanceof Date

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8366,11 +8366,50 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         }
         const deferredCommentIds = extractWakeCommentIds(deferredContextSeed);
         const deferredWakeReason = readNonEmptyString(deferredContextSeed.wakeReason);
+        let deferredCommentAfterTerminalCompletion = true;
+        if (deferredCommentIds.length > 0 && (issue.status === "done" || issue.status === "cancelled")) {
+          const latestDeferredComment = await tx
+            .select({
+              createdAt: sql<Date | null>`max(${issueComments.createdAt})`,
+            })
+            .from(issueComments)
+            .where(
+              and(
+                eq(issueComments.companyId, issue.companyId),
+                eq(issueComments.issueId, issue.id),
+                inArray(issueComments.id, deferredCommentIds),
+              ),
+            )
+            .then((rows) => rows[0]?.createdAt ?? null);
+          const latestTerminalCompletion = await tx
+            .select({ createdAt: activityLog.createdAt })
+            .from(activityLog)
+            .where(
+              and(
+                eq(activityLog.companyId, issue.companyId),
+                eq(activityLog.entityType, "issue"),
+                eq(activityLog.entityId, issue.id),
+                eq(activityLog.action, "issue.updated"),
+                or(
+                  sql`${activityLog.details} ->> 'status' = 'done'`,
+                  sql`${activityLog.details} ->> 'status' = 'cancelled'`,
+                ),
+              ),
+            )
+            .orderBy(desc(activityLog.createdAt))
+            .limit(1)
+            .then((rows) => rows[0]?.createdAt ?? null);
+          if (latestDeferredComment && latestTerminalCompletion) {
+            deferredCommentAfterTerminalCompletion =
+              new Date(latestDeferredComment).getTime() > new Date(latestTerminalCompletion).getTime();
+          }
+        }
         // Only human/comment-reopen interactions should revive completed issues;
-        // system follow-ups such as retry or cleanup wakes must not reopen closed work.
+        // system follow-ups and stale comment wakes must not reopen closed work.
         const shouldReopenDeferredCommentWake =
           deferredCommentIds.length > 0 &&
           (issue.status === "done" || issue.status === "cancelled") &&
+          deferredCommentAfterTerminalCompletion &&
           (
             deferred.requestedByActorType === "user" ||
             deferredWakeReason === "issue_reopened_via_comment"

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8370,7 +8370,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         if (deferredCommentIds.length > 0 && (issue.status === "done" || issue.status === "cancelled")) {
           const latestDeferredComment = await tx
             .select({
-              createdAt: sql<Date | null>`max(${issueComments.createdAt})`,
+              createdAt: sql<Date | string | null>`max(${issueComments.createdAt})`,
             })
             .from(issueComments)
             .where(
@@ -8383,8 +8383,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             .then((rows) => rows[0]?.createdAt ?? null);
           const latestTerminalCompletion = issue.completedAt ?? null;
           if (latestDeferredComment && latestTerminalCompletion) {
+            const latestDeferredCommentTime =
+              latestDeferredComment instanceof Date
+                ? latestDeferredComment.getTime()
+                : new Date(latestDeferredComment).getTime();
             deferredCommentAfterTerminalCompletion =
-              new Date(latestDeferredComment).getTime() > new Date(latestTerminalCompletion).getTime();
+              latestDeferredCommentTime > latestTerminalCompletion.getTime();
           }
         }
         // Only human/comment-reopen interactions should revive completed issues;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -8381,24 +8381,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               ),
             )
             .then((rows) => rows[0]?.createdAt ?? null);
-          const latestTerminalCompletion = await tx
-            .select({ createdAt: activityLog.createdAt })
-            .from(activityLog)
-            .where(
-              and(
-                eq(activityLog.companyId, issue.companyId),
-                eq(activityLog.entityType, "issue"),
-                eq(activityLog.entityId, issue.id),
-                eq(activityLog.action, "issue.updated"),
-                or(
-                  sql`${activityLog.details} ->> 'status' = 'done'`,
-                  sql`${activityLog.details} ->> 'status' = 'cancelled'`,
-                ),
-              ),
-            )
-            .orderBy(desc(activityLog.createdAt))
-            .limit(1)
-            .then((rows) => rows[0]?.createdAt ?? null);
+          const latestTerminalCompletion = issue.completedAt ?? null;
           if (latestDeferredComment && latestTerminalCompletion) {
             deferredCommentAfterTerminalCompletion =
               new Date(latestDeferredComment).getTime() > new Date(latestTerminalCompletion).getTime();


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through heartbeat-driven issue execution.
> - The heartbeat service promotes deferred comment wakes into new issue execution when a terminal issue receives a reopen-worthy signal.
> - The previous predicate treated any deferred comment id as sufficient, even when that comment predated the latest terminal completion.
> - That let stale human comments reopen already-completed review children and create status churn.
> - This pull request adds a freshness check between deferred comment timestamps and the latest terminal issue update activity.
> - The benefit is that stale deferred comments are suppressed while genuinely fresh post-completion comments can still reopen work.

## What Changed

- Added terminal-completion freshness evaluation to deferred comment reopen promotion in `server/src/services/heartbeat.ts`.
- Added regression coverage for stale pre-completion deferred comments and fresh post-completion deferred comments in `server/src/__tests__/heartbeat-comment-wake-batching.test.ts`.

## Verification

- `pnpm --filter @paperclipai/server typecheck`
- `pnpm exec vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts -t "predates terminal completion|newer than terminal completion"`
- `pnpm exec vitest run server/src/__tests__/heartbeat-comment-wake-batching.test.ts -t "batches deferred comment wakes"`

Note: the older batching test passes when run alone. The full targeted file has an existing grouping timeout when background heartbeat work continues against the embedded test DB after teardown; the new stale/fresh freshness cases pass.

## Risks

- Low behavioral risk: the change narrows reopen behavior only when deferred comments are older than the terminal completion event.
- A missing or unparseable timestamp falls back conservatively to the existing reopen path instead of suppressing legitimate work.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex GPT-5 via Paperclip/Codex local adapter. Implementation was produced by the CTO agent; this PR was published by the CEO agent from the verified local commit after upstream write access was unavailable.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
