### PR TITLE
fix(scripts): handle Windows junction in plugin-sdk link postinstall

### DIFF
--- a/scripts/link-plugin-dev-sdk.mjs
+++ b/scripts/link-plugin-dev-sdk.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, lstatSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdirSync, lstatSync, rmSync, symlinkSync, realpathSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -17,16 +17,31 @@ if (!existsSync(join(packageDir, "package.json"))) {
 
 mkdirSync(scopeDir, { recursive: true });
 
+let stat = null;
 try {
-  const stat = lstatSync(linkTarget);
-  if (stat.isSymbolicLink()) {
-    rmSync(linkTarget, { force: true });
-  } else {
+  stat = lstatSync(linkTarget);
+} catch (err) {
+  if (err.code !== "ENOENT") throw err;
+  // target does not exist yet
+}
+
+if (stat) {
+  if (!stat.isSymbolicLink()) {
     console.log("  i Keeping existing installed @paperclipai/plugin-sdk directory in place");
     process.exit(0);
   }
-} catch {
-  // target does not exist yet
+  // Already linked to the local SDK? Leave it as-is. On Windows pnpm creates a
+  // directory junction here, and re-creating a symlink may require extra privileges.
+  try {
+    if (realpathSync(linkTarget) === realpathSync(sdkDir)) {
+      console.log(`  ✓ @paperclipai/plugin-sdk already linked for ${packageDir}`);
+      process.exit(0);
+    }
+  } catch {
+    // fall through and re-link
+  }
+  // recursive: true is required to remove a directory symlink/junction on Windows.
+  rmSync(linkTarget, { recursive: true, force: true });
 }
 
 const relativeSdkDir = relative(scopeDir, sdkDir);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - In-repo plugins consume a workspace SDK (`@paperclipai/plugin-sdk`) that each plugin links into its own `node_modules` during `pnpm install` via a `postinstall` hook (`scripts/link-plugin-dev-sdk.mjs`)
> - On Windows, pnpm materializes that workspace dependency as a **directory junction**, not a regular symlink
> - The script's removal step used `rmSync(target, { force: true })` (no `recursive: true`), which throws `ERR_FS_EISDIR` on a junction; a too-broad `catch {}` then silently swallowed the error, leaving the junction in place
> - The next `symlinkSync` failed with `EEXIST`, breaking `pnpm install` on Windows (exit code 1)
> - This PR makes the script Windows-safe and idempotent: scope the catch to `ENOENT`, early-exit when the existing link already resolves to the SDK, and remove with `recursive: true` so junctions are cleaned up properly
> - Benefit: contributors on Windows can `pnpm install` without a fatal postinstall error, and genuine I/O errors are no longer hidden behind a blanket catch

## What Changed

- `scripts/link-plugin-dev-sdk.mjs`:
  - Scope the `lstatSync` catch to `ENOENT`; re-throw any other error instead of swallowing it.
  - Early-exit when the existing link already resolves to `packages/plugins/sdk` (the common case after pnpm has set up the junction on Windows; also avoids needing `SeCreateSymbolicLinkPrivilege` on re-runs).
  - Use `rmSync(target, { recursive: true, force: true })` so directory symlinks / Windows junctions are actually removed when re-linking is needed.

## Verification

Reproduced on Windows 11 + Node 24 + pnpm:

1. Before this change, fresh `pnpm install` failed with:
   ```
   Error: EEXIST: file already exists, symlink '..\..\..\sdk' -> '...\@paperclipai\plugin-sdk'
       at symlinkSync (node:fs:1879:11)
       at file:///.../scripts/link-plugin-dev-sdk.mjs:33:1
    ELIFECYCLE  Command failed with exit code 1.
   ```
2. After this change, `pnpm install` completes successfully (`Done in 6.2s`); the postinstall prints:
   ```
   ✓ @paperclipai/plugin-sdk already linked for <pluginDir>
   ```
3. Verified in isolation that `rmSync(link, { recursive: true, force: true })` removes a Windows junction but does **not** touch the junction target's contents.
4. No behavior change on macOS/Linux: `realpathSync` equality still triggers the early exit on re-runs, and `rmSync({recursive:true})` on a directory symlink still removes only the link.

## Risks

- Low. Install-time script only. Linux/macOS paths preserve prior behavior except for an earlier exit when the link is already correct (more conservative, not less). The catch is narrower — any genuine non-ENOENT lstat failure will now surface instead of being hidden, which is a strict improvement.

## Model Used

- Claude Opus 4.7 (model ID: `claude-opus-4-7`), invoked via Claude Code CLI on Windows. ~200k context, standard reasoning, tool use (filesystem + shell). Used to reproduce the failure (confirmed `ERR_FS_EISDIR` from `rmSync` on a Windows junction, and that it was being swallowed by the broad `catch {}` so `symlinkSync` then hit `EEXIST`) and to author the fix.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass — N/A; this is an install-time script. Verified by reproducing the failure and the success path with `pnpm install` on Windows.
- [x] I have added or updated tests where applicable — N/A; no test harness exists for repo install scripts.
- [x] If this change affects the UI, I have included before/after screenshots — N/A; no UI change.
- [x] I have updated relevant documentation to reflect my changes — inline comments updated; no external docs reference this script.
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
