### PR TITLE
feat(plugins): add issueProperty UI slot for inline property fields

### DIFF
--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -1123,11 +1123,13 @@ Recommended route pattern:
 
 ## 19.3.1 Issue Property Slots
 
-Plugins may add compact read-only fields to the issue properties panel (right
-sidebar). These render inline alongside built-in properties like Status,
-Priority, and Assignee.
+Plugins may add compact fields to the issue properties panel (right sidebar).
+These render inline alongside built-in properties like Status, Priority, and
+Assignee.
 
 Capability: `ui.issueProperty.register`
+
+### Manifest Declaration
 
 ```json
 {
@@ -1139,9 +1141,83 @@ Capability: `ui.issueProperty.register`
 }
 ```
 
+### Component Contract
+
 The component receives `{ context: { entityId, entityType, companyId } }` and
-should render a compact view suitable for the properties panel (badges, links,
-short lists). Avoid large or scrollable content — use a `detailTab` for that.
+should render a compact view suitable for the 320px-wide properties panel.
+
+**Guidelines:**
+
+- Match the host's `PropertyRow` layout: label on the left, value on the right
+- Keep content compact — avoid scrollable or expandable sections
+- Use `detailTab` for rich content that needs more space
+- The `displayName` from the manifest is shown as the field label
+- Use `usePluginData()` to fetch data from the worker
+
+### Recommended Field Patterns
+
+| Pattern | Use case | Example |
+|---------|----------|---------|
+| **Badge list** | Status tags, labels | `Open` `Merged` `Draft` |
+| **Link list** | Cross-system references | `#42 fix: balance` → GitHub |
+| **Text value** | Single scalar | `3 open PRs` |
+| **User/avatar** | Assignee from external system | `@octocat` with avatar |
+| **Status indicator** | CI/CD, sync state | `CI: Passing` with green dot |
+| **Count** | Summary metric | `5 linked PRs` |
+| **Empty state** | No data available | `No linked PRs` (muted text) |
+
+### Example Component
+
+```tsx
+import { usePluginData } from "@paperclipai/plugin-sdk/ui";
+
+export function LinkedPRsProperty({ context }) {
+  const { data } = usePluginData("card-prs", {
+    companyId: context.companyId,
+    issueId: context.entityId,
+  });
+
+  const prs = data?.pullRequests ?? [];
+
+  if (prs.length === 0) {
+    return (
+      <div style={{ padding: "4px 0", fontSize: "13px", opacity: 0.5 }}>
+        No linked PRs
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+      {prs.map((pr) => (
+        <a
+          key={pr.id}
+          href={pr.htmlUrl}
+          target="_blank"
+          rel="noopener"
+          style={{ fontSize: "13px", color: "#3b82f6", textDecoration: "none" }}
+        >
+          #{pr.number} {pr.title}
+        </a>
+      ))}
+    </div>
+  );
+}
+```
+
+### Styling Tokens
+
+To match the host's visual language, use these patterns:
+
+| Element | Style |
+|---------|-------|
+| Label | `font-size: 13px; opacity: 0.5; font-weight: 500` |
+| Value text | `font-size: 13px` |
+| Badge | `padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 600` |
+| Link | `color: #3b82f6; text-decoration: none` |
+| Empty state | `font-size: 13px; opacity: 0.5` |
+| Hint/description | `font-size: 11px; opacity: 0.4; margin-top: 2px` |
+| Container | `padding: 4px 0; max-width: 100%` |
 
 ## 19.4 Dashboard Widgets
 

--- a/doc/plugins/PLUGIN_SPEC.md
+++ b/doc/plugins/PLUGIN_SPEC.md
@@ -861,6 +861,7 @@ The host enforces capabilities in the SDK layer and refuses calls outside the gr
 - `ui.dashboardWidget.register`
 - `ui.commentAnnotation.register`
 - `ui.action.register`
+- `ui.issueProperty.register`
 
 ## 15.2 Forbidden Capabilities
 
@@ -1119,6 +1120,28 @@ Plugins may add tabs to:
 Recommended route pattern:
 
 - `/:companyPrefix/<entity>/:id?tab=<plugin-tab-id>`
+
+## 19.3.1 Issue Property Slots
+
+Plugins may add compact read-only fields to the issue properties panel (right
+sidebar). These render inline alongside built-in properties like Status,
+Priority, and Assignee.
+
+Capability: `ui.issueProperty.register`
+
+```json
+{
+  "type": "issueProperty",
+  "id": "my-linked-items",
+  "displayName": "Linked Items",
+  "exportName": "MyLinkedItemsProperty",
+  "entityTypes": ["issue"]
+}
+```
+
+The component receives `{ context: { entityId, entityType, companyId } }` and
+should render a compact view suitable for the properties panel (badges, links,
+short lists). Avoid large or scrollable content — use a `detailTab` for that.
 
 ## 19.4 Dashboard Widgets
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -797,6 +797,7 @@ export const PLUGIN_CAPABILITIES = [
   "ui.dashboardWidget.register",
   "ui.commentAnnotation.register",
   "ui.action.register",
+  "ui.issueProperty.register",
 ] as const;
 export type PluginCapability = (typeof PLUGIN_CAPABILITIES)[number];
 
@@ -867,6 +868,7 @@ export const PLUGIN_UI_SLOT_TYPES = [
   "commentContextMenuItem",
   "settingsPage",
   "companySettingsPage",
+  "issueProperty",
 ] as const;
 export type PluginUiSlotType = (typeof PLUGIN_UI_SLOT_TYPES)[number];
 

--- a/packages/shared/src/validators/plugin.test.ts
+++ b/packages/shared/src/validators/plugin.test.ts
@@ -148,6 +148,29 @@ describe("plugin UI slot validators", () => {
     expect(parsed.entityTypes).toEqual(["execution_workspace", "project_workspace"]);
   });
 
+  it("accepts issueProperty slots with issue entityType", () => {
+    const parsed = pluginUiSlotDeclarationSchema.parse({
+      type: "issueProperty",
+      id: "linked-prs",
+      displayName: "Pull Requests",
+      exportName: "LinkedPRsProperty",
+      entityTypes: ["issue"],
+    });
+
+    expect(parsed.entityTypes).toEqual(["issue"]);
+  });
+
+  it("rejects issueProperty slots without entityTypes", () => {
+    const parsed = pluginUiSlotDeclarationSchema.safeParse({
+      type: "issueProperty",
+      id: "linked-prs",
+      displayName: "Pull Requests",
+      exportName: "LinkedPRsProperty",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
   it("accepts execution_workspace as a toolbarButton entityType", () => {
     const parsed = pluginUiSlotDeclarationSchema.parse({
       type: "toolbarButton",

--- a/packages/shared/src/validators/plugin.ts
+++ b/packages/shared/src/validators/plugin.ts
@@ -288,7 +288,7 @@ export const pluginUiSlotDeclarationSchema = z.object({
   order: z.number().int().optional(),
 }).superRefine((value, ctx) => {
   // context-sensitive slots require explicit entity targeting.
-  const entityScopedTypes = ["detailTab", "taskDetailView", "contextMenuItem", "commentAnnotation", "commentContextMenuItem", "projectSidebarItem"];
+  const entityScopedTypes = ["detailTab", "taskDetailView", "contextMenuItem", "commentAnnotation", "commentContextMenuItem", "projectSidebarItem", "issueProperty"];
   if (
     entityScopedTypes.includes(value.type)
     && (!value.entityTypes || value.entityTypes.length === 0)

--- a/server/src/services/plugin-capability-validator.ts
+++ b/server/src/services/plugin-capability-validator.ts
@@ -151,6 +151,7 @@ const UI_SLOT_CAPABILITIES: Record<PluginUiSlotType, PluginCapability> = {
   settingsPage: "instance.settings.register",
   companySettingsPage: "instance.settings.register",
   routeSidebar: "ui.sidebar.register",
+  issueProperty: "ui.issueProperty.register",
 };
 
 /**

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -48,7 +48,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
-import { usePluginSlots, PluginSlotOutlet } from "@/plugins/slots";
+import { PluginSlotOutlet } from "@/plugins/slots";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { User, Hexagon, ArrowUpRight, Tag, Plus, GitBranch, FolderOpen, Check, ExternalLink, X, Clock, RotateCcw, Loader2, CheckCircle2 } from "lucide-react";
 import { AgentIcon } from "./AgentIconPicker";
@@ -2120,27 +2120,19 @@ export function IssueProperties({
  * panel. Each plugin slot receives the issue entity context and renders a
  * compact read-only view (e.g. linked PRs, Jira tickets, Slack threads).
  *
- * @see PLUGIN_SPEC.md §19 — UI Extension Model
+ * Uses PluginSlotOutlet which internally calls usePluginSlots and handles
+ * empty state (returns null when no slots match).
+ *
+ * @see PLUGIN_SPEC.md §19.3.1 — Issue Property Slots
  */
 function PluginIssuePropertySlots({ issueId, companyId }: { issueId: string; companyId: string }) {
-  const { slots } = usePluginSlots({
-    slotTypes: ["issueProperty"],
-    entityType: "issue",
-    companyId,
-  });
-
-  if (slots.length === 0) return null;
-
   return (
-    <>
-      <Separator className="my-2" />
-      <PluginSlotOutlet
-        slotTypes={["issueProperty"]}
-        entityType="issue"
-        context={{ entityId: issueId, entityType: "issue", companyId }}
-        className="flex flex-col gap-1"
-        itemClassName="text-sm"
-      />
-    </>
+    <PluginSlotOutlet
+      slotTypes={["issueProperty"]}
+      entityType="issue"
+      context={{ entityId: issueId, entityType: "issue", companyId }}
+      className="flex flex-col gap-1 border-t border-border pt-2 mt-2"
+      itemClassName="text-sm"
+    />
   );
 }

--- a/ui/src/components/IssueProperties.tsx
+++ b/ui/src/components/IssueProperties.tsx
@@ -48,6 +48,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
+import { usePluginSlots, PluginSlotOutlet } from "@/plugins/slots";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { User, Hexagon, ArrowUpRight, Tag, Plus, GitBranch, FolderOpen, Check, ExternalLink, X, Clock, RotateCcw, Loader2, CheckCircle2 } from "lucide-react";
 import { AgentIcon } from "./AgentIconPicker";
@@ -2090,6 +2091,9 @@ export function IssueProperties({
             )}
           </PropertyRow>
         )}
+        {/* Plugin-contributed issue property fields */}
+        <PluginIssuePropertySlots issueId={issue.id} companyId={company.id} />
+
         {issue.startedAt && (
           <PropertyRow label="Started">
             <span className="text-sm">{formatDateTime(issue.startedAt)}</span>
@@ -2108,5 +2112,35 @@ export function IssueProperties({
         </PropertyRow>
       </div>
     </div>
+  );
+}
+
+/**
+ * Renders plugin-contributed issue property fields inline in the properties
+ * panel. Each plugin slot receives the issue entity context and renders a
+ * compact read-only view (e.g. linked PRs, Jira tickets, Slack threads).
+ *
+ * @see PLUGIN_SPEC.md §19 — UI Extension Model
+ */
+function PluginIssuePropertySlots({ issueId, companyId }: { issueId: string; companyId: string }) {
+  const { slots } = usePluginSlots({
+    slotTypes: ["issueProperty"],
+    entityType: "issue",
+    companyId,
+  });
+
+  if (slots.length === 0) return null;
+
+  return (
+    <>
+      <Separator className="my-2" />
+      <PluginSlotOutlet
+        slotTypes={["issueProperty"]}
+        entityType="issue"
+        context={{ entityId: issueId, entityType: "issue", companyId }}
+        className="flex flex-col gap-1"
+        itemClassName="text-sm"
+      />
+    </>
   );
 }

--- a/ui/src/plugins/slots.tsx
+++ b/ui/src/plugins/slots.tsx
@@ -130,7 +130,7 @@ function buildRegistryKey(pluginKey: string, exportName: string): string {
 }
 
 function requiresEntityType(slotType: PluginUiSlotType): boolean {
-  return slotType === "detailTab" || slotType === "taskDetailView" || slotType === "contextMenuItem" || slotType === "commentAnnotation" || slotType === "commentContextMenuItem" || slotType === "projectSidebarItem" || slotType === "toolbarButton";
+  return slotType === "detailTab" || slotType === "taskDetailView" || slotType === "contextMenuItem" || slotType === "commentAnnotation" || slotType === "commentContextMenuItem" || slotType === "projectSidebarItem" || slotType === "toolbarButton" || slotType === "issueProperty";
 }
 
 function getErrorMessage(error: unknown): string {


### PR DESCRIPTION
## Thinking Path

Plugins like GitHub Manager need to surface cross-system links (linked PRs, Jira tickets) directly in the issue properties panel. Currently `detailTab` requires navigating to a separate tab — critical context is hidden. This PR adds a new `issueProperty` slot type that renders inline in the properties sidebar.

## What Changed

- **New slot type `issueProperty`** in `PLUGIN_UI_SLOT_TYPES` — entity-scoped, requires `entityTypes`
- **New capability `ui.issueProperty.register`** — follows the same pattern as `ui.detailTab.register`
- **Capability validator** maps `issueProperty` to the new capability
- **Slot validator** adds `issueProperty` to entity-scoped types requiring `entityTypes`
- **IssueProperties.tsx** renders `PluginSlotOutlet` for `issueProperty` slots inline, separated by a divider before timestamps
- **PLUGIN_SPEC.md §19.3.1** documents the new slot type with manifest example
- **Tests** validate acceptance with entityTypes and rejection without

### Files changed (6)
| File | Change |
|------|--------|
| `packages/shared/src/constants.ts` | Add `issueProperty` slot type + `ui.issueProperty.register` capability |
| `packages/shared/src/validators/plugin.ts` | Add to entity-scoped types |
| `packages/shared/src/validators/plugin.test.ts` | 2 new tests |
| `server/src/services/plugin-capability-validator.ts` | Map slot → capability |
| `ui/src/components/IssueProperties.tsx` | Render plugin slots in properties panel |
| `doc/plugins/PLUGIN_SPEC.md` | Document §19.3.1 Issue Property Slots |

## Verification

- [x] New slot type registered in constants
- [x] Capability added and mapped in validator
- [x] Entity-scoped validation enforced (entityTypes required)
- [x] IssueProperties renders PluginSlotOutlet with correct context
- [x] Documentation updated
- [x] Tests added (accept + reject cases)

## Risks

- **Low**: Additive change — no existing behavior modified
- Plugins that don't use `issueProperty` are unaffected
- The `PluginSlotOutlet` already handles error boundaries per plugin, so a broken plugin slot won't crash the properties panel

## Model Used

Claude Opus 4.6 (1M context) via Claude Code CLI. Codebase exploration, implementation, and test generation were AI-assisted with human review.

## Checklist

- [x] PR follows the template
- [x] Change is small and focused (one new slot type)
- [x] Tests added
- [x] Documentation updated
- [x] No breaking changes

Closes #6708