### PR TITLE
fix(opencode-local): fall back to opencode export when stdout has no text

### DIFF
--- a/packages/adapters/opencode-local/CHANGELOG.md
+++ b/packages/adapters/opencode-local/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @paperclipai/adapter-opencode-local
 
+## 0.3.2
+
+### Patch Changes
+
+- Add `parseOpenCodeSessionExport` and `opencode export` fallback in `runAttempt` when stdout has no text events (opencode v1.15.10+ compatibility).
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/adapters/opencode-local/package.json
+++ b/packages/adapters/opencode-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paperclipai/adapter-opencode-local",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "homepage": "https://github.com/paperclipai/paperclip",
   "bugs": {

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -44,7 +44,7 @@ import {
   readPaperclipIssueWorkModeFromContext,
   resolvePaperclipDesiredSkillNames,
 } from "@paperclipai/adapter-utils/server-utils";
-import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl } from "./parse.js";
+import { isOpenCodeUnknownSessionError, parseOpenCodeJsonl, parseOpenCodeSessionExport } from "./parse.js";
 import {
   ensureOpenCodeModelConfiguredAndAvailable,
   parseOpenCodeModelsOutput,
@@ -582,10 +582,38 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         onSpawn,
         onLog,
       });
+      let parsed = parseOpenCodeJsonl(proc.stdout);
+      // opencode v1.15.10+ no longer emits text/step_finish events to stdout.
+      // Fall back to `opencode export <sessionId>` to read the session DB.
+      if (!parsed.summary && !parsed.errorMessage && parsed.sessionId && !proc.timedOut && (proc.exitCode ?? 0) === 0) {
+        try {
+          await onLog("stdout", `[paperclip] No text in stdout; fetching response via opencode export (session ${parsed.sessionId}).\n`);
+          const exportProc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, ["export", parsed.sessionId], {
+            cwd,
+            env: preparedRuntimeConfig.env,
+            timeoutSec: Math.min(timeoutSec > 0 ? timeoutSec : 30, 30),
+            graceSec,
+            onLog: async () => {},
+          });
+          if ((exportProc.exitCode ?? 1) === 0 && exportProc.stdout.trim()) {
+            const exported = parseOpenCodeSessionExport(exportProc.stdout);
+            if (exported && exported.summary) {
+              parsed = {
+                ...parsed,
+                summary: exported.summary,
+                usage: exported.usage,
+                costUsd: exported.costUsd,
+              };
+            }
+          }
+        } catch (err) {
+          await onLog("stdout", `[paperclip] opencode export fallback failed: ${err instanceof Error ? err.message : String(err)}\n`);
+        }
+      }
       return {
         proc,
         rawStderr: proc.stderr,
-        parsed: parseOpenCodeJsonl(proc.stdout),
+        parsed,
       };
     };
 

--- a/packages/adapters/opencode-local/src/server/parse.test.ts
+++ b/packages/adapters/opencode-local/src/server/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseOpenCodeJsonl, isOpenCodeUnknownSessionError } from "./parse.js";
+import { parseOpenCodeJsonl, parseOpenCodeSessionExport, isOpenCodeUnknownSessionError } from "./parse.js";
 
 describe("parseOpenCodeJsonl", () => {
   it("parses assistant text, usage, cost, and errors", () => {
@@ -73,5 +73,43 @@ describe("parseOpenCodeJsonl", () => {
     expect(isOpenCodeUnknownSessionError("Session not found: s_123", "")).toBe(true);
     expect(isOpenCodeUnknownSessionError("", "unknown session id")).toBe(true);
     expect(isOpenCodeUnknownSessionError("all good", "")).toBe(false);
+  });
+});
+
+describe("parseOpenCodeSessionExport", () => {
+  it("extracts assistant text and usage from opencode export JSON", () => {
+    const exportJson = JSON.stringify({
+      info: {
+        cost: 0.001,
+        tokens: { input: 100, output: 30, reasoning: 5, cache: { read: 10 } },
+      },
+      messages: [
+        {
+          info: { role: "user" },
+          parts: [{ type: "text", text: "ignored" }],
+        },
+        {
+          info: { role: "assistant" },
+          parts: [
+            { type: "text", text: "First paragraph" },
+            { type: "text", text: "Second paragraph" },
+          ],
+        },
+      ],
+    });
+
+    const parsed = parseOpenCodeSessionExport(exportJson);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.summary).toBe("First paragraph\n\nSecond paragraph");
+    expect(parsed!.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 35,
+      cachedInputTokens: 10,
+    });
+    expect(parsed!.costUsd).toBeCloseTo(0.001, 6);
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseOpenCodeSessionExport("not json")).toBeNull();
   });
 });

--- a/packages/adapters/opencode-local/src/server/parse.ts
+++ b/packages/adapters/opencode-local/src/server/parse.ts
@@ -88,6 +88,41 @@ export function parseOpenCodeJsonl(stdout: string) {
   };
 }
 
+export function parseOpenCodeSessionExport(exportJson: string): {
+  summary: string;
+  usage: { inputTokens: number; outputTokens: number; cachedInputTokens: number };
+  costUsd: number;
+} | null {
+  try {
+    const d = JSON.parse(exportJson) as Record<string, unknown>;
+    const messages: string[] = [];
+    const info = (d.info ?? {}) as Record<string, unknown>;
+    const tokens = (info.tokens ?? {}) as Record<string, unknown>;
+    const cache = (tokens.cache ?? {}) as Record<string, unknown>;
+    for (const msg of (d.messages ?? []) as Array<Record<string, unknown>>) {
+      const role = (msg?.info as Record<string, unknown> | undefined)?.role;
+      if (role !== "assistant") continue;
+      for (const part of (msg.parts ?? []) as Array<Record<string, unknown>>) {
+        if (part.type === "text" && part.text) {
+          const text = String(part.text).trim();
+          if (text) messages.push(text);
+        }
+      }
+    }
+    return {
+      summary: messages.join("\n\n").trim(),
+      usage: {
+        inputTokens: Number(tokens.input) || 0,
+        outputTokens: (Number(tokens.output) || 0) + (Number(tokens.reasoning) || 0),
+        cachedInputTokens: Number(cache.read) || 0,
+      },
+      costUsd: Number(info.cost) || 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export function isOpenCodeUnknownSessionError(stdout: string, stderr: string): boolean {
   const haystack = `${stdout}\n${stderr}`
     .split(/\r?\n/)


### PR DESCRIPTION
## Summary

- Adds `parseOpenCodeSessionExport()` to parse `opencode export` JSON when stdout JSONL has no `text` events (opencode v1.15.10+).
- Updates `runAttempt` in `execute.ts` to call `opencode export <sessionId>` on clean exit with empty summary.
- Bumps `@paperclipai/adapter-opencode-local` to **0.3.2** with tests and changelog.

## Test plan

- [x] `npx vitest run packages/adapters/opencode-local/src/server/parse.test.ts` (5 tests)
- [x] `npm run build` in `packages/adapters/opencode-local`

## Context

Fixes the dist-level patch applied in Infobric Paperclip instance ([internal INFA-24/INFA-26](https://github.com/paperclipai/paperclip/issues)) for local `opencode_local` adapters.

Co-Authored-By: Paperclip <noreply@paperclip.ing>

Made with [Cursor](https://cursor.com)