### PR TITLE
fix: set UTF-8 encoding on child process streams to prevent garbled CJK output

### DIFF
--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -1950,6 +1950,9 @@ export async function runChildProcess(
         const startedAt = new Date().toISOString();
         const processGroupId = resolveProcessGroupId(child);
 
+        child.stdout?.setEncoding("utf8");
+        child.stderr?.setEncoding("utf8");
+
         const spawnPersistPromise =
           typeof child.pid === "number" && child.pid > 0 && opts.onSpawn
             ? opts.onSpawn({ pid: child.pid, processGroupId, startedAt }).catch((err) => {

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -221,6 +221,9 @@ async function spawnText(
       stdio: [options.stdin != null ? "pipe" : "ignore", "pipe", "pipe"],
     });
 
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+
     const maxBuffer = options.maxBuffer ?? 1024 * 128;
     let stdout = "";
     let stderr = "";


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agent adapters (Claude, Codex, Cursor, etc.) run as local child processes via Node.js `spawn`; SSH-connected agents run via a remote `spawn` wrapper
> - Multi-byte CJK characters (3 bytes each in UTF-8) were appearing as `?????` in the agent output stream shown in the UI
> - Root cause: without `setEncoding('utf8')`, Node.js `spawn` emits raw `Buffer` objects on `data` events; when a 3-byte character is split across two consecutive chunks, `String(chunk)` on an incomplete byte sequence silently corrupts each partial byte to `?`
> - This PR calls `setEncoding('utf8')` on `stdout` and `stderr` immediately after `spawn` in both the local subprocess path (`runChildProcess` in server-utils.ts) and the SSH remote path (`spawnText` in ssh.ts)
> - The benefit is that Node's built-in `StringDecoder` holds incomplete multi-byte sequences across chunk boundaries and emits complete characters, eliminating garbled CJK output with no behavioral change for ASCII content

## What Changed

- `packages/adapter-utils/src/server-utils.ts`: added `child.stdout?.setEncoding("utf8")` and `child.stderr?.setEncoding("utf8")` immediately after `spawn` in `runChildProcess` — covers all local agent adapters (Claude, Codex, Cursor, etc.)
- `packages/adapter-utils/src/ssh.ts`: same two lines added after `spawn` in `spawnText` — covers SSH remote execution path

## Verification

- Start app with `pnpm dev` and trigger an agent run that produces Chinese/Japanese/Korean output
- Confirm text renders correctly in the UI (no `?????`)
- ASCII and English output is unaffected (StringDecoder is a transparent passthrough for single-byte characters)
- All CI checks pass (Build, Typecheck, General tests, e2e, Verify serialized server suites)

## Risks

- Low risk. `setEncoding('utf8')` activates Node's built-in `StringDecoder` — a well-established API. It has no effect on non-CJK content. Both call sites use optional chaining (`?.`) so null streams are safely skipped. No migration, no breaking change, no behavioral shift for existing ASCII workflows.

## Model Used

- Provider: Anthropic
- Model: Claude Sonnet 4.6 (`claude-sonnet-4-6`)
- Context window: 200k tokens
- Mode: standard (no extended thinking)
- Tool use: enabled (file read/edit, bash/PowerShell, grep/glob)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — no new test added; the fix is a two-line Node.js API call with existing CI coverage
- [ ] If this change affects the UI, I have included before/after screenshots — N/A (backend stream fix)
- [ ] I have updated relevant documentation to reflect my changes — N/A (no API or behavior change)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
