### PR TITLE
fix(routes): propagate nested operation stdout/stderr/logBytes to workspace job result

### DIFF
--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -307,8 +307,12 @@ export function executionWorkspaceRoutes(db: Db) {
           }).then((nestedOperation) => ({
             status: "succeeded" as const,
             exitCode: 0,
+            stdout: nestedOperation?.stdoutExcerpt ?? null,
+            stderr: nestedOperation?.stderrExcerpt ?? null,
+            system: `Completed workspace job "${workspaceCommand.name}"\n`,
             metadata: {
               nestedOperationId: nestedOperation?.id ?? null,
+              nestedLogBytes: nestedOperation?.logBytes ?? null,
               runtimeServiceCount,
             },
           }));

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -487,8 +487,12 @@ export function projectRoutes(db: Db) {
           }).then((nestedOperation) => ({
             status: "succeeded" as const,
             exitCode: 0,
+            stdout: nestedOperation?.stdoutExcerpt ?? null,
+            stderr: nestedOperation?.stderrExcerpt ?? null,
+            system: `Completed workspace job "${workspaceCommand.name}"\n`,
             metadata: {
               nestedOperationId: nestedOperation?.id ?? null,
+              nestedLogBytes: nestedOperation?.logBytes ?? null,
               runtimeServiceCount,
             },
           }));


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies, and many of those agents react programmatically to workspace job results returned by the REST API.
> - The `executionWorkspaceRoutes` and `projectRoutes` modules both expose `start|stop|restart` actions that, when the workspace has a configured workspace-command, invoke that command through the nested-operation runner (`runWorkspaceJobForControl` → `recordWorkspaceCommandOperation`).
> - On the success path, the nested operation returns a typed record containing `id`, `stdoutExcerpt`, `stderrExcerpt`, `logBytes` — captured output and size that already exist on the returned object.
> - Both route call sites discard that record and return `{ status: "succeeded" as const, exitCode: 0, metadata: { nestedOperationId, runtimeServiceCount } }`, so the captured stdout/stderr/logBytes never make it into the response. UI users don't notice because the UI only renders `status: "succeeded"`; the gap shows up only when programmatic consumers need to inspect what the command actually printed.
> - This pull request reads those existing fields and passes them through to the response — `stdout`, `stderr`, `system` completion marker, and `nestedLogBytes` in `metadata` — for the success path.
> - The benefit is that the workspace-job result surface stops dropping stdout/stderr/logBytes that the nested operation already captured, with no schema change, no new types, and no UI impact (`status` is preserved exactly).

## What Changed

Replace the hardcoded success shape

```ts
}).then((nestedOperation) => ({
  status: "succeeded" as const,
  exitCode: 0,
  metadata: {
    nestedOperationId: nestedOperation?.id ?? null,
    runtimeServiceCount,
  },
}));
```

with a passthrough of the nested operation's success-path output fields:

```ts
}).then((nestedOperation) => ({
  status: "succeeded" as const,
  exitCode: 0,
  stdout: nestedOperation?.stdoutExcerpt ?? null,
  stderr: nestedOperation?.stderrExcerpt ?? null,
  system: `Completed workspace job "${workspaceCommand.name}"\n`,
  metadata: {
    nestedOperationId: nestedOperation?.id ?? null,
    nestedLogBytes: nestedOperation?.logBytes ?? null,
    runtimeServiceCount,
  },
}));
```

- `server/src/routes/execution-workspaces.ts` — `executionWorkspaceRoutes` nested-op branch (the `start|stop|restart` action with a configured workspace-command).
- `server/src/routes/projects.ts` — `projectRoutes` nested-op branch (project-workspace variant of the same flow).

Both sites have the same shape and discard the same fields; both get the same fix. The `system` line provides a one-shot human-readable completion marker matching the existing `system` convention used elsewhere in workspace-job result surfaces.

Net change: +8 / 0 across 2 files.

## Verification

- `pnpm --filter server typecheck` clean (every field read here already exists on the nested-operation result type, so no new types needed).
- `pnpm exec vitest run src/__tests__/execution-workspaces-routes.test.ts src/__tests__/execution-workspace-policy.test.ts` — **11/11 pass** on the head commit.
- `pnpm -r typecheck` across all 27 workspaces — clean.
- CI on the initial commit: 15/15 green including Greptile, Build, Canary Dry Run, Typecheck + Release Registry, General tests (server / workspaces-a / workspaces-b), Verify serialized server suites (1–4/4), e2e, policy, security/snyk, verify.

Honest scope note: this PR does not add a new test asserting the propagated values appear in the HTTP response. Existing route tests mock the nested-op runner, and the new fields are pure passthrough of values the current test mock does not produce. A follow-up sibling PR could harden the mock and add assertions; this PR keeps scope to the minimal correctness fix.

## Scope honesty: why `exitCode` is left at hardcoded `0`

The initial revision of this PR also propagated `nestedOperation?.exitCode`, framed as "real exit codes for failures." Greptile (P1) and a re-read of `server/src/services/workspace-runtime.ts:991-998` showed that claim is wrong:

```ts
if (code === 0) return operation;
const details = [stderr.trim(), stdout.trim()].filter(Boolean).join("\n");
throw new Error(
  details.length > 0
    ? `${input.label} failed: ${details}`
    : `${input.label} failed with exit code ${code ?? -1}`,
);
```

`recordWorkspaceCommandOperation` throws on any non-zero exit, so this PR's `.then()` handler only ever runs when the command succeeded — making `exitCode` always `0` (or `null` when no recorder was wired, where the `?? 0` fallback applies). Propagating it through the response would be a no-op for failure detection. Failures are surfaced as thrown errors that the route's existing error handler maps to non-2xx HTTP responses.

So this PR is scoped to the genuinely-additive case: stdout/stderr/logBytes/system on the success path. Surfacing real failure exit codes would require changing the recorder's throw-on-failure contract, which is out of scope here and would belong in a separate PR that touches every caller of `recordWorkspaceCommandOperation`.

## Risks

- **Low risk.** Both sites previously discarded fields that already existed on the nested-op result; the fix only stops discarding them. No schema change, no API surface contraction, no new types, no behavior change on the failure path.
- **Existing consumers reading `exitCode === 0` as a success sentinel are unaffected** — `exitCode` is unchanged.
- **Existing consumers ignoring the new `stdout` / `stderr` / `system` / `nestedLogBytes` fields are unaffected** — the response shape gains fields, never removes any.
- **The `system` line is a constant-format string interpolating `workspaceCommand.name`**, which is configuration-derived (not user input at this depth in the stack). No injection surface beyond what the workspace-command config already exposes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`. *(This PR is a small targeted bug fix in the response-passthrough layer, intended to fit Path 1 of CONTRIBUTING.md: one logical change, smallest possible file touch, no roadmap overlap.)*

## Model Used

- **Claude Opus 4.7 (1M context)** via the Anthropic SDK, extended-thinking mode, used for the source-code audit, fix design, Greptile-feedback response, and PR drafting. Tool-enabled environment (Bash, Read, Edit, Write, Grep, GitHub CLI via `gh`).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have run tests locally and they pass (11/11 in `execution-workspaces-routes` + `execution-workspace-policy`; workspace-wide `pnpm -r typecheck` clean; full CI 15/15 green on prior commit)
- [ ] I have added or updated tests where applicable — *intentionally out of scope; see Verification section for the honest rationale and the proposed follow-up.*
- [x] If this change affects the UI, I have included before/after screenshots — *N/A; server-side only. The UI consumes the existing `status` field, which is unchanged.*
- [x] I have updated relevant documentation to reflect my changes — *N/A; no public-API doc references the hardcoded shape, and the new fields are additive.*
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge
