### PR TITLE
fix(server): delete cost_events + finance_events before heartbeat_runs in companies.remove()

### DIFF
--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -280,13 +280,14 @@ export function companyService(db: Db) {
         }
         await tx.delete(agentTaskSessions).where(eq(agentTaskSessions.companyId, id));
         await tx.delete(activityLog).where(eq(activityLog.companyId, id));
+        // cost_events + finance_events FK-reference heartbeat_runs; delete them first
+        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
+        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
         await tx.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, id));
         await tx.delete(agentWakeupRequests).where(eq(agentWakeupRequests.companyId, id));
         await tx.delete(agentApiKeys).where(eq(agentApiKeys.companyId, id));
         await tx.delete(agentRuntimeState).where(eq(agentRuntimeState.companyId, id));
         await tx.delete(issueComments).where(eq(issueComments.companyId, id));
-        await tx.delete(costEvents).where(eq(costEvents.companyId, id));
-        await tx.delete(financeEvents).where(eq(financeEvents.companyId, id));
         await tx.delete(approvalComments).where(eq(approvalComments.companyId, id));
         await tx.delete(approvals).where(eq(approvals.companyId, id));
         await tx.delete(companySecrets).where(eq(companySecrets.companyId, id));


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, with each agent generating heartbeat runs (per-wakeup execution records) and cost events (per-LLM-call accounting rows) on a continuous basis.
> - Company lifecycle is owned by `server/src/services/companies.ts`; the `remove()` function runs a single transaction that deletes the company's history across roughly a dozen related tables before deleting the company row itself.
> - The schema has `cost_events.heartbeat_run_id` and `finance_events.heartbeat_run_id` as foreign keys into `heartbeat_runs(id)`, so any deletion of `heartbeat_runs` must follow deletion of those two child tables.
> - In master, `remove()` deletes `heartbeatRuns` before `costEvents` and `financeEvents`, so any company with even a single heartbeat run + associated cost event fails its delete with Postgres error 23503 (`update or delete on table "heartbeat_runs" violates foreign key constraint`). For any heartbeat-on company this happens within minutes of first wakeup.
> - This pull request reorders the two `tx.delete()` calls so `costEvents` and `financeEvents` are removed before `heartbeatRuns`.
> - The benefit is that `DELETE /api/companies/<id>` becomes safe to call from the UI or API for any company with execution history, removing the need for the current workaround of pre-deleting child rows directly in Postgres.

## What Changed

- Moved `tx.delete(costEvents)` ahead of `tx.delete(heartbeatRuns)` in `companies.remove()` (`server/src/services/companies.ts`).
- Moved `tx.delete(financeEvents)` ahead of `tx.delete(heartbeatRuns)` in the same transaction.
- Added a one-line comment noting the FK dependency on `heartbeat_runs(id)` so the ordering is not innocently re-broken later.

## Verification

**Reproduction on master** (without this patch):
1. Run any company with `heartbeat.enabled = true` for a few minutes so the agents emit heartbeat runs + cost events.
2. `curl -X DELETE -H "Authorization: Bearer <admin>" http://<paperclip>/api/companies/<id>`
3. Server returns HTTP 500 + Postgres error 23503 (`update or delete on "heartbeat_runs" violates foreign key constraint "cost_events_heartbeat_run_id_fkey"` and/or the `finance_events` equivalent).

**Confirmation on this branch:**
1. Cherry-pick this commit onto master, restart the server.
2. Repeat step 2 above against the same kind of company (heartbeat history + cost events).
3. Returns HTTP 200, company + all child rows deleted, no FK error.

**Live verification done by author** on 2026-05-26 against an internal Paperclip company (~100 issues, ~578 cost events, ~6700 heartbeat runs). API call succeeded, company + history fully purged, CRE Paperclip container restart clean (HTTP 200 on `/health`).

CI status as of submission: all 15 checks green (policy, typecheck, build, e2e, all 4 serialized server suites, workspaces-a/b, canary dry run, verify, Snyk, Greptile).

## Risks

**Low risk.** Pure reordering inside an existing transaction:

- No schema change, no new columns, no migration.
- No change to which tables get deleted — same set, same scope, same `eq(<table>.companyId, id)` filters.
- No change to any other code path; `remove()` is the only caller affected.
- Transaction semantics unchanged — if any delete fails the whole thing rolls back, same as before.
- No new dependencies, no behavioral shifts to surviving rows.

Worst case if the reorder is somehow wrong: same FK error as today, surfaced earlier in the transaction. No data loss path.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

Not applicable — bugfix, not a feature. `ROADMAP.md` does not list `companies.remove()` rework.

## Model Used

- **Provider:** Anthropic
- **Model:** Claude Opus 4.7 (model ID `claude-opus-4-7`)
- **Context window:** 1M tokens (`claude-opus-4-7[1m]` variant)
- **Mode:** Extended thinking enabled; tool use (Read/Edit/Bash via Claude Code CLI) used for source inspection, patch authoring, local rebuild, and PR submission.
- **Author role:** AI-assisted. Human (PR author `@hyamie`) directed the work, confirmed the root cause, executed the fix on a local fork (`hyamie/paperclip`), and validated the patch live against a production-shaped Paperclip instance before submitting upstream.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable *(no existing test covers `companies.remove()`; this PR matches that scope — open to adding one if maintainer prefers, but felt out of scope for a 2-line reorder bugfix)*
- [x] If this change affects the UI, I have included before/after screenshots *(N/A — server-only)*
- [x] I have updated relevant documentation to reflect my changes *(N/A — no doc references the old deletion order)*
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
