### PR TITLE
Guard live monitor handoffs from recovery churn

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -140,6 +140,7 @@ import {
   decideSuccessfulRunHandoff,
   findExistingFinishSuccessfulRunHandoffWake,
   findExistingRunLivenessContinuationWake,
+  isExplicitLiveMonitorContinuationComment,
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
   readContinuationAttempt,
 } from "./recovery/index.js";
@@ -4235,6 +4236,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       existingWake,
       budgetBlock,
       pauseHold,
+      explicitLiveMonitorContinuation,
     ] = await Promise.all([
       issue
         ? db
@@ -4360,6 +4362,22 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       issue
         ? treeControlSvc.getActivePauseHoldGate(issue.companyId, issue.id)
         : Promise.resolve(null),
+      issue
+        ? db
+          .select({ body: issueComments.body })
+          .from(issueComments)
+          .where(
+            and(
+              eq(issueComments.companyId, issue.companyId),
+              eq(issueComments.issueId, issue.id),
+              eq(issueComments.createdByRunId, run.id),
+              eq(issueComments.authorAgentId, run.agentId),
+            ),
+          )
+          .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+          .limit(10)
+          .then((rows) => rows.some((row) => isExplicitLiveMonitorContinuationComment(row.body)))
+        : Promise.resolve(false),
     ]);
 
     const decision = decideSuccessfulRunHandoff({
@@ -4375,6 +4393,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       hasExplicitBlockerPath: Boolean(explicitBlocker),
       hasOpenRecoveryIssue: Boolean(openRecoveryIssue),
       hasPauseHold: Boolean(pauseHold),
+      hasExplicitLiveMonitorContinuation: Boolean(explicitLiveMonitorContinuation),
       budgetBlocked: Boolean(budgetBlock),
       idempotentWakeExists: Boolean(existingWake),
     });

--- a/server/src/services/recovery/index.ts
+++ b/server/src/services/recovery/index.ts
@@ -56,6 +56,7 @@ export {
   buildSuccessfulRunHandoffRequiredNotice,
   decideSuccessfulRunHandoff,
   findExistingFinishSuccessfulRunHandoffWake,
+  isExplicitLiveMonitorContinuationComment,
   isSuccessfulRunHandoffRequiredNoticeBody,
 } from "./successful-run-handoff.js";
 export type {

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -9,6 +9,7 @@ import {
   buildSuccessfulRunHandoffRequiredNotice,
   decideSuccessfulRunHandoff,
   isIdempotentFinishSuccessfulRunHandoffWakeStatus,
+  isExplicitLiveMonitorContinuationComment,
   isSuccessfulRunHandoffRequiredNoticeBody,
   noticeMetadataReferencesRecoveryAction,
 } from "./successful-run-handoff.js";
@@ -52,6 +53,7 @@ function decide(overrides: Partial<Parameters<typeof decideSuccessfulRunHandoff>
     hasExplicitBlockerPath: false,
     hasOpenRecoveryIssue: false,
     hasPauseHold: false,
+    hasExplicitLiveMonitorContinuation: false,
     budgetBlocked: false,
     idempotentWakeExists: false,
     ...overrides,
@@ -128,6 +130,28 @@ describe("successful run handoff decision", () => {
       kind: "skip",
       reason: "explicit blocker path owns the next action",
     });
+  });
+
+  it("does not queue when the same run recorded a live monitor continuation", () => {
+    expect(decide({ hasExplicitLiveMonitorContinuation: true })).toEqual({
+      kind: "skip",
+      reason: "explicit live monitor continuation owns the next action",
+    });
+  });
+
+  it("recognizes narrow live-monitor continuation comments", () => {
+    expect(isExplicitLiveMonitorContinuationComment(
+      "finish_successful_run_handoff complete: no pending Projects Chat input; keep live monitor in_progress.",
+    )).toBe(true);
+    expect(isExplicitLiveMonitorContinuationComment(
+      "Source-scoped recovery action closeout: no actionable Projects Chat input yet; keeping live monitor path active.",
+    )).toBe(true);
+    expect(isExplicitLiveMonitorContinuationComment(
+      "Implemented the backend detector, but did not choose a final issue state.",
+    )).toBe(false);
+    expect(isExplicitLiveMonitorContinuationComment(
+      "No pending review input; continue implementation tomorrow.",
+    )).toBe(false);
   });
 
   it("does not queue when a successful run has no progress signal", () => {

--- a/server/src/services/recovery/successful-run-handoff.test.ts
+++ b/server/src/services/recovery/successful-run-handoff.test.ts
@@ -147,11 +147,23 @@ describe("successful run handoff decision", () => {
       "Source-scoped recovery action closeout: no actionable Projects Chat input yet; keeping live monitor path active.",
     )).toBe(true);
     expect(isExplicitLiveMonitorContinuationComment(
+      "Conversation monitor closeout: no new chat requests received; keeping issue in_progress.",
+    )).toBe(true);
+    expect(isExplicitLiveMonitorContinuationComment(
+      "Active monitor: waiting for the next message from the user.",
+    )).toBe(true);
+    expect(isExplicitLiveMonitorContinuationComment(
       "Implemented the backend detector, but did not choose a final issue state.",
     )).toBe(false);
     expect(isExplicitLiveMonitorContinuationComment(
       "No pending review input; continue implementation tomorrow.",
     )).toBe(false);
+    expect(isExplicitLiveMonitorContinuationComment(
+      "Deployed the live monitor service.",
+    )).toBe(false);
+    expect(isExplicitLiveMonitorContinuationComment(null)).toBe(false);
+    expect(isExplicitLiveMonitorContinuationComment(undefined)).toBe(false);
+    expect(isExplicitLiveMonitorContinuationComment("")).toBe(false);
   });
 
   it("does not queue when a successful run has no progress signal", () => {

--- a/server/src/services/recovery/successful-run-handoff.ts
+++ b/server/src/services/recovery/successful-run-handoff.ts
@@ -303,6 +303,29 @@ function isProductiveSuccessfulRun(input: {
   return Boolean(input.detectedProgressSummary);
 }
 
+export function isExplicitLiveMonitorContinuationComment(body: string | null | undefined) {
+  const normalized = (body ?? "").toLowerCase().replace(/\s+/g, " ").trim();
+  if (!normalized) return false;
+
+  const namesLiveMonitor =
+    normalized.includes("live monitor") ||
+    normalized.includes("conversation monitor") ||
+    normalized.includes("active monitor");
+  if (!namesLiveMonitor) return false;
+
+  const saysNoCurrentInput =
+    normalized.includes("no pending") ||
+    normalized.includes("no new") ||
+    normalized.includes("no actionable") ||
+    normalized.includes("waiting for the next");
+  if (!saysNoCurrentInput) return false;
+
+  return normalized.includes("input") ||
+    normalized.includes("request") ||
+    normalized.includes("message") ||
+    normalized.includes("chat");
+}
+
 export function buildSuccessfulRunHandoffInstruction(input: {
   issueIdentifier: string | null;
   sourceRunId: string;
@@ -342,6 +365,7 @@ export function decideSuccessfulRunHandoff(input: {
   hasExplicitBlockerPath: boolean;
   hasOpenRecoveryIssue: boolean;
   hasPauseHold: boolean;
+  hasExplicitLiveMonitorContinuation: boolean;
   budgetBlocked: boolean;
   idempotentWakeExists: boolean;
 }): SuccessfulRunHandoffDecision {
@@ -378,6 +402,9 @@ export function decideSuccessfulRunHandoff(input: {
   if (input.hasExplicitBlockerPath) return { kind: "skip", reason: "explicit blocker path owns the next action" };
   if (input.hasOpenRecoveryIssue) return { kind: "skip", reason: "open recovery issue owns the ambiguity" };
   if (input.hasPauseHold) return { kind: "skip", reason: "issue is under an active pause hold" };
+  if (input.hasExplicitLiveMonitorContinuation) {
+    return { kind: "skip", reason: "explicit live monitor continuation owns the next action" };
+  }
   if (input.budgetBlocked) return { kind: "skip", reason: "budget hard stop blocks corrective wake" };
   if (input.idempotentWakeExists) {
     return { kind: "skip", reason: "corrective handoff wake already exists for this source run" };


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents through issue-scoped runs and recovery wakes.
> - Successful-run handoff recovery catches runs that made progress but left their issue in `in_progress` without a next path.
> - Long-running conversation monitor issues can legitimately stay in `in_progress` while waiting for the next chat request.
> - The recovery flow was still treating explicit monitor closeout comments as missing disposition evidence.
> - This pull request teaches the handoff detector to recognize a narrow live-monitor continuation comment written by the same successful run.
> - The benefit is that monitor issues can remain live without repeated `finish_successful_run_handoff` or source-scoped recovery churn.

## What Changed

- Added `isExplicitLiveMonitorContinuationComment` for the narrow shape: no pending/new/actionable input plus live/conversation/active monitor wording.
- Wired `handleSuccessfulRunHandoff` to inspect comments created by the same run and same agent before queuing a corrective handoff wake.
- Added decision/classifier coverage for live-monitor comments and negative ordinary-work examples.

Diff stat against `origin/master`:

```text
 server/src/services/heartbeat.ts                   | 19 +++++++++++++++
 server/src/services/recovery/index.ts              |  1 +
 .../recovery/successful-run-handoff.test.ts        | 24 +++++++++++++++++++
 .../services/recovery/successful-run-handoff.ts    | 27 ++++++++++++++++++++++
 4 files changed, 71 insertions(+)
```

Relevant diff excerpt:

```diff
+export function isExplicitLiveMonitorContinuationComment(body: string | null | undefined) {
+  const normalized = (body ?? "").toLowerCase().replace(/\s+/g, " ").trim();
+  if (!normalized) return false;
+
+  const namesLiveMonitor =
+    normalized.includes("live monitor") ||
+    normalized.includes("conversation monitor") ||
+    normalized.includes("active monitor");
+  if (!namesLiveMonitor) return false;
+
+  const saysNoCurrentInput =
+    normalized.includes("no pending") ||
+    normalized.includes("no new") ||
+    normalized.includes("no actionable") ||
+    normalized.includes("waiting for the next");
+  if (!saysNoCurrentInput) return false;
+
+  return normalized.includes("input") ||
+    normalized.includes("request") ||
+    normalized.includes("message") ||
+    normalized.includes("chat");
+}
...
+      issue
+        ? db
+          .select({ body: issueComments.body })
+          .from(issueComments)
+          .where(
+            and(
+              eq(issueComments.companyId, issue.companyId),
+              eq(issueComments.issueId, issue.id),
+              eq(issueComments.createdByRunId, run.id),
+              eq(issueComments.authorAgentId, run.agentId),
+            ),
+          )
+          .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+          .limit(10)
+          .then((rows) => rows.some((row) => isExplicitLiveMonitorContinuationComment(row.body)))
+        : Promise.resolve(false),
```

## Verification

- `pnpm vitest run server/src/services/recovery/successful-run-handoff.test.ts`
- `pnpm typecheck`

## Risks

- Low risk. The suppression only applies to comments created by the same successful run and same agent, and the comment must explicitly name both live-monitor handling and absence of current input.
- The phrase detector is intentionally conservative; monitor comments that use different wording may still trigger recovery until covered by a future structured monitor state.
- No migrations, dependency changes, or UI changes.

## Model Used

- OpenAI GPT-5 Codex, Codex CLI coding agent with shell/tool use, medium reasoning effort.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
