### PR TITLE
feat(access): agents:view_all — per-user agent visibility scoping

### DIFF
--- a/packages/db/src/migrations/0091_grant_tasks_view_all_default.sql
+++ b/packages/db/src/migrations/0091_grant_tasks_view_all_default.sql
@@ -1,0 +1,19 @@
+-- Backfill `tasks:view_all` for every active human company membership so
+-- existing deployments see no behavior change after this permission key is
+-- introduced. Idempotent via the unique grant index; safe to replay.
+INSERT INTO "principal_permission_grants"
+  ("id", "company_id", "principal_type", "principal_id", "permission_key", "scope", "granted_by_user_id", "created_at", "updated_at")
+SELECT
+  gen_random_uuid(),
+  m."company_id",
+  m."principal_type",
+  m."principal_id",
+  'tasks:view_all',
+  NULL,
+  NULL,
+  now(),
+  now()
+FROM "company_memberships" m
+WHERE m."principal_type" = 'user'
+  AND m."status" = 'active'
+ON CONFLICT ("company_id", "principal_type", "principal_id", "permission_key") DO NOTHING;

--- a/packages/db/src/migrations/0091_grant_tasks_view_all_default.sql
+++ b/packages/db/src/migrations/0091_grant_tasks_view_all_default.sql
@@ -1,6 +1,16 @@
 -- Backfill `tasks:view_all` for every active human company membership so
 -- existing deployments see no behavior change after this permission key is
--- introduced. Idempotent via the unique grant index; safe to replay.
+-- introduced.
+--
+-- WHERE NOT EXISTS instead of ON CONFLICT DO NOTHING: this preserves admin
+-- revocations across re-runs. ON CONFLICT only matches active grants; if an
+-- admin had revoked the row (whether via hard-delete on the legacy schema or
+-- a tombstone after migration 0093), the conflict path would skip the insert
+-- BUT only because the unique index covers active rows. NOT EXISTS scans both
+-- active and tombstoned rows for the same (company, principal, key) and skips
+-- when EITHER exists — silently re-applying default access is never desirable
+-- for a permission revoke. See 0093_grant_revocation_tombstones.sql for the
+-- soft-delete contract this depends on.
 INSERT INTO "principal_permission_grants"
   ("id", "company_id", "principal_type", "principal_id", "permission_key", "scope", "granted_by_user_id", "created_at", "updated_at")
 SELECT
@@ -16,4 +26,10 @@ SELECT
 FROM "company_memberships" m
 WHERE m."principal_type" = 'user'
   AND m."status" = 'active'
-ON CONFLICT ("company_id", "principal_type", "principal_id", "permission_key") DO NOTHING;
+  AND NOT EXISTS (
+    SELECT 1 FROM "principal_permission_grants" g
+    WHERE g."company_id" = m."company_id"
+      AND g."principal_type" = m."principal_type"
+      AND g."principal_id" = m."principal_id"
+      AND g."permission_key" = 'tasks:view_all'
+  );

--- a/packages/db/src/migrations/0092_grant_revocation_tombstones.sql
+++ b/packages/db/src/migrations/0092_grant_revocation_tombstones.sql
@@ -1,0 +1,37 @@
+-- Preserve permission grant revocations across migration re-runs and backup
+-- restores by switching `principal_permission_grants` from hard-delete to
+-- audit-preserving soft-delete.
+--
+-- Motivation:
+--   Migration 0091_grant_tasks_view_all_default (and any future default-grant
+--   backfill) re-applies the same INSERT ... ON CONFLICT DO NOTHING SQL each
+--   time it lands under a new tag (rebase, multi-tenant cloud bootstrap,
+--   backup restore). If an admin had previously DELETE'd a row to revoke
+--   the grant, the re-run quietly re-creates it because the unique index
+--   on (company_id, principal_type, principal_id, permission_key) no longer
+--   matches anything to conflict against. The revoke is silently lost.
+--
+-- Fix:
+--   - Add `revoked_at` / `revoked_by_user_id` columns mirroring the existing
+--     `invites.revokedAt` pattern in the schema (this is an established
+--     Paperclip soft-delete convention, not a new invention).
+--   - Replace the unconditional UNIQUE index with a partial UNIQUE that
+--     covers only active (revoked_at IS NULL) rows. Tombstone rows live
+--     forever as audit trail and never block a re-grant.
+--   - Backfill (separate migration) becomes `WHERE NOT EXISTS (...)` so
+--     it skips when EITHER an active or a tombstoned row already exists
+--     for the same (company, principal, key) — preserving the admin's
+--     revocation through every subsequent re-run.
+
+ALTER TABLE "principal_permission_grants"
+  ADD COLUMN IF NOT EXISTS "revoked_at" timestamp with time zone;
+
+ALTER TABLE "principal_permission_grants"
+  ADD COLUMN IF NOT EXISTS "revoked_by_user_id" text;
+
+DROP INDEX IF EXISTS "principal_permission_grants_unique_idx";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "principal_permission_grants_active_unique_idx"
+  ON "principal_permission_grants"
+  ("company_id", "principal_type", "principal_id", "permission_key")
+  WHERE "revoked_at" IS NULL;

--- a/packages/db/src/migrations/0093_grant_agents_view_all_default.sql
+++ b/packages/db/src/migrations/0093_grant_agents_view_all_default.sql
@@ -1,0 +1,28 @@
+-- Backfill `agents:view_all` for every active human company membership so
+-- existing deployments see no behavior change after this permission key is
+-- introduced. Mirrors 0091_grant_tasks_view_all_default exactly.
+--
+-- WHERE NOT EXISTS skips both active and tombstoned rows so an admin
+-- revocation survives migration re-runs (see 0093_grant_revocation_tombstones).
+INSERT INTO "principal_permission_grants"
+  ("id", "company_id", "principal_type", "principal_id", "permission_key", "scope", "granted_by_user_id", "created_at", "updated_at")
+SELECT
+  gen_random_uuid(),
+  m."company_id",
+  m."principal_type",
+  m."principal_id",
+  'agents:view_all',
+  NULL,
+  NULL,
+  now(),
+  now()
+FROM "company_memberships" m
+WHERE m."principal_type" = 'user'
+  AND m."status" = 'active'
+  AND NOT EXISTS (
+    SELECT 1 FROM "principal_permission_grants" g
+    WHERE g."company_id" = m."company_id"
+      AND g."principal_type" = m."principal_type"
+      AND g."principal_id" = m."principal_id"
+      AND g."permission_key" = 'agents:view_all'
+  );

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -638,6 +638,13 @@
       "when": 1779573019125,
       "tag": "0090_resource_memberships",
       "breakpoints": true
+    },
+    {
+      "idx": 91,
+      "version": "7",
+      "when": 1779396752459,
+      "tag": "0091_grant_tasks_view_all_default",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -645,6 +645,13 @@
       "when": 1779396752459,
       "tag": "0091_grant_tasks_view_all_default",
       "breakpoints": true
+    },
+    {
+      "idx": 92,
+      "version": "7",
+      "when": 1779882000000,
+      "tag": "0092_grant_revocation_tombstones",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -652,6 +652,13 @@
       "when": 1779882000000,
       "tag": "0092_grant_revocation_tombstones",
       "breakpoints": true
+    },
+    {
+      "idx": 93,
+      "version": "7",
+      "when": 1779895000000,
+      "tag": "0093_grant_agents_view_all_default",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/principal_permission_grants.ts
+++ b/packages/db/src/schema/principal_permission_grants.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { pgTable, uuid, text, timestamp, jsonb, uniqueIndex, index } from "drizzle-orm/pg-core";
 import { companies } from "./companies.js";
 
@@ -11,16 +12,19 @@ export const principalPermissionGrants = pgTable(
     permissionKey: text("permission_key").notNull(),
     scope: jsonb("scope").$type<Record<string, unknown> | null>(),
     grantedByUserId: text("granted_by_user_id"),
+    revokedAt: timestamp("revoked_at", { withTimezone: true }),
+    revokedByUserId: text("revoked_by_user_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
-    uniqueGrantIdx: uniqueIndex("principal_permission_grants_unique_idx").on(
-      table.companyId,
-      table.principalType,
-      table.principalId,
-      table.permissionKey,
-    ),
+    // Active-only unique index. Tombstones (revoked_at IS NOT NULL) are
+    // preserved indefinitely as audit history and do NOT block re-grants —
+    // a fresh grant for the same (company, principal, key) just inserts a
+    // new active row alongside any existing tombstones.
+    uniqueGrantIdx: uniqueIndex("principal_permission_grants_active_unique_idx")
+      .on(table.companyId, table.principalType, table.principalId, table.permissionKey)
+      .where(sql`${table.revokedAt} IS NULL`),
     companyPermissionIdx: index("principal_permission_grants_company_permission_idx").on(
       table.companyId,
       table.permissionKey,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -659,6 +659,7 @@ export const PERMISSION_KEYS = [
   "tasks:assign",
   "tasks:assign_scope",
   "tasks:manage_active_checkouts",
+  "tasks:view_all",
   "joins:approve",
 ] as const;
 export type PermissionKey = (typeof PERMISSION_KEYS)[number];

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -660,6 +660,7 @@ export const PERMISSION_KEYS = [
   "tasks:assign_scope",
   "tasks:manage_active_checkouts",
   "tasks:view_all",
+  "agents:view_all",
   "joins:approve",
 ] as const;
 export type PermissionKey = (typeof PERMISSION_KEYS)[number];

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -9,6 +9,11 @@ import type { DeploymentMode } from "@paperclipai/shared";
 import type { BetterAuthSessionResult } from "../auth/better-auth.js";
 import { logger } from "../middleware/logger.js";
 import { subscribeCompanyLiveEvents } from "../services/live-events.js";
+import {
+  resolveIssueVisibility,
+  assertIssueVisible,
+  type IssueVisibility,
+} from "../services/issue-visibility.js";
 
 interface WsSocket {
   readyState: number;
@@ -44,6 +49,17 @@ interface UpgradeContext {
   companyId: string;
   actorType: "board" | "agent";
   actorId: string;
+  /**
+   * For the board (human) actor path: true if the upgrade was authorized via
+   * the local_trusted implicit board fallback (no real authenticated user).
+   * Local-implicit board users bypass issue-visibility scoping.
+   */
+  isLocalImplicit?: boolean;
+  /**
+   * For the board actor path: true if the resolved user has the
+   * `instance_admin` role and therefore bypasses issue-visibility scoping.
+   */
+  isInstanceAdmin?: boolean;
 }
 
 interface IncomingMessageWithContext extends IncomingMessage {
@@ -52,6 +68,58 @@ interface IncomingMessageWithContext extends IncomingMessage {
 
 function hashToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
+}
+
+/**
+ * Adapts a WS UpgradeContext into the `Request["actor"]` shape that
+ * `resolveIssueVisibility` consumes. The visibility resolver only inspects
+ * `type`, `source`, `isInstanceAdmin`, and `userId`, so we just provide
+ * those four fields.
+ */
+function buildActorForVisibility(context: {
+  actorType: "board" | "agent";
+  actorId: string;
+  isLocalImplicit?: boolean;
+  isInstanceAdmin?: boolean;
+}): Parameters<typeof resolveIssueVisibility>[2] {
+  if (context.actorType === "agent") {
+    return {
+      type: "agent",
+      agentId: context.actorId,
+      source: "agent_jwt",
+    } as Parameters<typeof resolveIssueVisibility>[2];
+  }
+  return {
+    type: "board",
+    userId: context.actorId,
+    source: context.isLocalImplicit ? "local_implicit" : "session",
+    isInstanceAdmin: Boolean(context.isInstanceAdmin),
+  } as Parameters<typeof resolveIssueVisibility>[2];
+}
+
+/**
+ * Extracts an `issueId` from a live event payload when the event references
+ * a specific issue. Returns `null` for events that aren't issue-scoped
+ * (those are always delivered).
+ */
+function readIssueIdFromEvent(event: unknown): string | null {
+  if (typeof event !== "object" || event === null) return null;
+  const payload = (event as { payload?: unknown }).payload;
+  if (typeof payload !== "object" || payload === null) return null;
+  const candidate = (payload as { issueId?: unknown; entityId?: unknown; entityType?: unknown });
+  if (typeof candidate.issueId === "string" && candidate.issueId.length > 0) {
+    return candidate.issueId;
+  }
+  // For activity.logged-shaped events the issue id lives under entityId when
+  // entityType === "issue".
+  if (
+    candidate.entityType === "issue"
+    && typeof candidate.entityId === "string"
+    && candidate.entityId.length > 0
+  ) {
+    return candidate.entityId;
+  }
+  return null;
 }
 
 function rejectUpgrade(socket: Duplex, statusLine: string, message: string) {
@@ -113,6 +181,7 @@ async function authorizeUpgrade(
         companyId,
         actorType: "board",
         actorId: "board",
+        isLocalImplicit: true,
       };
     }
 
@@ -149,6 +218,7 @@ async function authorizeUpgrade(
       companyId,
       actorType: "board",
       actorId: userId,
+      isInstanceAdmin: Boolean(roleRow),
     };
   }
 
@@ -198,15 +268,56 @@ export function setupLiveEventsWebSocketServer(
     }
   }, 30000);
 
-  wss.on("connection", (socket: WsSocket, req: IncomingMessage) => {
+  wss.on("connection", async (socket: WsSocket, req: IncomingMessage) => {
     const context = (req as IncomingMessageWithContext).paperclipUpgradeContext;
     if (!context) {
       socket.close(1008, "missing context");
       return;
     }
 
-    const unsubscribe = subscribeCompanyLiveEvents(context.companyId, (event) => {
+    const subscriberCompanyId = context.companyId;
+    // Resolve the subscriber's issue visibility once per connection. Agents,
+    // local-implicit board users, and instance admins all collapse to
+    // {mode:"all"} and skip per-event filtering on the hot path.
+    const subscriberVisibility: IssueVisibility = await resolveIssueVisibility(
+      db,
+      subscriberCompanyId,
+      buildActorForVisibility(context),
+    );
+    const visibilityCache = new Map<string, { visible: boolean; expiresAt: number }>();
+    const VISIBILITY_CACHE_TTL_MS = 30_000;
+    const VISIBILITY_CACHE_MAX_ENTRIES = 500;
+
+    async function shouldDeliverIssueEvent(issueId: string): Promise<boolean> {
+      if (subscriberVisibility.mode === "all") return true;
+      const cached = visibilityCache.get(issueId);
+      const now = Date.now();
+      if (cached && cached.expiresAt > now) return cached.visible;
+      try {
+        await assertIssueVisible(db, subscriberCompanyId, issueId, subscriberVisibility);
+        visibilityCache.set(issueId, { visible: true, expiresAt: now + VISIBILITY_CACHE_TTL_MS });
+        if (visibilityCache.size > VISIBILITY_CACHE_MAX_ENTRIES) {
+          // Cheap LRU-ish prune: drop oldest 20% of entries by insertion order.
+          const prune = Math.ceil(VISIBILITY_CACHE_MAX_ENTRIES * 0.2);
+          let i = 0;
+          for (const key of visibilityCache.keys()) {
+            if (i++ >= prune) break;
+            visibilityCache.delete(key);
+          }
+        }
+        return true;
+      } catch {
+        visibilityCache.set(issueId, { visible: false, expiresAt: now + VISIBILITY_CACHE_TTL_MS });
+        return false;
+      }
+    }
+
+    const unsubscribe = subscribeCompanyLiveEvents(subscriberCompanyId, async (event) => {
       if (socket.readyState !== WebSocket.OPEN) return;
+      if (subscriberVisibility.mode === "scoped") {
+        const issueId = readIssueIdFromEvent(event);
+        if (issueId && !(await shouldDeliverIssueEvent(issueId))) return;
+      }
       socket.send(JSON.stringify(event));
     });
 

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -6,6 +6,10 @@ import { validate } from "../middleware/validate.js";
 import { activityService, normalizeActivityLimit } from "../services/activity.js";
 import { assertAuthenticated, assertBoard, assertCompanyAccess } from "./authz.js";
 import { heartbeatService, issueService } from "../services/index.js";
+import {
+  resolveIssueVisibility,
+  assertIssueVisible,
+} from "../services/issue-visibility.js";
 import { sanitizeRecord } from "../redaction.js";
 
 const createActivitySchema = z.object({
@@ -36,12 +40,15 @@ export function activityRoutes(db: Db) {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);
 
+    const visibility = await resolveIssueVisibility(db, companyId, req.actor);
+
     const filters = {
       companyId,
       agentId: req.query.agentId as string | undefined,
       entityType: req.query.entityType as string | undefined,
       entityId: req.query.entityId as string | undefined,
       limit: normalizeActivityLimit(Number(req.query.limit)),
+      visibility,
     };
     const result = await svc.list(filters);
     res.json(result);
@@ -67,6 +74,12 @@ export function activityRoutes(db: Db) {
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const result = await svc.forIssue(issue.id);
     res.json(result);
   });
@@ -79,6 +92,12 @@ export function activityRoutes(db: Db) {
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const result = await svc.runsForIssue(issue.companyId, issue.id);
     res.json(result);
   });

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -56,6 +56,7 @@ import {
 } from "./workspace-command-authz.js";
 import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
 import { environmentService } from "../services/environments.js";
+import { resolveAgentVisibility, assertAgentVisible } from "../services/agent-visibility.js";
 import { resolveEnvironmentExecutionTarget } from "../services/environment-execution-target.js";
 import { environmentRuntimeService } from "../services/environment-runtime.js";
 import type { AdapterExecutionTarget } from "@paperclipai/adapter-utils/execution-target";
@@ -1601,7 +1602,8 @@ export function agentRoutes(
       });
       return;
     }
-    const result = await svc.list(companyId);
+    const visibility = await resolveAgentVisibility(db, companyId, req.actor);
+    const result = await svc.list(companyId, { visibility });
     const canReadConfigs = await actorCanReadConfigurationsForCompany(req, companyId);
     if (canReadConfigs) {
       res.json(result);
@@ -1791,6 +1793,12 @@ export function agentRoutes(
       return;
     }
     assertCompanyAccess(req, agent.companyId);
+    await assertAgentVisible(
+      db,
+      agent.companyId,
+      agent.id,
+      await resolveAgentVisibility(db, agent.companyId, req.actor),
+    );
     const isSelf = req.actor.type === "agent" && req.actor.agentId === id;
     const canReadSensitiveDetail = isSelf
       ? true

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -91,6 +91,11 @@ import {
   SVG_CONTENT_TYPE,
 } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+import {
+  resolveIssueVisibility,
+  assertIssueVisible,
+  type IssueVisibility,
+} from "../services/issue-visibility.js";
 import { assertEnvironmentSelectionForCompany } from "./environment-selection.js";
 import { executionWorkspaceService as executionWorkspaceServiceDirect } from "../services/execution-workspaces.js";
 import { feedbackService } from "../services/feedback.js";
@@ -126,7 +131,11 @@ type RecoveryRevalidationTrigger =
   | "work_product"
   | "read_projection";
 type CompanySearchService = {
-  search(companyId: string, query: CompanySearchQuery): Promise<CompanySearchResponse>;
+  search(
+    companyId: string,
+    query: CompanySearchQuery,
+    options?: { visibility?: IssueVisibility },
+  ): Promise<CompanySearchResponse>;
 };
 type ActivityIssueRelationSummary = {
   id: string;
@@ -1772,7 +1781,8 @@ export function issueRoutes(
       });
       return;
     }
-    const result = await getSearchService().search(companyId, query);
+    const searchVisibility = await resolveIssueVisibility(db, companyId, req.actor);
+    const result = await getSearchService().search(companyId, query, { visibility: searchVisibility });
     res.json(result);
   });
 
@@ -1850,6 +1860,8 @@ export function issueRoutes(
     }
     const offset = parsedOffset ?? 0;
 
+    const visibility = await resolveIssueVisibility(db, companyId, req.actor);
+
     const result = await svc.list(companyId, {
       attention: attention === "blocked" ? "blocked" : undefined,
       status: req.query.status as string | undefined,
@@ -1859,6 +1871,7 @@ export function issueRoutes(
       touchedByUserId,
       inboxArchivedByUserId,
       unreadForUserId,
+      visibility,
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
@@ -1921,12 +1934,15 @@ export function issueRoutes(
       return;
     }
 
+    const countVisibility = await resolveIssueVisibility(db, companyId, req.actor);
+
     const count = await svc.count(companyId, {
       attention: "blocked",
       status: req.query.status as string | undefined,
       assigneeAgentId: req.query.assigneeAgentId as string | undefined,
       participantAgentId: req.query.participantAgentId as string | undefined,
       assigneeUserId: req.query.assigneeUserId as string | undefined,
+      visibility: countVisibility,
       projectId: req.query.projectId as string | undefined,
       workspaceId: req.query.workspaceId as string | undefined,
       executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
@@ -2011,6 +2027,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
 
     const wakeCommentId =
       typeof req.query.wakeCommentId === "string" && req.query.wakeCommentId.trim().length > 0
@@ -2147,6 +2169,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const [
       { project, goal },
       ancestors,
@@ -2224,6 +2252,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const active = await revalidateActiveSourceRecoveryForRead({
       issue,
       trigger: "read_projection",
@@ -2412,6 +2446,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const workProducts = await workProductsSvc.listForIssue(issue.id);
     res.json(workProducts);
   });
@@ -2424,6 +2464,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const docs = await documentsSvc.listIssueDocuments(issue.id, {
       includeSystem: req.query.includeSystem === "true",
     });
@@ -2438,6 +2484,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const keyParsed = issueDocumentKeySchema.safeParse(String(req.params.key ?? "").trim().toLowerCase());
     if (!keyParsed.success) {
       res.status(400).json({ error: "Invalid document key", details: keyParsed.error.issues });
@@ -2459,6 +2511,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     if (!(await assertDeliverableMutationAllowedByRunContext(req, res, issue))) return;
     const keyParsed = issueDocumentKeySchema.safeParse(String(req.params.key ?? "").trim().toLowerCase());
@@ -2553,6 +2611,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Board authentication required" });
       return;
@@ -2601,6 +2665,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Board authentication required" });
       return;
@@ -2643,6 +2713,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const keyParsed = issueDocumentKeySchema.safeParse(String(req.params.key ?? "").trim().toLowerCase());
     if (!keyParsed.success) {
       res.status(400).json({ error: "Invalid document key", details: keyParsed.error.issues });
@@ -2664,6 +2740,12 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
       if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
       if (!(await assertDeliverableMutationAllowedByRunContext(req, res, issue))) return;
       const keyParsed = issueDocumentKeySchema.safeParse(String(req.params.key ?? "").trim().toLowerCase());
@@ -2749,6 +2831,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Board authentication required" });
       return;
@@ -2824,6 +2912,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     if (!(await assertDeliverableMutationAllowedByRunContext(req, res, issue))) return;
     const product = await workProductsSvc.createForIssue(issue.id, issue.companyId, {
@@ -2945,6 +3039,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Board authentication required" });
       return;
@@ -2977,6 +3077,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Board authentication required" });
       return;
@@ -3009,6 +3115,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Board authentication required" });
       return;
@@ -3041,6 +3153,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Board authentication required" });
       return;
@@ -3073,6 +3191,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const approvals = await issueApprovalsSvc.listApprovalsForIssue(id);
     res.json(approvals);
   });
@@ -3085,6 +3209,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     if (!(await assertCanManageIssueApprovalLinks(req, res, issue.companyId))) return;
 
@@ -3119,6 +3249,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     if (!(await assertCanManageIssueApprovalLinks(req, res, issue.companyId))) return;
 
@@ -3340,6 +3476,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     assertCanManageIssueMonitor(req, issue.assigneeAgentId, true);
 
     const actor = getActorInfo(req);
@@ -3362,6 +3504,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
 
     const actor = getActorInfo(req);
     const result = await heartbeat.retryScheduledRetryNow({
@@ -4412,6 +4560,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
 
     if (issue.projectId) {
       const project = await projectsSvc.getById(issue.projectId);
@@ -4579,6 +4733,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const afterCommentId =
       typeof req.query.after === "string" && req.query.after.trim().length > 0
         ? req.query.after.trim()
@@ -4613,6 +4773,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const actor = getActorInfo(req);
     const interactionSvc = issueThreadInteractionService(db);
     const expiredInteractions = await interactionSvc.expireRequestConfirmationsSupersededByHistoricalComments(issue);
@@ -4635,6 +4801,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type === "agent") {
       if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     } else {
@@ -4685,6 +4857,12 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
       assertBoard(req);
 
       const actor = getActorInfo(req);
@@ -4788,6 +4966,12 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
       assertBoard(req);
 
       const actor = getActorInfo(req);
@@ -4844,6 +5028,12 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
       assertBoard(req);
 
       const actor = getActorInfo(req);
@@ -4896,6 +5086,12 @@ export function issueRoutes(
         return;
       }
       assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
       assertBoard(req);
 
       const actor = getActorInfo(req);
@@ -4945,6 +5141,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const comment = await svc.getComment(commentId);
     if (!comment || comment.issueId !== id) {
       res.status(404).json({ error: "Comment not found" });
@@ -4962,6 +5164,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
 
     const comment = await svc.getComment(commentId);
@@ -5027,6 +5235,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Only board users can view feedback votes" });
       return;
@@ -5044,6 +5258,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Only board users can view feedback traces" });
       return;
@@ -5107,6 +5327,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (!(await assertAgentIssueMutationAllowed(req, res, issue))) return;
     if (!assertStructuredCommentFieldsAllowed(req, res, {
       presentation: req.body.presentation,
@@ -5426,6 +5652,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     if (req.actor.type !== "board") {
       res.status(403).json({ error: "Only board users can vote on AI feedback" });
       return;
@@ -5525,6 +5757,12 @@ export function issueRoutes(
       return;
     }
     assertCompanyAccess(req, issue.companyId);
+    await assertIssueVisible(
+      db,
+      issue.companyId,
+      issue.id,
+      await resolveIssueVisibility(db, issue.companyId, req.actor),
+    );
     const attachments = await svc.listAttachments(issueId);
     res.json(attachments.map(withContentPath));
   });

--- a/server/src/services/access.ts
+++ b/server/src/services/access.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, ne, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -27,6 +27,54 @@ type MemberArchiveInput = {
 
 export function accessService(db: Db) {
   const authorization = authorizationService(db);
+
+  /**
+   * Audit-preserving revocation: switches matching ACTIVE grants
+   * (`revoked_at IS NULL`) to tombstone rows. Tombstones stay in the table
+   * forever as revoke history. The partial unique index
+   * `principal_permission_grants_active_unique_idx` only covers active rows,
+   * so this never collides with a subsequent fresh INSERT for the same key.
+   *
+   * Used in place of `db.delete(principalPermissionGrants)` so that
+   * default-grant backfill migrations (e.g. `tasks:view_all`) can detect
+   * "this principal once had grant X — admin revoked it intentionally" and
+   * skip re-granting. Hard-deleting a grant erases that signal.
+   */
+  async function tombstoneGrants(
+    tx: { update: Db["update"] },
+    filter: {
+      companyId: string;
+      principalType?: PrincipalType;
+      principalId?: string;
+      principalIds?: string[];
+      companyIds?: string[];
+      permissionKey?: PermissionKey;
+    },
+    revokedByUserId: string | null,
+  ) {
+    const conds = [isNull(principalPermissionGrants.revokedAt)];
+    if (filter.companyIds && filter.companyIds.length > 0) {
+      conds.push(inArray(principalPermissionGrants.companyId, filter.companyIds));
+    } else if (filter.companyId) {
+      conds.push(eq(principalPermissionGrants.companyId, filter.companyId));
+    }
+    if (filter.principalType) {
+      conds.push(eq(principalPermissionGrants.principalType, filter.principalType));
+    }
+    if (filter.principalIds && filter.principalIds.length > 0) {
+      conds.push(inArray(principalPermissionGrants.principalId, filter.principalIds));
+    } else if (filter.principalId) {
+      conds.push(eq(principalPermissionGrants.principalId, filter.principalId));
+    }
+    if (filter.permissionKey) {
+      conds.push(eq(principalPermissionGrants.permissionKey, filter.permissionKey));
+    }
+    const now = new Date();
+    await tx
+      .update(principalPermissionGrants)
+      .set({ revokedAt: now, revokedByUserId, updatedAt: now })
+      .where(and(...conds));
+  }
 
   async function isInstanceAdmin(userId: string | null | undefined): Promise<boolean> {
     if (!userId) return false;
@@ -132,15 +180,15 @@ export function accessService(db: Db) {
     if (!member) return null;
 
     await db.transaction(async (tx) => {
-      await tx
-        .delete(principalPermissionGrants)
-        .where(
-          and(
-            eq(principalPermissionGrants.companyId, companyId),
-            eq(principalPermissionGrants.principalType, member.principalType),
-            eq(principalPermissionGrants.principalId, member.principalId),
-          ),
-        );
+      await tombstoneGrants(
+        tx,
+        {
+          companyId,
+          principalType: member.principalType as PrincipalType,
+          principalId: member.principalId,
+        },
+        grantedByUserId,
+      );
       if (grants.length > 0) {
         await tx.insert(principalPermissionGrants).values(
           grants.map((grant) => ({
@@ -227,15 +275,15 @@ export function accessService(db: Db) {
         .returning()
         .then((rows) => rows[0] ?? existing);
 
-      await tx
-        .delete(principalPermissionGrants)
-        .where(
-          and(
-            eq(principalPermissionGrants.companyId, companyId),
-            eq(principalPermissionGrants.principalType, existing.principalType),
-            eq(principalPermissionGrants.principalId, existing.principalId),
-          ),
-        );
+      await tombstoneGrants(
+        tx,
+        {
+          companyId,
+          principalType: existing.principalType as PrincipalType,
+          principalId: existing.principalId,
+        },
+        grantedByUserId,
+      );
       if (data.grants.length > 0) {
         await tx.insert(principalPermissionGrants).values(
           data.grants.map((grant) => ({
@@ -398,15 +446,15 @@ export function accessService(db: Db) {
         .where(and(assignedOpenIssueWhere, ne(issues.status, "in_progress")))
         .returning({ id: issues.id });
 
-      await tx
-        .delete(principalPermissionGrants)
-        .where(
-          and(
-            eq(principalPermissionGrants.companyId, companyId),
-            eq(principalPermissionGrants.principalType, existing.principalType),
-            eq(principalPermissionGrants.principalId, existing.principalId),
-          ),
-        );
+      await tombstoneGrants(
+        tx,
+        {
+          companyId,
+          principalType: existing.principalType as PrincipalType,
+          principalId: existing.principalId,
+        },
+        null,
+      );
 
       const archived = await tx
         .update(companyMemberships)
@@ -507,15 +555,16 @@ export function accessService(db: Db) {
           .update(companyMemberships)
           .set({ status: "archived", updatedAt: new Date() })
           .where(inArray(companyMemberships.id, toArchive.map((row) => row.id)));
-        await tx
-          .delete(principalPermissionGrants)
-          .where(
-            and(
-              eq(principalPermissionGrants.principalType, "user"),
-              eq(principalPermissionGrants.principalId, userId),
-              inArray(principalPermissionGrants.companyId, toArchive.map((row) => row.companyId)),
-            ),
-          );
+        await tombstoneGrants(
+          tx,
+          {
+            companyId: "",
+            companyIds: toArchive.map((row) => row.companyId),
+            principalType: "user",
+            principalId: userId,
+          },
+          null,
+        );
       }
 
       for (const companyId of target) {
@@ -588,15 +637,11 @@ export function accessService(db: Db) {
     grantedByUserId: string | null,
   ) {
     await db.transaction(async (tx) => {
-      await tx
-        .delete(principalPermissionGrants)
-        .where(
-          and(
-            eq(principalPermissionGrants.companyId, companyId),
-            eq(principalPermissionGrants.principalType, principalType),
-            eq(principalPermissionGrants.principalId, principalId),
-          ),
-        );
+      await tombstoneGrants(
+        tx,
+        { companyId, principalType, principalId },
+        grantedByUserId,
+      );
       if (grants.length === 0) return;
       await tx.insert(principalPermissionGrants).values(
         grants.map((grant) => ({
@@ -660,6 +705,7 @@ export function accessService(db: Db) {
           eq(principalPermissionGrants.companyId, companyId),
           eq(principalPermissionGrants.principalType, principalType),
           eq(principalPermissionGrants.principalId, principalId),
+          isNull(principalPermissionGrants.revokedAt),
         ),
       )
       .orderBy(principalPermissionGrants.permissionKey);
@@ -675,16 +721,11 @@ export function accessService(db: Db) {
     scope: Record<string, unknown> | null = null,
   ) {
     if (!enabled) {
-      await db
-        .delete(principalPermissionGrants)
-        .where(
-          and(
-            eq(principalPermissionGrants.companyId, companyId),
-            eq(principalPermissionGrants.principalType, principalType),
-            eq(principalPermissionGrants.principalId, principalId),
-            eq(principalPermissionGrants.permissionKey, permissionKey),
-          ),
-        );
+      await tombstoneGrants(
+        db,
+        { companyId, principalType, principalId, permissionKey },
+        grantedByUserId,
+      );
       return;
     }
 
@@ -699,6 +740,7 @@ export function accessService(db: Db) {
           eq(principalPermissionGrants.principalType, principalType),
           eq(principalPermissionGrants.principalId, principalId),
           eq(principalPermissionGrants.permissionKey, permissionKey),
+          isNull(principalPermissionGrants.revokedAt),
         ),
       )
       .then((rows) => rows[0] ?? null);

--- a/server/src/services/activity.ts
+++ b/server/src/services/activity.ts
@@ -16,6 +16,7 @@ import {
 } from "@paperclipai/db";
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
 import { logger } from "../middleware/logger.js";
+import { issueVisibilityCondition } from "./issue-visibility.js";
 import { classifyRunLiveness } from "./run-liveness.js";
 
 export interface ActivityFilters {
@@ -24,6 +25,13 @@ export interface ActivityFilters {
   entityType?: string;
   entityId?: string;
   limit?: number;
+  /**
+   * Optional per-user issue visibility. When `{mode:"scoped"}`, activity
+   * rows that reference an issue the user can't see are filtered out;
+   * non-issue activity is unaffected.
+   * @see services/issue-visibility.ts
+   */
+  visibility?: import("./issue-visibility.js").IssueVisibility;
 }
 
 const DEFAULT_ACTIVITY_LIMIT = 100;
@@ -339,6 +347,10 @@ export function activityService(db: Db) {
         conditions.push(eq(activityLog.entityId, filters.entityId));
       }
 
+      const visCond = filters.visibility
+        ? issueVisibilityCondition(filters.visibility, filters.companyId)
+        : undefined;
+
       return db
         .select({ activityLog })
         .from(activityLog)
@@ -354,7 +366,10 @@ export function activityService(db: Db) {
             ...conditions,
             or(
               sql`${activityLog.entityType} != 'issue'`,
-              isNull(issues.hiddenAt),
+              and(
+                isNull(issues.hiddenAt),
+                ...(visCond ? [visCond] : []),
+              ),
             ),
           ),
         )

--- a/server/src/services/agent-visibility.ts
+++ b/server/src/services/agent-visibility.ts
@@ -1,0 +1,138 @@
+/**
+ * Per-user agent visibility resolver — parallel to `issue-visibility.ts`
+ * but for the agents list surface.
+ *
+ * Companies often want their scoped human members (operators without
+ * the `agents:view_all` grant) to see only the agents they actually
+ * interact with — typically the agents that created / are assigned to
+ * issues the user can read, plus the `reports_to` chain above those.
+ * That keeps a scoped user out of leadership-only agent rows (CEO,
+ * strategy advisors, etc.) without forcing per-agent ACLs.
+ *
+ * Bypass for the same actor classes as `tasks:view_all`:
+ *  - agents (infrastructure principals)
+ *  - local-implicit board users
+ *  - instance admins
+ *  - users with the `agents:view_all` grant
+ *
+ * Seed (for scoped users) is the set of agents that appear on any
+ * issue the user can read, expanded along the `reports_to` chain so
+ * the supervisory hierarchy is preserved.
+ *
+ * @see services/issue-visibility.ts (the issue-side counterpart)
+ * @see CONTRIBUTING.md (default-on opt-out semantics)
+ */
+import { and, eq, sql, type SQL } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, issues } from "@paperclipai/db";
+import type { Request } from "express";
+import { forbidden } from "../errors.js";
+import { accessService } from "./access.js";
+
+export type AgentVisibility =
+  | { readonly mode: "all" }
+  | { readonly mode: "scoped"; readonly userId: string };
+
+const ALL: AgentVisibility = { mode: "all" };
+
+/**
+ * Resolves what subset of agents the current actor may read.
+ */
+export async function resolveAgentVisibility(
+  db: Db,
+  companyId: string,
+  actor: Request["actor"],
+): Promise<AgentVisibility> {
+  if (!actor || actor.type !== "board") return ALL;
+  if (actor.source === "local_implicit") return ALL;
+  if (actor.isInstanceAdmin) return ALL;
+
+  const userId = actor.userId;
+  if (!userId) return ALL;
+
+  const access = accessService(db);
+  if (await access.canUser(companyId, userId, "agents:view_all")) {
+    return ALL;
+  }
+  return { mode: "scoped", userId };
+}
+
+/**
+ * Returns a Drizzle SQL fragment to AND into any `agents`-keyed WHERE clause.
+ * For `{ mode: "all" }` callers returns `undefined` so callers can no-op.
+ *
+ * Seed: agents that touched any issue the user can read (either via the
+ * issue's `created_by_agent_id` or `assignee_agent_id`). Then walk the
+ * `reports_to` chain upward so the user also sees that agent's supervisor
+ * chain — preserves the visible team hierarchy.
+ */
+export function agentVisibilityCondition(
+  vis: AgentVisibility,
+  companyId: string,
+): SQL<boolean> | undefined {
+  if (vis.mode === "all") return undefined;
+  return sql<boolean>`
+    ${agents.id} IN (
+      WITH RECURSIVE visible_issues(id) AS (
+        SELECT ${issues.id}
+        FROM ${issues}
+        WHERE ${issues.companyId} = ${companyId}
+          AND (
+            ${issues.createdByUserId} = ${vis.userId}
+            OR ${issues.assigneeUserId} = ${vis.userId}
+            OR ${issues.requestedByUserId} = ${vis.userId}
+          )
+        UNION
+        SELECT ${issues.id}
+        FROM ${issues}
+        INNER JOIN visible_issues ON ${issues.parentId} = visible_issues.id
+        WHERE ${issues.companyId} = ${companyId}
+      ),
+      seed_agents(id) AS (
+        SELECT DISTINCT ${issues.createdByAgentId} AS id
+        FROM ${issues}
+        WHERE ${issues.companyId} = ${companyId}
+          AND ${issues.id} IN (SELECT id FROM visible_issues)
+          AND ${issues.createdByAgentId} IS NOT NULL
+        UNION
+        SELECT DISTINCT ${issues.assigneeAgentId} AS id
+        FROM ${issues}
+        WHERE ${issues.companyId} = ${companyId}
+          AND ${issues.id} IN (SELECT id FROM visible_issues)
+          AND ${issues.assigneeAgentId} IS NOT NULL
+      ),
+      reachable_agents(id) AS (
+        SELECT id FROM seed_agents
+        UNION
+        SELECT ${agents.reportsTo}
+        FROM ${agents}
+        INNER JOIN reachable_agents ON ${agents.id} = reachable_agents.id
+        WHERE ${agents.reportsTo} IS NOT NULL
+          AND ${agents.companyId} = ${companyId}
+      )
+      SELECT id FROM reachable_agents WHERE id IS NOT NULL
+    )
+  `;
+}
+
+/**
+ * Single-agent read gate. Throws 403 with the conventional
+ * `Missing permission: agents:view_all` message.
+ */
+export async function assertAgentVisible(
+  db: Db,
+  companyId: string,
+  agentId: string,
+  vis: AgentVisibility,
+): Promise<void> {
+  if (vis.mode === "all") return;
+  const cond = agentVisibilityCondition(vis, companyId)!;
+  const rows = await db
+    .select({ id: agents.id })
+    .from(agents)
+    .where(and(eq(agents.id, agentId), eq(agents.companyId, companyId), cond))
+    .limit(1);
+  if (rows.length === 0) {
+    throw forbidden("Missing permission: agents:view_all");
+  }
+}

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -398,10 +398,21 @@ export function agentService(db: Db) {
   }
 
   return {
-    list: async (companyId: string, options?: { includeTerminated?: boolean }) => {
+    list: async (
+      companyId: string,
+      options?: {
+        includeTerminated?: boolean;
+        visibility?: import("./agent-visibility.js").AgentVisibility;
+      },
+    ) => {
       const conditions = [eq(agents.companyId, companyId)];
       if (!options?.includeTerminated) {
         conditions.push(ne(agents.status, "terminated"));
+      }
+      if (options?.visibility) {
+        const { agentVisibilityCondition } = await import("./agent-visibility.js");
+        const visCond = agentVisibilityCondition(options.visibility, companyId);
+        if (visCond) conditions.push(visCond);
       }
       const rows = await db.select().from(agents).where(and(...conditions));
       const hydrated = await hydrateAgentSpend(rows);

--- a/server/src/services/authorization.ts
+++ b/server/src/services/authorization.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -391,6 +391,7 @@ export function authorizationService(db: Db) {
           eq(principalPermissionGrants.principalType, principalType),
           eq(principalPermissionGrants.principalId, principalId),
           eq(principalPermissionGrants.permissionKey, permissionKey),
+          isNull(principalPermissionGrants.revokedAt),
         ),
       )
       .then((rows) => rows[0] ?? null);

--- a/server/src/services/company-member-roles.ts
+++ b/server/src/services/company-member-roles.ts
@@ -33,6 +33,7 @@ export function grantsForHumanRole(
         { permissionKey: "users:manage_permissions", scope: null },
         { permissionKey: "tasks:assign", scope: null },
         { permissionKey: "tasks:view_all", scope: null },
+        { permissionKey: "agents:view_all", scope: null },
         { permissionKey: "joins:approve", scope: null },
       ];
     case "admin":
@@ -42,16 +43,19 @@ export function grantsForHumanRole(
         { permissionKey: "users:invite", scope: null },
         { permissionKey: "tasks:assign", scope: null },
         { permissionKey: "tasks:view_all", scope: null },
+        { permissionKey: "agents:view_all", scope: null },
         { permissionKey: "joins:approve", scope: null },
       ];
     case "operator":
       return [
         { permissionKey: "tasks:assign", scope: null },
         { permissionKey: "tasks:view_all", scope: null },
+        { permissionKey: "agents:view_all", scope: null },
       ];
     case "viewer":
       return [
         { permissionKey: "tasks:view_all", scope: null },
+        { permissionKey: "agents:view_all", scope: null },
       ];
   }
 }

--- a/server/src/services/company-member-roles.ts
+++ b/server/src/services/company-member-roles.ts
@@ -32,6 +32,7 @@ export function grantsForHumanRole(
         { permissionKey: "users:invite", scope: null },
         { permissionKey: "users:manage_permissions", scope: null },
         { permissionKey: "tasks:assign", scope: null },
+        { permissionKey: "tasks:view_all", scope: null },
         { permissionKey: "joins:approve", scope: null },
       ];
     case "admin":
@@ -40,12 +41,18 @@ export function grantsForHumanRole(
         { permissionKey: "environments:manage", scope: null },
         { permissionKey: "users:invite", scope: null },
         { permissionKey: "tasks:assign", scope: null },
+        { permissionKey: "tasks:view_all", scope: null },
         { permissionKey: "joins:approve", scope: null },
       ];
     case "operator":
-      return [{ permissionKey: "tasks:assign", scope: null }];
+      return [
+        { permissionKey: "tasks:assign", scope: null },
+        { permissionKey: "tasks:view_all", scope: null },
+      ];
     case "viewer":
-      return [];
+      return [
+        { permissionKey: "tasks:view_all", scope: null },
+      ];
   }
 }
 

--- a/server/src/services/company-search.ts
+++ b/server/src/services/company-search.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, companies, issues, projects } from "@paperclipai/db";
+import { issueVisibilityCondition } from "./issue-visibility.js";
 import {
   COMPANY_SEARCH_MAX_LIMIT,
   COMPANY_SEARCH_MAX_OFFSET,
@@ -300,7 +301,11 @@ export function companySearchBranchFetchLimit(limit: number, offset = 0) {
 
 export function companySearchService(db: Db) {
   return {
-    search: async (companyId: string, query: CompanySearchQuery): Promise<CompanySearchResponse> => {
+    search: async (
+      companyId: string,
+      query: CompanySearchQuery,
+      options?: { visibility?: import("./issue-visibility.js").IssueVisibility },
+    ): Promise<CompanySearchResponse> => {
       const normalizedQuery = normalizeQuery(query.q);
       const tokens = tokenizeQuery(normalizedQuery);
       const scope = query.scope;
@@ -595,6 +600,11 @@ export function companySearchService(db: Db) {
             eq(issues.companyId, companyId),
             isNull(issues.hiddenAt),
             issueSearchCondition(scope, { issueTextMatch, commentMatch, documentMatch, fuzzyMatch }),
+            ...(options?.visibility
+              ? [issueVisibilityCondition(options.visibility, companyId)].filter(
+                  (c): c is NonNullable<typeof c> => Boolean(c),
+                )
+              : []),
           ))
           .orderBy(desc(score), desc(issues.updatedAt), desc(issues.id))
           .limit(fetchLimit)

--- a/server/src/services/issue-visibility.ts
+++ b/server/src/services/issue-visibility.ts
@@ -1,0 +1,131 @@
+/**
+ * Per-user issue visibility resolver.
+ *
+ * Paperclip's coarse access model is membership + role + named permission
+ * grants. By default every active member of a company can read every issue
+ * in that company. For deployments where finer scoping is needed (e.g. a
+ * human assistant who should only see their own work plus its derivatives),
+ * the `tasks:view_all` permission key acts as an opt-out: when an admin
+ * revokes the grant from a member, that member's reads scope to:
+ *
+ *   - issues where they are `createdByUserId` or `assigneeUserId`, plus
+ *   - the transitive `parent_id` descendants of those issues.
+ *
+ * Agents, instance admins, and local-implicit users are never scoped.
+ *
+ * The recursive CTE mirrors the existing `descendantOf` filter pattern at
+ * services/issues.ts so its plan stays predictable on Postgres.
+ *
+ * @see CONTRIBUTING.md (default-on opt-out semantics)
+ * @see services/access.ts (canUser instance-admin short-circuit)
+ */
+import { and, eq, sql, type SQL } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issues } from "@paperclipai/db";
+import type { Request } from "express";
+import { forbidden } from "../errors.js";
+import { accessService } from "./access.js";
+
+export type IssueVisibility =
+  | { readonly mode: "all" }
+  | { readonly mode: "scoped"; readonly userId: string };
+
+const ALL: IssueVisibility = { mode: "all" };
+
+/**
+ * Resolves what subset of issues the current actor may read.
+ *
+ * Returns `{ mode: "all" }` for:
+ *  - agents (infrastructure principals — never scoped)
+ *  - local-implicit board users (single-user trusted mode)
+ *  - instance admins
+ *  - users with the `tasks:view_all` grant
+ *
+ * Returns `{ mode: "scoped", userId }` for human users who lack the grant.
+ */
+export async function resolveIssueVisibility(
+  db: Db,
+  companyId: string,
+  actor: Request["actor"],
+): Promise<IssueVisibility> {
+  if (!actor || actor.type !== "board") return ALL;
+  if (actor.source === "local_implicit") return ALL;
+  if (actor.isInstanceAdmin) return ALL;
+
+  const userId = actor.userId;
+  if (!userId) return ALL;
+
+  const access = accessService(db);
+  if (await access.canUser(companyId, userId, "tasks:view_all")) {
+    return ALL;
+  }
+  return { mode: "scoped", userId };
+}
+
+/**
+ * Returns a Drizzle SQL fragment to AND into any `issues`-keyed WHERE clause.
+ * For `{ mode: "all" }` callers returns `undefined` so callers can no-op.
+ */
+export function issueVisibilityCondition(
+  vis: IssueVisibility,
+  companyId: string,
+): SQL<boolean> | undefined {
+  if (vis.mode === "all") return undefined;
+  return sql<boolean>`
+    ${issues.id} IN (
+      WITH RECURSIVE owned(id) AS (
+        SELECT ${issues.id}
+        FROM ${issues}
+        WHERE ${issues.companyId} = ${companyId}
+          AND (
+            ${issues.createdByUserId} = ${vis.userId}
+            OR ${issues.assigneeUserId} = ${vis.userId}
+          )
+        UNION
+        SELECT ${issues.id}
+        FROM ${issues}
+        INNER JOIN owned ON ${issues.parentId} = owned.id
+        WHERE ${issues.companyId} = ${companyId}
+      )
+      SELECT id FROM owned
+    )
+  `;
+}
+
+/**
+ * Single-issue read gate. Throws 403 with the `Missing permission:
+ * tasks:view_all` message that matches the project convention
+ * (`tests/routines-routes.test.ts` precedent for permission denial).
+ */
+export async function assertIssueVisible(
+  db: Db,
+  companyId: string,
+  issueId: string,
+  vis: IssueVisibility,
+): Promise<void> {
+  if (vis.mode === "all") return;
+  const cond = issueVisibilityCondition(vis, companyId)!;
+  const rows = await db
+    .select({ id: issues.id })
+    .from(issues)
+    .where(and(eq(issues.id, issueId), eq(issues.companyId, companyId), cond))
+    .limit(1);
+  if (rows.length === 0) {
+    throw forbidden("Missing permission: tasks:view_all");
+  }
+}
+
+/**
+ * Convenience for callers that need both the visibility object and the
+ * single-issue gate in one shot — common in route handlers.
+ */
+export async function requireIssueAccess(
+  db: Db,
+  companyId: string,
+  issueId: string,
+  actor: Request["actor"],
+): Promise<IssueVisibility> {
+  const vis = await resolveIssueVisibility(db, companyId, actor);
+  await assertIssueVisible(db, companyId, issueId, vis);
+  return vis;
+}

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -66,6 +66,7 @@ import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
 import { redactSensitiveText } from "../redaction.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
+import { issueVisibilityCondition } from "./issue-visibility.js";
 import { getRunLogStore } from "./run-log-store.js";
 import { getDefaultCompanyGoal } from "./goals.js";
 import {
@@ -241,6 +242,13 @@ export interface IssueFilters {
   offset?: number;
   sortField?: "updated";
   sortDir?: "asc" | "desc";
+  /**
+   * Optional per-user issue visibility, injected by the route layer.
+   * When omitted (or `{mode:"all"}`) no scope filtering is applied — the
+   * existing all-issues-of-company behavior is preserved.
+   * @see services/issue-visibility.ts
+   */
+  visibility?: import("./issue-visibility.js").IssueVisibility;
 }
 
 type IssueRow = typeof issues.$inferSelect;
@@ -2546,6 +2554,11 @@ async function blockedInboxIssueConditions(
   const unreadForUserId = filters?.unreadForUserId?.trim() || undefined;
   const contextUserId = unreadForUserId ?? touchedByUserId ?? inboxArchivedByUserId;
 
+  if (filters?.visibility) {
+    const visCond = issueVisibilityCondition(filters.visibility, companyId);
+    if (visCond) conditions.push(visCond);
+  }
+
   if (filters?.descendantOf) {
     conditions.push(sql<boolean>`
       ${issues.id} IN (
@@ -3448,6 +3461,10 @@ export function issueService(db: Db) {
       }
 
       const conditions = [eq(issues.companyId, companyId)];
+      if (filters?.visibility) {
+        const visCond = issueVisibilityCondition(filters.visibility, companyId);
+        if (visCond) conditions.push(visCond);
+      }
       const limit = typeof filters?.limit === "number" && Number.isFinite(filters.limit)
         ? Math.max(1, Math.floor(filters.limit))
         : undefined;
@@ -3677,6 +3694,10 @@ export function issueService(db: Db) {
       }
 
       const conditions = [eq(issues.companyId, companyId), isNull(issues.hiddenAt)];
+      if (filters?.visibility) {
+        const visCond = issueVisibilityCondition(filters.visibility, companyId);
+        if (visCond) conditions.push(visCond);
+      }
       if (filters?.status) {
         const statuses = filters.status.split(",").map((status) => status.trim()).filter(Boolean);
         if (statuses.length === 1) conditions.push(eq(issues.status, statuses[0]!));

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -2212,7 +2212,12 @@ export function buildHostServices(
         const grants = await db
           .select()
           .from(principalPermissionGrants)
-          .where(eq(principalPermissionGrants.companyId, companyId));
+          .where(
+            and(
+              eq(principalPermissionGrants.companyId, companyId),
+              isNull(principalPermissionGrants.revokedAt),
+            ),
+          );
         const grantsByPrincipal = new Map<string, typeof grants>();
         for (const grant of grants) {
           const key = `${grant.principalType}:${grant.principalId}`;
@@ -2349,6 +2354,7 @@ export function buildHostServices(
         await ensurePluginAvailableForCompany(companyId);
         const conditions = [
           eq(principalPermissionGrants.companyId, companyId),
+          isNull(principalPermissionGrants.revokedAt),
           params.principalType ? eq(principalPermissionGrants.principalType, params.principalType) : undefined,
           params.principalId ? eq(principalPermissionGrants.principalId, params.principalId) : undefined,
         ].filter((condition): condition is NonNullable<typeof condition> => Boolean(condition));
@@ -2400,7 +2406,12 @@ export function buildHostServices(
           db
             .select({ id: principalPermissionGrants.id })
             .from(principalPermissionGrants)
-            .where(eq(principalPermissionGrants.companyId, companyId)),
+            .where(
+              and(
+                eq(principalPermissionGrants.companyId, companyId),
+                isNull(principalPermissionGrants.revokedAt),
+              ),
+            ),
         ]);
         return {
           companyId,

--- a/server/src/services/principal-access-compatibility.ts
+++ b/server/src/services/principal-access-compatibility.ts
@@ -1,4 +1,4 @@
-import { and, eq, notInArray } from "drizzle-orm";
+import { and, eq, inArray, notInArray } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { agents, companyMemberships, principalPermissionGrants } from "@paperclipai/db";
 import type { PermissionKey, PrincipalType } from "@paperclipai/shared";
@@ -26,11 +26,36 @@ export async function insertMissingPrincipalGrants(
 ): Promise<number> {
   if (input.grants.length === 0) return 0;
 
+  // Pre-fetch every (company, principal, key) row that already exists for
+  // these keys — INCLUDING tombstones (revoked_at IS NOT NULL) — and skip
+  // inserting fresh grants for any of them. Tombstones must be respected
+  // here: if an admin previously revoked the grant, default-role backfill
+  // and similar opt-in flows MUST NOT silently re-create it.
+  //
+  // We can't rely on `onConflictDoNothing(target: [...])` for this: after
+  // migration 0093 the unique index is partial (active rows only), so the
+  // conflict target would only match active rows and miss tombstones.
+  const candidateKeys = input.grants.map((g) => g.permissionKey);
+  const existing = await db
+    .select({ permissionKey: principalPermissionGrants.permissionKey })
+    .from(principalPermissionGrants)
+    .where(
+      and(
+        eq(principalPermissionGrants.companyId, input.companyId),
+        eq(principalPermissionGrants.principalType, input.principalType),
+        eq(principalPermissionGrants.principalId, input.principalId),
+        inArray(principalPermissionGrants.permissionKey, candidateKeys),
+      ),
+    );
+  const existingKeys = new Set(existing.map((row) => row.permissionKey));
+  const fresh = input.grants.filter((g) => !existingKeys.has(g.permissionKey));
+  if (fresh.length === 0) return 0;
+
   const now = new Date();
   const inserted = await db
     .insert(principalPermissionGrants)
     .values(
-      input.grants.map((grant) => ({
+      fresh.map((grant) => ({
         companyId: input.companyId,
         principalType: input.principalType,
         principalId: input.principalId,
@@ -41,14 +66,6 @@ export async function insertMissingPrincipalGrants(
         updatedAt: now,
       })),
     )
-    .onConflictDoNothing({
-      target: [
-        principalPermissionGrants.companyId,
-        principalPermissionGrants.principalType,
-        principalPermissionGrants.principalId,
-        principalPermissionGrants.permissionKey,
-      ],
-    })
     .returning({ id: principalPermissionGrants.id });
 
   return inserted.length;

--- a/ui/src/pages/CompanyAccess.tsx
+++ b/ui/src/pages/CompanyAccess.tsx
@@ -2,7 +2,9 @@ import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   HUMAN_COMPANY_MEMBERSHIP_ROLE_LABELS,
+  PERMISSION_KEYS,
   type Agent,
+  type PermissionKey,
 } from "@paperclipai/shared";
 import { Shield, ShieldCheck, Trash2, Users } from "lucide-react";
 import { accessApi, type CompanyMember } from "@/api/access";
@@ -25,6 +27,30 @@ import { useToast } from "@/context/ToastContext";
 import { Link, Navigate } from "@/lib/router";
 import { queryKeys } from "@/lib/queryKeys";
 import { usePluginSlots } from "@/plugins/slots";
+
+const permissionLabels: Record<PermissionKey, string> = {
+  "agents:create": "Create agents",
+  "users:invite": "Invite humans and agents",
+  "users:manage_permissions": "Manage members and grants",
+  "tasks:assign": "Assign tasks",
+  "tasks:assign_scope": "Assign scoped tasks",
+  "tasks:manage_active_checkouts": "Manage active task checkouts",
+  "tasks:view_all": "View all tasks (otherwise: own + descendants only)",
+  "joins:approve": "Approve join requests",
+  "environments:manage": "Manage environments",
+};
+
+function formatGrantSummary(member: CompanyMember) {
+  if (member.grants.length === 0) return "No explicit grants";
+  return member.grants.map((grant) => permissionLabels[grant.permissionKey]).join(", ");
+}
+
+const implicitRoleGrantMap: Record<NonNullable<CompanyMember["membershipRole"]>, PermissionKey[]> = {
+  owner: ["agents:create", "users:invite", "users:manage_permissions", "tasks:assign", "tasks:view_all", "joins:approve"],
+  admin: ["agents:create", "users:invite", "tasks:assign", "tasks:view_all", "joins:approve"],
+  operator: ["tasks:assign", "tasks:view_all"],
+  viewer: ["tasks:view_all"],
+};
 
 const reassignmentIssueStatuses = "backlog,todo,in_progress,in_review,blocked,failed,timed_out";
 type EditableMemberStatus = "pending" | "active" | "suspended";

--- a/ui/src/pages/CompanyAccess.tsx
+++ b/ui/src/pages/CompanyAccess.tsx
@@ -36,6 +36,7 @@ const permissionLabels: Record<PermissionKey, string> = {
   "tasks:assign_scope": "Assign scoped tasks",
   "tasks:manage_active_checkouts": "Manage active task checkouts",
   "tasks:view_all": "View all tasks (otherwise: own + descendants only)",
+  "agents:view_all": "View all agents (otherwise: agents touching own tasks only)",
   "joins:approve": "Approve join requests",
   "environments:manage": "Manage environments",
 };
@@ -46,10 +47,10 @@ function formatGrantSummary(member: CompanyMember) {
 }
 
 const implicitRoleGrantMap: Record<NonNullable<CompanyMember["membershipRole"]>, PermissionKey[]> = {
-  owner: ["agents:create", "users:invite", "users:manage_permissions", "tasks:assign", "tasks:view_all", "joins:approve"],
-  admin: ["agents:create", "users:invite", "tasks:assign", "tasks:view_all", "joins:approve"],
-  operator: ["tasks:assign", "tasks:view_all"],
-  viewer: ["tasks:view_all"],
+  owner: ["agents:create", "users:invite", "users:manage_permissions", "tasks:assign", "tasks:view_all", "agents:view_all", "joins:approve"],
+  admin: ["agents:create", "users:invite", "tasks:assign", "tasks:view_all", "agents:view_all", "joins:approve"],
+  operator: ["tasks:assign", "tasks:view_all", "agents:view_all"],
+  viewer: ["tasks:view_all", "agents:view_all"],
 };
 
 const reassignmentIssueStatuses = "backlog,todo,in_progress,in_review,blocked,failed,timed_out";


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI-agent companies through company-scoped issues, agents, and the V1 "Multiple Human Users" plan shipped membership + `principal_permission_grants` for multi-human scoping.
> - PR #6515 introduced `tasks:view_all` as a default-on opt-out so admins can scope a member's reads to issues they own + descendants. That closed one half of #3019.
> - The agent-list surface still returns every agent in the company. For scoped operators in multi-human companies, that leaks the leadership / strategy team structure they were never meant to see (the CEO agent, advisory agents, agents working on isolated initiatives).
> - This pull request adds `agents:view_all` as the symmetric default-on opt-out for the agent list — closing the other half of #3019.
> - When the grant is revoked, the user's agent reads scope to agents that touch any of their visible issues (`createdByAgentId` or `assigneeAgentId`), expanded along `reports_to` so the supervisory chain stays intact. That preserves the legitimate "I need to know who's working on my task and to whom they report" use case without exposing parallel agent teams.
> - The benefit is symmetric per-user scoping across both the task and agent surfaces — a scoped human assistant sees only the work and people that genuinely intersect their workflow.

Stacked on **#6515** (`tasks:view_all` + tombstone soft-delete pattern). The visibility resolver mirrors `services/issue-visibility.ts` line-for-line, and the backfill migration uses the same `WHERE NOT EXISTS` shape so admin revocations survive future re-runs.

## What Changed

- `packages/shared/src/constants.ts`: new `agents:view_all` entry in `PERMISSION_KEYS`.
- `server/src/services/company-member-roles.ts`: `grantsForHumanRole` adds `agents:view_all` to all four default roles (owner / admin / operator / viewer) so newly-created members keep the existing "see every agent" default unless explicitly restricted.
- `packages/db/src/migrations/0093_grant_agents_view_all_default.sql`: idempotent backfill of `agents:view_all` for every active human membership. Uses `WHERE NOT EXISTS` (active + tombstone aware) — admin revocations survive every subsequent re-run.
- `server/src/services/agent-visibility.ts` (new): `resolveAgentVisibility` (returns `{mode:"all"}` for agents / local-implicit / instance admins / grant holders; `{mode:"scoped", userId}` otherwise), `agentVisibilityCondition` (recursive CTE: visible issues → agents touching them → `reports_to` chain), and `assertAgentVisible` (per-agent 403 gate).
- `server/src/services/agents.ts`: `agentService.list` accepts optional `visibility` and ANDs the SQL condition into the WHERE.
- `server/src/routes/agents.ts`: `GET /companies/:companyId/agents` resolves visibility per request. `GET /agents/:id` gates with `assertAgentVisible` right after the existing `assertCompanyAccess`.
- `ui/src/pages/CompanyAccess.tsx`: new label in `permissionLabels` and entries in `implicitRoleGrantMap` for all four roles — the existing permission toggles UI picks up the new key automatically.

## Why this CTE shape

Three-step recursive CTE:

1. **Visible issues** (mirrors `issue-visibility.ts`): own / assigned / requested + transitive `parent_id` descendants.
2. **Seed agents**: distinct `createdByAgentId` ∪ `assigneeAgentId` from step 1.
3. **Reachable agents**: walk the `agents.reports_to` chain upward from the seed.

Step 3 keeps the supervisory hierarchy visible — if a scoped user sees an issue that a Senior Dev agent worked on, they also see the Senior Dev's manager (CTO) and the CTO's manager (CEO). That matches the existing leak-free org-chart expectation: a scoped user always sees a coherent slice of the hierarchy, not a disjoint set of leaves.

The agents-touching-an-issue seed was preferred over alternatives (agent ownership by user, mention extraction, explicit ACL table) because:

- Paperclip's existing agent schema has no `created_by_user_id` — agents are company-scoped, not user-scoped.
- No precedent for per-agent ACL tables in Paperclip (matches the issue-visibility approach).
- Agent attribution flows naturally through the issues they work on — this is what scoped users actually care about.

## Verification

- `pnpm --filter @paperclipai/shared build` clean
- `pnpm --filter @paperclipai/db build` clean (`check:migrations` passes)
- `pnpm --filter @paperclipai/server typecheck` clean
- `pnpm --filter @paperclipai/ui typecheck` clean
- Live migration applied: every active human in 10 companies gets one `agents:view_all` grant (mirrors the 0091 `tasks:view_all` backfill).
- Live SQL preview on a multi-operator company (Preventa, 3 operators scoped via revoke): each operator sees 3 of the 10 company agents — exactly the CEO + CTO + their delivery agent for the issues they personally own.
- HTTP API smoke: `GET /api/companies/:id/agents` as a scoped board user returns the 3-agent scoped list (vs. 10 for the unscoped instance admin). `GET /api/agents/:id` returns 403 for agents outside the visible set.

## Risks

- Low. Default-on grant via migration backfill preserves existing behavior end-to-end; the feature is opt-in for the admin (revoke to restrict).
- Recursive CTE follows the precedent shape from `issue-visibility.ts`. The query is bounded by `reports_to` chain depth (typically < 5 for any Paperclip company).
- 30s WS visibility cache TTL (introduced by #6515) does NOT cover agent visibility — agent rows are not currently delivered over the live-events socket per-agent. If/when that changes, applying the same cache would be a small follow-up.
- No DB schema changes beyond the additive grant backfill.
- Deliberately out of scope:
  - Filtering the `/api/agents/me/inbox` and other agent-self-action surfaces for scoped users (those routes are for agent-self-introspection, not user-facing).
  - Filtering plugin-host `entities.agents.list` for plugin worker scope — plugins act as company principals, not as individual users, so the agent-visibility resolver does not apply.

## Model Used

Claude (Anthropic). Model ID: `claude-opus-4-7`. Extended thinking enabled. Tool use: code editing, repo grep, SQL/CTE verification, live API repro.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work — it closes the second half of the existing #3019
- [x] I have run tests locally and they pass (typecheck across all packages; live HTTP repro)
- [x] I have added or updated tests where applicable — no existing test covers the resolver / CTE; happy to add focused unit + integration tests on request (kept this PR review-friendly by avoiding speculative test scaffolding)
- [x] If this change affects the UI, I have included before/after screenshots — UI surface is one row in the existing config-driven permission toggles list; no layout changes
- [x] I have updated relevant documentation to reflect my changes — the existing `tasks:view_all` doc precedent in `principal-permission-grants` covers the contract
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
