### PR TITLE
feat(plugins): add projects.create and projects.update capabilities

### DIFF
--- a/packages/plugins/sdk/src/host-client-factory.ts
+++ b/packages/plugins/sdk/src/host-client-factory.ts
@@ -158,10 +158,12 @@ export interface HostServices {
     get(params: WorkerToHostMethods["companies.get"][0]): Promise<WorkerToHostMethods["companies.get"][1]>;
   };
 
-  /** Provides `projects.list`, `projects.get`, `projects.listWorkspaces`, `projects.getPrimaryWorkspace`, `projects.getWorkspaceForIssue`. */
+  /** Provides `projects.list`, `projects.get`, `projects.create`, `projects.update`, `projects.listWorkspaces`, `projects.getPrimaryWorkspace`, `projects.getWorkspaceForIssue`. */
   projects: {
     list(params: WorkerToHostMethods["projects.list"][0]): Promise<WorkerToHostMethods["projects.list"][1]>;
     get(params: WorkerToHostMethods["projects.get"][0]): Promise<WorkerToHostMethods["projects.get"][1]>;
+    create(params: WorkerToHostMethods["projects.create"][0]): Promise<WorkerToHostMethods["projects.create"][1]>;
+    update(params: WorkerToHostMethods["projects.update"][0]): Promise<WorkerToHostMethods["projects.update"][1]>;
     listWorkspaces(params: WorkerToHostMethods["projects.listWorkspaces"][0]): Promise<WorkerToHostMethods["projects.listWorkspaces"][1]>;
     getPrimaryWorkspace(params: WorkerToHostMethods["projects.getPrimaryWorkspace"][0]): Promise<WorkerToHostMethods["projects.getPrimaryWorkspace"][1]>;
     getWorkspaceForIssue(params: WorkerToHostMethods["projects.getWorkspaceForIssue"][0]): Promise<WorkerToHostMethods["projects.getWorkspaceForIssue"][1]>;
@@ -323,6 +325,8 @@ const METHOD_CAPABILITY_MAP: Record<WorkerToHostMethodName, PluginCapability | n
   // Projects
   "projects.list": "projects.read",
   "projects.get": "projects.read",
+  "projects.create": "projects.create",
+  "projects.update": "projects.update",
   "projects.listWorkspaces": "project.workspaces.read",
   "projects.getPrimaryWorkspace": "project.workspaces.read",
   "projects.getWorkspaceForIssue": "project.workspaces.read",
@@ -520,6 +524,12 @@ export function createHostClientHandlers(
     }),
     "projects.get": gated("projects.get", async (params) => {
       return services.projects.get(params);
+    }),
+    "projects.create": gated("projects.create", async (params) => {
+      return services.projects.create(params);
+    }),
+    "projects.update": gated("projects.update", async (params) => {
+      return services.projects.update(params);
     }),
     "projects.listWorkspaces": gated("projects.listWorkspaces", async (params) => {
       return services.projects.listWorkspaces(params);

--- a/packages/plugins/sdk/src/protocol.ts
+++ b/packages/plugins/sdk/src/protocol.ts
@@ -712,6 +712,28 @@ export interface WorkerToHostMethods {
     params: { projectId: string; companyId: string },
     result: Project | null,
   ];
+  // Projects (write)
+  "projects.create": [
+    params: {
+      companyId: string;
+      name: string;
+      description?: string;
+      status?: string;
+      leadAgentId?: string;
+      targetDate?: string;
+      goalIds?: string[];
+    },
+    result: Project,
+  ];
+  "projects.update": [
+    params: {
+      projectId: string;
+      companyId: string;
+      patch: Record<string, unknown>;
+    },
+    result: Project | null,
+  ];
+
   "projects.listWorkspaces": [
     params: { projectId: string; companyId: string },
     result: PluginWorkspace[],

--- a/packages/plugins/sdk/src/testing.ts
+++ b/packages/plugins/sdk/src/testing.ts
@@ -626,6 +626,44 @@ export function createTestHarness(options: TestHarnessOptions): TestHarness {
         const project = projects.get(projectId);
         return isInCompany(project, companyId) ? project : null;
       },
+      async create(input) {
+        requireCapability(manifest, capabilitySet, "projects.create");
+        const id = `project-${Date.now()}`;
+        const project = {
+          id,
+          companyId: input.companyId,
+          urlKey: input.name.toLowerCase().replace(/\s+/g, "-"),
+          goalId: null,
+          goalIds: input.goalIds ?? [],
+          goals: [],
+          name: input.name,
+          description: input.description ?? null,
+          status: (input.status ?? "backlog") as any,
+          leadAgentId: input.leadAgentId ?? null,
+          targetDate: input.targetDate ?? null,
+          color: null,
+          env: null,
+          pauseReason: null,
+          pausedAt: null,
+          executionWorkspacePolicy: null,
+          codebase: { effectiveLocalFolder: "" } as any,
+          workspaces: [],
+          primaryWorkspace: null,
+          archivedAt: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as any;
+        projects.set(id, project);
+        return project;
+      },
+      async update(projectId, patch, companyId) {
+        requireCapability(manifest, capabilitySet, "projects.update");
+        const project = projects.get(projectId);
+        if (!isInCompany(project, companyId)) return null;
+        const updated = { ...project, ...patch, updatedAt: new Date() } as any;
+        projects.set(projectId, updated);
+        return updated;
+      },
       async listWorkspaces(projectId, companyId) {
         requireCapability(manifest, capabilitySet, "project.workspaces.read");
         if (!isInCompany(projects.get(projectId), companyId)) return [];

--- a/packages/plugins/sdk/src/types.ts
+++ b/packages/plugins/sdk/src/types.ts
@@ -665,6 +665,20 @@ export interface PluginProjectsClient {
   get(projectId: string, companyId: string): Promise<Project | null>;
 
   /**
+   * Create a new project in a company.
+   *
+   * Requires the `projects.create` capability.
+   */
+  create(input: { companyId: string; name: string; description?: string; status?: string; leadAgentId?: string; targetDate?: string; goalIds?: string[] }): Promise<Project>;
+
+  /**
+   * Update an existing project.
+   *
+   * Requires the `projects.update` capability.
+   */
+  update(projectId: string, patch: Record<string, unknown>, companyId: string): Promise<Project | null>;
+
+  /**
    * List all workspaces attached to a project.
    *
    * @param projectId - UUID of the project

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -569,6 +569,14 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
           return callHost("projects.get", { projectId, companyId });
         },
 
+        async create(input: { companyId: string; name: string; description?: string; status?: string; leadAgentId?: string; targetDate?: string; goalIds?: string[] }) {
+          return callHost("projects.create", input);
+        },
+
+        async update(projectId: string, patch: Record<string, unknown>, companyId: string) {
+          return callHost("projects.update", { projectId, companyId, patch });
+        },
+
         async listWorkspaces(projectId: string, companyId: string) {
           return callHost("projects.listWorkspaces", { projectId, companyId });
         },

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -581,6 +581,8 @@ export const PLUGIN_CAPABILITIES = [
   // Data Read
   "companies.read",
   "projects.read",
+  "projects.create",
+  "projects.update",
   "project.workspaces.read",
   "issues.read",
   "issue.relations.read",

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -581,8 +581,6 @@ export const PLUGIN_CAPABILITIES = [
   // Data Read
   "companies.read",
   "projects.read",
-  "projects.create",
-  "projects.update",
   "project.workspaces.read",
   "issues.read",
   "issue.relations.read",
@@ -598,6 +596,8 @@ export const PLUGIN_CAPABILITIES = [
   "issues.orchestration.read",
   "database.namespace.read",
   // Data Write
+  "projects.create",
+  "projects.update",
   "issues.create",
   "issues.update",
   "issue.relations.write",

--- a/server/src/services/plugin-capability-validator.ts
+++ b/server/src/services/plugin-capability-validator.ts
@@ -47,6 +47,8 @@ const OPERATION_CAPABILITIES: Record<string, readonly PluginCapability[]> = {
   "companies.get": ["companies.read"],
   "projects.list": ["projects.read"],
   "projects.get": ["projects.read"],
+  "projects.create": ["projects.create"],
+  "projects.update": ["projects.update"],
   "project.workspaces.list": ["project.workspaces.read"],
   "project.workspaces.get": ["project.workspaces.read"],
   "issues.list": ["issues.read"],

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -970,14 +970,21 @@ export function buildHostServices(
         const companyId = ensureCompanyId(params.companyId);
         await ensurePluginAvailableForCompany(companyId);
         const existing = requireInCompany("Project", await projects.getById(params.projectId), companyId);
-        const updated = (await projects.update(params.projectId, params.patch as any)) as Project | null;
+        // Sanitize the patch — strip protected fields that plugins must not overwrite
+        const patch = { ...(params.patch as Record<string, unknown>) };
+        delete patch.id;
+        delete patch.companyId;
+        delete patch.createdAt;
+        delete patch.updatedAt;
+        delete patch.archivedAt;
+        const updated = (await projects.update(params.projectId, patch as any)) as Project | null;
         if (updated) {
           await logPluginActivity({
             companyId,
             action: "project.updated",
             entityType: "project",
             entityId: updated.id,
-            details: { name: updated.name, patch: params.patch },
+            details: { name: updated.name, patch },
           });
         }
         return updated;

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -952,6 +952,36 @@ export function buildHostServices(
         const project = await projects.getById(params.projectId);
         return (inCompany(project, companyId) ? project : null) as Project | null;
       },
+      async create(params) {
+        const companyId = ensureCompanyId(params.companyId);
+        await ensurePluginAvailableForCompany(companyId);
+        const { companyId: _cid, ...projectData } = params;
+        const project = (await projects.create(companyId, projectData as any)) as Project;
+        await logPluginActivity({
+          companyId,
+          action: "project.created",
+          entityType: "project",
+          entityId: project.id,
+          details: { name: project.name },
+        });
+        return project;
+      },
+      async update(params) {
+        const companyId = ensureCompanyId(params.companyId);
+        await ensurePluginAvailableForCompany(companyId);
+        const existing = requireInCompany("Project", await projects.getById(params.projectId), companyId);
+        const updated = (await projects.update(params.projectId, params.patch as any)) as Project | null;
+        if (updated) {
+          await logPluginActivity({
+            companyId,
+            action: "project.updated",
+            entityType: "project",
+            entityId: updated.id,
+            details: { name: updated.name, patch: params.patch },
+          });
+        }
+        return updated;
+      },
       async listWorkspaces(params) {
         const companyId = ensureCompanyId(params.companyId);
         await ensurePluginAvailableForCompany(companyId);


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The plugin SDK exposes CRUD for issues (`issues.create`, `issues.update`) but only read access for projects (`projects.read`)
> - Connector plugins that sync from external PM tools (Zoho Projects, Linear, GitHub) need to create Paperclip projects when they encounter new remote projects during issue sync
> - Without `projects.create`, plugins must either require manual project setup or use workarounds that bypass the SDK's capability model
> - This PR adds `projects.create` and `projects.update` capabilities following the exact pattern of `issues.create`/`issues.update`
> - The benefit is enabling connector plugins to provide seamless bidirectional project sync without modifying Paperclip core

## What Changed

- Added `"projects.create"` and `"projects.update"` to `PLUGIN_CAPABILITIES` in the Data Write section
- Added protocol method signatures (`projects.create`, `projects.update`) with typed params/result tuples
- Added client interface methods and capability-to-method mappings in `host-client-factory.ts`
- Added runtime wiring in `worker-rpc-host.ts` (`ctx.projects.create()` and `ctx.projects.update()`)
- Added `create` and `update` to `PluginProjectsClient` interface in `types.ts`
- Added test harness stubs in `testing.ts`
- Implemented server handlers in `plugin-host-services.ts` calling existing `projects.create()` and `projects.update()` service methods
- `projects.update` handler sanitizes the patch — strips `id`, `companyId`, `createdAt`, `updatedAt`, `archivedAt` before forwarding (matching `issues.update` discipline)
- Added capability validator entries in `plugin-capability-validator.ts`

## Verification

- `pnpm --filter @paperclipai/shared build` — passes
- `pnpm --filter @paperclipai/plugin-sdk typecheck` — passes
- `pnpm --filter @paperclipai/server typecheck` — passes
- Plugin declaring `projects.create` can call `ctx.projects.create({ companyId, name })` successfully
- Plugin declaring `projects.update` can call `ctx.projects.update(projectId, patch, companyId)` successfully
- Plugin without `projects.create` capability gets a capability rejection error

## Risks

- Low risk — additive change only, no existing behavior modified
- New capabilities are opt-in (plugins must declare them in their manifest)
- Patch sanitization in `projects.update` prevents company-boundary bypass via protected field injection

## Model Used

- Claude Opus 4.6 (1M context) via Claude Code CLI
- Tool use and code execution capabilities

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge