### PR TITLE
fix(auth): respect forwarded protocol in auto base URL mode

### DIFF
--- a/server/src/__tests__/better-auth.test.ts
+++ b/server/src/__tests__/better-auth.test.ts
@@ -6,6 +6,7 @@ import {
   deriveAuthCookiePrefix,
   deriveAuthTrustedOrigins,
   shouldDisableSecureAuthCookies,
+  shouldUseSecureCookiesForAutoMode,
 } from "../auth/better-auth.js";
 
 const ORIGINAL_INSTANCE_ID = process.env.PAPERCLIP_INSTANCE_ID;
@@ -47,6 +48,17 @@ describe("Better Auth cookie scoping", () => {
     expect(getCookies({
       advanced: buildBetterAuthAdvancedOptions({ disableSecureCookies: true }),
     } as BetterAuthOptions).sessionToken.name).toBe("paperclip-pap-worktree.session_token");
+  });
+
+  it("can force secure cookies for request-time auto-mode selection", () => {
+    process.env.PAPERCLIP_INSTANCE_ID = "pap-worktree";
+
+    expect(buildBetterAuthAdvancedOptions({
+      useSecureCookies: true,
+    })).toEqual({
+      cookiePrefix: "paperclip-pap-worktree",
+      useSecureCookies: true,
+    });
   });
 
   it("disables secure cookies for authenticated private auto-origin dev servers", () => {
@@ -182,5 +194,23 @@ describe("Better Auth cookie scoping", () => {
     ]));
     expect(trustedOrigins).not.toContain("https://board.example.test:3100");
     expect(trustedOrigins).not.toContain("http://board.example.test:3100");
+  });
+
+  it("trusts forwarded protocol from loopback-side proxies in auto mode", () => {
+    expect(shouldUseSecureCookiesForAutoMode(new Headers({
+      "x-forwarded-proto": "https",
+    }), {
+      protocol: "http",
+      remoteAddress: "::ffff:127.0.0.1",
+    })).toBe(true);
+  });
+
+  it("ignores spoofed forwarded protocol from non-loopback clients", () => {
+    expect(shouldUseSecureCookiesForAutoMode(new Headers({
+      "x-forwarded-proto": "https",
+    }), {
+      protocol: "http",
+      remoteAddress: "192.168.1.20",
+    })).toBe(false);
   });
 });

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -8,6 +8,7 @@ const ORIGINAL_PAPERCLIP_LISTEN_PORT = process.env.PAPERCLIP_LISTEN_PORT;
 
 const {
   createAppMock,
+  createAutoModeBetterAuthInstancesMock,
   createBetterAuthInstanceMock,
   createDbMock,
   detectPortMock,
@@ -18,6 +19,7 @@ const {
   loadConfigMock,
 } = vi.hoisted(() => {
   const createAppMock = vi.fn(async () => ((_: unknown, __: unknown) => {}) as never);
+  const createAutoModeBetterAuthInstancesMock = vi.fn(() => ({ secure: {}, insecure: {} }));
   const createBetterAuthInstanceMock = vi.fn(() => ({}));
   const createDbMock = vi.fn(() => ({}) as never);
   const detectPortMock = vi.fn(async (port: number) => port);
@@ -39,6 +41,7 @@ const {
 
   return {
     createAppMock,
+    createAutoModeBetterAuthInstancesMock,
     createBetterAuthInstanceMock,
     createDbMock,
     detectPortMock,
@@ -192,11 +195,13 @@ vi.mock("../board-claim.js", () => ({
 }));
 
 vi.mock("../auth/better-auth.js", () => ({
+  createAutoModeBetterAuthInstances: createAutoModeBetterAuthInstancesMock,
   createBetterAuthHandler: vi.fn(() => undefined),
   createBetterAuthInstance: createBetterAuthInstanceMock,
   deriveAuthTrustedOrigins: deriveAuthTrustedOriginsMock,
   resolveBetterAuthSession: vi.fn(async () => null),
   resolveBetterAuthSessionFromHeaders: vi.fn(async () => null),
+  resolveBetterAuthSessionFromRequest: vi.fn(async () => null),
 }));
 
 import { startServer } from "../index.ts";
@@ -205,6 +210,7 @@ describe("startServer feedback export wiring", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     loadConfigMock.mockReturnValue(buildTestConfig());
+    createAutoModeBetterAuthInstancesMock.mockReturnValue({ secure: {}, insecure: {} });
     createBetterAuthInstanceMock.mockReturnValue({});
     deriveAuthTrustedOriginsMock.mockReturnValue([]);
     process.env.BETTER_AUTH_SECRET = "test-secret";
@@ -257,6 +263,7 @@ describe("startServer authenticated auth origin setup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     loadConfigMock.mockReturnValue(buildTestConfig());
+    createAutoModeBetterAuthInstancesMock.mockReturnValue({ secure: {}, insecure: {} });
     createBetterAuthInstanceMock.mockReturnValue({});
     deriveAuthTrustedOriginsMock.mockReturnValue([]);
     process.env.BETTER_AUTH_SECRET = "test-secret";

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -1,5 +1,5 @@
 import type { Request, RequestHandler } from "express";
-import type { IncomingHttpHeaders } from "node:http";
+import type { IncomingHttpHeaders, IncomingMessage } from "node:http";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { toNodeHandler } from "better-auth/node";
@@ -25,6 +25,16 @@ export type BetterAuthSessionResult = {
 };
 
 type BetterAuthInstance = ReturnType<typeof betterAuth>;
+type BetterAuthAutoInstances = {
+  secure: BetterAuthInstance;
+  insecure: BetterAuthInstance;
+};
+type BetterAuthRuntime = BetterAuthInstance | BetterAuthAutoInstances;
+type BetterAuthTransportContext = {
+  encrypted?: boolean;
+  protocol?: string | null;
+  remoteAddress?: string | null;
+};
 
 const AUTH_COOKIE_PREFIX_FALLBACK = "default";
 const AUTH_COOKIE_PREFIX_INVALID_SEGMENTS_RE = /[^a-zA-Z0-9_-]+/g;
@@ -37,10 +47,14 @@ export function deriveAuthCookiePrefix(instanceId = resolvePaperclipInstanceId()
   return `paperclip-${scopedInstanceId}`;
 }
 
-export function buildBetterAuthAdvancedOptions(input: { disableSecureCookies: boolean }) {
+export function buildBetterAuthAdvancedOptions(input: {
+  disableSecureCookies?: boolean;
+  useSecureCookies?: boolean;
+}) {
+  const useSecureCookies = input.useSecureCookies ?? (input.disableSecureCookies ? false : undefined);
   return {
     cookiePrefix: deriveAuthCookiePrefix(),
-    ...(input.disableSecureCookies ? { useSecureCookies: false } : {}),
+    ...(useSecureCookies === undefined ? {} : { useSecureCookies }),
   };
 }
 
@@ -83,6 +97,52 @@ function headersFromExpressRequest(req: Request): Headers {
   return headersFromNodeHeaders(req.headers);
 }
 
+function headersFromIncomingMessage(req: IncomingMessage): Headers {
+  return headersFromNodeHeaders(req.headers);
+}
+
+function isLoopbackAddress(remoteAddress: string | null | undefined): boolean {
+  if (!remoteAddress) return false;
+  const normalized = remoteAddress.trim().toLowerCase();
+  return normalized === "::1" || normalized === "127.0.0.1" || normalized === "::ffff:127.0.0.1";
+}
+
+function forwardedProtoFromHeaders(headers: Headers): "http" | "https" | null {
+  const value = headers.get("x-forwarded-proto");
+  if (!value) return null;
+  const proto = value.split(",")[0]?.trim().toLowerCase();
+  return proto === "http" || proto === "https" ? proto : null;
+}
+
+function isTlsSocket(value: unknown): value is { encrypted?: boolean } {
+  return typeof value === "object" && value !== null && "encrypted" in value;
+}
+
+export function shouldUseSecureCookiesForAutoMode(
+  headers: Headers,
+  transport: BetterAuthTransportContext = {},
+): boolean {
+  const forwardedProto = forwardedProtoFromHeaders(headers);
+  if (forwardedProto && isLoopbackAddress(transport.remoteAddress)) {
+    return forwardedProto === "https";
+  }
+  if (transport.protocol) {
+    return transport.protocol === "https";
+  }
+  return transport.encrypted === true;
+}
+
+function selectBetterAuthInstance(
+  auth: BetterAuthRuntime,
+  headers: Headers,
+  transport: BetterAuthTransportContext = {},
+): BetterAuthInstance {
+  if (!("secure" in auth) || !("insecure" in auth)) {
+    return auth;
+  }
+  return shouldUseSecureCookiesForAutoMode(headers, transport) ? auth.secure : auth.insecure;
+}
+
 export function deriveAuthTrustedOrigins(config: Config, opts?: { listenPort?: number }): string[] {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
   const trustedOrigins = new Set<string>();
@@ -112,9 +172,13 @@ export function deriveAuthTrustedOrigins(config: Config, opts?: { listenPort?: n
   return Array.from(trustedOrigins);
 }
 
-export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins: string[]): BetterAuthInstance {
+function createBetterAuthInstanceWithAdvancedOptions(
+  db: Db,
+  config: Config,
+  trustedOrigins: string[],
+  advanced: ReturnType<typeof buildBetterAuthAdvancedOptions>,
+): BetterAuthInstance {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
-  const publicUrl = process.env.PAPERCLIP_PUBLIC_URL?.trim() || baseUrl;
   const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET;
   if (!secret) {
     throw new Error(
@@ -122,14 +186,6 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
       "For local development, set BETTER_AUTH_SECRET=paperclip-dev-secret in your .env file.",
     );
   }
-  const disableSecureCookies = shouldDisableSecureAuthCookies({
-    deploymentMode: config.deploymentMode,
-    deploymentExposure: config.deploymentExposure,
-    authBaseUrlMode: config.authBaseUrlMode,
-    authPublicBaseUrl: config.authPublicBaseUrl,
-    publicUrl,
-  });
-
   const authConfig = {
     baseURL: baseUrl,
     secret,
@@ -148,7 +204,7 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
       requireEmailVerification: false,
       disableSignUp: config.authDisableSignUp,
     },
-    advanced: buildBetterAuthAdvancedOptions({ disableSecureCookies }),
+    advanced,
   };
 
   if (!baseUrl) {
@@ -158,7 +214,62 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins:
   return betterAuth(authConfig);
 }
 
-export function createBetterAuthHandler(auth: BetterAuthInstance): RequestHandler {
+export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins: string[]): BetterAuthInstance {
+  const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
+  const publicUrl = process.env.PAPERCLIP_PUBLIC_URL?.trim() || baseUrl;
+  const disableSecureCookies = shouldDisableSecureAuthCookies({
+    deploymentMode: config.deploymentMode,
+    deploymentExposure: config.deploymentExposure,
+    authBaseUrlMode: config.authBaseUrlMode,
+    authPublicBaseUrl: config.authPublicBaseUrl,
+    publicUrl,
+  });
+
+  return createBetterAuthInstanceWithAdvancedOptions(
+    db,
+    config,
+    trustedOrigins,
+    buildBetterAuthAdvancedOptions({ disableSecureCookies }),
+  );
+}
+
+export function createAutoModeBetterAuthInstances(
+  db: Db,
+  config: Config,
+  trustedOrigins: string[],
+): BetterAuthAutoInstances {
+  return {
+    secure: createBetterAuthInstanceWithAdvancedOptions(
+      db,
+      config,
+      trustedOrigins,
+      buildBetterAuthAdvancedOptions({ useSecureCookies: true }),
+    ),
+    insecure: createBetterAuthInstanceWithAdvancedOptions(
+      db,
+      config,
+      trustedOrigins,
+      buildBetterAuthAdvancedOptions({ useSecureCookies: false }),
+    ),
+  };
+}
+
+export function createBetterAuthHandler(auth: BetterAuthRuntime): RequestHandler {
+  if ("secure" in auth && "insecure" in auth) {
+    const secureHandler = toNodeHandler(auth.secure);
+    const insecureHandler = toNodeHandler(auth.insecure);
+    return (req, res, next) => {
+      const headers = headersFromExpressRequest(req);
+      const selected = selectBetterAuthInstance(auth, headers, {
+        encrypted: isTlsSocket(req.socket) ? req.socket.encrypted === true : false,
+        protocol: req.protocol,
+        remoteAddress: req.socket.remoteAddress ?? null,
+      });
+      const handler = selected === auth.secure ? secureHandler : insecureHandler;
+      void Promise.resolve(handler(req, res)).catch(next);
+    };
+  }
+
   const handler = toNodeHandler(auth);
   return (req, res, next) => {
     void Promise.resolve(handler(req, res)).catch(next);
@@ -166,10 +277,12 @@ export function createBetterAuthHandler(auth: BetterAuthInstance): RequestHandle
 }
 
 export async function resolveBetterAuthSessionFromHeaders(
-  auth: BetterAuthInstance,
+  auth: BetterAuthRuntime,
   headers: Headers,
+  transport: BetterAuthTransportContext = {},
 ): Promise<BetterAuthSessionResult | null> {
-  const api = (auth as unknown as { api?: { getSession?: (input: unknown) => Promise<unknown> } }).api;
+  const authInstance = selectBetterAuthInstance(auth, headers, transport);
+  const api = (authInstance as unknown as { api?: { getSession?: (input: unknown) => Promise<unknown> } }).api;
   if (!api?.getSession) return null;
 
   const sessionValue = await api.getSession({
@@ -196,9 +309,23 @@ export async function resolveBetterAuthSessionFromHeaders(
   return { session, user };
 }
 
+export async function resolveBetterAuthSessionFromRequest(
+  auth: BetterAuthRuntime,
+  req: IncomingMessage,
+): Promise<BetterAuthSessionResult | null> {
+  return resolveBetterAuthSessionFromHeaders(auth, headersFromIncomingMessage(req), {
+    encrypted: isTlsSocket(req.socket) ? req.socket.encrypted === true : false,
+    remoteAddress: req.socket.remoteAddress ?? null,
+  });
+}
+
 export async function resolveBetterAuthSession(
-  auth: BetterAuthInstance,
+  auth: BetterAuthRuntime,
   req: Request,
 ): Promise<BetterAuthSessionResult | null> {
-  return resolveBetterAuthSessionFromHeaders(auth, headersFromExpressRequest(req));
+  return resolveBetterAuthSessionFromHeaders(auth, headersFromExpressRequest(req), {
+    encrypted: isTlsSocket(req.socket) ? req.socket.encrypted === true : false,
+    protocol: req.protocol,
+    remoteAddress: req.socket.remoteAddress ?? null,
+  });
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,7 +5,7 @@
 // HTTP server, so trace coverage does not depend on incidental timing.
 import { instrumentationReady, shutdownInstrumentation } from "./instrumentation.js";
 import { existsSync, readFileSync, rmSync } from "node:fs";
-import { createServer } from "node:http";
+import { createServer, type IncomingMessage } from "node:http";
 import { resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
@@ -523,8 +523,8 @@ export async function startServer(): Promise<StartedServer> {
   let resolveSession:
     | ((req: ExpressRequest) => Promise<BetterAuthSessionResult | null>)
     | undefined;
-  let resolveSessionFromHeaders:
-    | ((headers: Headers) => Promise<BetterAuthSessionResult | null>)
+  let resolveSessionFromRequest:
+    | ((req: IncomingMessage) => Promise<BetterAuthSessionResult | null>)
     | undefined;
   if (config.deploymentMode === "local_trusted") {
     await ensureLocalTrustedBoardPrincipal(db as any);
@@ -535,11 +535,12 @@ export async function startServer(): Promise<StartedServer> {
   }
   if (config.deploymentMode === "authenticated") {
     const {
+      createAutoModeBetterAuthInstances,
       createBetterAuthHandler,
       createBetterAuthInstance,
       deriveAuthTrustedOrigins,
       resolveBetterAuthSession,
-      resolveBetterAuthSessionFromHeaders,
+      resolveBetterAuthSessionFromRequest,
     } = await import("./auth/better-auth.js");
     const derivedTrustedOrigins = deriveAuthTrustedOrigins(config, { listenPort });
     const envTrustedOrigins = (process.env.BETTER_AUTH_TRUSTED_ORIGINS ?? "")
@@ -559,10 +560,12 @@ export async function startServer(): Promise<StartedServer> {
       },
       "Authenticated mode auth origin configuration",
     );
-    const auth = createBetterAuthInstance(db as any, config, effectiveTrustedOrigins);
+    const auth = config.authBaseUrlMode === "auto"
+      ? createAutoModeBetterAuthInstances(db as any, config, effectiveTrustedOrigins)
+      : createBetterAuthInstance(db as any, config, effectiveTrustedOrigins);
     betterAuthHandler = createBetterAuthHandler(auth);
     resolveSession = (req) => resolveBetterAuthSession(auth, req);
-    resolveSessionFromHeaders = (headers) => resolveBetterAuthSessionFromHeaders(auth, headers);
+    resolveSessionFromRequest = (req) => resolveBetterAuthSessionFromRequest(auth, req);
     await initializeBoardClaimChallenge(db as any, { deploymentMode: config.deploymentMode });
     authReady = true;
   }
@@ -700,7 +703,7 @@ export async function startServer(): Promise<StartedServer> {
   
   setupLiveEventsWebSocketServer(server, db as any, {
     deploymentMode: config.deploymentMode,
-    resolveSessionFromHeaders,
+    resolveSessionFromRequest,
   });
 
   void reconcilePersistedRuntimeServicesOnStartup(db as any)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -997,29 +997,34 @@ export async function startServer(): Promise<StartedServer> {
   
   {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
-      const telemetryClient = getTelemetryClient();
-      if (telemetryClient) {
-        telemetryClient.stop();
-        await telemetryClient.flush();
-      }
-
-      const appShutdown = (app as { locals?: { paperclipShutdown?: () => void } }).locals?.paperclipShutdown;
-      appShutdown?.();
-
-      if (embeddedPostgres && embeddedPostgresStartedByThisProcess) {
-        logger.info({ signal }, "Stopping embedded PostgreSQL");
-        try {
-          await embeddedPostgres?.stop();
-        } catch (err) {
-          logger.error({ err }, "Failed to stop embedded PostgreSQL cleanly");
+      try {
+        const telemetryClient = getTelemetryClient();
+        if (telemetryClient) {
+          telemetryClient.stop();
+          await telemetryClient.flush();
         }
+
+        const appShutdown = (app as { locals?: { paperclipShutdown?: () => void } }).locals?.paperclipShutdown;
+        appShutdown?.();
+
+        if (embeddedPostgres && embeddedPostgresStartedByThisProcess) {
+          logger.info({ signal }, "Stopping embedded PostgreSQL");
+          try {
+            await embeddedPostgres?.stop();
+          } catch (err) {
+            logger.error({ err }, "Failed to stop embedded PostgreSQL cleanly");
+          }
+        }
+
+        // Flush buffered OTel spans before the process goes away; without this
+        // await the exporter's final batch is dropped on exit.
+        await shutdownInstrumentation();
+
+        process.exit(0);
+      } catch (err) {
+        logger.error({ err, signal }, "Failed to shut down cleanly");
+        process.exit(1);
       }
-
-      // Flush buffered OTel spans before the process goes away; without this
-      // await the exporter's final batch is dropped on exit.
-      await shutdownInstrumentation();
-
-      process.exit(0);
     };
 
     process.once("SIGINT", () => {

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -79,19 +79,6 @@ function parseBearerToken(rawAuth: string | string[] | undefined) {
   return token.length > 0 ? token : null;
 }
 
-function headersFromIncomingMessage(req: IncomingMessage): Headers {
-  const headers = new Headers();
-  for (const [key, raw] of Object.entries(req.headers)) {
-    if (!raw) continue;
-    if (Array.isArray(raw)) {
-      for (const value of raw) headers.append(key, value);
-      continue;
-    }
-    headers.set(key, raw);
-  }
-  return headers;
-}
-
 async function authorizeUpgrade(
   db: Db,
   req: IncomingMessage,
@@ -99,7 +86,7 @@ async function authorizeUpgrade(
   url: URL,
   opts: {
     deploymentMode: DeploymentMode;
-    resolveSessionFromHeaders?: (headers: Headers) => Promise<BetterAuthSessionResult | null>;
+    resolveSessionFromRequest?: (req: IncomingMessage) => Promise<BetterAuthSessionResult | null>;
   },
 ): Promise<UpgradeContext | null> {
   const queryToken = url.searchParams.get("token")?.trim() ?? "";
@@ -116,11 +103,11 @@ async function authorizeUpgrade(
       };
     }
 
-    if (opts.deploymentMode !== "authenticated" || !opts.resolveSessionFromHeaders) {
+    if (opts.deploymentMode !== "authenticated" || !opts.resolveSessionFromRequest) {
       return null;
     }
 
-    const session = await opts.resolveSessionFromHeaders(headersFromIncomingMessage(req));
+    const session = await opts.resolveSessionFromRequest(req);
     const userId = session?.user?.id;
     if (!userId) return null;
 
@@ -180,7 +167,7 @@ export function setupLiveEventsWebSocketServer(
   db: Db,
   opts: {
     deploymentMode: DeploymentMode;
-    resolveSessionFromHeaders?: (headers: Headers) => Promise<BetterAuthSessionResult | null>;
+    resolveSessionFromRequest?: (req: IncomingMessage) => Promise<BetterAuthSessionResult | null>;
   },
 ) {
   const wss = new WebSocketServer({ noServer: true });
@@ -248,7 +235,7 @@ export function setupLiveEventsWebSocketServer(
 
     void authorizeUpgrade(db, req, companyId, url, {
       deploymentMode: opts.deploymentMode,
-      resolveSessionFromHeaders: opts.resolveSessionFromHeaders,
+      resolveSessionFromRequest: opts.resolveSessionFromRequest,
     })
       .then((context) => {
         if (!context) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Authenticated deployments rely on Better Auth sessions, and the server supports `auth.baseUrlMode=auto` for local/private installs where the public URL is inferred from the incoming request.
> - Better Auth can emit `__Secure-` cookies when it believes the request is HTTPS, which breaks plain HTTP login because browsers drop secure cookies delivered over HTTP.
> - A direct `trustedProxyHeaders` fix would trust spoofable forwarded headers for every auto-mode request, which is unsafe when Paperclip is directly reachable.
> - This PR uses two Better Auth instances in auto mode, one secure and one insecure, then selects the right instance per request.
> - Forwarded protocol is trusted only when the request comes from a loopback-side proxy; otherwise Paperclip falls back to Express protocol or socket TLS state.
> - The benefit is that HTTP auto-mode login works without downgrading HTTPS reverse-proxy deployments or trusting arbitrary client headers.

## Linked Issues or Issue Description

Fixes: #1598

Related prior approach: #1623

Bug context:
- What happened: in authenticated `auto` base URL mode over plain HTTP, Better Auth could emit secure cookies that browsers silently drop, preventing login/session persistence.
- Expected behavior: auto mode should use non-secure cookies for HTTP requests and secure cookies for HTTPS requests.
- Steps to reproduce: run an authenticated private/local Paperclip server over HTTP in auto base URL mode, sign in, and observe the session cookie being rejected or not persisted.
- Paperclip version/commit: observed on the PR base before this auth cookie handling fix.
- Deployment mode: `authenticated` with private/local auto-origin deployment.

## What Changed

- Added dual Better Auth instance creation for `auto` mode: one instance forces secure cookies and one forces non-secure cookies.
- Added per-request selection based on loopback-only `X-Forwarded-Proto`, Express protocol, or raw socket TLS state.
- Updated HTTP auth handling and live-events WebSocket session resolution to pass enough request transport context for safe selection.
- Kept explicit public base URL mode on the existing single-instance path.
- Added regression coverage for forced secure-cookie options and loopback-only forwarded protocol trust.

## Verification

- `npx pnpm@9.15.4 exec vitest run server/src/__tests__/better-auth.test.ts server/src/__tests__/server-startup-feedback-export.test.ts` ✅
- `npx pnpm@9.15.4 --filter @paperclipai/server typecheck` ✅
- `npx pnpm@9.15.4 build` ✅
- `npx pnpm@9.15.4 -r typecheck` ⚠️ blocked by existing `packages/plugins/examples/plugin-kitchen-sink-example/src/ui/index.tsx` implicit-any typecheck failure outside this auth change.
- `npx pnpm@9.15.4 test:run` ⚠️ after fixing this PR's startup mock failures, remaining failures are outside this auth change: cursor remote sandbox command tests, heartbeat comment wake batching timeout, and workspace runtime default-branch symref setup.

## Risks

- Low to medium risk: the change touches authenticated session routing, but is scoped to Better Auth instance construction and request-time selection.
- Auto mode now builds two Better Auth instances at startup, so configuration must remain deterministic between the secure and insecure variants.
- Forwarded protocol is intentionally trusted only from loopback remote addresses to avoid client-spoofed header security regressions.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI GPT-5 Codex in Codex desktop, with repository tool use, GitHub CLI/API access, local TypeScript/Vitest/build verification, and tool-assisted conflict resolution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge