### PR TITLE
feat(issues): auto-wake CEO when direct report blocks on CEO-gated permission

### DIFF
--- a/server/src/__tests__/issue-comment-permission-block-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-comment-permission-block-wakeup-routes.test.ts
@@ -1,0 +1,290 @@
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const BUILDER_AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const CEO_AGENT_ID = "33333333-3333-4333-8333-333333333333";
+const ISSUE_ID = "11111111-1111-4111-8111-111111111111";
+
+const mockIssueService = vi.hoisted(() => ({
+  getById: vi.fn(),
+  assertCheckoutOwner: vi.fn(async () => undefined),
+  update: vi.fn(),
+  addComment: vi.fn(),
+  getDependencyReadiness: vi.fn(async () => ({ unresolvedBlockerCount: 1, blockerIssueIds: [] })),
+  getCurrentScheduledRetry: vi.fn(async () => null),
+  findMentionedAgents: vi.fn(async () => []),
+  listWakeableBlockedDependents: vi.fn(async () => []),
+  getWakeableParentAfterChildCompletion: vi.fn(async () => null),
+}));
+
+const mockHeartbeatService = vi.hoisted(() => ({
+  wakeup: vi.fn(async () => undefined),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+const mockPermissionBlockEscalationService = vi.hoisted(() => ({
+  evaluate: vi.fn(),
+  findUnblockOwnerAgent: vi.fn(),
+}));
+
+const mockAccessService = vi.hoisted(() => ({
+  canUser: vi.fn(async () => true),
+  decide: vi.fn(async () => ({ allowed: true, action: "issue.comment", reason: "allow_explicit_grant", explanation: "" })),
+  hasPermission: vi.fn(async () => true),
+}));
+
+const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
+
+const mockIssueThreadInteractionService = vi.hoisted(() => ({
+  expireRequestConfirmationsSupersededByComment: vi.fn(async () => []),
+  expireStaleRequestConfirmationsForIssueDocument: vi.fn(async () => []),
+}));
+
+const mockIssueRecoveryActionService = vi.hoisted(() => ({
+  getActiveForIssue: vi.fn(async () => null),
+  listActiveForIssues: vi.fn(async () => new Map()),
+  upsertSourceScoped: vi.fn(),
+  resolveActiveForIssue: vi.fn(),
+}));
+
+const mockRoutineService = vi.hoisted(() => ({
+  syncRunStatusForIssue: vi.fn(async () => undefined),
+}));
+
+vi.mock("../services/index.js", () => ({
+  companyService: () => ({
+    getById: vi.fn(async () => ({ id: "company-1", attachmentMaxBytes: 10 * 1024 * 1024 })),
+  }),
+  accessService: () => mockAccessService,
+  agentService: () => ({
+    getById: vi.fn(async () => null),
+    resolveByReference: vi.fn(async (_companyId: string, raw: string) => ({ ambiguous: false, agent: { id: raw } })),
+  }),
+  documentAnnotationService: () => ({ remapOpenThreadsForDocument: async () => [] }),
+  documentService: () => ({}),
+  executionWorkspaceService: () => ({}),
+  feedbackService: () => ({
+    listIssueVotesForUser: vi.fn(async () => []),
+    saveIssueVote: vi.fn(async () => ({ vote: null, consentEnabledNow: false, sharingEnabled: false })),
+  }),
+  goalService: () => ({}),
+  heartbeatService: () => mockHeartbeatService,
+  instanceSettingsService: () => ({
+    get: vi.fn(async () => ({
+      id: "instance-settings-1",
+      general: { censorUsernameInLogs: false, feedbackDataSharingPreference: "prompt" },
+    })),
+    listCompanyIds: vi.fn(async () => ["company-1"]),
+  }),
+  issueApprovalService: () => ({}),
+  issueRecoveryActionService: () => mockIssueRecoveryActionService,
+  issueReferenceService: () => ({
+    deleteDocumentSource: async () => undefined,
+    diffIssueReferenceSummary: () => ({
+      addedReferencedIssues: [],
+      removedReferencedIssues: [],
+      currentReferencedIssues: [],
+    }),
+    emptySummary: () => ({ outbound: [], inbound: [] }),
+    listIssueReferenceSummary: async () => ({ outbound: [], inbound: [] }),
+    syncComment: async () => undefined,
+    syncDocument: async () => undefined,
+    syncIssue: async () => undefined,
+  }),
+  issueService: () => mockIssueService,
+  issueThreadInteractionService: () => mockIssueThreadInteractionService,
+  logActivity: mockLogActivity,
+  permissionBlockEscalationService: () => mockPermissionBlockEscalationService,
+  projectService: () => ({}),
+  routineService: () => mockRoutineService,
+  workProductService: () => ({}),
+}));
+
+function makeBlockedIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    id: ISSUE_ID,
+    companyId: "company-1",
+    status: "blocked",
+    priority: "high",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    assigneeAgentId: BUILDER_AGENT_ID,
+    assigneeUserId: null,
+    createdByUserId: "local-board",
+    identifier: "HUM-162",
+    title: "CTO hire",
+    executionPolicy: null,
+    executionState: null,
+    hiddenAt: null,
+    ...overrides,
+  };
+}
+
+async function createApp(actorAgentId: string) {
+  const [{ errorHandler }, { issueRoutes }] = await Promise.all([
+    vi.importActual<typeof import("../middleware/index.js")>("../middleware/index.js"),
+    vi.importActual<typeof import("../routes/issues.js")>("../routes/issues.js"),
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: actorAgentId,
+      companyId: "company-1",
+      runId: "run-1",
+      source: "agent_key",
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+describe("blocked-comment permission escalation wakes the CEO", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIssueService.findMentionedAgents.mockResolvedValue([]);
+    mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
+    mockIssueService.getCurrentScheduledRetry.mockResolvedValue(null);
+    mockIssueService.getDependencyReadiness.mockResolvedValue({ unresolvedBlockerCount: 1, blockerIssueIds: [] });
+    mockHeartbeatService.wakeup.mockResolvedValue(undefined);
+    mockPermissionBlockEscalationService.evaluate.mockReset();
+  });
+
+  it("wakes the CEO with reason=direct_report_blocked_on_ceo_permission on the HUM-162 replay", async () => {
+    const blocked = makeBlockedIssue();
+    mockIssueService.getById.mockResolvedValue(blocked);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-1",
+      issueId: blocked.id,
+      companyId: blocked.companyId,
+      body: "Blocked. Missing permission: agents:create. Unblock owner: CEO.",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: BUILDER_AGENT_ID,
+      authorUserId: null,
+    });
+    mockPermissionBlockEscalationService.evaluate.mockResolvedValue({
+      targetAgentId: CEO_AGENT_ID,
+      targetAgentRole: "ceo",
+      match: {
+        trigger: "missing_permission",
+        permissionKey: "agents:create",
+        unblockOwnerRole: "ceo",
+      },
+    });
+
+    const app = await createApp(BUILDER_AGENT_ID);
+    const res = await request(app)
+      .post(`/api/issues/${blocked.id}/comments`)
+      .send({
+        body: "Blocked. Missing permission: agents:create. Unblock owner: CEO.",
+      });
+
+    expect(res.status).toBe(201);
+
+    await vi.waitFor(() => {
+      expect(mockPermissionBlockEscalationService.evaluate).toHaveBeenCalledWith({
+        companyId: blocked.companyId,
+        issueStatus: "blocked",
+        actorAgentId: BUILDER_AGENT_ID,
+        commentBody: "Blocked. Missing permission: agents:create. Unblock owner: CEO.",
+      });
+      expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+        CEO_AGENT_ID,
+        expect.objectContaining({
+          source: "automation",
+          reason: "direct_report_blocked_on_ceo_permission",
+          payload: expect.objectContaining({
+            issueId: blocked.id,
+            commentId: "comment-1",
+            blockedAgentId: BUILDER_AGENT_ID,
+            permissionKey: "agents:create",
+            unblockOwnerRole: "ceo",
+            trigger: "missing_permission",
+          }),
+          contextSnapshot: expect.objectContaining({
+            issueId: blocked.id,
+            taskId: blocked.id,
+            commentId: "comment-1",
+            wakeReason: "direct_report_blocked_on_ceo_permission",
+            source: "issue.comment.permission_block_escalation",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("does not wake the CEO when the comment does not name a permission gate", async () => {
+    const blocked = makeBlockedIssue();
+    mockIssueService.getById.mockResolvedValue(blocked);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-2",
+      issueId: blocked.id,
+      companyId: blocked.companyId,
+      body: "Waiting on upstream API.",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: BUILDER_AGENT_ID,
+      authorUserId: null,
+    });
+    mockPermissionBlockEscalationService.evaluate.mockResolvedValue(null);
+
+    const app = await createApp(BUILDER_AGENT_ID);
+    const res = await request(app)
+      .post(`/api/issues/${blocked.id}/comments`)
+      .send({ body: "Waiting on upstream API." });
+
+    expect(res.status).toBe(201);
+
+    await vi.waitFor(() => {
+      expect(mockPermissionBlockEscalationService.evaluate).toHaveBeenCalled();
+    });
+
+    const ceoWakes = mockHeartbeatService.wakeup.mock.calls.filter(
+      ([agentId]) => agentId === CEO_AGENT_ID,
+    );
+    expect(ceoWakes).toHaveLength(0);
+  });
+
+  it("does not double-wake when the assignee is already the CEO", async () => {
+    const blocked = makeBlockedIssue({ assigneeAgentId: CEO_AGENT_ID });
+    mockIssueService.getById.mockResolvedValue(blocked);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-3",
+      issueId: blocked.id,
+      companyId: blocked.companyId,
+      body: "Missing permission: agents:create",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: BUILDER_AGENT_ID,
+      authorUserId: null,
+    });
+    mockPermissionBlockEscalationService.evaluate.mockResolvedValue({
+      targetAgentId: CEO_AGENT_ID,
+      targetAgentRole: "ceo",
+      match: { trigger: "missing_permission", permissionKey: "agents:create", unblockOwnerRole: "ceo" },
+    });
+
+    const app = await createApp(BUILDER_AGENT_ID);
+    const res = await request(app)
+      .post(`/api/issues/${blocked.id}/comments`)
+      .send({ body: "Missing permission: agents:create" });
+
+    expect(res.status).toBe(201);
+
+    await vi.waitFor(() => {
+      const ceoWakes = mockHeartbeatService.wakeup.mock.calls.filter(([agentId]) => agentId === CEO_AGENT_ID);
+      // Either the assignee-wake or the escalation-wake fires, but not both.
+      expect(ceoWakes.length).toBe(1);
+    });
+  });
+});

--- a/server/src/__tests__/permission-block-escalation-service.test.ts
+++ b/server/src/__tests__/permission-block-escalation-service.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { detectPermissionBlockMarker } from "../services/permission-block-escalation.js";
+
+describe("detectPermissionBlockMarker", () => {
+  it("matches 'Missing permission: <key>' and extracts the key", () => {
+    const match = detectPermissionBlockMarker("Missing permission: agents:create");
+    expect(match).toEqual({
+      trigger: "missing_permission",
+      permissionKey: "agents:create",
+      unblockOwnerRole: "ceo",
+    });
+  });
+
+  it("matches the HUM-162 phrasing inside a multi-line blocked comment", () => {
+    const body = [
+      "Blocked. Cannot fire the hire payload.",
+      "",
+      "Missing permission: agents:create",
+      "",
+      "Unblock owner: CEO",
+    ].join("\n");
+    const match = detectPermissionBlockMarker(body);
+    expect(match?.permissionKey).toBe("agents:create");
+    expect(match?.unblockOwnerRole).toBe("ceo");
+  });
+
+  it("matches 'Unblock owner: CEO' when no permission key is present", () => {
+    const match = detectPermissionBlockMarker("blocked. unblock owner: CEO. need a board lever.");
+    expect(match).toEqual({
+      trigger: "unblock_owner_role",
+      permissionKey: null,
+      unblockOwnerRole: "ceo",
+    });
+  });
+
+  it("matches 'Unblock owner: Board' as ceo-target", () => {
+    const match = detectPermissionBlockMarker("status: blocked\nunblock owner: Board");
+    expect(match?.trigger).toBe("unblock_owner_role");
+    expect(match?.unblockOwnerRole).toBe("ceo");
+  });
+
+  it("matches the 'requires board approval and CEO action' phrase", () => {
+    const match = detectPermissionBlockMarker("This requires board approval and CEO action.");
+    expect(match?.trigger).toBe("board_approval_phrase");
+    expect(match?.unblockOwnerRole).toBe("ceo");
+  });
+
+  it("returns null for unrelated blocked comments", () => {
+    expect(detectPermissionBlockMarker("Blocked on upstream API outage.")).toBeNull();
+    expect(detectPermissionBlockMarker("waiting on the design review.")).toBeNull();
+    expect(detectPermissionBlockMarker("")).toBeNull();
+    expect(detectPermissionBlockMarker(null)).toBeNull();
+    expect(detectPermissionBlockMarker(undefined)).toBeNull();
+  });
+
+  it("does not match permission keys outside the 'Missing permission' marker", () => {
+    expect(detectPermissionBlockMarker("we use agents:create elsewhere but it's not blocked")).toBeNull();
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -875,6 +875,15 @@ export function issueRoutes(
   const documentAnnotationsSvc = documentAnnotationService(db);
   const issueReferencesSvc = issueReferenceService(db);
   const issueThreadInteractionsSvc = issueThreadInteractionService(db);
+  const permissionBlockEscalationFactory = Object.prototype.hasOwnProperty.call(
+    serviceIndex,
+    "permissionBlockEscalationService",
+  )
+    ? serviceIndex.permissionBlockEscalationService
+    : undefined;
+  const permissionBlockEscalationSvc = permissionBlockEscalationFactory?.(db) ?? {
+    evaluate: async () => null,
+  };
   const routinesSvc = routineService(db, {
     pluginWorkerManager: opts.pluginWorkerManager,
   });
@@ -4714,6 +4723,49 @@ export function issueRoutes(
         }
       }
 
+      if (comment && issue.status === "blocked" && actor.actorType === "agent" && actor.agentId) {
+        try {
+          const escalation = await permissionBlockEscalationSvc.evaluate({
+            companyId: issue.companyId,
+            issueStatus: issue.status,
+            actorAgentId: actor.agentId,
+            commentBody: comment.body,
+          });
+          if (escalation) {
+            addWakeup(escalation.targetAgentId, {
+              source: "automation",
+              triggerDetail: "system",
+              reason: "direct_report_blocked_on_ceo_permission",
+              payload: {
+                issueId: issue.id,
+                commentId: comment.id,
+                blockedAgentId: actor.agentId,
+                blockedComment: comment.body.slice(0, 240),
+                permissionKey: escalation.match.permissionKey,
+                unblockOwnerRole: escalation.match.unblockOwnerRole,
+                trigger: escalation.match.trigger,
+              },
+              requestedByActorType: actor.actorType,
+              requestedByActorId: actor.actorId,
+              contextSnapshot: {
+                issueId: issue.id,
+                taskId: issue.id,
+                commentId: comment.id,
+                wakeCommentId: comment.id,
+                source: "issue.update.permission_block_escalation",
+                wakeReason: "direct_report_blocked_on_ceo_permission",
+                blockedAgentId: actor.agentId,
+                permissionKey: escalation.match.permissionKey,
+                unblockOwnerRole: escalation.match.unblockOwnerRole,
+                trigger: escalation.match.trigger,
+              },
+            });
+          }
+        } catch (err) {
+          logger.warn({ err, issueId: issue.id }, "permission-block escalation evaluation failed on issue update");
+        }
+      }
+
       for (const { agentId, wakeup } of wakeups.values()) {
         heartbeat
           .wakeup(agentId, wakeup)
@@ -5766,6 +5818,49 @@ export function issueRoutes(
             source: "comment.mention",
           },
         });
+      }
+
+      if (currentIssue.status === "blocked" && actorIsAgent && actor.agentId) {
+        try {
+          const escalation = await permissionBlockEscalationSvc.evaluate({
+            companyId: currentIssue.companyId,
+            issueStatus: currentIssue.status,
+            actorAgentId: actor.agentId,
+            commentBody: comment.body,
+          });
+          if (escalation && !wakeups.has(escalation.targetAgentId)) {
+            wakeups.set(escalation.targetAgentId, {
+              source: "automation",
+              triggerDetail: "system",
+              reason: "direct_report_blocked_on_ceo_permission",
+              payload: {
+                issueId: currentIssue.id,
+                commentId: comment.id,
+                blockedAgentId: actor.agentId,
+                blockedComment: comment.body.slice(0, 240),
+                permissionKey: escalation.match.permissionKey,
+                unblockOwnerRole: escalation.match.unblockOwnerRole,
+                trigger: escalation.match.trigger,
+              },
+              requestedByActorType: actor.actorType,
+              requestedByActorId: actor.actorId,
+              contextSnapshot: {
+                issueId: currentIssue.id,
+                taskId: currentIssue.id,
+                commentId: comment.id,
+                wakeCommentId: comment.id,
+                source: "issue.comment.permission_block_escalation",
+                wakeReason: "direct_report_blocked_on_ceo_permission",
+                blockedAgentId: actor.agentId,
+                permissionKey: escalation.match.permissionKey,
+                unblockOwnerRole: escalation.match.unblockOwnerRole,
+                trigger: escalation.match.trigger,
+              },
+            });
+          }
+        } catch (err) {
+          logger.warn({ err, issueId: currentIssue.id }, "permission-block escalation evaluation failed on issue comment");
+        }
       }
 
       for (const [agentId, wakeup] of wakeups.entries()) {

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -47,6 +47,12 @@ export { resourceMembershipService, type ResourceMembershipPolicyHook } from "./
 export { inboxDismissalService } from "./inbox-dismissals.js";
 export { accessService } from "./access.js";
 export {
+  detectPermissionBlockMarker,
+  permissionBlockEscalationService,
+  type PermissionBlockMatch,
+  type PermissionBlockEscalationService,
+} from "./permission-block-escalation.js";
+export {
   backfillPrincipalAccessCompatibility,
   ensureHumanRoleDefaultGrants,
   insertMissingPrincipalGrants,

--- a/server/src/services/permission-block-escalation.ts
+++ b/server/src/services/permission-block-escalation.ts
@@ -1,0 +1,92 @@
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { agents, type Db } from "@paperclipai/db";
+
+export type PermissionBlockTrigger = "missing_permission" | "unblock_owner_role" | "board_approval_phrase";
+
+export type PermissionBlockMatch = {
+  trigger: PermissionBlockTrigger;
+  /** Permission key the comment named, if any. e.g. "agents:create". */
+  permissionKey: string | null;
+  /** Role the comment names as the unblock owner. Always "ceo" today. */
+  unblockOwnerRole: "ceo";
+};
+
+/**
+ * Patterns a direct-report agent uses to signal "I can't move; my manager has the lever."
+ * Conservative on purpose — we only fire CEO wakes when the comment is unambiguous.
+ */
+const MISSING_PERMISSION_RE = /missing\s+permission\s*[:\-]\s*([A-Za-z0-9_.:\-]+)/i;
+const UNBLOCK_OWNER_RE = /unblock\s+owner\s*[:\-]\s*(ceo|board)\b/i;
+const BOARD_APPROVAL_RE = /requires\s+board\s+approval\s+and\s+ceo\s+action/i;
+
+export function detectPermissionBlockMarker(body: string | null | undefined): PermissionBlockMatch | null {
+  if (!body || typeof body !== "string") return null;
+  const missing = MISSING_PERMISSION_RE.exec(body);
+  if (missing) {
+    return { trigger: "missing_permission", permissionKey: missing[1] ?? null, unblockOwnerRole: "ceo" };
+  }
+  if (UNBLOCK_OWNER_RE.test(body)) {
+    return { trigger: "unblock_owner_role", permissionKey: null, unblockOwnerRole: "ceo" };
+  }
+  if (BOARD_APPROVAL_RE.test(body)) {
+    return { trigger: "board_approval_phrase", permissionKey: null, unblockOwnerRole: "ceo" };
+  }
+  return null;
+}
+
+type UnblockOwnerAgentRow = {
+  id: string;
+  role: string;
+  status: string | null;
+};
+
+export function permissionBlockEscalationService(db: Db) {
+  /**
+   * Resolve the CEO-tier agent in this company that should receive an escalation wake.
+   * Prefers role=ceo, falls back to cto (mirrors recovery/service.ts stale-run escalation order).
+   * Skips terminated / pending_approval agents and the agent that authored the blocked comment.
+   */
+  async function findUnblockOwnerAgent(input: {
+    companyId: string;
+    excludeAgentId: string | null;
+  }): Promise<UnblockOwnerAgentRow | null> {
+    const rows = await db
+      .select({ id: agents.id, role: agents.role, status: agents.status, createdAt: agents.createdAt })
+      .from(agents)
+      .where(and(eq(agents.companyId, input.companyId), inArray(agents.role, ["ceo", "cto"])))
+      .orderBy(sql`case when ${agents.role} = 'ceo' then 0 else 1 end`, asc(agents.createdAt));
+    for (const row of rows) {
+      if (row.status === "pending_approval" || row.status === "terminated") continue;
+      if (input.excludeAgentId && row.id === input.excludeAgentId) continue;
+      return { id: row.id, role: row.role, status: row.status };
+    }
+    return null;
+  }
+
+  /**
+   * Evaluate whether a blocked-issue comment should auto-wake the CEO.
+   * Returns null when the issue is not blocked, the actor is not an agent, the
+   * comment does not name a permission gate, or no CEO/CTO agent is available.
+   */
+  async function evaluate(input: {
+    companyId: string;
+    issueStatus: string;
+    actorAgentId: string | null;
+    commentBody: string | null | undefined;
+  }): Promise<{ targetAgentId: string; targetAgentRole: string; match: PermissionBlockMatch } | null> {
+    if (input.issueStatus !== "blocked") return null;
+    if (!input.actorAgentId) return null;
+    const match = detectPermissionBlockMarker(input.commentBody);
+    if (!match) return null;
+    const target = await findUnblockOwnerAgent({
+      companyId: input.companyId,
+      excludeAgentId: input.actorAgentId,
+    });
+    if (!target) return null;
+    return { targetAgentId: target.id, targetAgentRole: target.role, match };
+  }
+
+  return { evaluate, findUnblockOwnerAgent };
+}
+
+export type PermissionBlockEscalationService = ReturnType<typeof permissionBlockEscalationService>;


### PR DESCRIPTION
## Summary

- When an agent posts a comment on a `blocked` issue that names a permission gate the CEO holds (e.g. `Missing permission: agents:create`, `Unblock owner: CEO`, or `requires board approval and CEO action`), Paperclip now schedules a CEO wake on that issue with reason `direct_report_blocked_on_ceo_permission`.
- Escalation runs in the existing wake-batch path for both `PATCH /issues/:id` (status → `blocked` + comment in one call) and `POST /issues/:id/comments` (comment on an already-blocked issue), so it merges cleanly with existing wakes and respects the same one-enqueue-per-agent dedupe.
- New focused service `permission-block-escalation.ts`: prose-pattern matcher + CEO/CTO agent resolver that mirrors `recovery/service.ts`'s stale-run escalation order. Wired through the `serviceIndex` optional-factory pattern (same shape as `issueTreeControlService`) so existing test mocks that don't export the new factory keep working.

## Motivation

HUM-162 stalled for 4.5 hours when Builder posted a clean `blocked` comment naming the exact unblock — *"Missing permission: agents:create. Unblock owner: CEO"* — but Builder is `heartbeat.enabled: false` and there was no automatic path to surface the issue to the CEO. The platform already had all the data (status = `blocked`, comment authored by the assignee, comment names a CEO-gated action); it just lacked the routing.

## Acceptance evidence

1. **New blocked comment from a non-CEO agent that names a CEO-gated unblock → CEO is woken on that issue.** Integration test: `server/src/__tests__/issue-comment-permission-block-wakeup-routes.test.ts` — Builder posts `Blocked. Missing permission: agents:create. Unblock owner: CEO.` on a `blocked` issue; `heartbeat.wakeup` is called with the CEO agent ID and reason `direct_report_blocked_on_ceo_permission`, with `permissionKey: "agents:create"`, `unblockOwnerRole: "ceo"`, `trigger: "missing_permission"` in the payload + context snapshot.
2. **Non-permission blocked comments don't trigger an escalation.** Same test file covers the negative case (`Waiting on upstream API.` — escalation service returns `null`, no CEO wake fires).
3. **No double-wake when the assignee is already the CEO.** Same test file covers `assigneeAgentId == targetAgentId` — exactly one wake fires for that agent.
4. **Matcher unit coverage:** `server/src/__tests__/permission-block-escalation-service.test.ts` covers all three trigger patterns (`Missing permission: <key>`, `Unblock owner: CEO|Board`, `requires board approval and CEO action`) and negative cases (empty/null/unrelated bodies, permission-key mentioned outside the marker).

## Test plan

- [x] `pnpm -F @paperclipai/server typecheck` — clean
- [x] `pnpm -F @paperclipai/server exec vitest run src/__tests__/permission-block-escalation-service.test.ts` — 7/7
- [x] `pnpm -F @paperclipai/server exec vitest run src/__tests__/issue-comment-permission-block-wakeup-routes.test.ts` — 3/3
- [x] Regression on all 51 `issue-*` / `heartbeat-*` / `permission-*` test files — 487/487 pass

## Notes for reviewers

- The escalation service runs **after** all existing wakeups have been added to the per-update wake batch, so the CEO wake won't duplicate an assignee/parent/mention wake for the same agent. It also explicitly skips the comment author and pending/terminated agents.
- Today the matcher only resolves `unblockOwnerRole = "ceo"` (with CTO as fallback target if no CEO is configured). The spec's stretch goal — a structured `unblockOwnerAgentId` / `unblockOwnerRole` field on `PATCH /issues/:id` — is intentionally deferred; the prose matcher already covers the HUM-162 replay shape and we can layer the structured field on top without changing the wake path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)