### PR TITLE
fix(adapter): add output keepalive timer for opencode_local adapter

### DIFF
--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -56,6 +56,35 @@ import { SANDBOX_INSTALL_COMMAND } from "../index.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
+const ADAPTER_OUTPUT_KEEPALIVE_INTERVAL_MS = 10 * 60 * 1000;
+const ADAPTER_OUTPUT_KEEPALIVE_MESSAGE =
+  "[paperclip heartbeat keepalive] adapter process is alive and working\n";
+
+function createKeepaliveOnLog(
+  originalOnLog: AdapterExecutionContext["onLog"],
+): { onLog: AdapterExecutionContext["onLog"]; cleanup: () => void } {
+  let lastRealOutput = Date.now();
+  let keepaliveTimer: ReturnType<typeof setInterval> | null = setInterval(() => {
+    if (Date.now() - lastRealOutput >= ADAPTER_OUTPUT_KEEPALIVE_INTERVAL_MS) {
+      originalOnLog("stdout", ADAPTER_OUTPUT_KEEPALIVE_MESSAGE);
+    }
+  }, ADAPTER_OUTPUT_KEEPALIVE_INTERVAL_MS);
+
+  const wrappedOnLog: AdapterExecutionContext["onLog"] = async (stream, message) => {
+    lastRealOutput = Date.now();
+    return originalOnLog(stream, message);
+  };
+
+  const cleanup = () => {
+    if (keepaliveTimer) {
+      clearInterval(keepaliveTimer);
+      keepaliveTimer = null;
+    }
+  };
+
+  return { onLog: wrappedOnLog, cleanup };
+}
+
 function firstNonEmptyLine(text: string): string {
   return (
     text
@@ -573,20 +602,25 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         });
       }
 
-      const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
-        cwd,
-        env: preparedRuntimeConfig.env,
-        stdin: prompt,
-        timeoutSec,
-        graceSec,
-        onSpawn,
-        onLog,
-      });
-      return {
-        proc,
-        rawStderr: proc.stderr,
-        parsed: parseOpenCodeJsonl(proc.stdout),
-      };
+      const { onLog: keepaliveOnLog, cleanup: keepaliveCleanup } = createKeepaliveOnLog(onLog);
+      try {
+        const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
+          cwd,
+          env: preparedRuntimeConfig.env,
+          stdin: prompt,
+          timeoutSec,
+          graceSec,
+          onSpawn,
+          onLog: keepaliveOnLog,
+        });
+        return {
+          proc,
+          rawStderr: proc.stderr,
+          parsed: parseOpenCodeJsonl(proc.stdout),
+        };
+      } finally {
+        keepaliveCleanup();
+      }
     };
 
     const toResult = (


### PR DESCRIPTION
Implements ANR-98: a periodic keepalive timer that emits "[paperclip heartbeat keepalive]" every 10 minutes when no real output has arrived, preventing false-positive silent-active-run watchdog evaluations (~27 recurrences).

## Changes
- 10-minute interval (well under 1h suspicion threshold)
- Tracks lastRealOutput to suppress keepalive when real output flows
- Cleanup on all exit paths via finally block
- Unique prefix for server-side classification

## Verification
- `pnpm --filter @paperclipai/adapter-opencode-local build` passes
- All CI checks pass: policy, typecheck, build, tests, e2e, canary dry-run

## Deployment
After merge, the Release CI will automatically publish a canary release (triggered by push to master). A stable release can be cut manually when ready.

Closes ANR-125
<!-- DevOps Engineer: All CI checks green, ready for merge → canary deploy -->