### PR TITLE
fix(ui): clarify token labels — New input / Cached input (ATT-41)

### DIFF
--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -1465,15 +1465,25 @@ function CostsSection({
         <div className="border border-border rounded-lg p-4">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 tabular-nums">
             <div>
-              <span className="text-xs text-muted-foreground block">Input tokens</span>
+              <span
+                className="text-xs text-muted-foreground block"
+                title="Fresh input tokens sent to the model (cache miss)"
+              >
+                New input
+              </span>
               <span className="text-lg font-semibold">{formatTokens(runtimeState.totalInputTokens)}</span>
             </div>
             <div>
-              <span className="text-xs text-muted-foreground block">Output tokens</span>
+              <span className="text-xs text-muted-foreground block">Output</span>
               <span className="text-lg font-semibold">{formatTokens(runtimeState.totalOutputTokens)}</span>
             </div>
             <div>
-              <span className="text-xs text-muted-foreground block">Cached tokens</span>
+              <span
+                className="text-xs text-muted-foreground block"
+                title="Input tokens served from the prompt cache (cache hit)"
+              >
+                Cached input
+              </span>
               <span className="text-lg font-semibold">{formatTokens(runtimeState.totalCachedInputTokens)}</span>
             </div>
             <div>
@@ -1490,7 +1500,18 @@ function CostsSection({
               <tr className="border-b border-border bg-accent/20">
                 <th className="text-left px-3 py-2 font-medium text-muted-foreground">Date</th>
                 <th className="text-left px-3 py-2 font-medium text-muted-foreground">Run</th>
-                <th className="text-right px-3 py-2 font-medium text-muted-foreground">Input</th>
+                <th
+                  className="text-right px-3 py-2 font-medium text-muted-foreground"
+                  title="Fresh input tokens sent to the model (cache miss)"
+                >
+                  New input
+                </th>
+                <th
+                  className="text-right px-3 py-2 font-medium text-muted-foreground"
+                  title="Input tokens served from the prompt cache (cache hit)"
+                >
+                  Cached input
+                </th>
                 <th className="text-right px-3 py-2 font-medium text-muted-foreground">Output</th>
                 <th className="text-right px-3 py-2 font-medium text-muted-foreground">Cost</th>
               </tr>
@@ -1503,6 +1524,7 @@ function CostsSection({
                     <td className="px-3 py-2">{formatDate(run.createdAt)}</td>
                     <td className="px-3 py-2 font-mono">{run.id.slice(0, 8)}</td>
                     <td className="px-3 py-2 text-right tabular-nums">{formatTokens(metrics.input)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{formatTokens(metrics.cached)}</td>
                     <td className="px-3 py-2 text-right tabular-nums">{formatTokens(metrics.output)}</td>
                     <td className="px-3 py-2 text-right tabular-nums">
                       {metrics.cost > 0
@@ -3461,7 +3483,12 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
           {hasMetrics && (
             <div className="border-t sm:border-t-0 sm:border-l border-border p-4 grid grid-cols-2 gap-x-4 sm:gap-x-8 gap-y-3 content-center tabular-nums">
               <div>
-                <div className="text-xs text-muted-foreground">Input</div>
+                <div
+                  className="text-xs text-muted-foreground"
+                  title="Fresh input tokens sent to the model (cache miss)"
+                >
+                  New input
+                </div>
                 <div className="text-sm font-medium font-mono">{formatTokens(metrics.input)}</div>
               </div>
               <div>
@@ -3469,7 +3496,12 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                 <div className="text-sm font-medium font-mono">{formatTokens(metrics.output)}</div>
               </div>
               <div>
-                <div className="text-xs text-muted-foreground">Cached</div>
+                <div
+                  className="text-xs text-muted-foreground"
+                  title="Input tokens served from the prompt cache (cache hit)"
+                >
+                  Cached input
+                </div>
                 <div className="text-sm font-medium font-mono">{formatTokens(metrics.cached)}</div>
               </div>
               <div>


### PR DESCRIPTION
## Summary

- Rename ambiguous \"Input\" / \"Cached\" token labels in agent runs panel to **\"New input\"** (cache miss) and **\"Cached input\"** (cache hit) for unambiguous interpretation
- Add missing **Cached input** column to the recent-runs table so per-run cache hit counts are visible
- Add `title` tooltip on each label explaining cache-miss vs cache-hit semantics

Fixes the confusing display where a run showed Input: 3 / Output: 884 / Cached: 327.1k — the \"3\" was only fresh (cache-miss) tokens, not total input, making the 1:222 input/output ratio appear nonsensical.

No data or computation changes — label rename only.

## Test plan

- [ ] Open `/agents/<slug>/runs` and verify summary panel shows \"New input\" / \"Cached input\" / \"Output\"
- [ ] Hover over labels to confirm tooltip text appears
- [ ] Verify runs table has Date / Run / New input / Cached input / Output / Cost columns
- [ ] Open a run detail and verify metrics panel uses same terminology
- [ ] Confirm total input interpretation is now unambiguous (new + cached = total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)