### PR TITLE
fix: harden stale-run freshness gate (FMA-2185)

### DIFF
--- a/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
+++ b/server/src/__tests__/heartbeat-active-run-output-watchdog.test.ts
@@ -798,4 +798,140 @@ describeEmbeddedPostgres("active-run output watchdog", () => {
     });
     expect(decision.createdByRunId).toBe(managerRunId);
   });
+
+  // FMA-2176 freshness-gate regression tests
+  // These tests prove the required behavior described in FMA-2175:
+  //   1. Repeated scans with no fresh evidence must produce at most ONE evaluation per run.
+  //   2. Genuinely new evidence (new output, events) must still allow a new evaluation.
+  //   3. The SDR 1649167f duplicate-loop shape must not recur.
+  //
+  // If the freshness gate is correctly implemented all three pass.
+  // If createOrUpdateStaleRunEvaluation still keys only on "no open evaluation exists"
+  // (i.e. the gate was not implemented), tests 1 and 3 fail with created=1 where 0 is expected.
+
+  it("freshness gate [1/3]: closing evaluation without a continue decision suppresses duplicate on next scan", async () => {
+    const now = new Date("2026-05-26T10:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    // First scan: evaluation should be created.
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first.created).toBe(1);
+    const firstEvaluationId = first.evaluationIssueIds[0];
+    expect(firstEvaluationId).toBeTruthy();
+
+    // Operator closes the evaluation without recording a continue/snooze decision.
+    // This simulates the false-positive dismissal pattern in the SDR duplicate loop.
+    await db
+      .update(issues)
+      .set({ status: "done", completedAt: now, updatedAt: now })
+      .where(eq(issues.id, firstEvaluationId!));
+
+    // No new output or events have occurred on the run — no fresh evidence.
+    // A second scan should NOT spawn another evaluation.
+    const second = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(second.created).toBe(0, "Freshness gate must suppress a sibling when no new evidence exists");
+
+    // Third scan — still no new evidence — still no new evaluation.
+    const third = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(third.created).toBe(0, "Freshness gate must be stable across repeated scans");
+
+    // Only one evaluation issue must ever exist for this run.
+    const allEvaluations = await db
+      .select({ id: issues.id, status: issues.status })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(allEvaluations).toHaveLength(1);
+    expect(allEvaluations[0]?.status).toBe("done");
+  });
+
+  it("freshness gate [2/3]: new run output after a terminal evaluation unlocks a new evaluation", async () => {
+    const now = new Date("2026-05-26T10:00:00.000Z");
+    const { companyId, runId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    // First scan: evaluation created.
+    const first = await heartbeat.scanSilentActiveRuns({ now, companyId });
+    expect(first.created).toBe(1);
+    const firstEvaluationId = first.evaluationIssueIds[0]!;
+
+    // Operator closes without a continue decision.
+    await db
+      .update(issues)
+      .set({ status: "done", completedAt: now, updatedAt: now })
+      .where(eq(issues.id, firstEvaluationId));
+
+    // Advance time: the run produces new output (fresh evidence).
+    const outputAt = new Date(now.getTime() + 5 * 60_000);
+    await db
+      .update(heartbeatRuns)
+      .set({ lastOutputAt: outputAt, lastOutputSeq: 5, lastOutputStream: "stdout", updatedAt: outputAt })
+      .where(eq(heartbeatRuns.id, runId));
+
+    // A scan after new output should create a fresh evaluation.
+    const nowWithNewOutput = new Date(outputAt.getTime() + ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000);
+    const second = await heartbeat.scanSilentActiveRuns({ now: nowWithNewOutput, companyId });
+    expect(second.created).toBe(1, "New run output must be accepted as fresh evidence to trigger a new evaluation");
+    expect(second.evaluationIssueIds[0]).not.toBe(firstEvaluationId);
+
+    const activeEvaluations = await db
+      .select({ id: issues.id, status: issues.status })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")))
+      .then((rows) => rows.filter((r) => !["done", "cancelled"].includes(r.status)));
+    expect(activeEvaluations).toHaveLength(1);
+  });
+
+  it("freshness gate [3/3]: SDR 1649167f duplicate-loop shape — repeated close cycles create at most one evaluation", async () => {
+    // Reproduces the loop observed on SDR run 1649167f-3c60-46f6-876d-ae6fa239f764:
+    //   close evaluation → next scan spawns identical sibling → close → next scan → ...
+    // After the freshness gate, the loop must be broken: at most one evaluation per run.
+    const now = new Date("2026-05-26T10:00:00.000Z");
+    const { companyId } = await seedRunningRun({
+      now,
+      ageMs: ACTIVE_RUN_OUTPUT_CRITICAL_THRESHOLD_MS + 60_000,
+    });
+    const heartbeat = heartbeatService(db);
+
+    // Simulate 5 close→scan cycles (as observed in the live queue).
+    for (let cycle = 0; cycle < 5; cycle++) {
+      const scan = await heartbeat.scanSilentActiveRuns({ now, companyId });
+
+      if (cycle === 0) {
+        // First scan must create the evaluation.
+        expect(scan.created).toBe(1);
+      } else {
+        // All subsequent scans after close must not create new evaluations.
+        expect(scan.created).toBe(
+          0,
+          `Cycle ${cycle}: freshness gate must suppress duplicate creation after prior evaluation was closed without new evidence`,
+        );
+      }
+
+      // Close the active evaluation (simulating the operator resolving each review).
+      const openEvalIds = scan.evaluationIssueIds;
+      for (const evalId of openEvalIds) {
+        await db
+          .update(issues)
+          .set({ status: "done", completedAt: now, updatedAt: now })
+          .where(eq(issues.id, evalId));
+      }
+    }
+
+    // Final assertion: total evaluations across all cycles must be exactly 1.
+    const totalEvaluations = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stale_active_run_evaluation")));
+    expect(totalEvaluations).toHaveLength(
+      1,
+      "Freshness gate must limit total evaluations to 1 for an unchanging run regardless of how many times prior evaluations are closed",
+    );
+  });
 });

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gt, gte, inArray, isNull, notInArray, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNull, lte, notInArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_ISSUE_GRAPH_LIVENESS_AUTO_RECOVERY_LOOKBACK_HOURS,
@@ -744,6 +744,218 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     return row ?? null;
   }
 
+  async function findLatestTerminalStaleRunEvaluation(companyId: string, runId: string) {
+    const [row] = await db
+      .select({
+        id: issues.id,
+        identifier: issues.identifier,
+        status: issues.status,
+        priority: issues.priority,
+        assigneeAgentId: issues.assigneeAgentId,
+        updatedAt: issues.updatedAt,
+        createdAt: issues.createdAt,
+        completedAt: issues.completedAt,
+        cancelledAt: issues.cancelledAt,
+      })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, companyId),
+          eq(issues.originKind, STALE_ACTIVE_RUN_EVALUATION_ORIGIN_KIND),
+          eq(issues.originId, runId),
+          isNull(issues.hiddenAt),
+          inArray(issues.status, ["done", "cancelled"]),
+        ),
+      )
+      .orderBy(desc(issues.updatedAt), desc(issues.createdAt))
+      .limit(1);
+    return row ?? null;
+  }
+
+  function staleRunEvaluationFreshnessAnchor(input: {
+    createdAt: Date;
+    updatedAt: Date;
+    completedAt: Date | null;
+    cancelledAt: Date | null;
+  }) {
+    return input.completedAt ?? input.cancelledAt ?? input.updatedAt ?? input.createdAt;
+  }
+
+  function staleActiveRunReasonSignature(level: "suspicious" | "critical") {
+    return `output_silence:${level}`;
+  }
+
+  const SOURCE_FRESHNESS_ACTIVITY_KEYS = [
+    "status",
+    "assigneeAgentId",
+    "assigneeUserId",
+    "priority",
+    "workMode",
+    "blockedByIssueIds",
+    "executionPolicy",
+    "executionState",
+    "monitorNextCheckAt",
+    "monitorWakeRequestedAt",
+    "monitorLastTriggeredAt",
+    "monitorAttemptCount",
+    "monitorNotes",
+    "monitorScheduledBy",
+    "executionWorkspaceId",
+    "executionWorkspacePreference",
+    "executionWorkspaceSettings",
+  ] as const;
+
+  function hasFreshSourceIssueActivityDetails(details: Record<string, unknown>) {
+    if (asBoolean(details.resumeIntent, false) || asBoolean(details.reopened, false)) return true;
+    const previous = parseObject(details._previous);
+    return SOURCE_FRESHNESS_ACTIVITY_KEYS.some((key) =>
+      Object.prototype.hasOwnProperty.call(details, key) ||
+      Object.prototype.hasOwnProperty.call(previous, key)
+    );
+  }
+
+  async function collectStaleRunFreshnessSignals(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    sourceIssue: typeof issues.$inferSelect | null;
+    latestTerminalEvaluation: NonNullable<Awaited<ReturnType<typeof findLatestTerminalStaleRunEvaluation>>>;
+    level: "suspicious" | "critical";
+    now: Date;
+  }) {
+    const reasons = new Set<string>();
+    const freshnessSince = staleRunEvaluationFreshnessAnchor(input.latestTerminalEvaluation);
+
+    if (input.level === "critical" && input.latestTerminalEvaluation.priority !== "high") {
+      reasons.add("threshold_band_crossed");
+    }
+    if (input.run.lastOutputAt && input.run.lastOutputAt > freshnessSince) {
+      reasons.add("run_output_delta");
+    }
+
+    const [recentRunEvent, sourceUpdates, activeRecoveryAction, expiredQuietDecision] = await Promise.all([
+      db
+        .select({ id: heartbeatRunEvents.id })
+        .from(heartbeatRunEvents)
+        .where(
+          and(
+            eq(heartbeatRunEvents.companyId, input.run.companyId),
+            eq(heartbeatRunEvents.runId, input.run.id),
+            gt(heartbeatRunEvents.createdAt, freshnessSince),
+          ),
+        )
+        .orderBy(desc(heartbeatRunEvents.createdAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+      input.sourceIssue
+        ? db
+          .select({ details: activityLog.details })
+          .from(activityLog)
+          .where(
+            and(
+              eq(activityLog.companyId, input.run.companyId),
+              eq(activityLog.action, "issue.updated"),
+              eq(activityLog.entityType, "issue"),
+              eq(activityLog.entityId, input.sourceIssue.id),
+              gt(activityLog.createdAt, freshnessSince),
+            ),
+          )
+          .orderBy(desc(activityLog.createdAt))
+          .limit(10)
+        : Promise.resolve([]),
+      input.sourceIssue
+        ? db
+          .select({
+            id: issueRecoveryActions.id,
+            kind: issueRecoveryActions.kind,
+            status: issueRecoveryActions.status,
+            updatedAt: issueRecoveryActions.updatedAt,
+          })
+          .from(issueRecoveryActions)
+          .where(
+            and(
+              eq(issueRecoveryActions.companyId, input.run.companyId),
+              eq(issueRecoveryActions.sourceIssueId, input.sourceIssue.id),
+              inArray(issueRecoveryActions.status, ["active", "escalated"]),
+              gt(issueRecoveryActions.updatedAt, freshnessSince),
+            ),
+          )
+          .orderBy(desc(issueRecoveryActions.updatedAt))
+          .limit(1)
+          .then((rows) => rows[0] ?? null)
+        : Promise.resolve(null),
+      db
+        .select({
+          id: heartbeatRunWatchdogDecisions.id,
+          decision: heartbeatRunWatchdogDecisions.decision,
+        })
+        .from(heartbeatRunWatchdogDecisions)
+        .where(
+          and(
+            eq(heartbeatRunWatchdogDecisions.companyId, input.run.companyId),
+            eq(heartbeatRunWatchdogDecisions.runId, input.run.id),
+            eq(heartbeatRunWatchdogDecisions.evaluationIssueId, input.latestTerminalEvaluation.id),
+            inArray(heartbeatRunWatchdogDecisions.decision, ["snooze", "continue"]),
+            lte(heartbeatRunWatchdogDecisions.snoozedUntil, input.now),
+          ),
+        )
+        .orderBy(desc(heartbeatRunWatchdogDecisions.createdAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+    ]);
+
+    if (recentRunEvent) {
+      reasons.add("run_event_delta");
+    }
+    if (sourceUpdates.some((row) => hasFreshSourceIssueActivityDetails(parseObject(row.details)))) {
+      reasons.add("source_issue_delta");
+    }
+    if (activeRecoveryAction) {
+      reasons.add("recovery_action_delta");
+    }
+    if (expiredQuietDecision) {
+      reasons.add("expired_quiet_window");
+    }
+
+    return {
+      freshnessSince,
+      reasons: Array.from(reasons),
+      staleReasonSignature: staleActiveRunReasonSignature(input.level),
+    };
+  }
+
+  async function recordSuppressedDuplicateStaleRunEvaluation(input: {
+    run: typeof heartbeatRuns.$inferSelect;
+    sourceIssue: typeof issues.$inferSelect | null;
+    latestTerminalEvaluation: NonNullable<Awaited<ReturnType<typeof findLatestTerminalStaleRunEvaluation>>>;
+    level: "suspicious" | "critical";
+    freshnessSince: Date;
+    staleReasonSignature: string;
+  }) {
+    const payload = {
+      previousEvaluationIssueId: input.latestTerminalEvaluation.id,
+      previousEvaluationIssueIdentifier: input.latestTerminalEvaluation.identifier,
+      previousEvaluationStatus: input.latestTerminalEvaluation.status,
+      previousEvaluationResolvedAt: input.freshnessSince.toISOString(),
+      sourceIssueId: input.sourceIssue?.id ?? null,
+      sourceIssueIdentifier: input.sourceIssue?.identifier ?? null,
+      level: input.level,
+      staleReasonSignature: input.staleReasonSignature,
+    };
+    await logActivity(db, {
+      companyId: input.run.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: input.run.agentId,
+      runId: input.run.id,
+      action: "heartbeat.output_stale_duplicate_suppressed",
+      entityType: "heartbeat_run",
+      entityId: input.run.id,
+      details: {
+        source: "recovery.scan_silent_active_runs",
+        ...payload,
+      },
+    });
+  }
+
   async function buildRunOutputSilence(
     run: Pick<
       typeof heartbeatRuns.$inferSelect,
@@ -1431,6 +1643,28 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         });
       }
       return { kind: "existing" as const, evaluationIssueId: existing.id };
+    }
+
+    const latestTerminalEvaluation = await findLatestTerminalStaleRunEvaluation(input.run.companyId, input.run.id);
+    if (latestTerminalEvaluation) {
+      const freshness = await collectStaleRunFreshnessSignals({
+        run: input.run,
+        sourceIssue,
+        latestTerminalEvaluation,
+        level,
+        now: input.now,
+      });
+      if (freshness.reasons.length === 0) {
+        await recordSuppressedDuplicateStaleRunEvaluation({
+          run: input.run,
+          sourceIssue,
+          latestTerminalEvaluation,
+          level,
+          freshnessSince: freshness.freshnessSince,
+          staleReasonSignature: freshness.staleReasonSignature,
+        });
+        return { kind: "skipped" as const };
+      }
     }
 
     const ownerAgentId = await resolveStaleRunOwnerAgentId({ run: input.run, runningAgent, sourceIssue });


### PR DESCRIPTION
## Summary\n- remove suppression-path writes to heartbeat_run_events to prevent duplicate evaluation feedback loops\n- treat expired continue decisions as freshness so re-arm behavior resumes after quiet window expiry\n- include regression coverage for suppression loop + re-arm freshness behavior\n\n## Verification\n- targeted vitest run from prior heartbeat: 4 passed, 0 failed (freshness-gate + re-arm cases)\n\n## Issue\n- FMA-2185\n- Unblocks QA re-validation in FMA-2176\n