### PR TITLE
Stop retry loop for missing heartbeat logs (404 polling)

### DIFF
--- a/ui/src/components/transcript/useLiveRunTranscripts.ts
+++ b/ui/src/components/transcript/useLiveRunTranscripts.ts
@@ -232,7 +232,8 @@ export function useLiveRunTranscripts({
           logOffsetByRunRef.current.set(run.id, offset + result.content.length);
         }
       } catch (error) {
-        if (error instanceof ApiError && error.status === 404 && isTerminalStatus(run.status)) {
+        if (error instanceof ApiError && error.status === 404) {
+          // Run may disappear after backend cancellation; stop retrying this run log.
           missingTerminalLogRunIdsRef.current.add(run.id);
         }
       } finally {

--- a/ui/src/pages/AgentDetail.tsx
+++ b/ui/src/pages/AgentDetail.tsx
@@ -3670,6 +3670,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
   const pendingLogLineRef = useRef("");
   const scrollContainerRef = useRef<ScrollContainer | null>(null);
   const isFollowingRef = useRef(false);
+  const missingLiveLogRunIdsRef = useRef<Set<string>>(new Set());
   const lastMetricsRef = useRef<{ scrollHeight: number; distanceFromBottom: number }>({
     scrollHeight: 0,
     distanceFromBottom: Number.POSITIVE_INFINITY,
@@ -3815,6 +3816,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
   useEffect(() => {
     let cancelled = false;
     pendingLogLineRef.current = "";
+    missingLiveLogRunIdsRef.current.delete(run.id);
     setLogLines([]);
     setLogOffset(0);
     setHasMoreLog(false);
@@ -3840,6 +3842,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
       } catch (err) {
         if (!cancelled) {
           if (isLive && isRunLogUnavailable(err)) {
+            missingLiveLogRunIdsRef.current.add(run.id);
             setLogLoading(false);
             return;
           }
@@ -3892,7 +3895,7 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
 
   // Poll shell log for running runs
   useEffect(() => {
-    if (!isLive || isStreamingConnected) return;
+    if (!isLive || isStreamingConnected || missingLiveLogRunIdsRef.current.has(run.id)) return;
     const interval = setInterval(async () => {
       try {
         const result = await heartbeatsApi.log(run.id, logOffset, 256_000);
@@ -3905,7 +3908,10 @@ function LogViewer({ run, adapterType }: { run: HeartbeatRun; adapterType: strin
           setLogOffset((prev) => prev + result.content.length);
         }
       } catch (err) {
-        if (isRunLogUnavailable(err)) return;
+        if (isRunLogUnavailable(err)) {
+          missingLiveLogRunIdsRef.current.add(run.id);
+          return;
+        }
         // ignore polling errors
       }
     }, 2000);


### PR DESCRIPTION
## Summary

Prevent the UI from getting stuck retrying heartbeat run logs that return `404` after the run is cancelled or removed. Affects both the transcript live polling and the agent detail live log viewer.

## Problem

When using a real account on a fresh Paperclip instance, the frontend would enter an infinite polling loop against `/api/heartbeat-runs/:runId/log` for runs that had been cancelled (or whose log was no longer available). Each request returned `404` but the polling loops did not mark the run as unavailable, so retries continued indefinitely.

Concrete repro observed:
- Run ID `d4cbc7e9-55a8-47e3-99fe-12c6ed18d53d` returning `404` for log endpoint
- Two independent polling paths kept retrying — one in `useLiveRunTranscripts` (transcript), one in `AgentDetail` (LogViewer)

## Root cause

Two code paths poll heartbeat logs and neither was treating `404` as a terminal signal in all branches:

1. **`ui/src/components/transcript/useLiveRunTranscripts.ts`** — only stopped retrying on `404` when the run was already in a terminal status, so live-cancelled runs leaked through.
2. **`ui/src/pages/AgentDetail.tsx`** — both the initial load and the periodic poll paths kept fetching after `404`.

## Fix

1. `useLiveRunTranscripts.ts`: mark the run as missing on any `404`, independent of run status.
2. `AgentDetail.tsx`: introduce `missingLiveLogRunIdsRef` and stop fetching for any run that has produced a `404` in either the initial load or the periodic poll.

## Files changed

- `ui/src/components/transcript/useLiveRunTranscripts.ts` (+2 / -1)
- `ui/src/pages/AgentDetail.tsx` (+8 / -2)

## Test plan

- [ ] Reproduce: cancel an in-flight run, confirm 404 polling stops within one tick of the next poll.
- [ ] Verify normal transcript streaming for active runs is unaffected.
- [ ] Verify AgentDetail LogViewer still backfills logs for live runs that exist.

---

🤖 Patch authored locally by Codex while debugging a self-hosted deploy. Happy to iterate on style / split commits if preferred.